### PR TITLE
fix(#6573): isEdgeVariableReferenced has no CREATE/MERGE case

### DIFF
--- a/docs/6573-isedgevariablereferenced-create-merge.md
+++ b/docs/6573-isedgevariablereferenced-create-merge.md
@@ -1,0 +1,54 @@
+# Issue #6573: isEdgeVariableReferenced has no CREATE/MERGE case
+
+## Summary
+
+`CypherVariableUsage.isEdgeVariableReferenced` decides whether a MATCH-bound relationship variable
+keeps its real binding (vs. being anonymized for the CSR/GAV fast path) by walking every clause type
+in `statement.getClausesInOrder()`. The top-level switch handled `RETURN`, `WITH`, `UNWIND`, `SET`,
+`REMOVE`, `DELETE`, `FOREACH`, `SUBQUERY` - but had no `case CREATE` / `case MERGE`, so it fell to
+`default` and the clause was never inspected.
+
+Contrast with `foreachReferencesVariable`'s own inner switch (same file), which already treats a
+nested `CREATE`/`MERGE` conservatively (`return true`). The top-level switch never got the same
+treatment.
+
+## Reproduction (from the issue)
+
+```cypher
+CREATE (a:Person {id:'a'})-[r:KNOWS {since: 2001}]->(b:Person {id:'b'})
+```
+```cypher
+MATCH (a:Person)-[r:KNOWS]->(b:Person) CREATE (c:Note {since: r.since}) RETURN c.since AS s
+```
+
+Expected: `s = 2001`. Actual (before fix): `s = null` - the relationship step bound `r` under an
+internal anonymous name (since nothing else in the query appeared, to this check, to reference it),
+so the CREATE clause's `r.since` read a missing binding and silently evaluated to `null`.
+
+## Fix
+
+Added a `case CREATE: case MERGE:` arm to the top-level switch in `isEdgeVariableReferenced`,
+mirroring `foreachReferencesVariable`'s conservative `return true`. A false positive there only
+forgoes the CSR/GAV fast path; a false negative silently drops a still-referenced edge, which is the
+failure class this whole method exists to prevent.
+
+File: `engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java`
+
+## Tests
+
+- `CypherVariableUsageTest.createReadsItInAnInlineProperty` / `.mergeReadsItInAnInlineProperty` -
+  unit-level checks parallel to the existing cases in that file (`setReadsItAsTargetAndAsValue`,
+  `removeReadsIt`, etc.), verified to fail without the fix.
+- `Issue6573CreateMergeEdgeVariableTest` - new end-to-end regression test running the issue's own
+  reproducer through the real Cypher engine (`createReadsTheEdgePropertyThroughAnInlineExpression`,
+  `mergeReadsTheEdgePropertyThroughAnInlineExpression`), also verified to fail (with a `null` result,
+  matching the issue's reported symptom exactly) without the fix, via a temporary `git stash` of the
+  production change.
+
+## Verification
+
+- `CypherVariableUsageTest` + `Issue6573CreateMergeEdgeVariableTest`: 23/23 pass.
+- Full `com.arcadedb.query.opencypher.**` package (excluding benchmark/slow/vector lanes): 8906
+  tests, 0 failures, 0 errors, 98 skipped (pre-existing skips, unrelated to this change).
+- Confirmed both new tests fail without the fix (temporarily stashed the production change) and pass
+  with it restored.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
@@ -197,6 +197,14 @@ public final class CypherVariableUsage {
             return true;
           break;
         }
+        case CREATE:
+        case MERGE:
+          // Inline property expressions inside a top-level CREATE/MERGE pattern may reference the
+          // variable (e.g. CREATE (c {prop: r.x})). Enumerating them cheaply is awkward, so stay
+          // conservative like foreachReferencesVariable's own CREATE/MERGE case: keep the edge binding.
+          // A false positive only forgoes the CSR/GAV fast path; a false negative would silently drop
+          // a still-referenced edge (the class of bug this method exists to prevent - issue #6573).
+          return true;
         default:
           break;
         }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableUsageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableUsageTest.java
@@ -116,6 +116,28 @@ class CypherVariableUsageTest {
     assertThat(isReferenced("MATCH (a)-[r:KNOWS]->(b) FOREACH (x IN [1] | DELETE r) RETURN a", "r")).isTrue();
   }
 
+  /**
+   * Issue #6573: an inline property expression inside a top-level CREATE or MERGE pattern reads the
+   * variable. The top-level switch had no {@code case CREATE}/{@code case MERGE} - unlike its sibling
+   * {@code foreachReferencesVariable}, which already treats a nested CREATE/MERGE conservatively - so
+   * it fell to {@code default} and the clause was never inspected. That anonymized the edge binding
+   * whenever nothing else in the query mentioned it, so {@code CREATE (c {prop: r.x})} silently read a
+   * missing binding and evaluated to null instead of the real value.
+   */
+  @Test
+  void createReadsItInAnInlineProperty() {
+    assertThat(isReferenced(
+        "MATCH (a)-[r:KNOWS]->(b) CREATE (c:Note {since: r.since}) RETURN c.since", "r"))
+        .isTrue();
+  }
+
+  @Test
+  void mergeReadsItInAnInlineProperty() {
+    assertThat(isReferenced(
+        "MATCH (a)-[r:KNOWS]->(b) MERGE (c:Note {since: r.since}) RETURN c.since", "r"))
+        .isTrue();
+  }
+
   @Test
   void aCallSubqueryReadsItByImportAndInsideItsBody() {
     assertThat(isReferenced("MATCH (a)-[r:KNOWS]->(b) CALL (r) { RETURN 1 AS one } RETURN one", "r")).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6573CreateMergeEdgeVariableTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6573CreateMergeEdgeVariableTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #6573.
+ * <p>
+ * {@code CypherVariableUsage.isEdgeVariableReferenced} decides whether a MATCH-bound relationship
+ * variable keeps its real binding (vs. being anonymized for the CSR/GAV fast path) by walking every
+ * clause type in {@code statement.getClausesInOrder()}. The top-level switch had no
+ * {@code case CREATE}/{@code case MERGE} - unlike its sibling {@code foreachReferencesVariable} in the
+ * same file, which already treats a nested CREATE/MERGE conservatively - so a top-level CREATE/MERGE
+ * fell to {@code default} and was never inspected. That anonymized the edge whenever nothing else in
+ * the query mentioned it, so an inline property expression like {@code CREATE (c {since: r.since})}
+ * silently read a missing binding and evaluated to null instead of the real value.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6573CreateMergeEdgeVariableTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (a:Person {id: 'a'})-[r:KNOWS {since: 2001}]->(b:Person {id: 'b'})");
+  }
+
+  /** The issue's own reproducer: a relationship read only inside a CREATE inline property. */
+  @Test
+  void createReadsTheEdgePropertyThroughAnInlineExpression() {
+    try (final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person)-[r:KNOWS]->(b:Person) CREATE (c:Note {since: r.since}) RETURN c.since AS s")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("s").intValue()).isEqualTo(2001);
+    }
+  }
+
+  /** Same defect via MERGE instead of CREATE. */
+  @Test
+  void mergeReadsTheEdgePropertyThroughAnInlineExpression() {
+    try (final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person)-[r:KNOWS]->(b:Person) MERGE (c:Note {since: r.since}) RETURN c.since AS s")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("s").intValue()).isEqualTo(2001);
+    }
+  }
+}


### PR DESCRIPTION
Closes #6573

## Summary

`CypherVariableUsage.isEdgeVariableReferenced` decides whether a MATCH-bound relationship variable
keeps its real binding (vs. being anonymized for the CSR/GAV fast path) by walking every clause type
in `statement.getClausesInOrder()`. The top-level switch handled `RETURN`, `WITH`, `UNWIND`, `SET`,
`REMOVE`, `DELETE`, `FOREACH`, `SUBQUERY` - but had no `case CREATE` / `case MERGE`, so a top-level
CREATE/MERGE clause fell to `default` and was never inspected.

Contrast with `foreachReferencesVariable`'s own inner switch (same file), which already treats a
nested `CREATE`/`MERGE` conservatively:
```java
case CREATE:
case MERGE:
  // Inline property expressions inside CREATE/MERGE patterns may reference the variable.
  // Enumerating them cheaply is awkward, so stay conservative: keep the edge binding.
  return true;
```
The top-level switch never got the same treatment.

### Reproduction

```cypher
CREATE (a:Person {id:'a'})-[r:KNOWS {since: 2001}]->(b:Person {id:'b'})
```
```cypher
MATCH (a:Person)-[r:KNOWS]->(b:Person) CREATE (c:Note {since: r.since}) RETURN c.since AS s
```

Expected: `s = 2001`. Actual (before fix): `s = null` - the relationship step bound `r` under an
internal anonymous name (nothing else in the query appeared, to this check, to reference it), so the
CREATE clause's `r.since` read a missing binding and silently evaluated to `null`.

## Fix

Added a `case CREATE: case MERGE:` arm to the top-level switch in `isEdgeVariableReferenced`,
mirroring `foreachReferencesVariable`'s conservative `return true`. A false positive there only
forgoes the CSR/GAV fast path; a false negative silently drops a still-referenced edge, which is the
failure class this whole method exists to prevent (same reasoning that motivated #6567's fix).

File: `engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java`

## Test plan

- [x] `CypherVariableUsageTest.createReadsItInAnInlineProperty` / `.mergeReadsItInAnInlineProperty` -
      unit-level checks parallel to the existing cases in that file (`setReadsItAsTargetAndAsValue`,
      `removeReadsIt`, etc.). Verified to fail (assert `true`, got `false`) without the fix.
- [x] `Issue6573CreateMergeEdgeVariableTest` - new end-to-end regression test running the issue's own
      reproducer through the real Cypher engine. Verified to fail with a `null` result (matching the
      issue's reported symptom exactly) without the fix, via a temporary stash of the production
      change.
- [x] Full `com.arcadedb.query.opencypher.**` package (excluding benchmark/slow/vector lanes): 8906
      tests, 0 failures, 0 errors, 98 skipped (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)