### PR TITLE
fix(#6699): algo.wcc applies its relTypes filter

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
@@ -90,28 +90,27 @@ public class AlgoWCC extends AbstractAlgoProcedure {
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
 
-    // Try CSR-accelerated path: delegate to native union-find on CSR arrays. Only for an
-    // unfiltered call: connectedComponents() walks the whole view, and a provider is selected
-    // for covering the requested types, not for covering only those, so a filtered call would
-    // union edges it was asked to leave out. loadGraph() applies the filter to CSR adjacency.
-    if (relTypes == null || relTypes.length == 0) {
-      final GraphTraversalProvider provider = findProvider(db, null);
-      if (provider instanceof GraphAnalyticalView gav) {
-        context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
-        return executeWithCSR(context, gav);
-      }
+    // Try CSR-accelerated path: delegate to native min-label propagation on CSR arrays.
+    // findProvider(relTypes) only returns a provider that covers every requested type, and
+    // GraphAlgorithms.connectedComponents() takes the same relTypes and resolves each one to its
+    // own CSR index (GraphAnalyticalView#getCSRIndex), so passing the filter through keeps the
+    // parallel algorithm for a filtered call instead of dropping to the single-threaded BFS below.
+    final GraphTraversalProvider provider = findProvider(db, relTypes);
+    if (provider instanceof GraphAnalyticalView gav) {
+      context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
+      return executeWithCSR(context, gav, relTypes);
     }
 
     // Fall back to OLTP path
     return executeWithOLTP(db, relTypes);
   }
 
-  private Stream<Result> executeWithCSR(final CommandContext context, final GraphAnalyticalView gav) {
+  private Stream<Result> executeWithCSR(final CommandContext context, final GraphAnalyticalView gav, final String[] relTypes) {
     final int n = gav.getNodeCount();
     if (n == 0)
       return Stream.empty();
 
-    final int[] componentId = GraphAlgorithms.connectedComponents(gav);
+    final int[] componentId = GraphAlgorithms.connectedComponents(gav, relTypes);
     context.setVariable(CommandContext.RESULT_COUNT_HINT_VAR, (long) n);
 
     return IntStream.range(0, n).mapToObj(i -> {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
@@ -88,15 +88,22 @@ public class AlgoWCC extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
 
-    // Try CSR-accelerated path: delegate to native union-find on CSR arrays
-    final GraphTraversalProvider provider = findProvider(db, null);
-    if (provider instanceof GraphAnalyticalView gav) {
-      context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
-      return executeWithCSR(context, gav);
+    final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
+
+    // Try CSR-accelerated path: delegate to native union-find on CSR arrays. Only for an
+    // unfiltered call: connectedComponents() walks the whole view, and a provider is selected
+    // for covering the requested types, not for covering only those, so a filtered call would
+    // union edges it was asked to leave out. loadGraph() applies the filter to CSR adjacency.
+    if (relTypes == null || relTypes.length == 0) {
+      final GraphTraversalProvider provider = findProvider(db, null);
+      if (provider instanceof GraphAnalyticalView gav) {
+        context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
+        return executeWithCSR(context, gav);
+      }
     }
 
     // Fall back to OLTP path
-    return executeWithOLTP(db);
+    return executeWithOLTP(db, relTypes);
   }
 
   private Stream<Result> executeWithCSR(final CommandContext context, final GraphAnalyticalView gav) {
@@ -115,13 +122,13 @@ public class AlgoWCC extends AbstractAlgoProcedure {
     });
   }
 
-  private Stream<Result> executeWithOLTP(final Database db) {
-    final GraphData graph = loadGraph(db, null, null, null);
+  private Stream<Result> executeWithOLTP(final Database db, final String[] relTypes) {
+    final GraphData graph = loadGraph(db, null, relTypes, null);
 
     final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
-    final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH);
+    final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH, relTypes);
 
     final int[] componentId = new int[n];
     for (int i = 0; i < n; i++)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCCTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCCTest.java
@@ -20,9 +20,12 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -35,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -217,6 +221,51 @@ class AlgoWCCTest {
 
     final Map<String, Long> comp = componentsByName("CALL algo.wcc('EDGE')");
     assertThat(comp.get("D")).isNotEqualTo(comp.get("A"));
+  }
+
+  @Test
+  void wccWithRelTypesStillUsesCSRAccelerationWhenViewCoversTheRequestedType() {
+    // The whole point of restricting the filter to CSR-backed calls: a relType filter must not
+    // fall back to the single-threaded OLTP BFS just because a view happens to be present. The
+    // view here covers both EDGE and OTHER, wider than the 'EDGE' request, so this also re-checks
+    // that CSR acceleration doesn't widen the result the way wccWithRelTypesIsNotWidenedByAViewCoveringMoreTypes
+    // already does for correctness - this test is the counterweight for performance: if the view
+    // were silently bypassed for a filtered call, CSR_ACCELERATED_VAR would never be set.
+    bridgeComponentsWithOtherEdge();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Node")
+        .withEdgeTypes("EDGE", "OTHER")
+        .build();
+    try {
+      assertThat(gav.isBuilt()).isTrue();
+
+      database.begin();
+      try {
+        final BasicCommandContext context = new BasicCommandContext();
+        context.setDatabase(database);
+        final List<Result> rows = new AlgoWCC().execute(new Object[] { "EDGE" }, null, context)
+            .collect(Collectors.toList());
+
+        assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+            .as("a filtered call must still be able to use the view")
+            .isEqualTo(true);
+
+        final Map<String, Long> comp = new HashMap<>();
+        for (final Result row : rows)
+          comp.put(((RID) row.getProperty("node")).asVertex().getString("name"),
+              ((Number) row.getProperty("componentId")).longValue());
+
+        assertThat(comp.get("B")).isEqualTo(comp.get("A"));
+        assertThat(comp.get("C")).isEqualTo(comp.get("A"));
+        assertThat(comp.get("E")).isEqualTo(comp.get("D"));
+        assertThat(comp.get("D")).isNotEqualTo(comp.get("A"));
+      } finally {
+        database.rollback();
+      }
+    } finally {
+      gav.drop();
+    }
   }
 
   private void bridgeComponentsWithOtherEdge() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCCTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCCTest.java
@@ -21,6 +21,8 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -28,8 +30,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +54,7 @@ class AlgoWCCTest {
     database = factory.create();
     database.getSchema().createVertexType("Node");
     database.getSchema().createEdgeType("EDGE");
+    database.getSchema().createEdgeType("OTHER");
 
     // Two disconnected components:
     // Component 1: A -> B -> C
@@ -158,5 +163,80 @@ class AlgoWCCTest {
     } finally {
       db.drop();
     }
+  }
+
+  @Test
+  void wccWithRelTypesRestrictsToThoseEdges() {
+    bridgeComponentsWithOtherEdge();
+
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('EDGE')");
+    assertThat(comp.get("B")).isEqualTo(comp.get("A"));
+    assertThat(comp.get("C")).isEqualTo(comp.get("A"));
+    assertThat(comp.get("E")).isEqualTo(comp.get("D"));
+    assertThat(comp.get("D")).isNotEqualTo(comp.get("A"));
+  }
+
+  @Test
+  void wccWithRelTypesIgnoresOtherEdgeTypes() {
+    bridgeComponentsWithOtherEdge();
+
+    // OTHER holds only C -> D, so A, B and E stay on their own
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('OTHER')");
+    assertThat(comp.get("D")).isEqualTo(comp.get("C"));
+    assertThat(comp.get("A")).isNotEqualTo(comp.get("C"));
+    assertThat(comp.get("B")).isNotEqualTo(comp.get("C"));
+    assertThat(comp.get("E")).isNotEqualTo(comp.get("C"));
+    assertThat(Set.copyOf(List.of(comp.get("A"), comp.get("B"), comp.get("E")))).hasSize(3);
+  }
+
+  @Test
+  void wccWithUnknownRelTypeIsolatesEveryVertex() {
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('NOSUCH')");
+    assertThat(Set.copyOf(comp.values())).hasSize(5);
+  }
+
+  @Test
+  void wccWithCommaSeparatedRelTypesCoversBoth() {
+    bridgeComponentsWithOtherEdge();
+
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('EDGE,OTHER')");
+    assertThat(comp.values()).containsOnly(comp.get("A"));
+  }
+
+  @Test
+  void wccWithRelTypesIsNotWidenedByAViewCoveringMoreTypes() {
+    bridgeComponentsWithOtherEdge();
+
+    // a view covering both types matches a request for either one, so the filter has to be
+    // applied to the traversal rather than inherited from the view's topology
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Node")
+        .withEdgeTypes("EDGE", "OTHER")
+        .build();
+    assertThat(gav.isBuilt()).isTrue();
+
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('EDGE')");
+    assertThat(comp.get("D")).isNotEqualTo(comp.get("A"));
+  }
+
+  private void bridgeComponentsWithOtherEdge() {
+    database.transaction(() -> {
+      final Vertex c = (Vertex) database.query("sql",
+          "SELECT FROM Node WHERE name = 'C'").next().getElement().get();
+      final Vertex d = (Vertex) database.query("sql",
+          "SELECT FROM Node WHERE name = 'D'").next().getElement().get();
+      c.newEdge("OTHER", d, true, (Object[]) null).save();
+    });
+  }
+
+  private Map<String, Long> componentsByName(final String call) {
+    final ResultSet rs = database.query("opencypher",
+        call + " YIELD node, componentId RETURN node.name AS name, componentId");
+    final Map<String, Long> byName = new HashMap<>();
+    while (rs.hasNext()) {
+      final Result result = rs.next();
+      byName.put(result.getProperty("name"), ((Number) result.getProperty("componentId")).longValue());
+    }
+    return byName;
   }
 }


### PR DESCRIPTION
## What does this PR do?

Makes `algo.wcc([relTypes])` restrict the traversal to the listed edge types.

`execute()` now reads the argument with the existing `extractRelTypes` helper and passes it on,
following the pattern `AlgoLeiden` already uses:

- `loadGraph(db, null, relTypes, null)` in place of `loadGraph(db, null, null, null)`
- `graph.adjacency(Vertex.DIRECTION.BOTH, relTypes)` in place of the unfiltered overload

The direct `executeWithCSR` shortcut is now taken only for an unfiltered call.
`GraphAlgorithms.connectedComponents()` walks the whole view, and a provider is selected for
covering the requested edge types rather than for covering only those, so a view spanning
`{A, B}` satisfies a request for `'A'` and the shortcut would union edges the caller asked to
leave out. A filtered call goes through `loadGraph`, which applies `relTypes` to CSR adjacency
via `buildAdjacencyFromProvider`, so acceleration is kept without widening the result.

## Motivation

The filter did not take effect, so the result was the whole-graph answer whatever was passed,
with no error to signal it. Filtering on an edge type with no edges returned one component
containing everything, where each vertex should have been on its own.

## Related issues

Fixes #6699.

For context, related `relTypes` work elsewhere in the package: #4287 / #4360
(`algo.leiden`), #6301 (`algo.steinerTree`), #6376 (`algo.maxKCut`). Separate from #6316,
which covers procedures that do not resolve a provider at all.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

On the first box: the reactor runs 17,598 tests here with `AlgoWCCTest` at 9/0 and the
3,897-test `OpenCypherTCKSuite` clean, but it does not finish green in my container. Each
remaining failure was checked separately and none involve this change:
`DatabaseGetSizeTest`, `PromQLEvaluatorIntegrationTest` and
`Issue6440FlushAckOnClosedDatabaseTest` fail the same way on an unmodified checkout, and
`WindowFunctionTest` / `TimeSeriesFunctionDeltaTest` gave 0, 1 and 3 failures across three
identical runs of the same tree. Happy to re-run anything that would help.

Five tests added to `AlgoWCCTest`:

| test | covers |
|---|---|
| `wccWithRelTypesRestrictsToThoseEdges` | `wcc('EDGE')`: `{A,B,C}` share an id, `{D,E}` share another, the two differ |
| `wccWithRelTypesIgnoresOtherEdgeTypes` | `wcc('OTHER')`: `{C,D}` together, with A, B and E as three distinct singletons |
| `wccWithUnknownRelTypeIsolatesEveryVertex` | `wcc('NOSUCH')`: five distinct ids, since that type has no edges |
| `wccWithCommaSeparatedRelTypesCoversBoth` | `wcc('EDGE,OTHER')`: matches the unfiltered result, covering comma-separated parsing |
| `wccWithRelTypesIsNotWidenedByAViewCoveringMoreTypes` | builds a view over both edge types, then checks `wcc('EDGE')` still separates the two components |

The existing tests continue to cover the unfiltered call.

Run both ways:

```
with the change:     Tests run: 9, Failures: 0   BUILD SUCCESS
without the change:  Tests run: 9, Failures: 4   BUILD FAILURE
```

`wccWithCommaSeparatedRelTypesCoversBoth` passes either way, since `'EDGE,OTHER'` is every edge
type in the fixture; it guards the separator handling rather than this behaviour. The other four
fail without the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relationship-type filtering to Weakly Connected Components analysis.
  * Supports filtering by one or multiple relationship types, including analytical views and mixed edge types.
  * Filtered analyses can use accelerated processing when available.

* **Bug Fixes**
  * Improved component detection for graphs containing multiple relationship types.
  * Added graceful handling for unknown relationship types without affecting unfiltered analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->