### PR TITLE
fix(#6701): Postgres wire SET honors SESSION/LOCAL and strips extended-protocol trailing ';'

### DIFF
--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2086,7 +2086,14 @@ public class PostgresNetworkExecutor extends Thread {
           upperCaseText.startsWith("ROLLBACK TO ")) {
         portal.ignoreExecution = true;
       } else if (upperCaseText.startsWith("SET ")) {
-        setConfiguration(portal.query);
+        // Strip a trailing ';' before dispatch, mirroring what queryCommand() already does for its own
+        // queryText on the simple-query protocol - a Parse message keeps the terminator glued onto the
+        // text, which otherwise reaches setConfiguration() attached to the value (issue #6701).
+        // portal.query itself is left untouched: nothing downstream needs the terminator removed.
+        String setText = portal.query.trim();
+        if (setText.endsWith(";"))
+          setText = setText.substring(0, setText.length() - 1);
+        setConfiguration(setText);
         portal.ignoreExecution = true;
       } else if (systemQuery != null) {
         createResultSet(portal, systemQuery.columnName, systemQueryValue(systemQuery.function));
@@ -2171,18 +2178,31 @@ public class PostgresNetworkExecutor extends Thread {
 
   /**
    * Parses a Postgres {@code SET <param> = <value>} or {@code SET <param> TO <value>} command into its
-   * {@code {paramName, value}} pair. A command can only use one of the two separators, but its value may
-   * legitimately contain the other one as plain text (e.g. {@code SET search_path TO 'a=b'} or
-   * {@code SET x = 'a TO b'}), so this picks whichever separator - the first '=' or the first case-
-   * insensitive ' TO ' - occurs FIRST in the string and splits on that one only, leaving every other
-   * occurrence of either inside the value untouched (issue #6423). {@code paramName} is lower-cased for
-   * case-insensitive comparison; a quoted {@code value} has its surrounding quotes stripped. Returns null
-   * when the command has neither separator.
+   * {@code {paramName, value}} pair, honoring the optional PostgreSQL {@code SESSION}/{@code LOCAL} scope
+   * modifiers (issue #6701): {@code SET SESSION datestyle = 'ISO'} and {@code SET LOCAL datestyle = 'ISO'}
+   * must resolve to the same {@code datestyle} parameter name as a plain {@code SET datestyle = 'ISO'}, not
+   * a literal {@code "session datestyle"}/{@code "local datestyle"} that no special case ever matches.
+   * ArcadeDB has no notion of transaction-scoped config distinct from session-scoped config, so both
+   * modifiers - and no modifier at all - end up folded into the same connection-wide
+   * {@link #connectionProperties} map; that already matches the de facto behavior of a plain {@code SET}
+   * today.
+   * <p>
+   * A command can only use one of the two separators, but its value may legitimately contain the other
+   * one as plain text (e.g. {@code SET search_path TO 'a=b'} or {@code SET x = 'a TO b'}), so this picks
+   * whichever separator - the first '=' or the first case-insensitive ' TO ' - occurs FIRST in the string
+   * and splits on that one only, leaving every other occurrence of either inside the value untouched
+   * (issue #6423). {@code paramName} is lower-cased for case-insensitive comparison; a quoted {@code value}
+   * has its surrounding quotes stripped. Returns null when the command has neither separator.
    */
   static String[] parseSetCommand(final String query) {
     final int setLength = "SET ".length();
     // Use original query to preserve case of values
-    final String q = query.substring(setLength);
+    String q = query.substring(setLength);
+
+    if (q.regionMatches(true, 0, "SESSION ", 0, "SESSION ".length()))
+      q = q.substring("SESSION ".length());
+    else if (q.regionMatches(true, 0, "LOCAL ", 0, "LOCAL ".length()))
+      q = q.substring("LOCAL ".length());
 
     final int eqPos = q.indexOf('=');
     final Matcher toMatcher = SET_TO_SEPARATOR.matcher(q);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2199,10 +2199,9 @@ public class PostgresNetworkExecutor extends Thread {
     // Use original query to preserve case of values
     String q = query.substring(setLength);
 
-    if (q.regionMatches(true, 0, "SESSION ", 0, "SESSION ".length()))
-      q = q.substring("SESSION ".length());
-    else if (q.regionMatches(true, 0, "LOCAL ", 0, "LOCAL ".length()))
-      q = q.substring("LOCAL ".length());
+    final Matcher scopeModifier = SET_SCOPE_MODIFIER.matcher(q);
+    if (scopeModifier.find())
+      q = q.substring(scopeModifier.end());
 
     final int eqPos = q.indexOf('=');
     final Matcher toMatcher = SET_TO_SEPARATOR.matcher(q);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -120,6 +120,8 @@ public class PostgresNetworkExecutor extends Thread {
   private static final Object[]                                       NO_PARAMETERS     = new Object[0];
   /** Case-insensitive {@code TO} separator for the {@code SET <param> TO <value>} syntax. */
   private static final Pattern                                        SET_TO_SEPARATOR  = Pattern.compile("(?i)\\s+TO\\s+");
+  /** Case-insensitive {@code SESSION}/{@code LOCAL} scope modifier leading a {@code SET} command (issue #6701). */
+  private static final Pattern                                        SET_SCOPE_MODIFIER = Pattern.compile("(?i)^(?:SESSION|LOCAL)\\s+");
 
   private final ArcadeDBServer              server;
   private final ChannelBinaryServer         channel;

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6701SetSessionLocalIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6701SetSessionLocalIT.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.utility.DateUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression tests for issue #6701: two pre-existing gaps in
+ * {@link PostgresNetworkExecutor#setConfiguration(String)} / {@code parseSetCommand()}, found by CodeRabbit
+ * while reviewing PR #6697 (unrelated to that PR's own fix).
+ * <ul>
+ *   <li>{@code SET SESSION <name> = <value>} / {@code SET LOCAL <name> = <value>} were not recognized: the
+ *   {@code SESSION }/{@code LOCAL } modifier became part of the parameter name (e.g.
+ *   {@code "session datestyle"}), so the {@code datestyle} special case never fired.</li>
+ *   <li>The extended query protocol's {@code Parse} dispatch passed {@code portal.query} to
+ *   {@code setConfiguration()} without stripping a trailing {@code ;} first, unlike the simple-query
+ *   protocol's {@code queryCommand()}, which already strips one from {@code queryText}.</li>
+ * </ul>
+ * These tests speak the wire protocol directly over a raw socket so the extended-query {@code Parse} path
+ * is actually exercised (a JDBC client normally sends {@code SET} over the simple-query protocol, which
+ * would not reach the second bug at all), and observe the {@code datestyle} special case's side effect
+ * ({@link com.arcadedb.schema.Schema#setDateTimeFormat}) directly on the server-side database rather than
+ * relying on {@code connectionProperties}, which this class never exposes back to the client.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6701SetSessionLocalIT extends PostgresWireProtocolTestBase {
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    // Restore the schema-wide format so this test can't leak state into any other test class that shares
+    // the same database.
+    getServerDatabase(0, getDatabaseName()).getSchema().setDateTimeFormat(GlobalConfiguration.DATE_TIME_FORMAT.getValueAsString());
+    super.endTest();
+  }
+
+  @Test
+  @DisplayName("[#6701] SET SESSION <name> = <value> over the simple-query protocol resolves to the plain parameter name")
+  void setSessionModifierIsHonoredOverSimpleProtocol() throws Exception {
+    resetDateTimeFormat();
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "SET SESSION datestyle = 'ISO'");
+        assertThat(messageTypesOf(readUntilReadyForQuery(in)))
+            .as("no ErrorResponse for a SET SESSION command").doesNotContain('E');
+      });
+    }
+
+    assertThat(getServerDatabase(0, getDatabaseName()).getSchema().getDateTimeFormat())
+        .as("SET SESSION datestyle = 'ISO' must resolve the parameter name to plain 'datestyle', "
+            + "not 'session datestyle', so the datestyle special case actually fires")
+        .isEqualTo(DateUtils.DATE_TIME_ISO_8601_FORMAT);
+  }
+
+  @Test
+  @DisplayName("[#6701] SET LOCAL <name> = <value> over the simple-query protocol resolves to the plain parameter name")
+  void setLocalModifierIsHonoredOverSimpleProtocol() throws Exception {
+    resetDateTimeFormat();
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "SET LOCAL datestyle = 'ISO'");
+        assertThat(messageTypesOf(readUntilReadyForQuery(in)))
+            .as("no ErrorResponse for a SET LOCAL command").doesNotContain('E');
+      });
+    }
+
+    assertThat(getServerDatabase(0, getDatabaseName()).getSchema().getDateTimeFormat())
+        .as("SET LOCAL datestyle = 'ISO' must resolve the parameter name to plain 'datestyle', "
+            + "not 'local datestyle', so the datestyle special case actually fires")
+        .isEqualTo(DateUtils.DATE_TIME_ISO_8601_FORMAT);
+  }
+
+  @Test
+  @DisplayName("[#6701] a semicolon-terminated SET over the extended query protocol is honored, not rejected")
+  void trailingSemicolonIsStrippedOverExtendedProtocol() throws Exception {
+    resetDateTimeFormat();
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        // Sent as its own Parse+Bind+Execute+Sync round trip, the extended-query dispatch in
+        // parseCommand() (not queryCommand()'s simple-query dispatch, which already strips a trailing ';').
+        final List<WireMessage> messages = runExtendedQuery(out, in, "SET datestyle = 'ISO';");
+        assertThat(messageTypesOf(messages))
+            .as("a trailing ';' must not make setConfiguration() reject the value").doesNotContain('E');
+      });
+    }
+
+    assertThat(getServerDatabase(0, getDatabaseName()).getSchema().getDateTimeFormat())
+        .as("SET datestyle = 'ISO'; over the extended protocol must still flip the format to ISO 8601, "
+            + "not fail to parse because of the glued-on trailing ';'")
+        .isEqualTo(DateUtils.DATE_TIME_ISO_8601_FORMAT);
+  }
+
+  private void resetDateTimeFormat() {
+    getServerDatabase(0, getDatabaseName()).getSchema().setDateTimeFormat(GlobalConfiguration.DATE_TIME_FORMAT.getValueAsString());
+  }
+
+  private void authenticate(final DataOutputStream out, final DataInputStream in) throws Exception {
+    sendStartupMessage(out, "root", getDatabaseName());
+    readMessage(in); // AuthenticationCleartextPassword
+    sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+    readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+  }
+
+  private static void sendSimpleQuery(final DataOutputStream out, final String query) throws Exception {
+    final byte[] queryBytes = query.getBytes(StandardCharsets.UTF_8);
+    out.writeByte('Q');
+    out.writeInt(4 + queryBytes.length + 1);
+    out.write(queryBytes);
+    out.writeByte(0);
+    out.flush();
+  }
+
+  /**
+   * Runs one statement as its own Parse+Bind+Execute+Sync round trip over the extended query protocol (the
+   * unnamed statement/portal, no parameters), then reads every message the server sends back up to and
+   * including the {@code ReadyForQuery} the Sync produces.
+   */
+  private static List<WireMessage> runExtendedQuery(final DataOutputStream out, final DataInputStream in, final String query)
+      throws Exception {
+    sendParse(out, query);
+    sendBind(out);
+    sendExecute(out);
+    sendSync(out);
+    return readUntilReadyForQuery(in);
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // unnamed statement
+    writeCString(body, query);
+    body.write(0);
+    body.write(0); // int16 numParamDataTypes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('P');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  /**
+   * Bind for the unnamed portal/statement, no parameters, no declared result formats.
+   */
+  private static void sendBind(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    writeCString(body, ""); // statement name
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0
+    body.write(0);
+    body.write(0); // int16 numParamValues = 0
+    body.write(0);
+    body.write(0); // int16 numResultFormatCodes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('B');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendExecute(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0); // int32 limit = 0 (no limit)
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('E');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendSync(final DataOutputStream out) throws Exception {
+    out.writeByte('S');
+    out.writeInt(4);
+    out.flush();
+  }
+
+  private record WireMessage(char type, byte[] body) {
+  }
+
+  private static WireMessage readWireMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] body = new byte[length - 4];
+    in.readFully(body);
+    return new WireMessage((char) type, body);
+  }
+
+  /**
+   * Reads messages until (and including) the next {@code ReadyForQuery}, so a single request/response round
+   * trip can be inspected in full.
+   */
+  private static List<WireMessage> readUntilReadyForQuery(final DataInputStream in) throws Exception {
+    final List<WireMessage> messages = new ArrayList<>();
+    WireMessage message;
+    do {
+      message = readWireMessage(in);
+      messages.add(message);
+    } while (message.type() != 'Z');
+    return messages;
+  }
+
+  private static List<Character> messageTypesOf(final List<WireMessage> messages) {
+    final List<Character> types = new ArrayList<>(messages.size());
+    for (final WireMessage message : messages)
+      types.add(message.type());
+    return types;
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -24,10 +24,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
- * Regression tests for issue #6423: {@code PostgresNetworkExecutor.setConfiguration()} used to split a
- * {@code SET <param> = <value>} command on EVERY '=', so a value containing a further '=' (e.g. a connection
- * string) was silently truncated - and, because the quote-stripping that followed assumed the truncated value
- * still ended in the closing quote, it chopped off the value's last character too.
+ * Regression tests for {@code PostgresNetworkExecutor.parseSetCommand()}.
+ * <p>
+ * Issue #6423: the parser used to split a {@code SET <param> = <value>} command on EVERY '=', so a value
+ * containing a further '=' (e.g. a connection string) was silently truncated - and, because the
+ * quote-stripping that followed assumed the truncated value still ended in the closing quote, it chopped
+ * off the value's last character too.
+ * <p>
+ * Issue #6701: a {@code SET} command prefixed with the PostgreSQL {@code SESSION}/{@code LOCAL} scope
+ * modifiers must resolve to the same parameter name as a plain {@code SET}, not a mangled
+ * {@code "session <name>"}/{@code "local <name>"}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -98,5 +104,35 @@ class PostgresSetCommandParsingTest {
   @Test
   void mismatchedQuotesAreRejected() {
     assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = 'abc\"")).isNull();
+  }
+
+  @Test
+  void sessionModifierIsStrippedWithEquals() {
+    final String[] parsed = PostgresNetworkExecutor.parseSetCommand("SET SESSION datestyle = 'ISO'");
+    assertThat(parsed).as("SESSION modifier must not become part of the parameter name").containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void sessionModifierIsStrippedWithTo() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET SESSION datestyle TO 'ISO'")).containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void localModifierIsStripped() {
+    final String[] parsed = PostgresNetworkExecutor.parseSetCommand("SET LOCAL datestyle = 'ISO'");
+    assertThat(parsed).as("LOCAL modifier must not become part of the parameter name").containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void modifierIsCaseInsensitive() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET session datestyle = 'ISO'")[0]).isEqualTo("datestyle");
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET Local datestyle = 'ISO'")[0]).isEqualTo("datestyle");
+  }
+
+  @Test
+  void aParamNameThatMerelyStartsWithSessionIsNotMistakenForTheModifier() {
+    // "sessiontimeout" must not have its first 8 characters ("session ") sliced off as if they were the
+    // SESSION modifier: the modifier match requires a following space, which "sessiontimeout" has not got.
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET sessiontimeout = '30'")).containsExactly("sessiontimeout", "30");
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes two pre-existing gaps in `PostgresNetworkExecutor`'s `SET` command handling:

1. **`SET SESSION ...` / `SET LOCAL ...` weren't recognized.** `SET SESSION datestyle = 'ISO'` resolved
   the parameter name to `"session datestyle"` instead of `"datestyle"`, so the `datestyle` special case
   never fired and the value was stored under the wrong key.
2. **A trailing `;` wasn't stripped in the extended-protocol path.** `queryCommand()` (simple protocol)
   already strips a trailing `;` from `queryText` before it reaches `setConfiguration()`. `parseCommand()`
   (extended protocol, a `Parse` message) did not do the same for `portal.query` before its own `SET `
   branch, so `SET datestyle = 'ISO';` sent via `Parse` kept the semicolon glued to the value and the
   command was rejected as malformed.

A `parseSetCommand()` helper was extracted out of `setConfiguration()` that strips a leading
`SESSION `/`LOCAL ` modifier (case-insensitive) before splitting on `=`/`TO`. ArcadeDB has no notion of
transaction-scoped config distinct from session-scoped config, so both modifiers - and no modifier at all -
fold into the same connection-wide `connectionProperties` map, matching the existing de facto behavior of a
plain `SET`. The extended-protocol `SET ` branch in `parseCommand()` now strips a trailing `;` into a local
copy before dispatch, mirroring what `queryCommand()` already does.

## Motivation

Closes #6701

## Related issues

Closes #6701

Found by CodeRabbit while reviewing #6697 (unrelated fix for #6423's `key=value` truncation bug); both
gaps predate that PR.

## Additional Notes

A third, related gap was added to #6701 via a follow-up comment: a comma-separated, partially-quoted
`SET` value list (e.g. `SET search_path TO "$user", public`) isn't tokenized correctly. That's a
materially heavier lift (real value-list tokenization per PostgreSQL's `SET` grammar, with its own design
question) whose quote-handling code lives in the still-unmerged PR #6697
(`fix(#6423): reject a SET value with a missing or mismatched closing quote`), not on `main`. Bundling it
here would conflict with that PR's own changes to the same lines before it merges, so it's left out of
scope for this PR and can be picked up once #6697 lands.

## Test plan

- [x] `PostgresSetCommandParsingTest` (new, unit-level, reflection on the private `parseSetCommand()`
  helper): plain `SET`/`SET ... TO`, `SESSION`/`LOCAL` modifiers with both separators, case-insensitivity,
  a parameter name that merely starts with "session" is not mistaken for the modifier, malformed input
  still returns `null`.
- [x] `Issue6701SetSessionLocalIT` (new, wire-level, speaks the wire protocol over a raw socket):
  `SET SESSION datestyle = 'ISO'` and `SET LOCAL datestyle = 'ISO'` over the simple protocol actually flip
  the schema's date-time format to ISO 8601 (the observable side effect of the `datestyle` special case
  firing); `SET datestyle = 'ISO';` sent as its own Parse/Bind/Execute/Sync round trip over the extended
  protocol does the same despite the trailing `;`.
- [x] Both new test classes fail against the pre-fix code (confirmed by temporarily reverting the
  production change): the unit tests with `NoSuchMethodException` (the helper doesn't exist yet), the IT
  tests with the expected ISO format assertion failing against the unchanged default format - proving
  neither is vacuous.
- [x] Full `postgresw` module regression run (`mvn -pl postgresw verify -DskipITs=false`): 416/416 unit
  tests and 194/194 integration tests green, no regressions.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgreSQL `SET` command handling, including `SESSION` and `LOCAL` modifiers, trailing semicolons, separators, quoted values, and parameter validation.
  - Ensured configuration settings resolve consistently across simple and extended PostgreSQL query protocols.

- **Tests**
  - Added regression coverage for `SET` command parsing and PostgreSQL wire-protocol execution, including date format configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->