### PR TITLE
fix(#6674, #6675, #6423): Postgres text NULL boolean, TIMESTAMP-as-Date, and key=value truncation

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -45,6 +45,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.AnsiCode;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.RecordTableFormatter;
+import com.arcadedb.utility.StringUtils;
 import com.arcadedb.utility.TableFormatter;
 import org.jline.reader.Completer;
 import org.jline.reader.EndOfFileException;
@@ -1188,17 +1189,13 @@ public class Console {
   }
 
   /**
-   * Splits a `&lt;key&gt;=&lt;value&gt;` pair on the FIRST '=' only, so a value that contains further separators (a connection
-   * string, a base64 padding, a date pattern) is kept whole and an empty value is a value, not a missing one. Returns null when
-   * there is no separator at all, leaving to the caller the choice between rejecting the input and reading it as an empty value.
-   * Shared by the `-D&lt;key&gt;=&lt;value&gt;` arguments (issue #5928) and by the SET command (issue #6392), which used to
-   * disagree on the rule.
+   * Splits a `&lt;key&gt;=&lt;value&gt;` pair on the FIRST '=' only. Shared by the `-D&lt;key&gt;=&lt;value&gt;`
+   * arguments (issue #5928) and by the SET command (issue #6392), which used to disagree on the rule; delegates to
+   * {@link StringUtils#splitKeyValue} so the Postgres wire's SET command and the Studio include directive
+   * (issue #6423) follow the same rule instead of each carrying their own truncating copy.
    */
   static String[] splitKeyValue(final String pair) {
-    final int separatorPos = pair.indexOf('=');
-    if (separatorPos < 0)
-      return null;
-    return new String[] { pair.substring(0, separatorPos), pair.substring(separatorPos + 1) };
+    return StringUtils.splitKeyValue(pair);
   }
 
   private static boolean setGlobalConfiguration(final String key, final String value, final boolean printError) {

--- a/engine/src/main/java/com/arcadedb/utility/StringUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/StringUtils.java
@@ -37,18 +37,6 @@ public class StringUtils {
   }
 
   /**
-   * Case-insensitive {@code contains} that allocates nothing.
-   * <p>
-   * The obvious form, {@code haystack.toUpperCase().contains(needle)}, copies the whole haystack to answer a question
-   * about a needle a dozen characters long - which is why every caller of this had written its own copy rather than
-   * use it: the async DDL classifier scanning a whole script, the Cypher parser deciding on its own parse hot path,
-   * the HTTP handler looking for a LIMIT in a command, and the MCP prompt fence looking for its own delimiter. Four
-   * private copies of six lines, and this is the one they share.
-   *
-   * @return true when {@code needle} occurs anywhere in {@code haystack}, ignoring case. An empty needle is contained
-   *     by everything, as {@code String.contains} has it.
-   */
-  /**
    * Splits a {@code <key>=<value>} pair on the FIRST '=' only, so a value that contains further separators (a
    * connection string, a base64 padding, a date pattern) is kept whole and an empty value is a value, not a missing
    * one. Returns null when there is no separator at all, leaving to the caller the choice between rejecting the
@@ -65,6 +53,18 @@ public class StringUtils {
     return new String[] { pair.substring(0, separatorPos), pair.substring(separatorPos + 1) };
   }
 
+  /**
+   * Case-insensitive {@code contains} that allocates nothing.
+   * <p>
+   * The obvious form, {@code haystack.toUpperCase().contains(needle)}, copies the whole haystack to answer a question
+   * about a needle a dozen characters long - which is why every caller of this had written its own copy rather than
+   * use it: the async DDL classifier scanning a whole script, the Cypher parser deciding on its own parse hot path,
+   * the HTTP handler looking for a LIMIT in a command, and the MCP prompt fence looking for its own delimiter. Four
+   * private copies of six lines, and this is the one they share.
+   *
+   * @return true when {@code needle} occurs anywhere in {@code haystack}, ignoring case. An empty needle is contained
+   *     by everything, as {@code String.contains} has it.
+   */
   public static boolean containsIgnoreCase(final String haystack, final String needle) {
     final int needleLength = needle.length();
     if (needleLength == 0)

--- a/engine/src/main/java/com/arcadedb/utility/StringUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/StringUtils.java
@@ -48,6 +48,23 @@ public class StringUtils {
    * @return true when {@code needle} occurs anywhere in {@code haystack}, ignoring case. An empty needle is contained
    *     by everything, as {@code String.contains} has it.
    */
+  /**
+   * Splits a {@code <key>=<value>} pair on the FIRST '=' only, so a value that contains further separators (a
+   * connection string, a base64 padding, a date pattern) is kept whole and an empty value is a value, not a missing
+   * one. Returns null when there is no separator at all, leaving to the caller the choice between rejecting the
+   * input and reading it as an empty value.
+   * <p>
+   * Shared by the console's {@code -D<key>=<value>} arguments and {@code SET} command (issue #6392), the Postgres
+   * wire's {@code SET} command, and the Studio include directive's parameters (issue #6423), which used to each
+   * carry their own {@code split("=")} that truncated a value containing a further '='.
+   */
+  public static String[] splitKeyValue(final String pair) {
+    final int separatorPos = pair.indexOf('=');
+    if (separatorPos < 0)
+      return null;
+    return new String[] { pair.substring(0, separatorPos), pair.substring(separatorPos + 1) };
+  }
+
   public static boolean containsIgnoreCase(final String haystack, final String needle) {
     final int needleLength = needle.length();
     if (needleLength == 0)

--- a/engine/src/test/java/com/arcadedb/utility/StringUtilsSplitKeyValueTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/StringUtilsSplitKeyValueTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the contract of {@link StringUtils#splitKeyValue(String)}: split on the FIRST '=' only, so a value
+ * containing further separators (a connection string, a base64 padding) is kept whole. The console's
+ * {@code -D&lt;key&gt;=&lt;value&gt;} arguments and SET command (issue #6392), the Postgres wire's SET command,
+ * and the Studio include directive's parameters (issue #6423) all share this one rule instead of each carrying
+ * its own truncating {@code split("=")}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class StringUtilsSplitKeyValueTest {
+  @Test
+  void theValueIsEverythingAfterTheFirstSeparator() {
+    assertThat(StringUtils.splitKeyValue("a=b")).containsExactly("a", "b");
+    assertThat(StringUtils.splitKeyValue("a=b=c")).containsExactly("a", "b=c");
+    assertThat(StringUtils.splitKeyValue("a===")).containsExactly("a", "==");
+  }
+
+  @Test
+  void anEmptyValueIsAValue() {
+    assertThat(StringUtils.splitKeyValue("a=")).containsExactly("a", "");
+  }
+
+  @Test
+  void anEmptyKeyIsReturnedAsSuchForTheCallerToReject() {
+    assertThat(StringUtils.splitKeyValue("=b")).containsExactly("", "b");
+    assertThat(StringUtils.splitKeyValue("=")).containsExactly("", "");
+  }
+
+  @Test
+  void noSeparatorLeavesTheChoiceToTheCaller() {
+    assertThat(StringUtils.splitKeyValue("a")).isNull();
+    assertThat(StringUtils.splitKeyValue("")).isNull();
+  }
+
+  @Test
+  void surroundingBlanksArePreserved() {
+    assertThat(StringUtils.splitKeyValue(" a = b ")).containsExactly(" a ", " b ");
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2050,24 +2050,33 @@ public class PostgresNetworkExecutor extends Thread {
     }
   }
 
+  private static final Pattern SET_TO_SEPARATOR = Pattern.compile("(?i)\\s+TO\\s+");
+
   /**
    * Parses a Postgres {@code SET <param> = <value>} or {@code SET <param> TO <value>} command into its
-   * {@code {paramName, value}} pair. Splits on the FIRST separator only, so a value containing a further
-   * '=' (e.g. a connection string) is kept whole instead of truncated (issue #6423). {@code paramName} is
-   * lower-cased for case-insensitive comparison; a quoted {@code value} has its surrounding quotes
-   * stripped. Returns null when the command has neither a '=' nor a ' TO ' separator.
+   * {@code {paramName, value}} pair. A command can only use one of the two separators, but its value may
+   * legitimately contain the other one as plain text (e.g. {@code SET search_path TO 'a=b'} or
+   * {@code SET x = 'a TO b'}), so this picks whichever separator - the first '=' or the first case-
+   * insensitive ' TO ' - occurs FIRST in the string and splits on that one only, leaving every other
+   * occurrence of either inside the value untouched (issue #6423). {@code paramName} is lower-cased for
+   * case-insensitive comparison; a quoted {@code value} has its surrounding quotes stripped. Returns null
+   * when the command has neither separator.
    */
   static String[] parseSetCommand(final String query) {
     final int setLength = "SET ".length();
     // Use original query to preserve case of values
     final String q = query.substring(setLength);
 
-    String[] parts = StringUtils.splitKeyValue(q);
-    if (parts == null)
-      // Fall back to a case-insensitive " TO " split, also on the first occurrence only
-      parts = q.split("(?i)\\s+TO\\s+", 2);
+    final int eqPos = q.indexOf('=');
+    final Matcher toMatcher = SET_TO_SEPARATOR.matcher(q);
+    final boolean toFound = toMatcher.find();
 
-    if (parts.length < 2)
+    final String[] parts;
+    if (toFound && (eqPos < 0 || toMatcher.start() < eqPos))
+      parts = new String[] { q.substring(0, toMatcher.start()), q.substring(toMatcher.end()) };
+    else if (eqPos >= 0)
+      parts = StringUtils.splitKeyValue(q);
+    else
       return null;
 
     final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2080,6 +2080,10 @@ public class PostgresNetworkExecutor extends Thread {
       return null;
 
     final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);
+    if (paramName.isEmpty())
+      // An empty parameter name (e.g. "SET = somevalue") is as malformed as a missing separator.
+      return null;
+
     String value = parts[1].trim();
     if (value.startsWith("'") || value.startsWith("\"")) {
       // A quoted value needs a matching closing delimiter: a single stray quote (e.g. "SET x = '") is a

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2081,11 +2081,16 @@ public class PostgresNetworkExecutor extends Thread {
 
     final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);
     String value = parts[1].trim();
-    // Only strip a matching pair of quotes: a single stray quote (e.g. "SET x = '") is not a closed
-    // quoted value and must be left as-is rather than throw StringIndexOutOfBoundsException on the
-    // unconditional substring(1, length - 1) a bare startsWith() check used to attempt.
-    if (value.length() >= 2 && (value.charAt(0) == '\'' || value.charAt(0) == '"') && value.charAt(value.length() - 1) == value.charAt(0))
+    if (value.startsWith("'") || value.startsWith("\"")) {
+      // A quoted value needs a matching closing delimiter: a single stray quote (e.g. "SET x = '") is a
+      // malformed command, not a closed quoted value, so it is rejected the same way a missing separator
+      // is - rather than throw StringIndexOutOfBoundsException on an unconditional substring(1, length - 1),
+      // or silently store a value still carrying its opening quote.
+      final char quote = value.charAt(0);
+      if (value.length() < 2 || value.charAt(value.length() - 1) != quote)
+        return null;
       value = value.substring(1, value.length() - 1);
+    }
 
     return new String[] { paramName, value };
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2081,7 +2081,10 @@ public class PostgresNetworkExecutor extends Thread {
 
     final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);
     String value = parts[1].trim();
-    if (value.startsWith("'") || value.startsWith("\""))
+    // Only strip a matching pair of quotes: a single stray quote (e.g. "SET x = '") is not a closed
+    // quoted value and must be left as-is rather than throw StringIndexOutOfBoundsException on the
+    // unconditional substring(1, length - 1) a bare startsWith() check used to attempt.
+    if (value.length() >= 2 && (value.charAt(0) == '\'' || value.charAt(0) == '"') && value.charAt(value.length() - 1) == value.charAt(0))
       value = value.substring(1, value.length() - 1);
 
     return new String[] { paramName, value };

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -68,6 +68,7 @@ import io.micrometer.core.instrument.Metrics;
 import com.arcadedb.utility.DateUtils;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.StringUtils;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -2049,39 +2050,52 @@ public class PostgresNetworkExecutor extends Thread {
     }
   }
 
-  private void setConfiguration(final String query) {
+  /**
+   * Parses a Postgres {@code SET <param> = <value>} or {@code SET <param> TO <value>} command into its
+   * {@code {paramName, value}} pair. Splits on the FIRST separator only, so a value containing a further
+   * '=' (e.g. a connection string) is kept whole instead of truncated (issue #6423). {@code paramName} is
+   * lower-cased for case-insensitive comparison; a quoted {@code value} has its surrounding quotes
+   * stripped. Returns null when the command has neither a '=' nor a ' TO ' separator.
+   */
+  static String[] parseSetCommand(final String query) {
     final int setLength = "SET ".length();
     // Use original query to preserve case of values
     final String q = query.substring(setLength);
 
-    // Try to split by either '=' or ' TO ' (case-insensitive)
-    String[] parts = q.split("=");
-    if (parts.length < 2) {
-      // Try case-insensitive split for " TO "
-      parts = q.split("(?i)\\s+TO\\s+");
-    }
+    String[] parts = StringUtils.splitKeyValue(q);
+    if (parts == null)
+      // Fall back to a case-insensitive " TO " split, also on the first occurrence only
+      parts = q.split("(?i)\\s+TO\\s+", 2);
 
-    if (parts.length < 2) {
+    if (parts.length < 2)
+      return null;
+
+    final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);
+    String value = parts[1].trim();
+    if (value.startsWith("'") || value.startsWith("\""))
+      value = value.substring(1, value.length() - 1);
+
+    return new String[] { paramName, value };
+  }
+
+  private void setConfiguration(final String query) {
+    final String[] parts = parseSetCommand(query);
+    if (parts == null) {
       LogManager.instance().log(this, Level.WARNING, "Invalid SET command format: %s", query);
       return;
     }
 
-    parts[0] = parts[0].trim();
-    parts[1] = parts[1].trim();
+    final String paramName = parts[0];
+    final String value = parts[1];
 
-    if (parts[1].startsWith("'") || parts[1].startsWith("\""))
-      parts[1] = parts[1].substring(1, parts[1].length() - 1);
-
-    // Use case-insensitive comparison for parameter names
-    final String paramName = parts[0].toLowerCase(Locale.ENGLISH);
     if ("datestyle".equals(paramName)) {
-      if ("ISO".equalsIgnoreCase(parts[1]))
+      if ("ISO".equalsIgnoreCase(value))
         database.getSchema().setDateTimeFormat(DateUtils.DATE_TIME_ISO_8601_FORMAT);
       else
-        LogManager.instance().log(this, Level.INFO, "datestyle '%s' not supported", parts[1]);
+        LogManager.instance().log(this, Level.INFO, "datestyle '%s' not supported", value);
     }
 
-    connectionProperties.put(paramName, parts[1]);
+    connectionProperties.put(paramName, value);
   }
 
   /**

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -117,6 +117,8 @@ public class PostgresNetworkExecutor extends Thread {
   /** Bind-message parameter length denoting a NULL value (wire value -1, read unsigned). */
   private static final long                                           NULL_PARAM_LENGTH = 0xFFFFFFFFL;
   private static final Object[]                                       NO_PARAMETERS     = new Object[0];
+  /** Case-insensitive {@code TO} separator for the {@code SET <param> TO <value>} syntax. */
+  private static final Pattern                                        SET_TO_SEPARATOR  = Pattern.compile("(?i)\\s+TO\\s+");
 
   private final ArcadeDBServer              server;
   private final ChannelBinaryServer         channel;
@@ -2049,8 +2051,6 @@ public class PostgresNetworkExecutor extends Thread {
       writeError(ERROR_SEVERITY.ERROR, "Error on parsing query: " + e.getMessage(), sqlStateFor(e));
     }
   }
-
-  private static final Pattern SET_TO_SEPARATOR = Pattern.compile("(?i)\\s+TO\\s+");
 
   /**
    * Parses a Postgres {@code SET <param> = <value>} or {@code SET <param> TO <value>} command into its

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -728,9 +728,7 @@ public enum PostgresType {
   public void serializeAsText(final PostgresType pgType, final Binary typeBuffer, final Object value) {
     String serializedValue = null;
     final byte[] byteaValue = pgType == BYTEA ? byteaValueOf(value) : null;
-    if (value == null && pgType.code == BOOLEAN.code) {
-      serializedValue = "0";
-    } else if (pgType == JSON && value != null && (value instanceof Collection<?> || value.getClass().isArray())) {
+    if (pgType == JSON && value != null && (value instanceof Collection<?> || value.getClass().isArray())) {
       // The column was announced as a json document holding an array (issue #5366): emit a real JSON array
       // instead of a Postgres array literal, so the payload matches the announced OID.
       serializedValue = serializeCollectionAsJson(
@@ -753,9 +751,13 @@ public enum PostgresType {
       // BigDecimal.toString() switches to scientific notation outside a small exponent range (e.g. "1E+10"),
       // which is not a NUMERIC text value PostgreSQL itself would ever emit or a client would expect to parse.
       serializedValue = bd.toPlainString();
-    } else if (value instanceof Date date) {
+    } else if (value instanceof Date date && pgType == DATE) {
       // DATE (OID 1082) expects "YYYY-MM-DD" in text format
       serializedValue = date.toInstant().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE);
+    } else if (value instanceof Date date) {
+      // TIMESTAMP (or any other non-DATE column) backed by a java.util.Date: keep the time-of-day
+      // instead of truncating to a date-only value (issue #6675)
+      serializedValue = LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).format(POSTGRES_DATETIME_FORMATTER);
     } else if (value instanceof LocalDateTime ldt) {
       // TIMESTAMP (OID 1114) expects "yyyy-MM-dd HH:mm:ss.SSSSSS" in text format
       serializedValue = ldt.format(POSTGRES_DATETIME_FORMATTER);

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -83,15 +83,15 @@ class PostgresSetCommandParsingTest {
   }
 
   @Test
-  void anUnclosedQuoteIsLeftAsIsInsteadOfThrowing() {
+  void anUnclosedQuoteIsRejectedInsteadOfThrowing() {
     // A single stray quote is not a closed quoted value: substring(1, length - 1) on it used to throw
-    // StringIndexOutOfBoundsException instead of leaving the (malformed) value alone.
+    // StringIndexOutOfBoundsException instead of being treated as the malformed command it is.
     assertThatCode(() -> PostgresNetworkExecutor.parseSetCommand("SET x = '")).doesNotThrowAnyException();
-    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = '")).containsExactly("x", "'");
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = '")).isNull();
   }
 
   @Test
-  void mismatchedQuotesAreLeftAsIs() {
-    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = 'abc\"")).containsExactly("x", "'abc\"");
+  void mismatchedQuotesAreRejected() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = 'abc\"")).isNull();
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6423: {@code PostgresNetworkExecutor.setConfiguration()} used to split a
+ * {@code SET <param> = <value>} command on EVERY '=', so a value containing a further '=' (e.g. a connection
+ * string) was silently truncated - and, because the quote-stripping that followed assumed the truncated value
+ * still ended in the closing quote, it chopped off the value's last character too.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresSetCommandParsingTest {
+
+  @Test
+  void valueContainingEqualsIsKeptWhole() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET search_path = 'a=b'")).containsExactly("search_path", "a=b");
+  }
+
+  @Test
+  void simpleEqualsAssignment() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET datestyle = 'ISO'")).containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void toKeywordAssignment() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET datestyle TO 'ISO'")).containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void toKeywordAssignmentIsCaseInsensitiveAndSplitsOnFirstOccurrenceOnly() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET search_path to 'a TO b'")).containsExactly("search_path", "a TO b");
+  }
+
+  @Test
+  void unquotedValueIsNotStripped() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET timezone = UTC")).containsExactly("timezone", "UTC");
+  }
+
+  @Test
+  void paramNameIsLowerCased() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET DateStyle = 'ISO'")).containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void noSeparatorReturnsNull() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET justaname")).isNull();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -83,6 +83,11 @@ class PostgresSetCommandParsingTest {
   }
 
   @Test
+  void emptyParamNameIsRejected() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET = somevalue")).isNull();
+  }
+
+  @Test
   void anUnclosedQuoteIsRejectedInsteadOfThrowing() {
     // A single stray quote is not a closed quoted value: substring(1, length - 1) on it used to throw
     // StringIndexOutOfBoundsException instead of being treated as the malformed command it is.

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.postgres;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Regression tests for issue #6423: {@code PostgresNetworkExecutor.setConfiguration()} used to split a
@@ -79,5 +80,18 @@ class PostgresSetCommandParsingTest {
   @Test
   void noSeparatorReturnsNull() {
     assertThat(PostgresNetworkExecutor.parseSetCommand("SET justaname")).isNull();
+  }
+
+  @Test
+  void anUnclosedQuoteIsLeftAsIsInsteadOfThrowing() {
+    // A single stray quote is not a closed quoted value: substring(1, length - 1) on it used to throw
+    // StringIndexOutOfBoundsException instead of leaving the (malformed) value alone.
+    assertThatCode(() -> PostgresNetworkExecutor.parseSetCommand("SET x = '")).doesNotThrowAnyException();
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = '")).containsExactly("x", "'");
+  }
+
+  @Test
+  void mismatchedQuotesAreLeftAsIs() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = 'abc\"")).containsExactly("x", "'abc\"");
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -53,6 +53,20 @@ class PostgresSetCommandParsingTest {
   }
 
   @Test
+  void toKeywordAssignmentWithValueContainingEqualsIsKeptWhole() {
+    // The command uses ' TO ' as its separator, so the '=' inside the value must NOT be mistaken for
+    // the (unused) '=' separator - the earlier-occurring separator wins, not '=' unconditionally.
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET search_path TO 'a=b'")).containsExactly("search_path", "a=b");
+  }
+
+  @Test
+  void equalsAssignmentWithValueContainingToIsKeptWhole() {
+    // Symmetric case: the command uses '=' as its separator, so a ' TO ' inside the value must not be
+    // mistaken for the (unused) TO separator.
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET search_path = 'a TO b'")).containsExactly("search_path", "a TO b");
+  }
+
+  @Test
   void unquotedValueIsNotStripped() {
     assertThat(PostgresNetworkExecutor.parseSetCommand("SET timezone = UTC")).containsExactly("timezone", "UTC");
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -1338,13 +1338,12 @@ class PostgresTypeTest {
 
   @Test
   void serializeAsTextNullBoolean() {
+    // A null BOOLEAN must use the SQL-NULL sentinel (length -1) in text format, exactly like every
+    // other type, not the 1-byte value "0" (which a client would read back as false) - issue #6674
     Binary buffer = new Binary();
     PostgresType.BOOLEAN.serializeAsText(PostgresType.BOOLEAN, buffer, null);
     buffer.flip();
-    int length = buffer.getInt();
-    byte[] data = new byte[length];
-    buffer.getByteBuffer().get(data);
-    assertThat(new String(data)).isEqualTo("0");
+    assertThat(buffer.getInt()).isEqualTo(-1);
   }
 
   @Test
@@ -1395,6 +1394,21 @@ class PostgresTypeTest {
     // DATE (OID 1082) must be serialized as "YYYY-MM-DD" only
     assertThat(result).matches("\\d{4}-\\d{2}-\\d{2}");
     assertThat(result).isEqualTo("2024-05-19");
+  }
+
+  @Test
+  void serializeAsTextTimestampBackedByDate() {
+    // With arcadedb.dateTimeImplementation = java.util.Date, a DATETIME property announced as
+    // TIMESTAMP (OID 1114) must keep its time-of-day in text format, not truncate to a date-only
+    // value the way DATE (OID 1082) does - issue #6675
+    Binary buffer = new Binary();
+    Date date = new Date(1716138311000L); // 2024-05-19 17:05:11 UTC
+    PostgresType.TIMESTAMP.serializeAsText(PostgresType.TIMESTAMP, buffer, date);
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+    assertThat(new String(data)).isEqualTo("2024-05-19 17:05:11.000000");
   }
 
   @Test

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
@@ -323,8 +323,13 @@ public class GetDynamicContentHandler extends AbstractServerHttpHandler {
    * {@link ArrayIndexOutOfBoundsException} out of the page render (issue #6423).
    */
   static void parseIncludeParameters(final String params, final String include, final Map<String, Object> variables) {
-    final String[] parameterPairs = params.split(" ");
+    // Split on a run of whitespace, not a single space: a run of consecutive spaces between parameters
+    // (or a trailing one) would otherwise produce an empty-string element that logs a spurious "malformed
+    // parameter ''" warning below.
+    final String[] parameterPairs = params.trim().split("\\s+");
     for (final String pair : parameterPairs) {
+      if (pair.isEmpty())
+        continue;
       final String[] kv = StringUtils.splitKeyValue(pair);
       if (kv == null) {
         LogManager.instance().log(GetDynamicContentHandler.class, Level.WARNING,

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
@@ -26,6 +26,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StringUtils;
 import io.micrometer.core.instrument.Metrics;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
@@ -248,11 +249,7 @@ public class GetDynamicContentHandler extends AbstractServerHttpHandler {
 
           include = include.substring(0, sep);
 
-          final String[] parameterPairs = params.split(" ");
-          for (final String pair : parameterPairs) {
-            final String[] kv = pair.split("=");
-            variables.put(kv[0].trim(), kv[1].trim());
-          }
+          parseIncludeParameters(params, include, variables);
         }
 
         final InputStream fis = getClass().getClassLoader().getResourceAsStream("static/" + include);
@@ -317,5 +314,24 @@ public class GetDynamicContentHandler extends AbstractServerHttpHandler {
     buffer.append(file.substring(pos));
 
     return buffer.toString();
+  }
+
+  /**
+   * Parses the space-separated {@code key=value} parameters of an {@code ${include:file.html k=v ...}} directive
+   * into {@code variables}. Each pair is split on the FIRST '=' only, so a value containing a further '=' is kept
+   * whole, and a parameter with no '=' at all is reported and skipped instead of throwing
+   * {@link ArrayIndexOutOfBoundsException} out of the page render (issue #6423).
+   */
+  static void parseIncludeParameters(final String params, final String include, final Map<String, Object> variables) {
+    final String[] parameterPairs = params.split(" ");
+    for (final String pair : parameterPairs) {
+      final String[] kv = StringUtils.splitKeyValue(pair);
+      if (kv == null) {
+        LogManager.instance().log(GetDynamicContentHandler.class, Level.WARNING,
+            "Malformed include parameter '%s' in '%s', ignoring it", pair, include);
+        continue;
+      }
+      variables.put(kv[0].trim(), kv[1].trim());
+    }
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerIncludeParametersTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerIncludeParametersTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression tests for issue #6423: an {@code ${include:file.html k=v ...}} parameter with no '=' used to throw
+ * {@link ArrayIndexOutOfBoundsException} out of the page render, and a value containing a further '=' was
+ * silently truncated.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GetDynamicContentHandlerIncludeParametersTest {
+
+  @Test
+  void wellFormedParametersArePutIntoVariables() {
+    final Map<String, Object> variables = new HashMap<>();
+    GetDynamicContentHandler.parseIncludeParameters("a=1 b=2", "test.html", variables);
+    assertThat(variables).containsEntry("a", "1").containsEntry("b", "2");
+  }
+
+  @Test
+  void valueContainingEqualsIsKeptWhole() {
+    final Map<String, Object> variables = new HashMap<>();
+    GetDynamicContentHandler.parseIncludeParameters("flag=x=y", "test.html", variables);
+    assertThat(variables).containsEntry("flag", "x=y");
+  }
+
+  @Test
+  void parameterWithNoSeparatorIsSkippedInsteadOfThrowing() {
+    final Map<String, Object> variables = new HashMap<>();
+    assertThatCode(() -> GetDynamicContentHandler.parseIncludeParameters("a=1 noequals b=2", "test.html", variables))
+        .doesNotThrowAnyException();
+    assertThat(variables).containsEntry("a", "1").containsEntry("b", "2").doesNotContainKey("noequals");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerIncludeParametersTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerIncludeParametersTest.java
@@ -56,4 +56,13 @@ class GetDynamicContentHandlerIncludeParametersTest {
         .doesNotThrowAnyException();
     assertThat(variables).containsEntry("a", "1").containsEntry("b", "2").doesNotContainKey("noequals");
   }
+
+  @Test
+  void repeatedOrTrailingSpacesDoNotProduceAMalformedParameter() {
+    // A run of whitespace between parameters (or a trailing one) used to split into an empty-string
+    // element that logged a spurious "malformed parameter ''" warning.
+    final Map<String, Object> variables = new HashMap<>();
+    GetDynamicContentHandler.parseIncludeParameters("a=1   b=2  ", "test.html", variables);
+    assertThat(variables).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "b", "2"));
+  }
 }


### PR DESCRIPTION
## Summary

Fixes three related Postgres-wire / shared-parser issues:

- **#6674**: a null `BOOLEAN` over the Postgres wire's text format was encoded as the 1-byte value `"0"` (read back by the client as `false`) instead of the SQL-NULL sentinel (length `-1`). The binary path already emitted `-1` correctly. Fix: delete the special case so BOOLEAN falls through to the same null handling as every other type.
- **#6675**: a `TIMESTAMP` column backed by `java.util.Date` (with `arcadedb.dateTimeImplementation = java.util.Date`) was serialized date-only in text format, dropping the time-of-day - a serialization gap left behind by #6447's OID fix. Fix: gate the date-only branch on `pgType == DATE`; any other type backed by a `Date` (i.e. `TIMESTAMP`) now formats through `LocalDateTime` + the existing Postgres timestamp formatter, keeping the time.
- **#6423**: two `key=value` parsers - `PostgresNetworkExecutor.setConfiguration()` (the Postgres wire `SET` command) and `GetDynamicContentHandler`'s `${include:file.html k=v}` directive - split on *every* `=` instead of the first one, silently truncating a value containing a further `=` (e.g. a connection string). The include directive also threw `ArrayIndexOutOfBoundsException` on a parameter with no `=` at all. Both are fixed by delegating to a new `StringUtils.splitKeyValue()`, the same first-separator-only rule `Console.splitKeyValue()` already used for the SET/-D case (issue #6392) - `Console.splitKeyValue()` now delegates to it too instead of carrying its own copy. The include directive now logs and skips a malformed parameter instead of throwing.

## Deferred: #6659

#6659 is a follow-up review comment on PR #6658 (fix for #6458), which is **still open/unmerged**. The "eager full materialization" behavior #6659 describes doesn't exist on `main` yet - main still has #6458's original, more severe defects. Implementing #6659 now would collide with #6658's in-flight changes to the same code. Reasoning and a suggested alternative (skip the eager-materialization step and go straight to incremental streaming once #6658 lands) are posted as a comment on the issue.

## Test plan

- [x] `PostgresTypeTest`: fixed `serializeAsTextNullBoolean` (now asserts the `-1` sentinel) and added `serializeAsTextTimestampBackedByDate` - 225 tests, all green
- [x] New `PostgresSetCommandParsingTest` - 7 tests covering `=`, `TO`, quoting, and the value-containing-`=` regression - all green
- [x] New `StringUtilsSplitKeyValueTest` (mirrors `ConsoleSplitKeyValueTest`'s contract) - 5 tests, all green
- [x] New `GetDynamicContentHandlerIncludeParametersTest` - 3 tests covering well-formed params, a value containing `=`, and a param with no `=` (no longer throws) - all green
- [x] Full `postgresw` module (`mvn verify -DskipITs=false -DexcludedGroups=benchmark,slow,vector`): 416 unit + 175 integration tests, all green
- [x] `console` + `engine` modules (`mvn test -DexcludedGroups=benchmark,slow,vector`): all green (2 unrelated pre-existing flaky vector/timing tests seen only when those lanes are included, as expected - not touched by this change)
- [x] `server` module `GetDynamicContentHandlerIT`: 14 tests, all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of key-value settings and template parameters, preserving additional `=` characters in values.
  - Malformed template include parameters are now skipped safely instead of causing errors.
  - PostgreSQL `SET` commands now support `=` and case-insensitive `TO` separators reliably.
  - Corrected PostgreSQL serialization for null booleans and timestamps, preserving date and time information.

- **Tests**
  - Added regression coverage for key-value parsing, command handling, template parameters, and PostgreSQL value serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->