### PR TITLE
fix(#6482): admit a label-disjunction anchor with a relationship into the openCypher optimizer

### DIFF
--- a/docs/6482-cypher-label-disjunction-anchor-relationship.md
+++ b/docs/6482-cypher-label-disjunction-anchor-relationship.md
@@ -1,0 +1,88 @@
+# Issue #6482: label-disjunction anchor with an incident relationship never reaches the optimizer
+
+## Root cause
+
+`CypherExecutionPlanner.shouldUseOptimizer()` bailed out of the cost-based optimizer for the whole
+statement whenever any node in a path had a label disjunction (`n:A|B`) *and* that path had an
+incident relationship. So `MATCH (n:A|B {id: $x})-[:REL]->(m) RETURN m` always fell straight to the
+legacy execution engine and never got the `NodeByLabelDisjunctionIndexSeek` speedup issue #6397 added
+for the relationship-free case (`MATCH (n:A|B {id: $x}) RETURN n`).
+
+The gate existed because `ExpandAll`/`ExpandInto`/`VarLengthExpand` each carry a single `targetLabel`
+(pushed by `CypherOptimizer.addTargetLabelFilter`, using `targetNode.getFirstLabel()`) and cannot
+represent OR semantics for a node reached over a relationship. That is a real limitation, but it only
+applies to a disjunction on a *non-anchor* node - the anchor itself is seeded by
+`IndexSelectionRule.createAnchorOperator`, which #6397 already taught to build a
+`NodeByLabelDisjunctionScan`/`NodeByLabelDisjunctionIndexSeek` for it, with no `targetLabel` involved at
+all.
+
+## Fix
+
+Two changes, working together:
+
+1. **`CypherExecutionPlanner.shouldUseOptimizer()`**: relaxed the per-node gate so a label-disjunction
+   node with an incident relationship no longer disqualifies the whole statement at the AST level. This
+   gate runs before anchor selection, so it cannot yet know which node a connected component's
+   cost-based anchor selection will land on.
+
+2. **`CypherOptimizer.optimize()`**: added a safety check, `hasUnanchoredLabelDisjunction`, run right
+   after each connected component's anchor is finalized (after `validateAnchorForUnidirectionalEdges`,
+   which can itself re-anchor away from the initially cost-selected node). If any node in that
+   component *other than* the chosen anchor still carries a label disjunction, `optimize()` returns
+   `null` for the whole statement - the same "not representable" signal the method already used for
+   other unsupported shapes - which sends the query back to the legacy pipeline that evaluates every
+   alternative correctly (no silent first-label-only filtering).
+
+This preserves correctness for every shape the optimizer cannot yet represent (disjunction on a
+non-anchor node - single relationship, chain, or variable-length hop) while unlocking the index-seek
+speedup for the common case: a disjunction anchor with an equality predicate, followed by one or more
+relationships to plain-labeled or unlabeled nodes.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java` - relaxed
+  `shouldUseOptimizer()`'s per-node disjunction gate.
+- `engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java` - added
+  `hasUnanchoredLabelDisjunction()` and its call site in the per-component anchor-selection loop.
+- `engine/src/test/java/com/arcadedb/query/opencypher/CypherDisjunctionAnchorWithRelationshipIssue6482Test.java`
+  (new) - regression test.
+
+## Tests
+
+New: `CypherDisjunctionAnchorWithRelationshipIssue6482Test`
+- `disjunctionAnchorWithEqualityPredicateAndRelationshipUsesTheOptimizer` - inline-property equality on
+  a disjunction anchor with a relationship now plans as `NodeByLabelDisjunctionIndexSeek` feeding
+  `ExpandAll`, via the cost-based optimizer.
+- `disjunctionAnchorViaWhereClauseWithRelationshipUsesTheOptimizer` - same, predicate in `WHERE`.
+- `bothAlternativesStillReachTheSameTargetOverTheRelationship` - both disjunction alternatives still
+  return the right row through the relationship.
+- `aValueNoAlternativeHasReturnsNothingEvenWithARelationship` - a value neither alternative has still
+  returns nothing.
+- `disjunctionOnTheExpandedNodeDoesNotUseTheOptimizerButStaysCorrect` - the safety-net direction: a
+  disjunction on the node a relationship expands *into* (not the anchor) is confirmed to skip the
+  optimizer (`doesNotContain("Execution Plan (Cost-Based Optimizer)")`) and still return correct rows
+  via the legacy engine.
+
+Existing regression coverage that pins the correctness of the fallback shape end-to-end (unaffected by
+this change, re-run to confirm no regression):
+`CypherLabelDisjunctionOnExpandedNodeIssue6338Test`, `CypherDisjunctionIndexSeekIssue6397Test`,
+`CypherDisjunctionCardinalityIssue6363Test`, `CypherLabelDisjunctionTest`,
+`CypherRelationshipTypeDisjunctionTest`.
+
+## Verification
+
+- `mvn -pl engine -am compile` - clean.
+- `mvn -pl engine -am test -Dtest=CypherDisjunctionAnchorWithRelationshipIssue6482Test` - 6/6 pass.
+- `mvn -pl engine -am test -Dtest=CypherDisjunctionAnchorWithRelationshipIssue6482Test,CypherLabelDisjunctionOnExpandedNodeIssue6338Test,CypherDisjunctionIndexSeekIssue6397Test,CypherDisjunctionCardinalityIssue6363Test,CypherLabelDisjunctionTest,CypherRelationshipTypeDisjunctionTest`
+  - all pass.
+- `mvn -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**' -DexcludedGroups=benchmark,slow,vector`
+  - BUILD SUCCESS; OpenCypher TCK compliance report: 3812/3897 passed, 0 failed, 85 skipped (same skip
+    count as before this change - unaffected suite).
+
+## Scope note (from the issue)
+
+Purely a missed-optimization / performance fix, not a correctness fix on its own: a disjunction +
+relationship query already returned the right rows via the legacy scan-only path before this change.
+Teaching `ExpandAll`/`ExpandInto` to accept a disjunction target (issue #6482's suggested shape #2,
+covering a disjunction on a *non-anchor* node) remains out of scope and unaddressed - that shape still
+falls back to the legacy engine, correctly, via the new `hasUnanchoredLabelDisjunction` safety check.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -200,6 +200,18 @@ public class CypherOptimizer {
         AnchorSelection componentAnchor = anchorSelector.selectAnchor(logicalPlan, excludedVariables);
         componentAnchor = validateAnchorForUnidirectionalEdges(componentAnchor, logicalPlan,
             component.relationships(), component.variables());
+
+        // Issue #6482: a label-disjunction node only seeds a NodeByLabelDisjunctionScan/IndexSeek when it
+        // IS the anchor. Any other node in this component that still carries a disjunction would be reached
+        // by ExpandAll/ExpandInto/VarLengthExpand, whose single targetLabel (addTargetLabelFilter) can only
+        // filter on the disjunction's first label - silently dropping rows that matched a later alternative.
+        // shouldUseOptimizer() admits the statement without knowing which node the cost-based selection
+        // above would land on, so verify it here, now that the concrete anchor is known, and decline the
+        // whole plan (falling back to the legacy pipeline, which evaluates every alternative correctly)
+        // rather than build an operator tree that would return an incomplete result.
+        if (hasUnanchoredLabelDisjunction(logicalPlan, component.variables(), componentAnchor.getVariable()))
+          return null;
+
         final PhysicalOperator componentAnchorOperator = createAnchorOperator(componentAnchor);
         final ExpansionPlan expansion = buildExpansionChain(logicalPlan, component.relationships(),
             componentAnchor, componentAnchorOperator, needsEdgeTracking, syntheticEdgeVarCounter);
@@ -460,6 +472,32 @@ public class CypherOptimizer {
     });
 
     return typeNames;
+  }
+
+  /**
+   * Returns {@code true} when some node in {@code componentVariables} other than {@code anchorVariable}
+   * carries a label disjunction (issue #6482). Such a node cannot be represented once it is not the
+   * anchor: it is reached by {@code ExpandAll}/{@code ExpandInto}/{@code VarLengthExpand}, and
+   * {@code addTargetLabelFilter} pushes only the disjunction's first label into those operators'
+   * single-label {@code targetLabel} field, which would silently filter out rows that matched a later
+   * alternative instead of raising an error.
+   *
+   * @param logicalPlan        the logical plan (for looking up each variable's {@link LogicalNode})
+   * @param componentVariables every node variable in the connected component the anchor was chosen for
+   * @param anchorVariable     the variable of the anchor {@link #buildExpansionChain} will expand from
+   * @return {@code true} if the plan is unsafe to build as-is and {@link #optimize()} should decline
+   * (return {@code null}) instead, falling back to the legacy pipeline
+   */
+  private boolean hasUnanchoredLabelDisjunction(final LogicalPlan logicalPlan, final Set<String> componentVariables,
+      final String anchorVariable) {
+    for (final String variable : componentVariables) {
+      if (variable.equals(anchorVariable))
+        continue;
+      final LogicalNode node = logicalPlan.getPatternNode(variable);
+      if (node != null && node.isLabelDisjunction() && node.getLabels().size() > 1)
+        return true;
+    }
+    return false;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
@@ -253,16 +253,17 @@ public class CypherExecutionPlanner {
             // Multi-label nodes: conjunction (n:A:B) is unsupported in the optimizer
             // (NodeByLabelScan uses a composite type name that does not match supersets,
             // e.g. A~B~C does not extend A~B). Disjunction (n:A|B) is routed to
-            // NodeByLabelDisjunctionScan, but only when the node has no incident
-            // relationships — ExpandAll/ExpandInto carry a single targetLabel and
-            // cannot represent OR semantics, so target-side disjunction falls back to
-            // the legacy path.
-            if (node.getLabels().size() > 1) {
-              if (!node.isLabelDisjunction())
-                return false;
-              if (path.getRelationshipCount() > 0)
-                return false;
-            }
+            // NodeByLabelDisjunctionScan or NodeByLabelDisjunctionIndexSeek (issue #6397), but only
+            // when the disjunction ends up seeding the pattern - ExpandAll/ExpandInto/VarLengthExpand
+            // carry a single targetLabel and cannot represent OR semantics for a node reached over a
+            // relationship (issue #6482). Which node becomes the anchor is a cost decision made later,
+            // per connected component, so this AST-level gate can only rule out what it already knows is
+            // unrepresentable (a conjunction); it does not yet know which node will anchor its component.
+            // CypherOptimizer#optimize() re-checks every disjunction node once the concrete anchor is
+            // chosen and declines (returns null, falling back to this same legacy path) whenever a
+            // disjunction landed on a non-anchor node instead.
+            if (node.getLabels().size() > 1 && !node.isLabelDisjunction())
+              return false;
 
             // An inline property map is an equality predicate, and LogicalPlan lowers it into one, so
             // the optimizer plans it exactly like the same comparison written in WHERE. Two shapes

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherDisjunctionAnchorWithRelationshipIssue6482Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherDisjunctionAnchorWithRelationshipIssue6482Test.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6482: a label-disjunction anchor with an incident relationship
+ * ({@code MATCH (n:A|B {id: $x})-[:REL]->(m) RETURN m}) used to bail out of the cost-based optimizer
+ * for the whole statement - {@code CypherExecutionPlanner.shouldUseOptimizer()} refused any path where a
+ * disjunction node had a relationship, even though the disjunction sits on the anchor and only the
+ * anchor is served by {@code NodeByLabelDisjunctionScan}/{@code NodeByLabelDisjunctionIndexSeek} (issue
+ * #6397). The query still returned correct rows through the legacy engine, just without the index-seek
+ * speedup.
+ * <p>
+ * Also pins the safety net this fix adds: when the disjunction is NOT on the anchor - it sits on a node
+ * reached by a relationship instead - the optimizer must still decline (fall back to the legacy engine)
+ * rather than build an {@code ExpandAll}/{@code ExpandInto} that can only filter on the disjunction's
+ * first label. {@link CypherLabelDisjunctionOnExpandedNodeIssue6338Test} already pins the end-to-end
+ * correctness of that shape; the assertions here additionally confirm those queries are not silently
+ * routed through the optimizer now that the AST-level gate has been relaxed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherDisjunctionAnchorWithRelationshipIssue6482Test extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      final var typeA = database.getSchema().createVertexType("Alpha6482");
+      typeA.createProperty("id", String.class);
+      typeA.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+
+      final var typeB = database.getSchema().createVertexType("Bravo6482");
+      typeB.createProperty("id", String.class);
+      typeB.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+
+      database.getSchema().createVertexType("Target6482");
+      database.getSchema().createEdgeType("LINKS6482");
+    });
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Alpha6482 {id: 'a1'})");
+      database.command("opencypher", "CREATE (:Bravo6482 {id: 'b1'})");
+      database.command("opencypher", "CREATE (:Target6482 {id: 't1'})");
+      database.command("opencypher",
+          "MATCH (n:Alpha6482 {id: 'a1'}), (m:Target6482 {id: 't1'}) CREATE (n)-[:LINKS6482]->(m)");
+      database.command("opencypher",
+          "MATCH (n:Bravo6482 {id: 'b1'}), (m:Target6482 {id: 't1'}) CREATE (n)-[:LINKS6482]->(m)");
+    });
+  }
+
+  @Test
+  void disjunctionAnchorWithEqualityPredicateAndRelationshipUsesTheOptimizer() {
+    final String query = "MATCH (n:Alpha6482|Bravo6482 {id: 'a1'})-[:LINKS6482]->(m:Target6482) RETURN m.id AS k";
+    final String plan = profilePlan(query);
+    assertThat(plan).as("plan\n%s", plan)
+        .contains("Execution Plan (Cost-Based Optimizer)")
+        .contains("NodeByLabelDisjunctionIndexSeek");
+
+    assertThat(ids(query)).containsExactly("t1");
+  }
+
+  @Test
+  void disjunctionAnchorViaWhereClauseWithRelationshipUsesTheOptimizer() {
+    final String query = "MATCH (n:Alpha6482|Bravo6482)-[:LINKS6482]->(m:Target6482) WHERE n.id = 'b1' RETURN m.id AS k";
+    final String plan = profilePlan(query);
+    assertThat(plan).as("plan\n%s", plan)
+        .contains("Execution Plan (Cost-Based Optimizer)")
+        .contains("NodeByLabelDisjunctionIndexSeek");
+
+    assertThat(ids(query)).containsExactly("t1");
+  }
+
+  @Test
+  void bothAlternativesStillReachTheSameTargetOverTheRelationship() {
+    assertThat(ids("MATCH (n:Alpha6482|Bravo6482 {id: 'a1'})-[:LINKS6482]->(m:Target6482) RETURN m.id AS k"))
+        .containsExactly("t1");
+    assertThat(ids("MATCH (n:Alpha6482|Bravo6482 {id: 'b1'})-[:LINKS6482]->(m:Target6482) RETURN m.id AS k"))
+        .containsExactly("t1");
+  }
+
+  @Test
+  void aValueNoAlternativeHasReturnsNothingEvenWithARelationship() {
+    assertThat(ids("MATCH (n:Alpha6482|Bravo6482 {id: 'nope'})-[:LINKS6482]->(m:Target6482) RETURN m.id AS k"))
+        .isEmpty();
+  }
+
+  /**
+   * The disjunction sits on the node a relationship expands INTO, not on the anchor. This is the shape
+   * {@link CypherLabelDisjunctionOnExpandedNodeIssue6338Test} already pins end-to-end; this assertion
+   * additionally confirms the optimizer declines it (falls back to the legacy engine) instead of silently
+   * filtering on only the disjunction's first label via {@code addTargetLabelFilter}.
+   */
+  @Test
+  void disjunctionOnTheExpandedNodeDoesNotUseTheOptimizerButStaysCorrect() {
+    final String query = "MATCH (m:Target6482)<-[:LINKS6482]-(n:Alpha6482|Bravo6482) RETURN n.id AS k ORDER BY k";
+    final String plan = profilePlan(query);
+    assertThat(plan).as("plan\n%s", plan).doesNotContain("Execution Plan (Cost-Based Optimizer)");
+
+    assertThat(ids(query)).containsExactly("a1", "b1");
+  }
+
+  private List<String> ids(final String cypher) {
+    final List<String> result = new ArrayList<>();
+    database.transaction(() -> {
+      final ResultSet rs = database.query("opencypher", cypher);
+      while (rs.hasNext())
+        result.add(rs.next().getProperty("k"));
+      rs.close();
+    });
+    return result;
+  }
+
+  private String profilePlan(final String cypher) {
+    final StringBuilder plan = new StringBuilder();
+    database.transaction(() -> {
+      final ResultSet rs = database.command("opencypher", "PROFILE " + cypher);
+      while (rs.hasNext())
+        rs.next();
+      plan.append(rs.getExecutionPlan().orElseThrow().prettyPrint(0, 2));
+      rs.close();
+    });
+    return plan.toString();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Admits a label-disjunction anchor with an incident relationship (`MATCH (n:A|B {id: $x})-[:REL]->(m) RETURN m`)
into the openCypher cost-based optimizer, so it can get the `NodeByLabelDisjunctionIndexSeek` speedup issue
#6397 already unlocked for the relationship-free shape (`MATCH (n:A|B {id: $x}) RETURN n`).

`CypherExecutionPlanner.shouldUseOptimizer()` previously bailed out of the optimizer for the **whole
statement** whenever any node in a path had a label disjunction *and* that path had an incident
relationship - even when the disjunction sat on the pattern's anchor, which never goes through
`ExpandAll`/`ExpandInto`/`VarLengthExpand` at all.

Two changes:

1. **`CypherExecutionPlanner.shouldUseOptimizer()`**: relaxed the per-node gate so a disjunction node
   with a relationship no longer disqualifies the statement at the AST level. This runs before anchor
   selection, so it can't yet know which node a component's cost-based anchor selection will land on.
2. **`CypherOptimizer.optimize()`**: added `hasUnanchoredLabelDisjunction()`, run right after each
   connected component's anchor is finalized (after `validateAnchorForUnidirectionalEdges`, which can
   itself re-anchor). If any node in that component *other than* the chosen anchor still carries a
   label disjunction, `optimize()` returns `null` - the plan falls back to the legacy pipeline, which
   evaluates every alternative correctly. This is the correctness guard: without it, a disjunction that
   lost the cost-based anchor tournament would be reached by `ExpandAll`/`ExpandInto`, whose single
   `targetLabel` (`addTargetLabelFilter`) only filters on the disjunction's *first* label, silently
   dropping rows that matched a later alternative.

## Motivation

Follow-up to #6397, found in that PR's review (see #6482). `MATCH (n:A|B {id: $x})-[:REL]->(m)` is
arguably the more common real-world shape for a disjunction anchor than a bare `RETURN n` with no
relationships, so this closes a real gap in when the index-seek speedup applies.

## Related issues

Closes #6482

Follow-up to #6397 (PR #6480).

## Additional Notes

Purely a missed-optimization / performance fix, not a correctness fix on its own - a disjunction +
relationship query already returned the right rows via the legacy scan-only path before this change.
The issue's suggested shape #2 (teaching `ExpandAll`/`ExpandInto` to accept a disjunction *target*,
covering a disjunction on a non-anchor node) remains explicitly out of scope; that shape now falls back
to the legacy engine correctly via the new safety check, exercised by
`disjunctionOnTheExpandedNodeDoesNotUseTheOptimizerButStaysCorrect` in the new test, and pinned
end-to-end by the pre-existing `CypherLabelDisjunctionOnExpandedNodeIssue6338Test`.

## Test plan

- [x] New regression test `CypherDisjunctionAnchorWithRelationshipIssue6482Test` (6 cases): disjunction
      anchor + relationship now uses `NodeByLabelDisjunctionIndexSeek` via the cost-based optimizer
      (inline property and `WHERE`-clause forms), both alternatives still reach the right target row, a
      value neither alternative has still returns nothing, and the safety-net direction - a disjunction
      on the node a relationship expands *into* - is confirmed to skip the optimizer and stay correct.
- [x] `mvn -pl engine -am test -Dtest=CypherDisjunctionAnchorWithRelationshipIssue6482Test` - 6/6 pass.
- [x] Existing related regression suites re-run clean:
      `CypherLabelDisjunctionOnExpandedNodeIssue6338Test`, `CypherDisjunctionIndexSeekIssue6397Test`,
      `CypherDisjunctionCardinalityIssue6363Test`, `CypherLabelDisjunctionTest`,
      `CypherRelationshipTypeDisjunctionTest`.
- [x] `mvn -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**' -DexcludedGroups=benchmark,slow,vector`
      (includes the full openCypher TCK suite) - BUILD SUCCESS, 3812/3897 scenarios passed, 0 failed, 85
      skipped (same skip count as before this change).

## Checklist

- [x] I have run the build using `mvn clean package` command (targeted `mvn -pl engine -am compile`/`test`; see test plan)
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cypher query planning for label-disjunction queries involving relationships.
  * Enabled optimized index-based execution when the disjunction is on the anchor node.
  * Preserved correct fallback behavior for unsupported query shapes.
  * Improved result handling for matching, non-matching, and relationship-expanded label alternatives.

* **Tests**
  * Added regression coverage for optimized execution and legacy fallback scenarios.

* **Documentation**
  * Documented the query-planning issue, supported cases, verification results, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->