### PR TITLE
fix(#6469): correct Type.convert Date->ZonedDateTime/Instant target class and add missing Number branches

### DIFF
--- a/docs/6469-datetype-convert-date-instant-zoneddatetime.md
+++ b/docs/6469-datetype-convert-date-instant-zoneddatetime.md
@@ -1,0 +1,75 @@
+# Issue #6469: Type.convert Date -> ZonedDateTime/Instant copy-paste bug, missing Number branch
+
+## Root cause
+
+`com.arcadedb.schema.Type.convert()` has one branch per configured `DATE_TIME_IMPLEMENTATION` target class
+(`LocalDateTime`, `ZonedDateTime`, `Instant`). The `ZonedDateTime` and `Instant` branches' `java.util.Date` arm
+each passed the wrong target class to `DateUtils.dateTime(...)`:
+
+- `ZonedDateTime` target's `Date` arm passed `LocalDateTime.class` instead of `ZonedDateTime.class`.
+- `Instant` target's `Date` arm passed `LocalDateTime.class` instead of `Instant.class`.
+
+Both `Calendar` arms right below them already used the correct target class, confirming the copy-paste-slip
+diagnosis in the issue. Neither the `ZonedDateTime` nor the `Instant` target had a `Number` branch at all
+(the `LocalDateTime` target does), so an epoch-millis `Number` set on such a property fell through `convert`
+unconverted.
+
+## Affected component
+
+`engine/src/main/java/com/arcadedb/schema/Type.java`, the `convert()` method's `ZonedDateTime.class` and
+`Instant.class` target branches.
+
+## Expected vs actual behavior
+
+- Expected: converting a `java.util.Date` into a `ZonedDateTime`-backed (or `Instant`-backed) DATETIME
+  property returns a value of that runtime type, and a `Number` (epoch millis) converts the same way a
+  `Date`/`Calendar` does.
+- Actual (before fix): the `Date` conversion returned a `LocalDateTime` instance regardless of the configured
+  target class, breaking `instanceof`/`equals` checks against the configured type. A `Number` value fell
+  through `convert` unconverted for both targets.
+
+## Fix
+
+In both branches, added a `Number` arm (mirroring the `LocalDateTime` target's `Number` handling, routed
+through `DateUtils.dateTime(..., ChronoUnit.MILLIS, <target>, ...)` to match how the existing `Date`/`Calendar`
+arms already treat their input as epoch millis) and corrected the `Date` arm's target class:
+
+- `ZonedDateTime` target: `Date` arm now passes `ZonedDateTime.class`; added `Number` arm.
+- `Instant` target: `Date` arm now passes `Instant.class`; added `Number` arm.
+
+## Tests added (TDD)
+
+`engine/src/test/java/com/arcadedb/schema/TypeTest.java` - added 4 new regression tests (existing tests were
+not modified, per project constraints):
+
+- `convertToZonedDateTimeFromDateReturnsZonedDateTime` - asserts the result `isInstanceOf(ZonedDateTime.class)`
+  and that the instant is preserved.
+- `convertToZonedDateTimeFromNumber` - asserts a `Number` (epoch millis) converts to a `ZonedDateTime` with
+  the same instant.
+- `convertToInstantFromDateReturnsInstant` - asserts the result `isInstanceOf(Instant.class)` and that the
+  instant is preserved.
+- `convertToInstantFromNumber` - asserts a `Number` (epoch millis) converts to an `Instant` with the same
+  instant.
+
+All 4 tests were confirmed to fail against the pre-fix code (proving the bug), then confirmed to pass after
+the fix.
+
+## Test results
+
+- `TypeTest`: 127/127 passed (including the 4 new regression tests).
+- `DateUtilsTest`: 15/15 passed.
+- `OffsetDateTimeStorageTest`: 2/2 passed.
+- `TypeConversionTest`: 12/12 passed.
+- `JsonSerializerTest`: 15/15 passed.
+- Full `com.arcadedb.schema.**` + `com.arcadedb.utility.**` packages: 859/859 passed.
+
+No regressions found.
+
+## Impact analysis
+
+Low-medium severity, as noted in the issue: the underlying instant was always preserved (both the buggy and
+fixed paths compute UTC millis identically), so this was an in-memory type-inconsistency bug, not an on-disk
+data-loss bug - after persist and reload the value re-materializes with the correct configured type regardless
+of this fix. It only affects installations that explicitly configure `DATE_TIME_IMPLEMENTATION` to
+`ZonedDateTime` or `Instant` (the default is `java.util.Date`), and only the in-memory value between a
+`java.util.Date`/`Number` being set and the record being flushed/reloaded.

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -716,8 +716,11 @@ public enum Type {
         if (value instanceof ZonedDateTime time) {
           if (property != null)
             return time.truncatedTo(DateUtils.getPrecisionFromType(property.getType()));
-        } else if (value instanceof Date date)
-          return DateUtils.dateTime(database, date.getTime(), ChronoUnit.MILLIS, LocalDateTime.class,
+        } else if (value instanceof Number number)
+          return DateUtils.dateTime(database, number.longValue(), ChronoUnit.MILLIS, ZonedDateTime.class,
+              property != null ? DateUtils.getPrecisionFromType(property.getType()) : ChronoUnit.MILLIS);
+        else if (value instanceof Date date)
+          return DateUtils.dateTime(database, date.getTime(), ChronoUnit.MILLIS, ZonedDateTime.class,
               property != null ? DateUtils.getPrecisionFromType(property.getType()) : ChronoUnit.MILLIS);
         else if (value instanceof Calendar calendar)
           return DateUtils.dateTime(database, calendar.getTimeInMillis(), ChronoUnit.MILLIS, ZonedDateTime.class,
@@ -747,8 +750,12 @@ public enum Type {
           if (property != null)
             return instant.truncatedTo(DateUtils.getPrecisionFromType(property.getType()));
         }
+        case Number number -> {
+          return DateUtils.dateTime(database, number.longValue(), ChronoUnit.MILLIS, Instant.class,
+              property != null ? DateUtils.getPrecisionFromType(property.getType()) : ChronoUnit.MILLIS);
+        }
         case Date date -> {
-          return DateUtils.dateTime(database, date.getTime(), ChronoUnit.MILLIS, LocalDateTime.class,
+          return DateUtils.dateTime(database, date.getTime(), ChronoUnit.MILLIS, Instant.class,
               property != null ? DateUtils.getPrecisionFromType(property.getType()) : ChronoUnit.MILLIS);
         }
         case Calendar calendar -> {

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -914,6 +914,58 @@ class TypeTest extends TestHelper {
     assertThat(result).isNotNull();
   }
 
+  /**
+   * Issue #6469: with the datetime implementation configured as {@code ZonedDateTime}, converting a
+   * {@code java.util.Date} used to return a {@code LocalDateTime} (a copy-paste slip: the {@code Date} arm passed
+   * {@code LocalDateTime.class} instead of {@code ZonedDateTime.class}, unlike the {@code Calendar} arm right below
+   * it which already used the correct target). The underlying instant was preserved, but the runtime type was wrong,
+   * which broke {@code instanceof ZonedDateTime} and {@code equals()} against a {@code ZonedDateTime}.
+   */
+  @Test
+  void convertToZonedDateTimeFromDateReturnsZonedDateTime() {
+    final Date now = new Date();
+    final Object result = Type.convert(database, now, ZonedDateTime.class);
+    assertThat(result).isInstanceOf(ZonedDateTime.class);
+    assertThat(((ZonedDateTime) result).toInstant().toEpochMilli()).isEqualTo(now.getTime());
+  }
+
+  /**
+   * Issue #6469: the {@code ZonedDateTime} target had no {@code Number} branch at all (unlike the
+   * {@code LocalDateTime} target), so an epoch-millis {@code Number} set on such a property fell through
+   * {@code convert} unconverted instead of becoming a {@code ZonedDateTime}.
+   */
+  @Test
+  void convertToZonedDateTimeFromNumber() {
+    final long epochMillis = 1_700_000_000_123L;
+    final Object result = Type.convert(database, epochMillis, ZonedDateTime.class);
+    assertThat(result).isInstanceOf(ZonedDateTime.class);
+    assertThat(((ZonedDateTime) result).toInstant().toEpochMilli()).isEqualTo(epochMillis);
+  }
+
+  /**
+   * Issue #6469: same copy-paste slip as {@link #convertToZonedDateTimeFromDateReturnsZonedDateTime()}, but for the
+   * {@code Instant} target - the {@code Date} arm returned a {@code LocalDateTime} instead of an {@code Instant}.
+   */
+  @Test
+  void convertToInstantFromDateReturnsInstant() {
+    final Date now = new Date();
+    final Object result = Type.convert(database, now, Instant.class);
+    assertThat(result).isInstanceOf(Instant.class);
+    assertThat(((Instant) result).toEpochMilli()).isEqualTo(now.getTime());
+  }
+
+  /**
+   * Issue #6469: the {@code Instant} target had no {@code Number} branch at all, matching the missing branch on the
+   * {@code ZonedDateTime} target.
+   */
+  @Test
+  void convertToInstantFromNumber() {
+    final long epochMillis = 1_700_000_000_123L;
+    final Object result = Type.convert(database, epochMillis, Instant.class);
+    assertThat(result).isInstanceOf(Instant.class);
+    assertThat(((Instant) result).toEpochMilli()).isEqualTo(epochMillis);
+  }
+
   @Test
   void convertToRIDFromString() {
     database.transaction(() -> {


### PR DESCRIPTION
## What does this PR do?

Fixes a copy-paste bug in `Type.convert()` for the `ZonedDateTime`- and `Instant`-backed DATETIME
implementations, and adds the missing `Number` (epoch millis) conversion branch to both.

Converting a `java.util.Date` into a `ZonedDateTime`-backed or `Instant`-backed DATETIME property returned a
`LocalDateTime` instance instead of the configured type: the `Date` arm of each target branch passed
`LocalDateTime.class` to `DateUtils.dateTime(...)` instead of the correct target class, while the `Calendar`
arm right below it already used the correct one. Neither target had a `Number` branch at all (unlike the
`LocalDateTime` target), so an epoch-millis `Number` set on such a property fell through `convert`
unconverted.

Closes #6469

## Motivation

Reported in #6469: with `DATE_TIME_IMPLEMENTATION=ZonedDateTime`, `doc.set("ts", new java.util.Date(...))`
followed by `doc.get("ts")` returned a `LocalDateTime`, so `instanceof ZonedDateTime` and `equals()` against
a `ZonedDateTime` failed. The underlying instant was preserved (both paths compute UTC millis identically),
and after persist+reload the value re-materializes with the correct type, so this was an in-memory type
inconsistency, not on-disk data loss. Only databases explicitly configured with `ZonedDateTime`/`Instant` as
the datetime implementation are affected (the default is `java.util.Date`).

## Related issues

Closes #6469

## Additional Notes

### Fix

- `ZonedDateTime` target: `Date` arm now passes `ZonedDateTime.class` (was `LocalDateTime.class`); added a
  `Number` arm routed through `DateUtils.dateTime(..., ChronoUnit.MILLIS, ZonedDateTime.class, ...)`, matching
  how the existing `Date`/`Calendar` arms already treat their input as epoch millis.
- `Instant` target: `Date` arm now passes `Instant.class` (was `LocalDateTime.class`); added a `Number` arm
  the same way.

### Tests (TDD)

Added 4 new regression tests to `engine/src/test/java/com/arcadedb/schema/TypeTest.java` (existing tests were
not modified, per project convention):

- `convertToZonedDateTimeFromDateReturnsZonedDateTime` - asserts the result `isInstanceOf(ZonedDateTime.class)`
  and that the instant is preserved.
- `convertToZonedDateTimeFromNumber` - asserts a `Number` (epoch millis) converts to a `ZonedDateTime` with
  the same instant.
- `convertToInstantFromDateReturnsInstant` - asserts the result `isInstanceOf(Instant.class)` and that the
  instant is preserved.
- `convertToInstantFromNumber` - asserts a `Number` (epoch millis) converts to an `Instant` with the same
  instant.

All 4 tests were confirmed to fail against the pre-fix code (proving the bug), then confirmed to pass after
the fix.

### Test results

- `TypeTest`: 127/127 passed (including the 4 new regression tests).
- `DateUtilsTest`: 15/15 passed.
- `OffsetDateTimeStorageTest`: 2/2 passed.
- `TypeConversionTest`: 12/12 passed.
- `JsonSerializerTest`: 15/15 passed.
- Full `com.arcadedb.schema.**` + `com.arcadedb.utility.**` packages: 859/859 passed.

No regressions found.

## Test plan

- [x] `mvn -pl engine -am test -Dtest=TypeTest` - 127/127 pass, including the 4 new regression tests that
      fail on the pre-fix code and pass after the fix.
- [x] `mvn -pl engine -am test -Dtest=DateUtilsTest,OffsetDateTimeStorageTest,TypeConversionTest,JsonSerializerTest`
      - all pass.
- [x] `mvn -pl engine -am test -Dtest='com.arcadedb.schema.**,com.arcadedb.utility.**'` - 859/859 pass, no
      regressions.
- [x] `mvn -pl engine -am compile` - clean compile.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected conversions from dates and epoch-millisecond values to `ZonedDateTime` and `Instant`.
  * Preserved millisecond precision during date/time conversions.

* **Documentation**
  * Added documentation describing the conversion issue, fixes, regression coverage, and impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->