### PR TITLE
fix(#6673): restore three-valued logic for list predicates inside aggregation projections

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
@@ -31,7 +31,6 @@ import com.arcadedb.query.opencypher.ast.ComparisonExpressionWrapper;
 import com.arcadedb.query.opencypher.ast.ListComprehensionExpression;
 import com.arcadedb.query.opencypher.ast.ListExpression;
 import com.arcadedb.query.opencypher.ast.ListIndexExpression;
-import com.arcadedb.query.opencypher.ast.ListPredicateExpression;
 import com.arcadedb.query.opencypher.ast.ListSliceExpression;
 import com.arcadedb.query.opencypher.ast.MapExpression;
 import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
@@ -101,8 +100,6 @@ public class ExpressionEvaluator {
       return evaluateMap(me, result, context);
     } else if (aggregationOverrides() != null && expression instanceof ListComprehensionExpression) {
       return evaluateListComprehension((ListComprehensionExpression) expression, result, context);
-    } else if (aggregationOverrides() != null && expression instanceof ListPredicateExpression) {
-      return evaluateListPredicate((ListPredicateExpression) expression, result, context);
     } else if (aggregationOverrides() != null && expression instanceof CaseExpression ce) {
       // Route CASE branches through this evaluator so a pre-computed aggregation nested inside a
       // branch (e.g. CASE WHEN ... THEN sum(v) END) resolves to its accumulated value instead of
@@ -237,48 +234,6 @@ public class ExpressionEvaluator {
         resultList.add(item);
     }
     return resultList;
-  }
-
-  /**
-   * Evaluates a list predicate expression (ALL/ANY/NONE/SINGLE) using this evaluator.
-   */
-  private Object evaluateListPredicate(final ListPredicateExpression expression,
-      final Result result, final CommandContext context) {
-    final Object listValue = evaluate(expression.getListExpression(), result, context);
-    if (listValue == null)
-      return null;
-
-    final Iterable<?> iterable;
-    if (listValue instanceof Iterable)
-      iterable = (Iterable<?>) listValue;
-    else
-      return expression.evaluate(result, context); // fallback
-
-    int matchCount = 0;
-    int totalCount = 0;
-    for (final Object item : iterable) {
-      totalCount++;
-      final ResultInternal iterResult = new ResultInternal();
-      if (result != null)
-        for (final String prop : result.getPropertyNames())
-          iterResult.setProperty(prop, result.getProperty(prop));
-      iterResult.setProperty(expression.getVariable(), item);
-
-      if (expression.getWhereExpression() != null) {
-        final Object filterValue = evaluate(expression.getWhereExpression(), iterResult, context);
-        if (filterValue instanceof Boolean && (Boolean) filterValue)
-          matchCount++;
-      } else {
-        matchCount++;
-      }
-    }
-
-    return switch (expression.getPredicateType()) {
-      case ALL -> matchCount == totalCount;
-      case ANY -> matchCount > 0;
-      case NONE -> matchCount == 0;
-      case SINGLE -> matchCount == 1;
-    };
   }
 
   private Object evaluateListSlice(final ListSliceExpression expression, final Result result,

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6673ListPredicateAggregation3vlTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6673ListPredicateAggregation3vlTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #6673.
+ * <p>
+ * The list predicates {@code all()}/{@code any()}/{@code none()}/{@code single()} lose Cypher
+ * three-valued logic (3VL) when evaluated inside a projection that also contains an aggregation:
+ * {@link com.arcadedb.query.opencypher.executor.ExpressionEvaluator} used to special-case
+ * {@code ListPredicateExpression} with its own {@code evaluateListPredicate} that counted only
+ * {@code Boolean.TRUE} matches and could only ever return {@code true} or {@code false}, never
+ * {@code null} - diverging from the primary AST implementation
+ * ({@link com.arcadedb.query.opencypher.ast.ListPredicateExpression#evaluate}) and from the
+ * openCypher truth tables, where a predicate that is {@code null} for every element yields
+ * {@code null}, not {@code false}/{@code true}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6673ListPredicateAggregation3vlTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (:Person {name: 'A'})");
+    database.command("opencypher", "CREATE (:Person {name: 'B'})");
+    database.command("opencypher", "CREATE (:Person {name: 'C'})");
+  }
+
+  @Test
+  void anyReturnsNullWhenEveryElementPredicateIsNullInsideAggregation() {
+    // Every element's predicate is null (x.nonexistent > 0 -> null) over a non-empty collected list.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN any(x IN collect(v) WHERE x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Object>getProperty("r")).isNull();
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
+  void allReturnsNullWhenEveryElementPredicateIsNullInsideAggregation() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN all(x IN collect(v) WHERE x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("r")).isNull();
+  }
+
+  @Test
+  void noneReturnsNullWhenEveryElementPredicateIsNullInsideAggregation() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN none(x IN collect(v) WHERE x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("r")).isNull();
+  }
+
+  @Test
+  void singleReturnsNullWhenEveryElementPredicateIsNullInsideAggregation() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN single(x IN collect(v) WHERE x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("r")).isNull();
+  }
+
+  @Test
+  void anyStillTrueWhenAtLeastOneElementMatchesInsideAggregation() {
+    // Sanity check: the fix must not turn a genuine match into null. Two elements are null, one is true.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN any(x IN collect(v) WHERE x.name = 'A' OR x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat((Boolean) rs.next().getProperty("r")).isTrue();
+  }
+
+  @Test
+  void noneStillFalseWhenAnElementMatchesInsideAggregation() {
+    // Sanity check: a genuine true predicate among nulls must still make none() false, not null.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN none(x IN collect(v) WHERE x.name = 'A' OR x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat((Boolean) rs.next().getProperty("r")).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary
- `all()`/`any()`/`none()`/`single()` lost Cypher three-valued logic (3VL) when evaluated inside a projection that also contains an aggregation (e.g. `RETURN any(x IN collect(v) WHERE x.nonexistent > 0)`): `ExpressionEvaluator.evaluateListPredicate` counted only `Boolean.TRUE` matches and could only ever return `true`/`false`, never `null`, diverging from the primary AST implementation (`ListPredicateExpression.evaluate`) and from the openCypher truth tables, where a predicate that is `null` for every element yields `null`.
- Root cause: `ExpressionEvaluator` kept a hand-rolled duplicate of the list-predicate 3VL logic for the aggregation-override case. But `ListPredicateExpression.evaluate()` already routes its list/where sub-expressions through the shared, thread-local aggregation-override-aware `ExpressionEvaluator` - the same mechanism `ReduceExpression` and `ListIndexExpression` already rely on without any special-casing. So the duplicate path was both unnecessary and (as this issue shows) prone to drifting out of sync with the primary implementation.
- Fix: delete `ExpressionEvaluator.evaluateListPredicate` and its dispatch branch, letting `ListPredicateExpression` fall through to the normal AST `evaluate()` fallback, same as `ReduceExpression`/`ListIndexExpression` already do.

## Test plan
- [x] Added `Issue6673ListPredicateAggregation3vlTest` covering `all/any/none/single` returning `null` when every element's predicate is `null` inside an aggregation projection, plus two sanity checks that a genuine match still yields `true`/`false` (not `null`) among nulls.
- [x] Confirmed the new test fails against the pre-fix code (4/6 failures) and passes after the fix.
- [x] `mvn -o -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**' -DexcludedGroups=benchmark,slow,vector` - 8934 tests, 1 unrelated pre-existing flake (`CypherGAVBoundTargetCardinalityTest`, no list-predicate/aggregation involvement, passes in isolation), 0 failures otherwise. OpenCypher TCK: 3812/3897 passed (unchanged pass rate).
- [x] `mvn -o -pl engine -am compile` clean.

Fixes #6673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cypher list-predicate evaluation within aggregations.
  * Corrected three-valued logic for `any()`, `all()`, `none()`, and `single()`, including proper `null` results when predicate outcomes are indeterminate.
  * Preserved expected behavior when matching elements are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->