### PR TITLE
fix(#6592): correct descending compacted-index partial-key scan

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -352,7 +352,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
   }
 
   protected LookupResult compareKey(final Binary currentPageBuffer, final int startIndexArray, final Object[] convertedKeys,
-      final int mid, final int count,
+      int mid, final int count,
       final int purpose) {
 
     final int result = compareKey(currentPageBuffer, startIndexArray, convertedKeys, mid, count);
@@ -384,6 +384,21 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
         positionsArray[i - firstKeyPos] = currentPageBuffer.getInt(startIndexArray + (i * INT_SERIALIZED_SIZE)) + keySerializedSize;
 
       return new LookupResult(true, false, lastKeyPos, positionsArray);
+    }
+
+    if (convertedKeys.length < binaryKeyTypes.length) {
+      // PARTIAL MATCHING: mid is an arbitrary position inside the run of entries sharing this prefix (wherever the
+      // binary search happened to converge) - walk to the run's boundary in the requested scan direction, exactly
+      // like LSMTreeIndexMutable.compareKey() does. Without this, a descending partial-key scan (composite-index
+      // prefix match, e.g. #6592) can start anywhere inside the matching group instead of at its highest entry,
+      // silently skipping the very rows ORDER BY ... DESC is supposed to return first.
+      if (purpose == 2) {
+        // ASCENDING ITERATOR: FIND THE MOST LEFT ITEM
+        mid = findFirstEntryOfSameKey(currentPageBuffer, convertedKeys, startIndexArray, mid);
+      } else if (purpose == 3) {
+        // DESCENDING ITERATOR: FIND THE MOST RIGHT ITEM
+        mid = findLastEntryOfSameKey(count, currentPageBuffer, convertedKeys, startIndexArray, mid);
+      }
     }
 
     // TODO: SET CORRECT VALUE POSITION FOR PARTIAL KEYS
@@ -563,8 +578,23 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
 
       int startingPageNumber;
       if (result.outside) {
-        // STARTS FROM THE BEGINNING OF THE NEXT PAGE
-        startingPageNumber = firstPageNumber + 1;
+        // lookupInPage()'s purpose=2/3 boundary handling is asymmetric (see LSMTreeIndexAbstract#lookupInPage): an
+        // ascending search only ever reports "outside" when the whole page sorts BELOW the search key (the
+        // "HIGHER than last" branch - purpose=2 has no special case there), so the next (higher-keyed) page is the
+        // right place to keep looking. A descending search only ever reports "outside" when the whole page sorts
+        // ABOVE the search key (the "LOWER than first" branch - purpose=3's special case is the "HIGHER than last"
+        // one instead), so it is the PREVIOUS (lower-keyed) page that can still hold the match, not the next one.
+        // Stepping +1 unconditionally here used to walk a descending partial-key (composite-index prefix) scan
+        // straight into an unrelated, higher-keyed page - possibly the next series' root page or another series
+        // entirely - and return whatever it found there as if it matched the search key (#6592 follow-up).
+        if (ascendingOrder) {
+          // STARTS FROM THE BEGINNING OF THE NEXT PAGE
+          startingPageNumber = firstPageNumber + 1;
+        } else
+          // STARTS FROM THE END OF THE PREVIOUS PAGE. If firstPageNumber was already this series' first data page,
+          // this lands below lastPageNumber and loadNextNonEmptyPage()'s loop simply does not run - the series
+          // correctly contributes no cursor rather than reading into the previous series' pages.
+          startingPageNumber = firstPageNumber - 1;
         posInPage = -1;
       } else {
         startingPageNumber = firstPageNumber;

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6592CompactedCompositePrefixDescTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6592CompactedCompositePrefixDescTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Follow-up regression test for https://github.com/ArcadeData/arcadedb/issues/6592: once the composite (multi-property)
+ * index in {@link SelectCompositeIndexTest} is actually used by the native {@link Select} query builder, a genuine bug
+ * surfaces on an index that has gone through LSM compaction (any long-running database) when the query does an
+ * {@code ORDER BY <trailing property> DESC} on a composite-index prefix match.
+ * <p>
+ * Two independent defects in {@link com.arcadedb.index.lsm.LSMTreeIndexCompacted}, both only reachable through a
+ * PARTIAL (prefix) key - i.e. a composite index where not every property is bound by equality - combined to produce
+ * this:
+ * <ol>
+ * <li>{@code compareKey()} never adjusted the binary-search {@code mid} to the boundary of the matching-prefix run
+ * (unlike {@code LSMTreeIndexMutable.compareKey()}, which does), so a descending partial-key scan could start
+ * anywhere inside the group instead of at its highest entry;</li>
+ * <li>{@code searchInCurrentPage()}'s "the search key is outside this data page" fallback always stepped to
+ * {@code firstPageNumber + 1}, which is only correct for an ASCENDING scan (where "outside" only ever means the page
+ * sorts below the search key). For a DESCENDING scan "outside" only ever means the page sorts ABOVE the search key,
+ * so the fallback needs to step to {@code firstPageNumber - 1} instead - stepping the wrong way walked the scan into
+ * an unrelated, higher-keyed page (possibly belonging to a different compacted series entirely) and returned
+ * whatever it found there as if it matched the WHERE clause.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6592CompactedCompositePrefixDescTest extends TestHelper {
+
+  private static final int    NOISE_GROUPS = 12;
+  private static final int    NOISE_ROWS   = 2_500;
+  private static final int    GROUP_SIZE   = 5;
+  private static final String PAD          = "x".repeat(64);
+
+  @Override
+  protected void beginTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+
+    final VertexType supplier = database.getSchema().createVertexType("Supplier", 1);
+    supplier.createProperty("key1", Type.STRING);
+    supplier.createProperty("key2", Type.STRING);
+    supplier.createProperty("orderedAt", Type.LONG);
+    supplier.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "key1", "key2", "orderedAt");
+
+    database.transaction(() -> {
+      // Noise groups both alphabetically BEFORE and AFTER the target "a"/"b" group, spread across enough data to
+      // force several compacted series (see buildMultiSeriesIndex() in Issue5214MultiSeriesRangeTest for the same
+      // RAM-bounded-compaction technique). Groups before "a" exercise the descending "outside" fallback (#6592
+      // follow-up); groups after it exercise the pre-existing ascending fallback, which must stay correct.
+      for (int g = 0; g < NOISE_GROUPS; g++) {
+        final String key1 = (g % 2 == 0 ? "0" : "z") + PAD + g;
+        for (int i = 0; i < NOISE_ROWS; i++)
+          database.newVertex("Supplier").set("key1", key1, "key2", "x", "orderedAt", (long) i).save();
+      }
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("Supplier").set("key1", "a", "key2", "b", "orderedAt", (long) i).save();
+    });
+
+    final TypeIndex typeIndex = database.getSchema().getType("Supplier").getIndexesByProperties("key1", "key2", "orderedAt")
+        .getFirst();
+    try {
+      assertThat(((IndexInternal) typeIndex).scheduleCompaction()).as("compaction scheduled").isTrue();
+      assertThat(((IndexInternal) typeIndex).compact()).as("compaction executed").isTrue();
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void orderByDescLimitOneReturnsTheMatchingGroupAfterCompaction() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", false)//
+          .limit(1)//
+          .compile();
+
+      final Vertex first = select.vertices().nextOrNull();
+
+      assertThat(first).isNotNull();
+      assertThat(first.getString("key1")).isEqualTo("a");
+      assertThat(first.getString("key2")).isEqualTo("b");
+      assertThat(first.getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1);
+    });
+  }
+
+  @Test
+  void orderByAscLimitOneStillReturnsTheMatchingGroupAfterCompaction() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", true)//
+          .limit(1)//
+          .compile();
+
+      final Vertex first = select.vertices().nextOrNull();
+
+      assertThat(first).isNotNull();
+      assertThat(first.getString("key1")).isEqualTo("a");
+      assertThat(first.getString("key2")).isEqualTo("b");
+      assertThat(first.getLong("orderedAt")).isZero();
+    });
+  }
+
+  @Test
+  void descendingScanReturnsExactlyTheMatchingGroupInOrder() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", false)//
+          .compile();
+
+      final List<Vertex> list = select.vertices().toList();
+
+      assertThat(list).hasSize(GROUP_SIZE);
+      for (int i = 0; i < GROUP_SIZE; i++) {
+        assertThat(list.get(i).getString("key1")).isEqualTo("a");
+        assertThat(list.get(i).getString("key2")).isEqualTo("b");
+        assertThat(list.get(i).getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1 - i);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up on #6592. After PR #6595 made the native `Select` query builder actually use a composite-index prefix match (equality on the leading properties, `ORDER BY` on the trailing property), the reporter found that a **descending** `ORDER BY` on such a query returns wrong or missing rows once the index has gone through LSM compaction - which any long-running database will eventually do.

Two independent defects in `LSMTreeIndexCompacted`, both reachable only through a **partial (prefix) key** - i.e. a composite index where not every property is bound by equality - combined to cause this:

1. `compareKey()` never adjusted the binary-search `mid` to the boundary of the matching-prefix run for a partial key, unlike `LSMTreeIndexMutable.compareKey()` (the mutable-page counterpart), which does. A descending scan could start anywhere inside the matching group instead of at its highest entry.
2. `searchInCurrentPage()`'s "the search key is outside this data page" fallback always stepped to `firstPageNumber + 1`, which is only correct for an **ascending** scan (where "outside" only ever means the page sorts *below* the search key - see the asymmetric boundary handling in `LSMTreeIndexAbstract#lookupInPage`). For a **descending** scan, "outside" only ever means the page sorts *above* the search key, so the fallback needs to step to `firstPageNumber - 1` instead. Stepping the wrong way walked the scan into an unrelated, higher-keyed page - possibly belonging to a different compacted series entirely - and returned whatever it found there as if it matched the `WHERE` clause. This is exactly what the reporter observed: a record whose `key1` didn't match the filter at all.

Both defects had to be fixed together to resolve the bug end to end (confirmed by reverting each individually against the new regression test).

## Test plan
- [x] New regression test `Issue6592CompactedCompositePrefixDescTest` (native `Select` builder, RAM-bounded forced compaction, noise groups both alphabetically before and after the target prefix to exercise both scan directions) - fails on `main` (2 of 3 tests), passes with the fix
- [x] Existing composite-index tests (`SelectCompositeIndexTest`, `CompositeIndexPartialKeySelectTest`) still pass
- [x] Existing multi-series compacted-index tests (`Issue5214MultiSeriesRangeTest`) still pass
- [x] Full `com.arcadedb.index.**` unit test package (excluding `benchmark`/`slow`/`vector` lanes) passes with no failures
- [x] `mvn -pl engine -am compile` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composite-index prefix searches during ascending and descending scans.
  * Prevented queries from reading entries outside the requested key range.
  * Corrected descending scans to return matching results in the proper order, including limited-result queries.

* **Tests**
  * Added regression coverage for compacted composite indexes with ascending and descending prefix queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->