### PR TITLE
fix(#6574): give the GQL standalone FILTER clause a handler so it actually filters

### DIFF
--- a/docs/6574-gql-filter-clause-noop.md
+++ b/docs/6574-gql-filter-clause-noop.md
@@ -65,3 +65,30 @@ between true and false).
 - Full `com.arcadedb.query.opencypher.**` package (excluding `benchmark`, `slow`, `vector`
   lanes) - 8907/8907 pass, 98 skipped, 0 failures, 0 errors. No regressions.
 - `mvn -pl engine -am compile` - clean compile.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/6688
+
+## Review cycles
+
+- **Cycle 1** - head `05556cb8d493e8588a397ae982dbd5cbca37536c` (initial commit). `claude` bot
+  review (issue comment, 2026-08-24T15:43:50Z): positive assessment, no actionable items.
+  Confirmed the fix's reasoning, the shared `WithClause` AST node claim, and the test coverage
+  design (false-predicate tests are what actually pin the fix, since a no-op also lets rows
+  through). One informational, explicitly non-blocking observation: `letClause`
+  (`LET letItem (COMMA letItem)*`) is in the same grammar `clause` alternative list and has the
+  same missing-handler gap `filterClause` had before this PR - suggested as a follow-up
+  issue/PR, out of scope for this one since `LET` binds a value rather than filtering rows and
+  may need its own AST node rather than reusing `WithClause`. No code changes required; working
+  tree stayed clean.
+
+## Deferred items
+
+None requiring developer follow-up in this PR. See "Review cycles" above for the one
+out-of-scope observation (`letClause` handler gap) the reviewer flagged for a possible
+separate issue.
+
+## Final state
+
+`clean-approval` after 1 review cycle.

--- a/docs/6574-gql-filter-clause-noop.md
+++ b/docs/6574-gql-filter-clause-noop.md
@@ -1,0 +1,67 @@
+# Issue #6574: GQL standalone FILTER clause parses but has zero effect
+
+## Root cause
+
+`Cypher25Parser.g4` defines a standalone `filterClause` (`FILTER WHERE? expression`), part of
+ISO/IEC 39075:2024 GQL, in the same family as the already-supported `forUnwindClause`
+(`FOR ... IN ...`, a synonym for `UNWIND`). The grammar rule parses successfully, but:
+
+- `ClauseDispatcher` registered a handler for every other clause type except `filterClause`.
+- `dispatch()` looped its handler map, found no match, and silently fell through (a comment
+  said "this should not happen with valid grammar").
+- `CypherASTBuilder` had no `visitFilterClause`.
+
+Net effect: `FILTER (<any expression>)` was accepted syntactically and completely ignored,
+regardless of whether the predicate was true or false - a silent-wrong-results bug, not a
+hard failure.
+
+## Fix
+
+Followed the issue's suggested approach, mirroring the precedent `handleOrderBySkipLimit`
+already sets for rewriting a GQL-only clause into the existing WHERE/WITH machinery:
+
+- `CypherASTBuilder.visitFilterClause(FilterClauseContext)` parses `FILTER WHERE? expression`
+  into a `WhereClause`, reusing the same boolean-expression parsing and AST-rewriter
+  simplification `visitWhereClause` uses.
+- `ClauseDispatcher` registers a `filterClause` handler that wraps the resulting `WhereClause`
+  in an implicit `WITH * WHERE <predicate>`, so the filter is applied at the correct position
+  in `clausesInOrder` - the same technique `handleOrderBySkipLimit` uses for a standalone
+  `ORDER BY` / `SKIP` / `LIMIT` clause (issue #3950).
+
+This required no grammar change (the `filterClause` rule already existed) and no changes to
+the optimizer or legacy execution paths, since both consume the shared `WithClause` AST node
+that `ClauseDispatcher` now produces for `FILTER`.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java`
+  - added `visitFilterClause`
+- `engine/src/main/java/com/arcadedb/query/opencypher/parser/ClauseDispatcher.java`
+  - registered `filterClause` -> `handleFilter`
+  - added `handleFilter`
+- `engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCypher25ClausesTest.java`
+  - added a "FILTER clause (issue #6574)" section with 5 regression tests
+
+## Tests
+
+New tests in `OpenCypherCypher25ClausesTest`:
+
+- `filterFalsePredicateProducesNoRows` - the issue's exact reproduction
+  (`FILTER (0 IN range(12, 1, -1)) RETURN 1 AS x`), asserts zero rows.
+- `filterTruePredicateProducesRow` - the true-predicate counterpart, asserts the row passes.
+- `filterWithWhereKeywordFalsePredicateProducesNoRows` / `...TrueProducesRow` - covers the
+  grammar's optional `WHERE` keyword form (`FILTER WHERE <expr>`).
+- `filterAfterMatchRestrictsRowsByProperty` - proves FILTER actually restricts rows from a
+  preceding `MATCH` by a property predicate, not just a constant.
+
+Before the fix, 3 of the 5 new tests failed (the two "true predicate" tests pass either way
+since a no-op also lets rows through, which is exactly the bug: no observable difference
+between true and false).
+
+## Verification
+
+- `mvn -pl engine -am test -Dtest=OpenCypherCypher25ClausesTest` - 45/45 pass (all new FILTER
+  tests included).
+- Full `com.arcadedb.query.opencypher.**` package (excluding `benchmark`, `slow`, `vector`
+  lanes) - 8907/8907 pass, 98 skipped, 0 failures, 0 errors. No regressions.
+- `mvn -pl engine -am compile` - clean compile.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/ClauseDispatcher.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/ClauseDispatcher.java
@@ -22,6 +22,7 @@ import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.OrderByClause;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
 import com.arcadedb.query.opencypher.ast.VariableExpression;
+import com.arcadedb.query.opencypher.ast.WhereClause;
 import com.arcadedb.query.opencypher.ast.WithClause;
 import com.arcadedb.query.opencypher.grammar.Cypher25Parser;
 import com.arcadedb.query.opencypher.rewriter.ProjectedOrderByNormalizer;
@@ -52,6 +53,7 @@ class ClauseDispatcher {
     register(Cypher25Parser.ClauseContext::mergeClause, this::handleMerge);
     register(Cypher25Parser.ClauseContext::unwindClause, this::handleUnwind);
     register(Cypher25Parser.ClauseContext::forUnwindClause, this::handleForUnwind);
+    register(Cypher25Parser.ClauseContext::filterClause, this::handleFilter);
     register(Cypher25Parser.ClauseContext::withClause, this::handleWith);
     register(Cypher25Parser.ClauseContext::returnClause, this::handleReturn);
     register(Cypher25Parser.ClauseContext::orderBySkipLimitClause, this::handleOrderBySkipLimit);
@@ -135,6 +137,20 @@ class ClauseDispatcher {
   private void handleWith(final Cypher25Parser.ClauseContext ctx, final StatementBuilder builder,
                           final CypherASTBuilder astBuilder) {
     builder.addWith(astBuilder.visitWithClause(ctx.withClause()));
+  }
+
+  private void handleFilter(final Cypher25Parser.ClauseContext ctx, final StatementBuilder builder,
+                            final CypherASTBuilder astBuilder) {
+    // GQL standalone FILTER is semantically equivalent to a leading WHERE (issue #6574,
+    // ISO/IEC 39075:2024 GQL). Represented as an implicit `WITH * WHERE <predicate>` so the
+    // filter is applied at the correct position in clausesInOrder, the same technique
+    // handleOrderBySkipLimit uses for a standalone ORDER BY / SKIP / LIMIT (issue #3950).
+    final WhereClause whereClause = astBuilder.visitFilterClause(ctx.filterClause());
+
+    final List<ReturnClause.ReturnItem> starItems = new ArrayList<>();
+    starItems.add(ReturnClause.ReturnItem.star());
+    final WithClause implicitWith = new WithClause(starItems, false, whereClause, null, null, null);
+    builder.addWith(implicitWith);
   }
 
   private void handleReturn(final Cypher25Parser.ClauseContext ctx, final StatementBuilder builder,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -1112,6 +1112,19 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
   }
 
   /**
+   * Visits a GQL standalone {@code FILTER (WHERE)? expression} clause (issue #6574, ISO/IEC
+   * 39075:2024 GQL). Semantically equivalent to a leading WHERE: parses the predicate as a
+   * boolean expression, simplifying boolean constants the same way {@link #visitWhereClause}
+   * does.
+   */
+  public WhereClause visitFilterClause(final Cypher25Parser.FilterClauseContext ctx) {
+    // Grammar: FILTER WHERE? expression
+    final BooleanExpression parsed = parseBooleanExpression(ctx.expression());
+    final BooleanExpression condition = (BooleanExpression) AST_REWRITER.rewrite(parsed);
+    return new WhereClause(condition);
+  }
+
+  /**
    * Parse an expression context into a BooleanExpression for WHERE clauses.
    * Handles logical operators (AND, OR, NOT), comparisons, IS NULL, IN, regex, etc.
    */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCypher25ClausesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCypher25ClausesTest.java
@@ -161,6 +161,56 @@ class OpenCypherCypher25ClausesTest {
   }
 
   // ---------------------------------------------------------------------------
+  // FILTER clause (issue #6574)
+  // ---------------------------------------------------------------------------
+
+  // Issue #6574: a standalone FILTER with a false predicate must suppress all rows
+  // instead of being silently ignored.
+  @Test
+  void filterFalsePredicateProducesNoRows() {
+    final ResultSet result = database.query("opencypher", "FILTER (0 IN range(12, 1, -1)) RETURN 1 AS x");
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  // Issue #6574: a standalone FILTER with a true predicate must let rows through.
+  @Test
+  void filterTruePredicateProducesRow() {
+    final ResultSet result = database.query("opencypher", "FILTER (1 IN range(12, 1, -1)) RETURN 1 AS x");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(((Number) result.next().getProperty("x")).intValue()).isEqualTo(1);
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  // Issue #6574: the grammar's optional WHERE keyword form (FILTER WHERE <expr>) must also filter.
+  @Test
+  void filterWithWhereKeywordFalsePredicateProducesNoRows() {
+    final ResultSet result = database.query("opencypher", "FILTER WHERE 1 = 2 RETURN 1 AS x");
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  void filterWithWhereKeywordTruePredicateProducesRow() {
+    final ResultSet result = database.query("opencypher", "FILTER WHERE 1 = 1 RETURN 1 AS x");
+    assertThat(result.hasNext()).isTrue();
+  }
+
+  // Issue #6574: FILTER must actually restrict rows produced by a preceding MATCH,
+  // the same way an equivalent WHERE would - not just no-op on a constant.
+  @Test
+  void filterAfterMatchRestrictsRowsByProperty() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name: 'Alice', age: 40})");
+      database.command("opencypher", "CREATE (:Person {name: 'Bob', age: 20})");
+    });
+
+    final ResultSet result = database.query("opencypher", "MATCH (n:Person) FILTER (n.age > 30) RETURN n.name AS name");
+    final List<String> names = new ArrayList<>();
+    while (result.hasNext())
+      names.add(result.next().getProperty("name"));
+    assertThat(names).containsExactly("Alice");
+  }
+
+  // ---------------------------------------------------------------------------
   // INSERT clause (issue #3365 section 1.1)
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Gives the GQL standalone `FILTER` clause (`FILTER WHERE? expression`, ISO/IEC 39075:2024 GQL,
same family as the already-supported `forUnwindClause` / `FOR ... IN ...` synonym for `UNWIND`)
a real handler in the OpenCypher parser pipeline, instead of parsing successfully and then
being silently ignored.

`Cypher25Parser.g4` already defined `filterClause`, and it parsed correctly (e.g.
`FILTER (x > 0) MATCH (n) RETURN n`), but no handler existed for it anywhere:

- `ClauseDispatcher` registered a handler for every other clause type but never for
  `filterClause`, so `dispatch()` fell through its "no handler found" branch and did nothing.
- `CypherASTBuilder` had no `visitFilterClause`.

The net effect was that `FILTER (<any expression>)` had zero observable effect regardless of
whether the predicate was true or false - a silent-wrong-results bug, not a hard failure, so
it would not surface unless a test specifically checked that FILTER actually filters.

Fix follows the precedent `handleOrderBySkipLimit` already sets for rewriting a GQL-only
clause into the existing WHERE/WITH machinery:

- `CypherASTBuilder.visitFilterClause` parses the predicate into a `WhereClause`, reusing the
  same boolean-expression parsing and AST-rewriter simplification `visitWhereClause` uses.
- `ClauseDispatcher.handleFilter` wraps that `WhereClause` in an implicit `WITH * WHERE
  <predicate>`, so the filter lands at the correct position in `clausesInOrder` - the same
  technique used for a standalone `ORDER BY` / `SKIP` / `LIMIT` clause (issue #3950).

No grammar change was needed (the `filterClause` rule already existed) and no changes to the
optimizer or legacy execution paths were needed either, since both consume the shared
`WithClause` AST node this PR now produces for `FILTER`.

Closes #6574

## Motivation

Found while investigating #6567. `FILTER` silently losing its filtering condition is a
silent-wrong-results class of bug: a query written with this GQL syntax instead of an
equivalent leading `WHERE` returns every row unconditionally, with no error and no visible
sign anything is wrong.

## Related issues

Closes #6574

## Additional Notes

None.

## Test plan

- [x] New regression tests in `OpenCypherCypher25ClausesTest` (FILTER clause section):
  - `filterFalsePredicateProducesNoRows` - the issue's exact reproduction
    (`FILTER (0 IN range(12, 1, -1)) RETURN 1 AS x`), asserts zero rows
  - `filterTruePredicateProducesRow` - true-predicate counterpart, asserts the row passes
  - `filterWithWhereKeywordFalsePredicateProducesNoRows` / `...TrueProducesRow` - covers the
    grammar's optional `WHERE` keyword form (`FILTER WHERE <expr>`)
  - `filterAfterMatchRestrictsRowsByProperty` - proves FILTER restricts rows from a preceding
    `MATCH` by a property predicate, not just a constant
  - Confirmed 3 of the 5 new tests failed before the fix (the false-predicate ones), proving
    the bug
- [x] `mvn -pl engine -am test -Dtest=OpenCypherCypher25ClausesTest` - 45/45 pass
- [x] Full `com.arcadedb.query.opencypher.**` package (excluding `benchmark`/`slow`/`vector`
  lanes) - 8907/8907 pass, 0 failures, 0 errors, no regressions
- [x] `mvn -pl engine -am compile` - clean compile

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
