### PR TITLE
fix(#6608): reject non-STRING arguments in remaining STRING positions of string functions

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/text/CharLengthFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/CharLengthFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.text;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -45,8 +46,11 @@ public class CharLengthFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    if (args[0] == null)
+    // STRING-only argument, same declared input domain as toUpper()/toLower()/trim() and the rest of the
+    // #5798 family - this function predates that fix and was never brought in line with it (issue #6608).
+    final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+    if (source == null)
       return null;
-    return (long) args[0].toString().length();
+    return (long) source.length();
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/text/LTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/LTrimFunction.java
@@ -52,13 +52,15 @@ public class LTrimFunction implements StatelessFunction {
       return source.stripLeading();
     }
     if (args.length == 2) {
-      // The primary argument is type-checked before a null trim character decides the answer, so an
-      // out-of-domain primary argument is still reported even when args[1] happens to be null (issue
-      // #5798 review: lTrim(5, null) must still be a type error, not a silent null).
+      // Both arguments are STRING-typed and type-checked before either being null decides the answer, so an
+      // out-of-domain argument is still reported regardless of which position happens to be null (issue
+      // #5798 review: lTrim(5, null) must still be a type error, not a silent null). The trim-character
+      // argument is STRING-typed too, same as the primary one - issue #6608: #5798 only covered this
+      // function's primary argument position, leaving the trim character to silently coerce via toString().
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
-      if (source == null || args[1] == null)
+      final String trimChar = CypherFunctionHelper.requireStringArgument(args[1], getName());
+      if (source == null || trimChar == null)
         return null;
-      final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.stripLeading();
       return stripLeading(source, trimChar);

--- a/engine/src/main/java/com/arcadedb/function/text/RTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/RTrimFunction.java
@@ -52,13 +52,15 @@ public class RTrimFunction implements StatelessFunction {
       return source.stripTrailing();
     }
     if (args.length == 2) {
-      // The primary argument is type-checked before a null trim character decides the answer, so an
-      // out-of-domain primary argument is still reported even when args[1] happens to be null (issue
-      // #5798 review: rTrim(5, null) must still be a type error, not a silent null).
+      // Both arguments are STRING-typed and type-checked before either being null decides the answer, so an
+      // out-of-domain argument is still reported regardless of which position happens to be null (issue
+      // #5798 review: rTrim(5, null) must still be a type error, not a silent null). The trim-character
+      // argument is STRING-typed too, same as the primary one - issue #6608: #5798 only covered this
+      // function's primary argument position, leaving the trim character to silently coerce via toString().
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
-      if (source == null || args[1] == null)
+      final String trimChar = CypherFunctionHelper.requireStringArgument(args[1], getName());
+      if (source == null || trimChar == null)
         return null;
-      final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.stripTrailing();
       return stripTrailing(source, trimChar);

--- a/engine/src/main/java/com/arcadedb/function/text/ReplaceFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/ReplaceFunction.java
@@ -47,12 +47,17 @@ public class ReplaceFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    // The primary argument is type-checked before a null secondary argument decides the answer, so an
-    // out-of-domain primary argument is still reported even when args[1] or args[2] happens to be null
-    // (issue #5798 review: replace(5, null, 'b') must still be a type error, not a silent null).
+    // Every argument is STRING-typed and type-checked before any of them being null decides the answer, so
+    // an out-of-domain argument is still reported regardless of which other position happens to be null
+    // (issue #5798 review: replace(5, null, 'b') must still be a type error, not a silent null). The search
+    // and replacement arguments are STRING-typed too, same as the primary one - issue #6608: #5798 only
+    // covered this function's primary argument position, leaving these two to silently coerce via
+    // toString().
     final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
-    if (source == null || args[1] == null || args[2] == null)
+    final String search = CypherFunctionHelper.requireStringArgument(args[1], getName());
+    final String replacement = CypherFunctionHelper.requireStringArgument(args[2], getName());
+    if (source == null || search == null || replacement == null)
       return null;
-    return source.replace(args[1].toString(), args[2].toString());
+    return source.replace(search, replacement);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSplitFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSplitFunction.java
@@ -49,13 +49,18 @@ public class CypherSplitFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    // The primary argument is type-checked before a null delimiter decides the answer, so an out-of-domain
-    // primary argument is still reported even when args[1] happens to be null (issue #5798 review:
-    // split(5, null) must still be a type error, not a silent null).
+    // Both arguments are STRING-typed and type-checked before either being null decides the answer, so an
+    // out-of-domain argument is still reported regardless of which position happens to be null (issue #5798
+    // review: split(5, null) must still be a type error, not a silent null). The delimiter is STRING-typed
+    // too, same as the primary argument - issue #6608: #5798 only covered this function's primary argument
+    // position, leaving the delimiter to silently coerce via toString(). Neo4j itself coerces a non-STRING
+    // delimiter, but ArcadeDB's own #5798 policy already rejects it in the primary position of this same
+    // function, so accepting it here would be an inconsistency within this build rather than a Neo4j
+    // compatibility concern.
     final String str = CypherFunctionHelper.requireStringArgument(args[0], getName());
-    if (str == null || args[1] == null)
+    final String delimiter = CypherFunctionHelper.requireStringArgument(args[1], getName());
+    if (str == null || delimiter == null)
       return null;
-    final String delimiter = args[1].toString();
 
     // An empty delimiter splits the string into its individual characters (Neo4j/Memgraph semantics).
     // Java's String.split("", -1) appends a spurious trailing empty string, so handle this case explicitly.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
@@ -59,25 +59,31 @@ public class CypherTrimFunction implements StatelessFunction {
     }
 
     if (args.length == 2) {
-      // 2-arg form: btrim(source, trimCharacter). The primary argument is type-checked before a null
-      // trim character decides the answer, so an out-of-domain primary argument is still reported even
-      // when args[1] happens to be null (issue #5798 review: btrim(5, null) must still be a type error,
-      // not a silent null).
+      // 2-arg form: btrim(source, trimCharacter). Both arguments are STRING-typed and type-checked before
+      // either being null decides the answer, so an out-of-domain argument is still reported regardless of
+      // which position happens to be null (issue #5798 review: btrim(5, null) must still be a type error,
+      // not a silent null). The trim-character argument is STRING-typed too, same as the primary one -
+      // issue #6608: #5798 only covered this function's primary argument position, leaving the trim
+      // character to silently coerce via toString().
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
-      if (source == null || args[1] == null)
+      final String trimChar = CypherFunctionHelper.requireStringArgument(args[1], getName());
+      if (source == null || trimChar == null)
         return null;
-      final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.strip();
       return stripLeading(stripTrailing(source, trimChar), trimChar);
     }
 
     if (args.length == 3) {
-      // SQL-style: trim(BOTH/LEADING/TRAILING char FROM string)
+      // SQL-style: trim(BOTH/LEADING/TRAILING char FROM string). The mode is not user data: the parser
+      // (CypherExpressionBuilder#parseTrimFunction) always supplies one of the three literal mode strings,
+      // never an arbitrary expression, so it needs no type check. The source (primary) argument is
+      // type-checked first, same ordering convention as every other function in this family, followed by
+      // the trim character - STRING-typed too, issue #6608: #5798 only reached this function's primary
+      // argument, at position 2 in this form.
       final String mode = args[0] != null ? args[0].toString() : null;
-      final String trimChar = args[1] != null ? args[1].toString() : null;
-
       final String source = CypherFunctionHelper.requireStringArgument(args[2], getName());
+      final String trimChar = CypherFunctionHelper.requireStringArgument(args[1], getName());
       if (source == null || trimChar == null)
         return null;
       if (trimChar.isEmpty()) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionSecondaryArgumentIssue6608Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionSecondaryArgumentIssue6608Test.java
@@ -168,6 +168,23 @@ class CypherStringFunctionSecondaryArgumentIssue6608Test extends TestHelper {
     assertThat(single("RETURN char_length('ab') AS r")).isEqualTo(2L);
   }
 
+  // ===================== pre-existing ambiguity noted by review, out of scope for this fix =====================
+
+  @Test
+  void btrimCalledWithThreePositionalArgumentsIsAPreExistingAmbiguityNotIntroducedByThisFix() {
+    // btrim() has no dedicated SQL-style grammar rule (only the reserved TRIM keyword does - see
+    // CypherExpressionBuilder#findTrimFunctionRecursive), so a 3-argument call to it is parsed as an
+    // ordinary function call and reaches CypherTrimFunction's args.length == 3 branch positionally:
+    // args[0] is read as "mode" (never LEADING/TRAILING, so it silently falls through to "trim both"),
+    // args[1] as the trim character, and args[2] as the source - NOT args[0] as the source a caller
+    // writing btrim(source, char, somethingElse) by analogy with the 2-arg form would expect. This
+    // predates #6608 (this fix only added the type check on args[1]/args[2], it did not change which
+    // position plays which role) and is pinned here as documented, current behaviour rather than fixed,
+    // since resolving it is a separate, unscoped question of whether btrim() should even accept 3
+    // arguments at all.
+    assertThat(single("RETURN btrim('unused-as-mode', 'x', 'xxabcxx') AS r")).isEqualTo("abc");
+  }
+
   private Object single(final String query) {
     try (final ResultSet rs = database.query("opencypher", query)) {
       assertThat(rs.hasNext()).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionSecondaryArgumentIssue6608Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionSecondaryArgumentIssue6608Test.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6608: issue #5798 (fixed by PR #5901) made several string functions reject a
+ * non-STRING value in their PRIMARY argument position, but the remaining STRING-typed argument positions of
+ * the same functions - {@code split()}'s delimiter, {@code replace()}'s search and replacement text,
+ * {@code trim()}/{@code btrim()}/{@code lTrim()}/{@code rTrim()}'s trim-character argument - still accepted
+ * any value and silently converted it via {@code Object.toString()}. {@code char.length()} (a.k.a.
+ * {@code char_length()}) was not covered by #5798 at all, in any argument position.
+ * <p>
+ * Handing a non-STRING value to one of these positions is the client's mistake and must be a
+ * {@link CommandSemanticException} (400), not a silently "successful" textual conversion, exactly as the
+ * primary argument position already behaves since #5798.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherStringFunctionSecondaryArgumentIssue6608Test extends TestHelper {
+
+  // ===================== the reproducers from the issue =====================
+
+  @Test
+  void replaceOfNonStringSearchOrReplacementArgumentIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN replace('a', 1, 'b') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN replace('a', 1, []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN replace('a', 'x', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void splitOfNonStringDelimiterIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN split('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("split()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void lTrimOfNonStringTrimCharacterIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN lTrim('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("lTrim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void rTrimOfNonStringTrimCharacterIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN rTrim('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("rTrim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void btrimOfNonStringTrimCharacterIsAClientTypeError() {
+    // 2-argument form: btrim(source, trimCharacter).
+    assertThatThrownBy(() -> consume("RETURN btrim('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void theSqlStyleThreeArgumentTrimFormRejectsANonStringTrimCharacter() {
+    // trim(BOTH/LEADING/TRAILING char FROM string): char is args[1], source is args[2].
+    assertThatThrownBy(() -> consume("RETURN trim(BOTH [] FROM 'a') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void charLengthOfANonStringArgumentIsAClientTypeError() {
+    // char.length() and char_length() are aliases resolving to the same executor (CypherFunctionFactory),
+    // so both report under the executor's own getName() spelling, same convention as the toUpper()/upper()
+    // aliases in issue #5798.
+    assertThatThrownBy(() -> consume("RETURN char.length([]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("char_length()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN char_length(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("char_length()")
+        .hasMessageContaining("STRING");
+  }
+
+  // ===================== the internal consistency controls from the issue still pass =====================
+
+  @Test
+  void thePrimaryArgumentPositionsFixedByIssue5798StillReject() {
+    assertThatThrownBy(() -> consume("RETURN split(5, ',') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("split()");
+    assertThatThrownBy(() -> consume("RETURN replace(5, 'a', 'b') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()");
+    assertThatThrownBy(() -> consume("RETURN btrim('a', 1, []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()");
+  }
+
+  // ===================== null propagation is not a type error =====================
+
+  @Test
+  void nullPropagationIsNotATypeError() {
+    assertThat(single("RETURN split('a,b', null) AS r")).isNull();
+    assertThat(single("RETURN replace('a', null, 'b') AS r")).isNull();
+    assertThat(single("RETURN replace('a', 'a', null) AS r")).isNull();
+    assertThat(single("RETURN lTrim('a', null) AS r")).isNull();
+    assertThat(single("RETURN rTrim('a', null) AS r")).isNull();
+    assertThat(single("RETURN btrim('a', null) AS r")).isNull();
+    assertThat(single("RETURN char.length(null) AS r")).isNull();
+  }
+
+  // ===================== explicit conversion still works =====================
+
+  @Test
+  void explicitToStringConversionStillWorks() {
+    assertThat(single("RETURN split('a1b', toString(1)) AS r").toString()).isEqualTo("[a, b]");
+    assertThat(single("RETURN replace('a1b', toString(1), 'x') AS r")).isEqualTo("axb");
+    assertThat(single("RETURN char.length(toString(42)) AS r")).isEqualTo(2L);
+  }
+
+  // ===================== valid arguments still work (no regression) =====================
+
+  @Test
+  void validArgumentsStillWork() {
+    assertThat(single("RETURN split('a,b', ',') AS r").toString()).isEqualTo("[a, b]");
+    assertThat(single("RETURN replace('abc', 'b', 'x') AS r")).isEqualTo("axc");
+    assertThat(single("RETURN lTrim('xxabc', 'x') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN rTrim('abcxx', 'x') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN btrim('xxabcxx', 'x') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN trim(BOTH 'x' FROM 'xxabcxx') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN char.length('ab') AS r")).isEqualTo(2L);
+    assertThat(single("RETURN char_length('ab') AS r")).isEqualTo(2L);
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Issue #5798 (fixed by PR #5901) made `split()`, `replace()`, `trim()`/`btrim()`, `lTrim()` and `rTrim()` reject a non-STRING value in their **primary** argument position with a client-facing type error (HTTP 400). Fixes #6608, which reports that the **remaining** STRING-typed argument positions of the same functions still silently coerced any value via `toString()`:

- `split()`'s delimiter (2nd argument)
- `replace()`'s search and replacement text (2nd and 3rd arguments)
- `trim()`/`btrim()`/`lTrim()`/`rTrim()`'s trim-character argument
- `char.length()` / `char_length()` - not covered by #5798 at all, any argument position

## Fix

Apply the existing `CypherFunctionHelper.requireStringArgument()` helper (introduced by #5901) to the remaining argument positions, so every STRING-typed argument position of these functions now follows the same policy the primary position already has. No new abstraction was needed - this reuses the exact mechanism #5798 established.

`split()`'s delimiter is a deliberate divergence from Neo4j (which coerces it): on this same build `split(5, ',')` already rejects a non-STRING primary argument, so accepting a non-STRING delimiter in the same function would be an internal inconsistency rather than a compatibility concession. Every other affected position already matches Neo4j's own rejection.

## Test plan

- [x] Added `CypherStringFunctionSecondaryArgumentIssue6608Test` reproducing every case from the issue (fails against the pre-fix code, passes after)
- [x] `CypherStringFunctionArgumentIssue5798Test` (the original fix's regression test) still passes
- [x] `CypherLeftRightSubstringFunctionArgumentIssue6609Test`, `OpenCypherStringFunctionsComprehensiveTest`, and the SQL-side trim/split method tests still pass
- [x] Full `com.arcadedb.query.opencypher.**` package run clean except one pre-existing flake (`CypherGAVBoundTargetCardinalityTest`, unrelated to string functions, passes in isolation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - String functions now require string-typed arguments instead of implicitly converting other values.
  - Improved validation for `char.length`, `replace`, `split`, `lTrim`, `rTrim`, and `trim`.
  - Invalid argument types now produce clear type errors, including when other arguments are null.
  - Null handling remains unchanged for valid inputs.

- **Tests**
  - Added regression coverage for secondary-argument validation, null propagation, aliases, and trimming variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->