### PR TITLE
fix(#6668): standalone leading OPTIONAL MATCH re-runs scan every pull batch

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/OptionalMatchStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/OptionalMatchStep.java
@@ -244,33 +244,37 @@ public class OptionalMatchStep extends AbstractExecutionStep {
             }
           }
         } else {
-          // No input: standalone OPTIONAL MATCH
-          // Execute match chain without input
-          matchChainStart.setPrevious(null);
-          final ResultSet matchResults = matchChainEnd.syncPull(context, Math.min(nRecords, MAX_BUFFER_SIZE));
+          // No input: standalone OPTIONAL MATCH.
+          // The match cursor is held in currentMatchResults (like the input path holds it across
+          // input rows) so that it resumes where it left off on every fetchMore call instead of
+          // re-running the pattern scan from scratch (issue #6668).
+          if (currentMatchResults == null) {
+            matchChainStart.setPrevious(null);
+            currentMatchResults = matchChainEnd.syncPull(context, Math.min(n, MAX_BUFFER_SIZE));
+          }
 
           // Collect matches with bounded buffer
           final int maxToFetch = Math.min(n, MAX_BUFFER_SIZE);
-          boolean foundAnyMatch = false;
-          while (buffer.size() < maxToFetch && matchResults.hasNext()) {
+          while (buffer.size() < maxToFetch && currentMatchResults.hasNext()) {
             guard.check();
-            buffer.add(matchResults.next());
-            foundAnyMatch = true;
+            buffer.add(currentMatchResults.next());
+            foundMatchForCurrent = true;
           }
 
-          // If no matches at all, return a single row with NULL values
-          if (!foundAnyMatch && buffer.isEmpty()) {
-            final ResultInternal nullResult = new ResultInternal();
-            for (final String varName : variableNames) {
-              nullResult.setProperty(varName, null);
-            }
-            buffer.add(nullResult);
-          }
-
-          if (!matchResults.hasNext()) {
+          if (!currentMatchResults.hasNext()) {
             finished = true;
+            currentMatchResults.close();
+            currentMatchResults = null;
+
+            // If no matches were found across the whole pattern, return a single row with NULL values
+            if (!foundMatchForCurrent) {
+              final ResultInternal nullResult = new ResultInternal();
+              for (final String varName : variableNames) {
+                nullResult.setProperty(varName, null);
+              }
+              buffer.add(nullResult);
+            }
           }
-          matchResults.close();
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/OptionalMatchStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/OptionalMatchStep.java
@@ -97,6 +97,8 @@ public class OptionalMatchStep extends AbstractExecutionStep {
       private ResultSet prevResults = null;
       private Result currentInputRow = null;
       private ResultSet currentMatchResults = null;
+      // With input: whether the current input row matched. Standalone (no input): whether the
+      // pattern matched at all across the whole scan, since there is no per-row input to reset it.
       private boolean foundMatchForCurrent = false;
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStandaloneOptionalMatchPullBatchIssue6668Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStandaloneOptionalMatchPullBatchIssue6668Test.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6668: a standalone {@code OPTIONAL MATCH} used as the first clause
+ * of a query kept its match cursor in a local variable that was re-created on every
+ * {@code fetchMore} call, so once the pattern had more rows than the pull batch size (100) it
+ * re-ran the scan from the beginning on every subsequent batch, emitting the first 100 rows
+ * repeatedly and never terminating.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherStandaloneOptionalMatchPullBatchIssue6668Test {
+  private static final int NODE_COUNT = 250;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/cypher6668").create();
+    database.transaction(() -> {
+      for (int i = 0; i < NODE_COUNT; i++)
+        database.command("opencypher", "CREATE (:Person {id: $id})", java.util.Map.of("id", i));
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  private List<Result> rows(final String query) {
+    final List<Result> rows = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+    return rows;
+  }
+
+  /**
+   * A standalone leading OPTIONAL MATCH whose cardinality exceeds the 100-row pull batch must
+   * terminate and emit each matched node exactly once, not repeat the first batch forever.
+   */
+  @Test
+  void standaloneOptionalMatchExceedingPullBatchTerminatesWithoutDuplicates() {
+    database.transaction(() -> {
+      final List<Result> rows = rows("OPTIONAL MATCH (n:Person) RETURN n.id AS id");
+
+      assertThat(rows).hasSize(NODE_COUNT);
+
+      final Set<Object> ids = new HashSet<>();
+      for (final Result row : rows)
+        ids.add(row.getProperty("id"));
+      assertThat(ids).hasSize(NODE_COUNT);
+    });
+  }
+
+  /**
+   * The no-match case must still resolve to a single all-NULL row once the (empty) pattern scan
+   * is exhausted.
+   */
+  @Test
+  void standaloneOptionalMatchWithNoMatchesEmitsSingleNullRow() {
+    database.transaction(() -> {
+      final List<Result> rows = rows("OPTIONAL MATCH (n:Person {id: -1}) RETURN n");
+
+      assertThat(rows).hasSize(1);
+      assertThat(rows.getFirst().<Object>getProperty("n")).isNull();
+    });
+  }
+
+  /**
+   * A leading OPTIONAL MATCH whose cardinality fits within a single pull batch must still work
+   * (this shape already passed before the fix, it pins the non-regressed case).
+   */
+  @Test
+  void standaloneOptionalMatchWithinPullBatchStillWorks() {
+    database.transaction(() -> {
+      final List<Result> rows = rows("OPTIONAL MATCH (n:Person {id: 0}) RETURN n.id AS id");
+
+      assertThat(rows).hasSize(1);
+      assertThat(rows.getFirst().<Object>getProperty("id")).isEqualTo(0);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #6668: a standalone `OPTIONAL MATCH` used as the first clause of a query re-ran its pattern scan from scratch on every pull batch, because the match cursor lived in a local variable recreated each `fetchMore` call instead of being held across calls. When the pattern matched more rows than the 100-row pull batch size, this caused the first batch of rows to be emitted repeatedly and the query to never terminate.
- Hoists the standalone cursor into the existing `currentMatchResults` field (mirroring how the with-input path already holds its cursor across input rows via that same field), so it resumes across `fetchMore` calls and `finished` is only set once that single cursor is genuinely exhausted.

## Test plan
- [x] New regression test `CypherStandaloneOptionalMatchPullBatchIssue6668Test` (250 `:Person` nodes, exceeding the 100-row pull batch): asserts the standalone `OPTIONAL MATCH` returns each node exactly once, plus no-match and within-batch cases.
- [x] Verified the new test reproduces the bug against the pre-fix code (OutOfMemoryError from unbounded duplicate emission).
- [x] Ran the full OpenCypher TCK suite plus related `OPTIONAL MATCH` regression tests: no regressions (2 unrelated pre-existing flaky tests confirmed to pass in isolation).

## Test plan (backend)
Verified via `mvn -o -pl engine -am test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved standalone `OPTIONAL MATCH` queries spanning multiple result batches.
  - Prevented duplicate rows and ensured results complete correctly.
  - Queries with no matches now return exactly one null-valued row.
  - Preserved expected behavior when matches fit within a single batch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->