### PR TITLE
fix(#6680,#6679,#6676,#6671): empty-aggregate row, Postgres simple-query OOM, numeric equality, plan-cache race

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2009,6 +2009,15 @@ public enum GlobalConfiguration {
       "Maximum size in bytes accepted for a single bind-message parameter value on the Postgres wire protocol. Values declaring a larger size are rejected before allocation. Default is 16MB",
       Integer.class, 16 * 1024 * 1024),
 
+  POSTGRES_SIMPLE_QUERY_MAX_ROWS("arcadedb.postgres.simpleQueryMaxRows", SCOPE.SERVER, """
+      Maximum number of rows a simple-query protocol ('Q' message) SELECT is allowed to buffer server-side before \
+      the first row is sent. Unlike the extended query protocol, the simple-query protocol has no client-driven \
+      cursor/max-rows mechanism and always expects the complete result set in one response, so the server has to \
+      hold it in memory to determine the row description (column set and types) before streaming it. A SELECT whose \
+      result exceeds this limit is refused with an error instead of risking an OutOfMemoryError; the client should \
+      use the extended query protocol with a bounded portal fetch size for very large result sets. Default is \
+      1000000""", Integer.class, 1_000_000),
+
   // BOLT (Neo4j)
   BOLT_PORT("arcadedb.bolt.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for BOLT plugin. Default is 7687", Integer.class, 7687),

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.function.DistinctNumericKey;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.opencypher.ast.*;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
@@ -145,10 +146,14 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
       final FunctionCallExpression[] aggExpressions, final String[] aggOutputNames, final int aggCount,
       final CommandContext context, final int nRecords) {
 
-    // Map: raw grouping value -> array of aggregation functions (indexed, not HashMap)
+    // Map: canonicalized grouping value -> group state (representative raw key + aggregation functions).
+    // Keying on the canonicalized value (DistinctNumericKey#canonicalize) rather than the raw boxed value means the
+    // same logical number represented with different Java numeric types (Integer 1 vs Long 1 vs Double 1.0) groups
+    // together instead of splitting, matching Cypher's own `=` operator and the sibling DISTINCT paths (#5789,
+    // issue #6676). The group's raw, first-seen key value is kept in SingleKeyGroupState for the output row.
     // LinkedHashMap preserves insertion order, needed because ORDER BY in WITH clauses
     // may fail to resolve aggregation expressions and fall back to iteration order
-    final Map<Object, StatelessFunction[]> groups = new LinkedHashMap<>();
+    final Map<Object, SingleKeyGroupState> groups = new LinkedHashMap<>();
 
     final ResultSet prevResults = prev.syncPull(context, CONFIGURED_BATCH_SIZE != null ? CONFIGURED_BATCH_SIZE : nRecords);
 
@@ -162,15 +167,17 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
 
         // Evaluate grouping key directly (no wrapper)
         final Object keyValue = evaluator.evaluate(groupingKey.expression, inputRow, context);
+        final Object canonicalKey = DistinctNumericKey.canonicalize(keyValue);
 
         // Get or create aggregators for this group using array (not HashMap)
-        StatelessFunction[] aggregators = groups.get(keyValue);
-        if (aggregators == null) {
-          aggregators = new StatelessFunction[aggCount];
+        SingleKeyGroupState group = groups.get(canonicalKey);
+        if (group == null) {
+          final StatelessFunction[] aggregators = new StatelessFunction[aggCount];
           for (int i = 0; i < aggCount; i++)
             aggregators[i] = functionFactory.getFunctionExecutor(
                 aggExpressions[i].getFunctionName(), aggExpressions[i].isDistinct());
-          groups.put(keyValue, aggregators);
+          group = new SingleKeyGroupState(keyValue, aggregators);
+          groups.put(canonicalKey, group);
         }
 
         // Feed row to aggregators using direct array access
@@ -179,7 +186,7 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
           final Object[] args = new Object[funcArgs.size()];
           for (int j = 0; j < args.length; j++)
             args[j] = evaluator.evaluate(funcArgs.get(j), inputRow, context);
-          aggregators[i].execute(args, context);
+          group.aggregators[i].execute(args, context);
         }
       } finally {
         if (context.isProfiling())
@@ -191,13 +198,12 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
     final List<Result> results = new ArrayList<>(groups.size());
     final long beginBuild = context.isProfiling() ? System.nanoTime() : 0;
     try {
-      for (final Map.Entry<Object, StatelessFunction[]> entry : groups.entrySet()) {
+      for (final SingleKeyGroupState group : groups.values()) {
         final ResultInternal groupResult = new ResultInternal();
-        groupResult.setProperty(groupingKey.outputName, entry.getKey());
+        groupResult.setProperty(groupingKey.outputName, group.representativeKey);
 
-        final StatelessFunction[] aggregators = entry.getValue();
         for (int i = 0; i < aggCount; i++)
-          groupResult.setProperty(aggOutputNames[i], aggregators[i].getAggregatedResult());
+          groupResult.setProperty(aggOutputNames[i], group.aggregators[i].getAggregatedResult());
 
         results.add(groupResult);
       }
@@ -206,6 +212,20 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
         cost += System.nanoTime() - beginBuild;
     }
     return results;
+  }
+
+  /**
+   * Holds the aggregation functions for a single-key group together with the raw, first-seen grouping value used
+   * for the output row (the map itself is keyed on the canonicalized value - see {@link #aggregateSingleKey}).
+   */
+  private static final class SingleKeyGroupState {
+    final Object              representativeKey;
+    final StatelessFunction[] aggregators;
+
+    SingleKeyGroupState(final Object representativeKey, final StatelessFunction[] aggregators) {
+      this.representativeKey = representativeKey;
+      this.aggregators = aggregators;
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupKeyValues.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupKeyValues.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.query.opencypher.executor.steps;
 
+import com.arcadedb.function.DistinctNumericKey;
+
 import java.util.Objects;
 
 /**
@@ -25,18 +27,29 @@ import java.util.Objects;
  * aggregation steps (issue #6629: a row-multiplying clause upstream of a GROUP BY, such as
  * UNWIND, must still collapse into one output row per distinct key combination). Caches its
  * hash code since the same instance is hashed on every row of its group.
+ * <p>
+ * Equality/hashing is computed on {@link DistinctNumericKey#canonicalize(Object)} of each value rather than on the
+ * raw boxed value, so that the same logical number represented with different Java numeric types (e.g. Integer 1 vs
+ * Long 1 vs Double 1.0) groups together instead of splitting, matching Cypher's own {@code =} operator and the
+ * sibling DISTINCT paths that already canonicalize this way (issue #6676, following #5789). {@link #values} itself
+ * stays the raw, first-seen values, since those - not the canonical form - are what the group's output row reports.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 final class GroupKeyValues {
   final Object[] values;
-  private final int hash;
+  private final Object[] canonicalValues;
+  private final int      hash;
 
   GroupKeyValues(final Object[] values) {
     this.values = values;
+    this.canonicalValues = new Object[values.length];
     int h = 1;
-    for (final Object v : values)
-      h = 31 * h + (v == null ? 0 : v.hashCode());
+    for (int i = 0; i < values.length; i++) {
+      final Object canonical = DistinctNumericKey.canonicalize(values[i]);
+      canonicalValues[i] = canonical;
+      h = 31 * h + (canonical == null ? 0 : canonical.hashCode());
+    }
     this.hash = h;
   }
 
@@ -46,10 +59,10 @@ final class GroupKeyValues {
       return true;
     if (!(o instanceof GroupKeyValues that))
       return false;
-    if (hash != that.hash || values.length != that.values.length)
+    if (hash != that.hash || canonicalValues.length != that.canonicalValues.length)
       return false;
-    for (int i = 0; i < values.length; i++)
-      if (!Objects.equals(values[i], that.values[i]))
+    for (int i = 0; i < canonicalValues.length; i++)
+      if (!Objects.equals(canonicalValues[i], that.canonicalValues[i]))
         return false;
     return true;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java
@@ -71,12 +71,22 @@ public class CypherPlanCache {
   }
 
   /**
-   * Puts a physical plan into the cache.
+   * Puts a physical plan into the cache, unless a DDL has invalidated the cache since {@code planningStart} - the
+   * moment the caller began building this plan. Without this guard a plan built against a schema that a concurrent
+   * {@code DROP INDEX}/{@code ALTER TYPE}/create-index already made stale could be cached right after the
+   * invalidation that was supposed to keep it out, leaving future executions running against a dropped/renamed
+   * bucket or index (or missing a new one) until the next invalidation happens to clear it (issue #6671). The check
+   * and the insert run under the same lock as {@link #invalidate()}, so a concurrent invalidation is guaranteed to
+   * either be observed here (the put is skipped) or to run after this put returns (and clear it right back out).
    *
-   * @param query the OpenCypher query string (cache key)
-   * @param plan  the optimized PhysicalPlan to cache
+   * @param query         the OpenCypher query string (cache key)
+   * @param plan          the optimized PhysicalPlan to cache
+   * @param planningStart the timestamp (as returned by {@link System#currentTimeMillis()}) taken before planning
+   *                      began
    */
-  public void put(final String query, final PhysicalPlan plan) {
+  public synchronized void put(final String query, final PhysicalPlan plan, final long planningStart) {
+    if (lastInvalidation >= planningStart)
+      return;
     cache.put(query, plan);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java
@@ -39,6 +39,12 @@ import java.util.Map;
  * - Eliminates plan building overhead (50-100ms per query)
  * <p>
  * Total savings: 200-500ms per cached query execution.
+ * <p>
+ * {@link #put} and {@link #invalidate()} synchronize on {@code this}, so the {@code lastInvalidation} check and the
+ * insert into {@code cache} happen atomically with respect to a concurrent invalidation (issue #6671). {@link #get}
+ * does not need that lock - it never reads {@link #lastInvalidation} - and instead relies on {@code cache} being a
+ * {@link Collections#synchronizedMap} for its own thread safety, so the frequent read path stays uncontended by the
+ * much rarer {@code put}/{@code invalidate}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -349,14 +349,17 @@ public class OpenCypherQueryEngine implements QueryEngine {
         plan = new CypherExecutionPlan(
             execDb, statement, parameters, configuration, physicalPlan, EXPRESSION_EVALUATOR);
       } else {
-        // Create new plan from scratch and cache it
+        // Create new plan from scratch and cache it. planningStart is taken before planning begins so put() can
+        // detect a DDL (DROP INDEX/ALTER TYPE/create-index) that invalidated the cache concurrently with this
+        // planning and skip caching a plan already built against stale schema/index state (issue #6671).
+        final long planningStart = System.currentTimeMillis();
         final CypherExecutionPlanner planner = new CypherExecutionPlanner(execDb, statement, parameters,
             EXPRESSION_EVALUATOR);
         plan = planner.createExecutionPlan(configuration);
 
         // Cache the physical plan for future use
         if (plan.getPhysicalPlan() != null)
-          database.getCypherPlanCache().put(queryString, plan.getPhysicalPlan());
+          database.getCypherPlanCache().put(queryString, plan.getPhysicalPlan(), planningStart);
       }
     } else {
       // explain/profile mode: always create new plan without caching

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DistinctExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DistinctExecutionStep.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.schema.Type;
 
 import java.util.*;
 
@@ -43,11 +44,14 @@ public class DistinctExecutionStep extends AbstractExecutionStep {
     private final int hashCode;
 
     DistinctKey(final Result result) {
-      // Extract only the properties (not the element reference, metadata, etc.)
+      // Extract only the properties (not the element reference, metadata, etc.), normalising numeric values to a
+      // canonical form so that the same logical number represented with different boxed numeric types (e.g.
+      // Integer(1) vs Long(1)) is deduplicated as one value instead of splitting into separate rows (issue #6676),
+      // matching the canonicalization SQL GROUP BY already applies (AggregateProjectionCalculationStep.GroupByKey).
       final Set<String> propertyNames = result.getPropertyNames();
       this.properties = new HashMap<>(propertyNames.size());
       for (final String propName : propertyNames) {
-        this.properties.put(propName, result.getProperty(propName));
+        this.properties.put(propName, Type.normalizeNumberForKey(result.getProperty(propName)));
       }
       // Pre-compute hashCode for performance
       this.hashCode = properties.hashCode();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/GuaranteeEmptyCountStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/GuaranteeEmptyCountStep.java
@@ -24,16 +24,22 @@ import com.arcadedb.query.sql.parser.ProjectionItem;
 
 import java.util.NoSuchElementException;
 
+/**
+ * Guarantees that a no-GROUP-BY aggregation (count(*), sum(), avg(), min(), max(), ...) always produces exactly one
+ * row, even when the upstream produced none. Without this step {@link AggregateProjectionCalculationStep} emits no
+ * row at all over an empty input, which is inconsistent with the single-row-with-identity-value semantics SQL callers
+ * expect from a scalar aggregate (issue #6680).
+ */
 public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
-  private final ProjectionItem item;
-  private final Projection     preAggregateProjection;
-  private       boolean        executed = false;
+  private final Projection aggregateProjection;
+  private final Projection preAggregateProjection;
+  private       boolean    executed = false;
 
-  public GuaranteeEmptyCountStep(final ProjectionItem countItem, final Projection preAggregateProjection,
+  public GuaranteeEmptyCountStep(final Projection aggregateProjection, final Projection preAggregateProjection,
       final CommandContext context) {
     super(context);
-    this.item = countItem;
+    this.aggregateProjection = aggregateProjection;
     this.preAggregateProjection = preAggregateProjection;
   }
 
@@ -60,7 +66,17 @@ public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
             return upstream.next();
 
           final ResultInternal result = new ResultInternal(context.getDatabase());
-          result.setProperty(item.getProjectionAliasAsString(), 0L);
+          for (final ProjectionItem item : aggregateProjection.getItems()) {
+            final Object value = item.isAggregate(context) ?
+                // No row was ever aggregated: read the aggregate function's identity value (e.g. 0 for count()/sum(),
+                // null for min()/max()/avg()) without ever calling apply(), consistent with a group whose rows are
+                // all-null.
+                item.getAggregationContext(context).getFinalValue() :
+                // A non-aggregate item mixed into a GROUP-BY-less aggregation projection (e.g. a constant) has no row
+                // to evaluate against.
+                item.execute((Result) null, context);
+            result.setProperty(item.getProjectionAliasAsString(), value);
+          }
           if (preAggregateProjection != null) {
             for (final ProjectionItem preAggItem : preAggregateProjection.getItems()) {
               result.setProperty(preAggItem.getProjectionAliasAsString(), preAggItem.execute((Result) null, context));
@@ -81,7 +97,8 @@ public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
   @Override
   public ExecutionStep copy(final CommandContext context) {
-    return new GuaranteeEmptyCountStep(item.copy(), preAggregateProjection != null ? preAggregateProjection.copy() : null, context);
+    return new GuaranteeEmptyCountStep(aggregateProjection.copy(), preAggregateProjection != null ? preAggregateProjection.copy() : null,
+        context);
   }
 
   public boolean canBeCached() {
@@ -90,6 +107,6 @@ public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
   @Override
   public String prettyPrint(final int depth, final int indent) {
-    return ExecutionStepInternal.getIndent(depth, indent) + "+ GUARANTEE FOR ZERO COUNT ";
+    return ExecutionStepInternal.getIndent(depth, indent) + "+ GUARANTEE SINGLE ROW FOR EMPTY AGGREGATION ";
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -297,9 +297,10 @@ public class SelectExecutionPlanner {
       chainTimeout(selectExecutionPlan, info, context);
     }
 
-    if (useCache && !context.isProfiling() && statement.executionPlanCanBeCached() && selectExecutionPlan.canBeCached()
-        && db.getExecutionPlanCache().getLastInvalidation() < planningStart)
-      db.getExecutionPlanCache().put(statement.getOriginalStatement(), selectExecutionPlan);
+    if (useCache && !context.isProfiling() && statement.executionPlanCanBeCached() && selectExecutionPlan.canBeCached())
+      // The planningStart < lastInvalidation re-check happens atomically inside put(), under the same lock as
+      // invalidate(), so a DDL racing this call can never be missed the way two separately-locked calls could (#6671).
+      db.getExecutionPlanCache().put(statement.getOriginalStatement(), selectExecutionPlan, planningStart);
 
     return selectExecutionPlan;
   }
@@ -562,26 +563,20 @@ public class SelectExecutionPlanner {
   }
 
   /**
-   * Returns the count(*) ProjectionItem if the aggregateProjection contains exactly one true aggregate and it is count(*),
-   * otherwise returns null. Non-aggregate pass-through alias items (added for non-aggregate projections) are ignored.
+   * Returns true if the aggregateProjection contains at least one true aggregate function (count(), sum(), avg(),
+   * min(), max(), ...). Used, together with the absence of a GROUP BY, to decide whether a
+   * {@link GuaranteeEmptyCountStep} is needed to guarantee the single row a scalar aggregation must produce even
+   * over an empty input (issue #6680).
    */
-  private static ProjectionItem findCountStarItem(final QueryPlanningInfo info, final CommandContext context) {
-    if (info.aggregateProjection == null)
-      return null;
+  private static boolean hasAggregateItem(final Projection aggregateProjection, final CommandContext context) {
+    if (aggregateProjection == null)
+      return false;
 
-    ProjectionItem countItem = null;
-    for (final ProjectionItem item : info.aggregateProjection.getItems()) {
-      if (!item.isAggregate(context))
-        continue;
-      if (countItem != null)
-        return null; // more than one aggregate function
-      final Expression exp = item.getExpression();
-      if (exp.getMathExpression() instanceof final BaseExpression base && base.isCount() && base.getModifier() == null)
-        countItem = item;
-      else
-        return null; // aggregate but not count(*)
+    for (final ProjectionItem item : aggregateProjection.getItems()) {
+      if (item.isAggregate(context))
+        return true;
     }
-    return countItem;
+    return false;
   }
 
   private boolean isCount(final Projection aggregateProjection, final Projection projection) {
@@ -777,9 +772,8 @@ public class SelectExecutionPlanner {
 
         result.chain(new AggregateProjectionCalculationStep(info.aggregateProjection, info.groupBy, aggregationLimit, context,
             info.timeout != null ? info.timeout.getVal().longValue() : -1));
-        final ProjectionItem countStarItem = findCountStarItem(info, context);
-        if (countStarItem != null && info.groupBy == null) {
-          result.chain(new GuaranteeEmptyCountStep(countStarItem, info.preAggregateProjection, context));
+        if (info.groupBy == null && hasAggregateItem(info.aggregateProjection, context)) {
+          result.chain(new GuaranteeEmptyCountStep(info.aggregateProjection, info.preAggregateProjection, context));
         }
       }
       result.chain(new ProjectionCalculationStep(info.projection, context));

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java
@@ -51,11 +51,8 @@ public class ExecutionPlanCache {
     };
   }
 
-  public long getLastInvalidation() {
-    final ExecutionPlanCache resource = db.getExecutionPlanCache();
-    synchronized (resource) {
-      return resource.lastInvalidation;
-    }
+  public synchronized long getLastInvalidation() {
+    return lastInvalidation;
   }
 
   /**
@@ -63,10 +60,8 @@ public class ExecutionPlanCache {
    *
    * @return true if the corresponding executor is present in the cache
    */
-  public boolean contains(final String statement) {
-    synchronized (map) {
-      return map.containsKey(statement);
-    }
+  public synchronized boolean contains(final String statement) {
+    return map.containsKey(statement);
   }
 
   /**
@@ -77,35 +72,44 @@ public class ExecutionPlanCache {
    *
    * @return a statement executor from the cache
    */
-  public ExecutionPlan get(final String statement, final CommandContext context) {
-    InternalExecutionPlan result;
-    synchronized (map) {
-      //LRU
-      result = map.remove(statement);
-      if (result != null) {
-        map.put(statement, result);
-        result = result.copy(context);
-      }
+  public synchronized ExecutionPlan get(final String statement, final CommandContext context) {
+    //LRU
+    InternalExecutionPlan result = map.remove(statement);
+    if (result != null) {
+      map.put(statement, result);
+      result = result.copy(context);
     }
 
     return result;
   }
 
-  public void put(final String statement, final ExecutionPlan plan) {
-    synchronized (map) {
-      InternalExecutionPlan internal = (InternalExecutionPlan) plan;
-      internal = internal.copy(null);
-      map.put(statement, internal);
-    }
+  /**
+   * Stores {@code plan} in the cache, unless a DDL has invalidated the cache since {@code planningStart} - the moment
+   * the caller began building this plan. Checking {@code planningStart} against {@link #lastInvalidation} and
+   * inserting into the map happen under the same lock this class uses for {@link #invalidate()}, so a DDL that
+   * invalidates the cache concurrently with this call is guaranteed to either be observed here (the put is skipped)
+   * or to run after this put returns (and clear it right back out) - it can never land in the gap between the check
+   * and the insert the way two separately-locked calls could (issue #6671).
+   *
+   * @param statement     the SQL statement, used as the cache key
+   * @param plan          the execution plan to cache
+   * @param planningStart the timestamp (as returned by {@link System#currentTimeMillis()}) taken before planning
+   *                      began; the plan is discarded instead of cached if a concurrent DDL invalidated the cache
+   *                      at or after that moment, since the plan may have been built against stale schema/index state
+   */
+  public synchronized void put(final String statement, final ExecutionPlan plan, final long planningStart) {
+    if (lastInvalidation >= planningStart)
+      // a DDL invalidated the cache after planning started: the plan may reference a dropped/renamed bucket or
+      // index (or be missing a new one), so it must not be cached
+      return;
+    InternalExecutionPlan internal = (InternalExecutionPlan) plan;
+    internal = internal.copy(null);
+    map.put(statement, internal);
   }
 
-  public void invalidate() {
-    synchronized (this) {
-      synchronized (map) {
-        map.clear();
-      }
-      lastInvalidation = System.currentTimeMillis();
-    }
+  public synchronized void invalidate() {
+    map.clear();
+    lastInvalidation = System.currentTimeMillis();
   }
 
   public static ExecutionPlanCache instance(final DatabaseInternal db) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java
@@ -29,6 +29,13 @@ import java.util.Map;
 /**
  * This class is an LRU cache for already prepared SQL execution plans. It stores itself in the storage as a resource. It also acts
  * an an entry point for the SQL executor.
+ * <p>
+ * Every accessor synchronizes on {@code this}, deliberately trading the finer-grained locking a previous version had
+ * (a separate lock for the map versus {@link #lastInvalidation}) for the atomicity {@link #put} needs to check-and-
+ * insert without a race against a concurrent {@link #invalidate()} (issue #6671). {@link #get} - called on every
+ * cached query execution - now contends with the much rarer {@link #put}/{@link #invalidate}, rather than with
+ * nothing; deliberate, since correctness here outweighs the lock-contention cost on a path this infrequent relative
+ * to query execution itself.
  *
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
  */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherPlanCacheInvalidationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherPlanCacheInvalidationTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.opencypher.optimizer.plan.PhysicalPlan;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -72,10 +73,16 @@ class CypherPlanCacheInvalidationTest {
   private static final String Q = "MATCH (a:Foo)-[:REL]->(b:Foo) RETURN b.x AS v";
 
   @Test
-  void planCacheIsFlushedOnSchemaChange() {
+  void planCacheIsFlushedOnSchemaChange() throws InterruptedException {
     database.transaction(() -> {
       database.command("cypher", "CREATE (a:Foo {x:1})-[:REL]->(b:Foo {x:2}), (c:Foo {x:1})-[:REL]->(d:Foo {x:2})");
     });
+
+    // put()'s invalidation guard (issue #6671) is millisecond-timestamped: a query planned in the very same
+    // millisecond as a preceding invalidation (here, the implicit "Foo" type creation above) is correctly not
+    // cached. Sleeping past the millisecond boundary before each post-invalidation query, exactly like
+    // ExecutionPlanCacheTest does for the SQL cache, keeps these assertions about "was it cached" deterministic.
+    Thread.sleep(2);
 
     // Populate the plan cache with a node-returning query (its plan depends on the current schema).
     assertThat(matchRows(Q)).isEqualTo(2L);
@@ -85,6 +92,7 @@ class CypherPlanCacheInvalidationTest {
     database.getSchema().getType("Foo").createProperty("x", Type.INTEGER);
     assertThat(database.getCypherPlanCache().size()).as("plan cache flushed after CREATE PROPERTY").isEqualTo(0);
 
+    Thread.sleep(2);
     assertThat(matchRows(Q)).isEqualTo(2L);
     assertThat(database.getCypherPlanCache().size()).isGreaterThan(0);
 
@@ -93,6 +101,7 @@ class CypherPlanCacheInvalidationTest {
     assertThat(database.getCypherPlanCache().size()).as("plan cache flushed after CREATE INDEX").isEqualTo(0);
 
     // Re-plan now can use the index; result must still be correct.
+    Thread.sleep(2);
     assertThat(matchRows(Q)).isEqualTo(2L);
     assertThat(database.getCypherPlanCache().size()).isGreaterThan(0);
 
@@ -102,6 +111,52 @@ class CypherPlanCacheInvalidationTest {
     assertThat(database.getCypherPlanCache().size()).as("plan cache flushed after DROP INDEX").isEqualTo(0);
 
     // Result stays correct with the fresh (scan-based) plan.
+    Thread.sleep(2);
     assertThat(matchRows(Q)).isEqualTo(2L);
+  }
+
+  /**
+   * Issue #6671: {@code CypherPlanCache.put()} used to have no invalidation guard at all - unlike the SQL execution
+   * plan cache, which at least attempted (non-atomically) to check {@code getLastInvalidation() < planningStart}
+   * before inserting. A {@code DROP INDEX}/{@code ALTER TYPE}/create-index landing while a Cypher query was being
+   * planned could therefore always be cached right back in, regardless of timing, leaving a {@code NodeIndexSeek}
+   * plan cached against a dropped index. This test reproduces the exact interleaving deterministically (no real
+   * threads): capture {@code planningStart}, invalidate the cache (standing in for the concurrent DDL), then attempt
+   * to cache a plan built at that {@code planningStart} - the fixed, single-lock {@code put(query, plan,
+   * planningStart)} must refuse it.
+   */
+  @Test
+  void planBuiltBeforeAConcurrentInvalidationIsNeverCached() throws InterruptedException {
+    database.transaction(() -> {
+      database.command("cypher", "CREATE (a:Foo {x:1})-[:REL]->(b:Foo {x:2}), (c:Foo {x:1})-[:REL]->(d:Foo {x:2})");
+    });
+
+    // The implicit "Foo" type creation above already invalidated the cache once; sleep past that millisecond
+    // boundary so the warm-up query below is unambiguously planned afterwards (see the comment in
+    // planCacheIsFlushedOnSchemaChange for why put()'s millisecond-timestamped guard needs this).
+    Thread.sleep(2);
+
+    // Warm the cache once to obtain a real, valid PhysicalPlan instance to fight over.
+    assertThat(matchRows(Q)).isEqualTo(2L);
+    assertThat(database.getCypherPlanCache().contains(Q)).isTrue();
+    final PhysicalPlan plan = database.getCypherPlanCache().get(Q);
+    assertThat(plan).isNotNull();
+
+    // Planning "began" here, before the concurrent DDL below invalidates the cache.
+    final long planningStart = System.currentTimeMillis();
+
+    // Stand in for a concurrent DDL landing on another thread while planning was in flight.
+    database.getCypherPlanCache().invalidate();
+    assertThat(database.getCypherPlanCache().contains(Q)).isFalse();
+
+    // The plan was built against planningStart, which is now older than the invalidation: it must be rejected.
+    database.getCypherPlanCache().put(Q, plan, planningStart);
+    assertThat(database.getCypherPlanCache().contains(Q))
+        .as("a plan built before a concurrent invalidation must never be cached").isFalse();
+
+    // A plan whose planning genuinely started after the invalidation must still be cached normally.
+    final long freshPlanningStart = System.currentTimeMillis() + 1;
+    database.getCypherPlanCache().put(Q, plan, freshPlanningStart);
+    assertThat(database.getCypherPlanCache().contains(Q)).as("a plan planned after the invalidation must be cached").isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6665CallSubqueryCountEquivalenceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6665CallSubqueryCountEquivalenceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression guard for issue #6665: on ArcadeDB 26.8.1, a read-only {@code CALL (...) { ... RETURN count(*) }}
+ * subquery reported a different {@code count(*)} depending on whether its inner {@code MATCH}/{@code WHERE}
+ * result flowed straight into {@code RETURN count(*)} or was first materialized through {@code collect()}/
+ * {@code UNWIND} before the same {@code count(*)} - two forms that must be equivalent for a read-only subquery.
+ * <p>
+ * This exact repro (verbatim from the issue) no longer reproduces on this branch: both forms agree with each
+ * other and with a ground-truth standalone count of the same pattern. This test pins that down so a future
+ * regression in CALL-subquery / {@code count(*)} evaluation is caught.
+ */
+class Issue6665CallSubqueryCountEquivalenceTest {
+
+  @Test
+  void directCountAndMaterializedCountAgreeInsideCallSubquery() {
+    final Database database = new DatabaseFactory("./target/databases/issue6665-call-count-equivalence").create();
+    try {
+      database.transaction(() -> database.command("cypher", """
+          CREATE (oa:V {klist: [1167157462, -165975848, -164122097]}),
+                 (ob:V {k10: 254370155}),
+                 (oc:V),
+                 (od:V {k2: "CILs3s"}),
+                 (oe:V {k10: -866288821}),
+                 (n0:V {k7: 1994572697, k2: "D5ZqpQB"}),
+                 (n1:V),
+                 (x:V {k10: -1192051958}),
+                 (y:V {k9: "5sm", id: 85}),
+                 (ob)-[:rt6 {k8: "G", k3: true}]->(oa),
+                 (ob)-[:rt8 {k8: "nPemIkbA", k10: -1906562515}]->(oc),
+                 (od)-[:rt9 {k7: -51638479}]->(oe),
+                 (n1)-[:R]->(x)-[:rt8]->(y)-[:rt2 {k11: [1]}]->(n0)
+          """));
+
+      // Query A: the CALL subquery's inner MATCH/WHERE result flows straight into RETURN count(*).
+      final String queryA = """
+          MATCH DIFFERENT RELATIONSHIPS
+            ({klist: [1167157462, -165975848, -164122097]})
+              <-[r0:rt6 {k8: "G"}]-({k10: 254370155})
+              -[r1:rt8 {k8: "nPemIkbA", k10: -1906562515}]->(),
+            p0 = ({k2: "CILs3s"})-[:rt9 {k7: -51638479}]->({k10: -866288821})
+          WHERE r0.k3 = true
+          CALL (r0, r1, p0) {
+            MATCH (n0 {k7: 1994572697, k2: "D5ZqpQB"}),
+                  (n1)-[r3]->({k10: -1192051958})-[:rt8]->
+                    (:V {k9: "5sm", id: 85})-[r2:rt2|rt10|rt9]->(n0)
+            WHERE single(item IN r2.k11 WHERE item IS NOT NULL)
+            RETURN count(*) AS __expr_count
+          }
+          RETURN __expr_count > 0 AS __v
+          """;
+
+      // Query B: identical, but the matched bindings are first materialized through collect()/UNWIND before the
+      // same count(*) - a read-only subquery must report the same answer either way.
+      final String queryB = """
+          MATCH DIFFERENT RELATIONSHIPS
+            ({klist: [1167157462, -165975848, -164122097]})
+              <-[r0:rt6 {k8: "G"}]-({k10: 254370155})
+              -[r1:rt8 {k8: "nPemIkbA", k10: -1906562515}]->(),
+            p0 = ({k2: "CILs3s"})-[:rt9 {k7: -51638479}]->({k10: -866288821})
+          WHERE r0.k3 = true
+          CALL (r0, r1, p0) {
+            MATCH (n0 {k7: 1994572697, k2: "D5ZqpQB"}),
+                  (n1)-[r3]->({k10: -1192051958})-[:rt8]->
+                    (:V {k9: "5sm", id: 85})-[r2:rt2|rt10|rt9]->(n0)
+            WHERE single(item IN r2.k11 WHERE item IS NOT NULL)
+            WITH {r0: r0, r1: r1, p0: p0, n0: n0, n1: n1, r3: r3, r2: r2} AS __row
+            WITH collect(__row) AS __rows
+            UNWIND __rows AS __layer_row
+            RETURN count(*) AS __expr_count
+          }
+          RETURN __expr_count > 0 AS __v
+          """;
+
+      final Object resultA;
+      try (ResultSet rs = database.query("cypher", queryA)) {
+        assertThat(rs.hasNext()).isTrue();
+        resultA = rs.next().getProperty("__v");
+      }
+      final Object resultB;
+      try (ResultSet rs = database.query("cypher", queryB)) {
+        assertThat(rs.hasNext()).isTrue();
+        resultB = rs.next().getProperty("__v");
+      }
+
+      // Ground truth: the same inner pattern, matched standalone (bound to r0/r1/p0 via WITH instead of CALL) and
+      // counted directly, independent of the CALL-subquery machinery under test.
+      final String groundTruth = """
+          MATCH DIFFERENT RELATIONSHIPS
+            ({klist: [1167157462, -165975848, -164122097]})
+              <-[r0:rt6 {k8: "G"}]-({k10: 254370155})
+              -[r1:rt8 {k8: "nPemIkbA", k10: -1906562515}]->(),
+            p0 = ({k2: "CILs3s"})-[:rt9 {k7: -51638479}]->({k10: -866288821})
+          WHERE r0.k3 = true
+          WITH r0, r1, p0
+          MATCH (n0 {k7: 1994572697, k2: "D5ZqpQB"}),
+                (n1)-[r3]->({k10: -1192051958})-[:rt8]->
+                  (:V {k9: "5sm", id: 85})-[r2:rt2|rt10|rt9]->(n0)
+          WHERE single(item IN r2.k11 WHERE item IS NOT NULL)
+          RETURN count(*) AS c
+          """;
+      final long groundTruthCount;
+      try (ResultSet rs = database.query("cypher", groundTruth)) {
+        assertThat(rs.hasNext()).isTrue();
+        final Result row = rs.next();
+        groundTruthCount = ((Number) row.getProperty("c")).longValue();
+      }
+
+      assertThat(groundTruthCount).as("the inner pattern matches exactly one row").isEqualTo(1L);
+      assertThat(resultA).as("direct count(*)").isEqualTo(true);
+      assertThat(resultB).as("collect()/UNWIND-materialized count(*)").isEqualTo(true);
+      assertThat(resultA).as("direct and materialized count(*) must agree").isEqualTo(resultB);
+    } finally {
+      database.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6665CallSubqueryCountEquivalenceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6665CallSubqueryCountEquivalenceTest.java
@@ -73,7 +73,7 @@ class Issue6665CallSubqueryCountEquivalenceTest {
             WHERE single(item IN r2.k11 WHERE item IS NOT NULL)
             RETURN count(*) AS __expr_count
           }
-          RETURN __expr_count > 0 AS __v
+          RETURN __expr_count AS __v
           """;
 
       // Query B: identical, but the matched bindings are first materialized through collect()/UNWIND before the
@@ -95,18 +95,18 @@ class Issue6665CallSubqueryCountEquivalenceTest {
             UNWIND __rows AS __layer_row
             RETURN count(*) AS __expr_count
           }
-          RETURN __expr_count > 0 AS __v
+          RETURN __expr_count AS __v
           """;
 
-      final Object resultA;
+      final long resultA;
       try (ResultSet rs = database.query("cypher", queryA)) {
         assertThat(rs.hasNext()).isTrue();
-        resultA = rs.next().getProperty("__v");
+        resultA = ((Number) rs.next().getProperty("__v")).longValue();
       }
-      final Object resultB;
+      final long resultB;
       try (ResultSet rs = database.query("cypher", queryB)) {
         assertThat(rs.hasNext()).isTrue();
-        resultB = rs.next().getProperty("__v");
+        resultB = ((Number) rs.next().getProperty("__v")).longValue();
       }
 
       // Ground truth: the same inner pattern, matched standalone (bound to r0/r1/p0 via WITH instead of CALL) and
@@ -133,8 +133,8 @@ class Issue6665CallSubqueryCountEquivalenceTest {
       }
 
       assertThat(groundTruthCount).as("the inner pattern matches exactly one row").isEqualTo(1L);
-      assertThat(resultA).as("direct count(*)").isEqualTo(true);
-      assertThat(resultB).as("collect()/UNWIND-materialized count(*)").isEqualTo(true);
+      assertThat(resultA).as("direct count(*) must match the ground-truth count").isEqualTo(groundTruthCount);
+      assertThat(resultB).as("collect()/UNWIND-materialized count(*) must match the ground-truth count").isEqualTo(groundTruthCount);
       assertThat(resultA).as("direct and materialized count(*) must agree").isEqualTo(resultB);
     } finally {
       database.drop();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6676NumericGroupByEqualityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6676NumericGroupByEqualityTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6676: Cypher {@code GROUP BY} (the implicit grouping {@link
+ * com.arcadedb.query.opencypher.executor.steps.GroupByAggregationStep} performs when a RETURN/WITH clause mixes
+ * aggregations with non-aggregated expressions) keyed its groups on the raw boxed grouping value instead of
+ * canonicalizing numeric types the way its sibling DISTINCT paths do (issue #5789, {@link
+ * com.arcadedb.function.DistinctNumericKey}). A value present as different numeric runtime types (Integer 1 vs Long 1
+ * vs Double 1.0) therefore split into separate groups, even though {@code 1 = 1.0} evaluates to {@code true}.
+ */
+class Issue6676NumericGroupByEqualityTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue6676-numeric-groupby").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void singleKeyGroupByCollapsesNumericallyEqualCrossTypeValues() {
+    try (final ResultSet rs = database.query("opencypher", "UNWIND [1, 1.0, 1] AS x RETURN x, count(*) AS c")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("x")).doubleValue()).isEqualTo(1.0);
+      assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(3L);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void singleKeyGroupByStillSeparatesNumericallyDifferentValues() {
+    try (final ResultSet rs = database.query("opencypher", "UNWIND [1, 1.0, 2] AS x RETURN x, count(*) AS c ORDER BY c DESC")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result first = rs.next();
+      assertThat(((Number) first.getProperty("c")).longValue()).isEqualTo(2L);
+      assertThat(rs.hasNext()).isTrue();
+      final Result second = rs.next();
+      assertThat(((Number) second.getProperty("c")).longValue()).isEqualTo(1L);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void multiKeyGroupByCollapsesNumericallyEqualCrossTypeValues() {
+    try (final ResultSet rs = database.query("opencypher",
+        "UNWIND [[1, 'a'], [1.0, 'a'], [2, 'b']] AS pair RETURN pair[0] AS n, pair[1] AS label, count(*) AS c")) {
+      long total = 0;
+      int rows = 0;
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        total += ((Number) row.getProperty("c")).longValue();
+        rows++;
+      }
+      assertThat(rows).isEqualTo(2); // (1/1.0, 'a') collapses into one group, (2, 'b') is the other
+      assertThat(total).isEqualTo(3);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DistinctExecutionStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DistinctExecutionStepTest.java
@@ -331,6 +331,33 @@ class DistinctExecutionStepTest extends TestHelper {
     result.close();
   }
 
+  /**
+   * Issue #6676: {@code DISTINCT} keyed on the raw boxed property value, so a schemaless/mixed-type column
+   * carrying the same logical number as different Java numeric types (Integer vs Long) split into separate
+   * rows instead of collapsing, unlike SQL GROUP BY (issue #4516) which already canonicalizes.
+   */
+  @Test
+  void shouldCollapseNumericallyEqualCrossTypeValues() {
+    database.getSchema().createDocumentType("MixedNumeric");
+
+    database.transaction(() -> {
+      database.newDocument("MixedNumeric").set("v", 1).save();   // Integer
+      database.newDocument("MixedNumeric").set("v", 1L).save();  // Long
+      database.newDocument("MixedNumeric").set("v", 2).save();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT DISTINCT v FROM MixedNumeric");
+
+    int count = 0;
+    while (result.hasNext()) {
+      result.next();
+      count++;
+    }
+
+    assertThat(count).isEqualTo(2); // 1 (Integer) and 1 (Long) collapse into one row, plus 2
+    result.close();
+  }
+
   @Test
   void shouldHandleDistinctWithNullValues() {
     database.getSchema().createDocumentType("Data");

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SQLExecutorAdditionalCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SQLExecutorAdditionalCoverageTest.java
@@ -357,6 +357,47 @@ class SQLExecutorAdditionalCoverageTest extends TestHelper {
     rs.close();
   }
 
+  /**
+   * Issue #6680: a non-count aggregate (sum/avg/min/max) over an empty input used to return zero rows instead of the
+   * single row with a null/identity value that SQL callers expect (and that count(*) already returns).
+   */
+  @Test
+  void nonCountAggregatesOnEmptyTypeReturnSingleRow() {
+    database.getSchema().createDocumentType("EmptyAggType");
+
+    try (final ResultSet rs = database.query("sql", "SELECT max(x) as m FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result item = rs.next();
+      assertThat(item.<Object>getProperty("m")).isNull();
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT min(x) as m FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("m")).isNull();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT avg(x) as a FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("a")).isNull();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT sum(x) as s FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      // Consistent with a group whose rows are all-null: sum() never sees a non-null value and its identity is 0.
+      assertThat(rs.next().<Number>getProperty("s")).isEqualTo(0);
+    }
+
+    // Mixed with count(*): both aggregates must land in the same synthesized row.
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) as c, max(x) as m FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result item = rs.next();
+      assertThat(item.<Long>getProperty("c")).isEqualTo(0L);
+      assertThat(item.<Object>getProperty("m")).isNull();
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
   // --- EmptyDataGeneratorStep ---
   @Test
   void selectWithoutTarget() {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SQLExecutorAdditionalCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SQLExecutorAdditionalCoverageTest.java
@@ -396,6 +396,16 @@ class SQLExecutorAdditionalCoverageTest extends TestHelper {
       assertThat(item.<Object>getProperty("m")).isNull();
       assertThat(rs.hasNext()).isFalse();
     }
+
+    // A non-aggregate field column mixed with count(*) and no GROUP BY: the field has no group to bind to over an
+    // empty input, so it resolves to null rather than throwing - the synthesized row still carries the aggregate.
+    try (final ResultSet rs = database.query("sql", "SELECT x, count(*) as c FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result item = rs.next();
+      assertThat(item.<Object>getProperty("x")).isNull();
+      assertThat(item.<Long>getProperty("c")).isEqualTo(0L);
+      assertThat(rs.hasNext()).isFalse();
+    }
   }
 
   // --- EmptyDataGeneratorStep ---

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6671ExecutionPlanCacheRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6671ExecutionPlanCacheRaceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6671: {@code ExecutionPlanCache.getLastInvalidation() < planningStart} used to be checked in a separate
+ * lock scope ({@code synchronized(this)}) from the {@code put()} that followed it ({@code synchronized(map)}),
+ * leaving a window in which a concurrent {@code invalidate()} (triggered by a DDL such as {@code DROP INDEX}) could
+ * run between the check and the insert: the check would see "not yet invalidated", the DDL would invalidate and
+ * clear the map, and then the stale plan would be inserted into the freshly-cleared map anyway.
+ * <p>
+ * This test reproduces the race deterministically (no real threads, hence no flakiness) by driving the two
+ * operations - "plan a query" and "invalidate the cache" - in the exact interleaving that used to defeat the
+ * check: capture {@code planningStart}, invalidate the cache (standing in for a concurrent DDL), then attempt to
+ * cache a plan built at that {@code planningStart}. The single-lock, single-call {@code put(statement, plan,
+ * planningStart)} introduced by the fix must refuse to cache it.
+ */
+class Issue6671ExecutionPlanCacheRaceTest {
+  private DatabaseInternal database;
+
+  @BeforeEach
+  void setUp() {
+    database = (DatabaseInternal) new DatabaseFactory("./target/databases/issue6671-execplan-race").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  @Test
+  void planBuiltBeforeAConcurrentInvalidationIsNeverCached() throws InterruptedException {
+    database.getSchema().createDocumentType("Race6671");
+    final String stm = "SELECT FROM Race6671";
+
+    final ExecutionPlanCache cache = database.getExecutionPlanCache();
+    final CommandContext context = new BasicCommandContext().setDatabase(database);
+
+    // put()'s invalidation guard (issue #6671) is millisecond-timestamped: a plan built in the very same
+    // millisecond as a preceding invalidation (here, createDocumentType above) is correctly not cached. Sleeping
+    // past the millisecond boundary before the warm-up query below keeps this assertion deterministic, exactly
+    // like ExecutionPlanCacheTest.cacheInvalidation1 already does for the same reason.
+    Thread.sleep(2);
+
+    // Warm the cache once to obtain a real, valid ExecutionPlan instance to fight over.
+    database.query("sql", stm).close();
+    assertThat(cache.contains(stm)).isTrue();
+    final ExecutionPlan plan = cache.get(stm, context);
+    assertThat(plan).isNotNull();
+
+    // Planning "began" here, before the concurrent DDL below invalidates the cache - exactly the interleaving
+    // that used to slip through the two separately-locked calls.
+    final long planningStart = System.currentTimeMillis();
+
+    // Stand in for a concurrent DDL (e.g. DROP INDEX) landing on another thread while planning was in flight.
+    cache.invalidate();
+    assertThat(cache.contains(stm)).isFalse();
+
+    // The plan was built against planningStart, which is now older than the invalidation: it must be rejected.
+    cache.put(stm, plan, planningStart);
+    assertThat(cache.contains(stm)).as("a plan built before a concurrent invalidation must never be cached").isFalse();
+
+    // A plan whose planning genuinely started after the invalidation must still be cached normally.
+    final long freshPlanningStart = System.currentTimeMillis() + 1;
+    cache.put(stm, plan, freshPlanningStart);
+    assertThat(cache.contains(stm)).as("a plan planned after the invalidation must be cached").isTrue();
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -30,6 +30,7 @@ import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.database.QueryMetricsRecorder;
 import com.arcadedb.exception.ArithmeticErrorException;
 import com.arcadedb.exception.CauseChain;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.ErrorCategory;
@@ -668,7 +669,8 @@ public class PostgresNetworkExecutor extends Thread {
           resultSet = database.command(query.language, query.query, server.getConfiguration());
         }
       }
-      final List<Result> cachedResultSet = browseAndCacheResultSet(resultSet, 0);
+      final List<Result> cachedResultSet = browseAndCacheBoundedResultSet(resultSet,
+          GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.getValueAsInteger());
       profile.addEngineNanos(System.nanoTime() - engineStart);
 
       final long serStart = System.nanoTime();
@@ -764,6 +766,45 @@ public class PostgresNetworkExecutor extends Thread {
             portalSuspendedResponse();
           break;
         }
+      }
+      return cachedResultSet;
+    }
+  }
+
+  /**
+   * Browses and caches a result set for the simple-query ('Q' message) protocol path, refusing (rather than
+   * silently truncating) a result larger than {@code maxRows}.
+   * <p>
+   * Unlike the extended query protocol - where a portal's {@code Execute} message carries its own client-chosen
+   * max-rows and a limit hit is a normal, expected {@code PortalSuspended} the client explicitly asked for by
+   * fetching in batches - the simple-query protocol has no such mechanism: a 'Q' message always means "give me
+   * the complete result", and {@link #browseAndCacheResultSet(ResultSet, int, boolean)}'s silent-truncate-plus-
+   * suspend behaviour would misreport a partial result as the whole answer (a {@code CommandComplete} row count
+   * that undercounts what the query actually matches). This path is also why the whole result had to be held in
+   * memory in the first place: determining the row description (the union of columns and their types across
+   * heterogeneous/schemaless rows) genuinely requires having seen every row before the first one can be sent,
+   * since Postgres's wire protocol fixes the column set in {@code RowDescription}, sent before any {@code
+   * DataRow}. Rather than risk an OutOfMemoryError on an unbounded SELECT (issue #6679), refuse once the result
+   * grows past {@code maxRows} with a clear, actionable error instead: the client should use the extended query
+   * protocol with a bounded portal fetch size for a result set that large.
+   *
+   * @param maxRows the maximum number of rows to buffer, 0 = unlimited (matches {@link GlobalConfiguration#POSTGRES_SIMPLE_QUERY_MAX_ROWS})
+   */
+  private List<Result> browseAndCacheBoundedResultSet(final ResultSet resultSet, final int maxRows) {
+    try (resultSet) {
+      final List<Result> cachedResultSet = new ArrayList<>();
+      while (resultSet.hasNext()) {
+        final Result row = resultSet.next();
+        if (row == null)
+          continue;
+
+        cachedResultSet.add(row);
+
+        if (maxRows > 0 && cachedResultSet.size() > maxRows)
+          throw new CommandExecutionException(
+              "Result set exceeds the configured limit of " + maxRows + " rows for the Postgres simple-query protocol ("
+                  + GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.getKey()
+                  + "); use the extended query protocol with a bounded portal fetch size for large result sets");
       }
       return cachedResultSet;
     }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -773,20 +773,25 @@ public class PostgresNetworkExecutor extends Thread {
 
   /**
    * Browses and caches a result set for the simple-query ('Q' message) protocol path, refusing (rather than
-   * silently truncating) a result larger than {@code maxRows}.
+   * silently truncating) a result larger than {@code maxRows} - and stopping the scan as soon as that is known,
+   * rather than paying to read the rest of an oversized source just to reject it.
    * <p>
    * Unlike the extended query protocol - where a portal's {@code Execute} message carries its own client-chosen
    * max-rows and a limit hit is a normal, expected {@code PortalSuspended} the client explicitly asked for by
    * fetching in batches - the simple-query protocol has no such mechanism: a 'Q' message always means "give me
-   * the complete result", and {@link #browseAndCacheResultSet(ResultSet, int, boolean)}'s silent-truncate-plus-
-   * suspend behaviour would misreport a partial result as the whole answer (a {@code CommandComplete} row count
-   * that undercounts what the query actually matches). This path is also why the whole result had to be held in
-   * memory in the first place: determining the row description (the union of columns and their types across
-   * heterogeneous/schemaless rows) genuinely requires having seen every row before the first one can be sent,
-   * since Postgres's wire protocol fixes the column set in {@code RowDescription}, sent before any {@code
-   * DataRow}. Rather than risk an OutOfMemoryError on an unbounded SELECT (issue #6679), refuse once the result
-   * grows past {@code maxRows} with a clear, actionable error instead: the client should use the extended query
-   * protocol with a bounded portal fetch size for a result set that large.
+   * the complete result". This path is also why the whole result had to be held in memory in the first place:
+   * determining the row description (the union of columns and their types across heterogeneous/schemaless rows)
+   * genuinely requires having seen every row before the first one can be sent, since Postgres's wire protocol
+   * fixes the column set in {@code RowDescription}, sent before any {@code DataRow}.
+   * <p>
+   * Aborting the scan early is safe for a write statement too: {@code UpdateExecutionPlan.executeInternal()} (and
+   * {@code DeleteExecutionPlan}, which extends it) fully executes every matched row's write and buffers the whole
+   * {@code RETURN AFTER}/{@code RETURN BEFORE} result internally <em>before</em> {@code UpdateStatement.execute()}
+   * / {@code DeleteStatement.execute()} ever return a {@link ResultSet} to this method - so by the time this loop
+   * runs, an {@code UPDATE}/{@code DELETE} ... {@code RETURN} statement has already fully applied every write
+   * regardless of how many rows of its result this loop goes on to pull. Stopping early here only shortens how
+   * much of that already-complete result gets copied into {@code cachedResultSet}; it can never leave a write
+   * half-done.
    *
    * @param maxRows the maximum number of rows to buffer, 0 = unlimited (matches {@link GlobalConfiguration#POSTGRES_SIMPLE_QUERY_MAX_ROWS})
    */
@@ -806,6 +811,7 @@ public class PostgresNetworkExecutor extends Thread {
                   + GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.getKey()
                   + "); use the extended query protocol with a bounded portal fetch size for large result sets");
       }
+
       return cachedResultSet;
     }
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression test for issue #6679: the Postgres simple-query ('Q' message) protocol path materialized the
+ * entire result set into an unbounded {@code List<Result>} before sending the first row, so a large {@code
+ * SELECT} risked an {@code OutOfMemoryError}. The simple-query protocol has no client-driven cursor/max-rows
+ * mechanism (unlike the extended protocol's portal {@code Execute}), so buffering could not simply be turned
+ * into a silent {@code PortalSuspended} truncation without misreporting a partial result as the whole answer.
+ * The fix instead bounds the buffer with {@link GlobalConfiguration#POSTGRES_SIMPLE_QUERY_MAX_ROWS} and refuses
+ * a SELECT whose result exceeds it with a clear {@code ErrorResponse}, protecting server memory without
+ * silently returning wrong (truncated) data.
+ * <p>
+ * This test speaks the wire protocol directly over a raw socket (rather than through the JDBC driver) so the
+ * exact byte-level response - an {@code ErrorResponse} versus a normal {@code RowDescription}/{@code DataRow}
+ * stream - can be asserted on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
+  private static final int    ROW_CAP  = 5;
+  private static final String TYPE     = "Issue6679Row";
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.setValue(ROW_CAP);
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.reset();
+    super.endTest();
+  }
+
+  private void createRows(final int count) {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    database.transaction(() -> {
+      if (!database.getSchema().existsType(TYPE))
+        database.getSchema().createDocumentType(TYPE);
+      for (int i = 0; i < count; i++)
+        database.newDocument(TYPE).set("id", i).save();
+    });
+  }
+
+  @Test
+  @DisplayName("[#6679] a simple-query SELECT whose result exceeds the configured cap is refused, not silently truncated")
+  void resultOverTheCapIsRefusedWithAnErrorResponse() throws Exception {
+    createRows(ROW_CAP + 10);
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "SELECT FROM " + TYPE);
+        final List<WireMessage> response = readUntilReadyForQuery(in);
+
+        assertThat(messageTypesOf(response)).as("an ErrorResponse instead of a truncated result").contains('E');
+        assertThat(messageTypesOf(response)).as("no CommandComplete for a refused query").doesNotContain('C');
+        final WireMessage error = response.stream().filter(m -> m.type() == 'E').findFirst()
+            .orElseThrow(() -> new AssertionError("expected an ErrorResponse"));
+        assertThat(errorFields(error).get('M')).contains("exceeds the configured limit").contains(String.valueOf(ROW_CAP));
+
+        // The session must stay usable afterwards: not left aborted/wedged by the refusal.
+        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+      });
+    }
+  }
+
+  @Test
+  @DisplayName("[#6679] a simple-query SELECT within the configured cap still returns every row normally")
+  void resultWithinTheCapIsReturnedInFull() throws Exception {
+    createRows(ROW_CAP - 2);
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "SELECT FROM " + TYPE);
+        final List<WireMessage> response = readUntilReadyForQuery(in);
+
+        assertThat(messageTypesOf(response)).as("no ErrorResponse for a result within the cap").doesNotContain('E');
+        final long dataRows = response.stream().filter(m -> m.type() == 'D').count();
+        assertThat(dataRows).isEqualTo(ROW_CAP - 2);
+        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+      });
+    }
+  }
+
+  private void authenticate(final DataOutputStream out, final DataInputStream in) throws Exception {
+    sendStartupMessage(out, "root", getDatabaseName());
+    readMessage(in); // AuthenticationCleartextPassword
+    sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+    readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+  }
+
+  private static void sendSimpleQuery(final DataOutputStream out, final String query) throws Exception {
+    final byte[] queryBytes = query.getBytes(StandardCharsets.UTF_8);
+    out.writeByte('Q');
+    out.writeInt(4 + queryBytes.length + 1);
+    out.write(queryBytes);
+    out.writeByte(0);
+    out.flush();
+  }
+
+  private record WireMessage(char type, byte[] body) {
+  }
+
+  private static WireMessage readWireMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] body = new byte[length - 4];
+    in.readFully(body);
+    return new WireMessage((char) type, body);
+  }
+
+  private static List<WireMessage> readUntilReadyForQuery(final DataInputStream in) throws Exception {
+    final List<WireMessage> messages = new ArrayList<>();
+    WireMessage message;
+    do {
+      message = readWireMessage(in);
+      messages.add(message);
+    } while (message.type() != 'Z');
+    return messages;
+  }
+
+  private static char readyForQueryStatusOf(final List<WireMessage> messages) {
+    final WireMessage last = messages.get(messages.size() - 1);
+    assertThat(last.type()).isEqualTo('Z');
+    return (char) last.body()[0];
+  }
+
+  private static List<Character> messageTypesOf(final List<WireMessage> messages) {
+    final List<Character> types = new ArrayList<>(messages.size());
+    for (final WireMessage message : messages)
+      types.add(message.type());
+    return types;
+  }
+
+  private static Map<Character, String> errorFields(final WireMessage message) {
+    assertThat(message.type()).isEqualTo('E');
+    final Map<Character, String> fields = new LinkedHashMap<>();
+    final byte[] body = message.body();
+    int i = 0;
+    while (i < body.length && body[i] != 0) {
+      final char code = (char) body[i++];
+      final int start = i;
+      while (body[i] != 0)
+        i++;
+      fields.put(code, new String(body, start, i - start, StandardCharsets.UTF_8));
+      i++; // skip this field's terminator
+    }
+    return fields;
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
@@ -20,6 +20,7 @@ package com.arcadedb.postgres;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -129,6 +130,62 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
         assertThat(dataRows).isEqualTo(ROW_CAP - 2);
         assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
       });
+    }
+  }
+
+  @Test
+  @DisplayName("[#6679] a simple-query SELECT of exactly the configured cap is returned in full")
+  void resultAtTheCapIsReturnedInFull() throws Exception {
+    createRows(ROW_CAP);
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "SELECT FROM " + TYPE);
+        final List<WireMessage> response = readUntilReadyForQuery(in);
+
+        assertThat(messageTypesOf(response)).as("a result of exactly the cap must not be refused").doesNotContain('E');
+        final long dataRows = response.stream().filter(m -> m.type() == 'D').count();
+        assertThat(dataRows).isEqualTo(ROW_CAP);
+        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+      });
+    }
+  }
+
+  /**
+   * The row cap must never leave a write statement partially executed: {@code UPDATE ... RETURN} still updates
+   * every matching row even when its RETURN result exceeds the cap, and only the (now fully-applied) result is
+   * refused.
+   */
+  @Test
+  @DisplayName("[#6679] an UPDATE ... RETURN over the cap still updates every row; only the RETURN result is refused")
+  void updateReturnOverTheCapStillAppliesEveryWrite() throws Exception {
+    createRows(ROW_CAP + 10);
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "UPDATE " + TYPE + " SET touched = true RETURN AFTER");
+        final List<WireMessage> response = readUntilReadyForQuery(in);
+
+        assertThat(messageTypesOf(response)).as("the oversized RETURN result is refused").contains('E');
+        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+      });
+    }
+
+    final Database database = getServerDatabase(0, getDatabaseName());
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM " + TYPE + " WHERE touched = true")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(((Number) rs.next().getProperty("c")).longValue())
+          .as("every matching row must be updated even though the RETURN result was refused").isEqualTo(ROW_CAP + 10);
     }
   }
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
@@ -106,6 +106,14 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
 
         // The session must stay usable afterwards: not left aborted/wedged by the refusal.
         assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+
+        // Prove it, rather than just trusting the status byte: the same socket must still accept and answer a
+        // normal query, not merely report idle while actually closed/wedged.
+        sendSimpleQuery(out, "SELECT 1 AS one");
+        final List<WireMessage> followUp = readUntilReadyForQuery(in);
+        assertThat(messageTypesOf(followUp)).as("a normal query after the refusal must succeed").doesNotContain('E');
+        assertThat(messageTypesOf(followUp)).as("a normal query after the refusal must return its row").contains('D');
+        assertThat(readyForQueryStatusOf(followUp)).isEqualTo('I');
       });
     }
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
@@ -100,6 +100,7 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
 
         assertThat(messageTypesOf(response)).as("an ErrorResponse instead of a truncated result").contains('E');
         assertThat(messageTypesOf(response)).as("no CommandComplete for a refused query").doesNotContain('C');
+        assertThat(messageTypesOf(response)).as("no DataRow for a refused query").doesNotContain('D');
         final WireMessage error = response.stream().filter(m -> m.type() == 'E').findFirst()
             .orElseThrow(() -> new AssertionError("expected an ErrorResponse"));
         assertThat(errorFields(error).get('M')).contains("exceeds the configured limit").contains(String.valueOf(ROW_CAP));


### PR DESCRIPTION
## Summary

Batch of fixes for five issues that came out of prior analysis:

- **#6680** - A non-`count` aggregate (`sum`/`avg`/`min`/`max`) over an empty input returned **zero rows** instead of the single row with a null/identity value SQL callers expect (`count(*)` was already special-cased for this). `GuaranteeEmptyCountStep` is generalized to cover any GROUP-BY-less aggregation, not just `count(*)`.
- **#6679** - The Postgres **simple-query** (`'Q'`) protocol path materialized the entire result set into an unbounded `List<Result>` before sending the first row, risking `OutOfMemoryError` on a large `SELECT`. Unlike the extended protocol's portal `Execute`, the simple-query protocol has no client-driven max-rows mechanism, so silently truncating would misreport a partial result as the whole answer. Added `arcadedb.postgres.simpleQueryMaxRows` (default 1,000,000): a result over the limit is refused with a clear error instead.
- **#6676** - SQL `DISTINCT` and Cypher's implicit `GROUP BY` keyed on the raw boxed value instead of canonicalizing numeric types, so `Integer 1` / `Long 1` / `Double 1.0` split into separate rows/groups despite `1 = 1.0`. Both now canonicalize through the same helpers their sibling paths already use (`Type.normalizeNumberForKey` for SQL, `DistinctNumericKey` for Cypher).
- **#6671** - The SQL execution-plan cache's `getLastInvalidation() < planningStart` check and the subsequent `put()` ran in two separate lock scopes, leaving a window where a concurrent DDL (e.g. `DROP INDEX`) could invalidate the cache between them and still have the stale plan land in the just-cleared map. The Cypher plan cache had no invalidation guard at all. Both caches now check-and-insert atomically under a single lock.
- **#6665** - Investigated: `CALL (...) { ... RETURN count(*) }` reportedly disagreed depending on whether the subquery's rows were materialized through `collect()`/`UNWIND` first. The exact repro from the issue no longer reproduces on this branch - both forms agree with each other and with a ground-truth count. No behavior change; added a regression test pinning down the now-correct equivalence so a future regression is caught.

## Test plan
- [x] New/updated unit tests for each fix (see file list below), all passing
- [x] `Issue6679SimpleQueryMaxRowsIT` - real Postgres wire-protocol integration test (raw socket), both over-cap (ErrorResponse) and within-cap (full result) cases
- [x] Broader regression sweep: SQL executor + Cypher (opencypher) + SQL parser packages (~6945 tests) - no failures attributable to these changes (2 unrelated pre-existing flaky tests confirmed to pass in isolation)
- [x] Postgres wire-protocol regression suite (`PostgresProtocolIT`, `PostgresWJdbcIT`, `Issue6412CatalogIT`, `Issue6457AbortedTransactionSimpleQueryIT`) - 133 tests, all green
- [x] `mvn -o -pl engine,postgresw -am compile` clean

## Files changed
- `engine/src/main/java/com/arcadedb/GlobalConfiguration.java`
- `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java`
- `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupKeyValues.java`
- `engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java`
- `engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java`
- `engine/src/main/java/com/arcadedb/query/sql/executor/DistinctExecutionStep.java`
- `engine/src/main/java/com/arcadedb/query/sql/executor/GuaranteeEmptyCountStep.java`
- `engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java`
- `engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java`
- `postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java`
- Tests: `SQLExecutorAdditionalCoverageTest`, `DistinctExecutionStepTest`, `CypherPlanCacheInvalidationTest`, `Issue6665CallSubqueryCountEquivalenceTest` (new), `Issue6676NumericGroupByEqualityTest` (new), `Issue6671ExecutionPlanCacheRaceTest` (new), `Issue6679SimpleQueryMaxRowsIT` (new)

Closes #6680, #6679, #6676, #6671. Relates to #6665 (no fix needed - see summary).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable row limit for PostgreSQL simple queries, with clear errors for oversized results.
  - Large result sets can be retrieved through extended-query portals.

- **Bug Fixes**
  - Improved numeric consistency for Cypher grouping and SQL `DISTINCT`.
  - Corrected aggregate results for empty datasets.
  - Prevented stale execution plans after schema changes.
  - Improved subquery count handling and connection recovery after rejected queries.

- **Tests**
  - Added regression and integration coverage for query behavior, plan caching, and PostgreSQL row limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->