### PR TITLE
fix(#6694): descending scan's root-page probe used ascending purpose for a composite-index prefix

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -500,13 +500,19 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       if (fromKeys != null) {
         final Binary rootPageBuffer = new Binary(rootPage.slice());
 
-        // Use purpose=2 (ascending iterator) instead of 1 (retrieve) for root page lookups when
+        // Use purpose=2/3 (ascending/descending iterator) instead of 1 (retrieve) for root page lookups when
         // keys are partial (fewer components than the composite index defines). Purpose=1 rejects
         // partial keys with "key is composed of N items, while the index defined M items".
-        // Purpose=2 allows partial key comparison which correctly matches by prefix.
+        // Purpose=2/3 allows partial key comparison, which correctly matches by prefix, and - like the data-page
+        // lookup in searchInCurrentPage() below - must follow the scan direction: compareKey()'s PARTIAL MATCHING
+        // walk resolves an ambiguous binary-search landing point to the FIRST entry of a same-prefix run for
+        // purpose=2 and the LAST entry for purpose=3. Using purpose=2 unconditionally made a descending scan's
+        // root-page probe always land on the series' FIRST (lowest-keyed) data page instead of its LAST
+        // (highest-keyed) one whenever a composite-index prefix match spanned multiple data pages within one
+        // compacted series, so the scan started too low and silently dropped whole series/pages (#6694).
         // For full keys, keep purpose=1 to preserve exact boundary behavior for descending ranges and the shared-leaf
         // (multi-page duplicate) positioning, both of which depend on purpose=1's value-run result.
-        final int fromPurpose = fromKeys.length < binaryKeyTypes.length ? 2 : 1;
+        final int fromPurpose = fromKeys.length < binaryKeyTypes.length ? (ascendingOrder ? 2 : 3) : 1;
         final LookupResult resultInRootPage = lookupInPage(rootPageNumber, rootPageCount + 1, rootPageBuffer, fromKeys,
             fromPurpose);
         if (!resultInRootPage.outside)

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/ArcadeData/arcadedb/issues/6694: {@code LSMTreeIndexCompacted.newIterators()}'s
+ * ROOT-PAGE lookup for a partial (composite-index prefix) key always used purpose=2 (ascending), regardless of the
+ * requested scan direction. #6692 fixed the analogous asymmetry at the DATA-page level ({@code searchInCurrentPage()},
+ * which already used {@code ascendingOrder ? 2 : 3}), but left the coarser root-page probe that PICKS which data page
+ * to start {@code searchInCurrentPage()} from always ascending.
+ * <p>
+ * This only surfaces when the composite-index prefix match ({@code key1='a' AND key2='b'}) itself spans MULTIPLE data
+ * pages within one compacted series - i.e. a group large enough that the root page holds a RUN of several
+ * page-boundary entries that all compare equal under a partial-key comparison. {@code compareKey()}'s "PARTIAL
+ * MATCHING" walk resolves an ambiguous binary-search landing point to the FIRST entry of that run for purpose=2 and
+ * the LAST entry for purpose=3; using purpose=2 unconditionally means a DESCENDING scan's root-page probe always
+ * lands on the FIRST (lowest-keyed) data page of the group instead of the LAST (highest-keyed) one, so the scan
+ * starts multiple pages too low and returns the wrong (or incomplete) rows.
+ * <p>
+ * The existing #6692 regression test ({@code Issue6592CompactedCompositePrefixDescTest}) used a target group small
+ * enough to live in a single data page, so it never exercised this specific branch - confirmed by the automated code
+ * review comment that filed this issue.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
+
+  private static final int GROUP_SIZE = 4_000;
+  private static final int PAGE_SIZE  = 8 * 1024;
+
+  @Override
+  protected void beginTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+
+    final VertexType supplier = database.getSchema().createVertexType("Supplier", 1);
+    supplier.createProperty("key1", Type.STRING);
+    supplier.createProperty("key2", Type.STRING);
+    supplier.createProperty("orderedAt", Type.LONG);
+    database.getSchema()
+        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Supplier", new String[] { "key1", "key2", "orderedAt" }, PAGE_SIZE);
+
+    database.transaction(() -> {
+      // A single prefix group large enough to span several data pages within one compacted series - the root page
+      // then holds a run of multiple page-boundary entries that all compare equal under the partial key (key1,key2).
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("Supplier").set("key1", "a", "key2", "b", "orderedAt", (long) i).save();
+    });
+
+    final TypeIndex typeIndex = database.getSchema().getType("Supplier").getIndexesByProperties("key1", "key2", "orderedAt")
+        .getFirst();
+    try {
+      assertThat(((IndexInternal) typeIndex).scheduleCompaction()).as("compaction scheduled").isTrue();
+      assertThat(((IndexInternal) typeIndex).compact()).as("compaction executed").isTrue();
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void orderByDescLimitOneReturnsTheHighestValueAfterCompaction() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", false)//
+          .limit(1)//
+          .compile();
+
+      final Vertex first = select.vertices().nextOrNull();
+
+      assertThat(first).isNotNull();
+      assertThat(first.getString("key1")).isEqualTo("a");
+      assertThat(first.getString("key2")).isEqualTo("b");
+      assertThat(first.getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1);
+    });
+  }
+
+  @Test
+  void descendingScanReturnsExactlyTheMatchingGroupInOrder() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", false)//
+          .compile();
+
+      final List<Vertex> list = select.vertices().toList();
+
+      assertThat(list).hasSize(GROUP_SIZE);
+      for (int i = 0; i < GROUP_SIZE; i++) {
+        assertThat(list.get(i).getString("key1")).isEqualTo("a");
+        assertThat(list.get(i).getString("key2")).isEqualTo("b");
+        assertThat(list.get(i).getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1 - i);
+      }
+    });
+  }
+
+  @Test
+  void orderByAscLimitOneStillReturnsTheLowestValueAfterCompaction() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", true)//
+          .limit(1)//
+          .compile();
+
+      final Vertex first = select.vertices().nextOrNull();
+
+      assertThat(first).isNotNull();
+      assertThat(first.getString("key1")).isEqualTo("a");
+      assertThat(first.getString("key2")).isEqualTo("b");
+      assertThat(first.getLong("orderedAt")).isZero();
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
@@ -68,9 +68,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("slow")
 class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
 
-  private static final int GROUP_SIZE = 4_000;
-  private static final int LOWER_GROUP_SIZE = 4_000;
-  private static final int PAGE_SIZE  = 8 * 1024;
+  private static final int GROUP_SIZE       = 4_000; // target ("a"/"b") group size
+  private static final int LOWER_GROUP_SIZE = 4_000; // independent: the noise ("0"/"x") group below it, sized separately
+  private static final int PAGE_SIZE        = 8 * 1024;
 
   @Override
   protected void beginTest() {

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.select;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.Schema;
@@ -30,6 +31,7 @@ import com.arcadedb.schema.VertexType;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,8 +52,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * starts multiple pages too low and returns the wrong (or incomplete) rows.
  * <p>
  * The existing #6692 regression test ({@code Issue6592CompactedCompositePrefixDescTest}) used a target group small
- * enough to live in a single data page, so it never exercised this specific branch - confirmed by the automated code
- * review comment that filed this issue.
+ * enough to live in a single data page, so it never exercised this specific branch.
+ * <p>
+ * A second, independent gap: switching the root-page purpose to 3 for a descending scan also changes which
+ * {@code lookupInPage} boundary branch fires when {@code fromKeys} sorts higher than every entry of an ENTIRE
+ * compacted series (not just one page within it) - the "outside" shortcut that used to emit that whole series as a
+ * single cursor (purpose=2's HIGHER-than-last branch, #5214) now instead routes through
+ * {@code searchInCurrentPage()}'s normal per-page probe via purpose=3's own HIGHER-than-last special case.
+ * {@link #descendingPartialKeyIteratorIncludesAnEntireLowerSeries()} builds a second, alphabetically LOWER prefix
+ * group large enough to compact into its own series and confirms a descending partial-key iterator starting above
+ * it still returns every one of its rows, in order, with none dropped.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -59,6 +69,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
 
   private static final int GROUP_SIZE = 4_000;
+  private static final int LOWER_GROUP_SIZE = 4_000;
   private static final int PAGE_SIZE  = 8 * 1024;
 
   @Override
@@ -75,6 +86,11 @@ class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
         .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Supplier", new String[] { "key1", "key2", "orderedAt" }, PAGE_SIZE);
 
     database.transaction(() -> {
+      // A prefix group alphabetically BELOW the target ("0" < "a"), large enough to compact into its own series -
+      // exercises a descending scan whose fromKeys sorts above this series' ENTIRE key range, not just one page of it.
+      for (int i = 0; i < LOWER_GROUP_SIZE; i++)
+        database.newVertex("Supplier").set("key1", "0", "key2", "x", "orderedAt", (long) i).save();
+
       // A single prefix group large enough to span several data pages within one compacted series - the root page
       // then holds a run of multiple page-boundary entries that all compare equal under the partial key (key1,key2).
       for (int i = 0; i < GROUP_SIZE; i++)
@@ -126,6 +142,38 @@ class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
         assertThat(list.get(i).getString("key1")).isEqualTo("a");
         assertThat(list.get(i).getString("key2")).isEqualTo("b");
         assertThat(list.get(i).getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1 - i);
+      }
+    });
+  }
+
+  @Test
+  void descendingPartialKeyIteratorIncludesAnEntireLowerSeries() {
+    database.transaction(() -> {
+      final TypeIndex typeIndex = database.getSchema().getType("Supplier").getIndexesByProperties("key1", "key2", "orderedAt")
+          .getFirst();
+
+      // Partial (2-of-3 component) descending iterator starting at the target group, with no lower bound: it must
+      // walk straight through the target group and then through the entire "0"/"x" series below it, dropping nothing.
+      final List<Object[]> keys = new ArrayList<>();
+      try (final IndexCursor cursor = typeIndex.iterator(false, new Object[] { "a", "b" }, true)) {
+        while (cursor.hasNext()) {
+          cursor.next();
+          keys.add(cursor.getKeys());
+        }
+      }
+
+      assertThat(keys).as("no rows from either group must be dropped").hasSize(GROUP_SIZE + LOWER_GROUP_SIZE);
+
+      for (int i = 0; i < GROUP_SIZE; i++) {
+        assertThat(keys.get(i)[0]).isEqualTo("a");
+        assertThat(keys.get(i)[1]).isEqualTo("b");
+        assertThat(keys.get(i)[2]).isEqualTo((long) (GROUP_SIZE - 1 - i));
+      }
+      for (int i = 0; i < LOWER_GROUP_SIZE; i++) {
+        final Object[] key = keys.get(GROUP_SIZE + i);
+        assertThat(key[0]).isEqualTo("0");
+        assertThat(key[1]).isEqualTo("x");
+        assertThat(key[2]).isEqualTo((long) (LOWER_GROUP_SIZE - 1 - i));
       }
     });
   }


### PR DESCRIPTION
## Summary

Fixes #6694.

`LSMTreeIndexCompacted.newIterators()`'s coarse root-page lookup - which picks which data
page to start `searchInCurrentPage()` from - always used `purpose=2` (ascending) for a
partial (composite-index prefix) key, regardless of the requested scan direction.

`compareKey()`'s "PARTIAL MATCHING" walk resolves an ambiguous binary-search landing point
to the **first** entry of a same-prefix run for `purpose=2` and the **last** entry for
`purpose=3`. Using `purpose=2` unconditionally meant a **descending** scan's root-page probe
always landed on a series' FIRST (lowest-keyed) data page instead of its LAST (highest-keyed)
one whenever a composite-index prefix match spanned multiple data pages within one compacted
series - so the scan started too low and silently **dropped whole series/pages**.

This is the same asymmetry #6692 already fixed at the DATA-page level
(`searchInCurrentPage()`, which correctly uses `ascendingOrder ? 2 : 3`); this PR applies the
identical fix at the coarser ROOT-page level, one layer up.

## Fix

Mirror the existing `ascendingOrder ? 2 : 3` pattern for the root-page purpose selection when
the key is partial:

```java
final int fromPurpose = fromKeys.length < binaryKeyTypes.length ? (ascendingOrder ? 2 : 3) : 1;
```

Full keys are untouched (still always `purpose=1`, as before).

## Test plan

- [x] New regression test `Issue6694CompactedRootPageDescendingPurposeTest`: builds a single
  composite-index prefix group (`key1='a', key2='b'`) large enough (4,000 rows, small page
  size) to span many data pages within a compacted series, then compacts and runs a
  `DESC` scan/`ORDER BY ... DESC`.
  - Reproduces the bug against unfixed code: only 641 of 4,000 expected rows returned
    (whole compacted series silently dropped).
  - Passes cleanly after the fix (all 3 test methods).
- [x] No-regression run: `Issue6592CompactedCompositePrefixDescTest`, `Issue5214MultiSeriesRangeTest`,
  `SelectCompositeIndexTest` - all green.
- [x] Full `com.arcadedb.index.lsm.*` package (20 test classes) - all green.
- [x] Broader index-package sweep (`LSMTreeSortedNonUniqueBuildTest`,
  `CompositeIndexPartialKeySelectTest`, `LSMTreeCompactionCorrectnessTest`,
  `Issue5662IndexCursorFollowUpsTest`, `Issue5517BloomFilterTest`,
  `Issue5517BloomFilterKeyTypesTest`, `Issue5386OutOfRangeSeekTest`,
  `LSMTreeIndexCompactionTest`, `Issue5681UnclosedDmlLeavesScanOpenTest`,
  `LSMTreeIndexKeyOrderCheckTest`, `Issue5802KeyOrderUpgradeWarningTest`,
  `DeleteFromIndexStepCloseTest`, `FileManagerTest`) - all green.
- [x] `mvn -pl engine -am compile` - clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed descending queries on compacted composite indexes when filtering by partial keys.
  - Ensured complete and correctly ordered results when matching entries span multiple data pages.
  - Preserved expected behavior for full-key and ascending partial-key lookups.

- **Tests**
  - Added regression coverage for descending, ascending, limited, and full-result index queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->