### PR TITLE
fix(#6561): guard JsonlImporterFormat's transaction commits/rollbacks with callerTransactionActiveOnEntry

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -93,6 +93,13 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     // failed record's rollback can never discard an earlier, already-successful one riding in the same batch.
     final boolean skipOnRowError = settings.isSkipOnRowError();
 
+    // "skip" mode commits/rolls back per record, so it must own the transaction outright - exactly like
+    // CSVImporterFormat/JSONImporterFormat (see ImporterSettings#isSkipOnRowError() and
+    // ImporterSettings#newExclusiveTransactionRequiredException()). Checked eagerly, before touching the database
+    // at all, so a caller-managed transaction's pending work is never at risk (issue #6561).
+    if (skipOnRowError && context.callerTransactionActiveOnEntry)
+      throw ImporterSettings.newExclusiveTransactionRequiredException();
+
     try (final InputStreamReader inputFileReader = new InputStreamReader(parser.getInputStream(),
         DatabaseFactory.getDefaultCharset())) {
       context.startedOn = System.currentTimeMillis();
@@ -141,8 +148,11 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
         // Skip mode commits every record individually (see above and the field comment on skipOnRowError); the
         // default "abort" mode keeps the coarser periodic commit for throughput, since any failure there aborts
-        // and rolls back the whole in-flight batch anyway (see the ImportException catch below).
-        if (skipOnRowError || context.parsed.get() % 1000 == 0) {
+        // and rolls back the whole in-flight batch anyway (see the ImportException catch below). Neither runs at
+        // all when the caller already owns the active transaction (skip mode never reaches here - see the guard
+        // above): a caller-managed transaction is never ours to commit piecemeal, only to accumulate into and hand
+        // back to whoever owns it (issue #6561).
+        if (!context.callerTransactionActiveOnEntry && (skipOnRowError || context.parsed.get() % 1000 == 0)) {
           database.commit();
           database.begin();
         }
@@ -163,7 +173,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     } finally {
-      if (database.isTransactionActive())
+      // Gated on callerTransactionActiveOnEntry exactly like the ImportException catch above (issue #6561): a
+      // transaction that predates this import is never ours to commit, on success or on failure - it's left open
+      // for whoever owns it to decide.
+      if (!context.callerTransactionActiveOnEntry && database.isTransactionActive())
         database.commit();
     }
     context.lastLapOn = System.currentTimeMillis();
@@ -646,8 +659,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       // already committed for the initial load, producing one very large WAL transaction for a restore with many
       // forward-referencing LINK properties. Skip mode commits every record individually, same reasoning as the
       // main loop: a failed record's rollback must never discard an earlier, already-reconciled one riding in the
-      // same batch.
-      if (skipOnRowError || ++reconciled % 1000 == 0) {
+      // same batch. Same callerTransactionActiveOnEntry gate as load()'s own periodic commit, and for the same
+      // reason (issue #6561): skip mode never reaches here when the caller owns the transaction (rejected eagerly
+      // in load()), and the default mode must not commit a transaction it doesn't own either.
+      if (!context.callerTransactionActiveOnEntry && (skipOnRowError || ++reconciled % 1000 == 0)) {
         database.commit();
         database.begin();
       }

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JsonLImporterIT {
@@ -399,6 +400,192 @@ class JsonLImporterIT {
     } finally {
       Files.deleteIfExists(jsonlFile);
     }
+  }
+
+  /**
+   * Issue #6561: {@code -onRowError skip} commits/rolls back per record, so - exactly like CSV/JSON (see
+   * {@code Issue5968ImporterSkipOnRowErrorTest}) - it must own the transaction outright and reject an already-active
+   * caller-managed transaction eagerly, rather than silently committing/discarding whatever the caller had pending
+   * on the first record.
+   */
+  @Test
+  void importDatabaseSkipModeRejectsInsideActiveTransaction() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-skip-active-tx-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, singleVertexJsonl());
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        // The caller starts their own transaction with unrelated pending work before handing the Database to the
+        // importer, exactly like the CSV/JSON counterparts in Issue5968ImporterSkipOnRowErrorTest.
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+        importer.settings.onRowError = "skip";
+
+        assertThatThrownBy(importer::load).isInstanceOf(ImportException.class)
+            .hasRootCauseInstanceOf(IllegalStateException.class);
+
+        // The guard must fire before touching the database at all: the caller's own transaction and its pending
+        // work must still be there for them to decide what to do with.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  /**
+   * Issue #6561: default "abort" mode has no exclusive-transaction-ownership guard (only "skip" mode rejects an
+   * already-active caller transaction, see {@link #importDatabaseSkipModeRejectsInsideActiveTransaction()}), so it
+   * must run directly inside a caller's own transaction without ever committing it - on success, the transaction
+   * must be left open for the caller to commit themselves, exactly like {@code CSVImporterFormat}/
+   * {@code JSONImporterFormat} (see {@code csvDocumentImportOnAllSuccessLeavesCallersExternallyManagedTransactionOpenForThemToCommit}
+   * in {@code Issue5968ImporterSkipOnRowErrorTest}).
+   */
+  @Test
+  void importDatabaseAbortModeInsideActiveTransactionLeavesTransactionOpenOnSuccess() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-abort-success-active-tx-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, singleVertexJsonl());
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+        Map<String, Object> result = importer.load();
+        assertThat(result).doesNotContainKey("errors");
+
+        // The import succeeded, but the transaction was never ours to commit: it must still be active, with the
+        // caller's own pre-existing work not yet durable, for the caller to commit (or roll back) themselves.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+        assertThat(db.countType("Person", true)).isEqualTo(1);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  /**
+   * Issue #6561, symmetric to {@link #importDatabaseAbortModeInsideActiveTransactionLeavesTransactionOpenOnSuccess()}
+   * but for the failure path: a failing record must still abort the import, but must not discard the caller's own
+   * pending work by committing OR rolling back a transaction this import never owned - it must be left exactly as
+   * the caller left it, active, for them alone to decide what happens to it next.
+   */
+  @Test
+  void importDatabaseAbortModeInsideActiveTransactionDoesNotCommitOrRollbackOnFailure() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-abort-failure-active-tx-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2},\"r\":\"#6:1\",\"t\":\"NonExistentType\",\"o\":[],\"i\":[]}}\n");
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+
+        assertThatThrownBy(importer::load).isInstanceOf(ImportException.class);
+
+        // The import failed, but the caller's own transaction - and therefore their pre-existing pending work -
+        // must still be there for them to decide what to do with: neither committed nor rolled back out from under
+        // them by an import that never owned this transaction.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  /**
+   * Issue #6561: the periodic {@code commit()}/{@code begin()} every 1000 records in default "abort" mode must not
+   * run at all while inside a caller-managed transaction - it must not silently commit the caller's transaction (and
+   * whatever unrelated work it holds) out from under them partway through a large import, replacing it with a fresh
+   * one the caller never asked for.
+   */
+  @Test
+  void importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyOnLargeImport() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-abort-periodic-active-tx-", ".jsonl");
+    try {
+      final int vertexCount = 1500; // exceeds the 1000-record periodic commit threshold
+      Files.writeString(jsonlFile, manyVerticesJsonl(vertexCount));
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+        Map<String, Object> result = importer.load();
+        assertThat(result).doesNotContainKey("errors");
+        assertThat(result).containsEntry("createdVertices", (long) vertexCount);
+
+        // If the periodic commit had fired (unguarded), the caller's transaction would have been replaced partway
+        // through - still "active" by the time load() returns, but a DIFFERENT, freshly-begun one that no longer
+        // holds the caller's own pre-existing pending work. Asserting the pending work is still there proves the
+        // ORIGINAL transaction survived intact, not just that some transaction happens to be active.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+        assertThat(db.countType("Person", true)).isEqualTo(vertexCount);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  private static String singleVertexJsonl() {
+    return ""
+        + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+        + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+        + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n"
+        + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n";
+  }
+
+  private static String manyVerticesJsonl(final int vertexCount) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(
+        "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n");
+    sb.append("{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n");
+    sb.append(
+        "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n");
+    for (int i = 0; i < vertexCount; ++i)
+      sb.append("{\"t\":\"v\",\"c\":{\"p\":{\"id\":").append(i).append("},\"r\":\"#6:").append(i)
+          .append("\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+    return sb.toString();
   }
 
   private static void checkImportedDatabase() {

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -567,6 +567,51 @@ class JsonLImporterIT {
     }
   }
 
+  /**
+   * Issue #6561 review follow-up: symmetric to
+   * {@link #importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyOnLargeImport()} but for
+   * {@code reconcileUnresolvedLinks()}'s own periodic commit rather than the main loop's - the large-import fixture
+   * used there carries no LINK properties, so its reconciliation pass is a no-op and never exercises this gate.
+   * Every vertex here (bar the last) has a forward-referencing {@code next} LINK property pointing at the vertex
+   * imported immediately after it, which is guaranteed unresolved on first pass (the referenced record hasn't been
+   * imported yet) and so lands in {@code pendingLinkReconciliation}, exercising the reconciliation pass's own
+   * periodic commit at the same >1000-entry scale.
+   */
+  @Test
+  void importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyDuringLinkReconciliation() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-abort-periodic-reconcile-active-tx-", ".jsonl");
+    try {
+      final int vertexCount = 1500; // exceeds the 1000-record periodic commit threshold
+      Files.writeString(jsonlFile, manyVerticesWithForwardLinksJsonl(vertexCount));
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+        Map<String, Object> result = importer.load();
+        assertThat(result).doesNotContainKey("errors");
+        assertThat(result).containsEntry("createdVertices", (long) vertexCount);
+
+        // Same reasoning as importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyOnLargeImport:
+        // asserting the caller's own pre-existing pending work is still there proves the ORIGINAL transaction
+        // survived the reconciliation pass intact, not just that some transaction happens to be active.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+        assertThat(db.countType("Person", true)).isEqualTo(vertexCount);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
   private static String singleVertexJsonl() {
     return ""
         + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
@@ -585,6 +630,28 @@ class JsonLImporterIT {
     for (int i = 0; i < vertexCount; ++i)
       sb.append("{\"t\":\"v\",\"c\":{\"p\":{\"id\":").append(i).append("},\"r\":\"#6:").append(i)
           .append("\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+    return sb.toString();
+  }
+
+  private static String manyVerticesWithForwardLinksJsonl(final int vertexCount) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(
+        "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n");
+    sb.append("{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n");
+    sb.append(
+        "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},"
+            + "\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{"
+            + "\"id\":{\"type\":\"INTEGER\",\"custom\":{}},"
+            + "\"next\":{\"type\":\"LINK\",\"custom\":{}}"
+            + "},\"indexes\":{},\"custom\":{}}}}}\n");
+    for (int i = 0; i < vertexCount; ++i) {
+      // Every vertex but the last points forward at the NEXT one in the stream (r="#6:(i+1)"), which hasn't been
+      // imported yet at the point this line is processed - guaranteed unresolved on first pass, so it lands in
+      // pendingLinkReconciliation for reconcileUnresolvedLinks() to fix up afterwards.
+      final String next = i < vertexCount - 1 ? ",\"next\":\"#6:" + (i + 1) + "\"" : "";
+      sb.append("{\"t\":\"v\",\"c\":{\"p\":{\"id\":").append(i).append(next).append("},\"r\":\"#6:").append(i)
+          .append("\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+    }
     return sb.toString();
   }
 


### PR DESCRIPTION
## What does this PR do?

`JsonlImporterFormat.load()` had no `ImporterContext#callerTransactionActiveOnEntry` guard at all,
unlike `CSVImporterFormat`/`JSONImporterFormat` (see `ImporterSettings#isSkipOnRowError()` for the
shared contract). This PR mirrors that existing contract on all four sites in the JSONL format that
touch the transaction:

1. `-onRowError skip` is now rejected eagerly (`ImporterSettings.newExclusiveTransactionRequiredException()`)
   when a caller-managed transaction is already active on entry, before touching the database at all -
   exactly like CSV/JSON. Previously the first successfully-imported record would commit the caller's
   transaction (replacing it with an unrelated fresh one), and the first failing record would roll back
   the caller's entire transaction, discarding whatever unrelated work it held.
2. The main loop's periodic `commit()`/`begin()` (every 1000 records in default "abort" mode) is now
   gated on `!context.callerTransactionActiveOnEntry`, so a caller's transaction is never silently
   committed out from under them partway through a large import.
3. `reconcileUnresolvedLinks()`'s own periodic commit (same 1000-record granularity, for the
   LINK/LIST-of-LINK/MAP-of-LINK reconciliation pass) is gated the same way.
4. The `finally` block's closing `database.commit()` is now gated the same way too. This was the
   sharpest defect of the four: even on a **failed** import - where the adjacent `catch (ImportException e)`
   block already correctly chose *not* to roll back the caller's transaction - the `finally` block ran
   anyway (as `finally` always does) and unconditionally committed it, durably persisting the caller's
   unrelated pending work despite the import reporting failure.

## Motivation

Closes #6561. Found during review of #6498/#6654: `CSVImporterFormat` and `JSONImporterFormat` both
guard the equivalent code paths against `callerTransactionActiveOnEntry`, but `JsonlImporterFormat`
was never brought in line with that contract - so embedding a JSONL import via the
`Importer(Database, String)` constructor, or running `IMPORT DATABASE` as an HTTP server command under
the default atomic/`autoCommit` behavior, could silently commit or discard the caller's own pending
transactional work.

## Related issues

Closes #6561.

## Additional Notes

### Tests

Added to `integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java`:

- `importDatabaseSkipModeRejectsInsideActiveTransaction` - `-onRowError skip` inside a caller-managed
  transaction is rejected eagerly (`IllegalStateException`), the caller's own pending work survives
  untouched.
- `importDatabaseAbortModeInsideActiveTransactionLeavesTransactionOpenOnSuccess` - a successful import
  inside a caller-managed transaction leaves that transaction open for the caller to commit, rather
  than committing it as a side effect.
- `importDatabaseAbortModeInsideActiveTransactionDoesNotCommitOrRollbackOnFailure` - a failing import
  inside a caller-managed transaction leaves that transaction open (neither committed nor rolled back)
  for the caller to decide - the regression test for defect #4 above (the `finally`-block bug), the
  sharpest of the four.
- `importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyOnLargeImport` - a
  1500-vertex import (exceeding the 1000-record periodic-commit threshold) inside a caller-managed
  transaction never fires the periodic commit, proven by asserting the caller's own pre-existing
  pending work is still present in the same transaction after `load()` returns (a silently-replaced
  transaction would still show `isTransactionActive() == true` but would have dropped that work).

All four were confirmed to fail against the pre-fix code (proving they exercise the bug described
above) and pass after the fix.

### Verification

- `mvn -pl integration verify -DskipITs=false -Dit.test=JsonLImporterIT`: full integration-module unit
  test suite (158 tests) + `JsonLImporterIT` (14 tests, including the 4 new ones above) all green.
- `Issue5968ImporterSkipOnRowErrorTest` (the equivalent CSV/JSON caller-transaction suite, 38 tests)
  still green - no regression in the sibling formats' behavior.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios