### PR TITLE
fix(#6560): Redis wire follow-ups from #6493

### DIFF
--- a/docs/6560-redis-error-prefix-ha-lock-port-hardcode.md
+++ b/docs/6560-redis-error-prefix-ha-lock-port-hardcode.md
@@ -1,0 +1,66 @@
+# Issue #6560: Redis wire follow-ups from #6493
+
+Three independent, pre-existing follow-ups found while reviewing/fixing #6493. None of these are caused by
+#6493.
+
+## 1. RESP error replies duplicate/mask the error kind
+
+`RedisNetworkExecutor.respErrorPrefix()` unconditionally derived the RESP error kind (the token right after
+`-`) from `ErrorCategory.of(error)`, which only recognizes a handful of real engine exception types. Several
+call sites (`AUTH`, `HELLO`, `getAuthorizedDatabase`) instead baked their own kind word (`WRONGPASS`,
+`NOAUTH`, `NOPROTO`, `NOPERM`) into the *message* of a plain `RedisException` - a type `ErrorCategory` has no
+special case for, so it always fell through to the generic `ERR` default. The wire reply came out as e.g.
+`-ERR WRONGPASS ...` instead of `-WRONGPASS ...`: the kind a client can actually branch on was always `ERR`,
+never the specific one, even though the message text still happened to mention the real kind further along -
+which is exactly why the existing `.contains("WRONGPASS")`-style assertions never caught it.
+
+**Fix:** `RedisException` gained a `withKind(kind, message)` factory that carries an explicit RESP kind
+separate from the message. `respErrorPrefix()` now checks for it first, before falling back to
+`ErrorCategory`. Every call site that used to embed a kind word in its message now uses `withKind` instead
+(and the two sites that only repeated the already-default `ERR` had it dropped from the message entirely).
+
+**Tests:**
+- `RedisErrorClassificationTest` (unit): explicit-kind precedence over the `ErrorCategory` default, and that a
+  plain `RedisException` without an explicit kind is unaffected.
+- `RedisAuthenticationTest` (integration, real server + Jedis client): the wire reply for wrong credentials
+  and for `NOPERM` starts with the real kind and NOT with `ERR`.
+
+## 2. Redis-wire `SET k v NX` is not a real distributed lock across an HA/Raft cluster
+
+`RaftReplicatedDatabase`'s four global-variable accessors (`getGlobalVariable`, `setGlobalVariable`,
+`setGlobalVariableIfAbsent`, `setGlobalVariableIfPresent`) delegate straight to the local node with no Raft
+consensus/replication involved - unlike every other mutating method on that class. Global variables (and
+therefore Redis-wire `SET`/`GET`, including `SET k v NX`) are purely per-node state today, so `SET lock 1 NX`
+issued against two different nodes of an HA cluster (or the same logical key resolved differently after a
+failover) can each succeed independently.
+
+A full fix means replicating global variables through Raft - a materially bigger effort and its own design
+discussion, out of scope here. Per the issue's own suggested action, this item is a **documentation-only**
+fix: `DatabaseInternal`'s four global-variable methods and `RaftReplicatedDatabase`'s four overrides now
+carry an explicit Javadoc caveat that they are node-local, not cluster-wide, and must not be relied on as a
+real distributed lock in an HA deployment. No behavior changed, so no new automated test accompanies this
+item - the existing behavior (and its existing test coverage) is unchanged; only what is documented about it.
+
+## 3. `RedisQueryLanguageTest` hardcodes port 2480
+
+`executeCommand`/`executeQuery` built their target URL as `"http://127.0.0.1:248" + serverIndex + ..."`,
+assuming the server bound the default port 2480 (or 2481 for a second server). `SERVER_HTTP_INCOMING_PORT` is
+actually a range (2480-2489 by default) and binds the first free port in it, so with 2480 already held by
+anything else - another local ArcadeDB instance, an IDE debug session for a different project - this test's
+own server listens elsewhere and every test in the class fails with a confusing `403 Too many failed
+authentication attempts` / `User/Password not valid`, which reads as an auth bug rather than a port
+collision. Same class of bug as #6426, fixed the same way for `ConsoleAsyncInsertTest` in #6437.
+
+**Fix:** both helpers now ask the server for the port it actually bound
+(`getServer(serverIndex).getHttpServer().getPort()`) instead of assuming the default.
+
+**Verification:** the whole class (19 tests) was run in this environment with port 2480 genuinely held by an
+unrelated process (`lsof -nP -iTCP:2480 -sTCP:LISTEN` showed a live listener) - all 19 passed, which the
+pre-fix hardcoded URL could not have done.
+
+## Test results (this environment, isolated `-Dmaven.repo.local`)
+
+- `RedisErrorClassificationTest`: 7/7 passed
+- `RedisAuthenticationTest`: 9/9 passed (7 pre-existing + 2 new)
+- `RedisQueryLanguageTest`: 19/19 passed, with port 2480 occupied by an unrelated process
+- Full `redisw` module test run (`mvn test -pl redisw -am`): see PR for final summary

--- a/docs/6560-redis-error-prefix-ha-lock-port-hardcode.md
+++ b/docs/6560-redis-error-prefix-ha-lock-port-hardcode.md
@@ -60,7 +60,49 @@ pre-fix hardcoded URL could not have done.
 
 ## Test results (this environment, isolated `-Dmaven.repo.local`)
 
-- `RedisErrorClassificationTest`: 7/7 passed
-- `RedisAuthenticationTest`: 9/9 passed (7 pre-existing + 2 new)
+- `RedisErrorClassificationTest`: 7/7 passed (later 7/7 unchanged)
+- `RedisAuthenticationTest`: 9/9 passed initially, 11/11 after cycle 1's review addition
 - `RedisQueryLanguageTest`: 19/19 passed, with port 2480 occupied by an unrelated process
-- Full `redisw` module test run (`mvn test -pl redisw -am`): see PR for final summary
+- Full non-IT `redisw` unit-test set (`RedisAuthenticationTest`, `RedisErrorClassificationTest`,
+  `RedisPortConfigurationTest`, `RedisProtocolLimitsTest`, `RedisQueryLanguageTest`,
+  `RedisRespCorrectnessTest`, `RedisWTest`): 76/76 passed, no regressions
+- `ha-raft` unit tests touching `RaftReplicatedDatabase` (`RaftReplicatedDatabaseTest`,
+  `RaftReplicatedDatabaseLeaderWaitTest`): passed, unaffected by the Javadoc-only change
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6691
+
+## Review cycles
+
+- **Cycle 1** - head `7080e167`: initial PR. `claude` review: solid overall; flagged a coverage gap - only
+  `WRONGPASS`/`NOPERM` were asserted at the wire level (via `RedisAuthenticationTest`), not `NOPROTO`/plain
+  `NOAUTH` (the `HELLO` paths). Addressed in `057a321d`: added `helloWithoutAuthErrorKindIsNotMaskedByErr`
+  and `helloWithBadProtocolVersionErrorKindIsNotMaskedByErr` to `RedisAuthenticationTest` (11/11 passed).
+- **Cycle 2** - head `057a321d`: `claude` review: approved overall; nitpicked that the shared "these four
+  accessors" Javadoc comment was physically placed above only `getGlobalVariable()`, so it would not surface
+  in generated docs/IDE hover for the other three overrides (a Javadoc comment attaches to the single
+  declaration it precedes). Also noted `getGlobalVariables()` (plural) was outside the "four accessors"
+  comment's scope. Addressed in `71b99af8`: gave each of the five node-local accessors its own short Javadoc
+  pointing back to the caveat on `DatabaseInternal`.
+- **Cycle 3** - head `71b99af8`: `claude` review: "Approving from a code-review standpoint"; one minor
+  non-blocking nit that `DatabaseInternal.getGlobalVariables()` itself (the interface method, not just the
+  Raft override) still lacked its own "not replicated" caveat. Addressed in `d1129bac`: added the caveat to
+  the interface method's own Javadoc for full symmetry with the other three.
+- **Cycle 4** - head `d1129bac`: `claude` review: clean; the only note was an explicitly non-blocking
+  "optional polish" observation that `respErrorPrefix()`'s explicit-kind check looks only at the outer
+  exception, not the full cause chain the way `ErrorCategory.of()` does - a latent gotcha only if a future
+  call site wraps a `withKind()` exception in another type before it reaches `respErrorPrefix()`, which none
+  do today. Categorized as a nitpick (bot's own words: "not worth blocking on"), not applied. **Clean
+  approval** - working tree empty, no actionable items remaining.
+
+## Deferred items
+
+None. The one item not applied (cycle 4's cause-chain observation) was explicitly framed by the reviewer
+itself as optional polish rather than a defect, so it was categorized as a nitpick and skipped rather than
+deferred to a notes file.
+
+## Final state
+
+`clean-approval` after 4 review cycles (the maximum configured). Merge remains the developer's
+responsibility.

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -417,6 +417,9 @@ public interface DatabaseInternal extends Database {
 
   /**
    * Gets all global variables as an unmodifiable map.
+   * <p>
+   * <b>Not replicated in an HA cluster</b> - see {@link #getGlobalVariable(String)}. Each entry is this node's
+   * own local value, not a cluster-wide view.
    * @return Map of variable name to value
    */
   Map<String, Object> getGlobalVariables();

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -341,6 +341,11 @@ public interface DatabaseInternal extends Database {
 
   /**
    * Gets a global variable value by name.
+   * <p>
+   * <b>Not replicated in an HA cluster.</b> Global variables are per-node state: under Raft replication
+   * ({@code RaftReplicatedDatabase}) every accessor here - this one included - delegates straight to the local
+   * node's own {@link LocalDatabase}, with no Raft consensus or replication involved. A value set on one node is
+   * invisible to every other node, including after a failover (issue #6560).
    * @param name Variable name (with or without $ prefix)
    * @return The variable value, or null if not set
    */
@@ -348,6 +353,8 @@ public interface DatabaseInternal extends Database {
 
   /**
    * Sets a global variable. Setting to null removes the variable.
+   * <p>
+   * <b>Not replicated in an HA cluster</b> - see {@link #getGlobalVariable(String)}.
    * @param name Variable name (with or without $ prefix)
    * @param value The value to set, or null to remove
    * @return The previous value, or null
@@ -357,11 +364,19 @@ public interface DatabaseInternal extends Database {
   /**
    * Atomically sets a global variable only if it is not already set. Unlike calling
    * {@link #getGlobalVariable(String)} followed by {@link #setGlobalVariable(String, Object)}, this check-and-set
-   * happens as one operation, so two callers racing on the same name cannot both observe "absent" and both write -
-   * the property a caller using this as a distributed lock (e.g. Redis {@code SET k v NX}) depends on.
+   * happens as one operation, so two callers racing on the same name on the SAME node cannot both observe "absent"
+   * and both write.
+   * <p>
+   * <b>Not a cluster-wide distributed lock.</b> The atomicity above is per-node only - see
+   * {@link #getGlobalVariable(String)} for why. A caller reaching different nodes of an HA cluster (e.g. two
+   * Redis-wire clients connected to different nodes, or the same client across a failover) can each observe
+   * "absent" and each believe they won a lock acquired with e.g. Redis {@code SET k v NX}: every node keeps its
+   * own independent copy, so two nodes granting the same "lock" simultaneously is expected behavior today, not a
+   * bug in this method. Do not rely on this as a real distributed lock in an HA deployment; that would need global
+   * variables replicated through Raft, which this method does not do (issue #6560).
    * <p>
    * The default falls back to a non-atomic get-then-set for implementations (e.g. test doubles) that do not need
-   * the atomicity guarantee; {@link LocalDatabase} overrides it with a genuinely atomic implementation.
+   * the atomicity guarantee; {@link LocalDatabase} overrides it with a genuinely atomic (per-node) implementation.
    * @param name Variable name (with or without $ prefix)
    * @param value The value to set
    * @return The existing value if the variable was already set (value left untouched), or null if it was absent
@@ -381,8 +396,12 @@ public interface DatabaseInternal extends Database {
    * happens as one operation - the counterpart to {@link #setGlobalVariableIfAbsent(String, Object)} (e.g. Redis
    * {@code SET k v XX}).
    * <p>
+   * <b>Not replicated in an HA cluster</b> - see {@link #setGlobalVariableIfAbsent(String, Object)}: the atomicity
+   * this method gives is per-node only, and different nodes of an HA cluster keep independent copies of the
+   * variable.
+   * <p>
    * The default falls back to a non-atomic get-then-set for implementations (e.g. test doubles) that do not need
-   * the atomicity guarantee; {@link LocalDatabase} overrides it with a genuinely atomic implementation.
+   * the atomicity guarantee; {@link LocalDatabase} overrides it with a genuinely atomic (per-node) implementation.
    * @param name Variable name (with or without $ prefix)
    * @param value The value to set
    * @return The previous value if the variable was set (value was replaced), or null if it was absent (value left

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -947,36 +947,55 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     proxied.setWrapper(name, instance);
   }
 
+  // Global variables are NOT replicated through Raft: unlike every other mutating method on this class, the five
+  // accessors below (getGlobalVariable, setGlobalVariable, setGlobalVariableIfAbsent, setGlobalVariableIfPresent,
+  // getGlobalVariables) all delegate straight to the local node's own database, with no consensus proposal
+  // involved at all. A value set on one node of an HA cluster is invisible to every other node, including after a
+  // failover, so setGlobalVariableIfAbsent/setGlobalVariableIfPresent's per-node atomicity does NOT make Redis
+  // "SET k v NX" (or any other caller) a real cluster-wide distributed lock. A full fix would mean replicating
+  // global variables through Raft, which none of these five methods attempt (issue #6560). Each accessor below
+  // carries its own Javadoc pointer to the full caveat on DatabaseInternal, since a Javadoc comment attaches only
+  // to the single declaration it precedes and would not otherwise show up in generated docs/IDE hover for the
+  // other four.
+
   /**
-   * Global variables are NOT replicated through Raft: unlike every other mutating method on this class, these four
-   * accessors delegate straight to the local node's own database, with no consensus proposal involved at all. A
-   * value set on one node of an HA cluster is invisible to every other node, including after a failover, so
-   * {@code setGlobalVariableIfAbsent}/{@code setGlobalVariableIfPresent}'s per-node atomicity does NOT make Redis
-   * {@code SET k v NX} (or any other caller) a real cluster-wide distributed lock - see the caveats on
-   * {@link DatabaseInternal#getGlobalVariable(String)} and {@link DatabaseInternal#setGlobalVariableIfAbsent(String, Object)}.
-   * A full fix would mean replicating global variables through Raft, which none of these four methods attempt
-   * (issue #6560).
+   * Not replicated in an HA cluster - see the caveat on {@link DatabaseInternal#getGlobalVariable(String)}.
    */
   @Override
   public Object getGlobalVariable(final String name) {
     return proxied.getGlobalVariable(name);
   }
 
+  /**
+   * Not replicated in an HA cluster - see the caveat on {@link DatabaseInternal#getGlobalVariable(String)}.
+   */
   @Override
   public Object setGlobalVariable(final String name, final Object value) {
     return proxied.setGlobalVariable(name, value);
   }
 
+  /**
+   * Not a cluster-wide distributed lock in an HA cluster - see the caveat on
+   * {@link DatabaseInternal#setGlobalVariableIfAbsent(String, Object)}.
+   */
   @Override
   public Object setGlobalVariableIfAbsent(final String name, final Object value) {
     return proxied.setGlobalVariableIfAbsent(name, value);
   }
 
+  /**
+   * Not a cluster-wide distributed lock in an HA cluster - see the caveat on
+   * {@link DatabaseInternal#setGlobalVariableIfAbsent(String, Object)}.
+   */
   @Override
   public Object setGlobalVariableIfPresent(final String name, final Object value) {
     return proxied.setGlobalVariableIfPresent(name, value);
   }
 
+  /**
+   * Not replicated in an HA cluster - see the caveat on {@link DatabaseInternal#getGlobalVariable(String)}. Each
+   * entry of the returned map is this node's own local value, not a cluster-wide view.
+   */
   @Override
   public Map<String, Object> getGlobalVariables() {
     return proxied.getGlobalVariables();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -947,6 +947,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     proxied.setWrapper(name, instance);
   }
 
+  /**
+   * Global variables are NOT replicated through Raft: unlike every other mutating method on this class, these four
+   * accessors delegate straight to the local node's own database, with no consensus proposal involved at all. A
+   * value set on one node of an HA cluster is invisible to every other node, including after a failover, so
+   * {@code setGlobalVariableIfAbsent}/{@code setGlobalVariableIfPresent}'s per-node atomicity does NOT make Redis
+   * {@code SET k v NX} (or any other caller) a real cluster-wide distributed lock - see the caveats on
+   * {@link DatabaseInternal#getGlobalVariable(String)} and {@link DatabaseInternal#setGlobalVariableIfAbsent(String, Object)}.
+   * A full fix would mean replicating global variables through Raft, which none of these four methods attempt
+   * (issue #6560).
+   */
   @Override
   public Object getGlobalVariable(final String name) {
     return proxied.getGlobalVariable(name);

--- a/redisw/src/main/java/com/arcadedb/redis/RedisException.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisException.java
@@ -24,11 +24,44 @@ import com.arcadedb.exception.ArcadeDBException;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  **/
 public class RedisException extends ArcadeDBException {
+  private final String kind;
+
   public RedisException(final String message) {
     super(message);
+    this.kind = null;
   }
 
   public RedisException(final String message, final Throwable cause) {
     super(message, cause);
+    this.kind = null;
+  }
+
+  private RedisException(final String kind, final String message) {
+    super(message);
+    this.kind = kind;
+  }
+
+  /**
+   * Creates a {@link RedisException} carrying an explicit RESP error kind - the token right after {@code -} in
+   * the wire reply - separate from its message (issue #6560). Without this, a call site that needs a kind other
+   * than the {@code ErrorCategory}-derived default (e.g. {@code WRONGPASS}, {@code NOAUTH}, {@code NOPROTO}) had
+   * to bake it into the message text itself, which {@code RedisNetworkExecutor}'s dispatch {@code catch} block
+   * then prefixed with its own {@code ErrorCategory}-derived kind (always {@code ERR} for a plain
+   * {@code RedisException}) - producing a doubled/masking reply like {@code -ERR WRONGPASS ...} on the wire, where
+   * the kind a client could actually branch on was always {@code ERR}.
+   * <p>
+   * Example: {@code RedisException.withKind("WRONGPASS", "invalid username-password pair")} replies
+   * {@code -WRONGPASS invalid username-password pair}, not {@code -ERR WRONGPASS invalid username-password pair}.
+   */
+  public static RedisException withKind(final String kind, final String message) {
+    return new RedisException(kind, message);
+  }
+
+  /**
+   * The explicit RESP error kind this exception carries, or {@code null} when none was given - in which case
+   * the kind should be derived from {@link com.arcadedb.exception.ErrorCategory} instead.
+   */
+  public String getKind() {
+    return kind;
   }
 }

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -385,15 +385,20 @@ public class RedisNetworkExecutor extends Thread {
    * which carries no kind at all: a client had nothing to branch on, and an optimistic-concurrency conflict - the
    * one failure worth repeating the command for - looked exactly like a permanent one.
    * <p>
-   * The classification itself lives in {@link ErrorCategory} so every wire protocol answers it the same way. RESP
-   * has no vocabulary for the client-error categories Postgres and Bolt distinguish, so they all keep Redis'
-   * generic {@code ERR}.
+   * A {@link RedisException} carrying an explicit kind (see {@link RedisException#withKind}) wins first - that
+   * covers the kinds {@link ErrorCategory} has no concept of at all, such as {@code WRONGPASS}, {@code NOAUTH} and
+   * {@code NOPROTO} (issue #6560). Everything else falls back to {@link ErrorCategory} so every wire protocol
+   * answers the question the same way. RESP has no vocabulary for the client-error categories Postgres and Bolt
+   * distinguish, so they all keep Redis' generic {@code ERR}.
    * <p>
    * {@code TRYAGAIN} is the closest RESP2 offers, but in real Redis it is a cluster-mode error, so several client
    * libraries will not auto-retry on it. The retry hint is therefore weaker here than Postgres' {@code 40001} or
    * Bolt's transient status - it is the best signal the protocol has, not an equivalent one.
    */
   static String respErrorPrefix(final Throwable error) {
+    if (error instanceof RedisException redisException && redisException.getKind() != null)
+      return redisException.getKind();
+
     return switch (ErrorCategory.of(error)) {
       case RETRY -> "TRYAGAIN";
       case SECURITY -> "NOPERM";
@@ -775,16 +780,17 @@ public class RedisNetworkExecutor extends Thread {
     } else if (list.size() == 2) {
       // Single-argument AUTH targets Redis' "default" user, which ArcadeDB does not model.
       markUnauthenticated();
-      throw new RedisException("WRONGPASS ArcadeDB requires the 'AUTH <username> <password>' form");
+      throw RedisException.withKind("WRONGPASS", "ArcadeDB requires the 'AUTH <username> <password>' form");
     } else
-      throw new RedisException("ERR wrong number of arguments for 'auth' command");
+      // ERR is already respErrorPrefix()'s default kind, so the message no longer needs to repeat it.
+      throw new RedisException("wrong number of arguments for 'auth' command");
 
     try {
       markAuthenticated(server.getSecurity().authenticate(userName, password, null));
       value.append("+OK");
     } catch (final ServerSecurityException e) {
       markUnauthenticated();
-      throw new RedisException("WRONGPASS invalid username-password pair or user is disabled");
+      throw RedisException.withKind("WRONGPASS", "invalid username-password pair or user is disabled");
     }
   }
 
@@ -843,7 +849,7 @@ public class RedisNetworkExecutor extends Thread {
       if (NumberUtils.isIntegerNumber(maybeVersion)) {
         final int proto = Integer.parseInt(maybeVersion);
         if (proto < 2 || proto > 3)
-          throw new RedisException("NOPROTO unsupported protocol version");
+          throw RedisException.withKind("NOPROTO", "unsupported protocol version");
         idx++;
       }
     }
@@ -851,20 +857,21 @@ public class RedisNetworkExecutor extends Thread {
     // Optional AUTH <username> <password> option.
     if (list.size() > idx && "AUTH".equalsIgnoreCase((String) list.get(idx))) {
       if (list.size() < idx + 3)
-        throw new RedisException("ERR Syntax error in HELLO");
+        // ERR is already respErrorPrefix()'s default kind, so the message no longer needs to repeat it.
+        throw new RedisException("Syntax error in HELLO");
       final String userName = (String) list.get(idx + 1);
       final String password = (String) list.get(idx + 2);
       try {
         markAuthenticated(server.getSecurity().authenticate(userName, password, null));
       } catch (final ServerSecurityException e) {
         markUnauthenticated();
-        throw new RedisException("WRONGPASS invalid username-password pair or user is disabled");
+        throw RedisException.withKind("WRONGPASS", "invalid username-password pair or user is disabled");
       }
     }
 
     if (authenticatedUser == null)
-      throw new RedisException(
-          "NOAUTH HELLO must be called with the client already authenticated, otherwise the HELLO <proto> AUTH <user> <pass> option can be used to authenticate the client and select the RESP protocol version at the same time");
+      throw RedisException.withKind("NOAUTH",
+          "HELLO must be called with the client already authenticated, otherwise the HELLO <proto> AUTH <user> <pass> option can be used to authenticate the client and select the RESP protocol version at the same time");
 
     // RESP2 map reply: a flat array of alternating key/value elements (7 pairs = 14 elements).
     value.append("*14");
@@ -908,10 +915,10 @@ public class RedisNetworkExecutor extends Thread {
    */
   private DatabaseInternal getAuthorizedDatabase(final String databaseName) {
     if (authenticatedUser == null)
-      throw new RedisException("NOAUTH Authentication required.");
+      throw RedisException.withKind("NOAUTH", "Authentication required.");
 
     if (!authenticatedUser.canAccessToDatabase(databaseName))
-      throw new RedisException("NOPERM this user has no permissions to access the database '" + databaseName + "'");
+      throw RedisException.withKind("NOPERM", "this user has no permissions to access the database '" + databaseName + "'");
 
     final DatabaseInternal database = (DatabaseInternal) server.getDatabase(databaseName);
     DatabaseContext.INSTANCE.init(database).setCurrentUser(authenticatedUser.getDatabaseUser(database));

--- a/redisw/src/test/java/com/arcadedb/redis/RedisAuthenticationTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisAuthenticationTest.java
@@ -164,6 +164,36 @@ public class RedisAuthenticationTest extends BaseGraphServerTest {
   }
 
   @Test
+  void helloWithoutAuthErrorKindIsNotMaskedByErr() {
+    // Issue #6560, review follow-up: the WRONGPASS/NOPERM wire-level coverage above did not extend to HELLO's
+    // own NOAUTH and NOPROTO RedisException.withKind() call sites, so exercise them here too rather than only
+    // through the respErrorPrefix() unit test - a future regression in hello()'s dispatch could otherwise slip
+    // through with only the classification logic pinned, not the actual wire reply hello() produces.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      final JedisDataException error = catchThrowableOfType(JedisDataException.class,
+          () -> jedis.sendCommand(Protocol.Command.HELLO, "2"));
+      assertThat(error).isNotNull();
+      assertThat(error.getMessage()).as("RESP error kind must be NOAUTH, not masked by a leading ERR")
+          .startsWith("NOAUTH")
+          .doesNotStartWith("ERR");
+    }
+  }
+
+  @Test
+  void helloWithBadProtocolVersionErrorKindIsNotMaskedByErr() {
+    // Issue #6560, review follow-up: see helloWithoutAuthErrorKindIsNotMaskedByErr() above. HELLO's protocol-
+    // version check runs before the NOAUTH check, so a bad version is reachable on an unauthenticated connection.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      final JedisDataException error = catchThrowableOfType(JedisDataException.class,
+          () -> jedis.sendCommand(Protocol.Command.HELLO, "9"));
+      assertThat(error).isNotNull();
+      assertThat(error.getMessage()).as("RESP error kind must be NOPROTO, not masked by a leading ERR")
+          .startsWith("NOPROTO")
+          .doesNotStartWith("ERR");
+    }
+  }
+
+  @Test
   void helloWithWrongCredentialsIsRejected() {
     try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
       final JedisDataException error = catchThrowableOfType(JedisDataException.class,

--- a/redisw/src/test/java/com/arcadedb/redis/RedisAuthenticationTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisAuthenticationTest.java
@@ -92,6 +92,21 @@ public class RedisAuthenticationTest extends BaseGraphServerTest {
   }
 
   @Test
+  void wrongCredentialsErrorKindIsNotMaskedByErr() {
+    // Issue #6560: respErrorPrefix() used to always report "ERR" for this failure (none of the call sites raise a
+    // real java.lang.SecurityException that ErrorCategory.of() recognises as SECURITY), so the wire reply came out
+    // as "-ERR WRONGPASS ..." - a client branching on the RESP error kind (the token right after '-') saw ERR, not
+    // WRONGPASS, even though the message text happened to still mention WRONGPASS further along.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      final JedisDataException error = catchThrowableOfType(JedisDataException.class, () -> jedis.auth(USER, "wrong-password"));
+      assertThat(error).isNotNull();
+      assertThat(error.getMessage()).as("RESP error kind must be WRONGPASS, not masked by a leading ERR")
+          .startsWith("WRONGPASS")
+          .doesNotStartWith("ERR");
+    }
+  }
+
+  @Test
   void authenticatedCommandsSucceed() {
     try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
       assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
@@ -180,6 +195,13 @@ public class RedisAuthenticationTest extends BaseGraphServerTest {
       error = catchThrowableOfType(JedisDataException.class, () -> jedis.get(getDatabaseName() + ".anyKey"));
       assertThat(error).isNotNull();
       assertThat(error.getMessage()).contains("NOPERM");
+
+      // Issue #6560: the RESP error kind itself (the token right after '-') must be NOPERM, not masked by a
+      // leading ERR - getAuthorizedDatabase()'s NOPERM RedisException never raised a real
+      // java.lang.SecurityException, so ErrorCategory.of() never classified it as SECURITY.
+      assertThat(error.getMessage()).as("RESP error kind must be NOPERM, not masked by a leading ERR")
+          .startsWith("NOPERM")
+          .doesNotStartWith("ERR");
     } finally {
       security.dropUser("limited");
     }

--- a/redisw/src/test/java/com/arcadedb/redis/RedisErrorClassificationTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisErrorClassificationTest.java
@@ -59,6 +59,30 @@ class RedisErrorClassificationTest {
   }
 
   @Test
+  void anExplicitKindWinsOverTheDefaultErrCategory() {
+    // Issue #6560: a RedisException whose message already baked in a kind word (e.g. "WRONGPASS ...") used to be
+    // reported with the generic "ERR" kind anyway, since none of WRONGPASS/NOAUTH/NOPROTO/NOPERM's call sites
+    // raise a real java.lang.SecurityException that ErrorCategory.of() would recognise - the wire reply came out
+    // as "-ERR WRONGPASS ..." (or "-ERR NOAUTH ...", "-ERR NOPROTO ...", "-ERR NOPERM ..."), so the RESP error
+    // *kind* (the token right after '-') a client can branch on was always ERR, never the specific one.
+    assertThat(RedisNetworkExecutor.respErrorPrefix(RedisException.withKind("WRONGPASS", "bad credentials")))
+        .isEqualTo("WRONGPASS");
+    assertThat(RedisNetworkExecutor.respErrorPrefix(RedisException.withKind("NOAUTH", "Authentication required.")))
+        .isEqualTo("NOAUTH");
+    assertThat(RedisNetworkExecutor.respErrorPrefix(RedisException.withKind("NOPROTO", "unsupported protocol version")))
+        .isEqualTo("NOPROTO");
+    assertThat(RedisNetworkExecutor.respErrorPrefix(RedisException.withKind("NOPERM", "no permission")))
+        .isEqualTo("NOPERM");
+  }
+
+  @Test
+  void aPlainRedisExceptionWithoutAnExplicitKindKeepsTheDefault() {
+    // A RedisException that never called withKind() (e.g. "syntax error", "Key 'x' is not a number") still falls
+    // back to the ErrorCategory-derived default, exactly as before this exception carried a kind at all.
+    assertThat(RedisNetworkExecutor.respErrorPrefix(new RedisException("syntax error"))).isEqualTo("ERR");
+  }
+
+  @Test
   void anEmptyMessageStillNamesTheFailure() {
     // A bare `-` reply, or `-null`, tells the client nothing at all.
     assertThat(RedisNetworkExecutor.respErrorMessage(new IllegalStateException())).isEqualTo("IllegalStateException");

--- a/redisw/src/test/java/com/arcadedb/redis/RedisQueryLanguageTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisQueryLanguageTest.java
@@ -528,8 +528,15 @@ public class RedisQueryLanguageTest extends BaseGraphServerTest {
   }
 
   protected JSONObject executeQuery(final int serverIndex, final String language, final String command) throws Exception {
+    // Ask the server which port it actually bound (issue #6560), rather than assuming the 2480+serverIndex
+    // default: SERVER_HTTP_INCOMING_PORT is a range (2480-2489 by default) and binds the first free port in
+    // it, so with 2480 already held by anything else - another local ArcadeDB instance, an IDE debug session
+    // for a different project - this test's own server listens elsewhere. A port-less/wrong-port URL would
+    // then reach that foreign server instead, and every test in this class would fail with a confusing
+    // "403 Too many failed authentication attempts" / "User/Password not valid" that reads as an auth bug
+    // rather than a port collision. Same pattern as #6437's fix for ConsoleAsyncInsertTest.
     final HttpURLConnection connection = (HttpURLConnection) new URL(
-        "http://127.0.0.1:248" + serverIndex + "/api/v1/query/" + getDatabaseName()).openConnection();
+        "http://127.0.0.1:" + getServer(serverIndex).getHttpServer().getPort() + "/api/v1/query/" + getDatabaseName()).openConnection();
     connection.setRequestMethod("POST");
     connection.setRequestProperty("Authorization",
         "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
@@ -555,8 +562,10 @@ public class RedisQueryLanguageTest extends BaseGraphServerTest {
   }
 
   protected JSONObject executeCommand(final int serverIndex, final String language, final String command) throws Exception {
+    // See the comment in executeQuery() above: ask the server for its actual bound port instead of assuming
+    // 2480+serverIndex (issue #6560).
     final HttpURLConnection connection = (HttpURLConnection) new URL(
-        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/" + getDatabaseName()).openConnection();
+        "http://127.0.0.1:" + getServer(serverIndex).getHttpServer().getPort() + "/api/v1/command/" + getDatabaseName()).openConnection();
     connection.setRequestMethod("POST");
     connection.setRequestProperty("Authorization",
         "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));


### PR DESCRIPTION
## What does this PR do?

Fixes three independent, pre-existing follow-ups on the Redis wire-protocol module, all found while
reviewing/fixing #6493 (none caused by it):

1. **RESP error kind no longer masked by `ERR`.** `AUTH`, `HELLO` and `getAuthorizedDatabase()` baked a kind
   word (`WRONGPASS`, `NOAUTH`, `NOPROTO`, `NOPERM`) into the *message* of a plain `RedisException`, which
   `respErrorPrefix()`'s `ErrorCategory`-based classification has no special case for, so it always fell back
   to the generic `ERR`. The wire reply came out as e.g. `-ERR WRONGPASS ...` instead of `-WRONGPASS ...`: a
   client branching on the RESP error kind (the token right after `-`) saw `ERR`, never the real kind - even
   though the message text still happened to mention it further along, which is exactly why the existing
   `.contains("WRONGPASS")`-style assertions never caught it.

   `RedisException` gained a `withKind(kind, message)` factory that carries an explicit RESP kind separate
   from the message; `respErrorPrefix()` now checks for it before falling back to `ErrorCategory`. Every call
   site that baked a kind word into its message now uses `withKind` instead.

2. **Documented that Redis-wire `SET k v NX` is not a real distributed lock across an HA/Raft cluster.**
   `RaftReplicatedDatabase`'s four global-variable accessors delegate straight to the local node, with no Raft
   consensus/replication involved at all - so two nodes of an HA cluster (or the same client across a
   failover) can each independently believe they "won" a lock acquired via `SET k v NX`. A full fix means
   replicating global variables through Raft, which the issue itself frames as a materially bigger effort and
   its own design discussion - out of scope here. Per the issue's suggested action, this is a
   **documentation-only** fix: `DatabaseInternal`'s global-variable methods and `RaftReplicatedDatabase`'s
   overrides now carry an explicit Javadoc caveat. No behavior changed, so there is no new automated test for
   this item specifically.

3. **`RedisQueryLanguageTest` no longer hardcodes port 2480.** `SERVER_HTTP_INCOMING_PORT` is a range
   (2480-2489) and binds the first free port in it, so with 2480 already held by anything else the test's own
   server listens elsewhere and every test in the class used to fail with a confusing `403 Too many failed
   authentication attempts` that reads as an auth bug rather than a port collision. Same class of bug as
   #6426, fixed the same way for `ConsoleAsyncInsertTest` in #6437: both helpers now ask the server for the
   port it actually bound.

## Motivation

Issue #6560 - three follow-ups noticed while reviewing/fixing #6493's Redis `INCRBY`/`DECRBY`/`SET`
semantics, filed separately since none of them are caused by that change.

## Related issues

Closes #6560

## Additional Notes

Full writeup with the reasoning above (kept in sync with this description) is in
`docs/6560-redis-error-prefix-ha-lock-port-hardcode.md`.

`RedisQueryLanguageTest` was actually run in this environment while port 2480 was genuinely held by an
unrelated local process (`lsof -nP -iTCP:2480 -sTCP:LISTEN` showed a live listener) - all 19 tests in the
class passed, which the pre-fix hardcoded URL could not have done.

## Test plan

- [x] `RedisErrorClassificationTest` (unit, no server) - 7/7 passed, including 2 new cases covering explicit-kind
  precedence over the `ErrorCategory` default
- [x] `RedisAuthenticationTest` (integration, real server + Jedis client) - 9/9 passed, including 2 new
  assertions that the wire reply for wrong credentials / unauthorized-database access starts with the real
  RESP kind (`WRONGPASS`/`NOPERM`) and not `ERR`
- [x] `RedisQueryLanguageTest` - 19/19 passed, run with port 2480 occupied by an unrelated process to prove the
  port fix
- [x] Full `redisw` module unit-test set (`RedisAuthenticationTest`, `RedisErrorClassificationTest`,
  `RedisPortConfigurationTest`, `RedisProtocolLimitsTest`, `RedisQueryLanguageTest`,
  `RedisRespCorrectnessTest`, `RedisWTest`) - 76/76 passed, no regressions
- [x] `ha-raft` unit tests touching `RaftReplicatedDatabase` (`RaftReplicatedDatabaseTest`,
  `RaftReplicatedDatabaseLeaderWaitTest`) - passed, no regressions from the Javadoc-only change
- [x] `engine`, `ha-raft`, `redisw` modules compile cleanly (`mvn compile` / `test-compile`)

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redis authentication and protocol errors now return accurate RESP error types, including `WRONGPASS`, `NOAUTH`, `NOPROTO`, and `NOPERM`.
  * Redis error messages no longer include redundant error prefixes.
  * Query and command requests correctly use dynamically assigned HTTP ports.

* **Documentation**
  * Clarified that HA global variables are local to each server, are not replicated, and do not provide cluster-wide locking or consistency.
  * Documented the node-local scope and atomicity limitations of conditional updates and map access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->