### PR TITLE
fix(#6670,#6669): correct MATCH GAV expand-into fast path and SELECT $var target caching

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
@@ -101,6 +101,17 @@ public class GraphTraversalProviderRegistry {
   }
 
   /**
+   * Returns true if any provider is registered for any database, without the lock/unwrap/WeakHashMap lookup
+   * {@link #findProvider} needs once it establishes that. Lets a caller that would otherwise do non-trivial work
+   * (e.g. building an edge-types array) just to pass it to {@link #findProvider} skip that work first in the
+   * overwhelmingly common case where no provider is registered at all - the same single-volatile-read short
+   * circuit {@link #findProvider} itself takes, exposed for callers that need it before they can call that method.
+   */
+  public static boolean hasAnyProviders() {
+    return hasAnyProviders;
+  }
+
+  /**
    * Finds the first ready provider that covers all the given edge types.
    *
    * @param database  the database

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -108,9 +108,9 @@ public class MatchEdgeTraverser {
   }
 
   /**
-   * Returns {@code false} for a while/maxDepth pattern item: {@link com.arcadedb.graph.GraphTraversalProvider
-   * #isConnectedTo} only ever answers whether two vertices are joined by a single hop, so a variable-depth item
-   * must keep going through the recursive {@link #executeTraversal} instead of taking the expand-into fast path.
+   * Returns {@code false} for a while/maxDepth pattern item: {@link GraphTraversalProvider#isConnectedTo} only
+   * ever answers whether two vertices are joined by a single hop, so a variable-depth item must keep going
+   * through the recursive {@link #executeTraversal} instead of taking the expand-into fast path.
    */
   private static boolean isSingleHopExpandable(final MatchPathItem item) {
     if (item == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -166,9 +166,7 @@ public class MatchEdgeTraverser {
             ? getExpandIntoDirection() : null;
         if (direction != null) {
           final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
-          final GraphTraversalProvider provider = edgeTypes.length == 0
-              ? GraphTraversalProviderRegistry.findProvider(context.getDatabase())
-              : GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
+          final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
           if (provider != null) {
             final int srcId = provider.getNodeId(sourceVertex.getIdentity());
             final int tgtId = provider.getNodeId(targetElem.getIdentity());

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -107,6 +107,26 @@ public class MatchEdgeTraverser {
     return this.edge.edge.in.alias;
   }
 
+  /**
+   * Returns the {@link Vertex.DIRECTION} the GAV expand-into fast path (see {@link #init}) should query, as seen
+   * from this traverser's own starting point (i.e. the vertex {@link #getStartingPointAlias()} names): the same
+   * direction {@link #traversePatternEdge} would use by invoking {@code item.getMethod().execute(...)}. Returns
+   * {@code null} when the pattern edge has no single direction to ask a provider about - no method (a
+   * {@code FieldMatchPathItem}/{@code MultiMatchPathItem}) or a method other than out/in/both (outE/inE/bothE/
+   * outV/inV need the edge or the far vertex itself, not just a connectivity check) - in which case the fast path
+   * is skipped in favour of the slow, always-correct traversal.
+   */
+  protected Vertex.DIRECTION getExpandIntoDirection() {
+    if (item == null || item.getMethod() == null)
+      return null;
+    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
+      case "out" -> Vertex.DIRECTION.OUT;
+      case "in" -> Vertex.DIRECTION.IN;
+      case "both" -> Vertex.DIRECTION.BOTH;
+      default -> null;
+    };
+  }
+
   protected void init(final CommandContext context) {
     if (downstream == null) {
       Identifiable startingElem = sourceRecord.getElementProperty(getStartingPointAlias());
@@ -125,15 +145,20 @@ public class MatchEdgeTraverser {
         else if (prevValue instanceof Result r)
           targetElem = r.getElement().orElse(null);
 
-        if (targetElem != null) {
-          final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(context.getDatabase());
+        // Only a plain out()/in()/both() hop is eligible: the fast path returns just the bound vertex, which is
+        // wrong for outE()/inE()/bothE()/outV()/inV() (an edge/vertex object is expected) and item.getMethod() is
+        // null for a FieldMatchPathItem/MultiMatchPathItem (no single direction to ask the provider about).
+        final Vertex.DIRECTION direction = targetElem != null && edge != null ? getExpandIntoDirection() : null;
+        if (direction != null) {
+          final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
+          final GraphTraversalProvider provider = edgeTypes.length == 0
+              ? GraphTraversalProviderRegistry.findProvider(context.getDatabase())
+              : GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
           if (provider != null) {
             final int srcId = provider.getNodeId(sourceVertex.getIdentity());
             final int tgtId = provider.getNodeId(targetElem.getIdentity());
             if (srcId >= 0 && tgtId >= 0) {
-              // Determine direction from the edge traversal
-              final Vertex.DIRECTION direction = edge != null && !edge.out ? Vertex.DIRECTION.IN : Vertex.DIRECTION.OUT;
-              if (provider.isConnectedTo(srcId, tgtId, direction)) {
+              if (provider.isConnectedTo(srcId, tgtId, direction, edgeTypes)) {
                 // Connected: return the target as the single result
                 final Document doc = (Document) targetElem.getRecord();
                 downstream = List.of(new ResultInternal(doc)).iterator();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -129,14 +129,7 @@ public class MatchEdgeTraverser {
    * is skipped in favour of the slow, always-correct traversal.
    */
   protected Vertex.DIRECTION getExpandIntoDirection() {
-    if (item == null || item.getMethod() == null)
-      return null;
-    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
-      case "out" -> Vertex.DIRECTION.OUT;
-      case "in" -> Vertex.DIRECTION.IN;
-      case "both" -> Vertex.DIRECTION.BOTH;
-      default -> null;
-    };
+    return MatchExecutionPlanner.directionFor(item, true);
   }
 
   protected void init(final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -147,7 +147,12 @@ public class MatchEdgeTraverser {
       }
 
       // Expand-into optimization: when both endpoints are already bound, use isConnectedTo()
-      // for O(log degree) binary search instead of traversing all neighbors
+      // for O(log degree) binary search instead of traversing all neighbors. This does not re-check the
+      // endpoint's own filters/class/cluster/rid (unlike executeTraversal(), which calls matchesFilters() etc.
+      // per candidate): those were already applied when the endpoint alias was first bound, and next()'s
+      // equals(prevValue, nextElement) check below (the same one the slow path relies on to reject a
+      // subsequent binding that disagrees with an earlier one) is what re-validates identity here, not a
+      // second filter pass. This is by design, not an oversight.
       final String endPointAlias = getEndpointAlias();
       final Object prevValue = sourceRecord.getProperty(endPointAlias);
       if (prevValue != null && startingElem instanceof Vertex sourceVertex) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -172,6 +172,8 @@ public class MatchEdgeTraverser {
         // hasAnyProviders() short-circuits on a single volatile read, avoiding extractEdgeLabels()'s array/string
         // work below for the overwhelmingly common case where no GAV provider is registered for any database.
         if (direction != null && GraphTraversalProviderRegistry.hasAnyProviders()) {
+          // direction != null already proved item.getMethod() != null (see getExpandIntoDirection()), which is
+          // what extractEdgeLabels() dereferences without its own null check - keep this call after that guard.
           final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
           final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
           if (provider != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -108,6 +108,18 @@ public class MatchEdgeTraverser {
   }
 
   /**
+   * Returns {@code false} for a while/maxDepth pattern item: {@link com.arcadedb.graph.GraphTraversalProvider
+   * #isConnectedTo} only ever answers whether two vertices are joined by a single hop, so a variable-depth item
+   * must keep going through the recursive {@link #executeTraversal} instead of taking the expand-into fast path.
+   */
+  private static boolean isSingleHopExpandable(final MatchPathItem item) {
+    if (item == null)
+      return false;
+    final var filter = item.getFilter();
+    return filter == null || (filter.getWhileCondition() == null && filter.getMaxDepth() == null);
+  }
+
+  /**
    * Returns the {@link Vertex.DIRECTION} the GAV expand-into fast path (see {@link #init}) should query, as seen
    * from this traverser's own starting point (i.e. the vertex {@link #getStartingPointAlias()} names): the same
    * direction {@link #traversePatternEdge} would use by invoking {@code item.getMethod().execute(...)}. Returns
@@ -147,8 +159,11 @@ public class MatchEdgeTraverser {
 
         // Only a plain out()/in()/both() hop is eligible: the fast path returns just the bound vertex, which is
         // wrong for outE()/inE()/bothE()/outV()/inV() (an edge/vertex object is expected) and item.getMethod() is
-        // null for a FieldMatchPathItem/MultiMatchPathItem (no single direction to ask the provider about).
-        final Vertex.DIRECTION direction = targetElem != null && edge != null ? getExpandIntoDirection() : null;
+        // null for a FieldMatchPathItem/MultiMatchPathItem (no single direction to ask the provider about). A
+        // while/maxDepth item is a variable-depth traversal - isConnectedTo() only ever answers a single hop, so
+        // it must keep going through the recursive executeTraversal() below instead.
+        final Vertex.DIRECTION direction = targetElem != null && edge != null && isSingleHopExpandable(item)
+            ? getExpandIntoDirection() : null;
         if (direction != null) {
           final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
           final GraphTraversalProvider provider = edgeTypes.length == 0

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -169,7 +169,9 @@ public class MatchEdgeTraverser {
         // it must keep going through the recursive executeTraversal() below instead.
         final Vertex.DIRECTION direction = targetElem != null && edge != null && isSingleHopExpandable(item)
             ? getExpandIntoDirection() : null;
-        if (direction != null) {
+        // hasAnyProviders() short-circuits on a single volatile read, avoiding extractEdgeLabels()'s array/string
+        // work below for the overwhelmingly common case where no GAV provider is registered for any database.
+        if (direction != null && GraphTraversalProviderRegistry.hasAnyProviders()) {
           final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
           final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
           if (provider != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.parser.AndBlock;
 import com.arcadedb.query.sql.parser.Bucket;
 import com.arcadedb.query.sql.parser.Expression;
@@ -411,6 +412,32 @@ public class MatchExecutionPlanner {
     for (int i = 0; i < params.size(); i++)
       labels[i] = params.get(i).toString().replace("'", "").replace("\"", "").trim();
     return labels;
+  }
+
+  /**
+   * Returns the {@link Vertex.DIRECTION} a GAV-accelerated traversal must query for a pattern edge's method
+   * (out/in/both), as seen from the vertex the traversal actually starts from - {@code forward} says whether
+   * that's the edge's syntactic out-side ({@code true}, e.g. {@link MatchEdgeTraverser}/a fused chain hop with
+   * {@code et.out}) or its in-side ({@code false}, e.g. {@link MatchReverseEdgeTraverser}/a hop with
+   * {@code !et.out}, which runs the method's reverse - the same out&harr;in flip
+   * {@link com.arcadedb.query.sql.parser.MethodCall#executeReverse} applies elsewhere). "both" has no opposite
+   * and stays as-is regardless of {@code forward}.
+   * <p>
+   * Returns {@code null} when the item has no single direction to ask a provider about (no method, or a method
+   * other than out/in/both) - the caller must then fall back to the slow, always-correct traversal instead.
+   * Package-visible: shared by {@link MatchEdgeTraverser}/{@link MatchReverseEdgeTraverser}'s single-hop
+   * expand-into fast path and {@link MatchGAVFusedStep}'s multi-hop fused DFS, both of which need the identical
+   * mapping (#6670).
+   */
+  static Vertex.DIRECTION directionFor(final MatchPathItem item, final boolean forward) {
+    if (item == null || item.getMethod() == null)
+      return null;
+    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
+      case "out" -> forward ? Vertex.DIRECTION.OUT : Vertex.DIRECTION.IN;
+      case "in" -> forward ? Vertex.DIRECTION.IN : Vertex.DIRECTION.OUT;
+      case "both" -> Vertex.DIRECTION.BOTH;
+      default -> null;
+    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -399,9 +399,11 @@ public class MatchExecutionPlanner {
   }
 
   /**
-   * Extracts edge type labels from a MATCH edge traversal's method parameters.
+   * Extracts edge type labels from a MATCH edge traversal's method parameters. Package-visible: also reused by
+   * {@link MatchEdgeTraverser}'s GAV expand-into fast path to pass the pattern's edge type(s) through to the
+   * provider instead of matching on any edge type (#6670).
    */
-  private static String[] extractEdgeLabels(final EdgeTraversal et) {
+  static String[] extractEdgeLabels(final EdgeTraversal et) {
     final var params = et.edge.item.getMethod().params;
     if (params == null || params.isEmpty())
       return new String[0];

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchGAVFusedStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchGAVFusedStep.java
@@ -137,17 +137,12 @@ class MatchGAVFusedStep extends AbstractExecutionStep {
 
     for (int i = 0; i < chainLen; i++) {
       final EdgeTraversal et = edges.get(i);
-      directions[i] = et.out ? Vertex.DIRECTION.OUT : Vertex.DIRECTION.IN;
-      // Extract edge labels from the method call parameters
-      final var methodParams = et.edge.item.getMethod().params;
-      if (methodParams != null && !methodParams.isEmpty()) {
-        final String[] labels = new String[methodParams.size()];
-        for (int p = 0; p < methodParams.size(); p++)
-          labels[p] = methodParams.get(p).toString().replace("'", "").replace("\"", "").trim();
-        edgeLabelsPerHop[i] = labels;
-      } else {
-        edgeLabelsPerHop[i] = new String[0];
-      }
+      // et.out is the schedule's forward/reverse flag, not the pattern's actual out()/in()/both() method - a
+      // reverse-scheduled in()/both() hop needs the same out<->in flip MatchReverseEdgeTraverser applies to its
+      // single-hop expand-into fast path (#6670). isFusibleEdge() already guarantees a plain out/in/both method,
+      // so this can never fall back to null here.
+      directions[i] = MatchExecutionPlanner.directionFor(et.edge.item, et.out);
+      edgeLabelsPerHop[i] = MatchExecutionPlanner.extractEdgeLabels(et);
       // The alias for this hop's endpoint
       aliases[i] = et.out ? et.edge.in.alias : et.edge.out.alias;
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchReverseEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchReverseEdgeTraverser.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.parser.MatchPathItem;
 import com.arcadedb.query.sql.parser.Rid;
 import com.arcadedb.query.sql.parser.WhereClause;
@@ -27,6 +28,7 @@ import com.arcadedb.query.sql.parser.WhereClause;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -45,6 +47,25 @@ public class MatchReverseEdgeTraverser extends MatchEdgeTraverser {
 
   protected String targetClassName(final MatchPathItem item, final CommandContext iCommandContext) {
     return edge.getLeftClass();
+  }
+
+  /**
+   * {@code item.getMethod()} is still the pattern edge's method as parsed from its syntactic out-side (this class
+   * never rewrites it), so the direction it names is relative to that side, not to {@link #getStartingPointAlias()}
+   * (the in-side, which this reverse traverser actually starts from) - the same out<->in flip
+   * {@link com.arcadedb.query.sql.parser.MethodCall#executeReverse} applies to pick the method it actually runs.
+   * "both" has no opposite and stays as-is.
+   */
+  @Override
+  protected Vertex.DIRECTION getExpandIntoDirection() {
+    if (item == null || item.getMethod() == null)
+      return null;
+    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
+      case "out" -> Vertex.DIRECTION.IN;
+      case "in" -> Vertex.DIRECTION.OUT;
+      case "both" -> Vertex.DIRECTION.BOTH;
+      default -> null;
+    };
   }
 
   protected String targetClusterName(final MatchPathItem item, final CommandContext iCommandContext) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchReverseEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchReverseEdgeTraverser.java
@@ -28,7 +28,6 @@ import com.arcadedb.query.sql.parser.WhereClause;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -58,14 +57,7 @@ public class MatchReverseEdgeTraverser extends MatchEdgeTraverser {
    */
   @Override
   protected Vertex.DIRECTION getExpandIntoDirection() {
-    if (item == null || item.getMethod() == null)
-      return null;
-    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
-      case "out" -> Vertex.DIRECTION.IN;
-      case "in" -> Vertex.DIRECTION.OUT;
-      case "both" -> Vertex.DIRECTION.BOTH;
-      default -> null;
-    };
+    return MatchExecutionPlanner.directionFor(item, false);
   }
 
   protected String targetClusterName(final MatchPathItem item, final CommandContext iCommandContext) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -137,11 +137,12 @@ public class SelectExecutionPlanner {
       info.projection.setDistinct(false);
     }
 
-    // Copied like every other clause below: optimizeQuery()/rewriteIndexChainsAsSubqueries() can rewrite a $var
-    // target's identifier into the resolved type name in place (#6669). Without the copy that write lands on the
-    // shared FromClause node StatementCache hands back for every execution of this SQL text, permanently pinning
-    // the cached Statement to whichever type the first execution resolved $var to - and racing any concurrent
-    // first execution on the same node.
+    // Copied like every other clause below: calculateTargetBuckets() (unconditional) and
+    // rewriteIndexChainsAsSubqueries() (only when a WHERE clause is present) can each rewrite a $var target's
+    // identifier into the resolved type name in place (#6669). Without the copy that write lands on the shared
+    // FromClause node StatementCache hands back for every execution of this SQL text, permanently pinning the
+    // cached Statement to whichever type the first execution resolved $var to - and racing any concurrent first
+    // execution on the same node.
     info.target = this.statement.getTarget() == null ? null : this.statement.getTarget().copy();
     info.whereClause = this.statement.getWhereClause() == null ? null : this.statement.getWhereClause().copy();
     info.perRecordLetClause = this.statement.getLetClause() == null ? null : this.statement.getLetClause().copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -137,7 +137,12 @@ public class SelectExecutionPlanner {
       info.projection.setDistinct(false);
     }
 
-    info.target = this.statement.getTarget();
+    // Copied like every other clause below: optimizeQuery()/rewriteIndexChainsAsSubqueries() can rewrite a $var
+    // target's identifier into the resolved type name in place (#6669). Without the copy that write lands on the
+    // shared FromClause node StatementCache hands back for every execution of this SQL text, permanently pinning
+    // the cached Statement to whichever type the first execution resolved $var to - and racing any concurrent
+    // first execution on the same node.
+    info.target = this.statement.getTarget() == null ? null : this.statement.getTarget().copy();
     info.whereClause = this.statement.getWhereClause() == null ? null : this.statement.getWhereClause().copy();
     info.perRecordLetClause = this.statement.getLetClause() == null ? null : this.statement.getLetClause().copy();
     info.groupBy = this.statement.getGroupBy() == null ? null : this.statement.getGroupBy().copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
@@ -313,6 +313,13 @@ public class FromItem extends SimpleNode {
     if (functionCall != null)
       return functionCall.isCacheable();
 
+    // A "$var" target resolves against a runtime CommandContext variable (see SelectExecutionPlanner's
+    // rewriteIndexChainsAsSubqueries()), so the compiled plan is only valid for the binding it was built with.
+    // Caching it under this statement's text would replay that one binding's type for every later execution
+    // regardless of what $var is bound to then (#6669).
+    if (identifier != null && identifier.getStringValue() != null && identifier.getStringValue().startsWith("$"))
+      return false;
+
     return true;
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.parser.MatchExpression;
+import com.arcadedb.query.sql.parser.MatchPathItem;
+import com.arcadedb.query.sql.parser.MatchStatement;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Focused unit tests for the GAV expand-into fast path in {@link MatchEdgeTraverser#init}, reproducing #6670:
+ * the fast path called {@code isConnectedTo()} with no edge type at all (matching on ANY type) and derived
+ * direction from the schedule's forward/reverse split instead of the pattern's actual out/in/both method.
+ * <p>
+ * Driving this from a full SQL MATCH query is unreliable here: the fast path only fires for an edge whose both
+ * endpoints are already bound by earlier edges in the same pattern (a cycle-closing edge), and getting the
+ * planner to schedule one - without it instead getting folded into a {@code MatchGAVFusedStep} chain, which
+ * bypasses {@link MatchEdgeTraverser} entirely - depends on scheduling heuristics that are not part of this
+ * bug. This test instead builds the minimal {@link EdgeTraversal}/bound-source-record scaffolding directly and
+ * drives {@link MatchEdgeTraverser#hasNext} itself, with a {@link GraphTraversalProvider} test double that
+ * records exactly which direction and edge types it was asked about.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MatchEdgeTraverserExpandIntoTest extends TestHelper {
+
+  /**
+   * Records the direction/edge types of the last {@link #isConnectedTo} call and answers a fixed "connected"
+   * verdict, so a test can assert both what the traverser asked and what it did with the answer.
+   */
+  private static final class RecordingProvider implements GraphTraversalProvider {
+    private final Map<RID, Integer> ridToId = new HashMap<>();
+    private final Map<Integer, RID> idToRid = new HashMap<>();
+    private       int               nextId  = 0;
+    private       boolean           connected;
+
+    Vertex.DIRECTION lastDirection;
+    String[]         lastEdgeTypes;
+
+    private int idFor(final RID rid) {
+      return ridToId.computeIfAbsent(rid, r -> {
+        final int id = nextId++;
+        idToRid.put(id, r);
+        return id;
+      });
+    }
+
+    @Override
+    public int getNodeCount() {
+      return ridToId.size();
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "recording-fake";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return idFor(rid);
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return idToRid.get(nodeId);
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return new int[0];
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return 0;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      lastDirection = direction;
+      lastEdgeTypes = edgeTypes;
+      return connected;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+  }
+
+  private RecordingProvider provider;
+
+  @AfterEach
+  void unregisterProvider() {
+    if (provider != null)
+      GraphTraversalProviderRegistry.unregister(database, provider);
+  }
+
+  private MatchPathItem parsePathItem(final String matchPattern) {
+    final MatchStatement stm = (MatchStatement) ((DatabaseInternal) database).getStatementCache()
+        .get("MATCH " + matchPattern + " RETURN a,b");
+    final MatchExpression expr = stm.getMatchExpressions().get(0);
+    return expr.getItems().get(0);
+  }
+
+  private EdgeTraversal edgeTraversal(final MatchPathItem item, final boolean forward) {
+    final PatternNode outNode = new PatternNode();
+    outNode.alias = "a";
+    final PatternNode inNode = new PatternNode();
+    inNode.alias = "b";
+    final PatternEdge patternEdge = new PatternEdge();
+    patternEdge.out = outNode;
+    patternEdge.in = inNode;
+    patternEdge.item = item;
+    return new EdgeTraversal(patternEdge, forward);
+  }
+
+  private ResultInternal boundSourceRecord(final Identifiable a, final Identifiable b) {
+    final ResultInternal sourceRecord = new ResultInternal(database);
+    sourceRecord.setProperty("a", a);
+    sourceRecord.setProperty("b", b);
+    return sourceRecord;
+  }
+
+  @Test
+  void expandIntoPassesPatternEdgeTypeToProvider() {
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isTrue();
+    // Before the fix, isConnectedTo() was called with no edge types at all (any type matches); it must now
+    // receive exactly the pattern's own type.
+    assertThat(provider.lastEdgeTypes).containsExactly("KNOWS");
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.OUT);
+  }
+
+  @Test
+  void expandIntoForwardDirectionMatchesMethodName() {
+    // a.in('KNOWS') must be checked as IN from a's perspective, not OUT: before the fix, the forward traverser
+    // always asked for OUT regardless of the pattern's actual out/in/both method.
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.in('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.IN);
+  }
+
+  @Test
+  void expandIntoReverseTraverserFlipsDirection() {
+    // MatchReverseEdgeTraverser starts from the pattern's in-side and runs the method's *reverse*, so for
+    // a.out('KNOWS') scheduled backward (starting at b) it must ask the provider for IN from b's perspective -
+    // before the fix, the reverse traverser inherited the same OUT-biased formula as the forward one.
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchReverseEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, false));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.IN);
+    assertThat(provider.lastEdgeTypes).containsExactly("KNOWS");
+  }
+
+  @Test
+  void expandIntoBothDirectionStaysBoth() {
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.both('KNOWS'){as:b}");
+
+    final BasicCommandContext forwardContext = new BasicCommandContext();
+    forwardContext.setDatabase(database);
+    final MatchEdgeTraverser forward = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+    assertThat(forward.hasNext(forwardContext)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.BOTH);
+
+    final BasicCommandContext reverseContext = new BasicCommandContext();
+    reverseContext.setDatabase(database);
+    final MatchEdgeTraverser reverse = new MatchReverseEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, false));
+    assertThat(reverse.hasNext(reverseContext)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.BOTH);
+  }
+
+  @Test
+  void expandIntoNotConnectedReturnsEmpty() {
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = false;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
@@ -66,6 +66,7 @@ class MatchEdgeTraverserExpandIntoTest extends TestHelper {
 
     Vertex.DIRECTION lastDirection;
     String[]         lastEdgeTypes;
+    int              isConnectedToCalls;
 
     private int idFor(final RID rid) {
       return ridToId.computeIfAbsent(rid, r -> {
@@ -122,6 +123,7 @@ class MatchEdgeTraverserExpandIntoTest extends TestHelper {
 
     @Override
     public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      isConnectedToCalls++;
       lastDirection = direction;
       lastEdgeTypes = edgeTypes;
       return connected;
@@ -288,5 +290,56 @@ class MatchEdgeTraverserExpandIntoTest extends TestHelper {
     context.setDatabase(database);
 
     assertThat(traverser.hasNext(context)).isFalse();
+  }
+
+  @Test
+  void expandIntoSkipsWhileConditionItems() {
+    // A while-conditioned item is a variable-depth traversal: isConnectedTo() only ever answers whether two
+    // vertices are joined by a single hop, so it must never be consulted here even though both endpoints are
+    // already bound - the recursive executeTraversal() has to run instead.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("KNOWS", b);
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b, while: ($depth < 2)}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    traverser.hasNext(context);
+    assertThat(provider.isConnectedToCalls).isZero();
+  }
+
+  @Test
+  void expandIntoSkipsMaxDepthItems() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("KNOWS", b);
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b, maxDepth: 2}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    traverser.hasNext(context);
+    assertThat(provider.isConnectedToCalls).isZero();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
@@ -245,6 +245,57 @@ class MatchEdgeTraverserExpandIntoTest extends TestHelper {
   }
 
   @Test
+  void expandIntoReverseInDirectionMapsToOut() {
+    // Same flip as expandIntoReverseTraverserFlipsDirection(), but for the "in" method: a.in('KNOWS') scheduled
+    // backward (starting at b, the method's actual out-side) must ask the provider for OUT from b's perspective.
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.in('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchReverseEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, false));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.OUT);
+  }
+
+  @Test
+  void expandIntoSkipsUnrecognizedMethod() {
+    // outE()/inE()/bothE()/outV()/inV() return an edge/vertex object the fast path doesn't produce, so
+    // getExpandIntoDirection() must fall through to null (its default case) for any method other than
+    // out/in/both, leaving the provider untouched even though both endpoints are bound.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("KNOWS", b);
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.outE('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    traverser.hasNext(context);
+    assertThat(provider.isConnectedToCalls).isZero();
+  }
+
+  @Test
   void expandIntoBothDirectionStaysBoth() {
     database.getSchema().createVertexType("Person");
     database.begin();

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchGAVFusedStepDirectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchGAVFusedStepDirectionTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the {@code MatchGAVFusedStep} sibling of #6670, found during code review: the fused
+ * multi-hop chain step ({@link MatchExecutionPlanner#collectFusibleChain}/{@code isFusibleEdge}) derived each
+ * hop's direction from the schedule's forward/reverse flag ({@code EdgeTraversal.out}) rather than the pattern's
+ * actual out/in/both method - the same root cause this PR fixes for the single-hop expand-into fast path, just
+ * in the chain-fusion path instead. {@code isFusibleEdge} explicitly allows {@code in()}/{@code both()} hops
+ * into a fused chain, so a chain with one of those and a GAV registered silently queried the wrong direction.
+ * <p>
+ * {@code createPlanForPattern} always runs the schedule's first edge through the regular (correct)
+ * {@code MatchStep}/{@code MatchEdgeTraverser} path - {@code collectFusibleChain} only starts looking from the
+ * second edge onward, and only actually uses {@link MatchGAVFusedStep} once it collects 2+ fusible edges there.
+ * A 2-hop pattern therefore never fuses (one edge is always peeled off first, leaving only one to "chain"); these
+ * tests use a 3-hop pattern so the second and third hops - the ones that actually go through
+ * {@code MatchGAVFusedStep} - carry the {@code in()}/{@code both()} method under test.
+ * <p>
+ * {@code MatchGAVFusedStep} does not evaluate each hop's own {@code where} clause (a separate, pre-existing
+ * limitation of the fused path, out of scope here), so each hop in the fixture uses its own edge type -
+ * FOLLOWS/KNOWS/KNOWS2 - to stay unambiguous by graph shape alone rather than relying on a filter the fused step
+ * would silently ignore. Sharing one KNOWS type across both fused hops would let the middle vertex's own
+ * outgoing edge (needed to test the second hop) also satisfy the first hop's direction check, masking exactly
+ * the bug this test exists to catch.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MatchGAVFusedStepDirectionTest extends TestHelper {
+
+  @Test
+  void fusedChainRespectsInMethodDirection() {
+    // Alice -FOLLOWS-> Bob (hop 0, not fused). Eve -KNOWS-> Bob and Eve -KNOWS2-> Dave (hops 1-2, fused):
+    // b.in('KNOWS') must find Eve via the INCOMING edge (Bob has no outgoing KNOWS edge at all, so the buggy
+    // OUT-only fused query finds nothing here), then c.out('KNOWS2') must find Dave.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.getSchema().createEdgeType("KNOWS");
+    database.getSchema().createEdgeType("KNOWS2");
+
+    database.begin();
+    final MutableVertex alice = database.newVertex("Person").set("name", "Alice").save();
+    final MutableVertex bob = database.newVertex("Person").set("name", "Bob").save();
+    final MutableVertex eve = database.newVertex("Person").set("name", "Eve").save();
+    final MutableVertex dave = database.newVertex("Person").set("name", "Dave").save();
+    alice.newEdge("FOLLOWS", bob);
+    eve.newEdge("KNOWS", bob);
+    eve.newEdge("KNOWS2", dave);
+    database.commit();
+
+    // Built via the builder (not `new GraphAnalyticalView(db)`, which never registers itself as a
+    // GraphTraversalProvider) so the query planner actually discovers and fuses this chain.
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS", "KNOWS", "KNOWS2")
+        .build();
+    try {
+      database.begin();
+      final ResultSet rs = database.query("sql",
+          """
+          MATCH {type: Person, as: a, where: (name = 'Alice')}.out('FOLLOWS'){as: b}.in('KNOWS'){as: c}\
+          .out('KNOWS2'){as: d} \
+          RETURN a.name as aName, b.name as bName, c.name as cName, d.name as dName""");
+
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("aName")).isEqualTo("Alice");
+      assertThat(row.<String>getProperty("bName")).isEqualTo("Bob");
+      assertThat(row.<String>getProperty("cName")).isEqualTo("Eve");
+      assertThat(row.<String>getProperty("dName")).isEqualTo("Dave");
+      assertThat(rs.hasNext()).isFalse();
+      database.commit();
+    } finally {
+      gav.drop();
+    }
+  }
+
+  @Test
+  void fusedChainRespectsBothMethodDirection() {
+    // Same shape as fusedChainRespectsInMethodDirection(), but with both() hops: b.both('KNOWS') must find Eve
+    // regardless of edge direction (Bob has only an INCOMING KNOWS edge, so the buggy code - which "both"
+    // degrades to whenever the schedule doesn't happen to reverse this hop - finds nothing here), then
+    // c.both('KNOWS2') must find Dave.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.getSchema().createEdgeType("KNOWS");
+    database.getSchema().createEdgeType("KNOWS2");
+
+    database.begin();
+    final MutableVertex alice = database.newVertex("Person").set("name", "Alice").save();
+    final MutableVertex bob = database.newVertex("Person").set("name", "Bob").save();
+    final MutableVertex eve = database.newVertex("Person").set("name", "Eve").save();
+    final MutableVertex dave = database.newVertex("Person").set("name", "Dave").save();
+    alice.newEdge("FOLLOWS", bob);
+    eve.newEdge("KNOWS", bob);
+    eve.newEdge("KNOWS2", dave);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS", "KNOWS", "KNOWS2")
+        .build();
+    try {
+      database.begin();
+      final ResultSet rs = database.query("sql",
+          """
+          MATCH {type: Person, as: a, where: (name = 'Alice')}.out('FOLLOWS'){as: b}.both('KNOWS'){as: c}\
+          .both('KNOWS2'){as: d} \
+          RETURN a.name as aName, b.name as bName, c.name as cName, d.name as dName""");
+
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("aName")).isEqualTo("Alice");
+      assertThat(row.<String>getProperty("bName")).isEqualTo("Bob");
+      assertThat(row.<String>getProperty("cName")).isEqualTo("Eve");
+      assertThat(row.<String>getProperty("dName")).isEqualTo("Dave");
+      assertThat(rs.hasNext()).isFalse();
+      database.commit();
+    } finally {
+      gav.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
@@ -75,8 +75,11 @@ class SelectVarTargetCacheTest extends TestHelper {
     assertThat(rs2.next().<String>getProperty("name")).isEqualTo("fromB");
     rs2.close();
 
-    // Third execution: back to TypeA. Also exercises the ExecutionPlanCache path (ctx1's plan may have been
-    // cached), which must not still be pinned to whichever type built the cached plan first.
+    // Third execution: back to TypeA. Reuses the same shared parsed Statement once more (not the
+    // ExecutionPlanCache: a $var target is non-cacheable, so createExecutionPlan() never consults that cache
+    // for this statement at all - see the assertion below), which must not still be pinned to whichever type
+    // built the first execution's plan.
+    assertThat(stmt1.executionPlanCanBeCached()).isFalse();
     final SelectStatement stmt3 = (SelectStatement) db.getStatementCache().get(sqlText);
     final BasicCommandContext ctx3 = new BasicCommandContext();
     ctx3.setDatabase(database);
@@ -85,5 +88,36 @@ class SelectVarTargetCacheTest extends TestHelper {
     assertThat(rs3.hasNext()).isTrue();
     assertThat(rs3.next().<String>getProperty("name")).isEqualTo("fromA");
     rs3.close();
+  }
+
+  @Test
+  void ordinaryTargetStillUsesExecutionPlanCache() {
+    // Companion to the test above: confirms marking a $var target non-cacheable in FromItem.isCacheable()
+    // didn't overreach and disable plan caching for a plain, literal-type target.
+    database.getSchema().createDocumentType("TypeA");
+    database.begin();
+    database.newDocument("TypeA").set("name", "fromA").save();
+    database.commit();
+
+    final String sqlText = "SELECT FROM TypeA";
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final SelectStatement stmt = (SelectStatement) db.getStatementCache().get(sqlText);
+    assertThat(stmt.executionPlanCanBeCached()).isTrue();
+
+    // ExecutionPlanCache.put() discards a plan built before the cache's own invalidation timestamp - both are
+    // millisecond System.currentTimeMillis() reads, so a plan built in the very same millisecond as the schema
+    // DDL above (which invalidates the cache) can lose that race under a busy JVM. Wait past it explicitly
+    // rather than asserting on elapsed time (see StallAwareStopwatch guidance): this loop bounds nothing, it
+    // just guarantees the plan is built strictly after the invalidation it must not lose to.
+    final long lastInvalidation = db.getExecutionPlanCache().getLastInvalidation();
+    while (System.currentTimeMillis() <= lastInvalidation) {
+      Thread.onSpinWait();
+    }
+
+    assertThat(db.getExecutionPlanCache().contains(sqlText)).isFalse();
+    final BasicCommandContext ctx = new BasicCommandContext();
+    ctx.setDatabase(database);
+    stmt.createExecutionPlan(ctx);
+    assertThat(db.getExecutionPlanCache().contains(sqlText)).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
@@ -108,7 +108,9 @@ class SelectVarTargetCacheTest extends TestHelper {
     // millisecond System.currentTimeMillis() reads, so a plan built in the very same millisecond as the schema
     // DDL above (which invalidates the cache) can lose that race under a busy JVM. Wait past it explicitly
     // rather than asserting on elapsed time (see StallAwareStopwatch guidance): this loop bounds nothing, it
-    // just guarantees the plan is built strictly after the invalidation it must not lose to.
+    // just guarantees the plan is built strictly after the invalidation it must not lose to. Deliberately
+    // unbounded rather than a @Timeout-guarded wait: the wall clock is guaranteed to advance, so this cannot
+    // hang - the only way to leave this loop is for time to pass, which it always does.
     final long lastInvalidation = db.getExecutionPlanCache().getLastInvalidation();
     while (System.currentTimeMillis() <= lastInvalidation) {
       Thread.onSpinWait();

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.sql.parser.LocalResultSet;
+import com.arcadedb.query.sql.parser.SelectStatement;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6669: {@code SelectExecutionPlanner.init()} aliased the statement's FROM target instead
+ * of copying it, so a later rewrite of a {@code $var} target (from
+ * {@code SelectExecutionPlanner#rewriteIndexChainsAsSubqueries}) mutated the FromClause node in place. That
+ * node is the exact object {@link com.arcadedb.query.sql.parser.StatementCache} hands back for every execution
+ * of the same SQL text, so the first execution's resolved type stuck permanently to the cached statement - and,
+ * via {@link com.arcadedb.query.sql.parser.ExecutionPlanCache} (also keyed purely by SQL text, independent of
+ * any variable binding), to the cached execution plan as well.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SelectVarTargetCacheTest extends TestHelper {
+
+  @Test
+  void reusedStatementWithDifferentVarTargetReturnsFreshType() {
+    database.getSchema().createDocumentType("TypeA");
+    database.getSchema().createDocumentType("TypeB");
+
+    database.begin();
+    database.newDocument("TypeA").set("name", "fromA").save();
+    database.newDocument("TypeB").set("name", "fromB").save();
+    database.commit();
+
+    final String sqlText = "SELECT FROM $t";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // First execution: $t = TypeA
+    final SelectStatement stmt1 = (SelectStatement) db.getStatementCache().get(sqlText);
+    final BasicCommandContext ctx1 = new BasicCommandContext();
+    ctx1.setDatabase(database);
+    ctx1.setVariable("$t", "TypeA");
+    final ResultSet rs1 = new LocalResultSet(stmt1.createExecutionPlan(ctx1));
+    assertThat(rs1.hasNext()).isTrue();
+    assertThat(rs1.next().<String>getProperty("name")).isEqualTo("fromA");
+    rs1.close();
+
+    // Second execution: StatementCache.get() returns the exact same parsed Statement instance for identical
+    // SQL text - proving this reuses the shared, potentially-mutated AST rather than a fresh parse.
+    final SelectStatement stmt2 = (SelectStatement) db.getStatementCache().get(sqlText);
+    assertThat(stmt2).isSameAs(stmt1);
+
+    final BasicCommandContext ctx2 = new BasicCommandContext();
+    ctx2.setDatabase(database);
+    ctx2.setVariable("$t", "TypeB");
+    final ResultSet rs2 = new LocalResultSet(stmt2.createExecutionPlan(ctx2));
+    assertThat(rs2.hasNext()).isTrue();
+    assertThat(rs2.next().<String>getProperty("name")).isEqualTo("fromB");
+    rs2.close();
+
+    // Third execution: back to TypeA. Also exercises the ExecutionPlanCache path (ctx1's plan may have been
+    // cached), which must not still be pinned to whichever type built the cached plan first.
+    final SelectStatement stmt3 = (SelectStatement) db.getStatementCache().get(sqlText);
+    final BasicCommandContext ctx3 = new BasicCommandContext();
+    ctx3.setDatabase(database);
+    ctx3.setVariable("$t", "TypeA");
+    final ResultSet rs3 = new LocalResultSet(stmt3.createExecutionPlan(ctx3));
+    assertThat(rs3.hasNext()).isTrue();
+    assertThat(rs3.next().<String>getProperty("name")).isEqualTo("fromA");
+    rs3.close();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two small, independent bugs found during other analysis:

**#6670** - `MatchEdgeTraverser`'s GAV expand-into fast path (both pattern endpoints already bound, e.g. a cycle-closing edge) asked the `GraphTraversalProvider` with no edge type at all (so any edge type satisfied it) and derived direction from the schedule's forward/reverse split instead of the pattern's actual `out`/`in`/`both` method - so a typed or `.in(...)`-directed pattern edge could match on the wrong type or direction. Fix:
- Restrict the fast path to plain `out()`/`in()`/`both()` hops (an `outE()`/`inE()`/`bothE()`/`outV()`/`inV()` method, or a `FieldMatchPathItem`/`MultiMatchPathItem` with no method at all, now falls through to the always-correct slow traversal).
- Pass the pattern's edge type(s) through to `GraphTraversalProviderRegistry.findProvider()` and `GraphTraversalProvider.isConnectedTo()` (reusing `MatchExecutionPlanner.extractEdgeLabels`, now package-visible, instead of duplicating the label-extraction logic).
- Derive direction from the parsed method name via a new `getExpandIntoDirection()`, overridden in `MatchReverseEdgeTraverser` to flip it (that class runs the method's *reverse* from the opposite endpoint, the same out&harr;in flip `MethodCall.executeReverse` applies).
- Also skip the fast path for a `while`/`maxDepth` pattern item (`isSingleHopExpandable()`): `isConnectedTo()` only ever answers a single-hop check, so a variable-depth item must keep going through the recursive `executeTraversal()`. This gap predates this PR - the original fast path had no such guard at all - and isn't covered by the issue's own repro, but is the same class of bug and is covered by dedicated regression tests.

**MatchGAVFusedStep sibling bug (found during review)** - the multi-hop chain-fusion GAV step has the exact same direction-derivation bug as the single-hop expand-into path above (`et.out ? OUT : IN`, ignoring the pattern's actual method), and `isFusibleEdge()` explicitly allows `in()`/`both()` hops into a fused chain. Fixed by extracting the direction mapping into a shared `MatchExecutionPlanner.directionFor(item, forward)`, now used by all three call sites (`MatchEdgeTraverser`, `MatchReverseEdgeTraverser`, `MatchGAVFusedStep`) instead of duplicating it.

**#6669** - `SelectExecutionPlanner.init()` aliased the statement's FROM target (`info.target = this.statement.getTarget()`) instead of copying it like every other clause. Two later planner steps resolve a `$var` target against the current `CommandContext` and rewrite the identifier in place - on the *shared* node, since it was never copied: `calculateTargetBuckets` (unconditional) and `rewriteIndexChainsAsSubqueries` (only when a WHERE clause is present). That node is exactly what `StatementCache` hands back for every execution of the same SQL text, so the first execution's resolved type stuck permanently to the cached statement (plus a data race on concurrent first executions). Fix:
- Copy the target in `init()`, matching every sibling clause (`whereClause`, `letClause`, `groupBy`, `orderBy`, `unwind`).
- Also mark a `$var` target as non-cacheable in `FromItem.isCacheable()`: `ExecutionPlanCache` is keyed purely by SQL text with no awareness of variable bindings, so even with the AST no longer corrupted, a `$var`-target plan built for the first binding would otherwise still get replayed for every later execution regardless of what `$var` is bound to then. Both fixes are needed for full correctness - suggesting this as the better alternative to the issue's single-fix options.

## Test plan

- [x] `MatchEdgeTraverserExpandIntoTest` (new): focused unit tests driving `MatchEdgeTraverser`/`MatchReverseEdgeTraverser` directly against a recording `GraphTraversalProvider` test double, asserting the exact direction/edge-types passed to `isConnectedTo()`. Verified to fail against the pre-fix code (4/5 assertions), pass after. A full-SQL-MATCH repro proved unreliable: the fast path only fires for a cycle-closing edge, and getting the planner to schedule one without folding it into an unrelated `MatchGAVFusedStep` chain depends on scheduling heuristics outside this bug's scope.
- [x] `MatchGAVFusedStepDirectionTest` (new): SQL-level regression for the fused-chain sibling bug, using a real registered GAV and a 3-hop pattern (fusion only kicks in from the schedule's second edge onward). Verified to fail against the pre-fix code (zero rows instead of the correct single row), pass after.
- [x] `SelectVarTargetCacheTest` (new): reuses the same parsed `Statement` instance (as `StatementCache` would) across two `createExecutionPlan()` calls with different `$t` bindings, asserting each returns data from its own bound type. Verified to fail against the pre-fix code, pass after.
- [x] Existing `MatchGAVExpandIntoTest` (all 3 tests) still green.
- [x] Full `com.arcadedb.query.sql.executor.**` and `com.arcadedb.query.sql.parser.**` test packages green - no regressions.
- [x] `mvn -o -pl engine -am compile` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved MATCH query traversal for eligible single-hop directional graph expansions while preserving recursive behavior for variable-depth patterns.
  - Improved forward, reverse, and bidirectional edge traversal, including edge-label handling.

- **Bug Fixes**
  - Prevented cached query plans from reusing variable-based targets with incorrect bindings.
  - Preserved correct behavior when shared query statements run with different runtime targets.

- **Tests**
  - Added coverage for edge types, traversal directions, disconnected endpoints, and variable-depth matches.
  - Added regression coverage for cached variable-based `SELECT` targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

