### PR TITLE
fix(#6657): expose close-time deferred graph rebuild via getStats()

### DIFF
--- a/bolt/conformance/COMPATIBILITY.md
+++ b/bolt/conformance/COMPATIBILITY.md
@@ -4,7 +4,7 @@
 
 Certification status of ArcadeDB's Bolt protocol against every official Neo4j driver, per the shared conformance spec ([`spec.yaml`](spec.yaml), epic #4882). Columns are driver language by pinned version ([`driver-versions.md`](driver-versions.md)).
 
-**Last verified:** 2026-08-23 03:49 UTC ([run](https://github.com/ArcadeData/arcadedb/actions/runs/32615904300))
+**Last verified:** 2026-08-24 03:51 UTC ([run](https://github.com/ArcadeData/arcadedb/actions/runs/32687391450))
 
 Legend: ✅ pass, ❌ fail, ⚠️ expected-fail / known limitation, ➖ not applicable, ⚪ skipped, `·` not reported. A `·` in a listed Coverage-gaps column means no result for that driver:version.
 

--- a/bolt/conformance/COMPATIBILITY.md
+++ b/bolt/conformance/COMPATIBILITY.md
@@ -4,7 +4,7 @@
 
 Certification status of ArcadeDB's Bolt protocol against every official Neo4j driver, per the shared conformance spec ([`spec.yaml`](spec.yaml), epic #4882). Columns are driver language by pinned version ([`driver-versions.md`](driver-versions.md)).
 
-**Last verified:** 2026-08-24 03:51 UTC ([run](https://github.com/ArcadeData/arcadedb/actions/runs/32687391450))
+**Last verified:** 2026-08-25 03:48 UTC ([run](https://github.com/ArcadeData/arcadedb/actions/runs/32805890160))
 
 Legend: ✅ pass, ❌ fail, ⚠️ expected-fail / known limitation, ➖ not applicable, ⚪ skipped, `·` not reported. A `·` in a listed Coverage-gaps column means no result for that driver:version.
 

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -45,6 +45,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.AnsiCode;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.RecordTableFormatter;
+import com.arcadedb.utility.StringUtils;
 import com.arcadedb.utility.TableFormatter;
 import org.jline.reader.Completer;
 import org.jline.reader.EndOfFileException;
@@ -1188,17 +1189,13 @@ public class Console {
   }
 
   /**
-   * Splits a `&lt;key&gt;=&lt;value&gt;` pair on the FIRST '=' only, so a value that contains further separators (a connection
-   * string, a base64 padding, a date pattern) is kept whole and an empty value is a value, not a missing one. Returns null when
-   * there is no separator at all, leaving to the caller the choice between rejecting the input and reading it as an empty value.
-   * Shared by the `-D&lt;key&gt;=&lt;value&gt;` arguments (issue #5928) and by the SET command (issue #6392), which used to
-   * disagree on the rule.
+   * Splits a `&lt;key&gt;=&lt;value&gt;` pair on the FIRST '=' only. Shared by the `-D&lt;key&gt;=&lt;value&gt;`
+   * arguments (issue #5928) and by the SET command (issue #6392), which used to disagree on the rule; delegates to
+   * {@link StringUtils#splitKeyValue} so the Postgres wire's SET command and the Studio include directive
+   * (issue #6423) follow the same rule instead of each carrying their own truncating copy.
    */
   static String[] splitKeyValue(final String pair) {
-    final int separatorPos = pair.indexOf('=');
-    if (separatorPos < 0)
-      return null;
-    return new String[] { pair.substring(0, separatorPos), pair.substring(separatorPos + 1) };
+    return StringUtils.splitKeyValue(pair);
   }
 
   private static boolean setGlobalConfiguration(final String key, final String value, final boolean printError) {

--- a/docs/6458-postgres-portal-suspension-execute-max-rows.md
+++ b/docs/6458-postgres-portal-suspension-execute-max-rows.md
@@ -1,0 +1,280 @@
+# Issue #6458 - Postgres Execute max-rows (portal suspension) broken
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/6458
+PR: https://github.com/ArcadeData/arcadedb/pull/6658
+
+## Problem
+
+The Postgres extended-protocol `Execute` with a non-zero max-row count (portal suspension) was broken three
+ways in `PostgresNetworkExecutor.executeCommand()`:
+
+- `PortalSuspended` was written *before* the data rows instead of after.
+- It was sent *together with* `CommandComplete` - the wire protocol allows exactly one terminator per
+  Execute.
+- The portal was removed on the very Execute that suspended it, so the client's follow-up `Execute` meant to
+  continue the fetch found no portal and got `NoData` - the result was silently truncated to the first batch
+  with no way to resume.
+
+A client that drives this path is any JDBC/cursor client with a non-zero `Execute` max-row count - pgjdbc
+with `autoCommit(false)` + `setFetchSize(n)` is the common case.
+
+## Fix
+
+- `executeCommand()` no longer removes the portal on lookup (`getPortal(portalName, false)`); it is only
+  discarded by an explicit `Close` or by a `Bind` reusing the same name.
+- The portal's whole result is materialized once into a new `PostgresPortal.fullResultSet` field - by
+  whichever of `Describe('P')` or the first `Execute` runs the statement first (`Describe` already has to
+  read every row to discover sparse-document columns, so reusing that materialization avoids re-running the
+  statement). Every `Execute` on the portal from then on slices `fullResultSet` by its own row-limit via a
+  `resultCursor`, so `DataRow`s are always written first, followed by exactly one terminator:
+  `PortalSuspended` when the slice stops on the limit with rows left, `CommandComplete` once drained.
+- `describeCommand()`'s own unconditional full materialization (a related, broader bug beyond the issue's
+  original scope: it discarded the client's row-limit entirely) is fixed the same way, sharing
+  `fullResultSet` with `executeCommand()` guarded by `portal.executed` so the statement runs exactly once
+  regardless of which message reaches it first.
+
+## Known, tracked limitations (out of scope for this PR)
+
+- **#6659** - the fix above eagerly materializes the entire result set into memory on the first
+  `Execute`/`Describe`, even for a client that only wants a single small page and never continues. This is a
+  real memory regression for that specific case compared to a (still-broken) pre-fix baseline. Documented in
+  `PostgresPortal.fullResultSet`'s Javadoc; a streaming redesign belongs in #6659, not here.
+- **#6660** - `bindCommand()` reuses the same `PostgresPortal` instance on a re-Bind of an already-executed
+  prepared statement (pgjdbc promotes a repeated `PreparedStatement` to a server-side statement) without
+  resetting `executed`/`fullResultSet`/`resultCursor`/`suspended`/`columns`/`rowDescriptionSent`. Pre-existing
+  bug, made more visible by this PR's new pagination state (a stale `resultCursor` can make the next slice
+  computation land on an empty range and report `CommandComplete` with an empty result on what should be a
+  fresh execution). Tracked separately; not conflated with this fix.
+
+## Tests
+
+`postgresw/src/test/java/com/arcadedb/postgres/Issue6458PortalSuspensionIT.java`:
+
+- `executeMaxRowsSendsRowsBeforeSuspendedNeverBothTerminatorsAndThePortalSurvivesToContinue` - raw wire-level
+  reproduction of all three original defects (Parse/Bind/Execute/Execute, no Describe), asserting message
+  ordering and terminator byte-by-byte. Confirmed failing pre-fix.
+- `describePortalThenExecuteWithASmallLimitReturnsOnlyThatManyRowsThenSuspends` - the Describe('P')-first
+  counterpart, covering the more consequential `describeCommand()` defect directly at the wire level (added
+  in review cycle 2, see below).
+- `aFetchSizeSmallerThanTheResultReturnsEveryRowAcrossSeveralSuspendedBatches` /
+  `aFetchSizeThatDividesTheResultExactlyStillReturnsEveryRow` - pgjdbc `setFetchSize` tests covering the
+  remainder-batch and exact-division pagination boundaries.
+- `aPortalThatSuspendsCanStillBeClosedExplicitlyWithoutBreakingTheConnection` - a suspended portal must still
+  be closeable without wedging the connection.
+
+Verified: `mvn -pl postgresw verify -DskipITs=false` (all classes, `excludedGroups=benchmark,slow,vector`).
+
+## Review cycles
+
+### Cycle 1 - head `0b13f9c7da` -> `08759526f1`
+
+`claude` bot review (PR issue comment, 2026-08-23T21:54:28Z). Two actionable points, both applied:
+
+- Eager full materialization on the plain-Execute path is now called out explicitly in
+  `PostgresPortal.fullResultSet`'s Javadoc, tracked as #6659.
+- The pre-existing re-Bind-of-an-already-executed-statement staleness bug is flagged at its exact site in
+  `bindCommand()`, tracked as #6660.
+- An "extract shared helper" nit was left as-is (reviewer marked it non-blocking; the two call sites are not
+  full duplicates).
+
+Commit: `address review: document known limitations, file follow-up issues` (`08759526f1`).
+
+### Cycle 2 - head `08759526f1` (unchanged through this review)
+
+`claude` bot review (PR issue comment, 2026-08-23T22:00:50Z) - landed on the same head as cycle 1's fix but
+was missed by the original SHA-only polling (the `claude` bot posts as a plain issue comment with no commit
+SHA on this org's repos) and is processed here once that gap in the orchestrating skill was fixed.
+
+- **Applied**: added `describePortalThenExecuteWithASmallLimitReturnsOnlyThatManyRowsThenSuspends`, closing
+  the one test-coverage gap the review found (no test had directly exercised `Describe('P')` followed by a
+  small-limit `Execute` at the wire level).
+- **Skipped** (rationale in `docs/review-deferred-0875952.md`): the eager-materialization performance note
+  (already tracked as #6659), the stale-rebind note (already tracked as #6660), and a cosmetic DEBUG-only
+  logging false-positive for sparse documents across batches (no correctness impact; the reviewer's own
+  assessment agrees it's cosmetic).
+
+See `docs/review-deferred-0875952.md` for the full rationale on each skipped item.
+
+Commit: `address review: add Describe('P')-then-small-limit wire test` (`59f3975122`).
+
+### Cycle 3 - head `59f3975122`
+
+`claude` bot review (PR issue comment, 2026-08-24T08:36:02Z) - independently re-verified the pagination
+slice-boundary logic, the `!portal.executed` guard consistency between `describeCommand()` and
+`executeCommand()`, and the catalog-query bypass, all confirmed correct. Two minor/optional points:
+
+- **Applied**: `openJdbcConnection()`'s test helper hardcoded `localhost:5432` instead of using
+  `GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()` like the raw-socket tests earlier in the same
+  file - switched for consistency.
+- **Skipped** (rationale in `docs/review-deferred-59f3975.md`): a naming-convention nit about
+  `review-deferred-*.md` not matching the repo's `<issue-number>-<description>.md` postmortem convention -
+  that filename is this orchestrating skill's own convention for a per-cycle review-response log, a distinct
+  kind of artifact from the issue-postmortem docs.
+
+See `docs/review-deferred-59f3975.md` for the full rationale.
+
+Commit: `address review: use configured Postgres port in JDBC test helper` (`b9c3a65177`).
+
+### Cycle 4 - head `b9c3a65177` (final)
+
+`claude` bot review (PR issue comment, 2026-08-24T08:40:50Z) - read the full diff across all 4 commits plus
+the current state of both source files and independently re-traced `executeCommand()`/`describeCommand()`.
+No actionable items:
+
+- **Correctness**: all three original defects confirmed fixed; the `end == total` boundary, the
+  cumulative-row-count `CommandComplete` tag, the shared `!portal.executed` guard, and a specific NPE
+  concern on `portal.fullResultSet.isEmpty()` in the catalog-query branch were all checked by hand and found
+  safe. No changes requested.
+- **Performance / #6659**: reiterates the already-tracked eager-materialization concern and recommends
+  treating #6659 as a near-term follow-up rather than a "someday" - a priority opinion on an already-filed,
+  already-open issue, not a request for a code change in this PR. No action taken here; noted for whoever
+  picks up #6659.
+- **#6660**: reconfirms the already-tracked, already-flagged pre-existing issue; explicitly "not asking for
+  it here."
+- **Minor / non-blocking**: repeats the `review-deferred-*.md` naming-convention observation from cycle 3
+  (same rationale as `docs/review-deferred-59f3975.md` still applies - skill convention, not this PR's to
+  redesign) and separately notes the `PostgresPortal.suspended` field-level comment reads as general-purpose
+  state when it's really pagination-branch-only - explicitly flagged by the reviewer itself as "not a real
+  issue, just noting."
+- **Security**: no concerns; the unrelated `bindCommand()` parameter-size guard visible in the diff context
+  was checked and fails closed correctly.
+
+No code changes made this cycle - every point was either already addressed (with a still-applicable
+rationale on record) or explicitly non-actionable per the reviewer's own text ("Nothing... rises to
+blocking," "not a real issue," "not asking for it here"). Working tree stayed empty; no new
+`review-deferred-*.md` file was needed since nothing new required a rationale beyond what cycles 2-3 already
+recorded.
+
+### Post-review: merge conflict with `main`, and #6660 turned out to be a live regression, not pre-existing
+
+Merging `main` into this branch conflicted in `PostgresNetworkExecutor.java`: `main` had picked up #6473
+(alias-column-type resolution), which added a third `resolveAliasToSourceProperty(portal)` argument to
+`getColumns()` at the same two call sites this PR changed to read from the new `portal.fullResultSet`
+instead of the pre-existing `portal.cachedResultSet`. Resolved by keeping this branch's `fullResultSet`
+reads and adding main's new argument; verified via `postgresw` compiling clean and
+`Issue6458PortalSuspensionIT` + `Issue6473AliasedColumnTypeResolutionIT` passing.
+
+That merge triggered the PR's CI, and `python-e2e-tests` failed on `test_asyncpg.py::test_parameterized_insert`
+(`assert len(rows) == 1` / `where 0 = len([])`) - a test that passed cleanly on `main` immediately before this
+merge. Reproduced directly against a locally built server with a minimal `asyncpg` script: a parameterized
+INSERT (which independently still hits a pre-existing, unrelated column-count `ProtocolError` the test already
+tolerates) succeeds and is visible to an immediate `SELECT ... WHERE id = $1`, but the exact same `SELECT`
+re-run moments later on the same connection returns zero rows.
+
+Root cause: **this was #6660**, already filed as "pre-existing and out of scope" during cycles 2-4 above - but
+it was #6458 itself that made it reachable from ordinary client behavior. Before #6458, a portal was removed
+right after its Execute completed, so a client reusing a cached prepared statement (asyncpg's default
+statement cache reusing a `PreparedStatement` for a repeated identical query, exactly like pgjdbc's
+server-side-statement promotion) always rebound onto a fresh portal. After #6458 deliberately stopped removing
+portals (needed for suspension to survive across Executes), that same reuse pattern now rebinds onto the
+*same, already-exhausted* `PostgresPortal` instance - `bindCommand()` never reset `executed`/`fullResultSet`/
+`resultCursor`, so the second run's Execute sliced an already-fully-consumed `fullResultSet` and returned an
+empty result instead of re-running the query. Confirmed at the wire level with a new regression test,
+`Issue6458PortalSuspensionIT#reBindingAnAlreadyExecutedPortalWithNoNewParseReRunsInsteadOfServingTheExhaustedFirstRun`
+(TDD: fails pre-fix with the second Execute jumping straight to an empty `CommandComplete`; passes post-fix).
+
+Fixed by resetting `executed`/`fullResultSet`/`cachedResultSet`/`resultCursor`/`suspended` in `bindCommand()`
+whenever it reuses an already-executed portal - but **only** when `portal.sqlStatement != null` (a real,
+engine-parsed query deferred to Execute). An earlier, ungated version of this reset also fired for
+`BEGIN`/`COMMIT`/`ROLLBACK`, whose response is precomputed once during `Parse` itself via
+`setEmptyResultSet()` and never touches `sqlStatement` - resetting that pre-computed state broke it before
+Execute ever ran, which surfaced as 3 of this class's own pgjdbc-driven tests failing with "Received
+resultset tuples, but no field structure for them" (pgjdbc pipelines its own internal `BEGIN`/`COMMIT`
+through the extended protocol using a cached statement, the same pattern as the bug itself). `columns`/
+`rowDescriptionSent` are deliberately left untouched by the reset too: they describe the statement's row
+shape, invariant across re-binds, and a client that skips `Describe` on a re-bind doesn't expect an
+unsolicited second `RowDescription`.
+
+Verified: the new regression test (red pre-fix, green post-fix, isolated and full-class runs); the full
+`postgresw` module - 408 unit tests + 183 integration tests, including every `BEGIN`/`COMMIT`/`ROLLBACK`-
+specific IT (`Issue6457AbortedTransactionSimpleQueryIT`, `Issue6543RollbackExtendedProtocolIT`,
+`Issue6545AbortedTransactionExtendedQueryIT`, `Issue6548AbortedTransactionRollbackExtendedProtocolIT`),
+`PostgresProtocolIT` (75 tests), and `PostgresWJdbcIT` (45 tests) - all green; and the original `asyncpg`
+repro re-run end-to-end against a freshly built server, confirming the second `SELECT` now returns the
+inserted row instead of an empty result.
+
+### Post-#6660: CodeRabbit found the deeper design bug the #6660 patch only papered over
+
+A second bot review, from `coderabbitai[bot]` (`#pullrequestreview-5008648991`, on head `105cdbb0b8` - the
+#6660 fix above), flagged the actual root cause: `bindCommand()` looked up the portal to bind by the
+*prepared statement's* name (`getPortal(sourcePreparedStatement, false)`) and stored that same mutable
+object under the new portal name too. Two portal names bound from one statement were never independent
+portals - they were two names for the same object. Concretely: bind `P1`, suspend it mid-fetch, then bind
+`P2` from the same statement with different parameters - `P2`'s Bind (and Execute) would silently
+reset/overwrite `P1`'s suspended progress, and a later `Execute(P1)` would resume or lose `P2`'s state
+instead of its own. The user asked "is it related?" for this one too, checked it directly against the code
+(confirmed: `getPortal(sourcePreparedStatement, false)` predates this PR by a long history - not something
+#6458 introduced), and chose to fix it now rather than defer to a follow-up issue.
+
+The #6660 patch (resetting `executed`/`fullResultSet`/etc. on a stale rebind) treated the symptom on one
+axis (same name, re-bound) but not the other (two different names, same object) - CodeRabbit's finding
+applies to the same lines that patch touched.
+
+**Real fix**: split "prepared statement" (PARSE's immutable output: query text, language, parameter types,
+the parsed `sqlStatement`, and - for `BEGIN`/`COMMIT`/`ROLLBACK`/a resolved catalog answer - PARSE's own
+precomputed response) from "portal" (one Bind's independent, mutable execution state). Added
+`PostgresPortal.bindFrom(template)`, which `bindCommand()` now calls to create a **fresh** portal for every
+single Bind, rather than mutating and re-storing the statement's own object. A new `preparedStatements` map
+(keyed by statement name, written once by `parseCommand()`, never mutated afterwards) sits alongside the
+existing `portals` map (keyed by portal name, written by `bindCommand()`, read by `describeCommand()`/
+`executeCommand()`/`closeCommand()`); `describeCommand()`'s `Describe('S')` branch (which names a *statement*,
+not a portal) now reads/writes `preparedStatements` instead. This **removed the #6660 patch's reset code
+entirely** - cloning from a never-mutated template makes every rebind start fresh on its own, more simply
+than the earlier gated reset did.
+
+Regression tests: extended `reBindingAnAlreadyExecutedPortalWithNoNewParseReRunsInsteadOfServingTheExhaustedFirstRun`
+(now expects a fresh `RowDescription` on the second run too, since it's a genuinely new portal - not the
+"preserve rowDescriptionSent" behavior the #6660 patch had), plus a new
+`twoPortalsFromOneStatementDoNotShareStateEvenWhenOneIsSuspended` matching CodeRabbit's exact scenario (bind
+`P1`, suspend it, bind+drain `P2` from the same statement, then confirm `P1` resumes from exactly where it
+left off). Both confirmed red against the pre-fix code, green after. Full `postgresw` module re-verified
+green (408 unit + 184 IT tests - one more IT than before, the new test), and the original `asyncpg` repro
+re-run end-to-end once more against a freshly built server.
+
+## Session 2: resuming the review loop (2026-08-24, later)
+
+A second `resolve-issue-with-review` run picked this issue back up and found PR #6658 already open,
+mergeable, and several review cycles in. Rather than open a duplicate PR, it continued iterating on the
+existing one from its worktree at `.worktrees/fix/6458-postgres-portal-suspension-execute-max-rows`.
+
+### Review cycles (this session)
+
+- **cycle 1** (head `8a6c710050`): cleanup only, in response to the prior session's last recorded review -
+  imported `IntStream` instead of a fully-qualified reference in the test class, and removed
+  `docs/review-deferred-0875952.md` / `docs/review-deferred-59f3975.md` (per-cycle scratch logs the review had
+  flagged as process artifacts that don't belong in the repo; their content was folded into the PR body
+  instead). Verified: 408 unit + 185 IT tests green. -> next `claude` review found a real gap (below).
+- **cycle 2** (head `abcfe5ac95`): fixed a genuine correctness regression the review found in `bindCommand()`'s
+  `portals.get(portalName)` fallback path - `PostgresPortal.bindFrom()` could clone from an already-executed,
+  mutable portal picked up via that fallback (reached when a Bind's `sourcePreparedStatement` name is not a
+  real, Parsed prepared statement), inheriting a stale `executed=true`/`cachedResultSet` while `fullResultSet`
+  stayed `null`, so `executeCommand()` served the OLD run's result instead of re-executing. Reinstated the
+  `#6660` reset (gated on `sqlStatement != null`) right after `bindFrom()`. New test
+  `bindFallbackOnAnUnknownSourceStatementReRunsInsteadOfServingTheStaleExecutedPortal` (TDD: red pre-fix,
+  green post-fix). 408 unit + 186 IT tests green. -> next review found the gate missed one more case (below).
+- **cycle 3** (head `1c94596efa`): extended cycle 2's reset gate to also cover a **deferred catalog query**
+  (`portal.catalogQuery = true`, `sqlStatement` null but genuinely re-executed per Execute, e.g. pgjdbc's
+  `DatabaseMetaData` table/column lookups against `pg_class`) - the un-extended gate missed this case since it
+  checked `sqlStatement != null` alone. New test
+  `bindFallbackOnAnUnknownSourceStatementReRunsADeferredCatalogQueryTooNotJustPlainSql` (TDD: red with the
+  un-extended gate, green post-fix). 408 unit + 187 IT tests green. -> next review: clean.
+- **cycle 4/"cycle 6" in PR-body numbering** (head `1c94596efa`, no new push): the `claude` review re-traced
+  the whole control flow end to end and found no further correctness issues ("Nothing here blocks merging").
+  Two minor, explicitly optional/out-of-scope notes: an edge case in the fallback template when a mismatched
+  client Binds onto a stale BEGIN/COMMIT/ROLLBACK portal (reviewer's own words: "arguably out of scope"), and
+  the `preparedStatements` map never being pruned on `Close('S')` (reviewer: "worth a follow-up issue"). Filed
+  the latter as #6698 rather than expanding this PR's scope; made no code change this cycle.
+
+### Deferred items
+
+None left unaddressed. #6659 (eager full materialization) and #6660 (fixed within this PR) were already
+tracked by the prior session. #6698 (`preparedStatements` never pruned on `Close('S')`) filed this session.
+
+## Final state
+
+**Clean approval** after this session's 3 fix cycles plus a clean confirming review, layered on top of the
+prior session's 4 review cycles and its own two-stage post-review fix (see above). Two follow-up issues remain
+open and explicitly out of scope for this PR: #6659 (eager result materialization) and #6698 (statement-map
+pruning). See PR #6658 for the full comment history.
+
+Merge remains the developer's responsibility - this loop does not merge PRs.

--- a/docs/6460-jsonl-import-link-property-remap.md
+++ b/docs/6460-jsonl-import-link-property-remap.md
@@ -1,0 +1,92 @@
+# Issue #6460: JSONL import does not remap LINK-typed property values
+
+## Root cause
+
+`JsonlImporterFormat` rebuilds an old-RID -> new-RID map (`ridIndex`) while importing, but only consulted it for
+edge endpoints (`loadEdge`'s `ridIndex.get(out)` / `ridIndex.get(in)`). A regular `LINK`-typed **property** value
+(and a `LIST`/`MAP` declared `OF LINK`) was passed straight through `loadProperties` -> `json2map` ->
+`convertFromJSONType` -> `MutableDocument.fromMap()`, none of which consult `ridIndex`. `Type.convert`'s LINK
+branch parses the string into an `RID` using the source database's RID string verbatim (`RID.create(database,
+"#<bucket>:<pos>")`). Because import recreates records at fresh positions, that RID pointed at an unrelated
+record (or none) in the target database - silent data corruption, no error raised.
+
+## Fix
+
+`integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java`:
+
+- `loadProperties` now calls a new `remapLinkProperties(DocumentType, Map)` after `json2map()` and before
+  `fromMap()`. For every property present in the JSON that the schema declares as `LINK`, or as `LIST`/`MAP`
+  declared `OF LINK`, the source RID string(s) are looked up in `ridIndex` and replaced with the resolved new
+  RID. Only schema-declared properties are touched - without a declared type there is no reliable way to tell a
+  LINK string ("#12:34") apart from an ordinary string that merely looks like one.
+- A value that cannot be resolved yet - it references a record that appears **later** in the source stream (a
+  forward reference) - is left as-is and its property name is recorded, keyed by the record's own new identity,
+  in `pendingLinkReconciliation`.
+- After the whole file has been read (every RID mapping is now known), `reconcileUnresolvedLinks()` revisits
+  every such record once, re-resolves the still-outstanding LINK values through `ridIndex`, and saves the record
+  again if anything changed. A value that still cannot be resolved after this (the referenced record was
+  excluded from the export, or the source link was already dangling) is left unchanged, matching the documented
+  pre-fix behavior for that case, and is not counted as an import error.
+- `loadDocument`, `loadVertex`, and `loadEdge` were updated to capture `loadProperties`' returned unresolved-name
+  set and register it against the record's identity once `save()` has assigned one.
+
+This mirrors, for properties, the same `ridIndex` mechanism edges already use for their endpoints - with a
+reconciliation pass added on top so forward references (which edges do not need to handle, since an edge always
+throws if an endpoint isn't found yet) are also fixed up instead of silently left wrong.
+
+## Test
+
+`integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java`:
+`importDatabaseRemapsLinkTypedPropertyValues` - hand-crafted JSONL with a `Person` type carrying a scalar `LINK`
+property (`bestFriend`) and a `LIST OF LINK` property (`friends`). Source `"r"` RIDs are deliberately NOT the
+sequence a fresh import would allocate, so any unremapped (still-old) value is directly observable:
+
+- `Person#2.bestFriend -> Person#1` is a **backward** reference (Person#1 already imported) - resolved
+  immediately by `remapLinkProperties`.
+- `Person#3.friends -> [Person#4]` is a **forward** reference (Person#4 imported later in the stream) - resolved
+  only by `reconcileUnresolvedLinks`.
+
+Verified TDD-style: reverted the fix (`git stash` on the production file only) and confirmed the test fails
+(`expected: #1:0 but was: #6:5`), then restored the fix and confirmed it passes.
+
+### Verification run
+
+- `JsonLImporterIT`, `JsonlExporterIT`, `Issue6455JsonlDateTimeRoundTripIT`: 12/12 passed.
+- Full `integration` module suite (`-DexcludedGroups=benchmark,slow,vector`): 157 tests, 0 failures, 9 skipped.
+- `mvn -pl integration -am compile`: BUILD SUCCESS.
+
+## Scope / limitations carried forward
+
+- Embedded-document (`EMBEDDED`) properties are not walked recursively for nested LINK values - out of scope of
+  the reported bug, which is about direct LINK/LIST-of-LINK/MAP-of-LINK properties on the record itself.
+- A LINK value that never resolves (the referenced record was excluded from the export via `-includeTypes` /
+  `-excludeTypes`, or was already a dangling link in the source database) is left as the original source RID
+  string, same as the pre-fix behavior for that specific case - there is nothing more correct to do without
+  external knowledge of intent, and it is not counted as an import error.
+- An unresolved forward-reference LINK value is transiently persisted as the raw *source*-database RID until
+  `reconcileUnresolvedLinks()` runs. If that property backs a UNIQUE index this can coincidentally collide with
+  another record's already-resolved value, raising a `DuplicateKeyException`. Confirmed real by tracing the code;
+  accepted as a known, documented (in `reconcileUnresolvedLinks`'s Javadoc and the PR's "Review follow-ups"
+  section) limitation rather than fixed, since a proper fix is a design choice (null placeholder / pre-scan /
+  keep documented) surfaced during review but not resolved in this PR - see "Review cycles" below.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6654
+
+## Review cycles
+
+Ran via the `resolve-issue-with-review` skill, `--max-cycles=4`. The `claude` bot on this repo posts its review
+as a plain PR issue comment (no commit SHA attached), gated on `createdAt` vs. the push timestamp.
+
+| Cycle | Head SHA | Review outcome | What was applied / deferred / skipped |
+|---|---|---|---|
+| 1 | `a0aedaa9f4` (initial PR) | Review posted 2026-08-23T20:53:47Z: 5 findings (2 correctness, 1 perf, 2 test-coverage, 1 minor) | Applied: periodic commit in `reconcileUnresolvedLinks()`; regression tests for MAP-of-LINK, the never-resolves case, and a LINK property on an edge. Deferred: UNIQUE-index collision on the transient placeholder RID (design decision). Skipped (rationale recorded): `pendingLinkReconciliation`'s memory footprint, duplicate list/map-walking logic between the two remap methods. |
+| 2 | `8c588accee` | Review posted 2026-08-24T07:44:40Z: `reconcileUnresolvedLinks()` had no error isolation, unlike the main loop | Applied: wrapped the per-entry reconciliation body in the same log/count/abort-or-skip handling as `loadDocument`/`loadVertex`/`loadEdge`; skip mode now commits every reconciled record. Skipped (rationale recorded): broad `catch (Exception e)` in `remapLinkValue`, eager allocation in `remapLinkProperties`, and a process question about committing review-transcript docs under `docs/`. |
+| 3 | `c83f2f7d72` | Review posted 2026-08-24T07:50:30Z: recommended an in-code Javadoc note for the UNIQUE-index limitation, and repeated the `docs/review-deferred-*.md` convention concern | Applied: added the limitation directly to `reconcileUnresolvedLinks()`'s Javadoc; removed the two `docs/review-deferred-*.md` sidecar files and folded their content into the PR body's new "Review follow-ups" section (two consecutive review cycles flagged permanent per-PR review transcripts under `docs/` as the wrong home for this). Skipped (rationale recorded in the PR body): minor asymmetries between `remapLinkProperties`/`reconcileUnresolvedLinks`, and the pre-existing (not a regression) fact that edge records are never added to `ridIndex`. |
+| 4 | `5383bcb1a0` | **Timeout** - the `claude-review` GitHub Action ran and completed successfully (`gh run view`: `status=completed`, `conclusion=success`) but posted no PR comment within the 15-minute poll window (checked again ~17 minutes after push: still nothing). Most likely read: nothing left to flag on this small, mostly-documentation diff, so the bot stayed silent rather than posting a redundant approval. | No new findings to act on. |
+
+**Final state: timeout** (cycle 4). All findings from cycles 1-3 were resolved (applied, or deferred/skipped with
+recorded rationale, now living in the PR body rather than in `docs/`) before the loop ran out of its configured
+cycles. Nothing is left pending review from this session's side; the PR is left open for the developer, per this
+skill's merge policy.

--- a/docs/6461-merge-anchor-stale-edge-list.md
+++ b/docs/6461-merge-anchor-stale-edge-list.md
@@ -1,0 +1,103 @@
+# Issue #6461: MERGE duplicates a relationship (and its far endpoint) when the anchor vertex was bound earlier in the same query
+
+## Root cause
+
+`MergeStep.executeMerge` wraps each row it processes in its own
+`database.transaction(() -> {...}, true)` call (added for #6367's auto-retry). When the caller has no
+outer transaction open - an unwrapped autocommit call, exactly the shape `BoltNetworkExecutor.handleRun`
+uses, and the shape a raw `database.command(...)` call has - each row's MERGE owns and commits its own
+transaction.
+
+The anchor vertex instance a row carries (bound by an earlier `MATCH`, or reused across `UNWIND` rows of
+the same MERGE clause) was loaded before that row's own transaction started. Once a **prior** row's MERGE
+appends the first edge in a given direction to that vertex - the one write that rewrites the vertex
+record's edge-list head pointer - the row's own in-memory instance still reflects the pre-append state.
+`findAllMatchingPaths` (via `traverseFromAnchor`) and `traverseFromNode` both took that instance straight
+from the row and called `vertex.getEdges(...)` on it directly, so the match half of a later row misses the
+edge/node a previous row already created and its create half runs, producing a duplicate.
+
+Confirmed empirically to be **still present at HEAD** before this fix (not masked by the existing
+`getMostUpdatedVertex`/transaction-record-cache mechanism, which only helps when the reader and the writer
+share the same `TransactionContext` - not the case here, since each unwrapped row commits and starts a new
+one).
+
+Over HTTP this is invisible: `DatabaseAbstractHandler.executeInTransaction()` wraps the *entire* autocommit
+command in one outer transaction, so every row's MERGE simply joins it and shares its transaction-local
+record cache - which is also why the pre-existing `MergeBoundAnchorRegression` tests (issue #4226) never
+caught this: they all wrap their MERGE call in an explicit `db.transaction(() -> ...)`.
+
+## Fix
+
+`MergeStep` re-resolves a bound anchor vertex to its latest committed state, via
+`context.getDatabase().lookupByRID(rid, true)`, right before its edges are enumerated - mirroring
+`SetStep.reloadLatestDoc()` (issue #5227). Two call sites needed it:
+
+- `findAllMatchingPaths`: the anchor vertex read from `baseResult` before it is handed to
+  `traverseFromAnchor` (the `anchorIdx > 0`, no-usable-index path).
+- `traverseFromNode`: the vertex resolved from the row's own binding (`forcedVertex == null`, i.e. the
+  node-0 anchor case reached when `anchorIdx == 0` or no anchor was found at all) before
+  `traverseEdgesFromVertex` walks it.
+
+A new private helper, `reloadAnchorVertex(Vertex)`, does the reload and is a no-op (returns the input
+unchanged) when the vertex has no identity yet (not persisted) or was concurrently deleted, leaving the
+existing not-found handling downstream to react to that.
+
+`tryFindPathByIndexSeek`'s own read of the anchor was left alone: it only uses the anchor for an identity
+`equals()` check against the freshly-index-resolved candidate's own (already fresh) edge list, never for
+edge enumeration on the anchor itself - which is exactly why the unique-index path was never affected by
+this bug in the first place (as the issue's "masked when indexed" note observes).
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue6461MergeAnchorStaleEdgeListTest.java`, two cases,
+both driven through unwrapped `database.command(...)` calls (no outer `database.transaction()`), matching
+the shape that actually exposes the bug:
+
+- `unwindMergeReusingBoundAnchorDoesNotDuplicateEdgeOrFarEndpoint` - the issue's realistic repro
+  (`MATCH ... UNWIND [10,10,20] AS cid MERGE (p)-[:HAS]->(c:Chi {id:cid})`); asserts 2 edges and one `Chi`
+  node per distinct id.
+- `repeatedMergeOnSameBoundPairDoesNotDuplicateEdge` - the issue's minimal form
+  (`MATCH (a),(b) MERGE (a)-[:L]->(b) MERGE (a)-[:L]->(b)`); asserts exactly 1 edge.
+
+Both fail on pre-fix `MergeStep` (3 edges / 2 edges respectively, matching the issue's reported counts) and
+pass after the fix.
+
+## Verification
+
+- `Issue6461MergeAnchorStaleEdgeListTest` (new): 2/2 pass.
+- `OpenCypherMergeTest` (46 tests, all `@Nested` regression groups including `MergeBoundAnchorRegression`
+  for #4226) + `OpenCypherMergeActionsTest` (13) + `Issue6367MergeStepAutoRetryTest` (1) +
+  `Issue6602MergeAfterEmptyMatchCardinalityTest` (7) + `MergeInsertSlowdownTest` (1) +
+  `RefactorMergeNodesTest` (13): all green, no regressions.
+- Full `com.arcadedb.query.opencypher.**` package (excluding `benchmark`/`slow`/`vector` lanes): see below.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6652
+
+## Review cycles
+
+- **Cycle 1** - head SHA `0e7de9f6` (push `2026-08-23T20:28:24Z`). Polled all three review surfaces
+  (`reviews[]`, inline `pulls/6652/comments`, and `claude`-authored PR issue comments newer than the push)
+  for the full 15-minute per-iteration window: no review landed on any surface.
+  - Cross-checked against the Actions run directly: `Claude Code Review` workflow run
+    [32664545721](https://github.com/ArcadeData/arcadedb/actions/runs/32664545721) triggered on this SHA,
+    ran to completion (`status=completed`, `conclusion=success`, 28 turns, ~186s), and its own log shows
+    `permission_denials_count: 6` and a final "No buffered inline comments" from the
+    post-buffered-inline-comments step - i.e. the bot's run finished without ever posting a top-level
+    `gh pr comment`, despite `Bash(gh pr comment:*)` being in its allowed-tools list. This is not a slow-bot
+    case (the workflow itself finished in ~5 minutes and never posted); as of this update, over 11 hours have
+    passed since the push with still no comment on the PR from `claude`.
+  - No code changes were made this cycle since no review feedback was ever received to act on.
+
+## Deferred items
+
+None - no review comments were received to categorize.
+
+## Final state
+
+**timeout** - the `claude` review bot's workflow run completed without posting a review comment on head
+SHA `0e7de9f6`. The PR is left open with the fix as pushed. This looks like the same class of infra issue
+tracked in `reference_review_bot_can_time_out_before_posting` (bot completes without posting, rather than
+never running at all) and may warrant a manual `@claude review` comment or maintainer trigger to get a
+review on this PR.

--- a/docs/6462-async-cross-slot-bidirectional-edge-wait.md
+++ b/docs/6462-async-cross-slot-bidirectional-edge-wait.md
@@ -1,0 +1,108 @@
+# Issue #6462: async cross-slot bidirectional edge - waitCompletion() / quiesceAsync() races
+
+## Root cause
+
+`DatabaseAsyncExecutorImpl.newEdge()` schedules the incoming-edge cascade task for a bidirectional
+cross-slot edge onto the **destination** worker's slot from **inside** the source task's own
+callback (`CreateEdgeAsyncTask`'s completion callback schedules `CreateIncomingEdgeAsyncTask`). That
+means the cascade can land on the destination worker strictly *after* that worker has already
+answered "I'm done" to a concurrent caller, in two different mechanisms:
+
+1. **`DatabaseAsyncExecutorImpl.waitCompletion(long)`** placed exactly one completion marker per
+   worker in a single pass. If the destination worker was idle, its marker could fire before the
+   cascade (still queued behind the still-running source task on a different worker) ever landed on
+   it - so the method could return "all done" while the in-edge was still pending.
+   `LocalDatabase.waitForAsyncCompletion()` already re-scans with a `do { ... } while
+   (isAsyncProcessing())` loop for exactly this reason (issue #6281), but that loop lives one level
+   above the executor - a caller reaching `waitCompletion()` directly through the public
+   `DatabaseAsyncExecutor` API bypassed it entirely.
+2. **`BucketIndexBuilder.create()`** calls `database.quiesceAsync()` (which parks every worker) but,
+   unlike `TypeIndexBuilder` and `RebuildIndexStatement`, never calls
+   `database.waitForAsyncCompletion()` first. A destination worker parked while idle does not wait
+   for a cascade that lands on it afterwards, so the scan underneath the quiescence can run before
+   that cascade's write is committed - the built index misses the entry until a later, unrelated
+   drain catches it up.
+
+## Fix
+
+1. `DatabaseAsyncExecutorImpl.waitCompletion(long)` (`engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java`):
+   the marker-placement body was extracted into a private `waitCompletionOnePass(...)`, and the public
+   method now loops `do { ... } while (isProcessing())`, mirroring the pattern
+   `LocalDatabase.waitForAsyncCompletion()` has used since #6281. This closes the race for every
+   direct caller of the public API, not only callers that happen to go through `LocalDatabase`.
+2. `BucketIndexBuilder.create()` (`engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java`):
+   added a `database.waitForAsyncCompletion()` call immediately before `database.quiesceAsync()`,
+   matching the pattern already used by `TypeIndexBuilder` (line ~207) and `RebuildIndexStatement`
+   (line ~146). By the time the quiescence starts, the executor is genuinely idle rather than racing
+   it.
+
+Both fixes are the minimal, precedented options from the issue's own "Suggested fix" list (options 1
+and 3); the more invasive option (reworking `quiesceWorkers()`'s park scheduling itself) was not
+needed once the drain happens first.
+
+## Tests
+
+- `engine/src/test/java/com/arcadedb/database/async/Issue6462CrossSlotWaitCompletionMissesCascadeTest.java`:
+  reproduces the `waitCompletion()` race with a plain task scheduled directly at the slot level (no
+  graph API, no dependency on which slot a RID happens to hash to) that, from inside its own
+  execution, schedules a follow-up task onto a different worker - mirroring `newEdge()`'s callback
+  shape. The follow-up is held open with a latch so the buggy and fixed behaviour are distinguished
+  deterministically (by what has/has not happened when `waitCompletion()` returns), not by timing.
+  Verified TDD-style: fails against the pre-fix code (`Expecting value to be false but was true`),
+  passes after the fix.
+- `engine/src/test/java/com/arcadedb/index/Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest.java`:
+  same reduction applied to `BucketIndexBuilder.create()` - a source task on one worker creates a
+  record targeting the OTHER worker's bucket from inside its own execution once released, and the
+  index build runs concurrently. Asserts that by the time `create()` returns, both the record and its
+  index entry are already present - not merely "eventually" once a later drain catches up. Verified
+  TDD-style: fails 3/3 runs against the pre-fix code (`expected: 1L but was: 0L`), passes 3/3 after.
+
+Both tests were run repeatedly (3x) against both the pre-fix and post-fix code to confirm they are
+not vacuously passing and are not flaky.
+
+## Verification
+
+- `mvn -pl engine -am test -Dtest='com.arcadedb.database.async.**,com.arcadedb.index.Issue6303*,com.arcadedb.index.Issue6462*' -DexcludedGroups=benchmark,slow,vector` - 69 tests, 0 failures.
+- `mvn -pl engine -am test -Dtest='com.arcadedb.index.**,com.arcadedb.schema.**,com.arcadedb.graph.**' -DexcludedGroups=benchmark,slow,vector` - 2213 tests, 0 failures (covers `AsyncWaitCompletionTimeoutTest`, `Issue6303AsyncQuiesceTest`, `AsyncCrossSlotSchedulingDeadlockTest`, and every index/schema/graph regression test in the module).
+- `mvn -pl engine -am compile` - clean.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6651
+
+## Review cycles
+
+- **Cycle 1** - head `1cb89451075f1409aa37a71de8c678a430acbeb9`: `claude[bot]` reviewed via issue
+  comment. Verdict: "No blocking issues found." Traced the happens-before chain of the
+  `waitCompletion()` fix independently and confirmed it sound; confirmed the `BucketIndexBuilder`
+  fix mirrors `TypeIndexBuilder`/`RebuildIndexStatement` exactly; confirmed both tests avoid
+  timing-based flakiness (latch/`completedTaskCount` polling, the one `Thread.sleep` only widens a
+  race window rather than gating an assertion, so worst case it fails to reproduce and passes
+  vacuously rather than failing falsely). One **non-blocking** observation, skipped (see below).
+  No code changes required - working tree stayed clean this cycle - so this is a clean approval on
+  cycle 1.
+
+### Deferred / skipped review items
+
+- **Skipped (nitpick, optional, explicitly non-blocking):** the reviewer noted that
+  `LocalDatabase.waitForAsyncCompletion()`'s own `do { ... } while (isAsyncProcessing())` loop
+  (#6281) is now a "loop-around-a-loop" on top of `waitCompletion()`'s new internal loop, and
+  suggested a possible follow-up to simplify it back to a single call. Not applied: the reviewer
+  itself flagged this as conditional on "not complicating the interrupt-handling special case"
+  `LocalDatabase.waitForAsyncCompletion()` currently has, explicitly called it harmless, and it
+  touches a different, separately-reasoned method than either of the two changes this issue is
+  about. Left as a possible future cleanup rather than folded into this fix.
+
+## Final state
+
+clean-approval (1 cycle)
+
+## Scope not addressed
+
+`DatabaseAsyncExecutorImpl.quiesceWorkers()` itself (the park-task machinery `quiesceAsync()` is built
+on) was left untouched. Draining first, as both fixes now do, removes the specific race the issue
+describes without needing to change that already carefully-reasoned, heavily-reviewed method (#6303).
+A caller who reaches `quiesceAsync()` directly without draining first (bypassing both
+`BucketIndexBuilder`/`TypeIndexBuilder`/`RebuildIndexStatement`, all of which now drain first) could
+still hit a variant of the destination-worker-parked-early race; no such direct caller exists in the
+codebase today.

--- a/docs/6463-insert-content-listparam-only-first.md
+++ b/docs/6463-insert-content-listparam-only-first.md
@@ -1,0 +1,88 @@
+# Issue #6463: `INSERT INTO ... CONTENT :listParam` inserts only the first list item
+
+## Summary
+
+`INSERT INTO <type> CONTENT :param` where the bound parameter is a `java.util.List` silently
+inserted only the **first** element of the list, with no error, unlike the equivalent JSON-array
+literal form (`CONTENT [{...}, {...}, ...]`), which creates one record per item.
+
+## Root cause
+
+`InsertExecutionPlanner.handleCreateRecord()` decides how many empty records `CreateRecordStep`
+should create (`tot`) by inspecting the parsed `InsertBody`:
+
+```java
+int tot = 1;
+if (body.getValueExpressions() != null && ...) tot = body.getValueExpressions().size();
+else if (body.getJsonArrayContent() != null && ...) tot = body.getJsonArrayContent().items.size();
+```
+
+There was no branch for a `CONTENT :param` **input parameter**, so `tot` stayed `1` regardless of
+what the parameter resolved to. `UpdateContentStep.handleContent()` already knew how to drain a
+`List`-valued parameter item by item (`parameterArray.get(arrayIndex++)`), but with `tot == 1` it
+was only ever driven once per upstream record, so items `1..n-1` were silently dropped.
+
+## Fix
+
+Input parameters are already bound into the `CommandContext` by the time the execution plan is
+built (`InsertStatement.execute()` calls `context.setInputParameters(...)` before
+`createExecutionPlan(context)`), so the fix resolves the `CONTENT` parameter at plan-build time and
+sizes `tot` from it when it is a non-empty `List`, mirroring the existing `getJsonArrayContent()`
+branch. A `Map`/`Document`-valued parameter (single record) is unaffected.
+
+`CreateVertexExecutionPlanner`/`CreateEdgeExecutionPlanner` extend `InsertExecutionPlanner` and
+reuse `handleCreateRecord()` unchanged, so `CREATE VERTEX/EDGE ... CONTENT :param` get the fix for
+free - confirmed with a dedicated test added during review (see cycle 2 below).
+
+## Deliberately unchanged edge case
+
+An empty-list `CONTENT :param` keeps `tot = 1` (one near-empty record created), matching the
+pre-existing behavior of an empty JSON-array literal (the `items.size() > 0` guard on the
+`getJsonArrayContent()` branch). This PR does not change that. Pinned by a dedicated test added
+during review (cycle 2).
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6647
+
+## Review cycles
+
+- **Cycle 1** - head `60fe0c0362` (initial push). Bot review (PR issue comment, no commit SHA -
+  https://github.com/ArcadeData/arcadedb/pull/6647#issuecomment posted 2026-08-23T20:22:47Z):
+  "No blocking issues found." One actionable-and-clear item: a positional-parameter (`?`) variant
+  of the `CONTENT :param` list case wasn't covered (only the named `:people` form was). Applied -
+  added `insertContentWithPositionalListParamCreatesOneRecordPerItem`. Two non-blocking notes
+  skipped with rationale: (a) `Set`/other `Collection`-valued `CONTENT` params fall through to
+  `tot = 1`, explicitly called out by the reviewer as pre-existing, symmetric with
+  `UpdateContentStep`'s existing `List`-only special case, and not a regression from this PR; (b)
+  style/consistency observations with no requested action. Response commit `9dfd443bc2`.
+- **Cycle 2** - head `9dfd443bc2`. Bot review (2026-08-24T07:27:47Z): "Nice, focused fix... My only
+  suggestion is the two small test additions noted above... neither blocks merging as-is." Two
+  actionable-and-clear items, both verified against the code before applying: (a) the
+  intentionally-unchanged empty-list edge case had no test pinning it down - applied
+  `insertContentWithEmptyListParamStillCreatesOneRecord`, confirmed by tracing
+  `UpdateContentStep.handleContent()` (an empty list never matches any of its branches, so the
+  record is created with no properties set, count stays 1); (b) `CREATE VERTEX ... CONTENT :param`
+  with a list was only covered "incidentally" via the shared planner code path, not with a
+  dedicated test - applied `createVertexContentWithListParamCreatesOneVertexPerItem`, after
+  verifying `CreateVertexExecutionPlanner extends InsertExecutionPlanner` and reuses
+  `handleCreateRecord()` unchanged. One non-blocking note skipped with rationale: resolving the
+  content parameter twice (once to size `tot`, once again in `UpdateContentStep` to drain it) is a
+  small duplication the reviewer itself called "not a real performance concern" - threading the
+  resolved list through would add complexity to a plan-build-time-only path for negligible gain.
+  Response commit `c48e7e5d35`.
+- **Cycle 3** - head `c48e7e5d35`. Bot review (2026-08-24T07:32:01Z): "No blocking issues found.
+  Nice, minimal fix..." No new actionable items - both prior minor observations (Collection-typed
+  params, double parameter resolution) were reduced to explicit "pre-existing limitation this fix
+  doesn't need to address" / "not worth optimizing." No code changes this cycle - clean approval.
+
+## Deferred items
+
+None. Every actionable-and-clear review item was applied within its cycle; every skipped item had
+an explicit non-blocking rationale from the reviewer itself (pre-existing/symmetric behavior, or
+an admitted non-concern), so nothing was deferred to a separate notes file.
+
+## Final state
+
+`clean-approval` after 3 review cycles (within `--max-cycles=4`). Merge is the developer's
+responsibility; this PR has not been merged.

--- a/docs/6464-empty-primitive-array-round-trips-list.md
+++ b/docs/6464-empty-primitive-array-round-trips-list.md
@@ -1,0 +1,151 @@
+# Issue #6464: Empty typed primitive-array property round-trips to an ArrayList, not an array
+
+## Summary
+
+`BinaryTypes.getTypeFromValue()` decided the binary type of a Java array from its **first element**:
+for a primitive array (`int[]`, `short[]`, `long[]`, `float[]`, `double[]`), the first element was
+sniffed with a pattern-match `switch`, and an empty array's "first element" is `null`, which fell
+through to `TYPE_LIST`. So the same property's runtime type after a reload depended on whether it
+happened to be empty: `new int[0]` round-tripped as an `ArrayList`, `new int[]{1,2}` round-tripped
+as `int[]`. `(int[]) doc.get("arr")` threw `ClassCastException` only in the empty case.
+
+For a boxed wrapper array (`Integer[]`, `Long[]`, `Short[]`, `Float[]`, `Double[]`) the code took the
+non-primitive-component-type branch unconditionally and always returned `TYPE_LIST`, regardless of
+content or of any declared `ARRAY_OF_*` schema property.
+
+## Fix
+
+`BinaryTypes.getTypeFromValue()` (`engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java`)
+now decides the `TYPE_ARRAY_OF_*` binary type from the array's **declared component type**
+(`value.getClass().getComponentType()`), matched against both the primitive class (`short.class`,
+`int.class`, ...) and its wrapper (`Short.class`, `Integer.class`, ...), instead of from the first
+element:
+
+- An empty primitive array now keeps its `TYPE_ARRAY_OF_*` type - the component type is known
+  regardless of length, so emptiness no longer collapses it to `TYPE_LIST`.
+- A boxed wrapper array (`Integer[]`, ...) is now also classified `TYPE_ARRAY_OF_*`, matching what
+  `Type.ARRAY_OF_INTEGERS` et al. already accept as an alternate input class
+  (`new Class<?>[] { int[].class, Integer[].class }` in `Type.java`) and already declare as their
+  canonical Java class (`int[].class`, not `Integer[].class`).
+- A heterogeneous `Object[]` (e.g. `list.toArray()`, whose component type is `Object`, not a numeric
+  wrapper) is unaffected and still classifies as `TYPE_LIST` - it only takes the new branches when the
+  array's *declared* component type is one of the five numeric primitives or their wrappers.
+
+`BinarySerializer.serializeValue()`'s five `TYPE_ARRAY_OF_*` cases used
+`java.lang.reflect.Array.getShort/getInt/getLong/getFloat/getDouble()`, which **reject** a boxed
+wrapper array with `IllegalArgumentException: Argument is not an array of primitive type` (verified
+with a standalone repro). Since a wrapper array can now reach these cases, each one branches on
+`instanceof <primitive>[]` and keeps the direct primitive read on that path (no behavior or
+performance change for the existing primitive-array path), falling back to an explicit
+`(Wrapper[]) value` unboxing loop only for the wrapper-array path. Deserialization is unchanged: all
+five `TYPE_ARRAY_OF_*` cases already produced a primitive array, so a boxed `Integer[]` property now
+round-trips as `int[]`, consistent with `Type.ARRAY_OF_INTEGERS.getJavaClass() == int[].class`.
+
+The now-unused `java.lang.reflect.Array` import was removed from `BinaryTypes.java` (still used
+elsewhere in `BinarySerializer.java`).
+
+## Why existing `Object[]` tests were unaffected
+
+`BinarySerializerTest.listPropertiesInDocument` sets `"arrayOfIntegers"` (etc.) to
+`listOfIntegers.toArray()`. `List.toArray()` returns `Object[]` regardless of the list's generic
+type - the array's actual `getComponentType()` is `Object.class`, not `Integer.class` - so that test
+continues to hit the `TYPE_LIST` branch exactly as before. Only an array whose *declared* component
+type is a genuine `Integer[]`/`Short[]`/etc. (e.g. `new Integer[]{1,2,3}` or
+`list.toArray(new Integer[0])`) is affected by the fix.
+
+## Tests added (`engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java`)
+
+- `emptyPrimitiveArrayKeepsItsArrayType` - asserts `BinaryTypes.getTypeFromValue()` classifies
+  `new short[0]`/`int[0]`/`long[0]`/`float[0]`/`double[0]` as the matching `TYPE_ARRAY_OF_*`, then a
+  full serialize/deserialize round trip confirms each reloads as the same empty primitive array type
+  (not `ArrayList`).
+- `boxedPrimitiveArraysSerializeAsTypedArrays` - same classifier assertion for empty
+  `Short[]`/`Integer[]`/`Long[]`/`Float[]`/`Double[]`, then a round trip with populated boxed arrays
+  confirms they reload as the corresponding primitive array with the same values.
+
+Both were confirmed **red** before the fix (`expected: 23 but was: 16`, i.e. `TYPE_LIST` instead of
+the declared `TYPE_ARRAY_OF_*`) and green after.
+
+## Verification run
+
+- `BinarySerializerTest`: 19/19 passed (2 new + all pre-existing, including
+  `arraysOfPrimitive` and `listPropertiesInDocument` which exercise the paths this fix must not
+  regress).
+- `com.arcadedb.serializer.**` + `com.arcadedb.schema.**`: 620/620 passed.
+- `com.arcadedb.index.vector.**` + `com.arcadedb.index.sparsevector.**` (excluding
+  `benchmark,vector,slow` lanes): 410/410 passed - these exercise `float[]`/`double[]` embeddings
+  heavily and confirm the primitive fast path is untouched.
+- `JavaBinarySerializerTest` + `com.arcadedb.graph.GraphBatch*Test`: 26/26 passed - the other caller
+  of `BinaryTypes.getTypeFromValue`/`BinarySerializer.serializeValue`.
+- `com.arcadedb.database.**` (excluding `benchmark,vector,slow`): 282/282 passed, 1 pre-existing
+  skip unrelated to this change.
+
+## Scope not addressed
+
+The issue's repro and suggested fix are both scoped to the five numeric `ARRAY_OF_*` types
+(`SHORT`/`INTEGER`/`LONG`/`FLOAT`/`DOUBLE`). `byte[]` is unaffected by the original bug (handled
+earlier in `getTypeFromValue` as `TYPE_BINARY`, unconditionally, regardless of emptiness) and is out
+of scope here.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6649
+
+## Review cycles
+
+- **Cycle 1** - head `f8bb9109` (PR open). `claude` bot review (posted as a PR issue comment, no
+  commit SHA - see note below) found one real bug: `getTypeFromValue()` classified any
+  `Short[]/Integer[]/Long[]/Float[]/Double[]` as `TYPE_ARRAY_OF_*` purely from component type,
+  regardless of content, but `BinarySerializer.serializeValue()`'s new `TYPE_ARRAY_OF_*` branches
+  unbox each wrapper element with an enhanced for-loop (`for (final Integer v : ints)
+  content.putNumber(v)`), which auto-unboxes and throws an uncaught `NullPointerException` on a
+  `null` element. Reachable via the ordinary public API for a schemaless property
+  (`doc.set("someIntArrayProp", new Integer[]{1, null, 3})`). **Verified** by reading
+  `BinarySerializer.java:663-720` - confirmed the auto-unboxing NPE is real for all five wrapper
+  types. **Applied**: added `BinaryTypes.arrayHasNullElement()` and fell back to `TYPE_LIST` in
+  `getTypeFromValue()` whenever a wrapper array contains a `null` element (the reviewer's first
+  suggested option - mirrors the pre-existing `Object[]` fallback and keeps the pre-#6464 behavior
+  for this case unchanged). Added regression test
+  `boxedPrimitiveArrayWithNullElementFallsBackToListInsteadOfNPE` covering the classifier and a full
+  serialize/deserialize round trip. Verification: `BinarySerializerTest` 20/20,
+  `com.arcadedb.serializer.**` + `com.arcadedb.schema.**` 621/621, `BUILD SUCCESS`. Pushed as
+  `ce4942b`.
+- **Cycle 2** - head `ce4942b`. `claude` bot review (PR issue comment) confirmed the
+  `arrayHasNullElement` fallback closes the NPE gap and the new regression test pins it; traced the
+  schema-declared-property path (`Type.convert()`'s `requireNonNullNumber`/`narrowToIntegral`) and
+  confirmed the null-fallback in this PR matters for schemaless properties and other
+  direct-serialization callers, which is the scope the added test exercises. **No blocking issues
+  found.** Three items raised, all explicitly non-blocking and left as-is (see below) - no code
+  change made this cycle, working tree stayed clean.
+
+### Nitpicks raised in cycle 2, not actioned (reviewer marked all three non-blocking)
+
+- `Type.TYPES_BY_USERTYPE` has no entries for the boxed wrapper array classes
+  (`Short[].class`/`Integer[].class`/...), only their primitive counterparts. Reviewer: "not touched
+  by this PR and not a regression... possibly worth a follow-up issue if that path exists." No such
+  call site was identified as in-scope for this issue; left as a possible future follow-up, not filed
+  separately since it is speculative ("if that path exists").
+- The five-way `componentType == X.class ? arrayHasNullElement(...) : ...` chain in
+  `getTypeFromValue()` repeats the same ternary shape and could be a small helper. Reviewer's own
+  words: "a nitpick, not a blocker... matches the existing style of the surrounding if/else chain."
+  Left as-is - the current form stays consistent with the chain's existing if/else style, which the
+  reviewer confirmed is more readable than the alternative here.
+- `Byte[]` (boxed) still falls through to `TYPE_LIST`, unlike the other four wrapper types. Reviewer:
+  "consistent with the stated scoping, just flagging it's not 'fixed' by symmetry." `byte[]`/`Byte[]`
+  were explicitly out of scope for issue #6464 from the start (see "Scope not addressed" above,
+  `byte[]` is handled earlier as `TYPE_BINARY` and was never affected by the original bug) - no change
+  needed.
+
+### Note on the review-polling bug this run started from
+
+Cycle 1's review (`f8bb9109`, 2026-08-23T20:28:27Z) was originally missed by a version of this skill's
+Phase 3a that only polled `reviews[]` and inline PR comments (both keyed by commit SHA) - the `claude`
+bot on this repo posts its review as a plain PR **issue comment** with no SHA at all. That polling gap
+is fixed in the current skill (adds a third surface: `gh pr view --json comments`, filtered to
+`claude`-authored comments newer than the push timestamp). Both cycles in this run were detected
+correctly by the fixed polling on the first or near-first poll.
+
+## Final state
+
+`clean-approval` - cycle 2 review found no blocking issues and required no further changes. Ready
+for developer review and merge (merge intentionally not performed by this skill).

--- a/docs/6469-datetype-convert-date-instant-zoneddatetime.md
+++ b/docs/6469-datetype-convert-date-instant-zoneddatetime.md
@@ -1,0 +1,75 @@
+# Issue #6469: Type.convert Date -> ZonedDateTime/Instant copy-paste bug, missing Number branch
+
+## Root cause
+
+`com.arcadedb.schema.Type.convert()` has one branch per configured `DATE_TIME_IMPLEMENTATION` target class
+(`LocalDateTime`, `ZonedDateTime`, `Instant`). The `ZonedDateTime` and `Instant` branches' `java.util.Date` arm
+each passed the wrong target class to `DateUtils.dateTime(...)`:
+
+- `ZonedDateTime` target's `Date` arm passed `LocalDateTime.class` instead of `ZonedDateTime.class`.
+- `Instant` target's `Date` arm passed `LocalDateTime.class` instead of `Instant.class`.
+
+Both `Calendar` arms right below them already used the correct target class, confirming the copy-paste-slip
+diagnosis in the issue. Neither the `ZonedDateTime` nor the `Instant` target had a `Number` branch at all
+(the `LocalDateTime` target does), so an epoch-millis `Number` set on such a property fell through `convert`
+unconverted.
+
+## Affected component
+
+`engine/src/main/java/com/arcadedb/schema/Type.java`, the `convert()` method's `ZonedDateTime.class` and
+`Instant.class` target branches.
+
+## Expected vs actual behavior
+
+- Expected: converting a `java.util.Date` into a `ZonedDateTime`-backed (or `Instant`-backed) DATETIME
+  property returns a value of that runtime type, and a `Number` (epoch millis) converts the same way a
+  `Date`/`Calendar` does.
+- Actual (before fix): the `Date` conversion returned a `LocalDateTime` instance regardless of the configured
+  target class, breaking `instanceof`/`equals` checks against the configured type. A `Number` value fell
+  through `convert` unconverted for both targets.
+
+## Fix
+
+In both branches, added a `Number` arm (mirroring the `LocalDateTime` target's `Number` handling, routed
+through `DateUtils.dateTime(..., ChronoUnit.MILLIS, <target>, ...)` to match how the existing `Date`/`Calendar`
+arms already treat their input as epoch millis) and corrected the `Date` arm's target class:
+
+- `ZonedDateTime` target: `Date` arm now passes `ZonedDateTime.class`; added `Number` arm.
+- `Instant` target: `Date` arm now passes `Instant.class`; added `Number` arm.
+
+## Tests added (TDD)
+
+`engine/src/test/java/com/arcadedb/schema/TypeTest.java` - added 4 new regression tests (existing tests were
+not modified, per project constraints):
+
+- `convertToZonedDateTimeFromDateReturnsZonedDateTime` - asserts the result `isInstanceOf(ZonedDateTime.class)`
+  and that the instant is preserved.
+- `convertToZonedDateTimeFromNumber` - asserts a `Number` (epoch millis) converts to a `ZonedDateTime` with
+  the same instant.
+- `convertToInstantFromDateReturnsInstant` - asserts the result `isInstanceOf(Instant.class)` and that the
+  instant is preserved.
+- `convertToInstantFromNumber` - asserts a `Number` (epoch millis) converts to an `Instant` with the same
+  instant.
+
+All 4 tests were confirmed to fail against the pre-fix code (proving the bug), then confirmed to pass after
+the fix.
+
+## Test results
+
+- `TypeTest`: 127/127 passed (including the 4 new regression tests).
+- `DateUtilsTest`: 15/15 passed.
+- `OffsetDateTimeStorageTest`: 2/2 passed.
+- `TypeConversionTest`: 12/12 passed.
+- `JsonSerializerTest`: 15/15 passed.
+- Full `com.arcadedb.schema.**` + `com.arcadedb.utility.**` packages: 859/859 passed.
+
+No regressions found.
+
+## Impact analysis
+
+Low-medium severity, as noted in the issue: the underlying instant was always preserved (both the buggy and
+fixed paths compute UTC millis identically), so this was an in-memory type-inconsistency bug, not an on-disk
+data-loss bug - after persist and reload the value re-materializes with the correct configured type regardless
+of this fix. It only affects installations that explicitly configure `DATE_TIME_IMPLEMENTATION` to
+`ZonedDateTime` or `Instant` (the default is `java.util.Date`), and only the in-memory value between a
+`java.util.Date`/`Number` being set and the record being flushed/reloaded.

--- a/docs/6482-cypher-label-disjunction-anchor-relationship.md
+++ b/docs/6482-cypher-label-disjunction-anchor-relationship.md
@@ -1,0 +1,88 @@
+# Issue #6482: label-disjunction anchor with an incident relationship never reaches the optimizer
+
+## Root cause
+
+`CypherExecutionPlanner.shouldUseOptimizer()` bailed out of the cost-based optimizer for the whole
+statement whenever any node in a path had a label disjunction (`n:A|B`) *and* that path had an
+incident relationship. So `MATCH (n:A|B {id: $x})-[:REL]->(m) RETURN m` always fell straight to the
+legacy execution engine and never got the `NodeByLabelDisjunctionIndexSeek` speedup issue #6397 added
+for the relationship-free case (`MATCH (n:A|B {id: $x}) RETURN n`).
+
+The gate existed because `ExpandAll`/`ExpandInto`/`VarLengthExpand` each carry a single `targetLabel`
+(pushed by `CypherOptimizer.addTargetLabelFilter`, using `targetNode.getFirstLabel()`) and cannot
+represent OR semantics for a node reached over a relationship. That is a real limitation, but it only
+applies to a disjunction on a *non-anchor* node - the anchor itself is seeded by
+`IndexSelectionRule.createAnchorOperator`, which #6397 already taught to build a
+`NodeByLabelDisjunctionScan`/`NodeByLabelDisjunctionIndexSeek` for it, with no `targetLabel` involved at
+all.
+
+## Fix
+
+Two changes, working together:
+
+1. **`CypherExecutionPlanner.shouldUseOptimizer()`**: relaxed the per-node gate so a label-disjunction
+   node with an incident relationship no longer disqualifies the whole statement at the AST level. This
+   gate runs before anchor selection, so it cannot yet know which node a connected component's
+   cost-based anchor selection will land on.
+
+2. **`CypherOptimizer.optimize()`**: added a safety check, `hasUnanchoredLabelDisjunction`, run right
+   after each connected component's anchor is finalized (after `validateAnchorForUnidirectionalEdges`,
+   which can itself re-anchor away from the initially cost-selected node). If any node in that
+   component *other than* the chosen anchor still carries a label disjunction, `optimize()` returns
+   `null` for the whole statement - the same "not representable" signal the method already used for
+   other unsupported shapes - which sends the query back to the legacy pipeline that evaluates every
+   alternative correctly (no silent first-label-only filtering).
+
+This preserves correctness for every shape the optimizer cannot yet represent (disjunction on a
+non-anchor node - single relationship, chain, or variable-length hop) while unlocking the index-seek
+speedup for the common case: a disjunction anchor with an equality predicate, followed by one or more
+relationships to plain-labeled or unlabeled nodes.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java` - relaxed
+  `shouldUseOptimizer()`'s per-node disjunction gate.
+- `engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java` - added
+  `hasUnanchoredLabelDisjunction()` and its call site in the per-component anchor-selection loop.
+- `engine/src/test/java/com/arcadedb/query/opencypher/CypherDisjunctionAnchorWithRelationshipIssue6482Test.java`
+  (new) - regression test.
+
+## Tests
+
+New: `CypherDisjunctionAnchorWithRelationshipIssue6482Test`
+- `disjunctionAnchorWithEqualityPredicateAndRelationshipUsesTheOptimizer` - inline-property equality on
+  a disjunction anchor with a relationship now plans as `NodeByLabelDisjunctionIndexSeek` feeding
+  `ExpandAll`, via the cost-based optimizer.
+- `disjunctionAnchorViaWhereClauseWithRelationshipUsesTheOptimizer` - same, predicate in `WHERE`.
+- `bothAlternativesStillReachTheSameTargetOverTheRelationship` - both disjunction alternatives still
+  return the right row through the relationship.
+- `aValueNoAlternativeHasReturnsNothingEvenWithARelationship` - a value neither alternative has still
+  returns nothing.
+- `disjunctionOnTheExpandedNodeDoesNotUseTheOptimizerButStaysCorrect` - the safety-net direction: a
+  disjunction on the node a relationship expands *into* (not the anchor) is confirmed to skip the
+  optimizer (`doesNotContain("Execution Plan (Cost-Based Optimizer)")`) and still return correct rows
+  via the legacy engine.
+
+Existing regression coverage that pins the correctness of the fallback shape end-to-end (unaffected by
+this change, re-run to confirm no regression):
+`CypherLabelDisjunctionOnExpandedNodeIssue6338Test`, `CypherDisjunctionIndexSeekIssue6397Test`,
+`CypherDisjunctionCardinalityIssue6363Test`, `CypherLabelDisjunctionTest`,
+`CypherRelationshipTypeDisjunctionTest`.
+
+## Verification
+
+- `mvn -pl engine -am compile` - clean.
+- `mvn -pl engine -am test -Dtest=CypherDisjunctionAnchorWithRelationshipIssue6482Test` - 6/6 pass.
+- `mvn -pl engine -am test -Dtest=CypherDisjunctionAnchorWithRelationshipIssue6482Test,CypherLabelDisjunctionOnExpandedNodeIssue6338Test,CypherDisjunctionIndexSeekIssue6397Test,CypherDisjunctionCardinalityIssue6363Test,CypherLabelDisjunctionTest,CypherRelationshipTypeDisjunctionTest`
+  - all pass.
+- `mvn -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**' -DexcludedGroups=benchmark,slow,vector`
+  - BUILD SUCCESS; OpenCypher TCK compliance report: 3812/3897 passed, 0 failed, 85 skipped (same skip
+    count as before this change - unaffected suite).
+
+## Scope note (from the issue)
+
+Purely a missed-optimization / performance fix, not a correctness fix on its own: a disjunction +
+relationship query already returned the right rows via the legacy scan-only path before this change.
+Teaching `ExpandAll`/`ExpandInto` to accept a disjunction target (issue #6482's suggested shape #2,
+covering a disjunction on a *non-anchor* node) remains out of scope and unaddressed - that shape still
+falls back to the legacy engine, correctly, via the new `hasUnanchoredLabelDisjunction` safety check.

--- a/docs/6560-redis-error-prefix-ha-lock-port-hardcode.md
+++ b/docs/6560-redis-error-prefix-ha-lock-port-hardcode.md
@@ -1,0 +1,108 @@
+# Issue #6560: Redis wire follow-ups from #6493
+
+Three independent, pre-existing follow-ups found while reviewing/fixing #6493. None of these are caused by
+#6493.
+
+## 1. RESP error replies duplicate/mask the error kind
+
+`RedisNetworkExecutor.respErrorPrefix()` unconditionally derived the RESP error kind (the token right after
+`-`) from `ErrorCategory.of(error)`, which only recognizes a handful of real engine exception types. Several
+call sites (`AUTH`, `HELLO`, `getAuthorizedDatabase`) instead baked their own kind word (`WRONGPASS`,
+`NOAUTH`, `NOPROTO`, `NOPERM`) into the *message* of a plain `RedisException` - a type `ErrorCategory` has no
+special case for, so it always fell through to the generic `ERR` default. The wire reply came out as e.g.
+`-ERR WRONGPASS ...` instead of `-WRONGPASS ...`: the kind a client can actually branch on was always `ERR`,
+never the specific one, even though the message text still happened to mention the real kind further along -
+which is exactly why the existing `.contains("WRONGPASS")`-style assertions never caught it.
+
+**Fix:** `RedisException` gained a `withKind(kind, message)` factory that carries an explicit RESP kind
+separate from the message. `respErrorPrefix()` now checks for it first, before falling back to
+`ErrorCategory`. Every call site that used to embed a kind word in its message now uses `withKind` instead
+(and the two sites that only repeated the already-default `ERR` had it dropped from the message entirely).
+
+**Tests:**
+- `RedisErrorClassificationTest` (unit): explicit-kind precedence over the `ErrorCategory` default, and that a
+  plain `RedisException` without an explicit kind is unaffected.
+- `RedisAuthenticationTest` (integration, real server + Jedis client): the wire reply for wrong credentials
+  and for `NOPERM` starts with the real kind and NOT with `ERR`.
+
+## 2. Redis-wire `SET k v NX` is not a real distributed lock across an HA/Raft cluster
+
+`RaftReplicatedDatabase`'s four global-variable accessors (`getGlobalVariable`, `setGlobalVariable`,
+`setGlobalVariableIfAbsent`, `setGlobalVariableIfPresent`) delegate straight to the local node with no Raft
+consensus/replication involved - unlike every other mutating method on that class. Global variables (and
+therefore Redis-wire `SET`/`GET`, including `SET k v NX`) are purely per-node state today, so `SET lock 1 NX`
+issued against two different nodes of an HA cluster (or the same logical key resolved differently after a
+failover) can each succeed independently.
+
+A full fix means replicating global variables through Raft - a materially bigger effort and its own design
+discussion, out of scope here. Per the issue's own suggested action, this item is a **documentation-only**
+fix: `DatabaseInternal`'s four global-variable methods and `RaftReplicatedDatabase`'s four overrides now
+carry an explicit Javadoc caveat that they are node-local, not cluster-wide, and must not be relied on as a
+real distributed lock in an HA deployment. No behavior changed, so no new automated test accompanies this
+item - the existing behavior (and its existing test coverage) is unchanged; only what is documented about it.
+
+## 3. `RedisQueryLanguageTest` hardcodes port 2480
+
+`executeCommand`/`executeQuery` built their target URL as `"http://127.0.0.1:248" + serverIndex + ..."`,
+assuming the server bound the default port 2480 (or 2481 for a second server). `SERVER_HTTP_INCOMING_PORT` is
+actually a range (2480-2489 by default) and binds the first free port in it, so with 2480 already held by
+anything else - another local ArcadeDB instance, an IDE debug session for a different project - this test's
+own server listens elsewhere and every test in the class fails with a confusing `403 Too many failed
+authentication attempts` / `User/Password not valid`, which reads as an auth bug rather than a port
+collision. Same class of bug as #6426, fixed the same way for `ConsoleAsyncInsertTest` in #6437.
+
+**Fix:** both helpers now ask the server for the port it actually bound
+(`getServer(serverIndex).getHttpServer().getPort()`) instead of assuming the default.
+
+**Verification:** the whole class (19 tests) was run in this environment with port 2480 genuinely held by an
+unrelated process (`lsof -nP -iTCP:2480 -sTCP:LISTEN` showed a live listener) - all 19 passed, which the
+pre-fix hardcoded URL could not have done.
+
+## Test results (this environment, isolated `-Dmaven.repo.local`)
+
+- `RedisErrorClassificationTest`: 7/7 passed (later 7/7 unchanged)
+- `RedisAuthenticationTest`: 9/9 passed initially, 11/11 after cycle 1's review addition
+- `RedisQueryLanguageTest`: 19/19 passed, with port 2480 occupied by an unrelated process
+- Full non-IT `redisw` unit-test set (`RedisAuthenticationTest`, `RedisErrorClassificationTest`,
+  `RedisPortConfigurationTest`, `RedisProtocolLimitsTest`, `RedisQueryLanguageTest`,
+  `RedisRespCorrectnessTest`, `RedisWTest`): 76/76 passed, no regressions
+- `ha-raft` unit tests touching `RaftReplicatedDatabase` (`RaftReplicatedDatabaseTest`,
+  `RaftReplicatedDatabaseLeaderWaitTest`): passed, unaffected by the Javadoc-only change
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6691
+
+## Review cycles
+
+- **Cycle 1** - head `7080e167`: initial PR. `claude` review: solid overall; flagged a coverage gap - only
+  `WRONGPASS`/`NOPERM` were asserted at the wire level (via `RedisAuthenticationTest`), not `NOPROTO`/plain
+  `NOAUTH` (the `HELLO` paths). Addressed in `057a321d`: added `helloWithoutAuthErrorKindIsNotMaskedByErr`
+  and `helloWithBadProtocolVersionErrorKindIsNotMaskedByErr` to `RedisAuthenticationTest` (11/11 passed).
+- **Cycle 2** - head `057a321d`: `claude` review: approved overall; nitpicked that the shared "these four
+  accessors" Javadoc comment was physically placed above only `getGlobalVariable()`, so it would not surface
+  in generated docs/IDE hover for the other three overrides (a Javadoc comment attaches to the single
+  declaration it precedes). Also noted `getGlobalVariables()` (plural) was outside the "four accessors"
+  comment's scope. Addressed in `71b99af8`: gave each of the five node-local accessors its own short Javadoc
+  pointing back to the caveat on `DatabaseInternal`.
+- **Cycle 3** - head `71b99af8`: `claude` review: "Approving from a code-review standpoint"; one minor
+  non-blocking nit that `DatabaseInternal.getGlobalVariables()` itself (the interface method, not just the
+  Raft override) still lacked its own "not replicated" caveat. Addressed in `d1129bac`: added the caveat to
+  the interface method's own Javadoc for full symmetry with the other three.
+- **Cycle 4** - head `d1129bac`: `claude` review: clean; the only note was an explicitly non-blocking
+  "optional polish" observation that `respErrorPrefix()`'s explicit-kind check looks only at the outer
+  exception, not the full cause chain the way `ErrorCategory.of()` does - a latent gotcha only if a future
+  call site wraps a `withKind()` exception in another type before it reaches `respErrorPrefix()`, which none
+  do today. Categorized as a nitpick (bot's own words: "not worth blocking on"), not applied. **Clean
+  approval** - working tree empty, no actionable items remaining.
+
+## Deferred items
+
+None. The one item not applied (cycle 4's cause-chain observation) was explicitly framed by the reviewer
+itself as optional polish rather than a defect, so it was categorized as a nitpick and skipped rather than
+deferred to a notes file.
+
+## Final state
+
+`clean-approval` after 4 review cycles (the maximum configured). Merge remains the developer's
+responsibility.

--- a/docs/6573-isedgevariablereferenced-create-merge.md
+++ b/docs/6573-isedgevariablereferenced-create-merge.md
@@ -1,0 +1,54 @@
+# Issue #6573: isEdgeVariableReferenced has no CREATE/MERGE case
+
+## Summary
+
+`CypherVariableUsage.isEdgeVariableReferenced` decides whether a MATCH-bound relationship variable
+keeps its real binding (vs. being anonymized for the CSR/GAV fast path) by walking every clause type
+in `statement.getClausesInOrder()`. The top-level switch handled `RETURN`, `WITH`, `UNWIND`, `SET`,
+`REMOVE`, `DELETE`, `FOREACH`, `SUBQUERY` - but had no `case CREATE` / `case MERGE`, so it fell to
+`default` and the clause was never inspected.
+
+Contrast with `foreachReferencesVariable`'s own inner switch (same file), which already treats a
+nested `CREATE`/`MERGE` conservatively (`return true`). The top-level switch never got the same
+treatment.
+
+## Reproduction (from the issue)
+
+```cypher
+CREATE (a:Person {id:'a'})-[r:KNOWS {since: 2001}]->(b:Person {id:'b'})
+```
+```cypher
+MATCH (a:Person)-[r:KNOWS]->(b:Person) CREATE (c:Note {since: r.since}) RETURN c.since AS s
+```
+
+Expected: `s = 2001`. Actual (before fix): `s = null` - the relationship step bound `r` under an
+internal anonymous name (since nothing else in the query appeared, to this check, to reference it),
+so the CREATE clause's `r.since` read a missing binding and silently evaluated to `null`.
+
+## Fix
+
+Added a `case CREATE: case MERGE:` arm to the top-level switch in `isEdgeVariableReferenced`,
+mirroring `foreachReferencesVariable`'s conservative `return true`. A false positive there only
+forgoes the CSR/GAV fast path; a false negative silently drops a still-referenced edge, which is the
+failure class this whole method exists to prevent.
+
+File: `engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java`
+
+## Tests
+
+- `CypherVariableUsageTest.createReadsItInAnInlineProperty` / `.mergeReadsItInAnInlineProperty` -
+  unit-level checks parallel to the existing cases in that file (`setReadsItAsTargetAndAsValue`,
+  `removeReadsIt`, etc.), verified to fail without the fix.
+- `Issue6573CreateMergeEdgeVariableTest` - new end-to-end regression test running the issue's own
+  reproducer through the real Cypher engine (`createReadsTheEdgePropertyThroughAnInlineExpression`,
+  `mergeReadsTheEdgePropertyThroughAnInlineExpression`), also verified to fail (with a `null` result,
+  matching the issue's reported symptom exactly) without the fix, via a temporary `git stash` of the
+  production change.
+
+## Verification
+
+- `CypherVariableUsageTest` + `Issue6573CreateMergeEdgeVariableTest`: 23/23 pass.
+- Full `com.arcadedb.query.opencypher.**` package (excluding benchmark/slow/vector lanes): 8906
+  tests, 0 failures, 0 errors, 98 skipped (pre-existing skips, unrelated to this change).
+- Confirmed both new tests fail without the fix (temporarily stashed the production change) and pass
+  with it restored.

--- a/docs/6574-gql-filter-clause-noop.md
+++ b/docs/6574-gql-filter-clause-noop.md
@@ -1,0 +1,94 @@
+# Issue #6574: GQL standalone FILTER clause parses but has zero effect
+
+## Root cause
+
+`Cypher25Parser.g4` defines a standalone `filterClause` (`FILTER WHERE? expression`), part of
+ISO/IEC 39075:2024 GQL, in the same family as the already-supported `forUnwindClause`
+(`FOR ... IN ...`, a synonym for `UNWIND`). The grammar rule parses successfully, but:
+
+- `ClauseDispatcher` registered a handler for every other clause type except `filterClause`.
+- `dispatch()` looped its handler map, found no match, and silently fell through (a comment
+  said "this should not happen with valid grammar").
+- `CypherASTBuilder` had no `visitFilterClause`.
+
+Net effect: `FILTER (<any expression>)` was accepted syntactically and completely ignored,
+regardless of whether the predicate was true or false - a silent-wrong-results bug, not a
+hard failure.
+
+## Fix
+
+Followed the issue's suggested approach, mirroring the precedent `handleOrderBySkipLimit`
+already sets for rewriting a GQL-only clause into the existing WHERE/WITH machinery:
+
+- `CypherASTBuilder.visitFilterClause(FilterClauseContext)` parses `FILTER WHERE? expression`
+  into a `WhereClause`, reusing the same boolean-expression parsing and AST-rewriter
+  simplification `visitWhereClause` uses.
+- `ClauseDispatcher` registers a `filterClause` handler that wraps the resulting `WhereClause`
+  in an implicit `WITH * WHERE <predicate>`, so the filter is applied at the correct position
+  in `clausesInOrder` - the same technique `handleOrderBySkipLimit` uses for a standalone
+  `ORDER BY` / `SKIP` / `LIMIT` clause (issue #3950).
+
+This required no grammar change (the `filterClause` rule already existed) and no changes to
+the optimizer or legacy execution paths, since both consume the shared `WithClause` AST node
+that `ClauseDispatcher` now produces for `FILTER`.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java`
+  - added `visitFilterClause`
+- `engine/src/main/java/com/arcadedb/query/opencypher/parser/ClauseDispatcher.java`
+  - registered `filterClause` -> `handleFilter`
+  - added `handleFilter`
+- `engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCypher25ClausesTest.java`
+  - added a "FILTER clause (issue #6574)" section with 5 regression tests
+
+## Tests
+
+New tests in `OpenCypherCypher25ClausesTest`:
+
+- `filterFalsePredicateProducesNoRows` - the issue's exact reproduction
+  (`FILTER (0 IN range(12, 1, -1)) RETURN 1 AS x`), asserts zero rows.
+- `filterTruePredicateProducesRow` - the true-predicate counterpart, asserts the row passes.
+- `filterWithWhereKeywordFalsePredicateProducesNoRows` / `...TrueProducesRow` - covers the
+  grammar's optional `WHERE` keyword form (`FILTER WHERE <expr>`).
+- `filterAfterMatchRestrictsRowsByProperty` - proves FILTER actually restricts rows from a
+  preceding `MATCH` by a property predicate, not just a constant.
+
+Before the fix, 3 of the 5 new tests failed (the two "true predicate" tests pass either way
+since a no-op also lets rows through, which is exactly the bug: no observable difference
+between true and false).
+
+## Verification
+
+- `mvn -pl engine -am test -Dtest=OpenCypherCypher25ClausesTest` - 45/45 pass (all new FILTER
+  tests included).
+- Full `com.arcadedb.query.opencypher.**` package (excluding `benchmark`, `slow`, `vector`
+  lanes) - 8907/8907 pass, 98 skipped, 0 failures, 0 errors. No regressions.
+- `mvn -pl engine -am compile` - clean compile.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/6688
+
+## Review cycles
+
+- **Cycle 1** - head `05556cb8d493e8588a397ae982dbd5cbca37536c` (initial commit). `claude` bot
+  review (issue comment, 2026-08-24T15:43:50Z): positive assessment, no actionable items.
+  Confirmed the fix's reasoning, the shared `WithClause` AST node claim, and the test coverage
+  design (false-predicate tests are what actually pin the fix, since a no-op also lets rows
+  through). One informational, explicitly non-blocking observation: `letClause`
+  (`LET letItem (COMMA letItem)*`) is in the same grammar `clause` alternative list and has the
+  same missing-handler gap `filterClause` had before this PR - suggested as a follow-up
+  issue/PR, out of scope for this one since `LET` binds a value rather than filtering rows and
+  may need its own AST node rather than reusing `WithClause`. No code changes required; working
+  tree stayed clean.
+
+## Deferred items
+
+None requiring developer follow-up in this PR. See "Review cycles" above for the one
+out-of-scope observation (`letClause` handler gap) the reviewer flagged for a possible
+separate issue.
+
+## Final state
+
+`clean-approval` after 1 review cycle.

--- a/docs/6579-native-select-limit-0-count.md
+++ b/docs/6579-native-select-limit-0-count.md
@@ -1,0 +1,94 @@
+# Issue #6579: Native select `.limit(0)` returns count 1 instead of 0
+
+## Root cause
+
+`SelectExecutor.executeCount()` incremented `count` before comparing it against `select.limit`:
+
+```java
+count++;
+if (select.limit > -1 && count >= select.limit)
+  break;
+```
+
+For `limit == 0`, the first matching record already bumped `count` to `1` before the `count >= limit`
+(`1 >= 0`) check ever got a chance to see `limit == 0` - so the wrong value (`1`) was already counted by
+the time the loop broke.
+
+## Fix
+
+Reordered the check to run before the increment (`engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java`,
+`executeCount()`):
+
+```java
+if (select.limit > -1 && count >= select.limit)
+  break;
+if (filterOutRecords != null)
+  filterOutRecords.add(record.getIdentity());
+count++;
+```
+
+## Investigated but not affected
+
+The issue asked to also check `SelectIterator`'s `hasNext()`/`fetchNext()` path (used by `.documents()`/
+`.vertices()`/etc.). Traced it: the constructor only consumes `skip` records (0 iterations when
+`skip == 0`), and `hasNext()` checks `returned >= (long) limit + skip` **before** calling `fetchNext()`.
+For `limit == 0, skip == 0` that is `0 >= 0`, true, so `hasNext()` returns `false` immediately without
+ever pulling a record. Same reasoning holds for the `ORDER BY` materialization path
+(`fetchResultInCaseOfOrderBy()`), whose `end = min(materialized.size(), skip + limit)` is `0` for
+`limit == 0`. Confirmed with the existing `okLimit`/`okSkip` tests plus manual review - no code change
+needed there.
+
+## Test
+
+Added `SelectExecutionTest.okCountWithLimitZero()` (TDD: written first, confirmed red against the
+pre-fix code with `expected: 0L but was: 1L`, green after the fix). Covers both repro shapes from the
+issue:
+- no-`WHERE` (unindexed full-type-scan) path
+- `AND`-shaped `WHERE` (the uncapped fallback path)
+
+## Verification
+
+- `mvn -pl engine -am test -Dtest=SelectExecutionTest` - 26/26 pass
+- `mvn -pl engine -am test -Dtest='Select*Test'` - 315/315 pass (all native-select and SQL select suites)
+- `mvn -pl engine -am test -Dtest=Issue6565SelectIndexCandidateLimitTest` - 20/20 pass (adjacent
+  candidate-cap logic touched by the same class, per the issue's own cross-reference to #6571/#6565)
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6683
+
+## Review cycles
+
+- **Cycle 1** - head `e718976202d273e2d9c2957fa35d1956e5416177`. `claude` review: no blocking issues;
+  confirmed the reorder is correct, confirmed `limit > 0` behavior is unchanged by hand-tracing, and noted
+  the already-safe indexed-cursor path (`MultiIndexCursor` stops before pulling any candidate for
+  `limit(0)`). One optional nit: add an assertion pinning that indexed-cursor path against a future
+  regression in `computeExactCandidateLimit()`. Applied (see `okCountWithLimitZero`'s third assertion,
+  `.where().property("id").eq().value(5).limit(0).count()`); no deferred items.
+- **Cycle 2** - head `bc85c6c51f9abaea4317eabdd6ee97019d77ae73`. `claude` review found a real regression
+  the cycle-1 fix introduced: the pre-increment `limit == 0` guard, on its own, moves the `break` so it
+  only fires from inside the `evaluateWhere()` match branch - so once `limit` is reached, the loop can
+  only stop on the *next* matching record, not the current one. With a selective WHERE and no
+  `(limit+1)`th match, `.where(...).limit(N).count()` degrades from an early-exit scan into a full scan of
+  the rest of the type. None of the existing tests caught it because they all use a WHERE matching every
+  row (or a unique-indexed single hit), so there's always an "(N+1)th" match available - and the returned
+  count is identical either way, only the number of records scanned changes. Verified the analysis by hand
+  and by reproducing it (temporarily reverting to the single-check version and confirming the suggested
+  regression test goes red). Fixed by restoring the original post-increment `count >= limit` check
+  alongside the new pre-increment one (the post-check is what gives the same-iteration early exit for
+  `limit > 0`; the pre-check only ever fires for `limit == 0`, since `count` can't reach a `limit > 0`
+  without the post-check already breaking the loop first). Added
+  `okCountWithLimitStopsEarlyDespiteReorder()` (also suggested by the review) to pin `evaluatedRecords` for
+  a `WHERE` with exactly one match followed by 500 non-matching records - proved it fails against the
+  single-check version before restoring the fix. No deferred items.
+- **Cycle 3** - head `4bf062d2382389b447e92a52c76ae6f4277be852`. `claude` review: clean approval. Manually
+  re-traced the pre/post-increment control flow for `limit == 0`, `limit > 0`, and `skip` interaction and
+  confirmed all three are correct; called out `okCountWithLimitStopsEarlyDespiteReorder` as "the right way
+  to catch a 'correct count, wrong complexity' regression that a value-only assertion would miss". One
+  non-blocking style nit (the new inline comment is long/all-caps, though consistent with the file's
+  existing `#6565`/`#5662` comment convention) - no action needed. No correctness, performance, or
+  security issues found; working tree stays clean. **Final state: clean-approval.**
+
+## Deferred items
+
+None.

--- a/docs/6584-command-request-limit-field.md
+++ b/docs/6584-command-request-limit-field.md
@@ -1,0 +1,109 @@
+# Issue #6584 — OpenAPI: CommandRequest omits 'limit', which PostCommandHandler honors
+
+## Root cause
+
+`server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java`
+declares two request schemas for the two `POST` command/query endpoints:
+
+- `createQueryRequestSchema()` — declares `command`, `language`, `params`,
+  `serializer`, and `limit`.
+- `createCommandRequestSchema()` — declares only `command`, `language`, `params`.
+
+Both `/api/v1/query/{database}` and `/api/v1/command/{database}` are served by
+`PostCommandHandler.execute()` (`PostQueryHandler` extends `PostCommandHandler` and
+overrides only `executeCommand()`, not `execute()`), which reads and honors a `limit`
+field from the request body identically for both endpoints:
+
+```java
+final Integer requestLimit = optionalIntField(requestMap, "limit");
+...
+final int autoLimit = requestLimit != null ? applyMaxResultRows(requestLimit, maxResultRows) : getDefaultRowLimit();
+```
+
+So the command endpoint accepts and honors `limit` exactly like the query endpoint, but
+the OpenAPI contract never told a generated client that. This is the second instance of
+this class of asymmetry between `CommandRequest` and `QueryRequest` — #6562 was the
+first, where `CommandRequest` omitted the required `language` field.
+
+## Affected components
+
+- `server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java`
+  (`createCommandRequestSchema()`)
+
+## Expected vs actual behavior
+
+- **Expected**: `CommandRequest` documents a `limit` field, mirroring
+  `QueryRequest`'s, since the same handler code path honors it identically for both
+  endpoints.
+- **Actual**: `CommandRequest` has no `limit` property, so a client generated strictly
+  from the OpenAPI contract has no typed way to cap a command's result set, even though
+  the server supports it.
+
+## Fix
+
+Added a `limit` property to `createCommandRequestSchema()` in `CoreApiSpec.java`,
+using the same description/example as `QueryRequest`'s `limit` property (the behavior
+is identical because both endpoints share `PostCommandHandler.execute()`).
+
+## Scope note
+
+The issue body also suggests auditing the rest of `CommandRequest` against
+`PostCommandHandler` "in the same pass". `PostCommandHandler.execute()` also reads
+`serializer`, `profileExecution`, `typeHints`, and `awaitResponse` from the request
+body, none of which are declared on `QueryRequest` either (only `serializer` is, on
+`QueryRequest`). Broadening either schema to cover all of those is a larger, separate
+change with its own design questions (e.g. whether `awaitResponse` and `typeHints`
+make sense to advertise on the query endpoint), so it is intentionally left out of this
+fix and left for a dedicated follow-up issue, consistent with how #6562 scoped itself to
+just the `language` field.
+
+## Tests
+
+Added `commandRequestDeclaresLimitMatchingQueryRequest()` to
+`server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java`,
+following the existing `commandRequestDeclaresLanguageAsRequired()` pattern:
+asserts `CommandRequest` declares a `limit` property, and that its type/description
+matches `QueryRequest`'s `limit` property (same underlying behavior, same contract
+language).
+
+## Test results
+
+- `mvn -pl server -am test -Dtest=CoreApiSpecTest` — 23/23 pass (new test proven to
+  fail against `main` first, then pass after the fix).
+- `mvn -pl server -am test -Dtest=PostCommandHandlerAutoLimitTest,PostCommandHandlerLargeContentTest,AbstractQueryHandlerTypedJsonMarkersTest`
+  — all pass (regression check on related handler behavior).
+- `PostCommandHandlerDecodeTest.javaScriptFunctionWithLogicalAndOperatorViaHTTP` fails
+  in this environment with "HTTP Port 2480 not available" — a pre-existing local port
+  conflict (another process already bound to 2480), unrelated to this change: the test
+  spins its own embedded server and doesn't touch the OpenAPI spec at all.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6682
+
+## Review cycles
+
+- **Cycle 1** — head `9bdf75e40b34617346e6fb00d8337e1269882d1a` (the fix commit).
+  `claude` bot review (posted as a PR issue comment, per this org's review-bot
+  behavior): **LGTM**, zero actionable items. It independently verified the root-cause
+  claim by reading `PostCommandHandler.execute()` directly, confirmed the added
+  `limit` property is "byte-for-byte identical" to `QueryRequest`'s, and called the
+  new test well-targeted ("asserts equality of type/description ... so it will
+  actually catch future divergence, not just absence"). Its one note - a shared
+  helper/constant so the `limit` property text can't drift between the two schemas
+  again - is explicitly framed as "not required for this fix" and "could be deferred
+  to whenever the broader ... parity audit ... happens", which is exactly the
+  follow-up already named in this PR's "Scope note" above. No code change applied;
+  working tree stayed empty. Treated as a clean approval.
+
+## Deferred items
+
+None requiring separate tracking. The reviewer's one optional suggestion (a shared
+`limit`-property helper to prevent `QueryRequest`/`CommandRequest` drift structurally)
+overlaps entirely with the broader `CommandRequest`/`QueryRequest` parity audit already
+called out in this doc's "Scope note" section as future follow-up work, so it is not
+duplicated into a separate notes file.
+
+## Final state
+
+`clean-approval` — 1 review cycle, LGTM, no code changes requested.

--- a/docs/6598-database-rid-asvertex-broad-catch.md
+++ b/docs/6598-database-rid-asvertex-broad-catch.md
@@ -1,0 +1,87 @@
+# #6598 - `DatabaseRID.asVertex(boolean)` reports every failure as "record not found"
+
+## Root cause
+
+`DatabaseRID.asVertex(boolean)` (`engine/src/main/java/com/arcadedb/database/DatabaseRID.java`) caught
+`Exception` broadly around `database.lookupByRID(...)` and rewrapped anything that was not already a
+`RecordNotFoundException` into one. Its sibling, `RID.asVertex(boolean)`, only ever caught `ClassCastException`
+(a RID that names a record which exists but is not a `Vertex`). The broad catch was introduced when
+`DatabaseRID` was added in 7d7d7aac6 and widened `ClassCastException` to `Exception` in the process.
+
+Consequences of the broad catch:
+- A `SecurityException` (permission denial) was reported to the caller as "record not found" - a healthy,
+  present record the caller simply was not allowed to read looked like data corruption.
+- A `ConcurrentModificationException` (`extends NeedRetryException`) - e.g. from `loadMultiPageRecord`
+  exhausting `TX_RETRIES` on a multi-page vertex body - silently became a non-retryable
+  `RecordNotFoundException`. The retry machinery never saw it, and the caller concluded the vertex was gone
+  when it was merely contended.
+
+## Affected component
+
+`engine/src/main/java/com/arcadedb/database/DatabaseRID.java` - `asVertex(boolean)`.
+
+## Fix
+
+Narrowed the catch from `Exception` to `ClassCastException`, matching `RID.asVertex(boolean)` exactly (the
+`RecordNotFoundException` passthrough arm is unchanged). This restores the pre-`DatabaseRID` behaviour and
+removes the whole class of masking. `asDocument`/`asEdge` in the same class already have no try/catch at all,
+so this also brings `asVertex` back in line with its neighbours.
+
+Per the issue's own preference ordering, this only applies fix (1) - the narrower catch. Fix (2) (also
+converting the surviving `ClassCastException` -> `RecordNotFoundException` translation into a message that
+names the actual type found) is explicitly called out in the issue as a separate behaviour-changing decision
+and is out of scope here.
+
+Items 2 (`ACCESS.DELETE_RECORD`'s past-tense wire name `deletedRecord`) and 3 (a note that #6491's diagnosis
+basis moved) are explicitly the "latent trap" / "pointer" halves of #6598, not "the one worth acting on" -
+left untouched, as the issue itself recommends.
+
+## Test plan
+
+New test: `engine/src/test/java/com/arcadedb/database/Issue6598DatabaseRidAsVertexBroadCatchTest.java`
+
+- Unit level (Mockito stub of `BasicDatabase`, isolates the catch contract from which engine code path
+  happens to raise each exception today):
+  - `aSecurityExceptionFromLookupSurvivesAsVertexUnwrapped` - a `SecurityException` from `lookupByRID`
+    reaches the caller unwrapped, not as `RecordNotFoundException`.
+  - `aRetryableConflictFromLookupSurvivesAsVertexUnwrapped` - a `ConcurrentModificationException` reaches
+    the caller unwrapped and stays a `NeedRetryException`.
+  - `aRecordNotFoundExceptionFromLookupIsRethrownAsIs` - unchanged passthrough behaviour.
+  - `aRecordThatIsNotAVertexStillReportsAsNotFound` - the one case `asVertex()` is meant to translate (a
+    `ClassCastException` because the record is not a `Vertex`) still becomes `RecordNotFoundException`.
+- End-to-end: `aPermissionDenialReachedThroughAsVertexIsNotReportedAsRecordNotFound` - a real database, a
+  principal granted `deleteRecord` but not `readRecord` (the exact scenario reported in the issue, reused
+  from #6586's `aPrincipalWithoutReadPermissionCannotReachTheDeleteAtAll` fixture pattern), reached through
+  `guarded[0].asVertex()` - the shortcut ordinary caller code uses, as opposed to `lookupByRID` directly,
+  which #6586's test used specifically to sidestep this bug.
+
+## Verification
+
+- `mvn -pl engine -am test -Dtest=Issue6598DatabaseRidAsVertexBroadCatchTest` - RED before the fix (3 of 5
+  assertions failed: the `SecurityException` and `ConcurrentModificationException` passthrough unit tests,
+  plus the end-to-end permission scenario), GREEN after.
+- `mvn -pl engine -am test -Dtest=Issue6598DatabaseRidAsVertexBroadCatchTest,DatabaseRIDTest,Issue6586MissingVertexDiagnosisTest,Issue6572DanglingVertexReferenceTest`
+  - 32 tests, 0 failures.
+- `mvn -pl engine -am test -Dtest=Issue687ClassCastEdgeCheckTest,Issue5279ConcurrentUpdateTest,RecordNotMaterialisedTest`
+  - 21 tests, 0 failures.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6681
+
+## Review cycles
+
+- Cycle 1: head `5ae25f9d0b` - claude bot review (issue comment, posted 2026-08-24T15:08:23Z): "looks
+  correct, safe, and ready to merge pending CI." No actionable items - two minor/non-blocking observations
+  only (a note that any other `RuntimeException` besides `SecurityException`/`ConcurrentModificationException`
+  now also propagates unwrapped, which is the intended, matching-`RID.asVertex()` behavior; and a sanity-check
+  suggestion on the end-to-end test's `factory.close()` after `restricted.drop()`, which the reviewer itself
+  judged "almost certainly fine"). Working tree stayed clean - no code change made in response.
+
+## Deferred items
+
+None. Both of the bot's observations were non-blocking FYI notes, not requests for a code change.
+
+## Final state
+
+clean-approval (cycle 1 of 4 max).

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3942,3 +3942,16 @@ index may be noticeably slower than the queries that follow it, where `close()` 
 instead. Below the 1,000-vector threshold, `close()` keeps rebuilding synchronously as before, unaffected.
 
 [#6067](https://github.com/ArcadeData/arcadedb/issues/6067)
+
+## `LSMVectorIndex.getStats()` reports whether the last close deferred a graph rebuild (#6657)
+
+The deferral above (#6067) is only visible in the log, at `FINE` level, unless an operator goes looking for it.
+`getStats()` now also carries a `closeTimeRebuildPending` entry: `1` when the most recent `close()` chose to skip a
+rebuild it would otherwise have run, `0` otherwise. It answers a narrower question than the existing `graphState`/
+`mutationsSinceRebuild` entries, which cannot by themselves distinguish "pending mutations because a session is
+mid-flight" from "pending mutations because close() chose not to pay for them" - and, unlike a plain in-memory
+counter would, it still reads `1` on a freshly reopened index, before that index has been searched again, which is
+the moment the question is actually useful: right before a query pays the deferred cost, not after. It clears back
+to `0` the moment that rebuild - deferred or not - actually completes.
+
+[#6657](https://github.com/ArcadeData/arcadedb/issues/6657)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3880,3 +3880,37 @@ read noticed first. An unreadable *chunk* of a vertex that does exist keeps the 
 `ConcurrentModificationException` and #5764's scoped advice, on both paths.
 
 [#6586](https://github.com/ArcadeData/arcadedb/issues/6586)
+
+## A Graph Analytical View that turns out not restorable from disk no longer blocks the query that found that out (#6641)
+
+Deferring a persisted CSR's read out of `open()` (#6632) removed a real cost - up to ~1s at 10M vertices - from a
+session that never queries the view, by marking it `READY` on a plausible file alone and reading it later,
+whenever a real query or an explicit `awaitReady()` asks. That worked for the case it was built for. It
+regressed a case it wasn't: when the deferred read finally runs and finds the persisted CSR unusable - its
+freshness certificate invalidated by a commit that landed between close and reopen, or the file itself
+corrupted - the query that triggered the read had, by then, already committed to the accelerated path. With
+nothing left to fall back to, it waited out a full `O(V+E)` rebuild synchronously: 5.6 seconds at 1M
+vertices in the reporter's measurements, on course for roughly a minute at 10M. Before #6632, the same
+situation cost that query nothing - `onRelevantCommit()` marked the view `STALE` eagerly, right at commit
+time, so the query planner routed straight past it to the ordinary path.
+
+Every step along the way was individually correct; the regression was in the aggregate. `GraphAnalyticalView
+.isReady()` is what `GraphTraversalProviderRegistry.findProvider()` uses to decide whether a query gets
+routed to this provider at all, and it answered `true` for a view whose persisted CSR had not actually been
+verified yet - a hint reported as a promise. By the time a query reached `checkBuilt()` on the strength of
+that answer, there was no way back: `checkBuilt()`'s callers have no unaccelerated fallback of their own, so
+finding the restore unusable there could only mean blocking through the rebuild it triggers, never stepping
+aside for it.
+
+`isReady()` now answers the question it is actually being asked - can a query safely be routed here right
+now - honestly: while a deferred restore is still unresolved, it dispatches the restore-or-rebuild in the
+background (a no-op if another caller already has) and reports not-ready for the query asking, exactly the
+answer an eagerly-marked `STALE` view would have given before #6632. That query takes the ordinary path;
+whichever query asks next sees whatever the background work resolved to - restored from disk, or freshly
+rebuilt - because by then `isReady()` reflects the real, verified state. "Never serve stale data" is
+unaffected: nothing changes about what a query sees once the view reports ready, only about which query pays
+for making it so. A caller that would rather wait out an accelerated first query than fall back keeps that
+option through `awaitReady()` (and, at `open()` time, `GAV_RESTORE_AWAIT_TIMEOUT`) - both already resolve the
+deferred restore explicitly and are unaffected by this change.
+
+[#6641](https://github.com/ArcadeData/arcadedb/issues/6641)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3914,3 +3914,31 @@ option through `awaitReady()` (and, at `open()` time, `GAV_RESTORE_AWAIT_TIMEOUT
 deferred restore explicitly and are unaffected by this change.
 
 [#6641](https://github.com/ArcadeData/arcadedb/issues/6641)
+
+## Closing a database no longer blocks on a full vector graph rebuild for large indexes (#6067)
+
+`LSMVectorIndex.close()` persists the graph before shutting down, so that a fast restart finds a ready-to-search
+graph rather than rebuilding on first open. For an index with any pending write (`graphState == MUTABLE`, or a
+first-ever build that never persisted), that persist has always meant a full `buildGraphFromScratch()` - there is
+no incremental update, so any rebuild reindexes every vector in the index, not just the ones written since the
+last build. That cost was paid synchronously on the closing thread regardless of index size: a single write to a
+200,000-vector index measured `close()` blocking for roughly 43 seconds, the same cost as writing a thousand
+vectors, because the rebuild's cost tracks total index size rather than what was actually written.
+
+`close()` now defers that rebuild instead of running it, for any index at or above the same size threshold the
+search path already uses to decide between a synchronous and an asynchronous rebuild (1,000 vectors,
+`arcadedb.vectorIndex.mutationsBeforeRebuild`'s sibling knob is unaffected). The vectors themselves are unaffected
+by any of this - they go through ordinary page/WAL persistence independent of the graph file, so nothing is lost
+by skipping the rebuild - only the graph's on-disk topology is left stale or absent. The next time that index is
+actually searched, after any reopen, the existing stale-persisted-graph detection (the same manifest/node-count
+check that already handles a persisted graph left behind by an unrelated shutdown) notices and rebuilds it lazily
+before answering the query.
+
+**Upgrading:** a session that writes to a large vector index and closes without ever searching it again no longer
+pays the rebuild cost at all - not at close, and not later, since nothing forces it until a search actually needs
+the graph. A session that does go on to search that index pays the same total rebuild cost as before, just moved
+from `close()` to that first query instead - so a query immediately after reopening a large, recently-written
+index may be noticeably slower than the queries that follow it, where `close()` used to absorb that latency
+instead. Below the 1,000-vector threshold, `close()` keeps rebuilding synchronously as before, unaffected.
+
+[#6067](https://github.com/ArcadeData/arcadedb/issues/6067)

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2009,6 +2009,15 @@ public enum GlobalConfiguration {
       "Maximum size in bytes accepted for a single bind-message parameter value on the Postgres wire protocol. Values declaring a larger size are rejected before allocation. Default is 16MB",
       Integer.class, 16 * 1024 * 1024),
 
+  POSTGRES_SIMPLE_QUERY_MAX_ROWS("arcadedb.postgres.simpleQueryMaxRows", SCOPE.SERVER, """
+      Maximum number of rows a simple-query protocol ('Q' message) SELECT is allowed to buffer server-side before \
+      the first row is sent. Unlike the extended query protocol, the simple-query protocol has no client-driven \
+      cursor/max-rows mechanism and always expects the complete result set in one response, so the server has to \
+      hold it in memory to determine the row description (column set and types) before streaming it. A SELECT whose \
+      result exceeds this limit is refused with an error instead of risking an OutOfMemoryError; the client should \
+      use the extended query protocol with a bounded portal fetch size for very large result sets. Default is \
+      1000000""", Integer.class, 1_000_000),
+
   // BOLT (Neo4j)
   BOLT_PORT("arcadedb.bolt.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for BOLT plugin. Default is 7687", Integer.class, 7687),

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -187,7 +187,11 @@ public class Profiler {
       final DatabaseAsyncExecutorImpl async = asyncIfExists(db);
       final DatabaseAsyncExecutorImpl.DBAsyncStats asyncStats = async != null ? async.getStats() : null;
       acc[STAT_ASYNC_QUEUE] += asyncStats != null ? asyncStats.queueSize : 0L;
-      acc[STAT_ASYNC_PARALLEL] = async != null ? async.getParallelLevel() : 0L;
+      // #6533: this used to be a plain assignment, so with more than one database open the exported reading was
+      // whichever database the identity-hashed iteration happened to visit last - not a sum, and unstable between
+      // consecutive scrapes of an unchanged server. Summed like every other entry in this array: the JVM-wide
+      // question this answers is "how many async worker threads does this process have", matching asyncQueueLength.
+      acc[STAT_ASYNC_PARALLEL] += async != null ? async.getParallelLevel() : 0L;
       acc[STAT_ASYNC_RETIRING] += asyncStats != null ? asyncStats.retiringWorkers : 0L;
     }
     return acc;

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -110,6 +110,13 @@ public interface DatabaseInternal extends Database {
 
   void checkPermissionsOnFile(int fileId, SecurityDatabaseUser.ACCESS access);
 
+  /**
+   * Per-type equivalent of {@link #checkPermissionsOnFile(int, SecurityDatabaseUser.ACCESS)} for a type that owns
+   * no bucket to check a file id against (a TimeSeries type: its data lives in its own engine, not a
+   * {@code LocalBucket}).
+   */
+  void checkPermissionsOnType(String typeName, SecurityDatabaseUser.ACCESS access);
+
   boolean checkTransactionIsActive(boolean createTx);
 
   boolean isAsyncProcessing();

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -341,6 +341,11 @@ public interface DatabaseInternal extends Database {
 
   /**
    * Gets a global variable value by name.
+   * <p>
+   * <b>Not replicated in an HA cluster.</b> Global variables are per-node state: under Raft replication
+   * ({@code RaftReplicatedDatabase}) every accessor here - this one included - delegates straight to the local
+   * node's own {@link LocalDatabase}, with no Raft consensus or replication involved. A value set on one node is
+   * invisible to every other node, including after a failover (issue #6560).
    * @param name Variable name (with or without $ prefix)
    * @return The variable value, or null if not set
    */
@@ -348,6 +353,8 @@ public interface DatabaseInternal extends Database {
 
   /**
    * Sets a global variable. Setting to null removes the variable.
+   * <p>
+   * <b>Not replicated in an HA cluster</b> - see {@link #getGlobalVariable(String)}.
    * @param name Variable name (with or without $ prefix)
    * @param value The value to set, or null to remove
    * @return The previous value, or null
@@ -357,11 +364,19 @@ public interface DatabaseInternal extends Database {
   /**
    * Atomically sets a global variable only if it is not already set. Unlike calling
    * {@link #getGlobalVariable(String)} followed by {@link #setGlobalVariable(String, Object)}, this check-and-set
-   * happens as one operation, so two callers racing on the same name cannot both observe "absent" and both write -
-   * the property a caller using this as a distributed lock (e.g. Redis {@code SET k v NX}) depends on.
+   * happens as one operation, so two callers racing on the same name on the SAME node cannot both observe "absent"
+   * and both write.
+   * <p>
+   * <b>Not a cluster-wide distributed lock.</b> The atomicity above is per-node only - see
+   * {@link #getGlobalVariable(String)} for why. A caller reaching different nodes of an HA cluster (e.g. two
+   * Redis-wire clients connected to different nodes, or the same client across a failover) can each observe
+   * "absent" and each believe they won a lock acquired with e.g. Redis {@code SET k v NX}: every node keeps its
+   * own independent copy, so two nodes granting the same "lock" simultaneously is expected behavior today, not a
+   * bug in this method. Do not rely on this as a real distributed lock in an HA deployment; that would need global
+   * variables replicated through Raft, which this method does not do (issue #6560).
    * <p>
    * The default falls back to a non-atomic get-then-set for implementations (e.g. test doubles) that do not need
-   * the atomicity guarantee; {@link LocalDatabase} overrides it with a genuinely atomic implementation.
+   * the atomicity guarantee; {@link LocalDatabase} overrides it with a genuinely atomic (per-node) implementation.
    * @param name Variable name (with or without $ prefix)
    * @param value The value to set
    * @return The existing value if the variable was already set (value left untouched), or null if it was absent
@@ -381,8 +396,12 @@ public interface DatabaseInternal extends Database {
    * happens as one operation - the counterpart to {@link #setGlobalVariableIfAbsent(String, Object)} (e.g. Redis
    * {@code SET k v XX}).
    * <p>
+   * <b>Not replicated in an HA cluster</b> - see {@link #setGlobalVariableIfAbsent(String, Object)}: the atomicity
+   * this method gives is per-node only, and different nodes of an HA cluster keep independent copies of the
+   * variable.
+   * <p>
    * The default falls back to a non-atomic get-then-set for implementations (e.g. test doubles) that do not need
-   * the atomicity guarantee; {@link LocalDatabase} overrides it with a genuinely atomic implementation.
+   * the atomicity guarantee; {@link LocalDatabase} overrides it with a genuinely atomic (per-node) implementation.
    * @param name Variable name (with or without $ prefix)
    * @param value The value to set
    * @return The previous value if the variable was set (value was replaced), or null if it was absent (value left
@@ -398,6 +417,9 @@ public interface DatabaseInternal extends Database {
 
   /**
    * Gets all global variables as an unmodifiable map.
+   * <p>
+   * <b>Not replicated in an HA cluster</b> - see {@link #getGlobalVariable(String)}. Each entry is this node's
+   * own local value, not a cluster-wide view.
    * @return Map of variable name to value
    */
   Map<String, Object> getGlobalVariables();

--- a/engine/src/main/java/com/arcadedb/database/DatabaseRID.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseRID.java
@@ -75,7 +75,7 @@ public class DatabaseRID extends RID {
       return (Vertex) database.lookupByRID(this, loadContent);
     } catch (final RecordNotFoundException e) {
       throw e;
-    } catch (final Exception e) {
+    } catch (final ClassCastException e) {
       throw new RecordNotFoundException("Record " + this + " not found", this, e);
     }
   }

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -736,6 +736,8 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
       // TimeSeries types store data in their own engine, not in regular buckets
       if (type instanceof LocalTimeSeriesType tsType) {
+        // Counting samples never loads a record through a bucket, so apply the equivalent per-type read check here.
+        checkPermissionsOnType(typeName, SecurityDatabaseUser.ACCESS.READ_RECORD);
         try {
           return tsType.getEngine().countSamples();
         } catch (final IOException e) {
@@ -890,6 +892,24 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       resource = "type '" + type + "'";
 
     throw new SecurityException("User '" + user.getName() + "' is not allowed to " + access.fullName + " on " + resource);
+  }
+
+  @Override
+  public void checkPermissionsOnType(final String typeName, final SecurityDatabaseUser.ACCESS access) {
+    if (security == null)
+      return;
+
+    final DatabaseContext.DatabaseContextTL dbContext = DatabaseContext.INSTANCE.getContextIfExists(databasePath);
+    if (dbContext == null)
+      return;
+    final SecurityDatabaseUser user = dbContext.getCurrentUser();
+    if (user == null)
+      return;
+
+    if (user.requestAccessOnType(typeName, access))
+      return;
+
+    throw new SecurityException("User '" + user.getName() + "' is not allowed to " + access.fullName + " on type '" + typeName + "'");
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -482,9 +482,12 @@ public interface DatabaseAsyncExecutor {
    * <p>
    * Since each worker crosses its own {@link #setCommitEvery(int)} boundary independently, this callback can now be
    * invoked far more often, and concurrently from multiple worker threads, than when it fired only at shutdown and
-   * from {@link #waitCompletion()}. The registered {@link OkCallback} must be thread-safe.
+   * from {@link #waitCompletion()}. The registered {@link OkCallback} must be thread-safe, and is invoked
+   * synchronously on the committing worker's own thread at every one of those boundaries - a slow or blocking
+   * callback directly throttles that worker's batch throughput, so keep it cheap.
    *
-   * @param callback Callback invoked every time this executor's shared batch transaction commits; must be thread-safe
+   * @param callback Callback invoked every time this executor's shared batch transaction commits; must be
+   *                 thread-safe and cheap, since it runs synchronously on the committing worker's thread
    */
   void onOk(OkCallback callback);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -97,6 +97,11 @@ public interface DatabaseAsyncExecutor {
    * Schedules the scan of the records contained in all the buckets defined by a type. This operation scans in sequence each bucket looking for documents, vertices and edges.
    * For each record found a call to #DocumentCallback.onRecord is invoked. If the callback returns false, the scan is terminated, otherwise it continues to
    * the next record.
+   * <p>
+   * If a bucket's own scan fails (I/O error, corruption - as opposed to a per-record error, which is instead routed
+   * to {@code errorRecordCallback} in the overload below), every other bucket is still scanned to completion and the
+   * failure is then rethrown from this call (wrapped in {@link com.arcadedb.exception.DatabaseOperationException} for
+   * a {@code RuntimeException}, raw for an {@code Error}) rather than being silently swallowed (issue #6467).
    *
    * @param typeName    The name of the type
    * @param polymorphic true if the records of all the subtypes must be included, otherwise only the records strictly contained in the #typeName
@@ -109,12 +114,17 @@ public interface DatabaseAsyncExecutor {
    * Schedules the scan of the records contained in all the buckets defined by a type. This operation scans in sequence each bucket looking for documents, vertices and edges.
    * For each record found a call to #DocumentCallback.onRecord is invoked. If the callback returns false, the scan is terminated, otherwise it continues to
    * the next record.
+   * <p>
+   * If a bucket's own scan fails (I/O error, corruption - as opposed to a per-record error, which is instead routed
+   * to {@code errorRecordCallback}), every other bucket is still scanned to completion and the failure is then
+   * rethrown from this call (wrapped in {@link com.arcadedb.exception.DatabaseOperationException} for a
+   * {@code RuntimeException}, raw for an {@code Error}) rather than being silently swallowed (issue #6467).
    *
    * @param typeName            The name of the type
    * @param polymorphic         true if the records of all the subtypes must be included, otherwise only the records strictly contained in the #typeName
    *                            will be scanned
    * @param callback            Callback to handle the loaded record document. Returns false to interrupt the scan operation, otherwise true to continue till the end
-   * @param errorRecordCallback Callback used in case of error during the scan
+   * @param errorRecordCallback Callback used in case of a per-record error during the scan
    */
   void scanType(String typeName, boolean polymorphic, DocumentCallback callback, ErrorRecordCallback errorRecordCallback);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -461,8 +461,18 @@ public interface DatabaseAsyncExecutor {
    * fires only once that batch has actually committed. A caller that must know a specific write is durable, rather
    * than merely applied, should register this callback (or call {@link #waitCompletion()}) rather than rely on
    * timing alone.
+   * <p>
+   * "Committed" here means WAL-durable and replay-safe on the next open, which is all a commit guarantees under the
+   * default {@link #setTransactionSync(WALFile.FlushType)} setting of {@code NO} - no {@code fsync} happens at that
+   * point, so the write can still be lost to a power loss or OS crash (though not to a JVM crash or restart) unless
+   * {@code setTransactionSync(YES_NOMETADATA)}/{@code YES_FULL} is configured. A caller that needs the stronger,
+   * disk-durability guarantee must opt into that setting explicitly; this callback's timing does not change with it.
+   * <p>
+   * Since each worker crosses its own {@link #setCommitEvery(int)} boundary independently, this callback can now be
+   * invoked far more often, and concurrently from multiple worker threads, than when it fired only at shutdown and
+   * from {@link #waitCompletion()}. The registered {@link OkCallback} must be thread-safe.
    *
-   * @param callback Callback invoked every time this executor's shared batch transaction commits
+   * @param callback Callback invoked every time this executor's shared batch transaction commits; must be thread-safe
    */
   void onOk(OkCallback callback);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -162,17 +162,24 @@ public interface DatabaseAsyncExecutor {
 
   /**
    * Schedules the request to create a record. If the record is created successfully, the callback @{@link NewRecordCallback} is executed.
+   * <p>
+   * The callback fires as soon as the create is applied to the worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can fail and roll the whole batch back, discarding this
+   * record even though the callback already fired (issue #6470). Register {@link #onOk(OkCallback)} (or call
+   * {@link #waitCompletion()}) for a signal that fires only once the batch has actually committed.
    *
    * @param record            Record to create
-   * @param newRecordCallback Callback invoked after the record has been created
+   * @param newRecordCallback Callback invoked after the record has been applied to the current batch
    */
   void createRecord(MutableDocument record, NewRecordCallback newRecordCallback);
 
   /**
    * Schedules the request to create a record. If the record is created successfully, the callback @{@link NewRecordCallback} is executed.
+   * <p>
+   * See {@link #createRecord(MutableDocument, NewRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record            Record to create
-   * @param newRecordCallback Callback invoked after the record has been created
+   * @param newRecordCallback Callback invoked after the record has been applied to the current batch
    * @param errorCallback     Callback invoked in case of error
    */
   void createRecord(MutableDocument record, NewRecordCallback newRecordCallback, final ErrorCallback errorCallback);
@@ -180,52 +187,70 @@ public interface DatabaseAsyncExecutor {
   /**
    * Schedules the request to create a record in a specific bucket. The bucket must be one defined in the schema to store the records of the current type.
    * If the record is created successfully, the callback @{@link NewRecordCallback} is executed.
+   * <p>
+   * See {@link #createRecord(MutableDocument, NewRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record            Record to create
-   * @param newRecordCallback Callback invoked after the record has been created
+   * @param newRecordCallback Callback invoked after the record has been applied to the current batch
    */
   void createRecord(Record record, String bucketName, NewRecordCallback newRecordCallback);
 
   /**
    * Schedules the request to create a record in a specific bucket. The bucket must be one defined in the schema to store the records of the current type.
    * If the record is created successfully, the callback @{@link NewRecordCallback} is executed.
+   * <p>
+   * See {@link #createRecord(MutableDocument, NewRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record            Record to create
-   * @param newRecordCallback Callback invoked after the record has been created
+   * @param newRecordCallback Callback invoked after the record has been applied to the current batch
    * @param errorCallback     Callback invoked in case of error
    */
   void createRecord(Record record, String bucketName, NewRecordCallback newRecordCallback, final ErrorCallback errorCallback);
 
   /**
    * Schedules the request to update a record. If the record is updated successfully, the callback @{@link UpdatedRecordCallback} is executed.
+   * <p>
+   * The callback fires as soon as the update is applied to the worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can fail and roll the whole batch back, undoing this update
+   * even though the callback already fired (issue #6470). Register {@link #onOk(OkCallback)} (or call
+   * {@link #waitCompletion()}) for a signal that fires only once the batch has actually committed.
    *
    * @param record               Record to update
-   * @param updateRecordCallback Callback invoked after the record has been updated
+   * @param updateRecordCallback Callback invoked after the record has been applied to the current batch
    */
   void updateRecord(MutableDocument record, UpdatedRecordCallback updateRecordCallback);
 
   /**
    * Schedules the request to update a record. If the record is updated successfully, the callback @{@link UpdatedRecordCallback} is executed.
+   * <p>
+   * See {@link #updateRecord(MutableDocument, UpdatedRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record               Record to update
-   * @param updateRecordCallback Callback invoked after the record has been updated
+   * @param updateRecordCallback Callback invoked after the record has been applied to the current batch
    * @param errorCallback        Callback invoked in case of error
    */
   void updateRecord(MutableDocument record, UpdatedRecordCallback updateRecordCallback, final ErrorCallback errorCallback);
 
   /**
    * Schedules the request to delete a record. If the record is deleted successfully, the callback @{@link DeletedRecordCallback} is executed.
+   * <p>
+   * The callback fires as soon as the delete is applied to the worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can fail and roll the whole batch back, undoing this delete
+   * even though the callback already fired (issue #6470). Register {@link #onOk(OkCallback)} (or call
+   * {@link #waitCompletion()}) for a signal that fires only once the batch has actually committed.
    *
    * @param record               Record to delete
-   * @param deleteRecordCallback Callback invoked after the record has been deleted
+   * @param deleteRecordCallback Callback invoked after the record has been applied to the current batch
    */
   void deleteRecord(Record record, DeletedRecordCallback deleteRecordCallback);
 
   /**
    * Schedules the request to delete a record. If the record is deleted successfully, the callback @{@link DeletedRecordCallback} is executed.
+   * <p>
+   * See {@link #deleteRecord(Record, DeletedRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record               Record to delete
-   * @param deleteRecordCallback Callback invoked after the record has been deleted
+   * @param deleteRecordCallback Callback invoked after the record has been applied to the current batch
    * @param errorCallback        Callback invoked in case of error
    */
   void deleteRecord(Record record, DeletedRecordCallback deleteRecordCallback, final ErrorCallback errorCallback);
@@ -424,9 +449,20 @@ public interface DatabaseAsyncExecutor {
   void setTransactionSync(WALFile.FlushType transactionSync);
 
   /**
-   * Defines a global callback to handle all the returns from asynchronous operations completed without errors.
+   * Defines a global callback invoked every time this executor's shared batch transaction actually commits: at the
+   * periodic {@link #setCommitEvery(int)} boundary, when a durability setting
+   * ({@link #setTransactionUseWAL(boolean)}/{@link #setTransactionSync(WALFile.FlushType)}) changes mid-batch, when a
+   * worker shuts down, and at the barrier {@link #waitCompletion()}/{@link #waitCompletion(long)} relies on.
+   * <p>
+   * This is the durability signal for {@link #createRecord}/{@link #updateRecord}/{@link #deleteRecord}: their own
+   * per-record callback (e.g. {@link NewRecordCallback}) fires as soon as the write is applied to the worker's
+   * current batch, which is not necessarily durable yet - a later task in the same still-open batch can fail and
+   * roll the whole batch back, undoing an op whose callback already fired (issue #6470). This callback, by contrast,
+   * fires only once that batch has actually committed. A caller that must know a specific write is durable, rather
+   * than merely applied, should register this callback (or call {@link #waitCompletion()}) rather than rely on
+   * timing alone.
    *
-   * @param callback Callback invoked when an asynchronous operation succeeds
+   * @param callback Callback invoked every time this executor's shared batch transaction commits
    */
   void onOk(OkCallback callback);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -449,10 +449,12 @@ public interface DatabaseAsyncExecutor {
   void setTransactionSync(WALFile.FlushType transactionSync);
 
   /**
-   * Defines a global callback invoked every time this executor's shared batch transaction actually commits: at the
-   * periodic {@link #setCommitEvery(int)} boundary, when a durability setting
-   * ({@link #setTransactionUseWAL(boolean)}/{@link #setTransactionSync(WALFile.FlushType)}) changes mid-batch, when a
-   * worker shuts down, and at the barrier {@link #waitCompletion()}/{@link #waitCompletion(long)} relies on.
+   * Defines a global callback invoked at every point a worker's shared batch transaction can commit: the periodic
+   * {@link #setCommitEvery(int)} boundary, when a durability setting
+   * ({@link #setTransactionUseWAL(boolean)}/{@link #setTransactionSync(WALFile.FlushType)}) changes mid-batch, and
+   * the barrier {@link #waitCompletion()}/{@link #waitCompletion(long)} relies on. A worker also invokes it
+   * unconditionally on shutdown, even when it had nothing left to commit, so a shutdown firing is not on its own
+   * proof that a write became durable at that moment.
    * <p>
    * This is the durability signal for {@link #createRecord}/{@link #updateRecord}/{@link #deleteRecord}: their own
    * per-record callback (e.g. {@link NewRecordCallback}) fires as soon as the write is applied to the worker's

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -2369,7 +2369,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // The cost is symmetric: an administrative resize now waits behind an index build for as long as the build's
     // own quiescence takes, bounded by {@link #quiesceTimeoutMillis()}. That is the correct precedence - a resize is
     // an administrative convenience, a scan under a torn view is a wrong answer - and it was already true in the
-    // other direction (a quiescence already waited behind a resize's own bounded drain).
+    // other direction (a quiescence already waited behind a resize's own bounded drain). One reachable shape of that
+    // wait (code review, PR #6661): a worker task that calls {@code setParallelLevel()} on its OWN executor while a
+    // quiescence started by someone else is in progress now blocks on {@code resizeLock} for up to
+    // {@code quiesceTimeoutMillis()} (60s by default) rather than only the previous brief scheduling-loop window -
+    // and that worker being blocked also means it never reaches the queued park task this quiescence is waiting on,
+    // so the two time out together rather than deadlocking. Nothing built into the engine does this (compaction and
+    // index builds never call {@code setParallelLevel()}); it is the same category of unusual call as the self-join
+    // {@link #awaitRetiredThreads(AsyncThread[])} already guards against, just bounded instead of unrecoverable.
     //
     // What is NOT closed: a worker a PRIOR shrink retired and left draining past its own {@code shutdownJoinTimeoutMs}
     // budget is alive but off the published array and not in this quiescence's snapshot, so it is not parked by it -

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -2427,19 +2427,24 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       return held;
 
     } finally {
+      // FAILURE PATH: let go of any worker that reached its park task before the failure - and do it BEFORE
+      // releasing resizeLock below - so the invariant the success path relies on holds on this path too: by the
+      // time resizeLock is released, every worker this quiescence touched is either still fully live (never
+      // reached the park task) or has already been let go, never one caught mid-release, still blocked on a latch
+      // that only this method can count down.
+      if (!handedOver && release != null)
+        release.countDown();
+
       // Released here regardless of outcome, INCLUDING success: by this point every worker snapshotted above has
-      // already confirmed parked (or the method is throwing), so a resize that starts the instant this unlocks can
-      // only retire or create workers this quiescence never promised to cover - see the class comment above.
-      // Holding it any longer, for the life of the handle the caller gets back, would put every later resize behind
-      // however long the caller keeps the scan open, which is not what "bounded by the quiesce timeout" means.
+      // already confirmed parked, or - on the failure path - just been released above, so a resize that starts the
+      // instant this unlocks can only retire or create workers this quiescence never promised to cover - see the
+      // class comment above. Holding it any longer, for the life of the handle the caller gets back, would put
+      // every later resize behind however long the caller keeps the scan open, which is not what "bounded by the
+      // quiesce timeout" means.
       resizeLock.unlock();
-      if (!handedOver) {
-        // Nothing owns the release, so it happens here: any worker that reached its park task before the failure is
-        // let go, and the lock goes back so the next caller can try.
-        if (release != null)
-          release.countDown();
+      if (!handedOver)
+        // The lock goes back so the next caller can try.
         quiesceLock.unlock();
-      }
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -422,6 +422,11 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
             // is durable), this fires only once the commit above has actually happened. Before this it fired only
             // at shutdown and from the waitCompletion() marker, so a long-running worker that kept hitting this
             // periodic boundary never told an onOk() listener anything until it stopped.
+            //
+            // onOk() only ever swallows an Exception thrown by the registered callback, not an Error - one would
+            // propagate out of this block with the commit above already done but database.begin() below not yet
+            // reached. Harmless: the next task's own `!database.isTransactionActive()` check in this same method
+            // begins a fresh transaction regardless, exactly as it would if this worker had never held one open.
             onOk();
             database.begin();
             // TransactionContext.begin()/reset() never reset useWAL/walFlush, so the stamp above would

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -141,6 +141,12 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * Serializes {@link #setParallelLevel(int)} against itself, and is held for the WHOLE resize - the publish AND
    * the wait for whatever the publish retired (issue #6526 review, point 2).
    * <p>
+   * Since issue #6534 it has a second holder with a different bound: {@link #quiesceWorkers()} takes it for its
+   * WHOLE quiescence too - the park-task scheduling AND the wait for every worker to confirm parked - not only the
+   * scheduling loop. So contention on this lock can now mean either a resize waiting on
+   * {@code shutdownJoinTimeoutMs} (10s default) or a quiescence waiting on {@link #quiesceTimeoutMillis()} (60s
+   * default); see the javadoc of both methods for why each holds it that long.
+   * <p>
    * The drain wait cannot be taken under {@code lifecycleLock}: that lock is what a concurrent {@code close()} or
    * {@code kill()} needs to force the very workers being waited for, so holding it across the wait would make the
    * wait the thing that prevents its own end. But releasing every lock leaves a second resize free to grow the pool

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1604,12 +1604,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * runs on. Bounded and loud (that timeout is logged at WARNING) rather than silent, and the alternative - waiting
    * without a bound - makes an administrative call hostage to a worker wedged in user code.
    * <p>
-   * <b>What it does not do.</b> A retired worker is not parked by a {@link #quiesceWorkers()} that is already in
-   * progress - the park task would land behind the exit marker on its queue - so an index build racing a shrink can
-   * still see a draining worker write under its scan. That is the same residual {@code quiesceWorkers()} already
-   * names for workers created after its own check, it is narrower here than it was under the teardown (the wait
-   * above closes it for anything that starts after the resize returns), and closing it properly means gating the
-   * async lifecycle on the quiescence, which is a lock on a path an index build has to race a resize to reach.
+   * <b>What it does not do (issue #6534, mostly closed).</b> {@code quiesceWorkers()} now takes {@code resizeLock}
+   * for its whole quiescence, not only the scheduling loop, so this method cannot publish a shrink - or a grow -
+   * while a quiescence is in progress: either blocks on {@code resizeLock} until the other finishes. The residual
+   * that survives is narrower than a plain race: a worker THIS resize retired and left draining past its own
+   * {@code shutdownJoinTimeoutMs} budget (the paragraph above) is alive, off the published array, and not covered by
+   * a quiescence that starts afterwards - the park task would land behind the exit marker already queued on it,
+   * which would never run. That corner needs the wedged worker to finish or be {@code kill()}ed, not a lock.
    */
   @Override
   public void setParallelLevel(final int parallelLevel) {
@@ -2352,8 +2353,40 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // parked on a latch nobody will ever count down is lost until the database closes, which is a worse outcome than
     // the failure that got us there.
     CountDownLatch release = null;
+
+    // HELD FOR THE WHOLE QUIESCENCE (issue #6534), not just the scheduling loop below. A shrinking
+    // setParallelLevel() also holds this lock across its own publish-and-wait, so as long as this method holds it
+    // too, no worker this quiescence is about to snapshot can be retired - or created by a concurrent grow - between
+    // the read of executorThreads and the moment every one of them has confirmed parked:
+    // <ul>
+    //   <li>a SHRINK cannot start while this is held, so a worker cannot leave the array unparked mid-quiescence;
+    //   the residual this closes is the one named on {@link #setParallelLevel(int)}: an index build that used to be
+    //   able to start while a shrink was draining and scan data a retired, unparked worker was still writing;</li>
+    //   <li>a GROW cannot start either, so a worker created after the snapshot below - which this quiescence could
+    //   never have parked, since it schedules exactly {@code threads.length} park tasks against that snapshot - no
+    //   longer exists to write anything unparked under the scan.</li>
+    // </ul>
+    // The cost is symmetric: an administrative resize now waits behind an index build for as long as the build's
+    // own quiescence takes, bounded by {@link #quiesceTimeoutMillis()}. That is the correct precedence - a resize is
+    // an administrative convenience, a scan under a torn view is a wrong answer - and it was already true in the
+    // other direction (a quiescence already waited behind a resize's own bounded drain).
+    //
+    // What is NOT closed: a worker a PRIOR shrink retired and left draining past its own {@code shutdownJoinTimeoutMs}
+    // budget is alive but off the published array and not in this quiescence's snapshot, so it is not parked by it -
+    // the corner {@code setParallelLevel()}'s javadoc names as "wedged inside user code", which this quiescence
+    // cannot help either since a park task behind that worker's already-queued {@code FORCE_EXIT} would never run.
+    //
+    // Lock order is quiesceLock (held) -> resizeLock -> lifecycleLock, and nothing takes them the other way round:
+    // setParallelLevel() never touches quiesceLock, and close()/kill() take only lifecycleLock.
+    resizeLock.lock();
     try {
-      final CountDownLatch parked;
+      final AsyncThread[] threads = executorThreads;
+      if (threads == null || threads.length == 0) {
+        // Shut down between the check above and here: nothing to park, and the lock this holds is given back by
+        // the handle like any other.
+        handedOver = true;
+        return new HeldQuiesce(null, true);
+      }
 
       // ONE PARK TASK PER WORKER, which needs the pool it is sized against to be the pool the tasks are scheduled
       // onto (#6526 review round 8). scheduleTask() re-reads executorThreads on every call, and since #6526 a slot
@@ -2363,41 +2396,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       // duplicates queued behind it never run: a latch sized for the old pool that can no longer reach zero, and a
       // caller - an index build - that waits out the whole quiesce timeout before failing. Measured: 60s and a
       // NeedRetryException where the answer should have been immediate.
-      //
-      // So the READ AND THE LOOP ARE BOTH INSIDE resizeLock, not just the loop: a snapshot taken outside it is
-      // already stale by the time the lock is acquired, which is the same bug one window earlier.
-      //
-      // Held for that ONLY, not for the quiescence: a shrink that lands afterwards is harmless, because the park
-      // task is already ahead of the exit marker on the retired worker's queue and still runs, counts down and
-      // parks. Keeping the lock any longer would put an administrative resize behind a whole index build.
-      //
-      // Lock order is quiesceLock (held) -> resizeLock -> lifecycleLock, and nothing takes them the other way
-      // round: setParallelLevel() never touches quiesceLock, and close()/kill() take only lifecycleLock.
-      resizeLock.lock();
-      try {
-        final AsyncThread[] threads = executorThreads;
-        if (threads == null || threads.length == 0) {
-          // Shut down between the check above and here: nothing to park, and the lock this holds is given back by
-          // the handle like any other.
-          handedOver = true;
-          return new HeldQuiesce(null, true);
-        }
+      final CountDownLatch parked = new CountDownLatch(threads.length);
+      release = new CountDownLatch(1);
 
-        parked = new CountDownLatch(threads.length);
-        release = new CountDownLatch(1);
-
-        for (int i = 0; i < threads.length; i++)
-          // waitIfQueueIsFull, so a busy worker is queued behind rather than skipped: an unparked worker is exactly
-          // the hole this method exists to close, and a `false` here would be one - which is why the old call
-          // site's discarded boolean mattered. Any refusal (a worker that has shut down) throws, and the finally
-          // below releases whatever was already parked.
-          if (!scheduleTask(i, new DatabaseAsyncParkWorker(parked, release), true, 0))
-            throw new NeedRetryException(
-                "Cannot quiesce the asynchronous executor of database '" + database.getName() + "': worker " + i
-                    + " refused the park task");
-      } finally {
-        resizeLock.unlock();
-      }
+      for (int i = 0; i < threads.length; i++)
+        // waitIfQueueIsFull, so a busy worker is queued behind rather than skipped: an unparked worker is exactly
+        // the hole this method exists to close, and a `false` here would be one - which is why the old call
+        // site's discarded boolean mattered. Any refusal (a worker that has shut down) throws, and the finally
+        // below releases whatever was already parked.
+        if (!scheduleTask(i, new DatabaseAsyncParkWorker(parked, release), true, 0))
+          throw new NeedRetryException(
+              "Cannot quiesce the asynchronous executor of database '" + database.getName() + "': worker " + i
+                  + " refused the park task");
 
       final long timeout = quiesceTimeoutMillis();
       try {
@@ -2417,6 +2427,12 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       return held;
 
     } finally {
+      // Released here regardless of outcome, INCLUDING success: by this point every worker snapshotted above has
+      // already confirmed parked (or the method is throwing), so a resize that starts the instant this unlocks can
+      // only retire or create workers this quiescence never promised to cover - see the class comment above.
+      // Holding it any longer, for the life of the handle the caller gets back, would put every later resize behind
+      // however long the caller keeps the scan open, which is not what "bounded by the quiesce timeout" means.
+      resizeLock.unlock();
       if (!handedOver) {
         // Nothing owns the release, so it happens here: any worker that reached its park task before the failure is
         // let go, and the lock goes back so the next caller can try.

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1303,7 +1303,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   @Override
   public void transaction(final Database.TransactionScope txBlock, final int retries, final OkCallback ok,
                           final ErrorCallback error, final int slot) {
-    scheduleTask(slot, new DatabaseAsyncTransaction(txBlock, retries, ok, error), true, backPressurePercentage);
+    scheduleTask(slot, new DatabaseAsyncTransaction(txBlock, retries, ok, error, captureCurrentUser()), true, backPressurePercentage);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -64,6 +64,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
@@ -416,6 +417,12 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
           if (database.isTransactionActive() && count % commitEvery == 0) {
             database.commit();
+            // #6470: the executor-wide onOk() callback is the durability signal for this batch - unlike a record
+            // op's own success callback (which reports the write applied to the still-open batch, not yet that it
+            // is durable), this fires only once the commit above has actually happened. Before this it fired only
+            // at shutdown and from the waitCompletion() marker, so a long-running worker that kept hitting this
+            // periodic boundary never told an onOk() listener anything until it stopped.
+            onOk();
             database.begin();
             // TransactionContext.begin()/reset() never reset useWAL/walFlush, so the stamp above would
             // "happen to" survive this cycle via object reuse even without this - re-applied explicitly
@@ -491,6 +498,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
       try {
         database.commit();
+        // #6470: another real commit of the shared batch, so the executor-wide durability signal fires here too.
+        onOk();
       } catch (final Throwable e) {
         // This commit closes out EARLIER tasks' accumulated work, not the task that triggered this check -
         // which has not run yet - so the failure must not be attributed to it: left uncaught, the caller's
@@ -1205,14 +1214,27 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
       final List<Bucket> buckets = type.getBuckets(polymorphic);
       final CountDownLatch semaphore = new CountDownLatch(buckets.size());
+      // #6467: shared across every bucket's task, so a bucket-level failure (I/O, corruption) is not silently
+      // dropped: without it, the failing task's own exception went only to the (typically unset) executor-wide
+      // onErrorCallback while completed() still counted the bucket down, so this method returned as if the whole
+      // type had been scanned.
+      final AtomicReference<Throwable> firstError = new AtomicReference<>();
 
       for (final Bucket b : buckets) {
         final int slot = getSlot(b.getFileId());
-        scheduleTask(slot, new DatabaseAsyncScanBucket(semaphore, callback, errorRecordCallback, b), true,
+        scheduleTask(slot, new DatabaseAsyncScanBucket(semaphore, callback, errorRecordCallback, b, firstError), true,
             backPressurePercentage);
       }
 
       semaphore.await();
+
+      // Rethrown here (rather than wrapped directly) so the generic catch below wraps it exactly like any other
+      // failure of this method, instead of nesting two DatabaseOperationExceptions with the same message.
+      final Throwable error = firstError.get();
+      if (error instanceof final RuntimeException re)
+        throw re;
+      if (error instanceof final Error err)
+        throw err;
 
     } catch (final Exception e) {
       throw new DatabaseOperationException(

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1228,8 +1228,11 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
       semaphore.await();
 
-      // Rethrown here (rather than wrapped directly) so the generic catch below wraps it exactly like any other
-      // failure of this method, instead of nesting two DatabaseOperationExceptions with the same message.
+      // Rethrown here (rather than wrapped directly) so a RuntimeException is wrapped by the generic catch below
+      // exactly like any other failure of this method, instead of nesting two DatabaseOperationExceptions with the
+      // same message. An Error is deliberately NOT caught there (Error does not extend Exception) and so escapes
+      // this method raw and unwrapped - the existing convention elsewhere in this class of never dressing up an
+      // Error, kept intentionally rather than an oversight.
       final Throwable error = firstError.get();
       if (error instanceof final RuntimeException re)
         throw re;

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -762,6 +762,34 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       timeout = Long.MAX_VALUE;
     final long beginTime = System.currentTimeMillis();
 
+    // LOOPED, not a single pass (issue #6462). One marker per worker answers about a snapshot taken
+    // at the moment each marker is OFFERED - not one consistent instant across every worker, because
+    // the offers are not simultaneous. A bidirectional cross-slot edge schedules its incoming-edge
+    // cascade task onto the DESTINATION worker from INSIDE the source task's own callback
+    // (DatabaseAsyncExecutorImpl#newEdge), so the cascade can land on that worker AFTER its marker
+    // already fired - the source worker's own marker, still queued behind the still-running source
+    // task, is the only thing left for a single pass to wait on, and once IT completes (the moment
+    // the source task's execute() returns, having already scheduled the cascade) this method could
+    // return with the cascade merely scheduled, not executed. LocalDatabase#waitForAsyncCompletion()
+    // has always re-scanned with exactly this do-while for the same reason (issue #6281); this method
+    // promises the identical thing in its own javadoc ("waits for the completion of all pending
+    // operations") and needs the identical loop to keep that promise for a caller who reaches it
+    // directly instead of through LocalDatabase.
+    do {
+      if (!waitCompletionOnePass(beginTime, timeout))
+        return false;
+    } while (isProcessing());
+
+    return true;
+  }
+
+  /**
+   * One marker-per-worker pass of {@link #waitCompletion(long)}: waits for everything queued or
+   * executing on every worker <b>at the moment each marker is offered</b> to finish. See that
+   * method's javadoc for why a single pass is not, on its own, a sound answer to "has everything
+   * finished".
+   */
+  private boolean waitCompletionOnePass(final long beginTime, final long timeout) {
     // FIRST, because an async command can submit async record tasks of its own and those must end up behind the
     // markers below rather than in front of them (issue #6303, item 3). Costs nothing when nothing was dispatched.
     if (!awaitCommands(beginTime, timeout))

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
@@ -26,32 +26,50 @@ import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.ErrorRecordCallback;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DatabaseAsyncScanBucket implements DatabaseAsyncTask {
-  public final CountDownLatch      semaphore;
-  public final DocumentCallback    userCallback;
-  public final ErrorRecordCallback errorRecordCallback;
-  public final Bucket              bucket;
+  public final CountDownLatch             semaphore;
+  public final DocumentCallback           userCallback;
+  public final ErrorRecordCallback        errorRecordCallback;
+  public final Bucket                     bucket;
+  // #6467: shared by every DatabaseAsyncScanBucket task of one scanType() call, so it can rethrow a bucket-level
+  // failure after every bucket has been drained instead of silently returning a partial scan. Null when a caller
+  // constructs the task directly without going through scanType() and does not care about that (kept optional
+  // rather than required, since scanning a single bucket in isolation needs nothing beyond what execute() itself
+  // already reports through the worker's own rollback/logging/onError handling).
+  public final AtomicReference<Throwable> firstError;
 
   public DatabaseAsyncScanBucket(final CountDownLatch semaphore, final DocumentCallback userCallback, final ErrorRecordCallback errorRecordCallback,
-      final Bucket bucket) {
+      final Bucket bucket, final AtomicReference<Throwable> firstError) {
     this.semaphore = semaphore;
     this.userCallback = userCallback;
     this.errorRecordCallback = errorRecordCallback;
     this.bucket = bucket;
+    this.firstError = firstError;
   }
 
   @Override
   public void execute(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
-    bucket.scan((rid, view) -> {
-      if (async.isShutdown())
-        return false;
+    try {
+      bucket.scan((rid, view) -> {
+        if (async.isShutdown())
+          return false;
 
-      final Record record = database.getRecordFactory()
-          .newImmutableRecord(database, database.getSchema().getType(database.getSchema().getTypeNameByBucketId(rid.getBucketId())), rid, view, null);
+        final Record record = database.getRecordFactory()
+            .newImmutableRecord(database, database.getSchema().getType(database.getSchema().getTypeNameByBucketId(rid.getBucketId())), rid, view, null);
 
-      return userCallback.onRecord((Document) record);
-    }, errorRecordCallback);
+        return userCallback.onRecord((Document) record);
+      }, errorRecordCallback);
+    } catch (final RuntimeException | Error e) {
+      // #6467: a bucket-level failure (I/O, corruption) used to be swallowed here - routed only to the executor-wide
+      // onErrorCallback (typically unset) while completed() still counted this bucket down, so scanType() returned
+      // as if every bucket had been scanned. Captured here so scanType() can rethrow it once every bucket is done,
+      // then rethrown so the worker's own rollback/logging/onError handling in executeTask() still runs unchanged.
+      if (firstError != null)
+        firstError.compareAndSet(null, e);
+      throw e;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
@@ -24,9 +24,11 @@ import com.arcadedb.database.DocumentCallback;
 import com.arcadedb.database.Record;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.ErrorRecordCallback;
+import com.arcadedb.log.LogManager;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 
 public class DatabaseAsyncScanBucket implements DatabaseAsyncTask {
   public final CountDownLatch             semaphore;
@@ -66,8 +68,13 @@ public class DatabaseAsyncScanBucket implements DatabaseAsyncTask {
       // onErrorCallback (typically unset) while completed() still counted this bucket down, so scanType() returned
       // as if every bucket had been scanned. Captured here so scanType() can rethrow it once every bucket is done,
       // then rethrown so the worker's own rollback/logging/onError handling in executeTask() still runs unchanged.
-      if (firstError != null)
-        firstError.compareAndSet(null, e);
+      if (firstError != null && !firstError.compareAndSet(null, e))
+        // A DIFFERENT bucket's failure already won the race to be the one scanType() rethrows: this one would
+        // otherwise vanish with no trace at all, even though it could be a distinct root cause (e.g. one bucket
+        // hitting an I/O error and another independently corrupted).
+        LogManager.instance().log(this, Level.SEVERE,
+            "Bucket '%s' failed during a parallel scan, but another bucket's failure will be the one reported to the caller",
+            e, bucket.getName());
       throw e;
     }
   }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java
@@ -19,20 +19,33 @@
 package com.arcadedb.database.async;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.security.SecurityDatabaseUser;
 
 public class DatabaseAsyncTransaction implements DatabaseAsyncTask {
   public final Database.TransactionScope tx;
   public final  int           retries;
   private final OkCallback    onOkCallback;
   private final ErrorCallback onErrorCallback;
+  // The principal that submitted the transaction, captured on the calling thread. It is bound onto the worker
+  // thread's DatabaseContext before execution so the engine per-user permission gates enforce on this async path
+  // too, the same as DatabaseAsyncCommand. Null in embedded/internal use, where no user is bound and the gates
+  // are a no-op.
+  public final SecurityDatabaseUser requestUser;
 
   public DatabaseAsyncTransaction(final Database.TransactionScope tx, final int retries, final OkCallback okCallback, final ErrorCallback errorCallback) {
+    this(tx, retries, okCallback, errorCallback, null);
+  }
+
+  public DatabaseAsyncTransaction(final Database.TransactionScope tx, final int retries, final OkCallback okCallback,
+      final ErrorCallback errorCallback, final SecurityDatabaseUser requestUser) {
     this.tx = tx;
     this.retries = retries;
     this.onOkCallback = okCallback;
     this.onErrorCallback = errorCallback;
+    this.requestUser = requestUser;
   }
 
   @Override
@@ -42,6 +55,24 @@ public class DatabaseAsyncTransaction implements DatabaseAsyncTask {
 
   @Override
   public void execute(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
+    // Bind the submitting principal onto this thread's DatabaseContext so the engine permission gates
+    // (LocalDatabase.checkPermissionsOnFile) enforce exactly as on the synchronous transports. Restore the
+    // previous binding afterwards, since the thread and its DatabaseContext are reused across tasks submitted
+    // by different users.
+    final DatabaseContext.DatabaseContextTL dbContext = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
+    final SecurityDatabaseUser previousUser = dbContext != null ? dbContext.getCurrentUser() : null;
+    if (dbContext != null)
+      dbContext.setCurrentUser(requestUser);
+
+    try {
+      executeTransaction(async, database);
+    } finally {
+      if (dbContext != null)
+        dbContext.setCurrentUser(previousUser);
+    }
+  }
+
+  private void executeTransaction(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
     ConcurrentModificationException lastException = null;
 
     if (database.isTransactionActive())

--- a/engine/src/main/java/com/arcadedb/database/async/DeletedRecordCallback.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DeletedRecordCallback.java
@@ -26,5 +26,10 @@ import com.arcadedb.database.Record;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public interface DeletedRecordCallback {
+  /**
+   * Invoked once the delete has been applied to the async worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can still fail and roll it back (issue #6470). See
+   * {@link DatabaseAsyncExecutor#onOk(OkCallback)} for a signal that fires only once the batch actually commits.
+   */
   void call(Record newRecord);
 }

--- a/engine/src/main/java/com/arcadedb/database/async/NewRecordCallback.java
+++ b/engine/src/main/java/com/arcadedb/database/async/NewRecordCallback.java
@@ -23,5 +23,10 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
 @ExcludeFromJacocoGeneratedReport
 public interface NewRecordCallback {
+  /**
+   * Invoked once the record has been applied to the async worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can still fail and roll it back (issue #6470). See
+   * {@link DatabaseAsyncExecutor#onOk(OkCallback)} for a signal that fires only once the batch actually commits.
+   */
   void call(Record newRecord);
 }

--- a/engine/src/main/java/com/arcadedb/database/async/OkCallback.java
+++ b/engine/src/main/java/com/arcadedb/database/async/OkCallback.java
@@ -22,5 +22,10 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
 @ExcludeFromJacocoGeneratedReport
 public interface OkCallback {
+  /**
+   * Invoked by {@link DatabaseAsyncExecutor#onOk(OkCallback)}, potentially concurrently from multiple worker
+   * threads (each worker crosses its own batch-commit boundary independently) - implementations must be
+   * thread-safe.
+   */
   void call();
 }

--- a/engine/src/main/java/com/arcadedb/database/async/UpdatedRecordCallback.java
+++ b/engine/src/main/java/com/arcadedb/database/async/UpdatedRecordCallback.java
@@ -28,5 +28,10 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
  */
 @ExcludeFromJacocoGeneratedReport
 public interface UpdatedRecordCallback {
+  /**
+   * Invoked once the update has been applied to the async worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can still fail and roll it back (issue #6470). See
+   * {@link DatabaseAsyncExecutor#onOk(OkCallback)} for a signal that fires only once the batch actually commits.
+   */
   void call(Record newRecord);
 }

--- a/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
+++ b/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
@@ -21,6 +21,8 @@ package com.arcadedb.function;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -87,17 +89,25 @@ public final class DistinctNumericKey {
   }
 
   /**
-   * Builds a composite string key from {@code names}, in iteration order, by rendering each name's
-   * canonicalized value as {@code name=value|}. Shared by every Cypher duplicate-elimination step
-   * (RETURN DISTINCT, WITH DISTINCT, UNION) that dedups on a set of named values, so the
-   * {@link #canonicalize(Object)} behavior - including the RID canonicalization above - only needs
-   * to be applied in one place. Callers control ordering (and hence key stability across rows) by
-   * choosing what {@code names} they pass; this method does not sort or otherwise reorder it.
+   * Builds a composite key from {@code names}, in iteration order, as a flat {@code [name, value, name,
+   * value, ...]} list of each name paired with its canonicalized value. Shared by every Cypher
+   * duplicate-elimination step (RETURN DISTINCT, WITH DISTINCT, UNION) that dedups on a set of named
+   * values, so the {@link #canonicalize(Object)} behavior - including the RID canonicalization above -
+   * only needs to be applied in one place. Callers control ordering (and hence key stability across
+   * rows) by choosing what {@code names} they pass; this method does not sort or otherwise reorder it.
+   * <p>
+   * The key is a {@link List}, not a delimited string: {@link List#equals(Object)} compares elements
+   * structurally, so a value whose canonicalized {@code toString()} happens to contain a delimiter
+   * character can never collide with a differently-shaped row the way a rendered {@code name=value|}
+   * string could (issue #6540) - e.g. one property {@code a = "1|b=2"} and two properties
+   * {@code a=1, b=2} used to both render as {@code "a=1|b=2|"}.
    */
-  public static String buildKey(final Iterable<String> names, final Function<String, Object> valueOf) {
-    final StringBuilder keyBuilder = new StringBuilder();
-    for (final String name : names)
-      keyBuilder.append(name).append('=').append(canonicalize(valueOf.apply(name))).append('|');
-    return keyBuilder.toString();
+  public static List<Object> buildKey(final Iterable<String> names, final Function<String, Object> valueOf) {
+    final List<Object> key = new ArrayList<>();
+    for (final String name : names) {
+      key.add(name);
+      key.add(canonicalize(valueOf.apply(name)));
+    }
+    return key;
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/agg/AggMaxItems.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/AggMaxItems.java
@@ -66,7 +66,7 @@ public class AggMaxItems extends AbstractAggFunction {
       return result;
     }
 
-    double maxValue = Double.MIN_VALUE;
+    double maxValue = Double.NEGATIVE_INFINITY; // NOT Double.MIN_VALUE, which is the smallest POSITIVE double (issue #6672)
     final List<Object> maxItems = new ArrayList<>();
 
     for (int i = 0; i < values.size(); i++) {

--- a/engine/src/main/java/com/arcadedb/function/agg/AggNth.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/AggNth.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.agg;
 
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.List;
@@ -54,7 +55,7 @@ public class AggNth extends AbstractAggFunction {
       return null;
 
     final List<Object> list = toObjectList(args[0]);
-    final int index = ((Number) args[1]).intValue();
+    final int index = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
 
     if (index < 0 || index >= list.size())
       return null;

--- a/engine/src/main/java/com/arcadedb/function/agg/AggSlice.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/AggSlice.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.agg;
 
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.Collections;
@@ -55,8 +56,9 @@ public class AggSlice extends AbstractAggFunction {
       return null;
 
     final List<Object> list = toObjectList(args[0]);
-    final int from = args[1] != null ? ((Number) args[1]).intValue() : 0;
-    final int to = args.length > 2 && args[2] != null ? ((Number) args[2]).intValue() : list.size();
+    final int from = args[1] != null ? CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue() : 0;
+    final int to = args.length > 2 && args[2] != null ?
+        CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue() : list.size();
 
     if (from >= list.size() || from >= to)
       return Collections.emptyList();

--- a/engine/src/main/java/com/arcadedb/function/agg/AggStatistics.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/AggStatistics.java
@@ -70,7 +70,7 @@ public class AggStatistics extends AbstractAggFunction {
     final long count = values.size();
     double sum = 0.0;
     double min = Double.MAX_VALUE;
-    double max = Double.MIN_VALUE;
+    double max = Double.NEGATIVE_INFINITY; // NOT Double.MIN_VALUE, which is the smallest POSITIVE double (issue #6672)
 
     for (final Double value : values) {
       sum += value;

--- a/engine/src/main/java/com/arcadedb/function/agg/PercentileContFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/PercentileContFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.agg;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class PercentileContFunction implements StatelessFunction {
     if (percentile < 0) {
       if (args[1] == null)
         throw new CommandExecutionException("percentileCont() percentile argument must not be null");
-      percentile = ((Number) args[1]).doubleValue();
+      percentile = CypherFunctionHelper.requireNumberArgument(args[1], getName()).doubleValue();
       if (percentile < 0.0 || percentile > 1.0)
         throw new CommandExecutionException("NumberOutOfRange: percentile must be between 0.0 and 1.0, got: " + percentile);
     }

--- a/engine/src/main/java/com/arcadedb/function/agg/PercentileDiscFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/PercentileDiscFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.agg;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class PercentileDiscFunction implements StatelessFunction {
     if (percentile < 0) {
       if (args[1] == null)
         throw new CommandExecutionException("percentileDisc() percentile argument must not be null");
-      percentile = ((Number) args[1]).doubleValue();
+      percentile = CypherFunctionHelper.requireNumberArgument(args[1], getName()).doubleValue();
       if (percentile < 0.0 || percentile > 1.0)
         throw new CommandExecutionException("NumberOutOfRange: percentile must be between 0.0 and 1.0, got: " + percentile);
     }

--- a/engine/src/main/java/com/arcadedb/function/cypher/CypherFunctionHelper.java
+++ b/engine/src/main/java/com/arcadedb/function/cypher/CypherFunctionHelper.java
@@ -70,30 +70,49 @@ public final class CypherFunctionHelper {
 
   /**
    * A numeric Cypher function: its canonical spelling - the one the runtime check uses, so both the parse-time and the
-   * runtime path phrase an error identically - and how many of its leading arguments are declared {@code INTEGER | FLOAT}.
-   * All of them for the whole family except {@code round(value, precision, mode)}, whose third argument is the STRING name
-   * of a rounding mode.
+   * runtime path phrase an error identically - and which of its arguments are declared {@code INTEGER | FLOAT}: the
+   * {@code numericArgs} positions starting at {@code startArg}. {@code startArg} is 0 for the whole family except
+   * {@code left()}/{@code right()}/{@code substring()}, whose leading argument is the STRING being sliced and whose
+   * numeric arguments start at position 1. {@code numericArgs} covers every remaining argument for the whole family
+   * except {@code round(value, precision, mode)}, whose third argument is the STRING name of a rounding mode.
    *
    * @param name        canonical function name, without parentheses
-   * @param numericArgs number of leading arguments that must be numeric, or {@link #ALL_ARGUMENTS}
+   * @param startArg    zero-based position of the first numeric argument
+   * @param numericArgs number of arguments, starting at {@code startArg}, that must be numeric, or {@link #ALL_ARGUMENTS}
    */
-  public record NumericSignature(String name, int numericArgs) {
+  public record NumericSignature(String name, int startArg, int numericArgs) {
+    public NumericSignature(final String name, final int numericArgs) {
+      this(name, 0, numericArgs);
+    }
+
+    /**
+     * Whether argument position {@code index} falls in this signature's numeric range.
+     */
+    public boolean isNumericPosition(final int index) {
+      return index >= startArg && (numericArgs == ALL_ARGUMENTS || index < startArg + numericArgs);
+    }
   }
 
   /**
    * The numeric Cypher functions, keyed by the lower-case name the parser produces, so that an argument already readable in
    * the query text can be rejected before the query runs, as Neo4j does. Kept in step with the numeric entries of
    * {@code CypherFunctionFactory.createCypherSpecificExecutor()}, which is what supplies the matching runtime check - a test
-   * asserts the two agree in both directions. See issue #5484.
+   * asserts the two agree in both directions. See issue #5484 (the pure-numeric family) and #6609 (left/right/substring's
+   * trailing numeric arguments).
    */
-  public static final Map<String, NumericSignature> NUMERIC_ARGUMENT_FUNCTIONS = Stream.concat(//
+  public static final Map<String, NumericSignature> NUMERIC_ARGUMENT_FUNCTIONS = Stream.of(//
           allArgumentsNumeric(//
               "abs", "ceil", "ceiling", "floor", "sqrt", "sign", "isNaN", //
               "exp", "log", "ln", "log10", //
               "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "cot", "coth", "sinh", "cosh", "tanh", //
               "degrees", "radians", "haversin"), //
           // round(value, precision, mode): only the first two arguments are numeric.
-          Stream.of(new NumericSignature("round", 2)))//
+          Stream.of(new NumericSignature("round", 2)), //
+          // left(string, length) / right(string, length): the length is numeric, the leading string is not.
+          Stream.of(new NumericSignature("left", 1, 1), new NumericSignature("right", 1, 1)), //
+          // substring(string, start, length): start and the optional length are numeric, the leading string is not.
+          Stream.of(new NumericSignature("substring", 1, 2)))//
+      .flatMap(stream -> stream)//
       .collect(Collectors.toUnmodifiableMap(signature -> signature.name().toLowerCase(Locale.ROOT), signature -> signature));
 
   private static Stream<NumericSignature> allArgumentsNumeric(final String... names) {

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -35,6 +35,7 @@ import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.WorkGuard;
 import com.arcadedb.utility.FileUtils;
 
 import java.util.HashMap;
@@ -159,6 +160,11 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     final Vertex start = paramSourceVertex;
     final Vertex goal = paramDestinationVertex;
 
+    // Neither maxDepth (defaults to Long.MAX_VALUE) nor graph exhaustion is a bound the caller controls, so
+    // arcadedb.command.timeout has to be consulted from inside this loop like every other graph-driven
+    // algorithm (issue #6459) - astar()/dijkstra() previously had no timeout/interrupt check at all.
+    final WorkGuard guard = WorkGuard.forCommand(ctx, NAME + "()");
+
     open.add(start);
 
     // The cost of going from start to start is zero.
@@ -167,6 +173,8 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     fScore.put(start, getHeuristicCost(start, null, goal, ctx));
 
     while (!open.isEmpty()) {
+      guard.check();
+
       Vertex current = open.poll();
 
       // we discussed about this feature in https://github.com/orientechnologies/orientdb/pull/6002#issuecomment-212492687

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -36,6 +36,7 @@ import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.function.sql.math.SQLFunctionMathAbstract;
+import com.arcadedb.query.sql.executor.WorkGuard;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.Pair;
 
@@ -203,6 +204,12 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
     shortestPathContext.queueRight.add(shortestPathContext.destinationVertex);
     shortestPathContext.rightVisited.add(shortestPathContext.destinationVertex.getIdentity());
 
+    // With no maxDepth (the default) the only bound left is graph exhaustion, and arcadedb.command.timeout was
+    // never consulted here - only the thread-interrupt check below, which needs an explicit cancel rather than
+    // the configured timeout (issue #6459). The deadline is checked once per BFS layer, matching the
+    // per-layer granularity already used by the Cypher unconstrained allShortestPaths() BFS.
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
     int depth = 1;
     while (true) {
       if (shortestPathContext.maxDepth != null && shortestPathContext.maxDepth <= depth) {
@@ -213,6 +220,7 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
 
       if (Thread.interrupted())
         throw new CommandExecutionException("The shortestPath() function has been interrupted");
+      guard.check();
 
       List<RID> neighborIdentity;
 

--- a/engine/src/main/java/com/arcadedb/function/text/CharLengthFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/CharLengthFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.text;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -45,8 +46,11 @@ public class CharLengthFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    if (args[0] == null)
+    // STRING-only argument, same declared input domain as toUpper()/toLower()/trim() and the rest of the
+    // #5798 family - this function predates that fix and was never brought in line with it (issue #6608).
+    final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+    if (source == null)
       return null;
-    return (long) args[0].toString().length();
+    return (long) source.length();
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/text/LTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/LTrimFunction.java
@@ -52,13 +52,15 @@ public class LTrimFunction implements StatelessFunction {
       return source.stripLeading();
     }
     if (args.length == 2) {
-      // The primary argument is type-checked before a null trim character decides the answer, so an
-      // out-of-domain primary argument is still reported even when args[1] happens to be null (issue
-      // #5798 review: lTrim(5, null) must still be a type error, not a silent null).
+      // Both arguments are STRING-typed and type-checked before either being null decides the answer, so an
+      // out-of-domain argument is still reported regardless of which position happens to be null (issue
+      // #5798 review: lTrim(5, null) must still be a type error, not a silent null). The trim-character
+      // argument is STRING-typed too, same as the primary one - issue #6608: #5798 only covered this
+      // function's primary argument position, leaving the trim character to silently coerce via toString().
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
-      if (source == null || args[1] == null)
+      final String trimChar = CypherFunctionHelper.requireStringArgument(args[1], getName());
+      if (source == null || trimChar == null)
         return null;
-      final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.stripLeading();
       return stripLeading(source, trimChar);

--- a/engine/src/main/java/com/arcadedb/function/text/LeftFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/LeftFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.text;
 
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -47,7 +48,9 @@ public class LeftFunction implements StatelessFunction {
     if (args[0] == null || args[1] == null)
       return null;
     final String str = args[0].toString();
-    final int length = ((Number) args[1]).intValue();
+    // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
+    // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
+    final int length = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     if (length < 0)
       // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching Neo4j/Memgraph.
       // CommandSemanticException extends CommandParsingException, which the HTTP handler maps to 400. See issue #5296.

--- a/engine/src/main/java/com/arcadedb/function/text/RTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/RTrimFunction.java
@@ -52,13 +52,15 @@ public class RTrimFunction implements StatelessFunction {
       return source.stripTrailing();
     }
     if (args.length == 2) {
-      // The primary argument is type-checked before a null trim character decides the answer, so an
-      // out-of-domain primary argument is still reported even when args[1] happens to be null (issue
-      // #5798 review: rTrim(5, null) must still be a type error, not a silent null).
+      // Both arguments are STRING-typed and type-checked before either being null decides the answer, so an
+      // out-of-domain argument is still reported regardless of which position happens to be null (issue
+      // #5798 review: rTrim(5, null) must still be a type error, not a silent null). The trim-character
+      // argument is STRING-typed too, same as the primary one - issue #6608: #5798 only covered this
+      // function's primary argument position, leaving the trim character to silently coerce via toString().
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
-      if (source == null || args[1] == null)
+      final String trimChar = CypherFunctionHelper.requireStringArgument(args[1], getName());
+      if (source == null || trimChar == null)
         return null;
-      final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.stripTrailing();
       return stripTrailing(source, trimChar);

--- a/engine/src/main/java/com/arcadedb/function/text/ReplaceFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/ReplaceFunction.java
@@ -47,12 +47,17 @@ public class ReplaceFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    // The primary argument is type-checked before a null secondary argument decides the answer, so an
-    // out-of-domain primary argument is still reported even when args[1] or args[2] happens to be null
-    // (issue #5798 review: replace(5, null, 'b') must still be a type error, not a silent null).
+    // Every argument is STRING-typed and type-checked before any of them being null decides the answer, so
+    // an out-of-domain argument is still reported regardless of which other position happens to be null
+    // (issue #5798 review: replace(5, null, 'b') must still be a type error, not a silent null). The search
+    // and replacement arguments are STRING-typed too, same as the primary one - issue #6608: #5798 only
+    // covered this function's primary argument position, leaving these two to silently coerce via
+    // toString().
     final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
-    if (source == null || args[1] == null || args[2] == null)
+    final String search = CypherFunctionHelper.requireStringArgument(args[1], getName());
+    final String replacement = CypherFunctionHelper.requireStringArgument(args[2], getName());
+    if (source == null || search == null || replacement == null)
       return null;
-    return source.replace(args[1].toString(), args[2].toString());
+    return source.replace(search, replacement);
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/text/RightFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/RightFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.text;
 
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -47,7 +48,9 @@ public class RightFunction implements StatelessFunction {
     if (args[0] == null || args[1] == null)
       return null;
     final String str = args[0].toString();
-    final int length = ((Number) args[1]).intValue();
+    // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
+    // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
+    final int length = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     if (length < 0)
       // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching Neo4j/Memgraph.
       // CommandSemanticException extends CommandParsingException, which the HTTP handler maps to 400. See issue #5296.

--- a/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.text;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -58,7 +58,9 @@ public class SubstringFunction implements StatelessFunction {
     if (args.length == 3 && args[2] != null) {
       final int length = CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue();
       if (length < 0)
-        throw new CommandExecutionException("substring(): negative length is not supported: " + length);
+        // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching CypherSubstringFunction
+        // (the executor Cypher's substring() actually resolves to) and left()/right(). See issue #5296/#5793.
+        throw new CommandSemanticException("substring(): negative length is not supported: " + length);
       return str.substring(start, Math.min(start + length, str.length()));
     }
     return str.substring(start);

--- a/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
@@ -53,7 +53,11 @@ public class SubstringFunction implements StatelessFunction {
     // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
     // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
     final int start = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
-    if (start < 0 || start > str.length())
+    if (start < 0)
+      // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching CypherSubstringFunction
+      // (the executor Cypher's substring() actually resolves to) instead of silently returning "". See issue #6609.
+      throw new CommandSemanticException("substring(): negative start index is not supported: " + start);
+    if (start > str.length())
       return "";
     if (args.length == 3 && args[2] != null) {
       final int length = CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue();

--- a/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
@@ -50,11 +50,13 @@ public class SubstringFunction implements StatelessFunction {
     if (args[0] == null || args[1] == null || CypherFunctionHelper.isExplicitNull(args, 2))
       return null;
     final String str = args[0].toString();
-    final int start = ((Number) args[1]).intValue();
+    // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
+    // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
+    final int start = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     if (start < 0 || start > str.length())
       return "";
     if (args.length == 3 && args[2] != null) {
-      final int length = ((Number) args[2]).intValue();
+      final int length = CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue();
       if (length < 0)
         throw new CommandExecutionException("substring(): negative length is not supported: " + length);
       return str.substring(start, Math.min(start + length, str.length()));

--- a/engine/src/main/java/com/arcadedb/function/vector/VectorCreateFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/vector/VectorCreateFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.vector;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.index.vector.VectorUtils;
 import com.arcadedb.query.sql.executor.CommandContext;
 
@@ -59,7 +60,7 @@ public class VectorCreateFunction implements StatelessFunction {
 
     // Validate dimension if provided
     if (args.length >= 2 && args[1] != null) {
-      final int expectedDimension = ((Number) args[1]).intValue();
+      final int expectedDimension = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
       if (result.length != expectedDimension)
         throw new CommandExecutionException(
             "Vector dimension mismatch: expected " + expectedDimension + " but got " + result.length);

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -293,12 +293,19 @@ public interface GraphTraversalProvider {
    * A caller that does not visit many nodes in a row - a single-source search that reads one node's edges per
    * step, already bounded by its own outer loop - passes {@code null} and pays nothing beyond one comparison per
    * edge.
+   * <p>
+   * {@code edgeTypes} is a plain array here rather than the other overload's varargs, deliberately: a fifth
+   * argument of a bare {@code null} would otherwise be ambiguous between binding to {@code edgeCheckpoint} here
+   * and to the other overload's {@code String... edgeTypes} (both are reference types, and neither overload is
+   * more specific than the other from a {@code null} literal), breaking any existing five-argument call this
+   * SPI already has. Requiring six arguments to reach this overload at all keeps every four- and five-argument
+   * call - including a bare {@code null} - resolving to the other one, unchanged.
    *
    * @param edgeCheckpoint called with the edge index within this call (0-based), or {@code null} to skip it
    */
   default NodeEdgeWeights edgeWeightsOf(final int nodeId, final Vertex.DIRECTION direction,
       final String propertyName, final double defaultWeight, final IntConsumer edgeCheckpoint,
-      final String... edgeTypes) {
+      final String[] edgeTypes) {
     if (!servesEdgeProperty(propertyName, edgeTypes))
       return null;
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -20,6 +20,8 @@ package com.arcadedb.graph;
 
 import com.arcadedb.database.RID;
 
+import java.util.function.IntConsumer;
+
 /**
  * SPI for accelerated graph traversal providers (e.g., Graph Analytical Views backed by CSR).
  * <p>
@@ -270,6 +272,33 @@ public interface GraphTraversalProvider {
    */
   default NodeEdgeWeights edgeWeightsOf(final int nodeId, final Vertex.DIRECTION direction,
       final String propertyName, final double defaultWeight, final String... edgeTypes) {
+    return edgeWeightsOf(nodeId, direction, propertyName, defaultWeight, null, edgeTypes);
+  }
+
+  /**
+   * Same as {@link #edgeWeightsOf(int, Vertex.DIRECTION, String, double, String...)}, with one addition:
+   * {@code edgeCheckpoint}, if not {@code null}, is called once per edge as the per-(type, direction) slices are
+   * copied into the returned arrays, with a counter that restarts at zero for every call to this method.
+   * <p>
+   * A caller that visits every node of the graph in turn - {@code AbstractAlgoProcedure}'s columnar adjacency
+   * build does, once per node - has no other way to stay abortable mid-node: this method already returns one
+   * fully-built {@link NodeEdgeWeights} per call, so a single node with a very large degree (a supernode) is
+   * otherwise one unabortable unit of work regardless of how often the caller checkpoints between nodes (issue
+   * #6715). Restarting the counter at zero rather than threading a running total through is deliberate, the same
+   * choice {@link com.arcadedb.query.sql.executor.WorkGuard#checkPeriodically} documents for a loop whose counter
+   * restarts: it bounds the worst-case latency to about one checkpoint stride into the largest node, whatever the
+   * node before it looked like, and it keeps this method free of any dependency on where the caller's own count
+   * comes from.
+   * <p>
+   * A caller that does not visit many nodes in a row - a single-source search that reads one node's edges per
+   * step, already bounded by its own outer loop - passes {@code null} and pays nothing beyond one comparison per
+   * edge.
+   *
+   * @param edgeCheckpoint called with the edge index within this call (0-based), or {@code null} to skip it
+   */
+  default NodeEdgeWeights edgeWeightsOf(final int nodeId, final Vertex.DIRECTION direction,
+      final String propertyName, final double defaultWeight, final IntConsumer edgeCheckpoint,
+      final String... edgeTypes) {
     if (!servesEdgeProperty(propertyName, edgeTypes))
       return null;
 
@@ -291,11 +320,14 @@ public interface GraphTraversalProvider {
     final int[] neighbors = new int[degree];
     final double[] weights = new double[degree];
     int pos = 0;
+    int edgeCount = 0;
     s = 0;
     for (final String type : types)
       for (final Vertex.DIRECTION d : directions) {
         final int[] slice = slices[s++];
         for (int j = 0; j < slice.length; j++) {
+          if (edgeCheckpoint != null)
+            edgeCheckpoint.accept(edgeCount++);
           neighbors[pos] = slice[j];
           final Object value = getEdgeProperty(nodeId, j, d, type, propertyName);
           weights[pos] = value instanceof Number num ? num.doubleValue() : defaultWeight;

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
@@ -120,15 +120,16 @@ public class GraphTraversalProviderRegistry {
       return null;
     // CopyOnWriteArrayList iteration is safe outside the lock
     for (final GraphTraversalProvider provider : list) {
-      if (!provider.isReady())
-        continue;
+      // Type coverage first, readiness second: coversEdgeType() is a pure, side-effect-free config check,
+      // while a GraphAnalyticalView's isReady() (see #6641) dispatches its deferred restore-from-disk as a
+      // side effect when one is pending. Calling isReady() first would eagerly resolve every registered
+      // view's deferred restore on every lookup - including ones this query doesn't even cover - which
+      // would quietly defeat #6632's "a view a session never actually needs shouldn't cost anything" goal
+      // for any multi-view database. Checking coverage first means isReady() only runs, and only pays that
+      // cost, for a provider that could actually be selected.
       if (edgeTypes == null || edgeTypes.length == 0) {
-        if (provider.coversEdgeType(null)) {
-          if (provider.isStale())
-            LogManager.instance().log(GraphTraversalProviderRegistry.class, Level.FINE,
-                "Using stale GraphTraversalProvider '%s' for query acceleration (data may not reflect latest commits)", provider.getName());
-          return provider;
-        }
+        if (!provider.coversEdgeType(null))
+          continue;
       } else {
         boolean allCovered = true;
         for (final String et : edgeTypes)
@@ -136,13 +137,15 @@ public class GraphTraversalProviderRegistry {
             allCovered = false;
             break;
           }
-        if (allCovered) {
-          if (provider.isStale())
-            LogManager.instance().log(GraphTraversalProviderRegistry.class, Level.FINE,
-                "Using stale GraphTraversalProvider '%s' for query acceleration (data may not reflect latest commits)", provider.getName());
-          return provider;
-        }
+        if (!allCovered)
+          continue;
       }
+      if (!provider.isReady())
+        continue;
+      if (provider.isStale())
+        LogManager.instance().log(GraphTraversalProviderRegistry.class, Level.FINE,
+            "Using stale GraphTraversalProvider '%s' for query acceleration (data may not reflect latest commits)", provider.getName());
+      return provider;
     }
     return null;
   }

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
@@ -24,6 +24,7 @@ import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.log.LogManager;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -118,36 +119,36 @@ public class GraphTraversalProviderRegistry {
     }
     if (list == null)
       return null;
-    // CopyOnWriteArrayList iteration is safe outside the lock
-    for (final GraphTraversalProvider provider : list) {
+    // CopyOnWriteArrayList iteration is safe outside the lock. Loop condition (not an explicit break/return
+    // in the body) stops at the first match, so isReady() - which now dispatches a GraphAnalyticalView's
+    // deferred restore-from-disk as a side effect, see #6641 - is never called on a provider past that point.
+    GraphTraversalProvider found = null;
+    final Iterator<GraphTraversalProvider> iterator = list.iterator();
+    while (found == null && iterator.hasNext()) {
+      final GraphTraversalProvider provider = iterator.next();
       // Type coverage first, readiness second: coversEdgeType() is a pure, side-effect-free config check,
-      // while a GraphAnalyticalView's isReady() (see #6641) dispatches its deferred restore-from-disk as a
-      // side effect when one is pending. Calling isReady() first would eagerly resolve every registered
-      // view's deferred restore on every lookup - including ones this query doesn't even cover - which
-      // would quietly defeat #6632's "a view a session never actually needs shouldn't cost anything" goal
-      // for any multi-view database. Checking coverage first means isReady() only runs, and only pays that
-      // cost, for a provider that could actually be selected.
-      if (edgeTypes == null || edgeTypes.length == 0) {
-        if (!provider.coversEdgeType(null))
-          continue;
-      } else {
+      // while isReady()'s dispatch is not. Checking coverage first means isReady() - and its cost - only
+      // ever runs on a provider that could actually be selected, not on every registered one #6632's
+      // "a view a session never actually needs shouldn't cost anything" goal for a multi-view database.
+      final boolean covers;
+      if (edgeTypes == null || edgeTypes.length == 0)
+        covers = provider.coversEdgeType(null);
+      else {
         boolean allCovered = true;
         for (final String et : edgeTypes)
           if (!provider.coversEdgeType(et)) {
             allCovered = false;
             break;
           }
-        if (!allCovered)
-          continue;
+        covers = allCovered;
       }
-      if (!provider.isReady())
-        continue;
-      if (provider.isStale())
-        LogManager.instance().log(GraphTraversalProviderRegistry.class, Level.FINE,
-            "Using stale GraphTraversalProvider '%s' for query acceleration (data may not reflect latest commits)", provider.getName());
-      return provider;
+      if (covers && provider.isReady())
+        found = provider;
     }
-    return null;
+    if (found != null && found.isStale())
+      LogManager.instance().log(GraphTraversalProviderRegistry.class, Level.FINE,
+          "Using stale GraphTraversalProvider '%s' for query acceleration (data may not reflect latest commits)", found.getName());
+    return found;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
@@ -101,6 +101,17 @@ public class GraphTraversalProviderRegistry {
   }
 
   /**
+   * Returns true if any provider is registered for any database, without the lock/unwrap/WeakHashMap lookup
+   * {@link #findProvider} needs once it establishes that. Lets a caller that would otherwise do non-trivial work
+   * (e.g. building an edge-types array) just to pass it to {@link #findProvider} skip that work first in the
+   * overwhelmingly common case where no provider is registered at all - the same single-volatile-read short
+   * circuit {@link #findProvider} itself takes, exposed for callers that need it before they can call that method.
+   */
+  public static boolean hasAnyProviders() {
+    return hasAnyProviders;
+  }
+
+  /**
    * Finds the first ready provider that covers all the given edge types.
    *
    * @param database  the database

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
@@ -172,12 +172,13 @@ public class GraphTraversalProviderRegistry {
 
     final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
     for (final GraphTraversalProvider provider : list) {
-      // A GraphAnalyticalView always goes through awaitReady(), regardless of isReady(): since a deferred
-      // restore-from-disk (see #6632) reports READY the moment a persisted CSR plausibly applies, before
-      // the disk read that actually resolves it has even run, isReady() alone is no longer a trustworthy
-      // "nothing left to do" signal for this provider type - awaitReady() is the one call that triggers
-      // that read. It is cheap/idempotent once nothing is pending (its own trigger call no-ops and the
-      // wait loop returns immediately), so this costs nothing extra for an already-settled view.
+      // A GraphAnalyticalView always goes through awaitReady(), regardless of isReady(): isReady() is
+      // accurate (see #6641 - it reports not-ready while a deferred restore-from-disk, #6632, is still
+      // unresolved rather than optimistically READY) but deliberately non-blocking, and this method's
+      // whole point is to actually wait for the deferred read to resolve, not just to ask whether it
+      // already has. awaitReady() is the one call that both triggers that read and blocks for it. It is
+      // cheap/idempotent once nothing is pending (its own trigger call no-ops and the wait loop returns
+      // immediately), so this costs nothing extra for an already-settled view.
       if (provider instanceof GraphAnalyticalView) {
         final long remainingNanos = deadlineNanos - System.nanoTime();
         if (remainingNanos <= 0)

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -258,6 +258,24 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   // which never sets this flag at all — keeps that method's own documented fail-fast contract unchanged.
   private volatile boolean           deferredRestoreInFlight;
 
+  // Monotonic ticket bumped by every path that DISPATCHES a snapshot-producing operation - build(),
+  // buildAsync(), onRelevantCommit()'s async rebuild, applyDelta()'s compaction rebuild, and
+  // dispatchDeferredRestore() - captured as that operation's own "myGeneration" at dispatch time. Right
+  // before actually committing a result to this.snapshot/this.status, an operation compares its captured
+  // value against the current field: if another, later-dispatched operation has since bumped it, this one
+  // has been superseded and skips the commit instead of overwriting a newer result with an older one
+  // (issue #6636). Every read and write of this field happens inside a block synchronized on `this`
+  // (build()/buildAsync()/onRelevantCommit()/applyDelta()/dispatchDeferredRestore() are themselves
+  // synchronized methods, and every executor-task commit site below re-enters synchronized(this) to write
+  // it), so a plain long - not volatile, not an Atomic - is sufficient: the monitor alone establishes the
+  // happens-before edge between one thread's bump and another's later read.
+  // Deliberately NOT bumped by applyDelta()'s own synchronous overlay merge (this.snapshot =
+  // current.withOverlay(merged)): that merge is cooperative with a concurrent compaction rebuild - which
+  // buffers and re-applies exactly those deltas against its own captured generation - not competing with
+  // it, so bumping here would make the compaction's own commit spuriously stale on every rebuild that
+  // overlaps so much as one incoming delta.
+  private long generation;
+
   // Incremental auto-update
   private DeltaCollector         deltaCollector;
   public static final int        DEFAULT_COMPACTION_THRESHOLD = 10_000;
@@ -338,6 +356,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // persisted file (or a wholly redundant rebuild) right after this scan already produced a fresh,
     // authoritative snapshot.
     pendingDiskRestore = false;
+    // Bumping unconditionally (no commit-time check needed here, unlike every other path below): this
+    // whole method is synchronized and runs the scan on the calling thread, so it holds this instance's
+    // monitor for its entire duration - nothing else that reads/writes `generation` can interleave. The
+    // bump alone is what matters: it retroactively supersedes any snapshot-producing task dispatched
+    // earlier but still in flight (issue #6636), e.g. an already-dispatched deferred restore-from-disk.
+    ++generation;
     final CountDownLatch latch = new CountDownLatch(1);
     readyLatch = latch;
     status = Status.BUILDING;
@@ -394,6 +418,10 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // restore-from-disk (see #6632). Also reached, harmlessly, from dispatchDeferredRestore()'s own
     // fallback call - pendingDiskRestore is already false there by the time it calls this.
     pendingDiskRestore = false;
+    // Captured at dispatch time, not when the background task actually starts its scan: see the
+    // `generation` field javadoc (issue #6636) - this is what lets a later-dispatched build correctly
+    // supersede an earlier one regardless of which finishes first.
+    final long myGeneration = ++generation;
     final CountDownLatch latch = new CountDownLatch(1);
     readyLatch = latch;
     status = Status.BUILDING;
@@ -414,29 +442,38 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
             final CSRBuilder.CSRResult result = builder.build(vertexTypes, edgeTypes);
             final long durationMs = System.currentTimeMillis() - buildStart;
 
+            boolean committed = false;
             synchronized (GraphAnalyticalView.this) {
-              this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
-              this.status = Status.READY;
-              GraphAnalyticalView.this.notifyAll();
-              if (deltaCollector == null)
-                registerChangeListeners();
+              if (myGeneration == generation) {
+                this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
+                this.status = Status.READY;
+                GraphAnalyticalView.this.notifyAll();
+                if (deltaCollector == null)
+                  registerChangeListeners();
+                committed = true;
+              } else
+                LogManager.instance().log(this, Level.FINE,
+                    "GraphAnalyticalView '%s': async build result discarded (superseded by a newer build/restore)", name);
             }
-            invalidateGraphStatisticsCache();
+            if (committed)
+              invalidateGraphStatisticsCache();
           } finally {
             if (database.isTransactionActive())
               database.rollback();
           }
         } catch (final Exception e) {
           synchronized (GraphAnalyticalView.this) {
-            this.buildError = e;
-            if (snapshot != null) {
-              this.status = Status.STALE;
-            } else {
-              this.status = Status.NOT_BUILT;
-              // Unregister failed GAV so the name can be reused for a fresh build
-              GraphTraversalProviderRegistry.unregister(database, this);
-              if (name != null)
-                GraphAnalyticalViewRegistry.unregister(database, name);
+            if (myGeneration == generation) {
+              this.buildError = e;
+              if (snapshot != null) {
+                this.status = Status.STALE;
+              } else {
+                this.status = Status.NOT_BUILT;
+                // Unregister failed GAV so the name can be reused for a fresh build
+                GraphTraversalProviderRegistry.unregister(database, this);
+                if (name != null)
+                  GraphAnalyticalViewRegistry.unregister(database, name);
+              }
             }
             GraphAnalyticalView.this.notifyAll();
           }
@@ -1667,6 +1704,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // this method actually started, never for an unrelated buildAsync()/onRelevantCommit() rebuild on a
     // brand-new view built directly (which keeps its own documented fail-fast contract unchanged).
     deferredRestoreInFlight = true;
+    // See the `generation` field javadoc (issue #6636): captured at dispatch time, before the executor
+    // task even queues, so a direct build()/buildAsync() call that runs and completes while this restore
+    // is still parked (e.g. waiting on BUILD_PERMITS) correctly supersedes it - even though the restore's
+    // own freshness certificate, re-sampled from scratch when it finally runs, would otherwise still
+    // "match" (nothing needs to have been committed for a redundant rescan to be dispatched).
+    final long myGeneration = ++generation;
     final CountDownLatch latch = new CountDownLatch(1);
     readyLatch = latch;
     status = Status.BUILDING;
@@ -1677,16 +1720,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
           BUILD_PERMITS.acquireUninterruptibly();
           final boolean restored;
           try {
-            restored = tryRestoreFromPersistedCsr();
+            restored = tryRestoreFromPersistedCsr(myGeneration);
           } finally {
             BUILD_PERMITS.release();
           }
           if (!restored) {
-            // No usable file after all (vanished, corrupted, or invalidated by a commit that landed while
-            // this was pending and unwatched) — fall back exactly as the eager #6583 path always did.
-            // Waited out here (this virtual thread parking costs nothing) rather than left to complete on
-            // its own dispatched task, so deferredRestoreInFlight stays true for the fallback's own
-            // duration too, not just for the near-instant hand-off to it.
+            // No usable file after all (vanished, corrupted, invalidated by a commit that landed while
+            // this was pending and unwatched, or superseded by a newer build/restore) — fall back exactly
+            // as the eager #6583 path always did. Waited out here (this virtual thread parking costs
+            // nothing) rather than left to complete on its own dispatched task, so deferredRestoreInFlight
+            // stays true for the fallback's own duration too, not just for the near-instant hand-off to it.
             buildAsync();
             awaitDeferredDiskRestoreSettled();
           }
@@ -1697,8 +1740,10 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
           // future checkBuilt() call (its latch is already counted down, so await() returns instantly,
           // and status never leaves BUILDING to end the loop). Mirrors buildAsync()'s own catch exactly.
           synchronized (this) {
-            buildError = e;
-            status = snapshot != null ? Status.STALE : Status.NOT_BUILT;
+            if (myGeneration == generation) {
+              buildError = e;
+              status = snapshot != null ? Status.STALE : Status.NOT_BUILT;
+            }
             notifyAll();
           }
           if (isBenignShutdownError(e))
@@ -1765,8 +1810,17 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * <p>
    * The guard clauses below are mirrored (cheaply, without the file read) by {@link #mayHavePersistedCsr()} —
    * KEEP THEM IN SYNC (review on PR #6633).
+   * <p>
+   * {@code expectedGeneration} is {@link #dispatchDeferredRestore()}'s own {@code myGeneration}, captured
+   * when it dispatched this restore. Checked right before the write to {@code this.snapshot}/{@code
+   * this.status}: a direct {@code build()}/{@code buildAsync()} that ran and completed while this restore
+   * was still in flight (e.g. parked on {@code BUILD_PERMITS}, which does not gate {@code build()}) bumps
+   * {@link #generation} past this value even when nothing was committed in between - so the certificate
+   * above can still "match" a now-superseded snapshot. Returns {@code true} (not {@code false}) in that
+   * case: a usable file WAS found, so {@link #dispatchDeferredRestore()} must not additionally trigger a
+   * redundant {@link #buildAsync()} fallback on top of the build that already won (issue #6636).
    */
-  synchronized boolean tryRestoreFromPersistedCsr() {
+  synchronized boolean tryRestoreFromPersistedCsr(final long expectedGeneration) {
     if (name == null)
       return false;
     if (!database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_PERSIST_CSR))
@@ -1806,6 +1860,19 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // awaitReady() caller may already be waiting on that installed latch. Counting down a *new* instance
     // instead would leave that caller hanging until its timeout even though the view is READY.
     final CountDownLatch latch = readyLatch;
+
+    if (expectedGeneration != generation) {
+      // A direct build()/buildAsync() (or another restore) already completed and published a fresher
+      // snapshot while this one was in flight — see this method's javadoc (issue #6636). The file we just
+      // loaded is redundant, not wrong; discard it without touching this.snapshot/this.status, but still
+      // wake any waiter parked on the latch/monitor this restore itself installed.
+      LogManager.instance().log(this, Level.FINE,
+          "GraphAnalyticalView '%s': persisted CSR restore discarded (superseded by a newer build/restore)", name);
+      this.notifyAll();
+      latch.countDown();
+      return true;
+    }
+
     this.snapshot = restored;
     this.status = Status.READY;
     this.notifyAll();
@@ -1868,6 +1935,9 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
         return;
       }
       asyncRebuildNeeded = false;
+      // See the `generation` field javadoc (issue #6636): captured at dispatch time so a later-dispatched
+      // build (e.g. a direct build()/buildAsync() call racing this rebuild) correctly supersedes it.
+      final long myGeneration = ++generation;
       final CountDownLatch latch = new CountDownLatch(1);
       this.readyLatch = latch;
       this.status = Status.BUILDING;
@@ -1885,14 +1955,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
               final long durationMs = System.currentTimeMillis() - buildStart;
               // Synchronized swap: check that the mode hasn't changed to SYNCHRONOUS during rebuild.
               // If it did, applyDelta() may have enriched the current snapshot with overlay deltas
-              // that would be lost by an unconditional swap.
+              // that would be lost by an unconditional swap. Also check generation: a direct build()/
+              // buildAsync() dispatched after this rebuild started must win even if this one finishes
+              // last (issue #6636).
               synchronized (GraphAnalyticalView.this) {
-                if (updateMode == UpdateMode.ASYNCHRONOUS) {
+                if (updateMode == UpdateMode.ASYNCHRONOUS && myGeneration == generation) {
                   this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
                   this.status = Status.READY;
                 } else
                   LogManager.instance().log(this, Level.INFO,
-                      "GraphAnalyticalView '%s': async rebuild result discarded (update mode changed to %s during rebuild)", name, updateMode);
+                      "GraphAnalyticalView '%s': async rebuild result discarded (update mode changed to %s during rebuild, or superseded by a newer build/restore)", name, updateMode);
               }
 
             } finally {
@@ -1900,8 +1972,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
                 database.rollback();
             }
           } catch (final Exception e) {
-            this.buildError = e;
-            this.status = Status.STALE;
+            synchronized (GraphAnalyticalView.this) {
+              if (myGeneration == generation) {
+                this.buildError = e;
+                this.status = Status.STALE;
+              }
+            }
             if (isBenignShutdownError(e))
               LogManager.instance().log(this, Level.FINE,
                   "Async rebuild of GraphAnalyticalView '%s' aborted because the database is closing", name);
@@ -1981,6 +2057,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       // Start buffering raw deltas for re-application after the swap
       pendingDeltas = new ArrayList<>();
 
+      // See the `generation` field javadoc (issue #6636): captured at dispatch time, deliberately NOT
+      // bumped by the synchronous overlay merge just above (or by any applyDelta() call re-entering while
+      // this compaction is in flight) - those deltas are buffered and re-applied against this same
+      // generation below, cooperatively, not competing with it. A direct build()/buildAsync() dispatched
+      // after this compaction started must still win if it finishes first.
+      final long myGeneration = ++generation;
+
       inFlightTasks.incrementAndGet();
       try {
         getExecutor().execute(() -> {
@@ -2004,6 +2087,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
                   // The current overlay is still valid and already has all deltas merged.
                   LogManager.instance().log(this, Level.INFO,
                       "GraphAnalyticalView '%s': compaction result discarded (delta buffer overflowed during rebuild)", name);
+                } else if (myGeneration != generation) {
+                  // Superseded by a newer build/restore (issue #6636): the buffered deltas were already
+                  // merged into the pre-compaction overlay by applyDelta() as they arrived, and that
+                  // overlay was discarded together with its base snapshot by whatever won instead, so
+                  // there is nothing left here to reapply them onto.
+                  LogManager.instance().log(this, Level.INFO,
+                      "GraphAnalyticalView '%s': compaction result discarded (superseded by a newer build/restore)", name);
                 } else {
                   Snapshot fresh = snapshotFromResult(result, durationMs, asOfTransactionId, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
 
@@ -2401,6 +2491,28 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     if (snap == null)
       throw new IllegalStateException("GraphAnalyticalView has not been built yet. Call build() first.");
     return snap;
+  }
+
+  /**
+   * Test-only hook: saturates the shared, JVM-wide {@link #BUILD_PERMITS} semaphore so any subsequently
+   * dispatched async build/restore/compaction task blocks right before it starts its scan or disk read,
+   * letting a test deterministically land a direct {@link #build()}/{@link #buildAsync()} call while that
+   * task is in flight but stalled. Must be paired with {@link #releaseAllBuildPermitsForTest()} in a
+   * {@code finally} block: forkCount=1 runs this module's tests in a single, sequential JVM, but a leaked
+   * acquisition would still starve every later test in that JVM of build permits.
+   */
+  static void acquireAllBuildPermitsForTest() {
+    BUILD_PERMITS.acquireUninterruptibly(MAX_CONCURRENT_BUILDS);
+  }
+
+  /** Test-only hook: releases the permits taken by {@link #acquireAllBuildPermitsForTest()}. */
+  static void releaseAllBuildPermitsForTest() {
+    BUILD_PERMITS.release(MAX_CONCURRENT_BUILDS);
+  }
+
+  /** Test-only hook: exposes {@link #deferredRestoreInFlight} so a test can poll for the dispatch. */
+  boolean isDeferredRestoreInFlightForTest() {
+    return deferredRestoreInFlight;
   }
 
   private static int sortedIntersectionCount(final int[] a, int startA, final int endA,

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1229,12 +1229,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * did for a genuinely stale view; whichever query asks next sees the resolved outcome (restored from disk,
    * or rebuilt) once the background work completes. Callers that would rather wait for an accelerated first
    * query use {@link #awaitReady} explicitly instead (see {@link com.arcadedb.GlobalConfiguration#GAV_RESTORE_AWAIT_TIMEOUT}).
+   * <p>
+   * The trigger call runs unconditionally, ahead of reading {@code status}: it is a cheap no-op once nothing
+   * is pending (single volatile read), and reading {@code status} afterwards - rather than short-circuiting to
+   * {@code false} on {@code pendingDiskRestore} alone - reports the real, resolved state on the rare race
+   * where another caller's dispatch settles between the two reads, instead of being needlessly pessimistic.
    */
   public boolean isReady() {
-    if (pendingDiskRestore) {
-      triggerDeferredDiskRestoreIfPending();
-      return false;
-    }
+    triggerDeferredDiskRestoreIfPending();
     final Status s = status;
     if (s == Status.READY)
       return true;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1213,7 +1213,28 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     return snap != null && snap.restoredFromDisk;
   }
 
+  /**
+   * Whether this provider can be handed to a query right now (see {@link GraphTraversalProviderRegistry#findProvider}).
+   * <p>
+   * A deferred restore-from-disk (see #6632) reports {@code status == READY} the moment a persisted CSR
+   * plausibly applies, before the disk read that actually verifies it has run - a hint, not a promise. Taking
+   * that at face value here would let a query commit to this provider and then, inside {@link #checkBuilt()},
+   * discover the file is unusable and block through a full {@code O(V+E)} rebuild with no way back to the
+   * ordinary path (issue #6641): every {@code checkBuilt()} caller reaches it only after this method has
+   * already said yes, so there is nothing left to fall back to once it is in there.
+   * <p>
+   * While a deferred restore is still pending, this triggers it in the background (a no-op if another caller
+   * already has) and reports not-ready for THIS call - exactly the answer an eagerly-marked {@code STALE} view
+   * would have given before #6632. The query this call belongs to takes the ordinary path, same as it always
+   * did for a genuinely stale view; whichever query asks next sees the resolved outcome (restored from disk,
+   * or rebuilt) once the background work completes. Callers that would rather wait for an accelerated first
+   * query use {@link #awaitReady} explicitly instead (see {@link com.arcadedb.GlobalConfiguration#GAV_RESTORE_AWAIT_TIMEOUT}).
+   */
   public boolean isReady() {
+    if (pendingDiskRestore) {
+      triggerDeferredDiskRestoreIfPending();
+      return false;
+    }
     final Status s = status;
     if (s == Status.READY)
       return true;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewRegistry.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewRegistry.java
@@ -90,6 +90,13 @@ public class GraphAnalyticalViewRegistry {
 
   /**
    * Returns all registered GAVs for a database that are ready for use.
+   * <p>
+   * Unlike {@link com.arcadedb.graph.GraphTraversalProviderRegistry#findProvider}, this has no coverage
+   * filter to check before {@code isReady()} - it means to list every view, not find one usable for a
+   * specific query. A future caller relying on this to be a cheap, side-effect-free read should know it
+   * is not one: {@code isReady()} dispatches a pending deferred restore-from-disk in the background for
+   * every view it is called on (see #6641), so calling this eagerly resolves every registered view's
+   * restore, not only the ones that turn out ready.
    */
   public static Map<String, GraphAnalyticalView> getReady(final Database database) {
     synchronized (REGISTRY) {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -500,13 +500,19 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       if (fromKeys != null) {
         final Binary rootPageBuffer = new Binary(rootPage.slice());
 
-        // Use purpose=2 (ascending iterator) instead of 1 (retrieve) for root page lookups when
+        // Use purpose=2/3 (ascending/descending iterator) instead of 1 (retrieve) for root page lookups when
         // keys are partial (fewer components than the composite index defines). Purpose=1 rejects
         // partial keys with "key is composed of N items, while the index defined M items".
-        // Purpose=2 allows partial key comparison which correctly matches by prefix.
+        // Purpose=2/3 allows partial key comparison, which correctly matches by prefix, and - like the data-page
+        // lookup in searchInCurrentPage() below - must follow the scan direction: compareKey()'s PARTIAL MATCHING
+        // walk resolves an ambiguous binary-search landing point to the FIRST entry of a same-prefix run for
+        // purpose=2 and the LAST entry for purpose=3. Using purpose=2 unconditionally made a descending scan's
+        // root-page probe always land on the series' FIRST (lowest-keyed) data page instead of its LAST
+        // (highest-keyed) one whenever a composite-index prefix match spanned multiple data pages within one
+        // compacted series, so the scan started too low and silently dropped whole series/pages (#6694).
         // For full keys, keep purpose=1 to preserve exact boundary behavior for descending ranges and the shared-leaf
         // (multi-page duplicate) positioning, both of which depend on purpose=1's value-run result.
-        final int fromPurpose = fromKeys.length < binaryKeyTypes.length ? 2 : 1;
+        final int fromPurpose = fromKeys.length < binaryKeyTypes.length ? (ascendingOrder ? 2 : 3) : 1;
         final LookupResult resultInRootPage = lookupInPage(rootPageNumber, rootPageCount + 1, rootPageBuffer, fromKeys,
             fromPurpose);
         if (!resultInRootPage.outside)

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -352,7 +352,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
   }
 
   protected LookupResult compareKey(final Binary currentPageBuffer, final int startIndexArray, final Object[] convertedKeys,
-      final int mid, final int count,
+      int mid, final int count,
       final int purpose) {
 
     final int result = compareKey(currentPageBuffer, startIndexArray, convertedKeys, mid, count);
@@ -384,6 +384,21 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
         positionsArray[i - firstKeyPos] = currentPageBuffer.getInt(startIndexArray + (i * INT_SERIALIZED_SIZE)) + keySerializedSize;
 
       return new LookupResult(true, false, lastKeyPos, positionsArray);
+    }
+
+    if (convertedKeys.length < binaryKeyTypes.length) {
+      // PARTIAL MATCHING: mid is an arbitrary position inside the run of entries sharing this prefix (wherever the
+      // binary search happened to converge) - walk to the run's boundary in the requested scan direction, exactly
+      // like LSMTreeIndexMutable.compareKey() does. Without this, a descending partial-key scan (composite-index
+      // prefix match, e.g. #6592) can start anywhere inside the matching group instead of at its highest entry,
+      // silently skipping the very rows ORDER BY ... DESC is supposed to return first.
+      if (purpose == 2) {
+        // ASCENDING ITERATOR: FIND THE MOST LEFT ITEM
+        mid = findFirstEntryOfSameKey(currentPageBuffer, convertedKeys, startIndexArray, mid);
+      } else if (purpose == 3) {
+        // DESCENDING ITERATOR: FIND THE MOST RIGHT ITEM
+        mid = findLastEntryOfSameKey(count, currentPageBuffer, convertedKeys, startIndexArray, mid);
+      }
     }
 
     // TODO: SET CORRECT VALUE POSITION FOR PARTIAL KEYS
@@ -563,8 +578,23 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
 
       int startingPageNumber;
       if (result.outside) {
-        // STARTS FROM THE BEGINNING OF THE NEXT PAGE
-        startingPageNumber = firstPageNumber + 1;
+        // lookupInPage()'s purpose=2/3 boundary handling is asymmetric (see LSMTreeIndexAbstract#lookupInPage): an
+        // ascending search only ever reports "outside" when the whole page sorts BELOW the search key (the
+        // "HIGHER than last" branch - purpose=2 has no special case there), so the next (higher-keyed) page is the
+        // right place to keep looking. A descending search only ever reports "outside" when the whole page sorts
+        // ABOVE the search key (the "LOWER than first" branch - purpose=3's special case is the "HIGHER than last"
+        // one instead), so it is the PREVIOUS (lower-keyed) page that can still hold the match, not the next one.
+        // Stepping +1 unconditionally here used to walk a descending partial-key (composite-index prefix) scan
+        // straight into an unrelated, higher-keyed page - possibly the next series' root page or another series
+        // entirely - and return whatever it found there as if it matched the search key (#6592 follow-up).
+        if (ascendingOrder) {
+          // STARTS FROM THE BEGINNING OF THE NEXT PAGE
+          startingPageNumber = firstPageNumber + 1;
+        } else
+          // STARTS FROM THE END OF THE PREVIOUS PAGE. If firstPageNumber was already this series' first data page,
+          // this lands below lastPageNumber and loadNextNonEmptyPage()'s loop simply does not run - the series
+          // correctly contributes no cursor rather than reading into the previous series' pages.
+          startingPageNumber = firstPageNumber - 1;
         posInPage = -1;
       } else {
         startingPageNumber = firstPageNumber;

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -563,10 +563,24 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
    * Delegated rather than left at the interface default: a sparse-vector posting key is a dimension identifier, so
    * the key-order mismatch of #5802 should never arise here - but that is an invariant about the keys, not a property
    * of this class, and answering {@code null} unconditionally would hide the mismatch if it ever did.
+   * <p>
+   * Also folds in {@link PaginatedSparseVectorEngine#untrustedSegmentCount()} (issue #6566): a segment merged before
+   * the recency-epoch fix of #6379 can still return a document that was deleted, and until now the only way to learn
+   * that was the once-per-instance WARNING log line at open/refresh time - unqueryable once the moment passed, and
+   * with no way to confirm a {@code REBUILD INDEX} actually cleared it. This makes the same condition answer through
+   * the surface every other index upgrade warning already uses: {@code schema:indexes}, {@code schema:index:<name>},
+   * Studio, and the HTTP admin API, all of which read {@link IndexInternal#getUpgradeWarning()} today.
    */
   @Override
   public String getUpgradeWarning() {
-    return underlyingIndex.getUpgradeWarning();
+    final String delegated = underlyingIndex.getUpgradeWarning();
+    final int untrustedSegments = engine.untrustedSegmentCount();
+    if (untrustedSegments == 0)
+      return delegated;
+    final String own = "%d of %d segment(s) carry a precedence that predates the recency-epoch fix (issue #6379); a "
+        + "document deleted before those segments were merged may still be returned by queries. Run 'REBUILD INDEX %s' "
+        + "once to rewrite them in the correct order.".formatted(untrustedSegments, engine.segmentCount(), getName());
+    return delegated == null ? own : delegated + " " + own;
   }
 
   @Override
@@ -653,6 +667,9 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     stats.put("memtablePostings", engine.memtablePostings());
     stats.put("totalPostings", engine.totalPostings());
     stats.put("segmentCount", (long) engine.segmentCount());
+    // Issue #6566: a queryable counterpart to the once-per-instance WARNING log line, so a monitoring system (or an
+    // operator re-checking after a REBUILD INDEX) can ask "is this index still affected" rather than grep for it.
+    stats.put("untrustedSegments", (long) engine.untrustedSegmentCount());
     return stats;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -564,22 +564,30 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
    * the key-order mismatch of #5802 should never arise here - but that is an invariant about the keys, not a property
    * of this class, and answering {@code null} unconditionally would hide the mismatch if it ever did.
    * <p>
-   * Also folds in {@link PaginatedSparseVectorEngine#untrustedSegmentCount()} (issue #6566): a segment merged before
-   * the recency-epoch fix of #6379 can still return a document that was deleted, and until now the only way to learn
+   * Also folds in {@link PaginatedSparseVectorEngine#segmentTrust()} (issue #6566): a segment merged before the
+   * recency-epoch fix of #6379 can still return a document that was deleted, and until now the only way to learn
    * that was the once-per-instance WARNING log line at open/refresh time - unqueryable once the moment passed, and
    * with no way to confirm a {@code REBUILD INDEX} actually cleared it. This makes the same condition answer through
    * the surface every other index upgrade warning already uses: {@code schema:indexes}, {@code schema:index:<name>},
    * Studio, and the HTTP admin API, all of which read {@link IndexInternal#getUpgradeWarning()} today.
+   * <p>
+   * Deliberately says nothing about WHAT to run: {@link #getName()} on this class is the physical per-bucket
+   * sub-index name, not the logical index {@code REBUILD INDEX} takes, and the contract on
+   * {@link IndexInternal#getUpgradeWarning()} is explicit that implementations say what is lost and why, not what to
+   * type - the caller ({@code LocalSchema.reportUpgradeWarning()}) resolves the logical name itself and appends the
+   * actual command, the same way {@link com.arcadedb.index.geospatial.LSMTreeGeoIndex#getUpgradeWarning()} leaves it
+   * (PR #6720 review: embedding a second, physical-named "Run 'REBUILD INDEX ...'" here would have shown an operator
+   * two different targets in the same message).
    */
   @Override
   public String getUpgradeWarning() {
     final String delegated = underlyingIndex.getUpgradeWarning();
-    final int untrustedSegments = engine.untrustedSegmentCount();
-    if (untrustedSegments == 0)
+    final PaginatedSparseVectorEngine.SegmentTrustSnapshot trust = engine.segmentTrust();
+    if (trust.untrusted() == 0)
       return delegated;
     final String own = "%d of %d segment(s) carry a precedence that predates the recency-epoch fix (issue #6379); a "
-        + "document deleted before those segments were merged may still be returned by queries. Run 'REBUILD INDEX %s' "
-        + "once to rewrite them in the correct order.".formatted(untrustedSegments, engine.segmentCount(), getName());
+        + "document deleted before those segments were merged may still be returned by queries.".formatted(
+        trust.untrusted(), trust.total());
     return delegated == null ? own : delegated + " " + own;
   }
 
@@ -666,10 +674,12 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     final Map<String, Long> stats = new HashMap<>();
     stats.put("memtablePostings", engine.memtablePostings());
     stats.put("totalPostings", engine.totalPostings());
-    stats.put("segmentCount", (long) engine.segmentCount());
+    // One snapshot for both, so the two numbers can never straddle a compaction landing in between (PR #6720 review).
+    final PaginatedSparseVectorEngine.SegmentTrustSnapshot trust = engine.segmentTrust();
+    stats.put("segmentCount", (long) trust.total());
     // Issue #6566: a queryable counterpart to the once-per-instance WARNING log line, so a monitoring system (or an
     // operator re-checking after a REBUILD INDEX) can ask "is this index still affected" rather than grep for it.
-    stats.put("untrustedSegments", (long) engine.untrustedSegmentCount());
+    stats.put("untrustedSegments", (long) trust.untrusted());
     return stats;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetrics.java
@@ -73,19 +73,24 @@ public final class LSMSparseVectorIndexMetrics {
       final TypeIndex typeIndex = sparse.getTypeIndex();
       final String key = typeIndex != null ? typeIndex.getName() : sparse.getName();
 
+      // One snapshot per engine for both counts, so a compaction landing between two separate reads cannot make a
+      // single bucket's own pair inconsistent (PR #6720 review); the sum across buckets below is still only as
+      // atomic as scraping several independent engines ever is, same as every other field aggregated here.
+      final PaginatedSparseVectorEngine.SegmentTrustSnapshot trust = engine.segmentTrust();
+
       final JSONObject entry;
       if (out.has(key)) {
         entry = out.getJSONObject(key);
         entry.put("memtablePostings", entry.getLong("memtablePostings", 0L) + engine.memtablePostings());
-        entry.put("segmentCount", entry.getInt("segmentCount", 0) + engine.segmentCount());
+        entry.put("segmentCount", entry.getInt("segmentCount", 0) + trust.total());
         entry.put("totalPostings", entry.getLong("totalPostings", 0L) + engine.totalPostings());
-        entry.put("untrustedSegments", entry.getInt("untrustedSegments", 0) + engine.untrustedSegmentCount());
+        entry.put("untrustedSegments", entry.getInt("untrustedSegments", 0) + trust.untrusted());
       } else {
         entry = new JSONObject();
         entry.put("memtablePostings", engine.memtablePostings());
-        entry.put("segmentCount", engine.segmentCount());
+        entry.put("segmentCount", trust.total());
         entry.put("totalPostings", engine.totalPostings());
-        entry.put("untrustedSegments", engine.untrustedSegmentCount());
+        entry.put("untrustedSegments", trust.untrusted());
         out.put(key, entry);
       }
     }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetrics.java
@@ -25,19 +25,23 @@ import com.arcadedb.serializer.json.JSONObject;
 
 /**
  * Builds a Studio-friendly snapshot of every {@link LSMSparseVectorIndex} live on a database:
- * memtable posting count, sealed segment count, and total postings. Operators read this on the
- * Server tab to spot a memtable that is not draining (compaction lag) or a runaway segment count
- * (size-tiered cascade jammed) without log-grepping or a JMX detour.
+ * memtable posting count, sealed segment count, total postings, and how many of those segments
+ * are still untrusted. Operators read this on the Server tab to spot a memtable that is not
+ * draining (compaction lag), a runaway segment count (size-tiered cascade jammed), or a segment
+ * whose precedence predates the recency-epoch fix (issue #6379) - without log-grepping or a JMX
+ * detour.
  * <p>
  * The shape returned is keyed by the user-facing {@link TypeIndex} name (e.g.
  * {@code Doc[tokens,weights]}) so Studio shows one row per logical index. Per-bucket physical
  * sub-indexes are summed under their parent {@code TypeIndex}, which is what an operator
  * thinks of as "the sparse-vector index". Values are pulled directly from the live engines -
- * no extra book-keeping; each counter is an O(1) read.
+ * no extra book-keeping; each counter is a cheap read bounded by the (small) active segment count.
  *
  * <pre>{
- *   "Doc[tokens,weights]":   { "memtablePostings": 12345, "segmentCount": 3, "totalPostings": 987654 },
- *   "Other[tokens,weights]": { "memtablePostings": 0,     "segmentCount": 1, "totalPostings": 543210 }
+ *   "Doc[tokens,weights]":   { "memtablePostings": 12345, "segmentCount": 3, "totalPostings": 987654,
+ *                               "untrustedSegments": 0 },
+ *   "Other[tokens,weights]": { "memtablePostings": 0,     "segmentCount": 1, "totalPostings": 543210,
+ *                               "untrustedSegments": 1 }
  * }</pre>
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -75,11 +79,13 @@ public final class LSMSparseVectorIndexMetrics {
         entry.put("memtablePostings", entry.getLong("memtablePostings", 0L) + engine.memtablePostings());
         entry.put("segmentCount", entry.getInt("segmentCount", 0) + engine.segmentCount());
         entry.put("totalPostings", entry.getLong("totalPostings", 0L) + engine.totalPostings());
+        entry.put("untrustedSegments", entry.getInt("untrustedSegments", 0) + engine.untrustedSegmentCount());
       } else {
         entry = new JSONObject();
         entry.put("memtablePostings", engine.memtablePostings());
         entry.put("segmentCount", engine.segmentCount());
         entry.put("totalPostings", engine.totalPostings());
+        entry.put("untrustedSegments", engine.untrustedSegmentCount());
         out.put(key, entry);
       }
     }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -1364,6 +1364,24 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
   }
 
   /**
+   * Count of currently active segments whose persisted precedence predates the recency-epoch fix (issue #6379) - the
+   * same condition {@link #warnOnPreRecencyEpochSegments} logs once at open/refresh time, re-derived from the live
+   * {@link #segments} snapshot on every call instead of latched by {@link #untrustedEpochWarned}. A log line can only
+   * be read once, at the moment it is emitted; this can be asked again at any time - including after a
+   * {@code REBUILD INDEX}, to confirm the remedy actually worked (issue #6566). O(active segment count), the same
+   * cost as {@link #segmentCount()} - cheap enough for {@link com.arcadedb.index.IndexInternal#getUpgradeWarning()}'s
+   * "called on every listing" contract, which is what surfaces this to {@code schema:indexes} / Studio / the HTTP
+   * admin API.
+   */
+  public int untrustedSegmentCount() {
+    int count = 0;
+    for (final PaginatedSegmentReader r : segments.get())
+      if (r.epochUntrusted())
+        count++;
+    return count;
+  }
+
+  /**
    * Ids of the active segments, sorted ascending.
    * <p>
    * <b>Not parallel to {@link #segmentEpochs()}.</b> This one sorts; that one preserves the array's

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -1364,21 +1364,39 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
   }
 
   /**
-   * Count of currently active segments whose persisted precedence predates the recency-epoch fix (issue #6379) - the
-   * same condition {@link #warnOnPreRecencyEpochSegments} logs once at open/refresh time, re-derived from the live
-   * {@link #segments} snapshot on every call instead of latched by {@link #untrustedEpochWarned}. A log line can only
-   * be read once, at the moment it is emitted; this can be asked again at any time - including after a
-   * {@code REBUILD INDEX}, to confirm the remedy actually worked (issue #6566). O(active segment count), the same
+   * A consistent point-in-time pairing of the active segment count and how many of those segments are untrusted,
+   * taken from a single {@link #segments} snapshot. Reading the two counters separately (as an earlier version of
+   * this fix did) can observe them straddling a compaction that lands in between the two reads - harmless for either
+   * number alone, but a formatted message that combines them ("N of M segments...") could then say something that
+   * was never true at any instant, such as more untrusted segments than active ones (PR #6720 review).
+   *
+   * @param total     active segment count, matching {@link #segmentCount()}
+   * @param untrusted how many of those carry a persisted precedence that predates the recency-epoch fix (issue #6379)
+   */
+  public record SegmentTrustSnapshot(int total, int untrusted) {
+  }
+
+  /**
+   * {@link #segmentTrust()}'s untrusted half, re-derived from the live {@link #segments} snapshot on every call
+   * instead of latched by {@link #untrustedEpochWarned} the way {@link #warnOnPreRecencyEpochSegments} is. A log
+   * line can only be read once, at the moment it is emitted; this can be asked again at any time - including after
+   * a {@code REBUILD INDEX}, to confirm the remedy actually worked (issue #6566). O(active segment count), the same
    * cost as {@link #segmentCount()} - cheap enough for {@link com.arcadedb.index.IndexInternal#getUpgradeWarning()}'s
    * "called on every listing" contract, which is what surfaces this to {@code schema:indexes} / Studio / the HTTP
    * admin API.
    */
   public int untrustedSegmentCount() {
-    int count = 0;
-    for (final PaginatedSegmentReader r : segments.get())
+    return segmentTrust().untrusted();
+  }
+
+  /** See {@link SegmentTrustSnapshot}. */
+  public SegmentTrustSnapshot segmentTrust() {
+    final PaginatedSegmentReader[] active = segments.get();
+    int untrusted = 0;
+    for (final PaginatedSegmentReader r : active)
       if (r.epochUntrusted())
-        count++;
-    return count;
+        untrusted++;
+    return new SegmentTrustSnapshot(active.length, untrusted);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -1960,6 +1960,17 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
    * and would otherwise say nothing, leaving only the leader's log to go on. That path runs on
    * every query, so {@link #untrustedEpochWarned} latches the line to once per engine instance
    * instead of once per refresh.
+   * <p>
+   * Deliberately says nothing about WHAT to run: {@link #indexName} here is the physical per-bucket
+   * sub-index name (as passed from {@code LSMSparseVectorIndex.openEngine()}), not the logical
+   * index {@code REBUILD INDEX} takes - the same distinction issue #6566's PR #6720 review fixed on
+   * {@link com.arcadedb.index.sparsevector.LSMSparseVectorIndex#getUpgradeWarning()}. This class has
+   * no access to the logical {@code TypeIndex} name to get that right, so it leaves the remedy to
+   * the surface that does: {@code getUpgradeWarning()} folds in {@link #untrustedSegmentCount()} for
+   * exactly this condition, and {@code LocalSchema.reportUpgradeWarning()} logs it - separately from
+   * this line - with the correct logical name and command (PR #6720 review, second round: an earlier
+   * version of this fix left this WARNING's own remedy clause wrong, so a reopen logged two lines for
+   * the same condition, one with a target that does not work).
    */
   private void warnOnPreRecencyEpochSegments(final List<PaginatedSegmentReader> readers) {
     int stale = 0;
@@ -1972,9 +1983,8 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
       return;
     LogManager.instance().log(this, Level.WARNING,
         "Sparse-vector index '%s' holds %d segment(s) whose precedence predates the recency-epoch fix (issue #6379); a "
-            + "document deleted before those segments were merged may still be returned by queries. Run "
-            + "'REBUILD INDEX %s' once to rewrite them in the correct order.",
-        null, indexName, stale, indexName);
+            + "document deleted before those segments were merged may still be returned by queries.",
+        null, indexName, stale);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3167,6 +3167,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
   /**
    * Minimum graph size to use async rebuild. Below this, synchronous rebuild is fast enough.
    * Above this threshold, a full rebuild can take seconds to minutes, so async is preferred.
+   * <p>
+   * Also the threshold {@link #flush()} uses to decide whether a close-time rebuild is cheap enough to run
+   * synchronously or should be deferred to the next open instead (issue #6067).
    */
   private static final int ASYNC_REBUILD_MIN_GRAPH_SIZE = 1000;
   private static final int[] EMPTY_ORDINALS             = new int[0];
@@ -6441,6 +6444,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 + "stay on disk and are re-indexed on the next open. This means flush() was called after "
                 + "releaseBackgroundResources() - both close paths are supposed to do the reverse",
             indexName, mutationsSinceSerialize.get());
+      } else if (needsBuild && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
+        // A synchronous full rebuild here would block close() for as long as the whole rebuild takes - measured
+        // (issue #6067) at 43s for a single write to a 200k-vector index, scaling with total index size rather
+        // than with what was actually written, because there is no incremental persist: any rebuild is a full
+        // rebuild. The vectors themselves are already durably persisted (ordinary page/WAL writes, unrelated to
+        // the graph); only the graph TOPOLOGY is stale or absent. Leave graphState as-is - MUTABLE, or LOADING
+        // with no persisted graph - and defer the rebuild to whenever this index is next actually searched,
+        // reusing the exact lazy-load/staleness-detection path (ensureGraphAvailable()) that already handles a
+        // stale persisted graph on every ordinary reopen. A session that closes and reopens without searching
+        // this index never pays the cost at all; one that does pays it at the query instead of at close().
+        LogManager.instance().log(this, Level.FINE,
+            "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
+                + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",
+            indexName, vectorIndex.size(), ASYNC_REBUILD_MIN_GRAPH_SIZE);
       } else if (needsBuild) {
         try {
           LogManager.instance()

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6505,12 +6505,33 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * recoverable - {@link #ensureGraphAvailable()} builds it from scratch on the next search - only the stats
    * signal for the gap between reopen and that search is unavailable, which is the narrower of the two arms this
    * covers.
-   *
-   * @param gf the graph file captured at the top of {@link #flush()}, before this close decided to skip the build
+   * <p>
+   * Guarded by {@link #graphBuildLock} - {@code tryLock()}, not {@code lock()} - because every other writer of
+   * this manifest (the normal post-build persist, both {@code markUnusable} failure paths) already holds it via
+   * {@code buildGraphFromScratchWithRetry()}, and {@code LSMVectorIndexGraphManifest}'s own class javadoc requires
+   * callers not to write one manifest concurrently: {@code markCloseDeferred()}'s read-then-write is not atomic,
+   * so racing it against an in-flight build's completion write could clobber a just-persisted fresh
+   * manifest with stale pre-build values. An async rebuild can still be running when {@code close()} calls
+   * {@code flush()} - {@code releaseBackgroundResources()} is what cancels it, and {@code close()} runs that
+   * AFTER {@code flush()} (see the "flush FIRST, release SECOND" note below) - so the race is real, not
+   * theoretical. A plain {@code lock()} would fix that only by blocking this close on whatever that other build
+   * still has left to do, which is exactly the synchronous-close cost issue #6067/#6653 exists to avoid; skipping
+   * the write when the lock is already held is safe instead of merely convenient - a build holding the lock is,
+   * by definition, about to run its own completion write, which clears this same flag on its own.
    */
   private void markCloseTimeRebuildDeferred(final LSMVectorIndexGraphFile gf) {
-    if (gf != null)
-      gf.getManifest().markCloseDeferred();
+    if (gf == null)
+      return;
+    if (graphBuildLock.tryLock()) {
+      try {
+        gf.getManifest().markCloseDeferred();
+      } finally {
+        graphBuildLock.unlock();
+      }
+    } else
+      LogManager.instance().log(this, Level.FINE,
+          "Not recording the close-time rebuild deferral for index %s: a graph build already holds the build "
+              + "lock and its own completion will supersede this note anyway", indexName);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6418,20 +6418,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
   public void flush() {
     if (status.compareAndSet(INDEX_STATUS.AVAILABLE, INDEX_STATUS.UNAVAILABLE)) {
 
-      // Build and persist graph if it hasn't been built yet
-      // This ensures the graph is available on next database open (fast restart)
-      // Build graph if it's in LOADING (never built) or MUTABLE (has pending changes) state
-      //
-      // LOADING means "not loaded into memory", which is not the same as "not
-      // persisted on disk": the graph loads lazily on the first search, so a
-      // session that never searched leaves it LOADING even when a complete
-      // graph is already on disk, and rebuilding then only reproduces a file
-      // that already exists. initializeGraphIndex() already draws exactly this
-      // distinction with the same predicate.
+      // Build and persist graph if it hasn't been built yet. This ensures the graph is available on next
+      // database open (fast restart). See needsGraphBuild() for exactly which states count as "needs one".
       final LSMVectorIndexGraphFile gf = graphFile;
-      final boolean graphAlreadyOnDisk = gf != null && gf.hasPersistedGraph();
-      final boolean needsBuild = vectorIndex.size() > 0 && (graphState == GraphState.MUTABLE
-          || (graphState == GraphState.LOADING && !graphAlreadyOnDisk));
+      final boolean needsBuild = needsGraphBuild(gf);
 
       if (needsBuild && !valid) {
         // Background resources are already gone, so there is no build pool to run this on - and asking for one
@@ -6492,6 +6482,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * {@code true} when the graph is behind the live vector set and a build has not been persisted for it yet.
+   * Shared between {@link #flush()} and {@link #releaseBackgroundResources()} (issue #6657's post-cancellation
+   * recheck) so the two cannot silently drift onto different predicates.
+   * <p>
+   * LOADING means "not loaded into memory", which is not the same as "not persisted on disk": the graph loads
+   * lazily on the first search, so a session that never searched leaves it LOADING even when a complete graph is
+   * already on disk, and rebuilding then only reproduces a file that already exists.
+   * {@code initializeGraphIndex()} already draws exactly this distinction with the same predicate.
+   */
+  private boolean needsGraphBuild(final LSMVectorIndexGraphFile gf) {
+    final boolean graphAlreadyOnDisk = gf != null && gf.hasPersistedGraph();
+    return vectorIndex.size() > 0 && (graphState == GraphState.MUTABLE
+        || (graphState == GraphState.LOADING && !graphAlreadyOnDisk));
+  }
+
+  /**
    * Records, in the graph's manifest sidecar, that this close chose to skip a rebuild it would otherwise have run
    * (issue #6657) - so {@link #getStats()} can answer "did the last close defer a rebuild" directly instead of an
    * operator having to go looking for the {@code FINE} log line above. Deliberately a manifest write rather than an
@@ -6515,9 +6521,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * {@code flush()} - {@code releaseBackgroundResources()} is what cancels it, and {@code close()} runs that
    * AFTER {@code flush()} (see the "flush FIRST, release SECOND" note below) - so the race is real, not
    * theoretical. A plain {@code lock()} would fix that only by blocking this close on whatever that other build
-   * still has left to do, which is exactly the synchronous-close cost issue #6067/#6653 exists to avoid; skipping
-   * the write when the lock is already held is safe instead of merely convenient - a build holding the lock is,
-   * by definition, about to run its own completion write, which clears this same flag on its own.
+   * still has left to do, which is exactly the synchronous-close cost issue #6067/#6653 exists to avoid, so a
+   * held lock is skipped here rather than waited for. That skip is not the full story on its own, though: a build
+   * holding the lock might go on to complete (its own write then correctly clears this flag) or might instead be
+   * CANCELLED by {@link #releaseBackgroundResources()} right after this method returns - and a cancelled build's
+   * {@code CancellationException} path does not touch the manifest at all. {@link #releaseBackgroundResources()}
+   * calls this method again, unconditionally, after it has cancelled and joined any in-flight build, by which
+   * point {@code graphState} reliably says which of the two happened - that second call is the actual backstop
+   * for a skip here, not "the build's completion write" alone.
    */
   private void markCloseTimeRebuildDeferred(final LSMVectorIndexGraphFile gf) {
     if (gf == null)
@@ -6636,6 +6647,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final GraphSearcherPool searchers = searcherPool;
     if (searchers != null)
       searchers.clear();
+
+    // Issue #6657, closing a false-negative gap in the deferral flag above: flush() runs BEFORE this method, so
+    // an async rebuild that flush() found already holding graphBuildLock - and therefore skipped marking, trusting
+    // "its own completion write" to account for it - may have been CANCELLED by the shutdown just above rather
+    // than actually completing. A cancelled build's CancellationException path (see the catch block around it)
+    // does not touch the manifest at all, successful or not, so the flag would otherwise sit wherever the last
+    // real build left it - typically false - even though a rebuild is now genuinely owed. By this point that
+    // build has been cancelled and joined (or logged above as a rare straggler that outlived the join), so
+    // graphState reliably distinguishes "it finished" (no longer MUTABLE, needsGraphBuild() now false - that
+    // build's own write already cleared the flag, nothing to do) from "it did not" (still MUTABLE, mark it now).
+    // Idempotent with flush()'s own attempt above: on the ordinary path where that one already succeeded, this
+    // re-write repeats the same true, at the cost of one extra small file read+write on the close of a large,
+    // recently-mutated index - not on every close.
+    final LSMVectorIndexGraphFile gfAfterRelease = graphFile;
+    if (needsGraphBuild(gfAfterRelease))
+      markCloseTimeRebuildDeferred(gfAfterRelease);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6446,6 +6446,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 + "stay on disk and are re-indexed on the next open. This means flush() was called after "
                 + "releaseBackgroundResources() - both close paths are supposed to do the reverse",
             indexName, mutationsSinceSerialize.get());
+        markCloseTimeRebuildDeferred(gf);
       } else if (needsBuild && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
         // A synchronous full rebuild here would block close() for as long as the whole rebuild takes - measured
         // (issue #6067) at 43s for a single write to a 200k-vector index, scaling with total index size rather
@@ -6463,6 +6464,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
                 + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",
             indexName, vectorIndex.size(), ASYNC_REBUILD_MIN_GRAPH_SIZE);
+        markCloseTimeRebuildDeferred(gf);
       } else if (needsBuild) {
         try {
           LogManager.instance()
@@ -6487,6 +6489,28 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 graphState);
       }
     }
+  }
+
+  /**
+   * Records, in the graph's manifest sidecar, that this close chose to skip a rebuild it would otherwise have run
+   * (issue #6657) - so {@link #getStats()} can answer "did the last close defer a rebuild" directly instead of an
+   * operator having to go looking for the {@code FINE} log line above. Deliberately a manifest write rather than an
+   * in-memory field: a fresh {@link LSMVectorIndex} instance is constructed on every database open (see the two
+   * {@code open()}/{@code create()} factory methods), so a plain field set here would be gone by the time anyone
+   * could read it - the whole point is to answer the question the moment BEFORE the next search would otherwise
+   * silently pay for it.
+   * <p>
+   * A no-op when {@code gf} is {@code null}: a never-yet-built index that was also never discovered on a previous
+   * load has no manifest path to write to. That index has no on-disk graph either, so the deferral is still fully
+   * recoverable - {@link #ensureGraphAvailable()} builds it from scratch on the next search - only the stats
+   * signal for the gap between reopen and that search is unavailable, which is the narrower of the two arms this
+   * covers.
+   *
+   * @param gf the graph file captured at the top of {@link #flush()}, before this close decided to skip the build
+   */
+  private void markCloseTimeRebuildDeferred(final LSMVectorIndexGraphFile gf) {
+    if (gf != null)
+      gf.getManifest().markCloseDeferred();
   }
 
   /**
@@ -6695,6 +6719,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
     stats.put("mutationsSinceRebuild", (long) mutationsSinceSerialize.get());
     stats.put("asyncRebuildInProgress", asyncRebuildInProgress ? 1L : 0L);
     stats.put("rebuildSnapshotGeneration", rebuildSnapshotGeneration);
+
+    // Whether the LAST close() skipped a rebuild it would otherwise have run (issue #6657), as opposed to
+    // graphState/mutationsSinceRebuild above, which cannot tell that apart from ordinary mid-session mutations.
+    // A small manifest read rather than a cached field: unlike the other stats above, this one specifically has
+    // to survive being read on a freshly reopened index, before that index's own first search - see
+    // markCloseTimeRebuildDeferred() for why a field would not.
+    final LSMVectorIndexGraphFile statsGraphFile = graphFile;
+    final LSMVectorIndexGraphManifest.Content manifestContent =
+        statsGraphFile != null ? statsGraphFile.getManifest().read() : null;
+    stats.put("closeTimeRebuildPending", manifestContent != null && manifestContent.closeDeferredRebuild() ? 1L : 0L);
 
     // Calculate mutations threshold (use configured value or default)
     final int defaultMutationsThreshold = getDatabase().getConfiguration()

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6657,9 +6657,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // build has been cancelled and joined (or logged above as a rare straggler that outlived the join), so
     // graphState reliably distinguishes "it finished" (no longer MUTABLE, needsGraphBuild() now false - that
     // build's own write already cleared the flag, nothing to do) from "it did not" (still MUTABLE, mark it now).
-    // Idempotent with flush()'s own attempt above: on the ordinary path where that one already succeeded, this
-    // re-write repeats the same true, at the cost of one extra small file read+write on the close of a large,
-    // recently-mutated index - not on every close.
+    // Idempotent with flush()'s own attempt above: on the ordinary path where that one already succeeded,
+    // markCloseDeferred()'s own already-true short-circuit turns this into a single extra read, not a rewrite -
+    // and only on the close of a large, recently-mutated index, not on every close.
+    //
+    // Known residual gap, same shape one layer further out: markCloseTimeRebuildDeferred()'s own tryLock() can
+    // still lose to a STRAGGLER build thread - one that outlived shutdownNow()'s 5s budget and the pool's
+    // awaitTermination() above (see the WARNING logged a few lines up) - if that straggler happens to be the one
+    // holding graphBuildLock at the exact moment this recheck runs. Narrow (needs both an unresponsive build AND
+    // it specifically being the lock holder right now) and not chased further: unlike the cancellation case this
+    // recheck exists for, there is no later "the build is definitely done by now" moment available to retry from
+    // inside this method. Same acceptance as the gf == null case in markCloseTimeRebuildDeferred()'s javadoc -
+    // documented rather than solved.
     final LSMVectorIndexGraphFile gfAfterRelease = graphFile;
     if (needsGraphBuild(gfAfterRelease))
       markCloseTimeRebuildDeferred(gfAfterRelease);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1344,11 +1344,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (graphState != GraphState.LOADING)
       return; // Graph already available or being built
 
-    lock.writeLock().lock();
+    // Serialize against buildGraphFromScratch() and other concurrent callers of this method, the same way
+    // buildGraphFromScratchWithRetry() serializes builders against each other (issue #6713). The persisted-graph
+    // validation below is O(live vector count) - for quantization types without inline storage it is one document
+    // lookup plus one property read per live vector - and used to run entirely under lock.writeLock(), stalling
+    // every reader and writer of the index for the whole scan on a session's first search that finds a persisted
+    // graph after a reopen, exactly the stall issue #5391 already moved buildGraphFromScratchExclusively's own
+    // validation loop off of. Builders wait on this mutex; searches and inserts never touch it, so serializing
+    // here does not reintroduce the stall. graphBuildLock is reentrant, so the fallback call to
+    // buildGraphFromScratch() at the end of this method - which acquires the same lock - is safe from here.
+    graphBuildLock.lock();
     try {
-      // Double-check after acquiring lock
+      // Double-check after acquiring the lock
       if (graphState != GraphState.LOADING)
-        return; // Another thread already started building
+        return; // Another thread already resolved this while we waited for graphBuildLock
 
       // Try to load persisted graph from disk
       // IMPORTANT: If PRODUCT quantization is enabled but PQ file doesn't exist, we need to rebuild
@@ -1492,10 +1501,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 indexName, staleReason);
             // Don't use the stale graph — fall through to buildGraphFromScratch() below
           } else {
-            // Graph is up to date — use it
-            this.graphIndex = loadedGraph;
-            this.graphState = GraphState.IMMUTABLE;
-            this.ordinalToVectorId = rebuiltOrdinalToVectorId;
+            // Graph is up to date — publish it under a brief write lock (issue #6713), then finish PQ
+            // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
+            lock.writeLock().lock();
+            try {
+              this.graphIndex = loadedGraph;
+              this.ordinalToVectorId = rebuiltOrdinalToVectorId;
+              if (graphState == GraphState.LOADING)
+                this.graphState = GraphState.IMMUTABLE;
+              // else: a concurrent put()/putBatch()/remove() already advanced graphState to MUTABLE while
+              // this validation ran unlocked. The freshly loaded graph is still a correct base for
+              // mergeWithDeltaScan() to merge against - it was built from a vectorIndex snapshot taken during
+              // that validation, and whatever changed since then is already in deltaVectors - but overwriting
+              // MUTABLE back to IMMUTABLE here would hide those pending deltas from search.
+            } finally {
+              lock.writeLock().unlock();
+            }
 
             // Build PQ if PRODUCT quantization is enabled but PQ file doesn't exist
             // This handles the case where graph was built before PRODUCT quantization was added
@@ -1523,12 +1544,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
         }
       }
 
+      // No persisted graph, load failed, or it was stale - build from scratch. buildGraphFromScratch()
+      // acquires graphBuildLock itself; since it is reentrant this is safe to call while already holding it.
+      buildGraphFromScratch();
     } finally {
-      lock.writeLock().unlock();
+      graphBuildLock.unlock();
     }
-
-    // No persisted graph or load failed - build from scratch
-    buildGraphFromScratch();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3169,7 +3169,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Above this threshold, a full rebuild can take seconds to minutes, so async is preferred.
    * <p>
    * Also the threshold {@link #flush()} uses to decide whether a close-time rebuild is cheap enough to run
-   * synchronously or should be deferred to the next open instead (issue #6067).
+   * synchronously or should be deferred to the next SEARCH on this index instead (issue #6067) - opening the
+   * database alone never triggers it, only {@link #ensureGraphAvailable()}/{@link #rebuildGraphBeforeSearch()}
+   * do, and that deferred rebuild is itself still synchronous on whichever search first reaches it, not async.
    */
   private static final int ASYNC_REBUILD_MIN_GRAPH_SIZE = 1000;
   private static final int[] EMPTY_ORDINALS             = new int[0];
@@ -6453,7 +6455,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // with no persisted graph - and defer the rebuild to whenever this index is next actually searched,
         // reusing the exact lazy-load/staleness-detection path (ensureGraphAvailable()) that already handles a
         // stale persisted graph on every ordinary reopen. A session that closes and reopens without searching
-        // this index never pays the cost at all; one that does pays it at the query instead of at close().
+        // this index never pays the cost at all; one that does pays it at the query instead of at close() - that
+        // follow-up rebuild is itself still synchronous on the search that triggers it (ensureGraphAvailable()'s
+        // stale-graph fallback is not gated by this same threshold), so this trades an unconditional cost on
+        // EVERY close() for a conditional one paid by at most one search, not for a non-blocking one.
         LogManager.instance().log(this, Level.FINE,
             "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
                 + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -236,6 +236,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // Serializes graph builds for this index (issue #5391). Held only by builders, never by readers or writers.
   private final ReentrantLock graphBuildLock = new ReentrantLock();
 
+  // Set only inside flush()'s two SKIP branches (issue #6657) - never by the branch that actually attempts a
+  // synchronous build, successfully or not - so releaseBackgroundResources()'s recheck of the same flag (see
+  // there) can tell "flush() chose not to pay for a rebuild" apart from "flush() tried and either failed or got
+  // re-mutated mid-build", which also leaves graphState at MUTABLE but is a different story the recheck must not
+  // relabel as a deferral. Reset at the top of every flush(), so a stale true from an earlier close on this same
+  // instance can never leak into a later, unrelated one. Plain instance field, not persisted: unlike the manifest
+  // flag it gates, its only job is to bridge flush() and releaseBackgroundResources() within ONE close() call on
+  // ONE instance, which is exactly the lifetime a field has.
+  private volatile boolean flushDeferredRebuild = false;
+
   // Index-scoped cache of materialized vectors, shared by every search on this index (issue #5412).
   // Beam search resolves one vector per distance evaluation; before this cache lived at index scope, each
   // query built its own 1024-entry map and discarded it on completion, so every query paid a full record
@@ -6423,6 +6433,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final LSMVectorIndexGraphFile gf = graphFile;
       final boolean needsBuild = needsGraphBuild(gf);
 
+      // Reset before deciding: see the field javadoc for why releaseBackgroundResources() needs this to
+      // distinguish "this flush() skipped" from "this flush() attempted (and possibly failed)".
+      flushDeferredRebuild = false;
+
       if (needsBuild && !valid) {
         // Background resources are already gone, so there is no build pool to run this on - and asking for one
         // would not fail, it would quietly BUILD one: getOrCreateGraphBuildPool() replaces a shut-down pool, and
@@ -6436,6 +6450,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 + "stay on disk and are re-indexed on the next open. This means flush() was called after "
                 + "releaseBackgroundResources() - both close paths are supposed to do the reverse",
             indexName, mutationsSinceSerialize.get());
+        flushDeferredRebuild = true;
         markCloseTimeRebuildDeferred(gf);
       } else if (needsBuild && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
         // A synchronous full rebuild here would block close() for as long as the whole rebuild takes - measured
@@ -6454,6 +6469,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
                 + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",
             indexName, vectorIndex.size(), ASYNC_REBUILD_MIN_GRAPH_SIZE);
+        flushDeferredRebuild = true;
         markCloseTimeRebuildDeferred(gf);
       } else if (needsBuild) {
         try {
@@ -6657,6 +6673,19 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // build has been cancelled and joined (or logged above as a rare straggler that outlived the join), so
     // graphState reliably distinguishes "it finished" (no longer MUTABLE, needsGraphBuild() now false - that
     // build's own write already cleared the flag, nothing to do) from "it did not" (still MUTABLE, mark it now).
+    //
+    // Gated on flushDeferredRebuild, not on needsGraphBuild() alone (review round 4): flush()'s OTHER branch -
+    // the one that actually ATTEMPTS a synchronous build rather than skipping - can also leave graphState at
+    // MUTABLE, either because the attempt failed (buildGraphFromScratchExclusively() then correctly writes
+    // closeDeferredRebuild=false via markUnusable()) or because new mutations arrived mid-build. Neither of those
+    // is "flush() chose to defer", and rechecking unconditionally would overwrite that correct false with a
+    // misleading true - mislabeling "close attempted a rebuild and it failed" as "close skipped the rebuild for
+    // performance". flushDeferredRebuild is set only inside flush()'s two skip branches and reset at the top of
+    // every flush(), so it answers exactly the question this recheck needs: did THIS close's flush() skip, not
+    // just "is a rebuild still owed for some reason". As a side effect this also keeps the recheck from ever
+    // firing on a path that never called flush() at all - LocalDatabase.closeInternal(true) (whole-database
+    // drop) and LocalDatabase.kill() (crash simulation) both call releaseBackgroundResources() without one.
+    //
     // Idempotent with flush()'s own attempt above: on the ordinary path where that one already succeeded,
     // markCloseDeferred()'s own already-true short-circuit turns this into a single extra read, not a rewrite -
     // and only on the close of a large, recently-mutated index, not on every close.
@@ -6669,9 +6698,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // recheck exists for, there is no later "the build is definitely done by now" moment available to retry from
     // inside this method. Same acceptance as the gf == null case in markCloseTimeRebuildDeferred()'s javadoc -
     // documented rather than solved.
-    final LSMVectorIndexGraphFile gfAfterRelease = graphFile;
-    if (needsGraphBuild(gfAfterRelease))
-      markCloseTimeRebuildDeferred(gfAfterRelease);
+    if (flushDeferredRebuild) {
+      final LSMVectorIndexGraphFile gfAfterRelease = graphFile;
+      if (needsGraphBuild(gfAfterRelease))
+        markCloseTimeRebuildDeferred(gfAfterRelease);
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -88,12 +88,12 @@ public class LSMVectorIndexGraphManifest {
    * @param vectorCount         number of ordinals the graph was built over, or {@link #UNUSABLE_VECTOR_COUNT}
    * @param fingerprint         fingerprint of the ordinal &rarr; (vector id, RID) correspondence
    * @param closeDeferredRebuild {@code true} when the pages this manifest describes are known stale because the
-   *                            most recent {@code close()} chose to defer the rebuild that would otherwise have
-   *                            brought them up to date (issue #6657), rather than run it synchronously. Always
-   *                            {@code false} again once a build actually completes - {@link #write(int, long)} and
-   *                            {@link #markUnusable(String)} both clear it - so it answers specifically "did the
-   *                            last close skip a rebuild", not the broader "is a rebuild owed" that
-   *                            {@code vectorCount}/{@code fingerprint} against the live index already answers.
+   *                             most recent {@code close()} chose to defer the rebuild that would otherwise have
+   *                             brought them up to date (issue #6657), rather than run it synchronously. Always
+   *                             {@code false} again once a build actually completes - {@link #write(int, long)} and
+   *                             {@link #markUnusable(String)} both clear it - so it answers specifically "did the
+   *                             last close skip a rebuild", not the broader "is a rebuild owed" that
+   *                             {@code vectorCount}/{@code fingerprint} against the live index already answers.
    */
   public record Content(int formatVersion, int vectorCount, long fingerprint, boolean closeDeferredRebuild) {
   }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -84,11 +84,18 @@ public class LSMVectorIndexGraphManifest {
   /**
    * What a persisted manifest says about the graph next to it.
    *
-   * @param formatVersion version of this file's own layout
-   * @param vectorCount   number of ordinals the graph was built over, or {@link #UNUSABLE_VECTOR_COUNT}
-   * @param fingerprint   fingerprint of the ordinal &rarr; (vector id, RID) correspondence
+   * @param formatVersion       version of this file's own layout
+   * @param vectorCount         number of ordinals the graph was built over, or {@link #UNUSABLE_VECTOR_COUNT}
+   * @param fingerprint         fingerprint of the ordinal &rarr; (vector id, RID) correspondence
+   * @param closeDeferredRebuild {@code true} when the pages this manifest describes are known stale because the
+   *                            most recent {@code close()} chose to defer the rebuild that would otherwise have
+   *                            brought them up to date (issue #6657), rather than run it synchronously. Always
+   *                            {@code false} again once a build actually completes - {@link #write(int, long)} and
+   *                            {@link #markUnusable(String)} both clear it - so it answers specifically "did the
+   *                            last close skip a rebuild", not the broader "is a rebuild owed" that
+   *                            {@code vectorCount}/{@code fingerprint} against the live index already answers.
    */
-  public record Content(int formatVersion, int vectorCount, long fingerprint) {
+  public record Content(int formatVersion, int vectorCount, long fingerprint, boolean closeDeferredRebuild) {
   }
 
   private final Path path;
@@ -175,15 +182,34 @@ public class LSMVectorIndexGraphManifest {
    * @param reason human-readable note stored in the file; nothing reads it back
    */
   public void markUnusable(final String reason) {
-    write(UNUSABLE_VECTOR_COUNT, 0L, reason);
+    write(UNUSABLE_VECTOR_COUNT, 0L, reason, false);
   }
 
   /**
    * Records the correspondence the just-committed graph was built over. Written through a temporary file so a
-   * crash mid-write cannot leave a truncated manifest that reads as a valid one.
+   * crash mid-write cannot leave a truncated manifest that reads as a valid one. Always clears
+   * {@link Content#closeDeferredRebuild()}: a build that reached this call completed, so whatever a previous
+   * {@code close()} deferred has now been paid for.
    */
   public void write(final int vectorCount, final long fingerprint) {
-    write(vectorCount, fingerprint, null);
+    write(vectorCount, fingerprint, null, false);
+  }
+
+  /**
+   * Marks the currently-described graph as stale because {@code close()} deferred the rebuild that would have
+   * refreshed it (issue #6657), rather than running it. Preserves whatever {@code vectorCount}/{@code fingerprint}
+   * are already on disk - this is not a new build, just a note that the existing pages are now known outdated -
+   * or falls back to {@link #UNUSABLE_VECTOR_COUNT} when nothing has ever been persisted here, so a first-ever
+   * build that a large index's close deferred is recorded too.
+   * <p>
+   * Cleared automatically the next time {@link #write(int, long)} or {@link #markUnusable(String)} runs, which is
+   * exactly when a rebuild - deferred or not - actually completes.
+   */
+  public void markCloseDeferred() {
+    final Content existing = read();
+    final int vectorCount = existing != null ? existing.vectorCount() : UNUSABLE_VECTOR_COUNT;
+    final long fingerprint = existing != null ? existing.fingerprint() : 0L;
+    write(vectorCount, fingerprint, null, true);
   }
 
   /**
@@ -193,7 +219,8 @@ public class LSMVectorIndexGraphManifest {
    * two different places, and a shared temp name would turn a future change to either of them into a corrupted
    * manifest. A unique name costs nothing and removes the assumption.
    */
-  private void write(final int vectorCount, final long fingerprint, final String reason) {
+  private void write(final int vectorCount, final long fingerprint, final String reason,
+      final boolean closeDeferredRebuild) {
     final Path temporary = path.resolveSibling(
         path.getFileName() + "." + Long.toHexString(System.nanoTime()) + ".tmp");
     try {
@@ -213,6 +240,7 @@ public class LSMVectorIndexGraphManifest {
       json.put("vectorCount", vectorCount);
       // As a string: a 64-bit fingerprint is not representable in the double a JSON number decodes to.
       json.put("fingerprint", Long.toString(fingerprint));
+      json.put("closeDeferredRebuild", closeDeferredRebuild);
       if (reason != null)
         json.put("reason", reason);
 
@@ -272,7 +300,8 @@ public class LSMVectorIndexGraphManifest {
         return null;
       }
       return new Content(formatVersion, json.getInt("vectorCount", -1),
-          Long.parseLong(json.getString("fingerprint", "0")));
+          Long.parseLong(json.getString("fingerprint", "0")),
+          json.getBoolean("closeDeferredRebuild", false));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "Could not read the vector graph manifest '%s': %s", path,
           e.getMessage());

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -210,9 +210,16 @@ public class LSMVectorIndexGraphManifest {
    * WARNING by {@link #read()}, not thrown) - indistinguishable from here. Accepted rather than plumbed through:
    * the fallback only downgrades an otherwise-valid manifest to "not usable", which forces one extra rebuild on
    * the next load and self-heals from there, the same cost a genuinely corrupt manifest would already pay.
+   * <p>
+   * Short-circuits to a single {@link #read()} (no write at all) when the flag already reads {@code true}: a
+   * large index left with pending mutations and closed repeatedly with no intervening search - each close still
+   * seeing the same {@code needsGraphBuild()} - would otherwise re-persist an identical manifest (temp file,
+   * write, atomic rename) on every single one of those closes for no observable change.
    */
   public void markCloseDeferred() {
     final Content existing = read();
+    if (existing != null && existing.closeDeferredRebuild())
+      return;
     final int vectorCount = existing != null ? existing.vectorCount() : UNUSABLE_VECTOR_COUNT;
     final long fingerprint = existing != null ? existing.fingerprint() : 0L;
     write(vectorCount, fingerprint, null, true);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -204,6 +204,12 @@ public class LSMVectorIndexGraphManifest {
    * <p>
    * Cleared automatically the next time {@link #write(int, long)} or {@link #markUnusable(String)} runs, which is
    * exactly when a rebuild - deferred or not - actually completes.
+   * <p>
+   * {@code read() == null} is treated as "nothing persisted yet" and takes the {@link #UNUSABLE_VECTOR_COUNT}
+   * fallback, which is also what a transient read failure or a format-version mismatch report (both logged as
+   * WARNING by {@link #read()}, not thrown) - indistinguishable from here. Accepted rather than plumbed through:
+   * the fallback only downgrades an otherwise-valid manifest to "not usable", which forces one extra rebuild on
+   * the next load and self-heals from there, the same cost a genuinely corrupt manifest would already pay.
    */
   public void markCloseDeferred() {
     final Content existing = read();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -143,7 +143,7 @@ public class ShortestPathExpression implements Expression {
     if (constraint != null) {
       final String[] typesArray = edgeTypes == null || edgeTypes.isEmpty() ? null : edgeTypes.toArray(new String[0]);
       final List<Object> filtered = ShortestPathStep.computeFilteredShortestPath(startVertex, endVertex,
-          traversalDirection, typesArray, constraint);
+          traversalDirection, typesArray, constraint, context);
       if (filtered == null || filtered.isEmpty())
         return allPaths ? new ArrayList<>() : null;
       // allShortestPaths() in expression position still yields the single shortest path found, matching the

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1422,6 +1422,7 @@ public class CypherExecutionPlan {
             applyProjectionToScope(nextWith.getItems(), boundVariables);
             // the skipped WITH starts a new segment (issue #6631)
             closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
+            propagateTaintThroughRenames(nextWith, disconnectedTaintedVariables);
             break;
           }
 
@@ -1436,6 +1437,7 @@ public class CypherExecutionPlan {
             applyProjectionToScope(nextWith.getItems(), boundVariables);
             // the skipped WITH starts a new segment (issue #6631)
             closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
+            propagateTaintThroughRenames(nextWith, disconnectedTaintedVariables);
             break;
           }
         }
@@ -1452,6 +1454,9 @@ public class CypherExecutionPlan {
         // hazard for that variable, since rows still flow through it one at a time rather than being
         // fully consumed; closeMatchSegment() taints it before the segment is cleared.
         closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
+        // A rename (WITH n AS m) doesn't change how rows flow either - propagate the taint onto the
+        // new name too, or a later DELETE of m would find nothing tainted under that name.
+        propagateTaintThroughRenames(withClause, disconnectedTaintedVariables);
         break;
 
       case MERGE:
@@ -2567,6 +2572,28 @@ public class CypherExecutionPlan {
               disconnectedTaintedVariables.add(relationship.getVariable());
         }
     currentSegmentMatchClauses.clear();
+  }
+
+  /**
+   * Propagates taint through a {@code WITH ... AS alias} rename: a rename doesn't change how rows flow
+   * any more than a same-name passthrough does (see {@link #closeMatchSegment}), so if the item being
+   * renamed is a bare reference to an already-tainted variable, its new alias is tainted too - otherwise
+   * a later DELETE of the alias would find nothing tainted under that name, even though it is exactly as
+   * hazardous as deleting the original variable would have been.
+   * <p>
+   * Only a bare variable reference is recognised as "the same entity under a new name" ({@code WITH n AS
+   * m}); an item computed from a tainted variable by any other expression ({@code WITH n.id AS m}, {@code
+   * WITH count(n) AS m}) produces a value that is no longer that entity, so it carries no taint forward.
+   */
+  private static void propagateTaintThroughRenames(final WithClause withClause,
+      final Set<String> disconnectedTaintedVariables) {
+    if (disconnectedTaintedVariables.isEmpty())
+      return;
+    for (final ReturnClause.ReturnItem item : withClause.getItems())
+      if (!item.isStar() && item.getAlias() != null
+          && item.getExpression() instanceof VariableExpression variableExpression
+          && disconnectedTaintedVariables.contains(variableExpression.getVariableName()))
+        disconnectedTaintedVariables.add(item.getAlias());
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1132,7 +1132,11 @@ public class CypherExecutionPlan {
           final WithClause withClause = entry.getTypedClause();
           currentStep = buildWithStepForOptimizer(withClause, currentStep, context, functionFactory);
           // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE
-          // that comes after it (issue #6631).
+          // that comes after it (issue #6631). Unlike buildExecutionStepsWithOrder()'s WITH case, a
+          // plain clear() here (no taint tracking for a DELETE that plainly forwards a disconnected
+          // variable through this WITH) is safe: CypherExecutionPlanner.shouldUseOptimizer() already
+          // refuses to build a physical plan at all when a mutating clause (DELETE included) follows any
+          // WITH, so this method never builds a DELETE fed by an already-cleared segment.
           currentSegmentMatchClauses.clear();
           break;
         }
@@ -1318,6 +1322,9 @@ public class CypherExecutionPlan {
     // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
     // whichever DELETE/FOREACH segment is reached next - see matchClausesHaveDisconnectedPatterns().
     final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
+    // Variables bound by a segment that WAS disconnected, kept forever once tainted (even across a WITH
+    // that merely forwards them unchanged) - see closeMatchSegment() and deleteMayTargetTaintedVariable().
+    final Set<String> disconnectedTaintedVariables = new HashSet<>();
 
     // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
     // never look at the incoming rows. That makes the enumerating form of them wrong the moment the seed row binds
@@ -1413,7 +1420,8 @@ public class CypherExecutionPlan {
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
             applyProjectionToScope(nextWith.getItems(), boundVariables);
-            currentSegmentMatchClauses.clear(); // the skipped WITH starts a new segment
+            // the skipped WITH starts a new segment (issue #6631)
+            closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
             break;
           }
 
@@ -1426,7 +1434,8 @@ public class CypherExecutionPlan {
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
             applyProjectionToScope(nextWith.getItems(), boundVariables);
-            currentSegmentMatchClauses.clear(); // the skipped WITH starts a new segment
+            // the skipped WITH starts a new segment (issue #6631)
+            closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
             break;
           }
         }
@@ -1438,9 +1447,11 @@ public class CypherExecutionPlan {
         currentStep = buildWithStep(withClause, currentStep, context, functionFactory);
         // An explicit WITH resets the scope to its own output variables; WITH * forwards the incoming one
         applyProjectionToScope(withClause.getItems(), boundVariables);
-        // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE/FOREACH
-        // that comes after it (issue #6631).
-        currentSegmentMatchClauses.clear();
+        // A WITH boundary starts a new segment (issue #6631) - but a WITH that plainly forwards a
+        // variable bound by a disconnected-pattern MATCH (e.g. WITH n, o) does not resolve the #6491
+        // hazard for that variable, since rows still flow through it one at a time rather than being
+        // fully consumed; closeMatchSegment() taints it before the segment is cleared.
+        closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
         break;
 
       case MERGE:
@@ -1487,8 +1498,9 @@ public class CypherExecutionPlan {
       case DELETE:
         final DeleteClause deleteClause = entry.getTypedClause();
         if (!deleteClause.isEmpty() && currentStep != null) {
-          final DeleteStep deleteStep =
-              new DeleteStep(deleteClause, context, matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
+          final boolean eagerMaterialize = matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
+              || deleteMayTargetTaintedVariable(deleteClause.getVariables(), disconnectedTaintedVariables);
+          final DeleteStep deleteStep = new DeleteStep(deleteClause, context, eagerMaterialize);
           deleteStep.setPrevious(currentStep);
           currentStep = deleteStep;
         }
@@ -1515,9 +1527,11 @@ public class CypherExecutionPlan {
 
       case FOREACH:
         final ForeachClause foreachClause = entry.getTypedClause();
+        final boolean foreachEagerMaterialize = foreachClause.containsDelete()
+            && (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
+                || deleteMayTargetTaintedVariable(collectForeachDeleteTargetVariables(foreachClause), disconnectedTaintedVariables));
         final ForeachStep foreachStep =
-            new ForeachStep(foreachClause, context, functionFactory,
-                foreachClause.containsDelete() && matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
+            new ForeachStep(foreachClause, context, functionFactory, foreachEagerMaterialize);
         if (currentStep != null) {
           foreachStep.setPrevious(currentStep);
         }
@@ -2525,6 +2539,77 @@ public class CypherExecutionPlan {
   }
 
   /**
+   * Closes the MATCH segment tracked in {@code currentSegmentMatchClauses} at a WITH boundary: if the
+   * segment being closed is itself disconnected, every node variable it bound is added to {@code
+   * disconnectedTaintedVariables} before the segment list is cleared for the next one.
+   * <p>
+   * A WITH that plainly forwards such a variable (e.g. {@code WITH n, o}) does not neutralize the
+   * issue #6491 hazard for it: rows out of a disconnected-pattern MATCH still flow one at a time through
+   * a non-aggregating WITH, so a later DELETE of that same variable can still race a not-yet-produced
+   * row exactly as it would with no WITH in between. Once tainted, a variable stays tainted for the rest
+   * of the statement - this can only make {@link #deleteMayTargetTaintedVariable} keep guarding a DELETE
+   * that no longer strictly needs it (e.g. after several more WITH-forwarding hops), never miss one that
+   * does; see the class-level trade-off note on {@link #matchClausesHaveDisconnectedPatterns}.
+   */
+  private static void closeMatchSegment(final List<MatchClause> currentSegmentMatchClauses,
+      final Set<String> disconnectedTaintedVariables) {
+    if (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses))
+      for (final MatchClause match : currentSegmentMatchClauses)
+        for (final PathPattern path : match.getPathPatterns())
+          for (final NodePattern node : path.getNodes())
+            if (node.getVariable() != null)
+              disconnectedTaintedVariables.add(node.getVariable());
+    currentSegmentMatchClauses.clear();
+  }
+
+  /**
+   * True when at least one of the given DELETE targets might read a variable in {@code
+   * disconnectedTaintedVariables} - see {@link #closeMatchSegment}.
+   * <p>
+   * A target that is a bare variable name is checked directly. A target that is a chained-access or
+   * function-call expression (e.g. {@code endNode(r)}, {@code p.node.id}) is not parsed here - it is
+   * conservatively treated as a possible reference to any tainted variable, mirroring how {@code
+   * DeleteStep} itself only special-cases the plain-variable form and falls back to full expression
+   * evaluation otherwise.
+   */
+  private static boolean deleteMayTargetTaintedVariable(final List<String> deleteTargets,
+      final Set<String> disconnectedTaintedVariables) {
+    if (disconnectedTaintedVariables.isEmpty() || deleteTargets == null)
+      return false;
+    for (final String target : deleteTargets) {
+      if (target.indexOf('.') < 0 && target.indexOf('[') < 0 && target.indexOf('(') < 0) {
+        if (disconnectedTaintedVariables.contains(target))
+          return true;
+      } else
+        return true; // non-trivial expression: cannot rule out a reference to a tainted variable
+    }
+    return false;
+  }
+
+  /**
+   * Collects the DELETE target variables of every DELETE clause in a FOREACH body, including nested
+   * FOREACH bodies - the same traversal as {@link ForeachClause#containsDelete()}, but gathering the
+   * targets instead of just checking for their presence.
+   */
+  private static List<String> collectForeachDeleteTargetVariables(final ForeachClause foreachClause) {
+    final List<String> targets = new ArrayList<>();
+    collectForeachDeleteTargetVariables(foreachClause, targets);
+    return targets;
+  }
+
+  private static void collectForeachDeleteTargetVariables(final ForeachClause foreachClause, final List<String> targets) {
+    for (final ClauseEntry entry : foreachClause.getInnerClauses()) {
+      if (entry.getType() == ClauseEntry.ClauseType.DELETE) {
+        final DeleteClause deleteClause = entry.getTypedClause();
+        if (deleteClause.getVariables() != null)
+          targets.addAll(deleteClause.getVariables());
+      } else if (entry.getType() == ClauseEntry.ClauseType.FOREACH) {
+        collectForeachDeleteTargetVariables((ForeachClause) entry.getTypedClause(), targets);
+      }
+    }
+  }
+
+  /**
    * Legacy method for building execution steps (fixed order).
    * Used when clause order information is not available.
    */
@@ -3024,6 +3109,13 @@ public class CypherExecutionPlan {
     }
 
     // Step 6: DELETE clause - delete vertices/edges
+    // Unscoped (statement.getMatchClauses()) is fine here, unlike the other two DeleteStep construction
+    // sites (issue #6631): this method only runs when statement.getClausesInOrder() is null/empty, which
+    // for a real parsed statement only happens when it has no tracked clauses of any kind - a
+    // WITH-containing, multi-segment statement always populates clausesInOrder. This method is also
+    // single-segment by construction regardless (it reads statement.getDeleteClause() and
+    // statement.getMatchClauses() - one flat list each, not one per WITH-delimited segment), so it never
+    // sees the multi-segment shape #6631 is about.
     if (statement.getDeleteClause() != null && !statement.getDeleteClause().isEmpty() && currentStep != null) {
       final DeleteStep deleteStep = new DeleteStep(
           statement.getDeleteClause(), context, matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2540,8 +2540,11 @@ public class CypherExecutionPlan {
 
   /**
    * Closes the MATCH segment tracked in {@code currentSegmentMatchClauses} at a WITH boundary: if the
-   * segment being closed is itself disconnected, every node variable it bound is added to {@code
-   * disconnectedTaintedVariables} before the segment list is cleared for the next one.
+   * segment being closed is itself disconnected, every node AND relationship variable it bound is added
+   * to {@code disconnectedTaintedVariables} before the segment list is cleared for the next one - a
+   * disconnected MATCH can rebind the same underlying edge across rows exactly as it can a vertex (see
+   * {@code DeleteStep}'s own {@code eagerMaterialize} field doc), so {@code DELETE r} needs the same
+   * guard as {@code DELETE n}.
    * <p>
    * A WITH that plainly forwards such a variable (e.g. {@code WITH n, o}) does not neutralize the
    * issue #6491 hazard for it: rows out of a disconnected-pattern MATCH still flow one at a time through
@@ -2555,10 +2558,14 @@ public class CypherExecutionPlan {
       final Set<String> disconnectedTaintedVariables) {
     if (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses))
       for (final MatchClause match : currentSegmentMatchClauses)
-        for (final PathPattern path : match.getPathPatterns())
+        for (final PathPattern path : match.getPathPatterns()) {
           for (final NodePattern node : path.getNodes())
             if (node.getVariable() != null)
               disconnectedTaintedVariables.add(node.getVariable());
+          for (final RelationshipPattern relationship : path.getRelationships())
+            if (relationship.getVariable() != null)
+              disconnectedTaintedVariables.add(relationship.getVariable());
+        }
     currentSegmentMatchClauses.clear();
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1051,6 +1051,9 @@ public class CypherExecutionPlan {
     // Apply post-MATCH operations using clausesInOrder to respect the order they appear
     // in the query (e.g. WITH before UNWIND, not the other way around).
     final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
+    // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
+    // whichever DELETE segment is reached next - see matchClausesHaveDisconnectedPatterns().
+    final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
     if (clausesInOrder != null) {
       for (final ClauseEntry entry : clausesInOrder) {
         switch (entry.getType()) {
@@ -1058,6 +1061,7 @@ public class CypherExecutionPlan {
           // MATCH pattern is handled by the optimizer above, but WHERE clauses
           // attached to MATCH clauses still need to be applied as filters.
           final MatchClause matchClause = entry.getTypedClause();
+          currentSegmentMatchClauses.add(matchClause);
           if (matchClause.hasWhereClause()) {
             final FilterPropertiesStep filterStep =
                 new FilterPropertiesStep(matchClause.getWhereClause(), context);
@@ -1091,7 +1095,7 @@ public class CypherExecutionPlan {
           final DeleteClause deleteClause = entry.getTypedClause();
           if (!deleteClause.isEmpty()) {
             final DeleteStep deleteStep = new DeleteStep(deleteClause, context,
-                matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));
+                matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
             deleteStep.setPrevious(currentStep);
             currentStep = deleteStep;
           }
@@ -1127,6 +1131,9 @@ public class CypherExecutionPlan {
         case WITH: {
           final WithClause withClause = entry.getTypedClause();
           currentStep = buildWithStepForOptimizer(withClause, currentStep, context, functionFactory);
+          // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE
+          // that comes after it (issue #6631).
+          currentSegmentMatchClauses.clear();
           break;
         }
 
@@ -1308,6 +1315,10 @@ public class CypherExecutionPlan {
     // can detect already-bound variables and avoid Cartesian products
     final Set<String> boundVariables = new HashSet<>(seedVariableNames);
 
+    // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
+    // whichever DELETE/FOREACH segment is reached next - see matchClausesHaveDisconnectedPatterns().
+    final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
+
     // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
     // never look at the incoming rows. That makes the enumerating form of them wrong the moment the seed row binds
     // one of those pattern variables - a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound to one
@@ -1391,6 +1402,7 @@ public class CypherExecutionPlan {
 
       case MATCH:
         final MatchClause matchClause = entry.getTypedClause();
+        currentSegmentMatchClauses.add(matchClause);
         if (matchClause.isOptional()) {
           // Try chained count optimization first (handles 2 consecutive OPTIONAL MATCH + count)
           final AbstractExecutionStep chainedOptimized = tryOptimizeChainedOptionalMatchCount(
@@ -1401,6 +1413,7 @@ public class CypherExecutionPlan {
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
             applyProjectionToScope(nextWith.getItems(), boundVariables);
+            currentSegmentMatchClauses.clear(); // the skipped WITH starts a new segment
             break;
           }
 
@@ -1413,6 +1426,7 @@ public class CypherExecutionPlan {
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
             applyProjectionToScope(nextWith.getItems(), boundVariables);
+            currentSegmentMatchClauses.clear(); // the skipped WITH starts a new segment
             break;
           }
         }
@@ -1424,6 +1438,9 @@ public class CypherExecutionPlan {
         currentStep = buildWithStep(withClause, currentStep, context, functionFactory);
         // An explicit WITH resets the scope to its own output variables; WITH * forwards the incoming one
         applyProjectionToScope(withClause.getItems(), boundVariables);
+        // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE/FOREACH
+        // that comes after it (issue #6631).
+        currentSegmentMatchClauses.clear();
         break;
 
       case MERGE:
@@ -1471,7 +1488,7 @@ public class CypherExecutionPlan {
         final DeleteClause deleteClause = entry.getTypedClause();
         if (!deleteClause.isEmpty() && currentStep != null) {
           final DeleteStep deleteStep =
-              new DeleteStep(deleteClause, context, matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));
+              new DeleteStep(deleteClause, context, matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
           deleteStep.setPrevious(currentStep);
           currentStep = deleteStep;
         }
@@ -1500,7 +1517,7 @@ public class CypherExecutionPlan {
         final ForeachClause foreachClause = entry.getTypedClause();
         final ForeachStep foreachStep =
             new ForeachStep(foreachClause, context, functionFactory,
-                foreachClause.containsDelete() && matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));
+                foreachClause.containsDelete() && matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
         if (currentStep != null) {
           foreachStep.setPrevious(currentStep);
         }
@@ -2485,7 +2502,7 @@ public class CypherExecutionPlan {
   }
 
   /**
-   * True when the statement's MATCH clauses, combined, have disconnected path patterns (see
+   * True when the given MATCH clauses, combined, have disconnected path patterns (see
    * {@link MatchClause#hasDisconnectedPathPatterns(List)}). A DELETE fed by such a MATCH must fully
    * read the upstream row set before deleting anything, or a later row can dereference a vertex/edge an
    * earlier row already deleted (issue #6491).
@@ -2496,12 +2513,12 @@ public class CypherExecutionPlan {
    * (a fresh {@code MatchNodeStep} chained onto {@code currentStep} either way), so both carry the same
    * hazard.
    * <p>
-   * Deliberately statement-wide rather than scoped to the MATCH clause(s) that actually precede a
-   * given DELETE segment (relevant only for a multi-segment statement with more than one WITH-separated
-   * MATCH/DELETE pair): this is a conservative superset, so it can only force eager materialization on
-   * a DELETE that did not strictly need it, never miss one that did. Disconnected patterns are rare
-   * enough that the extra precision is not worth the bookkeeping to thread "which MATCH clauses feed
-   * this DELETE" through {@code clausesInOrder}.
+   * Callers pass only the MATCH clause(s) of the segment feeding the DELETE/FOREACH in question
+   * (the MATCH clauses since the last WITH, tracked as {@code currentSegmentMatchClauses} while
+   * walking {@code clausesInOrder}), not every MATCH clause in the whole statement: a multi-segment
+   * statement with more than one WITH-separated MATCH/DELETE pair must not force eager materialization
+   * on a DELETE whose own segment has no disconnected pattern just because an unrelated, earlier
+   * segment does (issue #6631).
    */
   private static boolean matchClausesHaveDisconnectedPatterns(final List<MatchClause> matchClauses) {
     return MatchClause.hasDisconnectedPathPatterns(matchClauses);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSplitFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSplitFunction.java
@@ -49,13 +49,18 @@ public class CypherSplitFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    // The primary argument is type-checked before a null delimiter decides the answer, so an out-of-domain
-    // primary argument is still reported even when args[1] happens to be null (issue #5798 review:
-    // split(5, null) must still be a type error, not a silent null).
+    // Both arguments are STRING-typed and type-checked before either being null decides the answer, so an
+    // out-of-domain argument is still reported regardless of which position happens to be null (issue #5798
+    // review: split(5, null) must still be a type error, not a silent null). The delimiter is STRING-typed
+    // too, same as the primary argument - issue #6608: #5798 only covered this function's primary argument
+    // position, leaving the delimiter to silently coerce via toString(). Neo4j itself coerces a non-STRING
+    // delimiter, but ArcadeDB's own #5798 policy already rejects it in the primary position of this same
+    // function, so accepting it here would be an inconsistency within this build rather than a Neo4j
+    // compatibility concern.
     final String str = CypherFunctionHelper.requireStringArgument(args[0], getName());
-    if (str == null || args[1] == null)
+    final String delimiter = CypherFunctionHelper.requireStringArgument(args[1], getName());
+    if (str == null || delimiter == null)
       return null;
-    final String delimiter = args[1].toString();
 
     // An empty delimiter splits the string into its individual characters (Neo4j/Memgraph semantics).
     // Java's String.split("", -1) appends a spurious trailing empty string, so handle this case explicitly.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
@@ -49,7 +49,9 @@ public class CypherSubstringFunction implements StatelessFunction {
     if (args[0] == null || args[1] == null)
       return null;
     final String str = args[0].toString();
-    final int start = ((Number) args[1]).intValue();
+    // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
+    // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
+    final int start = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     if (start < 0)
       // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching left()/right().
       // CommandSemanticException extends CommandParsingException, which the HTTP handler maps to 400. See issue #5793/#5296.
@@ -62,7 +64,7 @@ public class CypherSubstringFunction implements StatelessFunction {
     if (start >= str.length())
       return "";
     if (args.length == 3) {
-      final int length = ((Number) args[2]).intValue();
+      final int length = CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue();
       if (length < 0)
         throw new CommandSemanticException("substring(): negative length is not supported: " + length);
       return str.substring(start, Math.min(start + length, str.length()));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
@@ -59,25 +59,31 @@ public class CypherTrimFunction implements StatelessFunction {
     }
 
     if (args.length == 2) {
-      // 2-arg form: btrim(source, trimCharacter). The primary argument is type-checked before a null
-      // trim character decides the answer, so an out-of-domain primary argument is still reported even
-      // when args[1] happens to be null (issue #5798 review: btrim(5, null) must still be a type error,
-      // not a silent null).
+      // 2-arg form: btrim(source, trimCharacter). Both arguments are STRING-typed and type-checked before
+      // either being null decides the answer, so an out-of-domain argument is still reported regardless of
+      // which position happens to be null (issue #5798 review: btrim(5, null) must still be a type error,
+      // not a silent null). The trim-character argument is STRING-typed too, same as the primary one -
+      // issue #6608: #5798 only covered this function's primary argument position, leaving the trim
+      // character to silently coerce via toString().
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
-      if (source == null || args[1] == null)
+      final String trimChar = CypherFunctionHelper.requireStringArgument(args[1], getName());
+      if (source == null || trimChar == null)
         return null;
-      final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.strip();
       return stripLeading(stripTrailing(source, trimChar), trimChar);
     }
 
     if (args.length == 3) {
-      // SQL-style: trim(BOTH/LEADING/TRAILING char FROM string)
+      // SQL-style: trim(BOTH/LEADING/TRAILING char FROM string). The mode is not user data: the parser
+      // (CypherExpressionBuilder#parseTrimFunction) always supplies one of the three literal mode strings,
+      // never an arbitrary expression, so it needs no type check. The source (primary) argument is
+      // type-checked first, same ordering convention as every other function in this family, followed by
+      // the trim character - STRING-typed too, issue #6608: #5798 only reached this function's primary
+      // argument, at position 2 in this form.
       final String mode = args[0] != null ? args[0].toString() : null;
-      final String trimChar = args[1] != null ? args[1].toString() : null;
-
       final String source = CypherFunctionHelper.requireStringArgument(args[2], getName());
+      final String trimChar = CypherFunctionHelper.requireStringArgument(args[1], getName());
       if (source == null || trimChar == null)
         return null;
       if (trimChar.isEmpty()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
@@ -197,6 +197,14 @@ public final class CypherVariableUsage {
             return true;
           break;
         }
+        case CREATE:
+        case MERGE:
+          // Inline property expressions inside a top-level CREATE/MERGE pattern may reference the
+          // variable (e.g. CREATE (c {prop: r.x})). Enumerating them cheaply is awkward, so stay
+          // conservative like foreachReferencesVariable's own CREATE/MERGE case: keep the edge binding.
+          // A false positive only forgoes the CSR/GAV fast path; a false negative would silently drop
+          // a still-referenced edge (the class of bug this method exists to prevent - issue #6573).
+          return true;
         default:
           break;
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
@@ -31,7 +31,6 @@ import com.arcadedb.query.opencypher.ast.ComparisonExpressionWrapper;
 import com.arcadedb.query.opencypher.ast.ListComprehensionExpression;
 import com.arcadedb.query.opencypher.ast.ListExpression;
 import com.arcadedb.query.opencypher.ast.ListIndexExpression;
-import com.arcadedb.query.opencypher.ast.ListPredicateExpression;
 import com.arcadedb.query.opencypher.ast.ListSliceExpression;
 import com.arcadedb.query.opencypher.ast.MapExpression;
 import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
@@ -101,8 +100,6 @@ public class ExpressionEvaluator {
       return evaluateMap(me, result, context);
     } else if (aggregationOverrides() != null && expression instanceof ListComprehensionExpression) {
       return evaluateListComprehension((ListComprehensionExpression) expression, result, context);
-    } else if (aggregationOverrides() != null && expression instanceof ListPredicateExpression) {
-      return evaluateListPredicate((ListPredicateExpression) expression, result, context);
     } else if (aggregationOverrides() != null && expression instanceof CaseExpression ce) {
       // Route CASE branches through this evaluator so a pre-computed aggregation nested inside a
       // branch (e.g. CASE WHEN ... THEN sum(v) END) resolves to its accumulated value instead of
@@ -237,48 +234,6 @@ public class ExpressionEvaluator {
         resultList.add(item);
     }
     return resultList;
-  }
-
-  /**
-   * Evaluates a list predicate expression (ALL/ANY/NONE/SINGLE) using this evaluator.
-   */
-  private Object evaluateListPredicate(final ListPredicateExpression expression,
-      final Result result, final CommandContext context) {
-    final Object listValue = evaluate(expression.getListExpression(), result, context);
-    if (listValue == null)
-      return null;
-
-    final Iterable<?> iterable;
-    if (listValue instanceof Iterable)
-      iterable = (Iterable<?>) listValue;
-    else
-      return expression.evaluate(result, context); // fallback
-
-    int matchCount = 0;
-    int totalCount = 0;
-    for (final Object item : iterable) {
-      totalCount++;
-      final ResultInternal iterResult = new ResultInternal();
-      if (result != null)
-        for (final String prop : result.getPropertyNames())
-          iterResult.setProperty(prop, result.getProperty(prop));
-      iterResult.setProperty(expression.getVariable(), item);
-
-      if (expression.getWhereExpression() != null) {
-        final Object filterValue = evaluate(expression.getWhereExpression(), iterResult, context);
-        if (filterValue instanceof Boolean && (Boolean) filterValue)
-          matchCount++;
-      } else {
-        matchCount++;
-      }
-    }
-
-    return switch (expression.getPredicateType()) {
-      case ALL -> matchCount == totalCount;
-      case ANY -> matchCount > 0;
-      case NONE -> matchCount == 0;
-      case SINGLE -> matchCount == 1;
-    };
   }
 
   private Object evaluateListSlice(final ListSliceExpression expression, final Result result,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.function.DistinctNumericKey;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.opencypher.ast.*;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
@@ -145,10 +146,14 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
       final FunctionCallExpression[] aggExpressions, final String[] aggOutputNames, final int aggCount,
       final CommandContext context, final int nRecords) {
 
-    // Map: raw grouping value -> array of aggregation functions (indexed, not HashMap)
+    // Map: canonicalized grouping value -> group state (representative raw key + aggregation functions).
+    // Keying on the canonicalized value (DistinctNumericKey#canonicalize) rather than the raw boxed value means the
+    // same logical number represented with different Java numeric types (Integer 1 vs Long 1 vs Double 1.0) groups
+    // together instead of splitting, matching Cypher's own `=` operator and the sibling DISTINCT paths (#5789,
+    // issue #6676). The group's raw, first-seen key value is kept in SingleKeyGroupState for the output row.
     // LinkedHashMap preserves insertion order, needed because ORDER BY in WITH clauses
     // may fail to resolve aggregation expressions and fall back to iteration order
-    final Map<Object, StatelessFunction[]> groups = new LinkedHashMap<>();
+    final Map<Object, SingleKeyGroupState> groups = new LinkedHashMap<>();
 
     final ResultSet prevResults = prev.syncPull(context, CONFIGURED_BATCH_SIZE != null ? CONFIGURED_BATCH_SIZE : nRecords);
 
@@ -162,15 +167,17 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
 
         // Evaluate grouping key directly (no wrapper)
         final Object keyValue = evaluator.evaluate(groupingKey.expression, inputRow, context);
+        final Object canonicalKey = DistinctNumericKey.canonicalize(keyValue);
 
         // Get or create aggregators for this group using array (not HashMap)
-        StatelessFunction[] aggregators = groups.get(keyValue);
-        if (aggregators == null) {
-          aggregators = new StatelessFunction[aggCount];
+        SingleKeyGroupState group = groups.get(canonicalKey);
+        if (group == null) {
+          final StatelessFunction[] aggregators = new StatelessFunction[aggCount];
           for (int i = 0; i < aggCount; i++)
             aggregators[i] = functionFactory.getFunctionExecutor(
                 aggExpressions[i].getFunctionName(), aggExpressions[i].isDistinct());
-          groups.put(keyValue, aggregators);
+          group = new SingleKeyGroupState(keyValue, aggregators);
+          groups.put(canonicalKey, group);
         }
 
         // Feed row to aggregators using direct array access
@@ -179,7 +186,7 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
           final Object[] args = new Object[funcArgs.size()];
           for (int j = 0; j < args.length; j++)
             args[j] = evaluator.evaluate(funcArgs.get(j), inputRow, context);
-          aggregators[i].execute(args, context);
+          group.aggregators[i].execute(args, context);
         }
       } finally {
         if (context.isProfiling())
@@ -191,13 +198,12 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
     final List<Result> results = new ArrayList<>(groups.size());
     final long beginBuild = context.isProfiling() ? System.nanoTime() : 0;
     try {
-      for (final Map.Entry<Object, StatelessFunction[]> entry : groups.entrySet()) {
+      for (final SingleKeyGroupState group : groups.values()) {
         final ResultInternal groupResult = new ResultInternal();
-        groupResult.setProperty(groupingKey.outputName, entry.getKey());
+        groupResult.setProperty(groupingKey.outputName, group.representativeKey);
 
-        final StatelessFunction[] aggregators = entry.getValue();
         for (int i = 0; i < aggCount; i++)
-          groupResult.setProperty(aggOutputNames[i], aggregators[i].getAggregatedResult());
+          groupResult.setProperty(aggOutputNames[i], group.aggregators[i].getAggregatedResult());
 
         results.add(groupResult);
       }
@@ -206,6 +212,20 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
         cost += System.nanoTime() - beginBuild;
     }
     return results;
+  }
+
+  /**
+   * Holds the aggregation functions for a single-key group together with the raw, first-seen grouping value used
+   * for the output row (the map itself is keyed on the canonicalized value - see {@link #aggregateSingleKey}).
+   */
+  private static final class SingleKeyGroupState {
+    final Object              representativeKey;
+    final StatelessFunction[] aggregators;
+
+    SingleKeyGroupState(final Object representativeKey, final StatelessFunction[] aggregators) {
+      this.representativeKey = representativeKey;
+      this.aggregators = aggregators;
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupKeyValues.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupKeyValues.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.query.opencypher.executor.steps;
 
+import com.arcadedb.function.DistinctNumericKey;
+
 import java.util.Objects;
 
 /**
@@ -25,18 +27,29 @@ import java.util.Objects;
  * aggregation steps (issue #6629: a row-multiplying clause upstream of a GROUP BY, such as
  * UNWIND, must still collapse into one output row per distinct key combination). Caches its
  * hash code since the same instance is hashed on every row of its group.
+ * <p>
+ * Equality/hashing is computed on {@link DistinctNumericKey#canonicalize(Object)} of each value rather than on the
+ * raw boxed value, so that the same logical number represented with different Java numeric types (e.g. Integer 1 vs
+ * Long 1 vs Double 1.0) groups together instead of splitting, matching Cypher's own {@code =} operator and the
+ * sibling DISTINCT paths that already canonicalize this way (issue #6676, following #5789). {@link #values} itself
+ * stays the raw, first-seen values, since those - not the canonical form - are what the group's output row reports.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 final class GroupKeyValues {
   final Object[] values;
-  private final int hash;
+  private final Object[] canonicalValues;
+  private final int      hash;
 
   GroupKeyValues(final Object[] values) {
     this.values = values;
+    this.canonicalValues = new Object[values.length];
     int h = 1;
-    for (final Object v : values)
-      h = 31 * h + (v == null ? 0 : v.hashCode());
+    for (int i = 0; i < values.length; i++) {
+      final Object canonical = DistinctNumericKey.canonicalize(values[i]);
+      canonicalValues[i] = canonical;
+      h = 31 * h + (canonical == null ? 0 : canonical.hashCode());
+    }
     this.hash = h;
   }
 
@@ -46,10 +59,10 @@ final class GroupKeyValues {
       return true;
     if (!(o instanceof GroupKeyValues that))
       return false;
-    if (hash != that.hash || values.length != that.values.length)
+    if (hash != that.hash || canonicalValues.length != that.canonicalValues.length)
       return false;
-    for (int i = 0; i < values.length; i++)
-      if (!Objects.equals(values[i], that.values[i]))
+    for (int i = 0; i < canonicalValues.length; i++)
+      if (!Objects.equals(canonicalValues[i], that.canonicalValues[i]))
         return false;
     return true;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.Record;
+import com.arcadedb.database.RID;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
@@ -386,7 +387,8 @@ public class MergeStep extends AbstractExecutionStep {
       return results;
     }
 
-    final Vertex anchorVertex = (Vertex) baseResult.getProperty(pathPattern.getNode(anchorIdx).getVariable());
+    // #6461: reload before walking its edges below - see reloadAnchorVertex.
+    final Vertex anchorVertex = reloadAnchorVertex((Vertex) baseResult.getProperty(pathPattern.getNode(anchorIdx).getVariable()));
     traverseFromAnchor(pathPattern, anchorIdx, anchorVertex, copyResult(baseResult), results);
     return results;
   }
@@ -733,7 +735,10 @@ public class MergeStep extends AbstractExecutionStep {
       if (bound instanceof Vertex v) {
         if (vertex != null && !vertex.equals(v))
           return;
-        vertex = v;
+        // #6461: vertex == null here means v is the row's own anchor instance (forcedVertex is only
+        // ever non-null when this node was just reached via a live edge traversal below, which is
+        // already fresh) - reload it before its edges are enumerated below. See reloadAnchorVertex.
+        vertex = vertex == null ? reloadAnchorVertex(v) : v;
       }
     }
 
@@ -1105,6 +1110,37 @@ public class MergeStep extends AbstractExecutionStep {
       // Record may have been removed or be inaccessible
     }
     return null;
+  }
+
+  /**
+   * Re-resolves a bound anchor vertex to its latest committed state before its edges are enumerated
+   * (issue #6461). {@code executeMerge} wraps each row in its own {@code database.transaction(..., true)}
+   * (see that method's Javadoc / issue #6367); when the caller has no outer transaction open, each row's
+   * MERGE owns and commits its own transaction. A vertex instance the row carries - bound by an earlier
+   * MATCH, or reused across UNWIND rows of the same MERGE - was loaded before its row's transaction
+   * started, so once a PRIOR row's MERGE appends the first edge in a direction to it (the one write that
+   * rewrites the vertex record's edge-list head pointer) the row's own instance still reflects the
+   * pre-append state and a direct {@code vertex.getEdges(...)} on it would miss that edge.
+   * <p>
+   * {@code database.lookupByRID} re-reads that RID - the current transaction's cache first, the page
+   * store otherwise - so it observes the latest COMMITTED state regardless of which transaction wrote it,
+   * unlike the row's own possibly-stale instance. Mirrors {@code SetStep.reloadLatestDoc} (issue #5227).
+   *
+   * @return the reloaded vertex, or {@code anchor} unchanged if it has no identity yet (not persisted) or
+   * was concurrently deleted (left for the ordinary not-found handling downstream to react to)
+   */
+  private Vertex reloadAnchorVertex(final Vertex anchor) {
+    if (anchor == null)
+      return null;
+    final RID rid = anchor.getIdentity();
+    if (rid == null)
+      return anchor;
+    try {
+      final Record fresh = context.getDatabase().lookupByRID(rid, true);
+      return fresh instanceof Vertex v ? v : anchor;
+    } catch (final RecordNotFoundException e) {
+      return anchor;
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/OptionalMatchStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/OptionalMatchStep.java
@@ -244,33 +244,37 @@ public class OptionalMatchStep extends AbstractExecutionStep {
             }
           }
         } else {
-          // No input: standalone OPTIONAL MATCH
-          // Execute match chain without input
-          matchChainStart.setPrevious(null);
-          final ResultSet matchResults = matchChainEnd.syncPull(context, Math.min(nRecords, MAX_BUFFER_SIZE));
+          // No input: standalone OPTIONAL MATCH.
+          // The match cursor is held in currentMatchResults (like the input path holds it across
+          // input rows) so that it resumes where it left off on every fetchMore call instead of
+          // re-running the pattern scan from scratch (issue #6668).
+          if (currentMatchResults == null) {
+            matchChainStart.setPrevious(null);
+            currentMatchResults = matchChainEnd.syncPull(context, Math.min(n, MAX_BUFFER_SIZE));
+          }
 
           // Collect matches with bounded buffer
           final int maxToFetch = Math.min(n, MAX_BUFFER_SIZE);
-          boolean foundAnyMatch = false;
-          while (buffer.size() < maxToFetch && matchResults.hasNext()) {
+          while (buffer.size() < maxToFetch && currentMatchResults.hasNext()) {
             guard.check();
-            buffer.add(matchResults.next());
-            foundAnyMatch = true;
+            buffer.add(currentMatchResults.next());
+            foundMatchForCurrent = true;
           }
 
-          // If no matches at all, return a single row with NULL values
-          if (!foundAnyMatch && buffer.isEmpty()) {
-            final ResultInternal nullResult = new ResultInternal();
-            for (final String varName : variableNames) {
-              nullResult.setProperty(varName, null);
-            }
-            buffer.add(nullResult);
-          }
-
-          if (!matchResults.hasNext()) {
+          if (!currentMatchResults.hasNext()) {
             finished = true;
+            currentMatchResults.close();
+            currentMatchResults = null;
+
+            // If no matches were found across the whole pattern, return a single row with NULL values
+            if (!foundMatchForCurrent) {
+              final ResultInternal nullResult = new ResultInternal();
+              for (final String varName : variableNames) {
+                nullResult.setProperty(varName, null);
+              }
+              buffer.add(nullResult);
+            }
           }
-          matchResults.close();
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/OptionalMatchStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/OptionalMatchStep.java
@@ -97,6 +97,8 @@ public class OptionalMatchStep extends AbstractExecutionStep {
       private ResultSet prevResults = null;
       private Result currentInputRow = null;
       private ResultSet currentMatchResults = null;
+      // With input: whether the current input row matched. Standalone (no input): whether the
+      // pattern matched at all across the whole scan, since there is no per-row input to reset it.
       private boolean foundMatchForCurrent = false;
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ProjectReturnStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ProjectReturnStep.java
@@ -80,7 +80,7 @@ public class ProjectReturnStep extends AbstractExecutionStep {
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
       private boolean finished = false;
-      private final Set<String> seenResults = distinct ? new HashSet<>() : null;
+      private final Set<List<Object>> seenResults = distinct ? new HashSet<>() : null;
 
       @Override
       public boolean hasNext() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -216,7 +216,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
     // matching edges only.
     final EdgeConstraint constraint = edgeConstraint(inputResult, context);
     if (constraint != null)
-      return computeFilteredShortestPath(source, target, patternDirection(), patternEdgeTypesArray(), constraint);
+      return computeFilteredShortestPath(source, target, patternDirection(), patternEdgeTypesArray(), constraint, context);
 
     // Collect every relationship type declared in the pattern. Variable-length type alternation
     // (e.g. [:R1|R2*]) is expressed as a single relationship with multiple types - all of them
@@ -290,7 +290,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
     final EdgeConstraint constraint = edgeConstraint(inputResult, context);
     if (constraint != null)
       return computeFilteredAllShortestPaths(source, target, patternDirection(), patternEdgeTypesArray(), constraint,
-          context.getDatabase());
+          context.getDatabase(), context);
 
     final List<String> edgeTypes;
     if (pattern.getRelationshipCount() > 0 && pattern.getRelationship(0).hasTypes())
@@ -526,9 +526,13 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * with different property values are disambiguated correctly.
    *
    * @param edgeTypes restrict edges to these types, or null/empty to allow any type
+   * @param context   the command context the deadline is read from; {@code null} leaves only the interrupt check
+   *                  (issue #6459 - this constrained BFS previously consulted neither, unlike the unconstrained
+   *                  frontier walk it falls back from)
    */
   public static List<Object> computeFilteredShortestPath(final Vertex source, final Vertex target,
-      final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint) {
+      final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint,
+      final CommandContext context) {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
@@ -548,9 +552,12 @@ public class ShortestPathStep extends AbstractExecutionStep {
     Deque<Vertex> frontier = new ArrayDeque<>();
     frontier.add(source);
 
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
     while (!frontier.isEmpty()) {
       if (Thread.interrupted())
         throw new CommandExecutionException("The shortestPath() function has been interrupted");
+      guard.check();
 
       final Deque<Vertex> next = new ArrayDeque<>();
       for (final Vertex v : frontier) {
@@ -606,10 +613,13 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * distinct paths OpenCypher requires.
    *
    * @param edgeTypes restrict edges to these types, or null/empty to allow any type
+   * @param context   the command context the deadline is read from; {@code null} leaves only the interrupt check
+   *                  (issue #6459 - this constrained BFS previously consulted neither, unlike the unconstrained
+   *                  layered BFS it falls back from)
    */
   public static List<List<Object>> computeFilteredAllShortestPaths(final Vertex source, final Vertex target,
       final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint,
-      final Database database) {
+      final Database database, final CommandContext context) {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
@@ -630,9 +640,12 @@ public class ShortestPathStep extends AbstractExecutionStep {
     int currentDepth = 0;
     int foundDepth = -1;
 
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
     while (!currentLayer.isEmpty()) {
       if (Thread.interrupted())
         throw new CommandExecutionException("The allShortestPaths() function has been interrupted");
+      guard.check();
 
       if (foundDepth >= 0 && currentDepth >= foundDepth)
         break;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
@@ -75,7 +75,7 @@ public class UnionStep extends AbstractExecutionStep {
       private ResultSet currentResultSet = null;
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
-      private final Set<String> seenResults = removeDuplicates ? new HashSet<>() : null;
+      private final Set<List<Object>> seenResults = removeDuplicates ? new HashSet<>() : null;
       private boolean finished = false;
 
       @Override
@@ -131,7 +131,7 @@ public class UnionStep extends AbstractExecutionStep {
 
               // Apply deduplication for UNION (not UNION ALL)
               if (removeDuplicates) {
-                final String resultKey = buildResultKey(result);
+                final List<Object> resultKey = buildResultKey(result);
                 if (seenResults.contains(resultKey))
                   continue; // Skip duplicate
                 seenResults.add(resultKey);
@@ -151,7 +151,7 @@ public class UnionStep extends AbstractExecutionStep {
        * DistinctNumericKey so numerically-equal values (issue #5789) and graph-element references
        * sharing one RID (issue #6488) collapse together.
        */
-      private String buildResultKey(final Result result) {
+      private List<Object> buildResultKey(final Result result) {
         return DistinctNumericKey.buildKey(result.getPropertyNames(), result::getProperty);
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
@@ -19,6 +19,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.function.DistinctNumericKey;
+import com.arcadedb.query.opencypher.InternalVariables;
 import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
@@ -79,7 +80,7 @@ public class WithStep extends AbstractExecutionStep {
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
       private boolean finished = false;
-      private final Set<String> seenResults = withClause.isDistinct() ? new HashSet<>() : null;
+      private final Set<List<Object>> seenResults = withClause.isDistinct() ? new HashSet<>() : null;
       private int skipped = 0;
       private int returned = 0;
 
@@ -188,7 +189,14 @@ public class WithStep extends AbstractExecutionStep {
               // renders as a placeholder instead of the actual values, so two references to the
               // very same record can render two different strings depending on load state alone
               // (issue #6488).
-              final String resultKey = DistinctNumericKey.buildKey(new TreeSet<>(projectedResult.getPropertyNames()), projectedResult::getProperty);
+              // WITH * forwards every property from the input row, including the executor's own
+              // internal bindings for anonymous pattern elements; those must not affect distinctness,
+              // the same reasoning ProjectReturnStep already applies to RETURN DISTINCT * (issue
+              // #5444), or two rows that only differ by such a binding would wrongly stay distinct
+              // (issue #6541).
+              final List<String> names = new TreeSet<>(projectedResult.getPropertyNames()).stream()
+                  .filter(name -> !InternalVariables.isInternal(name)).toList();
+              final List<Object> resultKey = DistinctNumericKey.buildKey(names, projectedResult::getProperty);
               if (seenResults.contains(resultKey))
                 continue;
               seenResults.add(resultKey);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -200,6 +200,18 @@ public class CypherOptimizer {
         AnchorSelection componentAnchor = anchorSelector.selectAnchor(logicalPlan, excludedVariables);
         componentAnchor = validateAnchorForUnidirectionalEdges(componentAnchor, logicalPlan,
             component.relationships(), component.variables());
+
+        // Issue #6482: a label-disjunction node only seeds a NodeByLabelDisjunctionScan/IndexSeek when it
+        // IS the anchor. Any other node in this component that still carries a disjunction would be reached
+        // by ExpandAll/ExpandInto/VarLengthExpand, whose single targetLabel (addTargetLabelFilter) can only
+        // filter on the disjunction's first label - silently dropping rows that matched a later alternative.
+        // shouldUseOptimizer() admits the statement without knowing which node the cost-based selection
+        // above would land on, so verify it here, now that the concrete anchor is known, and decline the
+        // whole plan (falling back to the legacy pipeline, which evaluates every alternative correctly)
+        // rather than build an operator tree that would return an incomplete result.
+        if (hasUnanchoredLabelDisjunction(logicalPlan, component.variables(), componentAnchor.getVariable()))
+          return null;
+
         final PhysicalOperator componentAnchorOperator = createAnchorOperator(componentAnchor);
         final ExpansionPlan expansion = buildExpansionChain(logicalPlan, component.relationships(),
             componentAnchor, componentAnchorOperator, needsEdgeTracking, syntheticEdgeVarCounter);
@@ -460,6 +472,32 @@ public class CypherOptimizer {
     });
 
     return typeNames;
+  }
+
+  /**
+   * Returns {@code true} when some node in {@code componentVariables} other than {@code anchorVariable}
+   * carries a label disjunction (issue #6482). Such a node cannot be represented once it is not the
+   * anchor: it is reached by {@code ExpandAll}/{@code ExpandInto}/{@code VarLengthExpand}, and
+   * {@code addTargetLabelFilter} pushes only the disjunction's first label into those operators'
+   * single-label {@code targetLabel} field, which would silently filter out rows that matched a later
+   * alternative instead of raising an error.
+   *
+   * @param logicalPlan        the logical plan (for looking up each variable's {@link LogicalNode})
+   * @param componentVariables every node variable in the connected component the anchor was chosen for
+   * @param anchorVariable     the variable of the anchor {@link #buildExpansionChain} will expand from
+   * @return {@code true} if the plan is unsafe to build as-is and {@link #optimize()} should decline
+   * (return {@code null}) instead, falling back to the legacy pipeline
+   */
+  private boolean hasUnanchoredLabelDisjunction(final LogicalPlan logicalPlan, final Set<String> componentVariables,
+      final String anchorVariable) {
+    for (final String variable : componentVariables) {
+      if (variable.equals(anchorVariable))
+        continue;
+      final LogicalNode node = logicalPlan.getPatternNode(variable);
+      if (node != null && node.isLabelDisjunction() && node.getLabels().size() > 1)
+        return true;
+    }
+    return false;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/ClauseDispatcher.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/ClauseDispatcher.java
@@ -22,6 +22,7 @@ import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.OrderByClause;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
 import com.arcadedb.query.opencypher.ast.VariableExpression;
+import com.arcadedb.query.opencypher.ast.WhereClause;
 import com.arcadedb.query.opencypher.ast.WithClause;
 import com.arcadedb.query.opencypher.grammar.Cypher25Parser;
 import com.arcadedb.query.opencypher.rewriter.ProjectedOrderByNormalizer;
@@ -52,6 +53,7 @@ class ClauseDispatcher {
     register(Cypher25Parser.ClauseContext::mergeClause, this::handleMerge);
     register(Cypher25Parser.ClauseContext::unwindClause, this::handleUnwind);
     register(Cypher25Parser.ClauseContext::forUnwindClause, this::handleForUnwind);
+    register(Cypher25Parser.ClauseContext::filterClause, this::handleFilter);
     register(Cypher25Parser.ClauseContext::withClause, this::handleWith);
     register(Cypher25Parser.ClauseContext::returnClause, this::handleReturn);
     register(Cypher25Parser.ClauseContext::orderBySkipLimitClause, this::handleOrderBySkipLimit);
@@ -135,6 +137,20 @@ class ClauseDispatcher {
   private void handleWith(final Cypher25Parser.ClauseContext ctx, final StatementBuilder builder,
                           final CypherASTBuilder astBuilder) {
     builder.addWith(astBuilder.visitWithClause(ctx.withClause()));
+  }
+
+  private void handleFilter(final Cypher25Parser.ClauseContext ctx, final StatementBuilder builder,
+                            final CypherASTBuilder astBuilder) {
+    // GQL standalone FILTER is semantically equivalent to a leading WHERE (issue #6574,
+    // ISO/IEC 39075:2024 GQL). Represented as an implicit `WITH * WHERE <predicate>` so the
+    // filter is applied at the correct position in clausesInOrder, the same technique
+    // handleOrderBySkipLimit uses for a standalone ORDER BY / SKIP / LIMIT (issue #3950).
+    final WhereClause whereClause = astBuilder.visitFilterClause(ctx.filterClause());
+
+    final List<ReturnClause.ReturnItem> starItems = new ArrayList<>();
+    starItems.add(ReturnClause.ReturnItem.star());
+    final WithClause implicitWith = new WithClause(starItems, false, whereClause, null, null, null);
+    builder.addWith(implicitWith);
   }
 
   private void handleReturn(final Cypher25Parser.ClauseContext ctx, final StatementBuilder builder,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -1112,6 +1112,19 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
   }
 
   /**
+   * Visits a GQL standalone {@code FILTER (WHERE)? expression} clause (issue #6574, ISO/IEC
+   * 39075:2024 GQL). Semantically equivalent to a leading WHERE: parses the predicate as a
+   * boolean expression, simplifying boolean constants the same way {@link #visitWhereClause}
+   * does.
+   */
+  public WhereClause visitFilterClause(final Cypher25Parser.FilterClauseContext ctx) {
+    // Grammar: FILTER WHERE? expression
+    final BooleanExpression parsed = parseBooleanExpression(ctx.expression());
+    final BooleanExpression condition = (BooleanExpression) AST_REWRITER.rewrite(parsed);
+    return new WhereClause(condition);
+  }
+
+  /**
    * Parse an expression context into a BooleanExpression for WHERE clauses.
    * Handles logical operators (AND, OR, NOT), comparisons, IS NULL, IN, regex, etc.
    */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -2387,10 +2387,17 @@ public class CypherSemanticValidator {
    * <p>
    * The trailing rounding mode of {@code round(value, precision, mode)} is not numeric; it is validated against the same
    * mode names the function itself accepts.
+   * <p>
+   * {@code left()}/{@code right()}/{@code substring()} (issue #6609) declare their numeric arguments starting at
+   * {@link CypherFunctionHelper.NumericSignature#startArg()} rather than at position 0: the leading argument is the
+   * STRING being sliced, which this check leaves alone (out of scope for #6609, same as it was for #5798/#5901).
    */
   private void checkStaticallyKnownNumericArgs(final CypherFunctionHelper.NumericSignature signature,
       final List<Expression> args) {
     for (int i = 0; i < args.size(); i++) {
+      if (i < signature.startArg())
+        continue;
+
       final Expression arg = args.get(i);
       final boolean isMap = arg instanceof MapExpression;
       // A bracketed list is a ListExpression rather than a literal holding a Collection, so it has to be recognised
@@ -2405,7 +2412,7 @@ public class CypherSemanticValidator {
       // Stands in for the literal purely so the message names the type: a MAP or a LIST<ANY>.
       final Object rendered = isMap ? Map.of() : isList ? List.of() : literal;
 
-      if (i < signature.numericArgs()) {
+      if (signature.isNumericPosition(i)) {
         if (isMap || isList || !(literal instanceof Number))
           throw CypherFunctionHelper.typeMismatch(signature.name(), CypherFunctionHelper.NUMERIC_DOMAIN, rendered);
       } else if ("round".equals(signature.name()))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
@@ -253,16 +253,17 @@ public class CypherExecutionPlanner {
             // Multi-label nodes: conjunction (n:A:B) is unsupported in the optimizer
             // (NodeByLabelScan uses a composite type name that does not match supersets,
             // e.g. A~B~C does not extend A~B). Disjunction (n:A|B) is routed to
-            // NodeByLabelDisjunctionScan, but only when the node has no incident
-            // relationships — ExpandAll/ExpandInto carry a single targetLabel and
-            // cannot represent OR semantics, so target-side disjunction falls back to
-            // the legacy path.
-            if (node.getLabels().size() > 1) {
-              if (!node.isLabelDisjunction())
-                return false;
-              if (path.getRelationshipCount() > 0)
-                return false;
-            }
+            // NodeByLabelDisjunctionScan or NodeByLabelDisjunctionIndexSeek (issue #6397), but only
+            // when the disjunction ends up seeding the pattern - ExpandAll/ExpandInto/VarLengthExpand
+            // carry a single targetLabel and cannot represent OR semantics for a node reached over a
+            // relationship (issue #6482). Which node becomes the anchor is a cost decision made later,
+            // per connected component, so this AST-level gate can only rule out what it already knows is
+            // unrepresentable (a conjunction); it does not yet know which node will anchor its component.
+            // CypherOptimizer#optimize() re-checks every disjunction node once the concrete anchor is
+            // chosen and declines (returns null, falling back to this same legacy path) whenever a
+            // disjunction landed on a non-anchor node instead.
+            if (node.getLabels().size() > 1 && !node.isLabelDisjunction())
+              return false;
 
             // An inline property map is an equality predicate, and LogicalPlan lowers it into one, so
             // the optimizer plans it exactly like the same comparison written in WHERE. Two shapes

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -917,9 +917,11 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
+      // Reserved before the row-header arrays are allocated, matching adjacency()'s own ordering: the budget
+      // is refused before a single byte of them is on the heap, not after (issue #6715 review).
+      reserveWeightedAdjacency(nodeCount, 0);
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
-      reserveWeightedAdjacency(nodeCount, 0);
       final long maxEntryCheckpoint = ADJACENCY_CHECKPOINT_ENTRIES / 3;
       long entries = 0;
       for (int i = 0; i < nodeCount; i++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -904,12 +904,19 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * dependency on {@link MemoryBudget}, so what is priced here is the cumulative cost across nodes, the same
      * bound {@link #reserveAdjacency} already gives the unweighted adjacency build; a single node whose row alone
      * exceeds the budget is still refused, just after that one row is built rather than during it.
+     * <p>
+     * The entries-seen checkpoint interval is capped by {@link MemoryBudget#capacityFor} against what is
+     * actually left of the configured budget, not only by {@code ADJACENCY_CHECKPOINT_ENTRIES / 3} (a third of
+     * {@link #adjacency}'s own constant, since a weighted entry costs {@code INT_BYTES + DOUBLE_BYTES} rather
+     * than {@code INT_BYTES} alone): reusing the unweighted constant outright would let a tight budget be
+     * overshot by three times as many bytes before a checkpoint ever fires (issue #6715 review).
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
       reserveWeightedAdjacency(nodeCount, 0);
+      final long entryCheckpoint = Math.min(ADJACENCY_CHECKPOINT_ENTRIES / 3, memory.capacityFor(INT_BYTES + DOUBLE_BYTES));
       long entries = 0;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
@@ -917,7 +924,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
         entries += edges.neighbors().length;
-        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
+        if (entries >= entryCheckpoint || (i & 1023) == 1023) {
           reserveWeightedAdjacency(0, entries);
           entries = 0;
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -905,18 +905,22 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * bound {@link #reserveAdjacency} already gives the unweighted adjacency build; a single node whose row alone
      * exceeds the budget is still refused, just after that one row is built rather than during it.
      * <p>
-     * The entries-seen checkpoint interval is capped by {@link MemoryBudget#capacityFor} against what is
-     * actually left of the configured budget, not only by {@code ADJACENCY_CHECKPOINT_ENTRIES / 3} (a third of
-     * {@link #adjacency}'s own constant, since a weighted entry costs {@code INT_BYTES + DOUBLE_BYTES} rather
-     * than {@code INT_BYTES} alone): reusing the unweighted constant outright would let a tight budget be
-     * overshot by three times as many bytes before a checkpoint ever fires (issue #6715 review).
+     * The entries-seen checkpoint interval is capped by {@link MemoryBudget#capacityFor}, recomputed after every
+     * reservation, against what is actually left of the configured budget - not only by
+     * {@code ADJACENCY_CHECKPOINT_ENTRIES / 3} (a third of {@link #adjacency}'s own constant, since a weighted
+     * entry costs {@code INT_BYTES + DOUBLE_BYTES} rather than {@code INT_BYTES} alone: reusing the unweighted
+     * constant outright would let a tight budget be overshot by three times as many bytes before a checkpoint
+     * ever fires). Capping only once before the loop would go stale as the budget fills up: capacity keeps
+     * shrinking with every reservation, so a threshold computed against the very first, most generous reading
+     * of it could let a later batch through that the remaining budget no longer has room for (issue #6715
+     * review).
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
       reserveWeightedAdjacency(nodeCount, 0);
-      final long entryCheckpoint = Math.min(ADJACENCY_CHECKPOINT_ENTRIES / 3, memory.capacityFor(INT_BYTES + DOUBLE_BYTES));
+      final long maxEntryCheckpoint = ADJACENCY_CHECKPOINT_ENTRIES / 3;
       long entries = 0;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
@@ -924,6 +928,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
         entries += edges.neighbors().length;
+        final long entryCheckpoint = Math.min(maxEntryCheckpoint, memory.capacityFor(INT_BYTES + DOUBLE_BYTES));
         if (entries >= entryCheckpoint || (i & 1023) == 1023) {
           reserveWeightedAdjacency(0, entries);
           entries = 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -603,12 +603,22 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
 
     // For whole-graph algorithms (null/empty relTypes), accept any ready provider that covers
     // all edge types. A partial-coverage provider would silently produce wrong results.
-    if (relTypes == null || relTypes.length == 0) {
-      for (final GraphTraversalProvider p : GraphTraversalProviderRegistry.getProviders(db))
-        if (p.isReady() && p.coversEdgeType(null))
-          return p;
+    if (relTypes != null && relTypes.length != 0)
+      return null;
+    // Coverage checked before readiness: coversEdgeType() is a pure config check, while a
+    // GraphAnalyticalView's isReady() (see #6641) dispatches its deferred restore-from-disk as a
+    // side effect when one is pending. Checking coverage first means a whole-graph algorithm only
+    // ever pays that cost for a provider it could actually use, not for every registered one -
+    // otherwise this loop would eagerly resolve every other view's deferred restore too, same
+    // regression GraphTraversalProviderRegistry.findProvider() was fixed against.
+    final Iterator<GraphTraversalProvider> iterator = GraphTraversalProviderRegistry.getProviders(db).iterator();
+    GraphTraversalProvider found = null;
+    while (found == null && iterator.hasNext()) {
+      final GraphTraversalProvider p = iterator.next();
+      if (p.coversEdgeType(null) && p.isReady())
+        found = p;
     }
-    return null;
+    return found;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -895,18 +895,48 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * per-type, per-direction slicing that keeps a weight with its own edge lives. Nothing about that pairing is
      * re-derived here, so the CSR path of an {@code algo.*} procedure, of {@code astar} and of
      * {@code bellmanFord} cannot drift apart from one another.
+     * <p>
+     * {@code guard::checkPeriodically} is threaded into {@code edgeWeightsOf} itself rather than only checked
+     * between two calls to it: one call already returns a fully-built row for one node, so a single supernode
+     * would otherwise be one unabortable unit of work regardless of how tightly the per-node loop below is
+     * checkpointed (issue #6715). The memory side of the same gap - a supernode's row is fully allocated before
+     * {@link #reserveWeightedAdjacency} ever runs - cannot be closed the same way without handing this SPI a
+     * dependency on {@link MemoryBudget}, so what is priced here is the cumulative cost across nodes, the same
+     * bound {@link #reserveAdjacency} already gives the unweighted adjacency build; a single node whose row alone
+     * exceeds the budget is still refused, just after that one row is built rather than during it.
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
+      reserveWeightedAdjacency(nodeCount, 0);
+      long entries = 0;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
-        final NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, types);
+        final NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, guard::checkPeriodically, types);
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
+        entries += edges.neighbors().length;
+        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
+          reserveWeightedAdjacency(0, entries);
+          entries = 0;
+        }
       }
+      reserveWeightedAdjacency(0, entries);
       return new WeightedAdjacency(neighbors, weights);
+    }
+
+    /**
+     * Charges {@code rows} neighbour/weight row-header pairs and {@code entries} (neighbour id + weight) pairs to
+     * the call's budget - the weighted counterpart of {@link #reserveAdjacency}, doubled because a
+     * {@link WeightedAdjacency} holds a neighbour array AND a weight array per node rather than one.
+     */
+    private void reserveWeightedAdjacency(final long rows, final long entries) {
+      if (rows == 0 && entries == 0)
+        return;
+      memory.reserve(saturatingSum(saturatingProduct(rows, MATRIX_ROW_OVERHEAD_BYTES * 2),
+              saturatingProduct(entries, INT_BYTES + DOUBLE_BYTES)), "the weighted adjacency",
+          rows > 0 ? rows + " nodes, " + entries + " edge entries" : entries + " edge entries");
     }
 
     /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentrality.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentrality.java
@@ -34,6 +34,11 @@ import java.util.stream.Stream;
  * Uses {@code vertex.countEdges()} for maximum efficiency — no edge objects are materialised.
  * </p>
  * <p>
+ * {@code direction} (default {@code BOTH}) selects which edges count towards {@code degree}/{@code score}: with
+ * {@code IN} or {@code OUT}, only that direction is counted (and the other of {@code inDegree}/{@code outDegree}
+ * is 0, since it was never read), rather than always summing both regardless of what was requested.
+ * </p>
+ * <p>
  * Example:
  * <pre>
  * CALL algo.degree()
@@ -77,7 +82,7 @@ public class AlgoDegreeCentrality extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final String dirArg = args.length > 1 ? extractString(args[1], "direction") : "BOTH";
+    final Vertex.DIRECTION dir = args.length > 1 ? parseDirection(extractString(args[1], "direction")) : Vertex.DIRECTION.BOTH;
 
     final Database db = context.getDatabase();
     final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
@@ -89,12 +94,10 @@ public class AlgoDegreeCentrality extends AbstractAlgoProcedure {
     final double norm = n > 1 ? (double) (n - 1) : 1.0;
 
     return vertices.stream().map(v -> {
-      final long in = relTypes != null && relTypes.length > 0 ?
-          v.countEdges(Vertex.DIRECTION.IN, relTypes) :
-          v.countEdges(Vertex.DIRECTION.IN);
-      final long out = relTypes != null && relTypes.length > 0 ?
-          v.countEdges(Vertex.DIRECTION.OUT, relTypes) :
-          v.countEdges(Vertex.DIRECTION.OUT);
+      // Only the requested direction(s) are counted: a caller that filters to IN or OUT is asking to skip the
+      // cost of the other one too, not only to have it excluded from the total.
+      final long in = dir != Vertex.DIRECTION.OUT ? countEdges(v, Vertex.DIRECTION.IN, relTypes) : 0;
+      final long out = dir != Vertex.DIRECTION.IN ? countEdges(v, Vertex.DIRECTION.OUT, relTypes) : 0;
       final long total = in + out;
       final ResultInternal r = new ResultInternal();
       r.setProperty("node", v.getIdentity());
@@ -104,5 +107,9 @@ public class AlgoDegreeCentrality extends AbstractAlgoProcedure {
       r.setProperty("score", total / norm);
       return (Result) r;
     });
+  }
+
+  private static long countEdges(final Vertex v, final Vertex.DIRECTION direction, final String[] relTypes) {
+    return relTypes != null && relTypes.length > 0 ? v.countEdges(direction, relTypes) : v.countEdges(direction);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
@@ -90,28 +90,27 @@ public class AlgoWCC extends AbstractAlgoProcedure {
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
 
-    // Try CSR-accelerated path: delegate to native union-find on CSR arrays. Only for an
-    // unfiltered call: connectedComponents() walks the whole view, and a provider is selected
-    // for covering the requested types, not for covering only those, so a filtered call would
-    // union edges it was asked to leave out. loadGraph() applies the filter to CSR adjacency.
-    if (relTypes == null || relTypes.length == 0) {
-      final GraphTraversalProvider provider = findProvider(db, null);
-      if (provider instanceof GraphAnalyticalView gav) {
-        context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
-        return executeWithCSR(context, gav);
-      }
+    // Try CSR-accelerated path: delegate to native min-label propagation on CSR arrays.
+    // findProvider(relTypes) only returns a provider that covers every requested type, and
+    // GraphAlgorithms.connectedComponents() takes the same relTypes and resolves each one to its
+    // own CSR index (GraphAnalyticalView#getCSRIndex), so passing the filter through keeps the
+    // parallel algorithm for a filtered call instead of dropping to the single-threaded BFS below.
+    final GraphTraversalProvider provider = findProvider(db, relTypes);
+    if (provider instanceof GraphAnalyticalView gav) {
+      context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
+      return executeWithCSR(context, gav, relTypes);
     }
 
     // Fall back to OLTP path
     return executeWithOLTP(db, relTypes);
   }
 
-  private Stream<Result> executeWithCSR(final CommandContext context, final GraphAnalyticalView gav) {
+  private Stream<Result> executeWithCSR(final CommandContext context, final GraphAnalyticalView gav, final String[] relTypes) {
     final int n = gav.getNodeCount();
     if (n == 0)
       return Stream.empty();
 
-    final int[] componentId = GraphAlgorithms.connectedComponents(gav);
+    final int[] componentId = GraphAlgorithms.connectedComponents(gav, relTypes);
     context.setVariable(CommandContext.RESULT_COUNT_HINT_VAR, (long) n);
 
     return IntStream.range(0, n).mapToObj(i -> {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
@@ -88,15 +88,22 @@ public class AlgoWCC extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
 
-    // Try CSR-accelerated path: delegate to native union-find on CSR arrays
-    final GraphTraversalProvider provider = findProvider(db, null);
-    if (provider instanceof GraphAnalyticalView gav) {
-      context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
-      return executeWithCSR(context, gav);
+    final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
+
+    // Try CSR-accelerated path: delegate to native union-find on CSR arrays. Only for an
+    // unfiltered call: connectedComponents() walks the whole view, and a provider is selected
+    // for covering the requested types, not for covering only those, so a filtered call would
+    // union edges it was asked to leave out. loadGraph() applies the filter to CSR adjacency.
+    if (relTypes == null || relTypes.length == 0) {
+      final GraphTraversalProvider provider = findProvider(db, null);
+      if (provider instanceof GraphAnalyticalView gav) {
+        context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
+        return executeWithCSR(context, gav);
+      }
     }
 
     // Fall back to OLTP path
-    return executeWithOLTP(db);
+    return executeWithOLTP(db, relTypes);
   }
 
   private Stream<Result> executeWithCSR(final CommandContext context, final GraphAnalyticalView gav) {
@@ -115,13 +122,13 @@ public class AlgoWCC extends AbstractAlgoProcedure {
     });
   }
 
-  private Stream<Result> executeWithOLTP(final Database db) {
-    final GraphData graph = loadGraph(db, null, null, null);
+  private Stream<Result> executeWithOLTP(final Database db, final String[] relTypes) {
+    final GraphData graph = loadGraph(db, null, relTypes, null);
 
     final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
-    final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH);
+    final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH, relTypes);
 
     final int[] componentId = new int[n];
     for (int i = 0; i < n; i++)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java
@@ -71,12 +71,22 @@ public class CypherPlanCache {
   }
 
   /**
-   * Puts a physical plan into the cache.
+   * Puts a physical plan into the cache, unless a DDL has invalidated the cache since {@code planningStart} - the
+   * moment the caller began building this plan. Without this guard a plan built against a schema that a concurrent
+   * {@code DROP INDEX}/{@code ALTER TYPE}/create-index already made stale could be cached right after the
+   * invalidation that was supposed to keep it out, leaving future executions running against a dropped/renamed
+   * bucket or index (or missing a new one) until the next invalidation happens to clear it (issue #6671). The check
+   * and the insert run under the same lock as {@link #invalidate()}, so a concurrent invalidation is guaranteed to
+   * either be observed here (the put is skipped) or to run after this put returns (and clear it right back out).
    *
-   * @param query the OpenCypher query string (cache key)
-   * @param plan  the optimized PhysicalPlan to cache
+   * @param query         the OpenCypher query string (cache key)
+   * @param plan          the optimized PhysicalPlan to cache
+   * @param planningStart the timestamp (as returned by {@link System#currentTimeMillis()}) taken before planning
+   *                      began
    */
-  public void put(final String query, final PhysicalPlan plan) {
+  public synchronized void put(final String query, final PhysicalPlan plan, final long planningStart) {
+    if (lastInvalidation >= planningStart)
+      return;
     cache.put(query, plan);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/CypherPlanCache.java
@@ -39,6 +39,12 @@ import java.util.Map;
  * - Eliminates plan building overhead (50-100ms per query)
  * <p>
  * Total savings: 200-500ms per cached query execution.
+ * <p>
+ * {@link #put} and {@link #invalidate()} synchronize on {@code this}, so the {@code lastInvalidation} check and the
+ * insert into {@code cache} happen atomically with respect to a concurrent invalidation (issue #6671). {@link #get}
+ * does not need that lock - it never reads {@link #lastInvalidation} - and instead relies on {@code cache} being a
+ * {@link Collections#synchronizedMap} for its own thread safety, so the frequent read path stays uncontended by the
+ * much rarer {@code put}/{@code invalidate}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -349,14 +349,17 @@ public class OpenCypherQueryEngine implements QueryEngine {
         plan = new CypherExecutionPlan(
             execDb, statement, parameters, configuration, physicalPlan, EXPRESSION_EVALUATOR);
       } else {
-        // Create new plan from scratch and cache it
+        // Create new plan from scratch and cache it. planningStart is taken before planning begins so put() can
+        // detect a DDL (DROP INDEX/ALTER TYPE/create-index) that invalidated the cache concurrently with this
+        // planning and skip caching a plan already built against stale schema/index state (issue #6671).
+        final long planningStart = System.currentTimeMillis();
         final CypherExecutionPlanner planner = new CypherExecutionPlanner(execDb, statement, parameters,
             EXPRESSION_EVALUATOR);
         plan = planner.createExecutionPlan(configuration);
 
         // Cache the physical plan for future use
         if (plan.getPhysicalPlan() != null)
-          database.getCypherPlanCache().put(queryString, plan.getPhysicalPlan());
+          database.getCypherPlanCache().put(queryString, plan.getPhysicalPlan(), planningStart);
       }
     } else {
       // explain/profile mode: always create new plan without caching

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -98,6 +98,16 @@ public class SelectExecutor {
             skipped++;
             continue;
           }
+          // #6579: A PRE-INCREMENT GUARD IS NEEDED FOR limit == 0 - OTHERWISE THE FIRST MATCH BUMPS count TO 1
+          // BEFORE count >= limit (1 >= 0) EVER GETS THE CHANCE TO STOP THE LOOP. THIS GUARD ALONE CAN ONLY EVER
+          // FIRE FOR limit == 0 THOUGH: FOR ANY limit > 0, count NEVER REACHES limit WITHOUT THE POST-INCREMENT
+          // CHECK BELOW ALREADY BREAKING THE LOOP FIRST - SO KEEPING THAT SECOND CHECK IS NOT REDUNDANT, IT IS
+          // WHAT PRESERVES THE SAME-ITERATION EARLY EXIT FOR limit > 0 (A REVIEW CAUGHT DROPPING IT: WITHOUT IT,
+          // ONCE THE LIMIT IS REACHED THE LOOP CAN ONLY BREAK ON THE *NEXT* MATCHING RECORD - VIA THE break BEING
+          // NESTED INSIDE THIS evaluateWhere() BRANCH - SO A SELECTIVE WHERE WITH NO (limit+1)TH MATCH DEGRADES A
+          // BOUNDED count() INTO A FULL SCAN OF THE REST OF THE TYPE)
+          if (select.limit > -1 && count >= select.limit)
+            break;
           if (filterOutRecords != null)
             filterOutRecords.add(record.getIdentity());
           count++;

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -571,6 +571,16 @@ public class SelectExecutor {
     if (!CURSOR_BUILDABLE_OPERATORS.contains(node.operator))
       return;
 
+    if (node.getParent().operator == SelectOperator.not)
+      // #6575: A LEAF DIRECTLY UNDER not WOULD OTHERWISE BUILD A "POSITIVE" CURSOR FOR THE UN-NEGATED CONDITION
+      // (E.G. AN eq CURSOR FOR NOT a = 'x' YIELDS THE RECORDS WHERE a = 'x' IS TRUE) - evaluateWhere() THEN
+      // REJECTS EVERY ONE OF THOSE CANDIDATES SINCE THEY ALL SATISFY THE POSITIVE CONDITION BY CONSTRUCTION, SO
+      // THE QUERY WOULD SILENTLY RETURN ZERO ROWS INSTEAD OF "EVERY RECORD WHERE a != 'x'". isTheNodeFullyIndexed()
+      // STILL SETS node.index HERE (SEE ITS not BRANCH), SO REFUSE THE CURSOR HERE INSTEAD, THE SAME WAY
+      // is_null/is_not_null LEAVES ARE ALREADY EXCLUDED THERE. NEITHER A FLUENT .not() NOR Select.json() REACH THIS
+      // TODAY, BUT THE DEFENSIVE POSTURE MUST HOLD THE MOMENT EITHER PATH OPENS UP.
+      return;
+
     if (node.getParent().operator == SelectOperator.or) {
       // UNDER AN 'OR' OPERATOR: BOTH SIDES MUST BE INDEXED, OTHERWISE CANNOT USE INDEXES
       if (node != node.getParent().right) {

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -49,6 +49,15 @@ public class SelectExecutor {
   // skip) TO A MultiIndexCursor
   int             indexCandidateLimit = -1;
 
+  // #6577: THE SINGLE SOURCE OF TRUTH FOR "WHICH OPERATORS CAN filterWithIndexesFinalNode() ACTUALLY TURN INTO AN
+  // IndexCursor" - isTheNodeFullyIndexed() MUST TREAT EXACTLY THIS SET, AND NO MORE, AS "THIS LEAF IS INDEXED".
+  // TREATING A WIDER SET AS INDEXED IS WHAT LET #6577 THROUGH: A neq/like/ilike LEAF PASSED THE "UNDER AN or, BOTH
+  // SIDES MUST BE INDEXED" GATE (BECAUSE ITS PROPERTY HAD AN INDEX) BUT THEN filterWithIndexesFinalNode()'S SWITCH
+  // FELL THROUGH TO A BARE return WITH NO CURSOR - SO THE WHOLE BRANCH SILENTLY CONTRIBUTED ZERO ROWS INSTEAD OF
+  // JUST RUNNING LESS EFFICIENTLY. KEEP BOTH CALL SITES READING THIS ONE FIELD SO THEY CANNOT DRIFT APART AGAIN.
+  private static final Set<SelectOperator> CURSOR_BUILDABLE_OPERATORS = EnumSet.of(SelectOperator.eq, SelectOperator.in_op,
+      SelectOperator.between, SelectOperator.gt, SelectOperator.ge, SelectOperator.lt, SelectOperator.le);
+
   static class IndexInfo {
     public final Index   index;
     public final String  property;
@@ -252,9 +261,10 @@ public class SelectExecutor {
       if (!cursors.isEmpty())
         return new MultiIndexCursor(cursors, indexCandidateLimit, true);
 
-      // NO CURSOR WAS ACTUALLY BUILT (E.G. A BARE neq/like/ilike LEAF: "INDEXED" PER isTheNodeFullyIndexed()'S LOOSER
-      // CHECK - SEE #6577 - BUT filterWithIndexesFinalNode()'S switch DOESN'T HANDLE THE OPERATOR), SO NO CAP WAS
-      // EVER APPLIED EITHER: RESET THE TEST-VISIBLE FIELD RATHER THAN LEAVE IT HOLDING A MISLEADING FINITE VALUE
+      // NO CURSOR WAS ACTUALLY BUILT (E.G. A BARE is_null/is_not_null/neq/like/ilike LEAF, WHICH isTheNodeFullyIndexed()
+      // CORRECTLY REFUSES TO TREAT AS INDEXED - SEE #6577 - SO node.index STAYS null AND filterWithIndexesFinalNode()
+      // NEVER RUNS), SO NO CAP WAS EVER APPLIED EITHER: RESET THE TEST-VISIBLE FIELD RATHER THAN LEAVE IT HOLDING A
+      // MISLEADING FINITE VALUE
       indexCandidateLimit = -1;
     }
     return null;
@@ -509,11 +519,9 @@ public class SelectExecutor {
     if (node == null)
       return null;
 
-    // node.index != null MEANS "isTheNodeFullyIndexed() FOUND AN INDEX ON THIS LEAF'S PROPERTY", NOT "THIS LEAF'S
-    // OPERATOR ACTUALLY PRODUCES A CURSOR" - IT'S SET FOR neq/like/ilike TOO (SEE #6577). HARMLESS TODAY BECAUSE A
-    // BARE SUCH LEAF STILL PRODUCES NO CURSOR IN filterWithIndexesFinalNode()'S switch, SO cursors STAYS EMPTY AND
-    // lookForIndexes() RETURNS null BEFORE ANY (WRONGLY-COMPUTED) CAP IS EVER USED - BUT #6577 IS WHERE TO FIX THIS
-    // AT THE SOURCE, NOT HERE
+    // node.index != null MEANS "isTheNodeFullyIndexed() FOUND AN INDEX ON THIS LEAF'S PROPERTY AND ITS OPERATOR IS
+    // CURSOR-BUILDABLE" (SEE CURSOR_BUILDABLE_OPERATORS, FIXED BY #6577) - SO A BARE neq/like/ilike LEAF NO LONGER
+    // REACHES HERE WITH node.index SET, AND THIS METHOD DOESN'T NEED TO KNOW ABOUT THAT DISTINCTION ITSELF.
     if (!(node.left instanceof SelectTreeNode))
       return node.index != null ? node : null;
 
@@ -555,6 +563,12 @@ public class SelectExecutor {
 
   private void filterWithIndexesFinalNode(final SelectTreeNode node, final List<IndexCursor> cursors) {
     if (node.index == null)
+      return;
+
+    // #6577: node.index != null ONLY MEANS THE PROPERTY HAS AN INDEX, NOT THAT THIS OPERATOR CAN BE TURNED INTO A
+    // CURSOR - isTheNodeFullyIndexed() NOW GUARDS AGAINST THIS TOO (SEE CURSOR_BUILDABLE_OPERATORS), BUT THIS CHECK
+    // STAYS AS A CHEAP DEFENSIVE MIRROR OF THE SWITCH BELOW IN CASE THAT INVARIANT IS EVER LOOSENED ELSEWHERE.
+    if (!CURSOR_BUILDABLE_OPERATORS.contains(node.operator))
       return;
 
     if (node.getParent().operator == SelectOperator.or) {
@@ -647,7 +661,11 @@ public class SelectExecutor {
       return true;
 
     if (!(node.left instanceof SelectTreeNode)) {
-      if (node.operator == SelectOperator.is_null || node.operator == SelectOperator.is_not_null)
+      // #6577: A LEAF IS "INDEXED" ONLY WHEN filterWithIndexesFinalNode()'S SWITCH CAN ACTUALLY BUILD A CURSOR FOR
+      // ITS OPERATOR - is_null/is_not_null WERE THE ONLY EXCLUSION HERE BEFORE, BUT neq/like/ilike NEVER PRODUCE A
+      // CURSOR EITHER (SEE CURSOR_BUILDABLE_OPERATORS). A neq/like/ilike LEAF MUST FALL BACK TO A FULL SCAN, SAME AS
+      // is_null/is_not_null, RATHER THAN LET AN or SIBLING TREAT IT AS INDEXED AND SILENTLY DROP ITS MATCHES.
+      if (!CURSOR_BUILDABLE_OPERATORS.contains(node.operator))
         return false;
 
       if (!(node.right instanceof SelectPropertyValue)) {

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -2149,11 +2149,15 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
             // Process right side normally
             if (ctx.LPAREN() != null) {
-              final List<Expression> expressions = new ArrayList<>();
-              for (int i = 1; i < ctx.expression().size(); i++) {
-                expressions.add((Expression) visit(ctx.expression(i)));
+              // ctx.expression() (no-arg) rescans the whole child list every call, and so does the indexed
+              // ctx.expression(i) accessor it backs - calling either in a loop condition/body is O(n) per
+              // iteration, O(n^2) overall for an N-item list (#6640). Fetch the list once and index into it.
+              final List<SQLParser.ExpressionContext> exprCtxs = ctx.expression();
+              final ArrayLiteralExpression arrayLiteral = new ArrayLiteralExpression();
+              for (int i = 1; i < exprCtxs.size(); i++) {
+                arrayLiteral.addItem((Expression) visit(exprCtxs.get(i)));
               }
-              condition.right = expressions;
+              condition.rightMathExpression = arrayLiteral;
             } else {
               final Expression rightExpr = (Expression) visit(ctx.expression(1));
               if (rightExpr.mathExpression instanceof final BaseExpression baseExpr) {
@@ -2188,9 +2192,14 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     if (ctx.LPAREN() != null) {
       // Form: IN (expr1, expr2, ...) - explicit parentheses at IN level
+      // ctx.expression() (no-arg) rescans the whole child list every call, and so does the indexed
+      // ctx.expression(i) accessor it backs - calling either of them in a loop condition/body is O(n) per
+      // iteration, O(n^2) overall for an N-item list (#6640). Fetch the list once and index into it.
+      final List<SQLParser.ExpressionContext> exprCtxs = ctx.expression();
+
       // Check if it's a single parameter: IN (?)
-      if (ctx.expression().size() == 2) {
-        final Expression rightExpr = (Expression) visit(ctx.expression(1));
+      if (exprCtxs.size() == 2) {
+        final Expression rightExpr = (Expression) visit(exprCtxs.get(1));
 
         // Check if this is an input parameter
         if (rightExpr.mathExpression instanceof final BaseExpression baseExpr) {
@@ -2203,11 +2212,16 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       }
 
       // Multiple expressions or non-parameter: IN (expr1, expr2, ...)
-      final List<Expression> expressions = new ArrayList<>();
-      for (int i = 1; i < ctx.expression().size(); i++) {
-        expressions.add((Expression) visit(ctx.expression(i)));
+      // Wrapped as an ArrayLiteralExpression (same representation as the bracket syntax IN [...]) so a
+      // literal parenthesized list is index-aware exactly like the other IN forms - see InCondition#isIndexAware.
+      // Building the FetchFromIndexStep list from a table-scan-with-per-row-contains() (#6640) instead of a
+      // single index probe per value made a 15,000-value IN() ~1000x slower than the same values as a bound
+      // parameter, even on an indexed property.
+      final ArrayLiteralExpression arrayLiteral = new ArrayLiteralExpression();
+      for (int i = 1; i < exprCtxs.size(); i++) {
+        arrayLiteral.addItem((Expression) visit(exprCtxs.get(i)));
       }
-      condition.right = expressions;
+      condition.rightMathExpression = arrayLiteral;
     } else {
       // Form: IN expression (could be array literal, input parameter, subquery, etc.)
       final SQLParser.ExpressionContext exprCtx = ctx.expression(1);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CountFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CountFromIndexStep.java
@@ -18,9 +18,12 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.Index;
 import com.arcadedb.query.sql.parser.IndexIdentifier;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 
 import java.util.NoSuchElementException;
 
@@ -66,6 +69,9 @@ public class CountFromIndexStep extends AbstractExecutionStep {
         final long begin = context.isProfiling() ? System.nanoTime() : 0;
         try {
           final Index idx = context.getDatabase().getSchema().getIndexByName(target.getIndexName());
+          // The index's own entry count never loads a record through its bucket, so apply the same per-type read
+          // check a normal record load would go through.
+          SecurityHelper.checkAccessOnIndex((DatabaseInternal) context.getDatabase(), idx, SecurityDatabaseUser.ACCESS.READ_RECORD);
           final long size = idx.countEntries();
           executed = true;
           final ResultInternal result = new ResultInternal(context.getDatabase());

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
@@ -25,6 +26,8 @@ import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.RangeIndex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.parser.*;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.utility.Pair;
 
 import java.io.IOException;
@@ -117,6 +120,8 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
     initialized = true;
     final long begin = context.isProfiling() ? System.nanoTime() : 0;
     try {
+      // Removing an index entry directly never goes through the bucket's own DELETE_RECORD check, so apply it here.
+      SecurityHelper.checkAccessOnIndex((DatabaseInternal) context.getDatabase(), index, SecurityDatabaseUser.ACCESS.DELETE_RECORD);
       init(condition);
       nextEntry = loadNextEntry(context);
     } catch (final IOException e) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DistinctExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DistinctExecutionStep.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.schema.Type;
 
 import java.util.*;
 
@@ -43,11 +44,14 @@ public class DistinctExecutionStep extends AbstractExecutionStep {
     private final int hashCode;
 
     DistinctKey(final Result result) {
-      // Extract only the properties (not the element reference, metadata, etc.)
+      // Extract only the properties (not the element reference, metadata, etc.), normalising numeric values to a
+      // canonical form so that the same logical number represented with different boxed numeric types (e.g.
+      // Integer(1) vs Long(1)) is deduplicated as one value instead of splitting into separate rows (issue #6676),
+      // matching the canonicalization SQL GROUP BY already applies (AggregateProjectionCalculationStep.GroupByKey).
       final Set<String> propertyNames = result.getPropertyNames();
       this.properties = new HashMap<>(propertyNames.size());
       for (final String propName : propertyNames) {
-        this.properties.put(propName, result.getProperty(propName));
+        this.properties.put(propName, Type.normalizeNumberForKey(result.getProperty(propName)));
       }
       // Pre-compute hashCode for performance
       this.hashCode = properties.hashCode();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java
@@ -39,21 +39,35 @@ import java.util.List;
  * DeleteExecutionPlan}/{@code UpdateExecutionPlan}/{@code DDLExecutionPlan}/{@code
  * SingleOpExecutionPlan}: {@link ScriptLineStep#syncPull} special-cases exactly those types to
  * eagerly run them, so staying outside that set is what keeps a chained EXPLAIN from being run.
+ * <p>
+ * The same reasoning covers {@code PROFILE EXPLAIN <statement>}: {@code ProfileStatement.execute()}
+ * is itself a caller that pulls whatever {@code statement.createExecutionPlan()} hands back, so an
+ * inner {@link com.arcadedb.query.sql.parser.ExplainStatement} nested under {@code PROFILE} used to
+ * be just as exploitable as the {@code sqlscript} case - {@code PROFILE EXPLAIN UPDATE ...} silently
+ * ran the update too. Wrapping here closes that path as well: EXPLAIN's non-execution contract wins
+ * regardless of what encloses it, so {@code PROFILE EXPLAIN <statement>} degrades to plan-only output
+ * with no execution and no real cost numbers, rather than {@code PROFILE} unwrapping the inner
+ * statement and running it for real.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class ExplainExecutionPlan implements InternalExecutionPlan {
-  private final CommandContext context;
-  private final ExecutionPlan  wrappedPlan;
-  private       boolean        executed = false;
+  private final CommandContext        context;
+  private final InternalExecutionPlan wrappedPlan;
+  private       boolean               executed = false;
 
-  public ExplainExecutionPlan(final CommandContext context, final ExecutionPlan wrappedPlan) {
+  public ExplainExecutionPlan(final CommandContext context, final InternalExecutionPlan wrappedPlan) {
     this.context = context;
     this.wrappedPlan = wrappedPlan;
   }
 
-  public ExecutionPlan getWrappedPlan() {
+  public InternalExecutionPlan getWrappedPlan() {
     return wrappedPlan;
+  }
+
+  @Override
+  public void close() {
+    wrappedPlan.close();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Execution plan returned by {@code EXPLAIN <statement>} when it is not run through
+ * {@code Statement.execute()} directly, but instead chained into an enclosing plan - a script
+ * ({@code SQLScriptQueryEngine}), or a nested block (FOREACH, IF, WHILE, RETRY, LET). All of
+ * those callers treat whatever {@code Statement.createExecutionPlan(CommandContext)} returns as
+ * an executable plan and chain/pull it to completion, so an EXPLAIN whose {@code
+ * createExecutionPlan()} passed the wrapped statement's own plan straight through - as it used
+ * to - handed them something that, once pulled, actually ran the wrapped statement. For a write
+ * statement (UPDATE/INSERT/DELETE/...) that silently performed the write EXPLAIN promised not to
+ * (issue #6648).
+ * <p>
+ * This plan wraps the built-but-not-pulled plan of the wrapped statement and, on
+ * {@link #fetchNext(int)}, reports its description without ever pulling it - the same contract
+ * {@link com.arcadedb.query.sql.parser.ExplainResultSet} gives callers that go through {@code
+ * execute()}. It also deliberately is not an {@code InsertExecutionPlan}/{@code
+ * DeleteExecutionPlan}/{@code UpdateExecutionPlan}/{@code DDLExecutionPlan}/{@code
+ * SingleOpExecutionPlan}: {@link ScriptLineStep#syncPull} special-cases exactly those types to
+ * eagerly run them, so staying outside that set is what keeps a chained EXPLAIN from being run.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class ExplainExecutionPlan implements InternalExecutionPlan {
+  private final CommandContext context;
+  private final ExecutionPlan  wrappedPlan;
+  private       boolean        executed = false;
+
+  public ExplainExecutionPlan(final CommandContext context, final ExecutionPlan wrappedPlan) {
+    this.context = context;
+    this.wrappedPlan = wrappedPlan;
+  }
+
+  public ExecutionPlan getWrappedPlan() {
+    return wrappedPlan;
+  }
+
+  @Override
+  public ResultSet fetchNext(final int n) {
+    if (executed)
+      return new InternalResultSet();
+
+    executed = true;
+
+    final ResultInternal result = new ResultInternal();
+    result.setProperty("executionPlan", wrappedPlan.toResult());
+    result.setProperty("executionPlanAsString", wrappedPlan.prettyPrint(0, 3));
+
+    final InternalResultSet resultSet = new InternalResultSet(result);
+    resultSet.setPlan(this);
+    return resultSet;
+  }
+
+  @Override
+  public void reset(final CommandContext context) {
+    executed = false;
+  }
+
+  @Override
+  public boolean canBeCached() {
+    return false;
+  }
+
+  @Override
+  public List<ExecutionStep> getSteps() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String prettyPrint(final int depth, final int indent) {
+    return wrappedPlan.prettyPrint(depth, indent);
+  }
+
+  @Override
+  public Result toResult() {
+    final ResultInternal result = new ResultInternal(context.getDatabase());
+    result.setProperty("type", "ExplainExecutionPlan");
+    result.setProperty("javaType", getClass().getName());
+    result.setProperty("prettyPrint", prettyPrint(0, 2));
+    result.setProperty("wrapped", wrappedPlan.toResult());
+    return result;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClusterExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClusterExecutionStep.java
@@ -62,6 +62,9 @@ public class FetchFromClusterExecutionStep extends AbstractExecutionStep {
   @Override
   public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
     pullPrevious(context, nRecords);
+    // A blocking consumer (aggregation, ORDER BY, DISTINCT) with no WHERE to guard can otherwise drain
+    // the whole bucket past arcadedb.command.timeout without anything ever checking it (issue #6465).
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
     final long begin = context.isProfiling() ? System.nanoTime() : 0;
     try {
       if (iterator == null) {
@@ -112,6 +115,8 @@ public class FetchFromClusterExecutionStep extends AbstractExecutionStep {
           try {
             if (nFetched >= nRecords)
               throw new NoSuchElementException();
+
+            guard.check();
 
 //            if (ORDER_DESC == order && !iterator.hasPrevious()) {
 //              throw new NoSuchElementException();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -103,6 +103,10 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     init(context.getDatabase());
 
+    // A blocking consumer (aggregation, ORDER BY, DISTINCT) with no WHERE to guard can otherwise drain
+    // the whole index past arcadedb.command.timeout without anything ever checking it (issue #6465).
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
     return new ResultSet() {
       int localCount = 0;
 
@@ -121,6 +125,8 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       public Result next() {
         if (!hasNext())
           throw new NoSuchElementException();
+
+        guard.check();
 
         final long begin = context.isProfiling() ? System.nanoTime() : 0;
         try {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
@@ -44,6 +45,8 @@ import com.arcadedb.query.sql.parser.PCollection;
 import com.arcadedb.query.sql.parser.ValueExpression;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.serializer.BinaryTypes;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.Pair;
@@ -264,6 +267,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     if (index == null) {
       index = (RangeIndex) db.getSchema().getIndexByName(indexName);
     }
+    // This cursor answers straight from the index, without loading each record through its bucket, so apply the
+    // same per-type read check a normal record load would go through.
+    SecurityHelper.checkAccessOnIndex((DatabaseInternal) db, index, SecurityDatabaseUser.ACCESS.READ_RECORD);
     try {
       if (condition == null) {
         processFlatIteration();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -550,14 +550,19 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     // consistent with the multi-value handling in processInCondition().
     if (!(value instanceof Identifiable) && MultiValue.isMultiValue(value)) {
       final List<PCollection> result = new ArrayList<>();
+      // `tail` does not depend on `elemInKey`: it is `key` with its (already-consumed) first expression
+      // dropped, the same for every element `value` expands into. Computing it once here instead of once
+      // per element avoids deep-copying the whole remaining key - including a large literal IN-list still
+      // sitting in a later slot - on every one of `value`'s elements, which made this loop quadratic in the
+      // element count (#6640: a 15,000-value IN() on an indexed property took ~10s here alone).
+      final PCollection tail = key.copy();
+      tail.getExpressions().removeFirst();
       for (final Object elemInKey : MultiValue.getMultiValueIterable(value)) {
         final PCollection newHead = new PCollection();
         for (final Expression exp : head.getExpressions())
           newHead.add(exp.copy());
 
         newHead.add(toExpression(unwrapSubQueryResult(elemInKey)));
-        final PCollection tail = key.copy();
-        tail.getExpressions().removeFirst();
         result.addAll(cartesianProduct(newHead, tail));
       }
       return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
@@ -69,6 +69,10 @@ public class FetchFromRidsStep extends AbstractExecutionStep {
       this.rids = SelectExecutionPlanner.resolveRidEqualityOrInListAtRuntime(ridCondition, context);
       iterator = this.rids.iterator();
     }
+    // A RID list dominated by missing/deleted entries scans the whole list inside one fetchNext() call, the
+    // same class of unbounded-inner-loop gap ScanWithFilterStep guards for a WHERE that rejects everything
+    // (issue #6465).
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
     return new ResultSet() {
       int internalNext = 0;
 
@@ -77,6 +81,7 @@ public class FetchFromRidsStep extends AbstractExecutionStep {
           return;
         }
         while (iterator.hasNext()) {
+          guard.check();
           final RID nextRid = iterator.next();
           if (nextRid == null)
             continue;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaIndexesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaIndexesStep.java
@@ -18,13 +18,18 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.utility.FileUtils;
 
 import java.io.IOException;
@@ -56,8 +61,15 @@ public class FetchFromSchemaIndexesStep extends AbstractExecutionStep {
       final long begin = context.isProfiling() ? System.nanoTime() : 0;
       try {
         final Schema schema = context.getDatabase().getSchema();
+        final SecurityDatabaseUser currentUser = currentUser(context);
 
         for (final Index index : schema.getIndexes()) {
+          // Hide, rather than throw on, an index the current user cannot read the owning type of - matching how
+          // schema:types treats a restricted type (issue #4238).
+          final DocumentType type = index.getTypeName() == null ? null : schema.getType(index.getTypeName());
+          if (!SecurityHelper.canAccessType(currentUser, type, SecurityDatabaseUser.ACCESS.READ_RECORD))
+            continue;
+
           final ResultInternal r = new ResultInternal(context.getDatabase());
           result.add(r);
 
@@ -139,6 +151,12 @@ public class FetchFromSchemaIndexesStep extends AbstractExecutionStep {
         cursor = 0;
       }
     };
+  }
+
+  private static SecurityDatabaseUser currentUser(final CommandContext context) {
+    final DatabaseInternal database = (DatabaseInternal) context.getDatabase();
+    final DatabaseContext.DatabaseContextTL dbContext = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
+    return dbContext != null ? dbContext.getCurrentUser() : null;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaTypesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaTypesStep.java
@@ -36,6 +36,7 @@ import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -75,7 +76,7 @@ public class FetchFromSchemaTypesStep extends AbstractExecutionStep {
           // RemoteSchema.reload() lists every type on its first command and aborted the whole
           // listing the first time it hit a restricted type, locking the remote driver out
           // even from types the user was allowed to read.
-          if (!canReadAnyBucket(currentUser, type))
+          if (!SecurityHelper.canAccessType(currentUser, type, SecurityDatabaseUser.ACCESS.READ_RECORD))
             continue;
 
           final ResultInternal r = new ResultInternal(context.getDatabase());
@@ -235,24 +236,6 @@ public class FetchFromSchemaTypesStep extends AbstractExecutionStep {
     final DatabaseInternal database = (DatabaseInternal) context.getDatabase();
     final DatabaseContext.DatabaseContextTL dbContext = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
     return dbContext != null ? dbContext.getCurrentUser() : null;
-  }
-
-  /**
-   * Returns true when the type is visible to the current user (issue #4238). With no security
-   * context (embedded usage or root) every type is visible. Otherwise, the type is visible when
-   * the user has READ_RECORD on at least one of its buckets - matching the principle that a user
-   * with partial access should still see the resource in catalog listings.
-   */
-  private static boolean canReadAnyBucket(final SecurityDatabaseUser user, final DocumentType type) {
-    if (user == null)
-      return true;
-    final List<Bucket> buckets = type.getBuckets(false);
-    if (buckets.isEmpty())
-      return true;
-    for (final Bucket b : buckets)
-      if (user.requestAccessOnFile(b.getFileId(), SecurityDatabaseUser.ACCESS.READ_RECORD))
-        return true;
-    return false;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTimeSeriesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTimeSeriesStep.java
@@ -18,12 +18,15 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.utility.DateUtils;
 
 import java.io.IOException;
@@ -86,6 +89,10 @@ public class FetchFromTimeSeriesStep extends AbstractExecutionStep {
     try {
       if (!fetched) {
         try {
+          // A TimeSeries type stores its rows in its own engine, not in a bucket LocalBucket's read check could
+          // gate, so apply the equivalent per-type read check here.
+          SecurityHelper.checkAccessOnType((DatabaseInternal) context.getDatabase(), tsType, SecurityDatabaseUser.ACCESS.READ_RECORD);
+
           final TimeSeriesEngine engine = tsType.getEngine();
           if (engine == null)
             throw new CommandExecutionException(

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/GuaranteeEmptyCountStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/GuaranteeEmptyCountStep.java
@@ -24,16 +24,22 @@ import com.arcadedb.query.sql.parser.ProjectionItem;
 
 import java.util.NoSuchElementException;
 
+/**
+ * Guarantees that a no-GROUP-BY aggregation (count(*), sum(), avg(), min(), max(), ...) always produces exactly one
+ * row, even when the upstream produced none. Without this step {@link AggregateProjectionCalculationStep} emits no
+ * row at all over an empty input, which is inconsistent with the single-row-with-identity-value semantics SQL callers
+ * expect from a scalar aggregate (issue #6680).
+ */
 public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
-  private final ProjectionItem item;
-  private final Projection     preAggregateProjection;
-  private       boolean        executed = false;
+  private final Projection aggregateProjection;
+  private final Projection preAggregateProjection;
+  private       boolean    executed = false;
 
-  public GuaranteeEmptyCountStep(final ProjectionItem countItem, final Projection preAggregateProjection,
+  public GuaranteeEmptyCountStep(final Projection aggregateProjection, final Projection preAggregateProjection,
       final CommandContext context) {
     super(context);
-    this.item = countItem;
+    this.aggregateProjection = aggregateProjection;
     this.preAggregateProjection = preAggregateProjection;
   }
 
@@ -60,7 +66,17 @@ public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
             return upstream.next();
 
           final ResultInternal result = new ResultInternal(context.getDatabase());
-          result.setProperty(item.getProjectionAliasAsString(), 0L);
+          for (final ProjectionItem item : aggregateProjection.getItems()) {
+            final Object value = item.isAggregate(context) ?
+                // No row was ever aggregated: read the aggregate function's identity value (e.g. 0 for count()/sum(),
+                // null for min()/max()/avg()) without ever calling apply(), consistent with a group whose rows are
+                // all-null.
+                item.getAggregationContext(context).getFinalValue() :
+                // A non-aggregate item mixed into a GROUP-BY-less aggregation projection (e.g. a constant) has no row
+                // to evaluate against.
+                item.execute((Result) null, context);
+            result.setProperty(item.getProjectionAliasAsString(), value);
+          }
           if (preAggregateProjection != null) {
             for (final ProjectionItem preAggItem : preAggregateProjection.getItems()) {
               result.setProperty(preAggItem.getProjectionAliasAsString(), preAggItem.execute((Result) null, context));
@@ -81,7 +97,8 @@ public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
   @Override
   public ExecutionStep copy(final CommandContext context) {
-    return new GuaranteeEmptyCountStep(item.copy(), preAggregateProjection != null ? preAggregateProjection.copy() : null, context);
+    return new GuaranteeEmptyCountStep(aggregateProjection.copy(), preAggregateProjection != null ? preAggregateProjection.copy() : null,
+        context);
   }
 
   public boolean canBeCached() {
@@ -90,6 +107,6 @@ public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
   @Override
   public String prettyPrint(final int depth, final int indent) {
-    return ExecutionStepInternal.getIndent(depth, indent) + "+ GUARANTEE FOR ZERO COUNT ";
+    return ExecutionStepInternal.getIndent(depth, indent) + "+ GUARANTEE SINGLE ROW FOR EMPTY AGGREGATION ";
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
@@ -131,6 +131,14 @@ public class InsertExecutionPlanner {
       tot = body.getValueExpressions().size();
     else if (body != null && body.getJsonArrayContent() != null && body.getJsonArrayContent().items.size() > 0)
       tot = body.getJsonArrayContent().items.size();
+    else if (body != null && body.getContentInputParam() != null) {
+      // A CONTENT input parameter that resolves to a List must create one record per item, exactly like the
+      // JSON-array literal form above (#6463). The parameter is already bound in the context by the time the
+      // execution plan is created (see InsertStatement.execute), so it can be sized here rather than deferred.
+      final Object paramValue = body.getContentInputParam().getValue(context.getInputParameters());
+      if (paramValue instanceof List<?> list && !list.isEmpty())
+        tot = list.size();
+    }
 
     if (targetType == null && targetBucket != null) {
       // #5636: the `else bucket = null` arm below makes this guard reachable, but ONLY for the case where no name

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -108,9 +108,9 @@ public class MatchEdgeTraverser {
   }
 
   /**
-   * Returns {@code false} for a while/maxDepth pattern item: {@link com.arcadedb.graph.GraphTraversalProvider
-   * #isConnectedTo} only ever answers whether two vertices are joined by a single hop, so a variable-depth item
-   * must keep going through the recursive {@link #executeTraversal} instead of taking the expand-into fast path.
+   * Returns {@code false} for a while/maxDepth pattern item: {@link GraphTraversalProvider#isConnectedTo} only
+   * ever answers whether two vertices are joined by a single hop, so a variable-depth item must keep going
+   * through the recursive {@link #executeTraversal} instead of taking the expand-into fast path.
    */
   private static boolean isSingleHopExpandable(final MatchPathItem item) {
     if (item == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -166,9 +166,7 @@ public class MatchEdgeTraverser {
             ? getExpandIntoDirection() : null;
         if (direction != null) {
           final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
-          final GraphTraversalProvider provider = edgeTypes.length == 0
-              ? GraphTraversalProviderRegistry.findProvider(context.getDatabase())
-              : GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
+          final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
           if (provider != null) {
             final int srcId = provider.getNodeId(sourceVertex.getIdentity());
             final int tgtId = provider.getNodeId(targetElem.getIdentity());

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -107,6 +107,26 @@ public class MatchEdgeTraverser {
     return this.edge.edge.in.alias;
   }
 
+  /**
+   * Returns the {@link Vertex.DIRECTION} the GAV expand-into fast path (see {@link #init}) should query, as seen
+   * from this traverser's own starting point (i.e. the vertex {@link #getStartingPointAlias()} names): the same
+   * direction {@link #traversePatternEdge} would use by invoking {@code item.getMethod().execute(...)}. Returns
+   * {@code null} when the pattern edge has no single direction to ask a provider about - no method (a
+   * {@code FieldMatchPathItem}/{@code MultiMatchPathItem}) or a method other than out/in/both (outE/inE/bothE/
+   * outV/inV need the edge or the far vertex itself, not just a connectivity check) - in which case the fast path
+   * is skipped in favour of the slow, always-correct traversal.
+   */
+  protected Vertex.DIRECTION getExpandIntoDirection() {
+    if (item == null || item.getMethod() == null)
+      return null;
+    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
+      case "out" -> Vertex.DIRECTION.OUT;
+      case "in" -> Vertex.DIRECTION.IN;
+      case "both" -> Vertex.DIRECTION.BOTH;
+      default -> null;
+    };
+  }
+
   protected void init(final CommandContext context) {
     if (downstream == null) {
       Identifiable startingElem = sourceRecord.getElementProperty(getStartingPointAlias());
@@ -125,15 +145,20 @@ public class MatchEdgeTraverser {
         else if (prevValue instanceof Result r)
           targetElem = r.getElement().orElse(null);
 
-        if (targetElem != null) {
-          final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(context.getDatabase());
+        // Only a plain out()/in()/both() hop is eligible: the fast path returns just the bound vertex, which is
+        // wrong for outE()/inE()/bothE()/outV()/inV() (an edge/vertex object is expected) and item.getMethod() is
+        // null for a FieldMatchPathItem/MultiMatchPathItem (no single direction to ask the provider about).
+        final Vertex.DIRECTION direction = targetElem != null && edge != null ? getExpandIntoDirection() : null;
+        if (direction != null) {
+          final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
+          final GraphTraversalProvider provider = edgeTypes.length == 0
+              ? GraphTraversalProviderRegistry.findProvider(context.getDatabase())
+              : GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
           if (provider != null) {
             final int srcId = provider.getNodeId(sourceVertex.getIdentity());
             final int tgtId = provider.getNodeId(targetElem.getIdentity());
             if (srcId >= 0 && tgtId >= 0) {
-              // Determine direction from the edge traversal
-              final Vertex.DIRECTION direction = edge != null && !edge.out ? Vertex.DIRECTION.IN : Vertex.DIRECTION.OUT;
-              if (provider.isConnectedTo(srcId, tgtId, direction)) {
+              if (provider.isConnectedTo(srcId, tgtId, direction, edgeTypes)) {
                 // Connected: return the target as the single result
                 final Document doc = (Document) targetElem.getRecord();
                 downstream = List.of(new ResultInternal(doc)).iterator();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -129,14 +129,7 @@ public class MatchEdgeTraverser {
    * is skipped in favour of the slow, always-correct traversal.
    */
   protected Vertex.DIRECTION getExpandIntoDirection() {
-    if (item == null || item.getMethod() == null)
-      return null;
-    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
-      case "out" -> Vertex.DIRECTION.OUT;
-      case "in" -> Vertex.DIRECTION.IN;
-      case "both" -> Vertex.DIRECTION.BOTH;
-      default -> null;
-    };
+    return MatchExecutionPlanner.directionFor(item, true);
   }
 
   protected void init(final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -147,7 +147,12 @@ public class MatchEdgeTraverser {
       }
 
       // Expand-into optimization: when both endpoints are already bound, use isConnectedTo()
-      // for O(log degree) binary search instead of traversing all neighbors
+      // for O(log degree) binary search instead of traversing all neighbors. This does not re-check the
+      // endpoint's own filters/class/cluster/rid (unlike executeTraversal(), which calls matchesFilters() etc.
+      // per candidate): those were already applied when the endpoint alias was first bound, and next()'s
+      // equals(prevValue, nextElement) check below (the same one the slow path relies on to reject a
+      // subsequent binding that disagrees with an earlier one) is what re-validates identity here, not a
+      // second filter pass. This is by design, not an oversight.
       final String endPointAlias = getEndpointAlias();
       final Object prevValue = sourceRecord.getProperty(endPointAlias);
       if (prevValue != null && startingElem instanceof Vertex sourceVertex) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -172,6 +172,8 @@ public class MatchEdgeTraverser {
         // hasAnyProviders() short-circuits on a single volatile read, avoiding extractEdgeLabels()'s array/string
         // work below for the overwhelmingly common case where no GAV provider is registered for any database.
         if (direction != null && GraphTraversalProviderRegistry.hasAnyProviders()) {
+          // direction != null already proved item.getMethod() != null (see getExpandIntoDirection()), which is
+          // what extractEdgeLabels() dereferences without its own null check - keep this call after that guard.
           final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
           final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
           if (provider != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -108,6 +108,18 @@ public class MatchEdgeTraverser {
   }
 
   /**
+   * Returns {@code false} for a while/maxDepth pattern item: {@link com.arcadedb.graph.GraphTraversalProvider
+   * #isConnectedTo} only ever answers whether two vertices are joined by a single hop, so a variable-depth item
+   * must keep going through the recursive {@link #executeTraversal} instead of taking the expand-into fast path.
+   */
+  private static boolean isSingleHopExpandable(final MatchPathItem item) {
+    if (item == null)
+      return false;
+    final var filter = item.getFilter();
+    return filter == null || (filter.getWhileCondition() == null && filter.getMaxDepth() == null);
+  }
+
+  /**
    * Returns the {@link Vertex.DIRECTION} the GAV expand-into fast path (see {@link #init}) should query, as seen
    * from this traverser's own starting point (i.e. the vertex {@link #getStartingPointAlias()} names): the same
    * direction {@link #traversePatternEdge} would use by invoking {@code item.getMethod().execute(...)}. Returns
@@ -147,8 +159,11 @@ public class MatchEdgeTraverser {
 
         // Only a plain out()/in()/both() hop is eligible: the fast path returns just the bound vertex, which is
         // wrong for outE()/inE()/bothE()/outV()/inV() (an edge/vertex object is expected) and item.getMethod() is
-        // null for a FieldMatchPathItem/MultiMatchPathItem (no single direction to ask the provider about).
-        final Vertex.DIRECTION direction = targetElem != null && edge != null ? getExpandIntoDirection() : null;
+        // null for a FieldMatchPathItem/MultiMatchPathItem (no single direction to ask the provider about). A
+        // while/maxDepth item is a variable-depth traversal - isConnectedTo() only ever answers a single hop, so
+        // it must keep going through the recursive executeTraversal() below instead.
+        final Vertex.DIRECTION direction = targetElem != null && edge != null && isSingleHopExpandable(item)
+            ? getExpandIntoDirection() : null;
         if (direction != null) {
           final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
           final GraphTraversalProvider provider = edgeTypes.length == 0

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -169,7 +169,9 @@ public class MatchEdgeTraverser {
         // it must keep going through the recursive executeTraversal() below instead.
         final Vertex.DIRECTION direction = targetElem != null && edge != null && isSingleHopExpandable(item)
             ? getExpandIntoDirection() : null;
-        if (direction != null) {
+        // hasAnyProviders() short-circuits on a single volatile read, avoiding extractEdgeLabels()'s array/string
+        // work below for the overwhelmingly common case where no GAV provider is registered for any database.
+        if (direction != null && GraphTraversalProviderRegistry.hasAnyProviders()) {
           final String[] edgeTypes = MatchExecutionPlanner.extractEdgeLabels(edge);
           final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(context.getDatabase(), edgeTypes);
           if (provider != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.parser.AndBlock;
 import com.arcadedb.query.sql.parser.Bucket;
 import com.arcadedb.query.sql.parser.Expression;
@@ -411,6 +412,32 @@ public class MatchExecutionPlanner {
     for (int i = 0; i < params.size(); i++)
       labels[i] = params.get(i).toString().replace("'", "").replace("\"", "").trim();
     return labels;
+  }
+
+  /**
+   * Returns the {@link Vertex.DIRECTION} a GAV-accelerated traversal must query for a pattern edge's method
+   * (out/in/both), as seen from the vertex the traversal actually starts from - {@code forward} says whether
+   * that's the edge's syntactic out-side ({@code true}, e.g. {@link MatchEdgeTraverser}/a fused chain hop with
+   * {@code et.out}) or its in-side ({@code false}, e.g. {@link MatchReverseEdgeTraverser}/a hop with
+   * {@code !et.out}, which runs the method's reverse - the same out&harr;in flip
+   * {@link com.arcadedb.query.sql.parser.MethodCall#executeReverse} applies elsewhere). "both" has no opposite
+   * and stays as-is regardless of {@code forward}.
+   * <p>
+   * Returns {@code null} when the item has no single direction to ask a provider about (no method, or a method
+   * other than out/in/both) - the caller must then fall back to the slow, always-correct traversal instead.
+   * Package-visible: shared by {@link MatchEdgeTraverser}/{@link MatchReverseEdgeTraverser}'s single-hop
+   * expand-into fast path and {@link MatchGAVFusedStep}'s multi-hop fused DFS, both of which need the identical
+   * mapping (#6670).
+   */
+  static Vertex.DIRECTION directionFor(final MatchPathItem item, final boolean forward) {
+    if (item == null || item.getMethod() == null)
+      return null;
+    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
+      case "out" -> forward ? Vertex.DIRECTION.OUT : Vertex.DIRECTION.IN;
+      case "in" -> forward ? Vertex.DIRECTION.IN : Vertex.DIRECTION.OUT;
+      case "both" -> Vertex.DIRECTION.BOTH;
+      default -> null;
+    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -399,9 +399,11 @@ public class MatchExecutionPlanner {
   }
 
   /**
-   * Extracts edge type labels from a MATCH edge traversal's method parameters.
+   * Extracts edge type labels from a MATCH edge traversal's method parameters. Package-visible: also reused by
+   * {@link MatchEdgeTraverser}'s GAV expand-into fast path to pass the pattern's edge type(s) through to the
+   * provider instead of matching on any edge type (#6670).
    */
-  private static String[] extractEdgeLabels(final EdgeTraversal et) {
+  static String[] extractEdgeLabels(final EdgeTraversal et) {
     final var params = et.edge.item.getMethod().params;
     if (params == null || params.isEmpty())
       return new String[0];

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchGAVFusedStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchGAVFusedStep.java
@@ -137,17 +137,12 @@ class MatchGAVFusedStep extends AbstractExecutionStep {
 
     for (int i = 0; i < chainLen; i++) {
       final EdgeTraversal et = edges.get(i);
-      directions[i] = et.out ? Vertex.DIRECTION.OUT : Vertex.DIRECTION.IN;
-      // Extract edge labels from the method call parameters
-      final var methodParams = et.edge.item.getMethod().params;
-      if (methodParams != null && !methodParams.isEmpty()) {
-        final String[] labels = new String[methodParams.size()];
-        for (int p = 0; p < methodParams.size(); p++)
-          labels[p] = methodParams.get(p).toString().replace("'", "").replace("\"", "").trim();
-        edgeLabelsPerHop[i] = labels;
-      } else {
-        edgeLabelsPerHop[i] = new String[0];
-      }
+      // et.out is the schedule's forward/reverse flag, not the pattern's actual out()/in()/both() method - a
+      // reverse-scheduled in()/both() hop needs the same out<->in flip MatchReverseEdgeTraverser applies to its
+      // single-hop expand-into fast path (#6670). isFusibleEdge() already guarantees a plain out/in/both method,
+      // so this can never fall back to null here.
+      directions[i] = MatchExecutionPlanner.directionFor(et.edge.item, et.out);
+      edgeLabelsPerHop[i] = MatchExecutionPlanner.extractEdgeLabels(et);
       // The alias for this hop's endpoint
       aliases[i] = et.out ? et.edge.in.alias : et.edge.out.alias;
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchReverseEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchReverseEdgeTraverser.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.parser.MatchPathItem;
 import com.arcadedb.query.sql.parser.Rid;
 import com.arcadedb.query.sql.parser.WhereClause;
@@ -27,6 +28,7 @@ import com.arcadedb.query.sql.parser.WhereClause;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -45,6 +47,25 @@ public class MatchReverseEdgeTraverser extends MatchEdgeTraverser {
 
   protected String targetClassName(final MatchPathItem item, final CommandContext iCommandContext) {
     return edge.getLeftClass();
+  }
+
+  /**
+   * {@code item.getMethod()} is still the pattern edge's method as parsed from its syntactic out-side (this class
+   * never rewrites it), so the direction it names is relative to that side, not to {@link #getStartingPointAlias()}
+   * (the in-side, which this reverse traverser actually starts from) - the same out<->in flip
+   * {@link com.arcadedb.query.sql.parser.MethodCall#executeReverse} applies to pick the method it actually runs.
+   * "both" has no opposite and stays as-is.
+   */
+  @Override
+  protected Vertex.DIRECTION getExpandIntoDirection() {
+    if (item == null || item.getMethod() == null)
+      return null;
+    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
+      case "out" -> Vertex.DIRECTION.IN;
+      case "in" -> Vertex.DIRECTION.OUT;
+      case "both" -> Vertex.DIRECTION.BOTH;
+      default -> null;
+    };
   }
 
   protected String targetClusterName(final MatchPathItem item, final CommandContext iCommandContext) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchReverseEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchReverseEdgeTraverser.java
@@ -28,7 +28,6 @@ import com.arcadedb.query.sql.parser.WhereClause;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -58,14 +57,7 @@ public class MatchReverseEdgeTraverser extends MatchEdgeTraverser {
    */
   @Override
   protected Vertex.DIRECTION getExpandIntoDirection() {
-    if (item == null || item.getMethod() == null)
-      return null;
-    return switch (item.getMethod().methodName.getStringValue().toLowerCase(Locale.ENGLISH)) {
-      case "out" -> Vertex.DIRECTION.IN;
-      case "in" -> Vertex.DIRECTION.OUT;
-      case "both" -> Vertex.DIRECTION.BOTH;
-      default -> null;
-    };
+    return MatchExecutionPlanner.directionFor(item, false);
   }
 
   protected String targetClusterName(final MatchPathItem item, final CommandContext iCommandContext) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MaxMinFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MaxMinFromIndexStep.java
@@ -18,9 +18,12 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.RangeIndex;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 
 import java.util.NoSuchElementException;
 
@@ -72,6 +75,10 @@ public class MaxMinFromIndexStep extends AbstractExecutionStep {
 
         final long begin = context.isProfiling() ? System.nanoTime() : 0;
         try {
+          // Reading the index's own key range directly never loads a record through its bucket, so apply the same
+          // per-type read check a normal record load would go through.
+          SecurityHelper.checkAccessOnIndex((DatabaseInternal) context.getDatabase(), index, SecurityDatabaseUser.ACCESS.READ_RECORD);
+
           Object resultValue = null;
 
           // For MAX: iterate descending (false), for MIN: iterate ascending (true)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -2231,12 +2231,6 @@ public class SelectExecutionPlanner {
    * the runtime caller lets it propagate as a genuine execution error.
    */
   private static Object resolveInRightHandRawValue(final InCondition in, final CommandContext context) {
-    if (in.right instanceof List<?> list) {
-      final List<Object> values = new ArrayList<>(list.size());
-      for (final Object item : list)
-        values.add(item instanceof Expression itemExpr ? extractRidValue(itemExpr, context) : item);
-      return values;
-    }
     if (in.getRightMathExpression() != null)
       return in.getRightMathExpression().execute((Result) null, context);
     if (in.getRightParam() != null)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -137,11 +137,12 @@ public class SelectExecutionPlanner {
       info.projection.setDistinct(false);
     }
 
-    // Copied like every other clause below: optimizeQuery()/rewriteIndexChainsAsSubqueries() can rewrite a $var
-    // target's identifier into the resolved type name in place (#6669). Without the copy that write lands on the
-    // shared FromClause node StatementCache hands back for every execution of this SQL text, permanently pinning
-    // the cached Statement to whichever type the first execution resolved $var to - and racing any concurrent
-    // first execution on the same node.
+    // Copied like every other clause below: calculateTargetBuckets() (unconditional) and
+    // rewriteIndexChainsAsSubqueries() (only when a WHERE clause is present) can each rewrite a $var target's
+    // identifier into the resolved type name in place (#6669). Without the copy that write lands on the shared
+    // FromClause node StatementCache hands back for every execution of this SQL text, permanently pinning the
+    // cached Statement to whichever type the first execution resolved $var to - and racing any concurrent first
+    // execution on the same node.
     info.target = this.statement.getTarget() == null ? null : this.statement.getTarget().copy();
     info.whereClause = this.statement.getWhereClause() == null ? null : this.statement.getWhereClause().copy();
     info.perRecordLetClause = this.statement.getLetClause() == null ? null : this.statement.getLetClause().copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -297,9 +297,10 @@ public class SelectExecutionPlanner {
       chainTimeout(selectExecutionPlan, info, context);
     }
 
-    if (useCache && !context.isProfiling() && statement.executionPlanCanBeCached() && selectExecutionPlan.canBeCached()
-        && db.getExecutionPlanCache().getLastInvalidation() < planningStart)
-      db.getExecutionPlanCache().put(statement.getOriginalStatement(), selectExecutionPlan);
+    if (useCache && !context.isProfiling() && statement.executionPlanCanBeCached() && selectExecutionPlan.canBeCached())
+      // The planningStart < lastInvalidation re-check happens atomically inside put(), under the same lock as
+      // invalidate(), so a DDL racing this call can never be missed the way two separately-locked calls could (#6671).
+      db.getExecutionPlanCache().put(statement.getOriginalStatement(), selectExecutionPlan, planningStart);
 
     return selectExecutionPlan;
   }
@@ -562,26 +563,20 @@ public class SelectExecutionPlanner {
   }
 
   /**
-   * Returns the count(*) ProjectionItem if the aggregateProjection contains exactly one true aggregate and it is count(*),
-   * otherwise returns null. Non-aggregate pass-through alias items (added for non-aggregate projections) are ignored.
+   * Returns true if the aggregateProjection contains at least one true aggregate function (count(), sum(), avg(),
+   * min(), max(), ...). Used, together with the absence of a GROUP BY, to decide whether a
+   * {@link GuaranteeEmptyCountStep} is needed to guarantee the single row a scalar aggregation must produce even
+   * over an empty input (issue #6680).
    */
-  private static ProjectionItem findCountStarItem(final QueryPlanningInfo info, final CommandContext context) {
-    if (info.aggregateProjection == null)
-      return null;
+  private static boolean hasAggregateItem(final Projection aggregateProjection, final CommandContext context) {
+    if (aggregateProjection == null)
+      return false;
 
-    ProjectionItem countItem = null;
-    for (final ProjectionItem item : info.aggregateProjection.getItems()) {
-      if (!item.isAggregate(context))
-        continue;
-      if (countItem != null)
-        return null; // more than one aggregate function
-      final Expression exp = item.getExpression();
-      if (exp.getMathExpression() instanceof final BaseExpression base && base.isCount() && base.getModifier() == null)
-        countItem = item;
-      else
-        return null; // aggregate but not count(*)
+    for (final ProjectionItem item : aggregateProjection.getItems()) {
+      if (item.isAggregate(context))
+        return true;
     }
-    return countItem;
+    return false;
   }
 
   private boolean isCount(final Projection aggregateProjection, final Projection projection) {
@@ -777,9 +772,8 @@ public class SelectExecutionPlanner {
 
         result.chain(new AggregateProjectionCalculationStep(info.aggregateProjection, info.groupBy, aggregationLimit, context,
             info.timeout != null ? info.timeout.getVal().longValue() : -1));
-        final ProjectionItem countStarItem = findCountStarItem(info, context);
-        if (countStarItem != null && info.groupBy == null) {
-          result.chain(new GuaranteeEmptyCountStep(countStarItem, info.preAggregateProjection, context));
+        if (info.groupBy == null && hasAggregateItem(info.aggregateProjection, context)) {
+          result.chain(new GuaranteeEmptyCountStep(info.aggregateProjection, info.preAggregateProjection, context));
         }
       }
       result.chain(new ProjectionCalculationStep(info.projection, context));

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -137,7 +137,12 @@ public class SelectExecutionPlanner {
       info.projection.setDistinct(false);
     }
 
-    info.target = this.statement.getTarget();
+    // Copied like every other clause below: optimizeQuery()/rewriteIndexChainsAsSubqueries() can rewrite a $var
+    // target's identifier into the resolved type name in place (#6669). Without the copy that write lands on the
+    // shared FromClause node StatementCache hands back for every execution of this SQL text, permanently pinning
+    // the cached Statement to whichever type the first execution resolved $var to - and racing any concurrent
+    // first execution on the same node.
+    info.target = this.statement.getTarget() == null ? null : this.statement.getTarget().copy();
     info.whereClause = this.statement.getWhereClause() == null ? null : this.statement.getWhereClause().copy();
     info.perRecordLetClause = this.statement.getLetClause() == null ? null : this.statement.getLetClause().copy();
     info.groupBy = this.statement.getGroupBy() == null ? null : this.statement.getGroupBy().copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java
@@ -51,11 +51,8 @@ public class ExecutionPlanCache {
     };
   }
 
-  public long getLastInvalidation() {
-    final ExecutionPlanCache resource = db.getExecutionPlanCache();
-    synchronized (resource) {
-      return resource.lastInvalidation;
-    }
+  public synchronized long getLastInvalidation() {
+    return lastInvalidation;
   }
 
   /**
@@ -63,10 +60,8 @@ public class ExecutionPlanCache {
    *
    * @return true if the corresponding executor is present in the cache
    */
-  public boolean contains(final String statement) {
-    synchronized (map) {
-      return map.containsKey(statement);
-    }
+  public synchronized boolean contains(final String statement) {
+    return map.containsKey(statement);
   }
 
   /**
@@ -77,35 +72,44 @@ public class ExecutionPlanCache {
    *
    * @return a statement executor from the cache
    */
-  public ExecutionPlan get(final String statement, final CommandContext context) {
-    InternalExecutionPlan result;
-    synchronized (map) {
-      //LRU
-      result = map.remove(statement);
-      if (result != null) {
-        map.put(statement, result);
-        result = result.copy(context);
-      }
+  public synchronized ExecutionPlan get(final String statement, final CommandContext context) {
+    //LRU
+    InternalExecutionPlan result = map.remove(statement);
+    if (result != null) {
+      map.put(statement, result);
+      result = result.copy(context);
     }
 
     return result;
   }
 
-  public void put(final String statement, final ExecutionPlan plan) {
-    synchronized (map) {
-      InternalExecutionPlan internal = (InternalExecutionPlan) plan;
-      internal = internal.copy(null);
-      map.put(statement, internal);
-    }
+  /**
+   * Stores {@code plan} in the cache, unless a DDL has invalidated the cache since {@code planningStart} - the moment
+   * the caller began building this plan. Checking {@code planningStart} against {@link #lastInvalidation} and
+   * inserting into the map happen under the same lock this class uses for {@link #invalidate()}, so a DDL that
+   * invalidates the cache concurrently with this call is guaranteed to either be observed here (the put is skipped)
+   * or to run after this put returns (and clear it right back out) - it can never land in the gap between the check
+   * and the insert the way two separately-locked calls could (issue #6671).
+   *
+   * @param statement     the SQL statement, used as the cache key
+   * @param plan          the execution plan to cache
+   * @param planningStart the timestamp (as returned by {@link System#currentTimeMillis()}) taken before planning
+   *                      began; the plan is discarded instead of cached if a concurrent DDL invalidated the cache
+   *                      at or after that moment, since the plan may have been built against stale schema/index state
+   */
+  public synchronized void put(final String statement, final ExecutionPlan plan, final long planningStart) {
+    if (lastInvalidation >= planningStart)
+      // a DDL invalidated the cache after planning started: the plan may reference a dropped/renamed bucket or
+      // index (or be missing a new one), so it must not be cached
+      return;
+    InternalExecutionPlan internal = (InternalExecutionPlan) plan;
+    internal = internal.copy(null);
+    map.put(statement, internal);
   }
 
-  public void invalidate() {
-    synchronized (this) {
-      synchronized (map) {
-        map.clear();
-      }
-      lastInvalidation = System.currentTimeMillis();
-    }
+  public synchronized void invalidate() {
+    map.clear();
+    lastInvalidation = System.currentTimeMillis();
   }
 
   public static ExecutionPlanCache instance(final DatabaseInternal db) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExecutionPlanCache.java
@@ -29,6 +29,13 @@ import java.util.Map;
 /**
  * This class is an LRU cache for already prepared SQL execution plans. It stores itself in the storage as a resource. It also acts
  * an an entry point for the SQL executor.
+ * <p>
+ * Every accessor synchronizes on {@code this}, deliberately trading the finer-grained locking a previous version had
+ * (a separate lock for the map versus {@link #lastInvalidation}) for the atomicity {@link #put} needs to check-and-
+ * insert without a race against a concurrent {@link #invalidate()} (issue #6671). {@link #get} - called on every
+ * cached query execution - now contends with the much rarer {@link #put}/{@link #invalidate}, rather than with
+ * nothing; deliberate, since correctness here outweighs the lock-contention cost on a path this infrequent relative
+ * to query execution itself.
  *
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
@@ -23,7 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.Database;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.ExecutionPlan;
+import com.arcadedb.query.sql.executor.ExplainExecutionPlan;
 import com.arcadedb.query.sql.executor.InternalExecutionPlan;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -53,10 +53,9 @@ public class ExplainStatement extends Statement {
     context.setInputParameters(args);
     context.setProfiling(true);
 
-    final ExecutionPlan executionPlan = statement.createExecutionPlan(context);
+    final ExplainExecutionPlan executionPlan = (ExplainExecutionPlan) createExecutionPlan(context);
 
-    final ExplainResultSet result = new ExplainResultSet(executionPlan);
-    return result;
+    return new ExplainResultSet(executionPlan.getWrappedPlan());
   }
 
   @Override
@@ -69,15 +68,24 @@ public class ExplainStatement extends Statement {
     context.setInputParameters(params);
     context.setProfiling(true);
 
-    final ExecutionPlan executionPlan = statement.createExecutionPlan(context);
+    final ExplainExecutionPlan executionPlan = (ExplainExecutionPlan) createExecutionPlan(context);
 
-    final ExplainResultSet result = new ExplainResultSet(executionPlan);
-    return result;
+    return new ExplainResultSet(executionPlan.getWrappedPlan());
   }
 
+  /**
+   * Builds the wrapped statement's plan without executing it, and hands it back inside an
+   * {@link ExplainExecutionPlan} rather than passing it through directly. Every caller that
+   * chains a nested statement's plan by calling this method (a sqlscript, or a FOREACH/IF/WHILE/
+   * RETRY/LET block) pulls whatever comes back to completion, so returning the wrapped statement's
+   * own executable plan here - as this used to - let a chained {@code EXPLAIN <write statement>}
+   * silently perform the write (issue #6648). {@link #execute} unwraps the result back out via
+   * {@link ExplainExecutionPlan#getWrappedPlan()} to keep returning an {@link ExplainResultSet} as
+   * before.
+   */
   @Override
   public InternalExecutionPlan createExecutionPlan(final CommandContext context) {
-    return statement.createExecutionPlan(context);
+    return new ExplainExecutionPlan(context, statement.createExecutionPlan(context));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
@@ -116,5 +116,19 @@ public class ExplainStatement extends Statement {
   public boolean isIdempotent() {
     return true;
   }
+
+  /**
+   * Delegates to the wrapped statement, same as {@link ExpressionStatement#refersToParent()} does
+   * for its expression. Without this override, {@code Statement.refersToParent()}'s default throws
+   * {@code UnsupportedOperationException}, which surfaced as a hard failure for any
+   * {@code LET $x = (EXPLAIN <statement>)} inside a SELECT's LET clause - {@code
+   * SelectExecutionPlanner.splitLet()} calls this to decide whether the LET can be hoisted to a
+   * single global evaluation or must be re-evaluated per record, and needs an answer for the
+   * wrapped statement either way.
+   */
+  @Override
+  public boolean refersToParent() {
+    return statement.refersToParent();
+  }
 }
 /* JavaCC - OriginalChecksum=9fdd24510993cbee32e38a51c838bdb4 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
@@ -313,6 +313,13 @@ public class FromItem extends SimpleNode {
     if (functionCall != null)
       return functionCall.isCacheable();
 
+    // A "$var" target resolves against a runtime CommandContext variable (see SelectExecutionPlanner's
+    // rewriteIndexChainsAsSubqueries()), so the compiled plan is only valid for the binding it was built with.
+    // Caching it under this statement's text would replay that one binding's type for every later execution
+    // regardless of what $var is bound to then (#6669).
+    if (identifier != null && identifier.getStringValue() != null && identifier.getStringValue().startsWith("$"))
+      return false;
+
     return true;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
@@ -326,6 +326,13 @@ public class InCondition extends BooleanExpression {
   }
 
   public boolean isIndexAware(final IndexSearchInfo info) {
+    // A NOT IN has no negated-cursor counterpart in FetchFromIndexStep: every branch below builds a cursor
+    // over the values that DO match, not their complement, so treating a `not` condition as index-aware here
+    // would fetch the wrong rows. Declining leaves it to the full-scan evaluator, whose `evaluate()` already
+    // applies `not` correctly - the same reasoning already tracked for the native Select API in #6575.
+    if (not)
+      return false;
+
     // Handle normal syntax: field IN [values]
     if (left.isBaseIdentifier()) {
       if (info.getField().equals(left.getDefaultAlias().getStringValue())) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
@@ -42,7 +42,12 @@ public class InCondition extends BooleanExpression {
   public SelectStatement       rightStatement;
   public InputParameter        rightParam;
   public MathExpression        rightMathExpression;
-  public Object                right;
+  /**
+   * Fallback for the rare {@code (SELECT ...) IN <expr>} shape whose {@code <expr>} is neither a list, an input
+   * parameter, nor a plain math expression (e.g. it wraps a nested where-condition). A literal list - parenthesized
+   * or bracketed - is normalized into {@link #rightMathExpression} instead, so index lookup only has one shape to handle.
+   */
+  public Expression            right;
   public boolean               not;
 
   private static final Object  UNSET                    = new Object();
@@ -74,19 +79,8 @@ public class InCondition extends BooleanExpression {
       rightVal = rightParam.getValue(context.getInputParameters());
     else if (rightMathExpression != null)
       rightVal = rightMathExpression.execute(currentRecord, context);
-    else if (right instanceof List<?> list) {
-      // Handle IN (expr1, expr2, ...) - evaluate each expression
-      final List<Object> values = new ArrayList<>();
-      for (final Object item : list) {
-        if (item instanceof Expression expr) {
-          values.add(expr.execute(currentRecord, context));
-        } else {
-          values.add(item);
-        }
-      }
-      rightVal = values;
-    } else if (right != null)
-      rightVal = right;
+    else if (right != null)
+      rightVal = right.execute(currentRecord, context);
 
     return rightVal;
   }
@@ -116,19 +110,8 @@ public class InCondition extends BooleanExpression {
       rightVal = rightParam.getValue(context.getInputParameters());
     else if (rightMathExpression != null)
       rightVal = rightMathExpression.execute(currentRecord, context);
-    else if (right instanceof List<?> list) {
-      // Handle IN (expr1, expr2, ...) - evaluate each expression
-      final List<Object> values = new ArrayList<>();
-      for (final Object item : list) {
-        if (item instanceof Expression expr) {
-          values.add(expr.execute(currentRecord, context));
-        } else {
-          values.add(item);
-        }
-      }
-      rightVal = values;
-    } else if (right != null)
-      rightVal = right;
+    else if (right != null)
+      rightVal = right.execute(currentRecord, context);
 
     return rightVal;
   }
@@ -252,20 +235,13 @@ public class InCondition extends BooleanExpression {
       builder.append("(");
       rightStatement.toString(params, builder);
       builder.append(")");
-    } else if (right != null) {
-      builder.append(convertToString(right));
     } else if (rightParam != null) {
       rightParam.toString(params, builder);
     } else if (rightMathExpression != null) {
       rightMathExpression.toString(params, builder);
+    } else if (right != null) {
+      right.toString(params, builder);
     }
-  }
-
-  private String convertToString(final Object o) {
-    if (o instanceof String string)
-      return "\"" + string.replace("\"", "\\\"") + "\"";
-
-    return o.toString();
   }
 
   @Override
@@ -276,7 +252,7 @@ public class InCondition extends BooleanExpression {
     result.rightMathExpression = rightMathExpression == null ? null : rightMathExpression.copy();
     result.rightStatement = rightStatement == null ? null : rightStatement.copy();
     result.rightParam = rightParam == null ? null : rightParam.copy();
-    result.right = right;
+    result.right = right == null ? null : right.copy();
     result.not = not;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ProfileStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ProfileStatement.java
@@ -125,5 +125,16 @@ public class ProfileStatement extends Statement {
   public boolean isIdempotent() {
     return true;
   }
+
+  /**
+   * Delegates to the wrapped statement. Same gap and same fix as
+   * {@link ExplainStatement#refersToParent()}: without this override, {@code
+   * LET $x = (PROFILE <statement>)} inside a SELECT's LET clause throws
+   * {@code UnsupportedOperationException} out of {@code Statement.refersToParent()}'s default.
+   */
+  @Override
+  public boolean refersToParent() {
+    return statement.refersToParent();
+  }
 }
 /* JavaCC - OriginalChecksum=9fdd24510993cbee32e38a51c838bdb4 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -89,6 +89,17 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
     // async worker is still holding in its open batch, and produce the same silently incomplete index #6281 is about.
     // Holding it twice on the paths that already do is free: quiescence is reentrant per thread.
     //
+    // DRAINED FIRST, exactly as TypeIndexBuilder and RebuildIndexStatement already do, and not merely as a copy of
+    // their comment (issue #6462). A bidirectional cross-slot edge schedules its incoming-edge cascade task onto the
+    // destination worker from INSIDE the source task's own callback (DatabaseAsyncExecutorImpl#newEdge), which can
+    // still be sitting queued - unscheduled or unexecuted - at the instant quiesceAsync() below hands out its park
+    // tasks: a park already confirmed on that destination worker does not wait for a cascade that lands on it
+    // afterwards, so the scan below could run without ever seeing that edge's IN side. waitForAsyncCompletion()'s own
+    // re-scan loop (issue #6281) is what closes that window - it does not return until a whole pass finds nothing
+    // left to drain, cascades included - so quiesceAsync() then starts from an executor that is genuinely idle rather
+    // than racing it.
+    database.waitForAsyncCompletion();
+
     // A QUIESCENCE AND NOT JUST THE BARRIER OF #6281 (issue #6303, item 2). The barrier answers about the past, and
     // that is only half of what a build needs: the other half is that nothing writes DURING the scan. This method
     // used to reach for that half with a pause task per worker, scheduled and forgotten - the boolean scheduleTask

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -66,9 +66,12 @@ public class LocalDocumentType implements DocumentType {
   protected final RecordEventsRegistry              events                       = new RecordEventsRegistry();
   protected final Map<String, Object>               custom                       = new HashMap<>();
   protected       List<Bucket>                      buckets                      = new ArrayList<>();
-  protected       List<Bucket>                      cachedPolymorphicBuckets     = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
+  // Copy-on-write reassigned under schema mutation and read lock-free by query planning (getBuckets(true)/
+  // getBucketIds(true)): volatile so a planning thread has a happens-before edge against a concurrent
+  // ALTER TYPE ... BUCKET, matching the LocalSchema.bucketId2TypeMap publication pattern (issue #6678).
+  protected volatile List<Bucket>                   cachedPolymorphicBuckets     = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
   protected       List<Integer>                     bucketIds                    = new ArrayList<>();
-  protected       List<Integer>                     cachedPolymorphicBucketIds   = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
+  protected volatile List<Integer>                  cachedPolymorphicBucketIds   = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
   protected       BucketSelectionStrategy           bucketSelectionStrategy      = new RoundRobinBucketSelectionStrategy();
   protected       Set<String>                       propertiesWithDefaultDefined = Collections.emptySet();
   // Map: primary bucket id -> external bucket id. Populated lazily when the first EXTERNAL property is

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -716,8 +716,11 @@ public enum Type {
         if (value instanceof ZonedDateTime time) {
           if (property != null)
             return time.truncatedTo(DateUtils.getPrecisionFromType(property.getType()));
-        } else if (value instanceof Date date)
-          return DateUtils.dateTime(database, date.getTime(), ChronoUnit.MILLIS, LocalDateTime.class,
+        } else if (value instanceof Number number)
+          return DateUtils.dateTime(database, number.longValue(), ChronoUnit.MILLIS, ZonedDateTime.class,
+              property != null ? DateUtils.getPrecisionFromType(property.getType()) : ChronoUnit.MILLIS);
+        else if (value instanceof Date date)
+          return DateUtils.dateTime(database, date.getTime(), ChronoUnit.MILLIS, ZonedDateTime.class,
               property != null ? DateUtils.getPrecisionFromType(property.getType()) : ChronoUnit.MILLIS);
         else if (value instanceof Calendar calendar)
           return DateUtils.dateTime(database, calendar.getTimeInMillis(), ChronoUnit.MILLIS, ZonedDateTime.class,
@@ -747,8 +750,12 @@ public enum Type {
           if (property != null)
             return instant.truncatedTo(DateUtils.getPrecisionFromType(property.getType()));
         }
+        case Number number -> {
+          return DateUtils.dateTime(database, number.longValue(), ChronoUnit.MILLIS, Instant.class,
+              property != null ? DateUtils.getPrecisionFromType(property.getType()) : ChronoUnit.MILLIS);
+        }
         case Date date -> {
-          return DateUtils.dateTime(database, date.getTime(), ChronoUnit.MILLIS, LocalDateTime.class,
+          return DateUtils.dateTime(database, date.getTime(), ChronoUnit.MILLIS, Instant.class,
               property != null ? DateUtils.getPrecisionFromType(property.getType()) : ChronoUnit.MILLIS);
         }
         case Calendar calendar -> {

--- a/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
+++ b/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
@@ -67,6 +67,18 @@ public interface SecurityDatabaseUser {
 
   boolean requestAccessOnFile(int fileId, ACCESS access);
 
+  /**
+   * Per-type access check keyed on the type name rather than a bucket file id. Only path available to gate a type
+   * that owns no bucket of its own - a TimeSeries type stores its data in its own engine, not in a
+   * {@code LocalBucket}, so it has no file id {@link #requestAccessOnFile} could check against.
+   * <p>
+   * Defaults to {@code true} (unrestricted) so an implementation that has no notion of type-name-keyed permissions
+   * behaves exactly as it did before this method existed.
+   */
+  default boolean requestAccessOnType(String typeName, ACCESS access) {
+    return true;
+  }
+
   String getName();
 
   long getResultSetLimit();

--- a/engine/src/main/java/com/arcadedb/security/SecurityHelper.java
+++ b/engine/src/main/java/com/arcadedb/security/SecurityHelper.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.security;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.index.Index;
+import com.arcadedb.schema.DocumentType;
+
+import java.util.List;
+
+/**
+ * Resolves the per-type ACL check for a {@link DocumentType} regardless of whether it owns a bucket a
+ * {@link SecurityDatabaseUser#requestAccessOnFile(int, SecurityDatabaseUser.ACCESS)} can be checked against
+ * (a normal document/vertex/edge type) or not (a TimeSeries type, whose data lives in its own engine): every
+ * bucket of one type carries the identical access array (it is resolved from the type name alone), so checking
+ * the first bucket is equivalent to checking all of them.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class SecurityHelper {
+
+  private SecurityHelper() {
+  }
+
+  /**
+   * Throws a {@link SecurityException} if the current user (if any) is not entitled to {@code access} on
+   * {@code type}. A {@code null} type is a no-op, consistent with the query executor steps that resolve a type
+   * from a name and treat "not found" as "nothing to check".
+   */
+  public static void checkAccessOnType(final DatabaseInternal database, final DocumentType type, final SecurityDatabaseUser.ACCESS access) {
+    if (type == null)
+      return;
+
+    final List<Integer> bucketIds = type.getBucketIds(false);
+    if (!bucketIds.isEmpty())
+      database.checkPermissionsOnFile(bucketIds.getFirst(), access);
+    else
+      database.checkPermissionsOnType(type.getName(), access);
+  }
+
+  /**
+   * Same as {@link #checkAccessOnType(DatabaseInternal, DocumentType, SecurityDatabaseUser.ACCESS)}, resolving the
+   * type that owns {@code index} first. A manual index (bound to no type) is a no-op: there is no type to gate.
+   */
+  public static void checkAccessOnIndex(final DatabaseInternal database, final Index index, final SecurityDatabaseUser.ACCESS access) {
+    final String typeName = index.getTypeName();
+    if (typeName == null)
+      return;
+
+    checkAccessOnType(database, database.getSchema().getType(typeName), access);
+  }
+
+  /**
+   * Non-throwing form for catalog listings (e.g. {@code SELECT FROM schema:types}, {@code schema:indexes}): whether
+   * {@code type} should be visible to {@code user} at all, i.e. it grants {@code access} on at least one of the
+   * type's buckets (or, for a bucket-less type, by name). A {@code null} user (no security context: embedded usage
+   * or root) or a {@code null} type sees everything.
+   */
+  public static boolean canAccessType(final SecurityDatabaseUser user, final DocumentType type, final SecurityDatabaseUser.ACCESS access) {
+    if (user == null || type == null)
+      return true;
+
+    final List<Integer> bucketIds = type.getBucketIds(false);
+    if (bucketIds.isEmpty())
+      return user.requestAccessOnType(type.getName(), access);
+
+    for (final int bucketId : bucketIds)
+      if (user.requestAccessOnFile(bucketId, access))
+        return true;
+    return false;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -652,38 +652,71 @@ public class BinarySerializer {
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_SHORTS: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Array.getShort(value, i));
+      // `Array.getShort()` is the fast primitive-array path: java.lang.reflect.Array's typed getters reject a boxed
+      // Short[] with IllegalArgumentException ("not an array of primitive type"), so a wrapper array - now also
+      // classified TYPE_ARRAY_OF_SHORTS, issue #6464 - is unboxed explicitly instead.
+      if (value instanceof short[] shorts) {
+        content.putUnsignedNumber(shorts.length);
+        for (final short v : shorts)
+          content.putNumber(v);
+      } else {
+        final Short[] shorts = (Short[]) value;
+        content.putUnsignedNumber(shorts.length);
+        for (final Short v : shorts)
+          content.putNumber(v);
+      }
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_INTEGERS: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Array.getInt(value, i));
+      if (value instanceof int[] ints) {
+        content.putUnsignedNumber(ints.length);
+        for (final int v : ints)
+          content.putNumber(v);
+      } else {
+        final Integer[] ints = (Integer[]) value;
+        content.putUnsignedNumber(ints.length);
+        for (final Integer v : ints)
+          content.putNumber(v);
+      }
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_LONGS: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Array.getLong(value, i));
+      if (value instanceof long[] longs) {
+        content.putUnsignedNumber(longs.length);
+        for (final long v : longs)
+          content.putNumber(v);
+      } else {
+        final Long[] longs = (Long[]) value;
+        content.putUnsignedNumber(longs.length);
+        for (final Long v : longs)
+          content.putNumber(v);
+      }
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_FLOATS: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Float.floatToIntBits(Array.getFloat(value, i)));
+      if (value instanceof float[] floats) {
+        content.putUnsignedNumber(floats.length);
+        for (final float v : floats)
+          content.putNumber(Float.floatToIntBits(v));
+      } else {
+        final Float[] floats = (Float[]) value;
+        content.putUnsignedNumber(floats.length);
+        for (final Float v : floats)
+          content.putNumber(Float.floatToIntBits(v));
+      }
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_DOUBLES: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Double.doubleToLongBits(Array.getDouble(value, i)));
+      if (value instanceof double[] doubles) {
+        content.putUnsignedNumber(doubles.length);
+        for (final double v : doubles)
+          content.putNumber(Double.doubleToLongBits(v));
+      } else {
+        final Double[] doubles = (Double[]) value;
+        content.putUnsignedNumber(doubles.length);
+        for (final Double v : doubles)
+          content.putNumber(Double.doubleToLongBits(v));
+      }
       break;
     }
     default:

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
@@ -29,7 +29,6 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.DateUtils;
 import org.locationtech.spatial4j.shape.Shape;
 
-import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -175,17 +174,39 @@ public class BinaryTypes {
         // SERIALIZE THE RESULT AS A MAP
         type = TYPE_MAP;
     } else if (value.getClass().isArray()) {
-      if (value.getClass().getComponentType().isPrimitive()) {
-        final Object firstElement = Array.getLength(value) > 0 ? Array.get(value, 0) : null;
-        type = switch (firstElement) {
-          case Short i -> TYPE_ARRAY_OF_SHORTS;
-          case Integer i -> TYPE_ARRAY_OF_INTEGERS;
-          case Long l -> TYPE_ARRAY_OF_LONGS;
-          case Float v -> TYPE_ARRAY_OF_FLOATS;
-          case Double v -> TYPE_ARRAY_OF_DOUBLES;
-          case null, default -> TYPE_LIST;
-        };
-      } else
+      // DECIDE THE BINARY TYPE FROM THE ARRAY'S DECLARED COMPONENT TYPE, NOT FROM ITS FIRST ELEMENT: SNIFFING THE
+      // FIRST ELEMENT MADE AN EMPTY PRIMITIVE ARRAY (WHOSE "FIRST ELEMENT" IS null) FALL BACK TO TYPE_LIST, SO THE
+      // SAME PROPERTY'S RUNTIME TYPE DEPENDED ON WHETHER IT HAPPENED TO BE EMPTY (ISSUE #6464). THE COMPONENT TYPE
+      // ALSO COVERS A BOXED WRAPPER ARRAY (Short[]/Integer[]/Long[]/Float[]/Double[]) SUPPLIED FOR A DECLARED
+      // ARRAY_OF_* PROPERTY, WHICH WAS PREVIOUSLY ALWAYS DOWNGRADED TO TYPE_LIST REGARDLESS OF CONTENT.
+      //
+      // A WRAPPER ARRAY CAN HOLD A null ELEMENT (A PRIMITIVE ARRAY CANNOT), AND BinarySerializer's
+      // TYPE_ARRAY_OF_* BRANCHES UNBOX EACH ELEMENT WITH AN ENHANCED FOR-LOOP, WHICH WOULD THROW AN UNCAUGHT NPE ON
+      // A null ENTRY. FALL BACK TO TYPE_LIST WHEN A WRAPPER ARRAY CONTAINS ANY null ELEMENT: TYPE_LIST SERIALIZES
+      // EACH ELEMENT INDIVIDUALLY WITH ITS OWN TYPE_NULL TAG, WHICH IS EXACTLY HOW SUCH AN ARRAY WAS HANDLED
+      // BEFORE #6464 AND KEEPS THAT CASE BACKWARD COMPATIBLE.
+      final Class<?> componentType = value.getClass().getComponentType();
+      if (componentType == short.class)
+        type = TYPE_ARRAY_OF_SHORTS;
+      else if (componentType == Short.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_SHORTS;
+      else if (componentType == int.class)
+        type = TYPE_ARRAY_OF_INTEGERS;
+      else if (componentType == Integer.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_INTEGERS;
+      else if (componentType == long.class)
+        type = TYPE_ARRAY_OF_LONGS;
+      else if (componentType == Long.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_LONGS;
+      else if (componentType == float.class)
+        type = TYPE_ARRAY_OF_FLOATS;
+      else if (componentType == Float.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_FLOATS;
+      else if (componentType == double.class)
+        type = TYPE_ARRAY_OF_DOUBLES;
+      else if (componentType == Double.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_DOUBLES;
+      else
         type = TYPE_LIST;
 
     } else if (value instanceof Iterable)
@@ -217,6 +238,18 @@ public class BinaryTypes {
     }
 
     return type;
+  }
+
+  /**
+   * Scans a boxed wrapper array (Short[]/Integer[]/Long[]/Float[]/Double[]) for a null element. Used by
+   * {@link #getTypeFromValue(Object, Property)} to decide whether the array is safe to classify as one of the
+   * TYPE_ARRAY_OF_* binary types, whose serializer unboxes every element and would NPE on a null one.
+   */
+  private static boolean arrayHasNullElement(final Object[] array) {
+    for (final Object element : array)
+      if (element == null)
+        return true;
+    return false;
   }
 
   public static int getTypeSize(final byte type) {

--- a/engine/src/main/java/com/arcadedb/utility/StringUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/StringUtils.java
@@ -37,18 +37,6 @@ public class StringUtils {
   }
 
   /**
-   * Case-insensitive {@code contains} that allocates nothing.
-   * <p>
-   * The obvious form, {@code haystack.toUpperCase().contains(needle)}, copies the whole haystack to answer a question
-   * about a needle a dozen characters long - which is why every caller of this had written its own copy rather than
-   * use it: the async DDL classifier scanning a whole script, the Cypher parser deciding on its own parse hot path,
-   * the HTTP handler looking for a LIMIT in a command, and the MCP prompt fence looking for its own delimiter. Four
-   * private copies of six lines, and this is the one they share.
-   *
-   * @return true when {@code needle} occurs anywhere in {@code haystack}, ignoring case. An empty needle is contained
-   *     by everything, as {@code String.contains} has it.
-   */
-  /**
    * Splits a {@code <key>=<value>} pair on the FIRST '=' only, so a value that contains further separators (a
    * connection string, a base64 padding, a date pattern) is kept whole and an empty value is a value, not a missing
    * one. Returns null when there is no separator at all, leaving to the caller the choice between rejecting the
@@ -65,6 +53,18 @@ public class StringUtils {
     return new String[] { pair.substring(0, separatorPos), pair.substring(separatorPos + 1) };
   }
 
+  /**
+   * Case-insensitive {@code contains} that allocates nothing.
+   * <p>
+   * The obvious form, {@code haystack.toUpperCase().contains(needle)}, copies the whole haystack to answer a question
+   * about a needle a dozen characters long - which is why every caller of this had written its own copy rather than
+   * use it: the async DDL classifier scanning a whole script, the Cypher parser deciding on its own parse hot path,
+   * the HTTP handler looking for a LIMIT in a command, and the MCP prompt fence looking for its own delimiter. Four
+   * private copies of six lines, and this is the one they share.
+   *
+   * @return true when {@code needle} occurs anywhere in {@code haystack}, ignoring case. An empty needle is contained
+   *     by everything, as {@code String.contains} has it.
+   */
   public static boolean containsIgnoreCase(final String haystack, final String needle) {
     final int needleLength = needle.length();
     if (needleLength == 0)

--- a/engine/src/main/java/com/arcadedb/utility/StringUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/StringUtils.java
@@ -48,6 +48,23 @@ public class StringUtils {
    * @return true when {@code needle} occurs anywhere in {@code haystack}, ignoring case. An empty needle is contained
    *     by everything, as {@code String.contains} has it.
    */
+  /**
+   * Splits a {@code <key>=<value>} pair on the FIRST '=' only, so a value that contains further separators (a
+   * connection string, a base64 padding, a date pattern) is kept whole and an empty value is a value, not a missing
+   * one. Returns null when there is no separator at all, leaving to the caller the choice between rejecting the
+   * input and reading it as an empty value.
+   * <p>
+   * Shared by the console's {@code -D<key>=<value>} arguments and {@code SET} command (issue #6392), the Postgres
+   * wire's {@code SET} command, and the Studio include directive's parameters (issue #6423), which used to each
+   * carry their own {@code split("=")} that truncated a value containing a further '='.
+   */
+  public static String[] splitKeyValue(final String pair) {
+    final int separatorPos = pair.indexOf('=');
+    if (separatorPos < 0)
+      return null;
+    return new String[] { pair.substring(0, separatorPos), pair.substring(separatorPos + 1) };
+  }
+
   public static boolean containsIgnoreCase(final String haystack, final String needle) {
     final int needleLength = needle.length();
     if (needleLength == 0)

--- a/engine/src/test/java/com/arcadedb/Issue6533ProfilerAsyncParallelLevelTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6533ProfilerAsyncParallelLevelTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.async.DatabaseAsyncExecutorImpl;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6533: {@code Profiler.collectDatabaseStats()} folded every open database's stat into
+ * one accumulator with {@code +=}, except {@code asyncParallelLevel}, which was a plain assignment. With more than
+ * one database open, the exported reading was whichever database the identity-hashed iteration visited last - not a
+ * sum - and could change between consecutive scrapes of an otherwise unchanged server, since {@code IdentityHashMap}
+ * iteration order depends on identity hash codes that vary per run.
+ * <p>
+ * Asserts both that the reading is the SUM across the open databases (not one of them) and that it is STABLE across
+ * repeated {@code toJSON()} calls, since the failure mode this guards against is instability, not merely a wrong
+ * one-off value.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6533ProfilerAsyncParallelLevelTest {
+
+  private static final String DB_PATH_1 = "target/databases/issue6533-profiler-async-parallel-1";
+  private static final String DB_PATH_2 = "target/databases/issue6533-profiler-async-parallel-2";
+
+  @Test
+  void asyncParallelLevelIsTheSumAcrossOpenDatabasesAndStaysStable() {
+    FileUtils.deleteRecursively(new File(DB_PATH_1));
+    FileUtils.deleteRecursively(new File(DB_PATH_2));
+
+    try (final DatabaseFactory factory1 = new DatabaseFactory(DB_PATH_1);
+         final DatabaseFactory factory2 = new DatabaseFactory(DB_PATH_2)) {
+
+      final long baseline = profilerAsyncParallelLevel();
+
+      final Database db1 = factory1.create();
+      final Database db2 = factory2.create();
+      try {
+        final DatabaseAsyncExecutorImpl async1 = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) db1).async();
+        final DatabaseAsyncExecutorImpl async2 = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) db2).async();
+
+        // Two DIFFERENT levels, so an assignment that merely picked "whichever was visited last" would read as one
+        // of these two values rather than their sum, and could flip between them across scrapes.
+        async1.setParallelLevel(3);
+        async2.setParallelLevel(5);
+
+        final long expected = baseline + 3 + 5;
+
+        // Read several times: the bug was not a wrong single snapshot but an UNSTABLE one across scrapes of an
+        // unchanged server (IdentityHashMap iteration order depends on identity hash codes).
+        for (int i = 0; i < 5; i++)
+          assertThat(profilerAsyncParallelLevel())
+              .as("asyncParallelLevel must be the sum across every open database, not whichever one iteration " +
+                  "happened to visit last, and must stay stable across repeated scrapes")
+              .isEqualTo(expected);
+      } finally {
+        db1.drop();
+        db2.drop();
+      }
+
+      assertThat(profilerAsyncParallelLevel())
+          .as("closing both databases must remove their contribution from the JVM-wide reading")
+          .isEqualTo(baseline);
+    }
+  }
+
+  private static long profilerAsyncParallelLevel() {
+    return Profiler.INSTANCE.toJSON().getJSONObject("asyncParallelLevel").getLong("count", -1L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue6598DatabaseRidAsVertexBroadCatchTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6598DatabaseRidAsVertexBroadCatchTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.security.SecurityDatabaseUser;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * #6598 item 1: {@link DatabaseRID#asVertex(boolean)} used to catch every {@code Exception} out of
+ * {@code lookupByRID} and rewrap it as {@link RecordNotFoundException}, so a permission denial or a retryable
+ * conflict was reported to the caller as "record not found" - a healthy, present record that simply could not be
+ * reached for a reason that had nothing to do with it being missing.
+ * <p>
+ * Its sibling {@link RID#asVertex(boolean)} was never widened this way: it only ever caught {@link ClassCastException}
+ * (a RID that names a record which is not a vertex). {@link DatabaseRID#asVertex(boolean)} must behave the same.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6598DatabaseRidAsVertexBroadCatchTest {
+
+  // ---------------------------------------------------------------------------------------------------------
+  // Unit level: pins the catch contract directly against a stubbed BasicDatabase, independent of which engine
+  // code path happens to raise each exception today.
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aSecurityExceptionFromLookupSurvivesAsVertexUnwrapped() {
+    final BasicDatabase database = mock(BasicDatabase.class);
+    final DatabaseRID rid = new DatabaseRID(database, 0, 0L);
+    final SecurityException denial = new SecurityException("User 'test' is not allowed to readRecord");
+    when(database.lookupByRID(any(RID.class), anyBoolean())).thenThrow(denial);
+
+    final Throwable thrown = catchThrowable(() -> rid.asVertex(true));
+
+    assertThat(thrown).as("a permission denial must not be reported as a missing record")
+        .isInstanceOf(SecurityException.class)
+        .isNotInstanceOf(RecordNotFoundException.class)
+        .isSameAs(denial);
+  }
+
+  @Test
+  void aRetryableConflictFromLookupSurvivesAsVertexUnwrapped() {
+    final BasicDatabase database = mock(BasicDatabase.class);
+    final DatabaseRID rid = new DatabaseRID(database, 0, 0L);
+    final ConcurrentModificationException conflict = new ConcurrentModificationException("retry me");
+    when(database.lookupByRID(any(RID.class), anyBoolean())).thenThrow(conflict);
+
+    final Throwable thrown = catchThrowable(() -> rid.asVertex(true));
+
+    assertThat(thrown).as("a retryable conflict must keep being retryable, not become a permanent not-found")
+        .isInstanceOf(NeedRetryException.class)
+        .isNotInstanceOf(RecordNotFoundException.class)
+        .isSameAs(conflict);
+  }
+
+  @Test
+  void aRecordNotFoundExceptionFromLookupIsRethrownAsIs() {
+    final BasicDatabase database = mock(BasicDatabase.class);
+    final DatabaseRID rid = new DatabaseRID(database, 0, 0L);
+    final RecordNotFoundException notFound = new RecordNotFoundException("Record " + rid + " not found", rid);
+    when(database.lookupByRID(any(RID.class), anyBoolean())).thenThrow(notFound);
+
+    final Throwable thrown = catchThrowable(() -> rid.asVertex(true));
+
+    assertThat(thrown).isSameAs(notFound);
+  }
+
+  @Test
+  void aRecordThatIsNotAVertexStillReportsAsNotFound() {
+    // A ClassCastException is the one case asVertex() is meant to translate: the record exists, but is not a
+    // Vertex. Preserved exactly as RID.asVertex(boolean) already behaves.
+    final BasicDatabase database = mock(BasicDatabase.class);
+    final DatabaseRID rid = new DatabaseRID(database, 0, 0L);
+    final Document notAVertex = mock(Document.class);
+    when(database.lookupByRID(any(RID.class), anyBoolean())).thenAnswer(invocation -> notAVertex);
+
+    final Throwable thrown = catchThrowable(() -> rid.asVertex(true));
+
+    assertThat(thrown).isInstanceOf(RecordNotFoundException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(rid);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // End-to-end: the exact scenario reported in #6598 - a principal granted deleteRecord but not readRecord,
+  // reaching the vertex through DatabaseRID.asVertex() (the shortcut ordinary caller code uses) rather than
+  // lookupByRID directly (which #6586's test used specifically to avoid this bug).
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aPermissionDenialReachedThroughAsVertexIsNotReportedAsRecordNotFound() {
+    final String path = "target/databases/Issue6598PermissionProbe";
+
+    final DatabaseFactory factory = new DatabaseFactory(path).setSecurity(db -> {
+    });
+    if (factory.exists())
+      factory.open().drop();
+
+    final Database restricted = factory.create();
+    try {
+      restricted.transaction(() -> restricted.getSchema().createVertexType("Guarded", 1));
+
+      final RID[] guarded = new RID[1];
+      restricted.transaction(() -> {
+        final MutableVertex v = restricted.newVertex("Guarded");
+        v.save();
+        guarded[0] = v.getIdentity();
+      });
+      assertThat(guarded[0]).as("BaseRecord.upgradeRID must hand back a DatabaseRID for this test to mean anything")
+          .isInstanceOf(DatabaseRID.class);
+
+      final Set<SecurityDatabaseUser.ACCESS> granted = EnumSet.of(SecurityDatabaseUser.ACCESS.DELETE_RECORD);
+      DatabaseContext.INSTANCE.getContext(restricted.getDatabasePath()).setCurrentUser(userGranting(granted));
+
+      final Throwable thrown = catchThrowable(
+          () -> restricted.transaction(() -> guarded[0].asVertex(), false, 1));
+
+      assertThat(thrown).as("a healthy record denied by permissions must not be reported as missing: %s", thrown)
+          .isInstanceOf(SecurityException.class)
+          .isNotInstanceOf(RecordNotFoundException.class);
+    } finally {
+      DatabaseContext.INSTANCE.getContext(restricted.getDatabasePath()).setCurrentUser(null);
+      restricted.drop();
+      factory.close();
+    }
+  }
+
+  /** A principal that allows the database wholesale and exactly {@code granted} on every file. */
+  private static SecurityDatabaseUser userGranting(final Set<SecurityDatabaseUser.ACCESS> granted) {
+    return new SecurityDatabaseUser() {
+      @Override
+      public String getName() {
+        return "restricted";
+      }
+
+      @Override
+      public boolean requestAccessOnDatabase(final DATABASE_ACCESS access) {
+        return true;
+      }
+
+      @Override
+      public boolean requestAccessOnFile(final int fileId, final ACCESS access) {
+        return granted.contains(access);
+      }
+
+      @Override
+      public long getResultSetLimit() {
+        return -1L;
+      }
+
+      @Override
+      public long getReadTimeout() {
+        return -1L;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6462CrossSlotWaitCompletionMissesCascadeTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6462CrossSlotWaitCompletionMissesCascadeTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6462: a bidirectional cross-slot edge schedules its incoming-edge cascade
+ * task onto the DESTINATION worker's slot from INSIDE the source task's own callback -
+ * {@code DatabaseAsyncExecutorImpl.newEdge()} schedules {@code CreateIncomingEdgeAsyncTask} onto
+ * {@code destinationSlot} from inside {@code CreateEdgeAsyncTask}'s completion callback - i.e.
+ * AFTER the destination worker may already have confirmed a completion marker to a concurrent
+ * {@link DatabaseAsyncExecutorImpl#waitCompletion(long)} caller. The public {@code waitCompletion()}
+ * promises to wait "for the completion of all pending operations" ({@link DatabaseAsyncExecutor})
+ * but placed exactly one marker per worker in a single pass, with no way to notice a task that
+ * landed on a worker AFTER that worker's own marker had already fired.
+ * <p>
+ * This reproduces the shape without touching the graph API at all: a plain task on worker 0 that,
+ * once released, schedules a follow-up task onto worker 1 from inside its own execution - mirroring
+ * {@code CreateEdgeAsyncTask}'s callback scheduling {@code CreateIncomingEdgeAsyncTask}. The
+ * follow-up is held open with a latch so the buggy and fixed behaviour can be told apart
+ * deterministically (by what has and has not happened when {@code waitCompletion()} returns) rather
+ * than by timing.
+ */
+class Issue6462CrossSlotWaitCompletionMissesCascadeTest extends TestHelper {
+
+  @Test
+  @Timeout(30)
+  void waitCompletionMustNotReturnBeforeACrossSlotCascadeTaskCompletes() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Force thread re-creation so the fresh pair of workers is used regardless of any prior level.
+    async.recreateThreadsForTests();
+
+    final CountDownLatch sourceTaskRunning = new CountDownLatch(1);
+    final CountDownLatch releaseSourceTask = new CountDownLatch(1);
+    final CountDownLatch cascadeStarted    = new CountDownLatch(1);
+    final CountDownLatch releaseCascade    = new CountDownLatch(1);
+    final AtomicBoolean  cascadeCompleted  = new AtomicBoolean(false);
+
+    // SOURCE TASK on slot 0 - mirrors CreateEdgeAsyncTask: once released, it schedules a follow-up
+    // task onto slot 1 FROM INSIDE its own execution, exactly as newEdge()'s cross-slot callback
+    // schedules CreateIncomingEdgeAsyncTask onto the destination slot.
+    async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        sourceTaskRunning.countDown();
+        awaitLatch(releaseSourceTask);
+
+        async.scheduleTask(1, new DatabaseAsyncTask() {
+          @Override
+          public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+            cascadeStarted.countDown();
+            awaitLatch(releaseCascade);
+            cascadeCompleted.set(true);
+          }
+
+          @Override
+          public boolean requiresActiveTx() {
+            return false;
+          }
+        }, true, 0);
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    }, true, 0);
+
+    assertThat(sourceTaskRunning.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // AT THIS POINT: worker 0's queue holds the still-blocked source task; worker 1 is completely
+    // idle. This is exactly the state waitCompletion() sees when it places one marker per worker in
+    // a single pass: worker 1's marker has nothing ahead of it and is free to fire long before the
+    // source task's callback ever reaches the line that schedules the cascade onto worker 1.
+    final CountDownLatch waitCompletionReturned = new CountDownLatch(1);
+    final AtomicBoolean  waitCompletionResult   = new AtomicBoolean();
+    final Thread waiter = new Thread(() -> {
+      waitCompletionResult.set(async.waitCompletion(20_000));
+      waitCompletionReturned.countDown();
+    }, "waitCompletion-caller");
+    waiter.setDaemon(true);
+    waiter.start();
+
+    // Worker 1's marker must have fired before the source task is released - proven with the same
+    // observable worker 1's completed-task counter already used elsewhere in this suite
+    // (AsyncHelpingSlowPeerProgressTest), never a fixed sleep: nothing but waitCompletion()'s own
+    // marker can complete on worker 1 before this point.
+    final DatabaseAsyncExecutorImpl.AsyncThread worker1 = findWorkerThread(db, 1);
+    final long deadline = System.currentTimeMillis() + 10_000;
+    while (worker1.completedTaskCount == 0) {
+      if (System.currentTimeMillis() > deadline)
+        throw new AssertionError("Worker 1's completion marker never fired");
+      Thread.sleep(5);
+    }
+
+    // waitCompletion() must still be waiting on worker 0 at this point (its own trailing marker sits
+    // behind the still-blocked source task) - true regardless of the fix.
+    assertThat(waitCompletionReturned.getCount()).as("waitCompletion() must still be waiting on worker 0").isEqualTo(1L);
+
+    // RELEASE THE SOURCE TASK: it now schedules the cascade onto worker 1, whose own marker has
+    // ALREADY fired - the exact race #6462 describes - and then finishes, letting worker 0's own
+    // trailing marker run.
+    releaseSourceTask.countDown();
+
+    assertThat(cascadeStarted.await(10, TimeUnit.SECONDS)).as("the cascade task must be scheduled and started").isTrue();
+
+    // THE ASSERTION: with the cascade deliberately held open, a waitCompletion() that returns now
+    // provably returned before "all pending operations" completed - the bug (#6462). The fix must
+    // block here until the cascade is released below.
+    assertThat(waitCompletionReturned.await(500, TimeUnit.MILLISECONDS))
+        .as("waitCompletion() must not return while a cross-slot cascade task scheduled from another task's own "
+            + "callback is still running")
+        .isFalse();
+
+    releaseCascade.countDown();
+
+    assertThat(waitCompletionReturned.await(10, TimeUnit.SECONDS)).as("waitCompletion() must eventually return").isTrue();
+    assertThat(waitCompletionResult.get()).as("waitCompletion() must report success, not a timeout").isTrue();
+    assertThat(cascadeCompleted.get()).as("the cascade must have completed by the time waitCompletion() returned").isTrue();
+
+    waiter.join(5000);
+  }
+
+  private static void awaitLatch(final CountDownLatch latch) {
+    try {
+      if (!latch.await(20, TimeUnit.SECONDS))
+        throw new AssertionError("Latch never released within 20s");
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+
+  private static DatabaseAsyncExecutorImpl.AsyncThread findWorkerThread(final DatabaseInternal db, final int slot) {
+    final String name = "AsyncExecutor-" + db.getName() + "-" + slot;
+    return (DatabaseAsyncExecutorImpl.AsyncThread) Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().equals(name)).findFirst()
+        .orElseThrow(() -> new IllegalStateException("Worker thread " + name + " not found"));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -134,12 +134,15 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
   }
 
   /**
-   * End-to-end: {@code LocalBucket.scan()} always rethrows a {@link DatabaseIsReadOnlyException} raised by the
-   * user's per-record callback regardless of whether an {@code errorRecordCallback} is set - a deliberate
-   * abort-the-whole-scan signal, and the real, reachable analogue of "a bucket's scan throws (I/O / corruption)"
-   * the issue describes, as opposed to an ordinary per-record error (which already correctly routes through
-   * {@code errorRecordCallback} and is not what this test is about). Two buckets are used so the fix's per-bucket
-   * capture is proven to still let the OTHER bucket be scanned to completion.
+   * End-to-end: {@code LocalBucket.scan()} rethrows a {@link DatabaseIsReadOnlyException} raised by the user's
+   * per-record callback rather than routing it through {@code errorRecordCallback} - a deliberate abort-the-whole-
+   * scan signal, and the real, reachable analogue of "a bucket's scan throws (I/O / corruption)" the issue
+   * describes, as opposed to an ordinary per-record error (which already correctly routes through
+   * {@code errorRecordCallback} and is not what this test is about). This test uses no {@code errorRecordCallback}
+   * (the 3-arg {@code scanType()} overload), which is exactly the case that always rethrows; a non-null one that
+   * returns {@code true} for this exception would too, but one that returns {@code false} would instead stop the
+   * scan without rethrowing. Two buckets are used so the fix's per-bucket capture is proven to still let the OTHER
+   * bucket be scanned to completion.
    */
   @Test
   void scanTypePropagatesABucketLevelFailureInsteadOfReturningAPartialScan() {

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -153,9 +153,9 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
         allIds.add(database.newDocument(TYPE).set("id", i).save().getIdentity());
     });
 
-    final Set<RID>            scannedIds     = ConcurrentHashMap.newKeySet();
-    final AtomicInteger       scanned        = new AtomicInteger();
-    final AtomicReference<Integer> failingBucketId = new AtomicReference<>();
+    final Set<RID>      scannedIds      = ConcurrentHashMap.newKeySet();
+    final AtomicInteger scanned         = new AtomicInteger();
+    final AtomicInteger failingBucketId = new AtomicInteger(-1);
 
     assertThatThrownBy(() -> database.async().scanType(TYPE, true, record -> {
       scannedIds.add(record.getIdentity());

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.engine.ErrorRecordCallback;
+import com.arcadedb.engine.RawRecordCallback;
+import com.arcadedb.exception.DatabaseIsReadOnlyException;
+import com.arcadedb.exception.DatabaseOperationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for #6467: {@link DatabaseAsyncExecutorImpl#scanType} must not return successfully when one of
+ * its per-bucket tasks fails with a bucket-level (as opposed to per-record) exception - that used to be swallowed,
+ * routed only to the (typically unset) executor-wide error callback while the per-bucket latch still counted down,
+ * so the caller saw a silently partial scan.
+ */
+class Issue6467ScanTypeBucketFailureTest extends TestHelper {
+
+  private static final String TYPE = "Issue6467Item";
+
+  /**
+   * Direct unit test of the fix's mechanism: a bucket whose {@code scan()} throws must have that exception captured
+   * into the shared holder AND rethrown (so the existing per-task rollback/logging in the worker still runs
+   * unchanged), and {@code completed()} must still fire so a caller blocked in {@code scanType()} is never left
+   * hanging on a failed bucket.
+   */
+  @Test
+  void failingBucketScanIsCapturedRethrownAndStillCompletes() {
+    final RuntimeException injected = new RuntimeException("simulated bucket I/O failure");
+
+    final Bucket brokenBucket = new Bucket() {
+      @Override
+      public RID createRecord(final Record record, final boolean discardRecordAfter) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void updateRecord(final Record record, final boolean discardRecordAfter) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public com.arcadedb.database.Binary getRecord(final RID rid) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean existsRecord(final RID rid) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void deleteRecord(final RID rid) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void deleteRecord(final RID rid, final boolean force) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void scan(final RawRecordCallback callback, final ErrorRecordCallback errorRecordCallback) {
+        throw injected;
+      }
+
+      @Override
+      public Iterator<Record> iterator() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Iterator<Record> inverseIterator() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public long count() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public int getFileId() {
+        return 0;
+      }
+
+      @Override
+      public String getName() {
+        return "brokenBucket";
+      }
+    };
+
+    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+    final CountDownLatch             latch      = new CountDownLatch(1);
+    final DatabaseAsyncScanBucket task = new DatabaseAsyncScanBucket(latch, record -> true, null, brokenBucket, firstError);
+
+    assertThatThrownBy(() -> task.execute(null, null)).isSameAs(injected);
+    assertThat(firstError.get()).isSameAs(injected);
+
+    task.completed();
+    assertThat(latch.getCount()).isZero();
+  }
+
+  /**
+   * End-to-end: {@code LocalBucket.scan()} always rethrows a {@link DatabaseIsReadOnlyException} raised by the
+   * user's per-record callback regardless of whether an {@code errorRecordCallback} is set - a deliberate
+   * abort-the-whole-scan signal, and the real, reachable analogue of "a bucket's scan throws (I/O / corruption)"
+   * the issue describes, as opposed to an ordinary per-record error (which already correctly routes through
+   * {@code errorRecordCallback} and is not what this test is about). Two buckets are used so the fix's per-bucket
+   * capture is proven to still let the OTHER bucket be scanned to completion.
+   */
+  @Test
+  void scanTypePropagatesABucketLevelFailureInsteadOfReturningAPartialScan() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE, 2);
+      for (int i = 0; i < 20; i++)
+        database.newDocument(TYPE).set("id", i).save();
+    });
+
+    final AtomicInteger scanned = new AtomicInteger();
+
+    assertThatThrownBy(() -> database.async().scanType(TYPE, true, record -> {
+      if (scanned.incrementAndGet() == 5)
+        throw new DatabaseIsReadOnlyException("simulated bucket-level scan failure");
+      return true;
+    })).isInstanceOf(DatabaseOperationException.class);
+
+    // The failing bucket aborts after its 5th record, but the other bucket must still be drained to completion
+    // instead of the whole scan silently stopping - proving scanType() no longer just swallows the failure.
+    assertThat(scanned.get()).isGreaterThanOrEqualTo(5);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -60,7 +60,47 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
   void failingBucketScanIsCapturedRethrownAndStillCompletes() {
     final RuntimeException injected = new RuntimeException("simulated bucket I/O failure");
 
-    final Bucket brokenBucket = new Bucket() {
+    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+    final CountDownLatch             latch      = new CountDownLatch(1);
+    final DatabaseAsyncScanBucket task =
+        new DatabaseAsyncScanBucket(latch, record -> true, null, brokenBucket("brokenBucket", injected), firstError);
+
+    assertThatThrownBy(() -> task.execute(null, null)).isSameAs(injected);
+    assertThat(firstError.get()).isSameAs(injected);
+
+    task.completed();
+    assertThat(latch.getCount()).isZero();
+  }
+
+  /**
+   * A second bucket failing after {@code firstError} is already claimed must not be silently dropped: it loses the
+   * {@code compareAndSet} race to be the one {@code scanType()} rethrows, but is still logged, and its own task
+   * still rethrows so the worker's own rollback/logging/{@code onError} handling runs for it too. No real
+   * concurrency is needed to exercise this deterministically: {@code compareAndSet}'s outcome depends only on
+   * {@code firstError}'s current value, so calling the two tasks sequentially against one shared holder reproduces
+   * the "already claimed" branch exactly as a genuine race would.
+   */
+  @Test
+  void aSecondConcurrentlyFailingBucketLosesTheRaceButIsStillRethrown() {
+    final RuntimeException firstFailure  = new RuntimeException("first bucket failure");
+    final RuntimeException secondFailure = new RuntimeException("second bucket failure");
+
+    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+    final DatabaseAsyncScanBucket taskA =
+        new DatabaseAsyncScanBucket(new CountDownLatch(1), record -> true, null, brokenBucket("bucketA", firstFailure), firstError);
+    final DatabaseAsyncScanBucket taskB =
+        new DatabaseAsyncScanBucket(new CountDownLatch(1), record -> true, null, brokenBucket("bucketB", secondFailure), firstError);
+
+    assertThatThrownBy(() -> taskA.execute(null, null)).isSameAs(firstFailure);
+    assertThat(firstError.get()).isSameAs(firstFailure);
+
+    // taskB still rethrows its OWN exception even though it lost the race to populate firstError.
+    assertThatThrownBy(() -> taskB.execute(null, null)).isSameAs(secondFailure);
+    assertThat(firstError.get()).as("the first bucket's failure is still the one scanType() will report").isSameAs(firstFailure);
+  }
+
+  private static Bucket brokenBucket(final String name, final RuntimeException toThrow) {
+    return new Bucket() {
       @Override
       public RID createRecord(final Record record, final boolean discardRecordAfter) {
         throw new UnsupportedOperationException();
@@ -93,7 +133,7 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
 
       @Override
       public void scan(final RawRecordCallback callback, final ErrorRecordCallback errorRecordCallback) {
-        throw injected;
+        throw toThrow;
       }
 
       @Override
@@ -118,19 +158,9 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
 
       @Override
       public String getName() {
-        return "brokenBucket";
+        return name;
       }
     };
-
-    final AtomicReference<Throwable> firstError = new AtomicReference<>();
-    final CountDownLatch             latch      = new CountDownLatch(1);
-    final DatabaseAsyncScanBucket task = new DatabaseAsyncScanBucket(latch, record -> true, null, brokenBucket, firstError);
-
-    assertThatThrownBy(() -> task.execute(null, null)).isSameAs(injected);
-    assertThat(firstError.get()).isSameAs(injected);
-
-    task.completed();
-    assertThat(latch.getCount()).isZero();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -28,7 +28,11 @@ import com.arcadedb.exception.DatabaseIsReadOnlyException;
 import com.arcadedb.exception.DatabaseOperationException;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -139,22 +143,31 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
    */
   @Test
   void scanTypePropagatesABucketLevelFailureInsteadOfReturningAPartialScan() {
+    final List<RID> allIds = new ArrayList<>();
     database.transaction(() -> {
       database.getSchema().createDocumentType(TYPE, 2);
       for (int i = 0; i < 20; i++)
-        database.newDocument(TYPE).set("id", i).save();
+        allIds.add(database.newDocument(TYPE).set("id", i).save().getIdentity());
     });
 
-    final AtomicInteger scanned = new AtomicInteger();
+    final Set<RID>            scannedIds     = ConcurrentHashMap.newKeySet();
+    final AtomicInteger       scanned        = new AtomicInteger();
+    final AtomicReference<Integer> failingBucketId = new AtomicReference<>();
 
     assertThatThrownBy(() -> database.async().scanType(TYPE, true, record -> {
-      if (scanned.incrementAndGet() == 5)
+      scannedIds.add(record.getIdentity());
+      if (scanned.incrementAndGet() == 5) {
+        failingBucketId.set(record.getIdentity().getBucketId());
         throw new DatabaseIsReadOnlyException("simulated bucket-level scan failure");
+      }
       return true;
     })).isInstanceOf(DatabaseOperationException.class);
 
-    // The failing bucket aborts after its 5th record, but the other bucket must still be drained to completion
-    // instead of the whole scan silently stopping - proving scanType() no longer just swallows the failure.
-    assertThat(scanned.get()).isGreaterThanOrEqualTo(5);
+    // Every record that lives in a DIFFERENT bucket than the one that failed must have been scanned: that bucket's
+    // task is unaffected by the other one's exception and must still drain to completion, rather than the whole
+    // scan silently stopping partway through (which is the exact bug #6467 is about).
+    final List<RID> otherBucketIds = allIds.stream().filter(rid -> rid.getBucketId() != failingBucketId.get()).toList();
+    assertThat(otherBucketIds).isNotEmpty();
+    assertThat(scannedIds).containsAll(otherBucketIds);
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6470AsyncSuccessCallbackDurabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6470AsyncSuccessCallbackDurabilityTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.database.async;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
+import com.arcadedb.engine.WALFile;
 import com.arcadedb.event.AfterRecordCreateListener;
 import org.junit.jupiter.api.Test;
 
@@ -129,5 +130,41 @@ class Issue6470AsyncSuccessCallbackDurabilityTest extends TestHelper {
     assertThat(onOkInvocations.get()).isGreaterThanOrEqualTo(2);
 
     database.transaction(() -> assertThat(database.countType(TYPE, true)).isEqualTo(12));
+  }
+
+  /**
+   * The other real commit point {@code onOk()} was extended to cover: a durability-setting change
+   * ({@code setTransactionSync}/{@code setTransactionUseWAL}) mid-batch forces the worker to commit its
+   * already-open transaction under its OLD flags before applying the new ones - see
+   * {@code DatabaseAsyncExecutorImpl.closeTransactionBoundaryIfDurabilityPolicyChanged()}.
+   */
+  @Test
+  void executorWideOnOkFiresAtTheDurabilityPolicyBoundary() throws Exception {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1));
+    // Large enough that the periodic commitEvery boundary this test is NOT about never fires here.
+    database.async().setCommitEvery(100);
+
+    final AtomicInteger  onOkInvocations = new AtomicInteger();
+    final CountDownLatch fired           = new CountDownLatch(1);
+    database.async().onOk(() -> {
+      onOkInvocations.incrementAndGet();
+      fired.countDown();
+    });
+
+    // Single bucket, so both creates land on the same worker in submission order: the 1st opens a
+    // transaction stamped with the CURRENT durability flags and leaves it open (commitEvery is nowhere
+    // near reached); the flag flip in between is picked up only when the 2nd create is dispatched, at
+    // which point that still-open transaction's stamped flags no longer match and must be committed first.
+    database.async().createRecord(database.newDocument(TYPE), null);
+    database.async().setTransactionSync(WALFile.FlushType.YES_NOMETADATA);
+    database.async().createRecord(database.newDocument(TYPE), null);
+
+    assertThat(fired.await(30, TimeUnit.SECONDS))
+        .as("onOk() must fire when a durability-setting change forces a boundary commit mid-batch")
+        .isTrue();
+
+    database.async().waitCompletion();
+    assertThat(onOkInvocations.get()).isGreaterThanOrEqualTo(1);
+    database.transaction(() -> assertThat(database.countType(TYPE, true)).isEqualTo(2));
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6470AsyncSuccessCallbackDurabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6470AsyncSuccessCallbackDurabilityTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.event.AfterRecordCreateListener;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for #6470: an async {@code createRecord}/{@code updateRecord}/{@code deleteRecord}'s own success
+ * callback (e.g. {@link NewRecordCallback}) fires as soon as the write is applied to the worker's current batch
+ * transaction, which is not necessarily durable yet - a later sibling failure in the same still-open batch can still
+ * roll the whole thing back, discarding a write whose callback already fired.
+ * <p>
+ * That per-record timing is unchanged by this fix (and is exercised, unchanged, by
+ * {@code Issue6281AsyncBatchIndexBuildTest} and others that rely on it as a "this task has run" signal rather than a
+ * durability signal - changing it broke that suite). What was missing, and what {@code Issue6470} is actually about,
+ * is a reliable way to know a write IS durable: {@link DatabaseAsyncExecutor#onOk(OkCallback)} - previously fired
+ * only at executor shutdown and from the {@code waitCompletion()} marker - now also fires at the periodic
+ * {@code setCommitEvery(int)} boundary and at a durability-setting boundary commit, so it is a complete signal for
+ * every point this shared batch can actually commit.
+ */
+class Issue6470AsyncSuccessCallbackDurabilityTest extends TestHelper {
+
+  private static final String TYPE = "Issue6470Item";
+
+  /**
+   * Documents the (intentional, unchanged) provisional nature of the per-record callback: it fires for the 1st and
+   * 2nd creates below even though the 3rd's failure rolls the whole still-open batch back and discards them.
+   */
+  @Test
+  void perRecordCallbackFiresBeforeTheBatchIsNecessarilyDurable() {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1));
+
+    final AtomicInteger errors    = new AtomicInteger();
+    final List<RID>     confirmed = new CopyOnWriteArrayList<>();
+
+    // Keyed off content rather than a raw listener-call count, so the trigger is unambiguous regardless of how many
+    // times the engine happens to invoke an after-create listener per create.
+    final AfterRecordCreateListener throwOnMarked = record -> {
+      if ("fail".equals(((Document) record).getString("marker")))
+        throw new RuntimeException("injected error on third create");
+    };
+
+    database.async().setCommitEvery(10);
+    database.async().onError(e -> errors.incrementAndGet());
+
+    database.getEvents().registerListener(throwOnMarked);
+    try {
+      // 1st and 2nd creates succeed and stay in the still-open batch; the 3rd's listener throws, rolling the whole
+      // batch back (1st and 2nd included); the 4th runs in the fresh transaction begun after that rollback.
+      database.async().createRecord(database.newDocument(TYPE).set("marker", "ok"), r -> confirmed.add(r.getIdentity()));
+      database.async().createRecord(database.newDocument(TYPE).set("marker", "ok"), r -> confirmed.add(r.getIdentity()));
+      database.async().createRecord(database.newDocument(TYPE).set("marker", "fail"), r -> confirmed.add(r.getIdentity()));
+      database.async().createRecord(database.newDocument(TYPE).set("marker", "ok"), r -> confirmed.add(r.getIdentity()));
+
+      database.async().waitCompletion();
+    } finally {
+      database.getEvents().unregisterListener(throwOnMarked);
+    }
+
+    assertThat(errors.get()).isEqualTo(1);
+
+    // By design: the per-record callback already fired for the 1st and 2nd creates too, even though the 3rd's
+    // failure rolled the whole still-open batch back and discarded them - it reports "applied", not "durable".
+    assertThat(confirmed).hasSize(3);
+
+    // Only the 4th create - the one in the fresh transaction begun after the rollback - actually exists.
+    database.transaction(() -> assertThat(database.countType(TYPE, true)).isEqualTo(1));
+  }
+
+  /**
+   * The actual fix: {@code onOk()} now fires at the periodic {@code commitEvery} boundary, so a caller has a
+   * reliable durability signal without needing to wait for the executor to go idle or shut down.
+   */
+  @Test
+  void executorWideOnOkFiresAtThePeriodicCommitBoundary() throws Exception {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1));
+
+    database.async().setCommitEvery(5);
+
+    final CountDownLatch firstBoundaryCommitted = new CountDownLatch(1);
+    final AtomicInteger  onOkInvocations        = new AtomicInteger();
+    database.async().onOk(() -> {
+      onOkInvocations.incrementAndGet();
+      firstBoundaryCommitted.countDown();
+    });
+
+    for (int i = 0; i < 12; i++)
+      database.async().createRecord(database.newDocument(TYPE), null);
+
+    // Proves the periodic commitEvery boundary itself signals durability - not just the final waitCompletion()
+    // marker, which has not been called yet at this point.
+    assertThat(firstBoundaryCommitted.await(30, TimeUnit.SECONDS))
+        .as("onOk() must fire at the periodic commitEvery boundary, before waitCompletion() is even called")
+        .isTrue();
+
+    database.async().waitCompletion();
+
+    // 12 creates over a batch of 5 cross the periodic boundary twice (at the 5th and 10th), so at least 2 by the
+    // time the loop above already observed 1 of them. (waitCompletion()'s own completion marker also triggers onOk()
+    // on every worker, including idle ones, so the final count is not asserted precisely here.)
+    assertThat(onOkInvocations.get()).isGreaterThanOrEqualTo(2);
+
+    database.transaction(() -> assertThat(database.countType(TYPE, true)).isEqualTo(12));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.database.async;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -47,7 +48,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class Issue6534QuiesceResizeRaceTest extends TestHelper {
 
+  // The 3s polling window below (code review, PR #6661) puts this on the slower end - comparable to the
+  // WORKER_HOLD_MS-scale tests in Issue6526AsyncExecutorFollowUpsTest, which carry the same tag.
   @Test
+  @Tag("slow")
   @Timeout(60)
   void aGrowCannotPublishWhileAQuiescenceIsStillWaitingOnABusyWorker() throws Exception {
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
@@ -90,18 +90,21 @@ class Issue6534QuiesceResizeRaceTest extends TestHelper {
     }, "issue6534-quiescer");
     quiescer.start();
 
-    // Give the quiescer time to acquire resizeLock, snapshot the pool and schedule its park task - which now sits
-    // queued behind the busy task above and cannot run until releaseTask counts down.
-    Thread.sleep(300);
-
     final Thread grower = new Thread(() -> async.setParallelLevel(3), "issue6534-grower");
     grower.start();
 
-    // The grow must still be blocked on resizeLock: give it a moment, then confirm it has NOT published yet.
-    Thread.sleep(300);
-    assertThat(async.getThreadCount())
-        .as("a grow must not publish a new pool size while a quiescence is still waiting on a busy worker to park")
-        .isEqualTo(1);
+    // Polled rather than a single check after a fixed sleep (code review, PR #6661): a one-shot check could flake
+    // on a slow/contended runner that had not yet let the quiescer reach resizeLock.lock() and schedule its park
+    // task within the sleep window, reporting a false pass rather than exercising the race. Sampling continuously
+    // over a generous window means the assertion only ever fails when the grow ACTUALLY published early - which is
+    // the regression this test exists to catch - not when the scheduler was merely slow to run the quiescer.
+    final long deadline = System.currentTimeMillis() + 3_000;
+    while (System.currentTimeMillis() < deadline) {
+      assertThat(async.getThreadCount())
+          .as("a grow must not publish a new pool size while a quiescence is still waiting on a busy worker to park")
+          .isEqualTo(1);
+      Thread.sleep(20);
+    }
     assertThat(quiesceReturned.getCount()).as("the quiescence itself must still be waiting too").isEqualTo(1L);
 
     // Let the busy task finish: its park task can now run, count down the latch and let the quiescence complete.

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6534: {@code quiesceWorkers()} used to release {@code resizeLock} right after
+ * scheduling its park tasks, BEFORE waiting for them to be confirmed. A concurrent {@code setParallelLevel()} GROW
+ * landing in that window published brand-new workers that this quiescence's park latch was never sized to include -
+ * so the quiescence could confirm "everything is parked" and hand back a clean barrier while a worker that came into
+ * existence a moment earlier was free to write, entirely unparked. An index build reading right after would then be
+ * scanning under a torn view, precisely the failure {@code quiesceWorkers()} exists to prevent (#6281).
+ * <p>
+ * The fix holds {@code resizeLock} for the WHOLE quiescence (scheduling AND the await), not just the scheduling
+ * loop, so a concurrent {@code setParallelLevel()} - grow or shrink - cannot publish anything until every worker this
+ * quiescence knows about has confirmed parked. This test pins that: a grow attempted while the quiescence is
+ * genuinely stuck waiting on a busy worker must not be able to publish its new pool size until the quiescence
+ * itself completes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6534QuiesceResizeRaceTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void aGrowCannotPublishWhileAQuiescenceIsStillWaitingOnABusyWorker() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(1);
+
+    // Occupies the only worker so the park task the quiescence schedules behind it cannot run until this is
+    // released - which is what keeps the quiescence stuck in parked.await() for as long as this test needs.
+    final CountDownLatch taskStarted = new CountDownLatch(1);
+    final CountDownLatch releaseTask = new CountDownLatch(1);
+    assertThat(async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal db) {
+        taskStarted.countDown();
+        try {
+          assertThat(releaseTask.await(30, TimeUnit.SECONDS)).isTrue();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public void completed() {
+      }
+    }, true, 0)).isTrue();
+    assertThat(taskStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+    final AtomicReference<Throwable> quiesceFailure = new AtomicReference<>();
+    final CountDownLatch quiesceReturned = new CountDownLatch(1);
+    // quiesceLock is a plain ReentrantLock, so the handle it hands out must be closed by the SAME thread that
+    // acquired it - the quiescer below both opens and closes it, never the main test thread.
+    final CountDownLatch closeQuiesce = new CountDownLatch(1);
+    final Thread quiescer = new Thread(() -> {
+      try (final AsyncQuiesce quiesce = async.quiesceWorkers()) {
+        quiesceReturned.countDown();
+        assertThat(closeQuiesce.await(30, TimeUnit.SECONDS)).isTrue();
+      } catch (final Throwable e) {
+        quiesceFailure.set(e);
+        quiesceReturned.countDown();
+      }
+    }, "issue6534-quiescer");
+    quiescer.start();
+
+    // Give the quiescer time to acquire resizeLock, snapshot the pool and schedule its park task - which now sits
+    // queued behind the busy task above and cannot run until releaseTask counts down.
+    Thread.sleep(300);
+
+    final Thread grower = new Thread(() -> async.setParallelLevel(3), "issue6534-grower");
+    grower.start();
+
+    // The grow must still be blocked on resizeLock: give it a moment, then confirm it has NOT published yet.
+    Thread.sleep(300);
+    assertThat(async.getThreadCount())
+        .as("a grow must not publish a new pool size while a quiescence is still waiting on a busy worker to park")
+        .isEqualTo(1);
+    assertThat(quiesceReturned.getCount()).as("the quiescence itself must still be waiting too").isEqualTo(1L);
+
+    // Let the busy task finish: its park task can now run, count down the latch and let the quiescence complete.
+    releaseTask.countDown();
+
+    assertThat(quiesceReturned.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(quiesceFailure.get()).isNull();
+
+    closeQuiesce.countDown();
+    quiescer.join(30_000);
+    assertThat(quiescer.isAlive()).isFalse();
+    assertThat(quiesceFailure.get()).isNull();
+
+    grower.join(30_000);
+    assertThat(grower.isAlive()).as("the grow must not hang once the quiescence releases resizeLock").isFalse();
+    assertThat(async.getThreadCount()).as("the grow must have published once it was finally allowed to").isEqualTo(3);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/text/TextStatelessFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/text/TextStatelessFunctionsTest.java
@@ -279,8 +279,18 @@ class TextStatelessFunctionsTest {
 
     // Start beyond string length returns empty
     assertThat(fn.execute(new Object[]{"hello", 100}, null)).isEqualTo("");
-    // Negative start returns empty
-    assertThat(fn.execute(new Object[]{"hello", -1}, null)).isEqualTo("");
+  }
+
+  @Test
+  void substringNegativeStartIsAClientErrorNotSilentlyEmpty() {
+    // A negative start is an invalid user-supplied value, so it must be a CommandSemanticException (HTTP 400),
+    // matching CypherSubstringFunction - the executor Cypher's substring() actually resolves to - rather than the
+    // silent "" this unregistered twin used to return for the same condition (issue #6609).
+    final SubstringFunction fn = new SubstringFunction();
+
+    assertThatThrownBy(() -> fn.execute(new Object[]{"hello", -1}, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("negative start");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/function/text/TextStatelessFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/text/TextStatelessFunctionsTest.java
@@ -291,6 +291,32 @@ class TextStatelessFunctionsTest {
         .isInstanceOf(CommandSemanticException.class);
   }
 
+  @Test
+  void substringNegativeLengthIsAClientErrorNotAnInternalOne() {
+    // A negative length is an invalid user-supplied value, so it must be a CommandSemanticException (HTTP 400),
+    // matching CypherSubstringFunction - the executor Cypher's substring() actually resolves to - rather than the
+    // CommandExecutionException (HTTP 500) this unregistered twin used to throw for the same condition (issue #6609).
+    final SubstringFunction fn = new SubstringFunction();
+
+    assertThatThrownBy(() -> fn.execute(new Object[]{"hello", 0, -1}, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("negative length");
+  }
+
+  @Test
+  void substringOfListArgumentIsAClientTypeError() {
+    // Same unchecked-cast class of bug as left()/right() (issue #6609): a LIST at the start/length position must be
+    // a client type error, not the java.lang.ClassCastException the unchecked cast used to let escape.
+    final SubstringFunction fn = new SubstringFunction();
+
+    assertThatThrownBy(() -> fn.execute(new Object[]{"hello", List.of(1, 2)}, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("LIST");
+    assertThatThrownBy(() -> fn.execute(new Object[]{"hello", 0, List.of(1, 2)}, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("LIST");
+  }
+
   // ============ SplitFunction tests ============
 
   @Test

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2819,9 +2819,6 @@ class GraphAnalyticalViewTest extends TestHelper {
         .as("issue #6641: the query planner must route to the ordinary OLTP path instead of a provider "
             + "that will block the query through a full rebuild")
         .isNull();
-    assertThat(restored.isBuilt())
-        .as("checking readiness must not itself perform the rebuild on the calling thread")
-        .isFalse();
 
     // "Never serve stale data" still holds: the background resolution (triggered above) eventually
     // produces the correct, up-to-date snapshot for whichever query asks next.
@@ -2881,7 +2878,6 @@ class GraphAnalyticalViewTest extends TestHelper {
         .as("issue #6641: a corrupted persisted CSR must not be advertised as ready before it is verified")
         .isFalse();
     assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS")).isNull();
-    assertThat(restored.isBuilt()).isFalse();
 
     assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
     assertThat(restored.isRestoredFromPersistedCsr()).isFalse();

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2756,6 +2756,142 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6641: a follow-up to #6632/#6633. Deferring the CSR read out of {@code open()}
+   * left the view reporting {@code READY} (via {@code pendingDiskRestore}) before the restore had actually
+   * been verified. When a commit landed in between - invalidating the persisted CSR's freshness certificate
+   * - the query that happened to trigger the deferred read discovered the file was unusable only once
+   * already committed to the accelerated path, and paid for a full {@code O(V+E)} rebuild synchronously
+   * instead of the ordinary OLTP path it would have used before #6632 (when {@code onRelevantCommit()} eagerly
+   * marked the view {@code STALE} and provider resolution rejected it up front).
+   * <p>
+   * The fix moves the "is this actually resolved yet" check to {@link GraphAnalyticalView#isReady()} itself:
+   * while a deferred restore is still pending, {@code isReady()} triggers it in the background but reports
+   * not-ready for the caller that asks, so {@link GraphTraversalProviderRegistry#findProvider} routes that
+   * query to the ordinary path - exactly as an eagerly-marked {@code STALE} view would have. Verifies both
+   * that this query-time gate reports not-ready synchronously (no query ever blocks on it) and that the
+   * background resolution still reaches the correct, freshly-rebuilt answer afterwards - "never serve stale
+   * data" is preserved even though nobody waited for it.
+   */
+  @Test
+  void issue6641_interveningCommitInvalidatesDeferredRestoreWithoutBlockingQuery() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final RID aId = database.newVertex("Person").save().getIdentity();
+    final RID bId = database.newVertex("Person").save().getIdentity();
+    ((Vertex) database.lookupByRID(aId, true)).modify().newEdge("FOLLOWS", (Vertex) database.lookupByRID(bId, true));
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-6641-commit-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-6641-commit-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.getStatus())
+        .as("a plausible persisted CSR must still mark the view provisionally READY on reopen (#6632)")
+        .isEqualTo(GraphAnalyticalView.Status.READY);
+    assertThat(restored.isBuilt())
+        .as("nothing has triggered the deferred restore yet")
+        .isFalse();
+
+    // Invalidates the persisted CSR's freshness certificate - the deferred read, whenever it runs, must
+    // find it unusable and require a full rebuild.
+    database.begin();
+    final RID cId = database.newVertex("Person").save().getIdentity();
+    ((Vertex) database.lookupByRID(bId, true)).modify().newEdge("FOLLOWS", (Vertex) database.lookupByRID(cId, true));
+    database.commit();
+
+    // The query planner's gate must not hand out a provider it hasn't actually verified is usable: this
+    // must return false/null synchronously, without waiting for (or triggering, from the caller's point of
+    // view) any O(V+E) rebuild - it only kicks that off in the background.
+    assertThat(restored.isReady())
+        .as("issue #6641: a provisionally-READY view with an unresolved deferred restore must not be "
+            + "advertised as ready until it is actually verified - the caller has no way to recover once "
+            + "committed to a provider that turns out to need a synchronous rebuild")
+        .isFalse();
+    assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS"))
+        .as("issue #6641: the query planner must route to the ordinary OLTP path instead of a provider "
+            + "that will block the query through a full rebuild")
+        .isNull();
+    assertThat(restored.isBuilt())
+        .as("checking readiness must not itself perform the rebuild on the calling thread")
+        .isFalse();
+
+    // "Never serve stale data" still holds: the background resolution (triggered above) eventually
+    // produces the correct, up-to-date snapshot for whichever query asks next.
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("the certificate mismatch must have forced a real rebuild, not a stale disk restore")
+        .isFalse();
+    assertThat(restored.getNodeCount()).isEqualTo(3);
+    assertThat(restored.getEdgeCount()).isEqualTo(2);
+    assertThat(restored.isReady())
+        .as("once the background rebuild has completed, the view is genuinely ready")
+        .isTrue();
+    assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS")).isNotNull();
+
+    restored.drop();
+  }
+
+  /**
+   * Regression for issue #6641, corrupted-file variant: the same query-time gate must also protect against
+   * a persisted CSR that is present and passes its certificate check, but is otherwise unusable (truncated
+   * or corrupted) - not only against a certificate invalidated by an intervening commit.
+   */
+  @Test
+  void issue6641_corruptedPersistedCsrInvalidatesDeferredRestoreWithoutBlockingQuery() throws Exception {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-6641-corrupt-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    // fileFor() resolves through the schema (for its filename encoding), so it must run before close().
+    final File csrFile = GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-6641-corrupt-test");
+    final String dbPath = database.getDatabasePath();
+    database.close();
+
+    assertThat(csrFile).exists();
+    try (final RandomAccessFile raf = new RandomAccessFile(csrFile, "rw")) {
+      raf.setLength(Math.min(raf.length(), 64));
+    }
+
+    database = new DatabaseFactory(dbPath).open();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-6641-corrupt-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.isBuilt()).isFalse();
+
+    assertThat(restored.isReady())
+        .as("issue #6641: a corrupted persisted CSR must not be advertised as ready before it is verified")
+        .isFalse();
+    assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS")).isNull();
+    assertThat(restored.isBuilt()).isFalse();
+
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr()).isFalse();
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+    assertThat(restored.getEdgeCount()).isEqualTo(1);
+
+    restored.drop();
+  }
+
+  /**
    * Regression for issue #6632: a session that opens a database with a persisted-CSR view and never
    * queries it must not pay for the deferred restore at shutdown() either — shutdown() has no reason to
    * wait for work that was never triggered, and {@code persistCsrIfPossible()} must not attempt to

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2888,6 +2888,79 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6641 code review: {@link GraphTraversalProviderRegistry#findProvider} used to
+   * call {@code isReady()} before {@code coversEdgeType()} in its scan of registered providers. That was
+   * harmless while {@code isReady()} was a pure read, but this PR gives it a side effect - dispatching a
+   * pending deferred restore-from-disk in the background (see {@link GraphAnalyticalView#isReady()}) - so
+   * checking readiness before coverage meant a query for one view's edge type would eagerly trigger every
+   * *other* registered view's deferred restore too, just by virtue of being iterated. That quietly weakens
+   * #6632's "a view a session never actually needs shouldn't cost anything" promise for any multi-view
+   * database. Verifies the fix (coverage checked first, so {@code isReady()} - and its dispatch - only ever
+   * runs on a provider that could actually be selected): with two views covering disjoint edge types, a
+   * lookup for one type must not touch the other view's pending restore at all.
+   */
+  @Test
+  void issue6641_findProviderDoesNotTriggerUnrelatedViewsDeferredRestore() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.getSchema().createEdgeType("LIKES");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    a.newEdge("LIKES", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-6641-follows-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+    GraphAnalyticalView.builder(database)
+        .withName("csr-6641-likes-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("LIKES")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView follows = GraphAnalyticalViewRegistry.get(database, "csr-6641-follows-test");
+    final GraphAnalyticalView likes = GraphAnalyticalViewRegistry.get(database, "csr-6641-likes-test");
+    assertThat(follows).isNotNull();
+    assertThat(likes).isNotNull();
+    assertThat(follows.getStatus())
+        .as("both views' persisted CSRs must still be provisionally READY, unresolved, right after reopen")
+        .isEqualTo(GraphAnalyticalView.Status.READY);
+    assertThat(likes.getStatus()).isEqualTo(GraphAnalyticalView.Status.READY);
+
+    // A query for FOLLOWS only: findProvider() must resolve the FOLLOWS view's deferred restore as a side
+    // effect of checking it, but must never even look at whether LIKES is ready - it doesn't cover FOLLOWS.
+    GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS");
+
+    assertThat(follows.getStatus())
+        .as("the FOLLOWS view was a real candidate for this lookup, so its deferred restore must have been "
+            + "dispatched (status flips to BUILDING synchronously, before the background work even starts)")
+        .isEqualTo(GraphAnalyticalView.Status.BUILDING);
+    assertThat(likes.getStatus())
+        .as("issue #6641: the LIKES view does not cover FOLLOWS and must never have been asked about "
+            + "readiness at all - its deferred restore must stay untouched")
+        .isEqualTo(GraphAnalyticalView.Status.READY);
+    assertThat(likes.isBuilt())
+        .as("untouched means untouched: no restore, no rebuild, nothing read from disk for this view")
+        .isFalse();
+
+    assertThat(follows.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(follows.isRestoredFromPersistedCsr()).isTrue();
+    assertThat(likes.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(likes.isRestoredFromPersistedCsr()).isTrue();
+
+    follows.drop();
+    likes.drop();
+  }
+
+  /**
    * Regression for issue #6632: a session that opens a database with a persisted-CSR view and never
    * queries it must not pay for the deferred restore at shutdown() either — shutdown() has no reason to
    * wait for work that was never triggered, and {@code persistCsrIfPossible()} must not attempt to

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2853,6 +2853,81 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6636: a direct {@code build()} (e.g. {@code REBUILD GRAPH ANALYTICAL VIEW})
+   * that runs and completes WHILE a deferred restore-from-disk is already dispatched and in flight - not
+   * merely pending, unlike {@link #csrLazyPendingRestoreSupersededByDirectRebuildIsNotReTriggered} - must
+   * not have its fresh snapshot overwritten once the in-flight restore finally gets a chance to run.
+   * <p>
+   * {@code build()} is not gated by {@code BUILD_PERMITS}, so it can complete before an already-dispatched
+   * restore even starts reading the file. If nothing was committed in the meantime, the restore's freshness
+   * certificate still matches the database's current state, so - without a fix - it "succeeds" and clobbers
+   * the just-rebuilt snapshot with the persisted one, misreporting {@code isRestoredFromPersistedCsr()}.
+   * <p>
+   * Saturates the shared {@code BUILD_PERMITS} semaphore (via the test-only hook) so the dispatched
+   * restore's background task parks right before it would read the file, then lands {@code build()} while
+   * it is stuck there, then releases the permits and lets the restore run to completion.
+   */
+  @Test
+  void csrLazyRestoreInFlightSupersededByDirectBuildIsNotOverwritten() throws Exception {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-lazy-inflight-race-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-lazy-inflight-race-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.isBuilt())
+        .as("nothing has triggered the deferred restore yet")
+        .isFalse();
+
+    GraphAnalyticalView.acquireAllBuildPermitsForTest();
+    final Thread restoreTrigger = new Thread(() -> restored.awaitReady(10, TimeUnit.SECONDS));
+    try {
+      restoreTrigger.start();
+      final long dispatchDeadline = System.currentTimeMillis() + 5_000;
+      while (!restored.isDeferredRestoreInFlightForTest() && System.currentTimeMillis() < dispatchDeadline)
+        Thread.sleep(5);
+      assertThat(restored.isDeferredRestoreInFlightForTest())
+          .as("the deferred restore must have dispatched and be parked waiting for a build permit")
+          .isTrue();
+
+      // Simulates REBUILD GRAPH ANALYTICAL VIEW: a direct build() call, bypassing checkBuilt()/awaitReady()
+      // and BUILD_PERMITS, running to completion while the restore above is still stuck acquiring a permit.
+      restored.build();
+      assertThat(restored.isRestoredFromPersistedCsr())
+          .as("a direct rebuild must produce a fresh scan, not a disk restore")
+          .isFalse();
+      assertThat(restored.getNodeCount()).isEqualTo(2);
+    } finally {
+      // Releases exactly the permits acquired above, regardless of whether an assertion failed.
+      GraphAnalyticalView.releaseAllBuildPermitsForTest();
+    }
+    restoreTrigger.join(10_000);
+
+    // The deferred restore, once unparked, must discover it was superseded by the fresher direct build()
+    // and discard its own (redundant, certificate-matching) result rather than overwriting it.
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("the direct rebuild's snapshot must win over the in-flight deferred restore, even though the restore's own certificate still matched")
+        .isFalse();
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+
+    restored.drop();
+  }
+
+  /**
    * Regression for issue #6583 code review: {@code GAV_PERSIST_CSR=false} must suppress persistence
    * entirely - no file written at close, and a reopen must fall back to the full rebuild rather than
    * finding (and trusting) a leftover file from before the setting was flipped off.

--- a/engine/src/test/java/com/arcadedb/index/Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.async.DatabaseAsyncExecutorImpl;
+import com.arcadedb.database.async.DatabaseAsyncTask;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6462, the {@code BucketIndexBuilder} half: {@code quiesceAsync()} parks each
+ * worker once its OWN queue is drained, but a task still mid-flight on a DIFFERENT worker can
+ * schedule a follow-up onto an already-parked worker's queue from inside its own execution - exactly
+ * what a bidirectional cross-slot edge does ({@code DatabaseAsyncExecutorImpl#newEdge} schedules the
+ * incoming-edge task onto the destination slot from inside the source task's own callback). The
+ * follow-up then sits queued behind the park, uncommitted and invisible, while a
+ * {@code BucketIndexBuilder} scan concurrent with it runs anyway - the built index misses the entry.
+ * <p>
+ * Reduced to a plain task scheduled directly at the slot level (as
+ * {@code AsyncCrossSlotSchedulingDeadlockTest} and {@code Issue6303AsyncQuiesceTest} already do)
+ * rather than through the graph API: a task on one worker, still blocked, that - once released -
+ * creates a record targeting the OTHER worker's bucket from inside its own execution, mirroring the
+ * shape exactly without depending on which slot a given RID happens to hash to.
+ */
+class Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void bucketIndexBuildMustNotMissARecordFromACrossSlotCascadeStillInFlight() throws Exception {
+    final DatabaseInternal            db    = (DatabaseInternal) database;
+    final DatabaseAsyncExecutorImpl   async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    final Bucket vBucket  = database.getSchema().getType("V").getBuckets(false).get(0);
+    final int    destSlot = async.getSlot(vBucket.getFileId());
+    final int    sourceSlot = 1 - destSlot;
+
+    final CountDownLatch sourceTaskRunning = new CountDownLatch(1);
+    final CountDownLatch releaseSourceTask = new CountDownLatch(1);
+    final CountDownLatch cascadeCreated    = new CountDownLatch(1);
+
+    // SOURCE TASK on the OTHER slot - mirrors CreateEdgeAsyncTask: once released, it creates a
+    // record targeting the index's own bucket FROM INSIDE its own execution, exactly as newEdge()'s
+    // cross-slot callback schedules CreateIncomingEdgeAsyncTask onto the destination slot.
+    async.scheduleTask(sourceSlot, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        sourceTaskRunning.countDown();
+        awaitLatch(releaseSourceTask);
+
+        final MutableDocument v = database.newDocument("V");
+        v.set("id", 42);
+        database.async().createRecord(v, record -> cascadeCreated.countDown());
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    }, true, 0);
+
+    assertThat(sourceTaskRunning.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Runs the build concurrently, on its own thread: it must block until the source task (still
+    // held below) and whatever it schedules have fully drained.
+    final AtomicReference<com.arcadedb.index.Index> builtIndex = new AtomicReference<>();
+    final CountDownLatch                            buildDone  = new CountDownLatch(1);
+    final Thread builder = new Thread(() -> {
+      try {
+        builtIndex.set(database.getSchema().buildBucketIndex("V", vBucket.getName(), new String[] { "id" })
+            .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create());
+      } finally {
+        buildDone.countDown();
+      }
+    }, "index-builder");
+    builder.setDaemon(true);
+    builder.start();
+
+    // Widens the window a real cross-slot edge would leave open: with the pre-#6462-fix code,
+    // quiesceAsync() parks the (idle, nothing queued yet) destination worker essentially instantly
+    // once the build starts above - far under this bound - so releasing the source task only after
+    // this sleep reliably reproduces the race rather than depending on it by luck.
+    Thread.sleep(300);
+
+    releaseSourceTask.countDown();
+
+    // NOT gated on cascadeCreated: that latch only counts down once the cross-slot record's own async
+    // task has actually EXECUTED and committed - which, for the very race under test, may not happen
+    // until after quiesceAsync() has already released the workers. Waiting for it first would silently
+    // wait out the bug. buildDone is the only synchronization point that matters here: create() cannot
+    // even reach its quiesceAsync() call's parked.await() until the source task has finished (its own
+    // trailing park sits queued behind it), so by the time create() returns, the cross-slot record has
+    // at least been SCHEDULED - the question the assertions below answer is whether it was also seen.
+    assertThat(buildDone.await(30, TimeUnit.SECONDS)).as("the index build must complete").isTrue();
+    builder.join(5000);
+
+    // THE ASSERTION: a record whose cross-slot creation was already scheduled before the build even
+    // started quiescing must be visible in both the type and the freshly built index the INSTANT
+    // create() returns - not eventually, once some later drain happens to catch it up. That "eventually"
+    // is exactly the silently incomplete index #6462 is about: a caller reading right after the DDL
+    // statement returns must not see a database that has not caught up with its own recent past.
+    assertThat(builtIndex.get()).as("the build must have produced an index").isNotNull();
+    assertThat(database.countType("V", false))
+        .as("a record whose cross-slot creation was already scheduled before the build started quiescing must be "
+            + "committed by the time the build - a DDL statement - returns")
+        .isEqualTo(1);
+    assertThat(builtIndex.get().countEntries())
+        .as("a record created by a cross-slot cascade still in flight when the build started must not be missing "
+            + "from the built index")
+        .isEqualTo(1);
+
+    // Sanity: the record is not permanently lost either way - only the timing guarantee is under test.
+    assertThat(cascadeCreated.await(10, TimeUnit.SECONDS)).as("the cross-slot record must eventually be created")
+        .isTrue();
+  }
+
+  private static void awaitLatch(final CountDownLatch latch) {
+    try {
+      if (!latch.await(20, TimeUnit.SECONDS))
+        throw new AssertionError("Latch never released within 20s");
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue6640ParenthesizedInListIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6640ParenthesizedInListIndexTest.java
@@ -23,9 +23,11 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -48,6 +50,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * child list on every call (also O(n^2)). All three combined made a 15,000-value literal {@code IN()} on an
  * indexed property ~1000x slower than the identical values passed as a bound parameter; fixed, the two forms
  * perform the same.
+ * <p>
+ * Making the parenthesized list index-aware also exposed a pre-existing correctness bug shared with the bracket
+ * form: {@code isIndexAware()} never checked {@code not}, so {@code trackId NOT IN [2,5,9]} was already fetching
+ * the LISTED rows through the index instead of excluding them (same class of bug as #6575 for the native Select
+ * API - a negated leaf has no complement in {@code FetchFromIndexStep}). Fixed alongside this change by declining
+ * to use the index whenever {@code not} is set, for every right-hand shape.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -100,6 +108,28 @@ class Issue6640ParenthesizedInListIndexTest extends TestHelper {
   }
 
   @Test
+  void negatedParenthesizedInListDoesNotUseTheIndexAndExcludesTheListedRows() {
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        database.newVertex("Track").set("trackId", (long) i).save();
+    });
+
+    database.transaction(() -> {
+      // A negated IN has no complement in FetchFromIndexStep: every code path there builds a cursor over
+      // the values that DO match, not their complement. isIndexAware() must decline whenever `not` is set,
+      // for every right-hand shape (parenthesized list, bracket array, bound parameter) - not just this
+      // one - otherwise the query silently returns the listed rows instead of excluding them.
+      final ResultSet explain = database.query("sql", "explain select from Track where trackId not in (2, 5, 9)");
+      assertThat(explain.getExecutionPlan().get().prettyPrint(0, 2)).doesNotContain("FETCH FROM INDEX");
+
+      final List<Long> ids = database.query("sql", "select trackId from Track where trackId not in (2, 5, 9) order by trackId")
+          .stream().map(r -> r.<Long>getProperty("trackId")).toList();
+      assertThat(ids).containsExactly(0L, 1L, 3L, 4L, 6L, 7L, 8L);
+    });
+  }
+
+  @Test
+  @Tag("slow")
   void literalAndBoundParameterFormsAgreeOnLargeLists() {
     final int ROWS = 20_000;
     database.transaction(() -> {
@@ -113,7 +143,7 @@ class Issue6640ParenthesizedInListIndexTest extends TestHelper {
     database.transaction(() -> {
       final List<Long> viaLiteral = database.query("sql", "select from Track where trackId in (" + literalInList + ")")
           .stream().map(r -> r.<Long>getProperty("trackId")).toList();
-      final List<Long> viaBoundParam = database.query("sql", "select from Track where trackId in :ids", java.util.Map.of("ids", chosen))
+      final List<Long> viaBoundParam = database.query("sql", "select from Track where trackId in :ids", Map.of("ids", chosen))
           .stream().map(r -> r.<Long>getProperty("trackId")).toList();
 
       assertThat(viaLiteral).containsExactlyInAnyOrderElementsOf(chosen);
@@ -122,6 +152,7 @@ class Issue6640ParenthesizedInListIndexTest extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   void largeLiteralInListStaysNearLinearNotQuadratic() {
     final int ROWS = 30_000;
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/index/Issue6640ParenthesizedInListIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6640ParenthesizedInListIndexTest.java
@@ -182,10 +182,13 @@ class Issue6640ParenthesizedInListIndexTest extends TestHelper {
     // 15,000-item literal IN() take ~40s where the equivalent bound parameter took ~50ms (#6640).
     database.transaction(() -> database.query("sql", buildInQuery(2_000)).close());
 
+    // assertStayedUnder, not assertGaveUpWithin: the bound IS the assertion here, standing in for the
+    // near-linear complexity claim - there is no other practical way to express "not quadratic". Widening
+    // this bound would not be a safe loosening, it would quietly delete the regression coverage.
     final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     database.transaction(() -> database.query("sql", buildInQuery(20_000)).close());
-    stopwatch.assertGaveUpWithin(5_000,
-        "a near-linear 20,000-item literal IN() against an indexed property from the pre-fix quadratic full-scan/copy/parse cost");
+    stopwatch.assertStayedUnder(5_000,
+        "a near-linear 20,000-item literal IN() against an indexed property, not the pre-fix quadratic full-scan/copy/parse cost");
   }
 
   private String buildInQuery(final int n) {

--- a/engine/src/test/java/com/arcadedb/index/Issue6640ParenthesizedInListIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6640ParenthesizedInListIndexTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #6640: {@code WHERE prop IN (v1, v2, ..., vN)} - the parenthesized literal-list form of IN, the most common
+ * shape in hand-written SQL - never used the index. {@code InCondition.isIndexAware()} only recognised the
+ * bracket-array form ({@code IN [v1,...]}) and the bound-parameter form ({@code IN ?}/{@code IN :name}); a
+ * parenthesized literal list fell back to a full bucket scan that re-evaluated the whole N-item list, by
+ * linear search, against every row. A 15,000-item list on an indexed property was reported at ~350 rows/sec
+ * (a 36M-row production table) and reproduced here at essentially the same rate on 200,000 rows - proportional
+ * to row count, not list size, which is what gives a full scan away.
+ * <p>
+ * Fixing that alone uncovered two further bugs the literal-list path had never been able to reach before:
+ * {@link com.arcadedb.query.sql.executor.FetchFromIndexStep#init} expanding a multi-value key
+ * ({@code cartesianProduct}) deep-copied the entire remaining key - including the N-item list itself - once
+ * per expanded element (O(n^2)), and {@code SQLASTBuilder.visitInCondition} built the list by calling the
+ * ANTLR-generated indexed accessor {@code ctx.expression(i)} in a loop, which rescans the whole parse-tree
+ * child list on every call (also O(n^2)). All three combined made a 15,000-value literal {@code IN()} on an
+ * indexed property ~1000x slower than the identical values passed as a bound parameter; fixed, the two forms
+ * perform the same.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6640ParenthesizedInListIndexTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Track");
+      database.getSchema().getType("Track").createProperty("trackId", Type.LONG);
+      database.getSchema().buildTypeIndex("Track", new String[] { "trackId" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(true)
+          .create();
+    });
+  }
+
+  @Test
+  void literalParenthesizedInListUsesTheIndex() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql", "explain select from Track where trackId in (1, 2, 3)");
+      final String plan = rs.getExecutionPlan().get().prettyPrint(0, 2);
+      assertThat(plan).contains("FETCH FROM INDEX");
+    });
+  }
+
+  @Test
+  void singleItemParenthesizedInListUsesTheIndex() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql", "explain select from Track where trackId in (1)");
+      final String plan = rs.getExecutionPlan().get().prettyPrint(0, 2);
+      assertThat(plan).contains("FETCH FROM INDEX");
+    });
+  }
+
+  @Test
+  void literalParenthesizedInListReturnsExactRowsWithDuplicatesAndMisses() {
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        database.newVertex("Track").set("trackId", (long) i).save();
+    });
+
+    database.transaction(() -> {
+      // 9 is repeated in the list and 100 does not exist: the index-based fetch must neither duplicate
+      // nor invent rows, exactly like the pre-fix full-scan evaluator.
+      final ResultSet rs = database.query("sql", "select trackId from Track where trackId in (2, 5, 9, 9, 100) order by trackId");
+      final List<Long> ids = rs.stream().map(r -> r.<Long>getProperty("trackId")).toList();
+      assertThat(ids).containsExactly(2L, 5L, 9L);
+    });
+  }
+
+  @Test
+  void literalAndBoundParameterFormsAgreeOnLargeLists() {
+    final int ROWS = 20_000;
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newVertex("Track").set("trackId", (long) i).save();
+    });
+
+    final List<Long> chosen = new Random(42).longs(0, ROWS).distinct().limit(6_000).boxed().collect(Collectors.toList());
+    final String literalInList = chosen.stream().map(String::valueOf).collect(Collectors.joining(","));
+
+    database.transaction(() -> {
+      final List<Long> viaLiteral = database.query("sql", "select from Track where trackId in (" + literalInList + ")")
+          .stream().map(r -> r.<Long>getProperty("trackId")).toList();
+      final List<Long> viaBoundParam = database.query("sql", "select from Track where trackId in :ids", java.util.Map.of("ids", chosen))
+          .stream().map(r -> r.<Long>getProperty("trackId")).toList();
+
+      assertThat(viaLiteral).containsExactlyInAnyOrderElementsOf(chosen);
+      assertThat(viaLiteral).containsExactlyInAnyOrderElementsOf(viaBoundParam);
+    });
+  }
+
+  @Test
+  void largeLiteralInListStaysNearLinearNotQuadratic() {
+    final int ROWS = 30_000;
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newVertex("Track").set("trackId", (long) i).save();
+    });
+
+    // A 10x larger literal IN-list must not take anywhere near 100x longer. Before the fix, three compounding
+    // O(n^2) costs - a full bucket scan, FetchFromIndexStep.cartesianProduct() copying the whole remaining key
+    // per expanded element, and the ANTLR AST builder rescanning the parse tree per list item - made a
+    // 15,000-item literal IN() take ~40s where the equivalent bound parameter took ~50ms (#6640).
+    database.transaction(() -> database.query("sql", buildInQuery(2_000)).close());
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    database.transaction(() -> database.query("sql", buildInQuery(20_000)).close());
+    stopwatch.assertGaveUpWithin(5_000,
+        "a near-linear 20,000-item literal IN() against an indexed property from the pre-fix quadratic full-scan/copy/parse cost");
+  }
+
+  private String buildInQuery(final int n) {
+    final StringBuilder sql = new StringBuilder("select from Track where trackId in (");
+    for (int i = 0; i < n; i++) {
+      if (i > 0)
+        sql.append(',');
+      sql.append(i);
+    }
+    sql.append(')');
+    return sql.toString();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue6640ParenthesizedInListIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6640ParenthesizedInListIndexTest.java
@@ -114,18 +114,34 @@ class Issue6640ParenthesizedInListIndexTest extends TestHelper {
         database.newVertex("Track").set("trackId", (long) i).save();
     });
 
+    // A negated IN has no complement in FetchFromIndexStep: every code path there builds a cursor over the
+    // values that DO match, not their complement. isIndexAware() must decline whenever `not` is set, for
+    // every right-hand shape - parenthesized list, bracket array, bound parameter - not just the one this
+    // PR touches, otherwise the query silently returns the listed rows instead of excluding them. The
+    // bracket-array and bound-parameter forms already reached the index before this PR, so this locks in
+    // the guard fixing a pre-existing bug for them too, not just guarding against the new parenthesized path.
     database.transaction(() -> {
-      // A negated IN has no complement in FetchFromIndexStep: every code path there builds a cursor over
-      // the values that DO match, not their complement. isIndexAware() must decline whenever `not` is set,
-      // for every right-hand shape (parenthesized list, bracket array, bound parameter) - not just this
-      // one - otherwise the query silently returns the listed rows instead of excluding them.
-      final ResultSet explain = database.query("sql", "explain select from Track where trackId not in (2, 5, 9)");
+      assertNotInDeclinesTheIndexAndExcludesTheListedRows("select from Track where trackId not in (2, 5, 9)",
+          "select trackId from Track where trackId not in (2, 5, 9) order by trackId");
+      assertNotInDeclinesTheIndexAndExcludesTheListedRows("select from Track where trackId not in [2, 5, 9]",
+          "select trackId from Track where trackId not in [2, 5, 9] order by trackId");
+    });
+    database.transaction(() -> {
+      final ResultSet explain = database.query("sql", "explain select from Track where trackId not in :ids", Map.of("ids", List.of(2L, 5L, 9L)));
       assertThat(explain.getExecutionPlan().get().prettyPrint(0, 2)).doesNotContain("FETCH FROM INDEX");
 
-      final List<Long> ids = database.query("sql", "select trackId from Track where trackId not in (2, 5, 9) order by trackId")
+      final List<Long> ids = database.query("sql", "select trackId from Track where trackId not in :ids order by trackId", Map.of("ids", List.of(2L, 5L, 9L)))
           .stream().map(r -> r.<Long>getProperty("trackId")).toList();
       assertThat(ids).containsExactly(0L, 1L, 3L, 4L, 6L, 7L, 8L);
     });
+  }
+
+  private void assertNotInDeclinesTheIndexAndExcludesTheListedRows(final String explainQuery, final String selectQuery) {
+    final ResultSet explain = database.query("sql", "explain " + explainQuery);
+    assertThat(explain.getExecutionPlan().get().prettyPrint(0, 2)).doesNotContain("FETCH FROM INDEX");
+
+    final List<Long> ids = database.query("sql", selectQuery).stream().map(r -> r.<Long>getProperty("trackId")).toList();
+    assertThat(ids).containsExactly(0L, 1L, 3L, 4L, 6L, 7L, 8L);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
@@ -180,6 +180,15 @@ class Issue6566UntrustedSegmentSurfaceTest extends TestHelper {
             + "physical per-bucket sub-index name (%s) this fix used to embed a second time", engineName)
         .anyMatch(w -> w.contains("#6379") && w.contains(remedyLine) && countOccurrences(w, "REBUILD INDEX") == 1
             && !w.contains(engineName));
+
+    // Exhaustive, not anyMatch: a second, wrongly-targeted WARNING could coexist with the correct one above and
+    // an anyMatch-only assertion would not notice (PR #6720 review, round 2 - PaginatedSparseVectorEngine's own
+    // warnOnPreRecencyEpochSegments() log line had exactly this bug, undetected by this test's first version).
+    // Every captured line is checked, not just the one this test is looking for.
+    assertThat(warnings)
+        .as("no captured WARNING may pair 'REBUILD INDEX' with the physical per-bucket sub-index name (%s)",
+            engineName)
+        .noneMatch(w -> w.contains("REBUILD INDEX") && w.contains(engineName));
   }
 
   private LSMSparseVectorIndex sparseSubIndex(final String typeName) {

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6566: whether a sparse-vector index still holds a segment whose
+ * precedence predates the recency-epoch fix (issue #6379) used to be observable only as a
+ * once-per-instance {@code WARNING} log line - nothing could alert on it, and once a node had been
+ * up for a while there was no way to ask "is this index still affected" without restarting it, nor
+ * to confirm a {@code REBUILD INDEX} actually cleared it.
+ * <p>
+ * {@link PaginatedSparseVectorEngine#untrustedSegmentCount()} re-derives the same condition
+ * {@code warnOnPreRecencyEpochSegments} logs, but from the live segment snapshot on every call
+ * instead of latching it once - so it is what {@link LSMSparseVectorIndex#getStats()},
+ * {@link LSMSparseVectorIndex#getUpgradeWarning()} (the same surface {@code schema:indexes},
+ * {@code schema:index:<name>}, Studio and the HTTP admin API already read for every other index
+ * upgrade warning) and {@link LSMSparseVectorIndexMetrics#buildJSON} now expose.
+ * <p>
+ * "Legacy-shaped" segments are synthesised the way a pre-#6379 build actually left them on disk:
+ * parents recorded, recency epoch left at 0 - the same fixture
+ * {@code PaginatedSparseVectorEngineCompactionRecencyTest#preRecencyEpochMergedSegmentIsReportedAtOpen}
+ * uses to pin the WARNING log line itself.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6566UntrustedSegmentSurfaceTest extends TestHelper {
+
+  private static final int DIM = 0;
+
+  @Test
+  void untrustedSegmentCountReportsALegacyShapedSegmentAndConfirmsARebuildClearsIt() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // A legacy merge: parents recorded, epoch never set - the on-disk shape a pre-#6379 build left behind.
+    database.transaction(() -> {
+      final SparseSegmentComponent component = newComponent(db, "UntrustedSurfaceTest_seg99");
+      try (final SparseSegmentBuilder b = new SparseSegmentBuilder(component, SegmentParameters.defaults())) {
+        b.setSegmentId(99L);
+        b.setRecencyEpoch(0L); // what a pre-fix builder left in the slot
+        b.setParentSegments(new long[] { 90L, 91L });
+        b.startDim(DIM);
+        b.appendPosting(new RID(0, 500L), 0.5f);
+        b.endDim();
+        b.finish();
+      }
+    });
+
+    try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine(db, "UntrustedSurfaceTest",
+        SegmentParameters.defaults(), /* memtableFlushThreshold */ 100_000L, /* tierFanout */ 1_000_000,
+        /* tierBasePostings */ 1L)) {
+      assertThat(engine.segmentCount()).isEqualTo(1);
+      assertThat(engine.untrustedSegmentCount())
+          .as("the legacy-shaped segment must be counted, not only logged").isEqualTo(1);
+    }
+
+    // The remedy: drop the legacy segment and rebuild the index content from scratch, exactly what
+    // REBUILD INDEX does at the storage level - a fresh segment with no parents.
+    final var legacyComponent = ((LocalSchema) db.getSchema().getEmbedded()).getFileByName("UntrustedSurfaceTest_seg99");
+    assertThat(legacyComponent).isNotNull();
+    db.getFileManager().dropFile(legacyComponent.getFileId());
+
+    try (final PaginatedSparseVectorEngine rebuilt = new PaginatedSparseVectorEngine(db, "UntrustedSurfaceTest",
+        SegmentParameters.defaults(), /* memtableFlushThreshold */ 100_000L, /* tierFanout */ 1_000_000,
+        /* tierBasePostings */ 1L)) {
+      assertThat(rebuilt.segmentCount())
+          .as("the legacy segment must be gone, not merely outnumbered").isZero();
+      rebuilt.put(DIM, new RID(0, 501L), 0.7f);
+      rebuilt.flush();
+      assertThat(rebuilt.untrustedSegmentCount())
+          .as("a queryable stat, not only a latched log line: it must be able to go back to zero and say so, "
+              + "confirming the remedy actually worked").isZero();
+    }
+  }
+
+  /**
+   * End-to-end through the {@link LSMSparseVectorIndex} an ordinary {@code CREATE INDEX ... LSM_SPARSE_VECTOR}
+   * produces: the surface a monitoring system or Studio would actually read, not only the engine underneath it.
+   */
+  @Test
+  void upgradeWarningAndStatsSurfaceTheUntrustedSegmentThroughTheRealIndex() throws Exception {
+    final String typeName = "UntrustedSurfaceDoc";
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(typeName);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+      database.getSchema().buildTypeIndex(typeName, new String[] { "tokens", "weights" })
+          .withSparseVectorType().withDimensions(100).create();
+
+      final MutableDocument doc = database.newDocument(typeName);
+      doc.set("tokens", new int[] { 1, 5 });
+      doc.set("weights", new float[] { 0.3f, 0.7f });
+      doc.save();
+    });
+
+    final LSMSparseVectorIndex sparse = sparseSubIndex(typeName);
+    sparse.getEngine().flush();
+    final String engineName = sparse.getName(); // the per-bucket physical index name the engine's segments are keyed under
+
+    assertThat(sparse.getUpgradeWarning())
+        .as("nothing has been merged from a pre-#6379 segment yet").isNull();
+    assertThat(sparse.getStats().get("untrustedSegments")).isZero();
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    database.transaction(() -> {
+      final SparseSegmentComponent component = newComponent(db, engineName + "_seg999");
+      try (final SparseSegmentBuilder b = new SparseSegmentBuilder(component, SegmentParameters.defaults())) {
+        b.setSegmentId(999L);
+        b.setRecencyEpoch(0L);
+        b.setParentSegments(new long[] { 900L, 901L });
+        b.startDim(DIM);
+        b.appendPosting(new RID(0, 500L), 0.5f);
+        b.endDim();
+        b.finish();
+      }
+    });
+
+    reopenDatabase();
+
+    final LSMSparseVectorIndex reopened = sparseSubIndex(typeName);
+    assertThat(reopened.getStats().get("untrustedSegments"))
+        .as("the reopened index must count the legacy segment now on disk").isEqualTo(1L);
+    assertThat(reopened.getUpgradeWarning())
+        .as("the same surface every other index upgrade warning uses (schema:indexes, Studio, HTTP admin) "
+            + "must name both the issue and the remedy")
+        .contains("#6379").contains("REBUILD INDEX");
+  }
+
+  private LSMSparseVectorIndex sparseSubIndex(final String typeName) {
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName(typeName + "[tokens,weights]");
+    return (LSMSparseVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+  }
+
+  private static SparseSegmentComponent newComponent(final DatabaseInternal db, final String name) {
+    try {
+      final SparseSegmentComponent c = new SparseSegmentComponent(db, name, db.getDatabasePath() + "/" + name,
+          ComponentFile.MODE.READ_WRITE, SparseSegmentComponent.DEFAULT_PAGE_SIZE);
+      ((LocalSchema) db.getSchema().getEmbedded()).registerFile(c);
+      return c;
+    } catch (final IOException e) {
+      throw new RuntimeException("failed to create sparse segment component '" + name + "'", e);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
@@ -24,6 +24,8 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.Type;
@@ -31,6 +33,10 @@ import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -146,15 +152,34 @@ class Issue6566UntrustedSegmentSurfaceTest extends TestHelper {
       }
     });
 
-    reopenDatabase();
+    // Capture what the schema-load warning actually says on reopen (PR #6720 review): getUpgradeWarning() must
+    // describe the problem only, and LocalSchema.reportUpgradeWarning() - the sole caller that knows the LOGICAL
+    // TypeIndex name - must be the one and only place "REBUILD INDEX" is appended, naming that logical index and
+    // not the physical per-bucket sub-index name this test's own engineName variable holds.
+    final List<String> warnings = Collections.synchronizedList(new ArrayList<>());
+    final Logger originalLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(new CapturingLogger(warnings, originalLogger));
+    try {
+      reopenDatabase();
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
 
     final LSMSparseVectorIndex reopened = sparseSubIndex(typeName);
     assertThat(reopened.getStats().get("untrustedSegments"))
         .as("the reopened index must count the legacy segment now on disk").isEqualTo(1L);
     assertThat(reopened.getUpgradeWarning())
-        .as("the same surface every other index upgrade warning uses (schema:indexes, Studio, HTTP admin) "
-            + "must name both the issue and the remedy")
-        .contains("#6379").contains("REBUILD INDEX");
+        .as("getUpgradeWarning() itself must say what is lost, not what to type - the physical sub-index name "
+            + "must never appear in a 'REBUILD INDEX' clause it assembles")
+        .contains("#6379").doesNotContain("REBUILD INDEX");
+
+    final String logicalName = typeName + "[tokens,weights]";
+    final String remedyLine = "REBUILD INDEX `" + logicalName + "`";
+    assertThat(warnings)
+        .as("the schema-load WARNING must name the LOGICAL index for REBUILD INDEX exactly once, never the "
+            + "physical per-bucket sub-index name (%s) this fix used to embed a second time", engineName)
+        .anyMatch(w -> w.contains("#6379") && w.contains(remedyLine) && countOccurrences(w, "REBUILD INDEX") == 1
+            && !w.contains(engineName));
   }
 
   private LSMSparseVectorIndex sparseSubIndex(final String typeName) {
@@ -170,6 +195,67 @@ class Issue6566UntrustedSegmentSurfaceTest extends TestHelper {
       return c;
     } catch (final IOException e) {
       throw new RuntimeException("failed to create sparse segment component '" + name + "'", e);
+    }
+  }
+
+  private static int countOccurrences(final String haystack, final String needle) {
+    int count = 0;
+    for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length()))
+      count++;
+    return count;
+  }
+
+  /**
+   * Captures WARNING-and-above messages while forwarding everything to the real logger, matching the pattern
+   * {@code PaginatedSparseVectorEngineCompactionRecencyTest} uses for the same purpose. The fixed-arity overload
+   * must NOT delegate to the varargs one: the fixed arity is the exact match, so it would recurse until the stack
+   * dies.
+   */
+  private static final class CapturingLogger implements Logger {
+    private final List<String> warnings;
+    private final Logger       delegate;
+
+    CapturingLogger(final List<String> warnings, final Logger delegate) {
+      this.warnings = warnings;
+      this.delegate = delegate;
+    }
+
+    private void capture(final Level level, final String message, final Object... args) {
+      if (message == null || level.intValue() < Level.WARNING.intValue())
+        return;
+      String formatted = message;
+      if (args != null && args.length > 0) {
+        try {
+          formatted = message.formatted(args);
+        } catch (final Exception ignored) {
+          // Raw template is good enough for the substring matching the assertions do.
+        }
+      }
+      warnings.add(formatted);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+        final Object arg15, final Object arg16, final Object arg17) {
+      capture(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
+          arg15, arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      capture(level, message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetricsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetricsTest.java
@@ -101,9 +101,13 @@ class LSMSparseVectorIndexMetricsTest extends TestHelper {
         .as("entry must expose segmentCount").isTrue();
     assertThat(entry.has("totalPostings"))
         .as("entry must expose totalPostings").isTrue();
+    assertThat(entry.has("untrustedSegments"))
+        .as("entry must expose untrustedSegments (issue #6566)").isTrue();
     assertThat(entry.getLong("memtablePostings")).isGreaterThanOrEqualTo(0L);
     assertThat(entry.getInt("segmentCount")).isGreaterThanOrEqualTo(0);
     // 5 docs * 3 nnz = 15 postings, summed across however many buckets exist.
     assertThat(entry.getLong("totalPostings")).isEqualTo(15L);
+    // Nothing here was merged from a pre-#6379 segment, so the fresh index must read as trusted.
+    assertThat(entry.getInt("untrustedSegments")).isZero();
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngineCompactionRecencyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngineCompactionRecencyTest.java
@@ -506,9 +506,13 @@ class PaginatedSparseVectorEngineCompactionRecencyTest extends TestHelper {
         b.finish();
       }
     });
+    // No "Run 'REBUILD INDEX ...'" clause: this class only knows the physical per-bucket sub-index
+    // name, not the logical one the command actually takes, so it leaves the remedy to
+    // LocalSchema.reportUpgradeWarning() (PR #6720 review) - not exercised here, which opens the
+    // engine directly rather than through a full database/schema load.
     assertThat(warningsWhileOpening(db, "LegacyScanStaleTest"))
         .as("a segment with parents whose epoch equals its id predates the fix and must be reported")
-        .anyMatch(w -> w.contains("#6379") && w.contains("REBUILD INDEX"));
+        .anyMatch(w -> w.contains("#6379") && !w.contains("REBUILD INDEX"));
   }
 
   /**
@@ -560,7 +564,7 @@ class PaginatedSparseVectorEngineCompactionRecencyTest extends TestHelper {
 
     assertThat(warningsWhileOpening(db, "LegacyAbsorbTest"))
         .as("the doubt must be inherited by the merge, not erased by it")
-        .anyMatch(w -> w.contains("#6379") && w.contains("REBUILD INDEX"));
+        .anyMatch(w -> w.contains("#6379"));
   }
 
   /** Open an engine over {@code indexName} with a capturing logger installed, and return what it warned. */

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
@@ -141,6 +141,96 @@ class Issue6067DeferredCloseRebuildTest {
     }
   }
 
+  /**
+   * Sibling of the test above, covering the OTHER arm of the same {@code needsBuild} condition:
+   * {@code graphState == LOADING && !graphAlreadyOnDisk} (a graph never built at all, as opposed to one rebuilt
+   * after an existing build). Both arms reach the identical deferral branch in {@code flush()} and the identical
+   * fallback in {@code ensureGraphAvailable()}, but only the rebuilt-index arm was covered above.
+   * <p>
+   * {@code graphState} starts as {@code LOADING} on every constructed instance (both "new index" and "load
+   * existing index"), but a fresh insert into a never-built index flips it straight to {@code MUTABLE} - so a
+   * single populate-then-close session actually exercises the MUTABLE arm, same as the test above, not this one.
+   * Reaching {@code LOADING} at {@code flush()} time needs a session that touches the index NEITHER by writing
+   * NOR by searching: reopen a large index that a previous session already left un-built (deferred by the fix
+   * under test), and close it again immediately - {@code graphState} then stays exactly what the constructor set
+   * it to.
+   * <p>
+   * Unlike the test above, this one is NOT a fails-before/passes-after timing pin: the pre-fix code always builds
+   * and persists a graph on every close that has one to do, so the very state this test needs (a large index,
+   * closed twice, with no persisted graph either time) is only reachable once the fix exists - pre-fix, the
+   * first close already does the build, and the second close then finds nothing left to do and is trivially
+   * fast for an unrelated reason. So instead of timing, this pins {@code graphRebuildCount} directly: zero
+   * rebuilds across both closes, exactly one once the deferred data is finally searched.
+   */
+  @Test
+  void closeDefersTheFirstEverBuildForALargeIndexToo() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        // Closes with graphState == MUTABLE (see javadoc above) - the fix under test defers this build too, so
+        // no graph is persisted yet. That is the starting condition this test actually needs, not its subject.
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: LOADING - reopening alone (with no write or search in this session) must not "
+                + "advance graphState, otherwise this does not exercise the "
+                + "graphState == LOADING && !graphAlreadyOnDisk arm")
+            .isEqualTo(0L); // GraphState.LOADING
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: above the async-rebuild threshold, otherwise close() takes the pre-existing "
+                + "small-graph synchronous path unaffected by this fix")
+            .isGreaterThanOrEqualTo(1000L);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("precondition: the previous session's close must not have built anything either, or this test "
+                + "is not exercising the LOADING && !graphAlreadyOnDisk arm at all")
+            .isZero();
+
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("neither close() above must have built anything: this pins the actual behaviour under test, "
+                + "since a timing bound alone cannot distinguish 'deferred' from 'nothing was ever built', see "
+                + "the class javadoc")
+            .isZero();
+
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("cnt")).isEqualTo((long) NUM_VECTORS);
+        }
+
+        final var results = index.findNeighborsFromVector(randomVector(new Random(7)), 5, 64);
+        assertThat(results)
+            .as("the deferred first-ever build must still make every vector reachable by search after reopen")
+            .hasSize(5);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("the search above must be what finally triggers the deferred build - it was owed since the "
+                + "first close two sessions ago")
+            .isEqualTo(1L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
   private static float[] extraVector() {
     return randomVector(new Random(5));
   }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6067: {@code flush()}'s rebuild-before-close condition (triggered whenever
+ * {@code graphState == MUTABLE}, i.e. any write since the last graph build) always calls
+ * {@code buildGraphFromScratch()} SYNCHRONOUSLY on the closing thread, with no size-based deferral - unlike the
+ * search path's {@code rebuildGraphBeforeSearch()}, which already runs an async rebuild above 1000 vectors
+ * ({@code ASYNC_REBUILD_MIN_GRAPH_SIZE}).
+ * <p>
+ * Measured on the issue (comment from 2026-08-23): a single write to a 200,000-vector index made {@code close()}
+ * block for ~43 seconds - the same cost whether one vector or a thousand were written, because the rebuild is
+ * always a full one. The fix defers the close-time rebuild to the next search on the index once the index is at
+ * or above {@code ASYNC_REBUILD_MIN_GRAPH_SIZE}, reusing {@code ensureGraphAvailable()}'s existing
+ * stale-persisted-graph detection (already exercised on every ordinary reopen) rather than paying the full cost
+ * synchronously inside {@code close()}.
+ * <p>
+ * Two things are pinned here, because either alone would pass against a half-fix: {@code close()} itself must
+ * return promptly (not merely "eventually", which a half-fixed async-but-still-blocking-close variant could also
+ * satisfy), and no data may be lost - a later reopen and search must still find every vector, including the one
+ * written after the last full build, once the deferred rebuild actually runs.
+ * <p>
+ * Same per-vector build parameters as {@code LSMVectorIndexCloseCancelsInFlightBuildTest} (128 dimensions,
+ * {@code maxConnections=64}, {@code beamWidth=400}), scaled up to 20,000 vectors so a full rebuild reliably takes
+ * multiple real seconds - long enough that the tripwire bound below cannot pass by accident.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6067DeferredCloseRebuildTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6067DeferredCloseRebuildTest";
+  private static final int    DIMENSIONS      = 128;
+  private static final int    NUM_VECTORS     = 20_000;
+  private static final int    MAX_CONNECTIONS = 64;
+  private static final int    BEAM_WIDTH      = 400;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void closeDefersTheRebuildForALargeMutatedIndexInsteadOfBlockingOnAFullRebuild() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        // Force one complete, persisted build so the index starts IMMUTABLE rather than LOADING - isolates the
+        // case under test (a single write after an already-built graph) from the separate first-ever-build case.
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState")).as("precondition: graph must be built and IMMUTABLE first")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+
+        // One more write - mirrors the issue's own measurement that cost does not scale with what was written.
+        db.transaction(
+            () -> db.newDocument("Doc").set("id", NUM_VECTORS).set("vector", extraVector()).save());
+
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise flush()'s rebuild-before-close condition is never reached")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: above the async-rebuild threshold, otherwise close() takes the pre-existing "
+                + "small-graph synchronous path unaffected by this fix")
+            .isGreaterThanOrEqualTo(1000L);
+
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        db.close();
+        // Measured on this fixture: ~50ms deferred vs. ~2.4s for a full synchronous rebuild - the bound below
+        // is a tripwire between the two (see StallAwareStopwatch), with wide margin on both sides.
+        stopwatch.assertGaveUpWithin(1_000,
+            "a close() that defers the graph rebuild from one that runs a full synchronous rebuild to completion");
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Reopen and verify nothing was lost: the deferred rebuild must still make every vector - including the one
+    // written after the last full build - reachable by search once it actually runs, proving the fix trades
+    // promptness for a lazily-paid rebuild, not for correctness.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("cnt")).isEqualTo((long) (NUM_VECTORS + 1));
+        }
+
+        final LSMVectorIndex index = vectorIndex(db);
+        final var results = index.findNeighborsFromVector(extraVector(), 5, 64);
+        assertThat(results)
+            .as("the deferred rebuild must still make the vector written right before close() reachable by "
+                + "search after reopen")
+            .hasSize(5);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static float[] extraVector() {
+    return randomVector(new Random(5));
+  }
+
+  private static void populate(final Database db) {
+    final Random rnd = new Random(7);
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = 0; i < NUM_VECTORS; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+      if (i % 1000 == 999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657CancelledBuildRecheckTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657CancelledBuildRecheckTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the gap review found in issue #6657's own fix: {@code markCloseTimeRebuildDeferred()} skips
+ * the manifest write when {@code graphBuildLock.tryLock()} fails, reasoning that a build holding the lock is
+ * "about to run its own completion write, which clears this same flag on its own". That is only true if the build
+ * actually COMPLETES. When {@code close()} instead CANCELS an in-flight async rebuild -
+ * {@code releaseBackgroundResources()} does exactly that, and runs right after {@code flush()} - the cancelled
+ * build's {@code CancellationException} path never touches the manifest, so without a backstop the flag would be
+ * left wherever it was before this close (typically {@code false}), even though a rebuild is now genuinely owed:
+ * a false negative in the exact "why is my first query after reopen slow" moment the stat exists to answer.
+ * <p>
+ * Deterministic rather than racing a real JVector build's timing (which {@code LSMVectorIndexCloseCancelsInFlightBuildTest}
+ * already shows is a legitimate but non-trivial thing to pin reliably): a helper thread holds
+ * {@code graphBuildLock} directly, standing in for "a build is genuinely in progress", and releases it only after
+ * {@code flush()} has already observed it contended - simulating the point at which a real cancellation would have
+ * freed the lock without ever writing the manifest. The test then checks that the SECOND attempt, inside
+ * {@code releaseBackgroundResources()}, catches what the first one had to skip.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6657CancelledBuildRecheckTest {
+  private static final String DB_ROOT     = "target/test-databases/Issue6657CancelledBuildRecheckTest";
+  private static final int    DIMENSIONS  = 8;
+  private static final int    NUM_VECTORS = 1_005; // at/above ASYNC_REBUILD_MIN_GRAPH_SIZE (1000)
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void releaseBackgroundResourcesRecordsTheDeferralThatFlushHadToSkipBecauseABuildHeldTheLock() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        final Random rnd = new Random(13);
+        db.transaction(() -> {
+          final var type = db.getSchema().createDocumentType("Doc");
+          type.createProperty("id", Type.INTEGER);
+          type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+          db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+              + ", \"similarity\": \"COSINE\" }");
+        });
+        db.begin();
+        for (int i = 0; i < NUM_VECTORS; i++) {
+          db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+          if (i % 500 == 499) {
+            db.commit();
+            db.begin();
+          }
+        }
+        db.commit();
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise flush() never reaches the deferral branch at all")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: at/above the async-rebuild threshold, the exact branch the reviewed race is about")
+            .isGreaterThanOrEqualTo(1000L);
+
+        final ReentrantLock graphBuildLock = graphBuildLock(index);
+        final CountDownLatch lockHeld = new CountDownLatch(1);
+        final CountDownLatch releaseLock = new CountDownLatch(1);
+        final Thread lockHolder = new Thread(() -> {
+          graphBuildLock.lock();
+          try {
+            lockHeld.countDown();
+            releaseLock.await();
+          } catch (final InterruptedException ignored) {
+            // test teardown path only
+          } finally {
+            graphBuildLock.unlock();
+          }
+        }, "test-graph-build-lock-holder");
+        lockHolder.setDaemon(true);
+        lockHolder.start();
+
+        assertThat(lockHeld.await(5, TimeUnit.SECONDS))
+            .as("the helper thread must genuinely hold graphBuildLock before flush() runs, otherwise this test "
+                + "does not exercise the contended tryLock() at all")
+            .isTrue();
+
+        // flush()'s ASYNC_REBUILD_MIN_GRAPH_SIZE branch: needsBuild is true, but markCloseTimeRebuildDeferred()'s
+        // tryLock() must fail while the helper thread holds the lock - standing in for a real async rebuild still
+        // running at this exact point in close().
+        index.flush();
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("flush() must have skipped the write while the lock was held - this is the state a cancelled "
+                + "build would otherwise leave behind uncorrected")
+            .isEqualTo(0L);
+
+        // Stand-in for cancellation freeing the lock without ever writing the manifest (a real CancellationException
+        // path does not call writeGraphManifest()/markGraphManifestUnusable() either).
+        releaseLock.countDown();
+        lockHolder.join(5_000);
+        assertThat(lockHolder.isAlive()).as("the helper thread must have released the lock before proceeding").isFalse();
+
+        // This is the call under test: its tail recheck must catch what flush() had to skip, now that the lock is
+        // free and graphState still says a build is genuinely owed.
+        index.releaseBackgroundResources();
+
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("releaseBackgroundResources()'s recheck must record the deferral flush() could not - this is the "
+                + "false-negative the review comment identified")
+            .isEqualTo(1L);
+      } finally {
+        if (db.isOpen())
+          db.drop();
+      }
+    }
+  }
+
+  private static ReentrantLock graphBuildLock(final LSMVectorIndex index) throws ReflectiveOperationException {
+    final Field field = LSMVectorIndex.class.getDeclaredField("graphBuildLock");
+    field.setAccessible(true);
+    return (ReentrantLock) field.get(index);
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6657: {@code getStats()} did not say whether the last {@code close()} deferred a
+ * graph rebuild (issue #6067/#6653) - an operator debugging "why is my first query after reopen slow" had to go
+ * looking for the {@code FINE} log line {@code LSMVectorIndex.flush()} emits, rather than checking a stat
+ * alongside the existing {@code graphState}/{@code graphRebuildCount}/{@code mutationsSinceRebuild} entries.
+ * <p>
+ * Three things are pinned, because a half-fix could satisfy any two on its own: the {@code closeTimeRebuildPending}
+ * stat must turn on exactly when {@code close()} defers a rebuild, it must still read {@code 1} on a <b>freshly
+ * reopened</b> index - i.e. a brand-new {@link LSMVectorIndex} instance, not the one that set it - before that
+ * index has been searched (the whole point: answering the question BEFORE the next search silently pays for it),
+ * and it must clear back to {@code 0} once that search actually runs the deferred rebuild.
+ * <p>
+ * A normal close that never deferred anything (below the async-rebuild threshold) is also pinned at {@code 0}, to
+ * catch a stat that reads "true" unconditionally.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6657CloseTimeRebuildPendingStatTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6657CloseTimeRebuildPendingStatTest";
+  private static final int    DIMENSIONS      = 16;
+  private static final int    NUM_VECTORS     = 1_005; // just above ASYNC_REBUILD_MIN_GRAPH_SIZE (1000)
+  private static final int    MAX_CONNECTIONS = 8;
+  private static final int    BEAM_WIDTH      = 32;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void closeTimeRebuildPendingTurnsOnAtDeferralSurvivesReopenAndClearsOnceTheDeferredRebuildRuns() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        // Force one complete, persisted build so the index starts IMMUTABLE - isolates the deferral this test is
+        // about (a write after an already-built graph) from the separate first-ever-build arm.
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("a graph that has just been built cleanly must not report a pending close-time deferral")
+            .isEqualTo(0L);
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // One more write on top of the already-built graph - the exact shape flush()'s ASYNC_REBUILD_MIN_GRAPH_SIZE
+    // branch defers instead of rebuilding synchronously.
+    final LSMVectorIndex indexAtDeferralTime;
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        indexAtDeferralTime = vectorIndex(db);
+        db.transaction(() -> db.newDocument("Doc").set("id", NUM_VECTORS).set("vector", extraVector()).save());
+
+        assertThat(indexAtDeferralTime.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise flush()'s deferral branch is never reached")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(indexAtDeferralTime.getStats().get("totalVectors"))
+            .as("precondition: at or above the async-rebuild threshold, otherwise close() rebuilds synchronously "
+                + "and never sets the stat at all")
+            .isGreaterThanOrEqualTo(1000L);
+        assertThat(indexAtDeferralTime.getStats().get("closeTimeRebuildPending"))
+            .as("precondition: not yet deferred - nothing has closed yet this session")
+            .isEqualTo(0L);
+
+        db.close();
+
+        // Same object reference the deferring close() ran on: confirms flush() itself set the stat, before even
+        // checking whether it is observable on a later, different instance (asserted below).
+        assertThat(indexAtDeferralTime.getStats().get("closeTimeRebuildPending"))
+            .as("close() deferred a rebuild above the threshold - the stat must say so immediately")
+            .isEqualTo(1L);
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Reopen: a brand-new LSMVectorIndex instance is constructed here (LSMVectorIndex.open() factory), with none
+    // of indexAtDeferralTime's in-memory state. If the stat were a plain instance field it would read 0 here no
+    // matter what the previous session did - this is the assertion that rules that design out.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex reopenedIndex = vectorIndex(db);
+        assertThat(reopenedIndex).as("reopen must hand back a different Java instance").isNotSameAs(indexAtDeferralTime);
+
+        assertThat(reopenedIndex.getStats().get("graphState"))
+            .as("precondition: LOADING - nothing in this session has searched or written yet")
+            .isEqualTo(0L); // GraphState.LOADING
+        assertThat(reopenedIndex.getStats().get("closeTimeRebuildPending"))
+            .as("the deferral from the previous session's close() must still read 1 on this fresh instance, "
+                + "before this session's first search - this is the actual "
+                + "\"why is my first query after reopen slow\" moment the issue is about")
+            .isEqualTo(1L);
+        assertThat(reopenedIndex.getStats().get("graphRebuildCount"))
+            .as("precondition: nothing has rebuilt yet in this fresh instance")
+            .isZero();
+
+        // The search that finally pays for the deferred rebuild (ensureGraphAvailable() -> buildGraphFromScratch(),
+        // synchronous on this call since the graph is not yet loaded this session).
+        final var results = reopenedIndex.findNeighborsFromVector(extraVector(), 5, 64);
+        assertThat(results)
+            .as("the deferred rebuild must still make the vector written right before the deferring close() "
+                + "reachable by search")
+            .hasSize(5);
+
+        assertThat(reopenedIndex.getStats().get("graphRebuildCount"))
+            .as("the search above must be what finally runs the deferred build")
+            .isEqualTo(1L);
+        assertThat(reopenedIndex.getStats().get("closeTimeRebuildPending"))
+            .as("the deferred rebuild caught up - the stat must clear")
+            .isEqualTo(0L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static float[] extraVector() {
+    return randomVector(new Random(5));
+  }
+
+  private static void populate(final Database db) {
+    final Random rnd = new Random(7);
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", com.arcadedb.schema.Type.INTEGER);
+      type.createProperty("vector", com.arcadedb.schema.Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = 0; i < NUM_VECTORS; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+      if (i % 500 == 499) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657InvalidPathRebuildPendingStatTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657InvalidPathRebuildPendingStatTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Companion to {@link Issue6657CloseTimeRebuildPendingStatTest}, covering the OTHER call site of
+ * {@code markCloseTimeRebuildDeferred()} inside {@code flush()}: the {@code needsBuild && !valid} branch, taken
+ * when {@code flush()} runs after {@code releaseBackgroundResources()} instead of before it - its own WARNING log
+ * says this "should not be reachable" through the ordinary {@code close()} path, since both close paths flush
+ * BEFORE releasing. Reaching it here means calling {@code flush()}/{@code releaseBackgroundResources()} directly,
+ * out of {@code close()}'s order, the same inversion the WARNING log guards against.
+ * <p>
+ * Small and fast on purpose - unlike the size-threshold branch, this one does not need
+ * {@code ASYNC_REBUILD_MIN_GRAPH_SIZE} vectors to reach, only {@code graphState == MUTABLE}.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6657InvalidPathRebuildPendingStatTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue6657InvalidPathRebuildPendingStatTest";
+  private static final int    DIMENSIONS = 8;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void flushAfterBackgroundResourcesAreReleasedStillRecordsTheDeferral() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        final Random rnd = new Random(11);
+        db.transaction(() -> {
+          final var type = db.getSchema().createDocumentType("Doc");
+          type.createProperty("id", Type.INTEGER);
+          type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+          db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+              + ", \"similarity\": \"COSINE\" }");
+        });
+        db.transaction(() -> db.newDocument("Doc").set("id", 0).set("vector", randomVector(rnd)).save());
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise needsBuild is false and flush() takes neither deferral branch")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("closeTimeRebuildPending")).isEqualTo(0L);
+
+        // The inversion the WARNING log in flush() describes: release BEFORE flush, not after. Exercised directly
+        // rather than through db.close(), which always does these two in the safe order.
+        index.releaseBackgroundResources();
+        index.flush();
+
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("the !valid branch of flush() must record the deferral exactly like the size-threshold branch does")
+            .isEqualTo(1L);
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657RecheckDoesNotMislabelUnattemptedFlushTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657RecheckDoesNotMislabelUnattemptedFlushTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the mislabeling gap review round 4 found in {@code releaseBackgroundResources()}'s
+ * post-cancellation recheck (added addressing round 2): the recheck used to key off {@code needsGraphBuild()}
+ * alone, which is {@code true} whenever {@code graphState == MUTABLE} for ANY reason - not only "flush() skipped
+ * an owed rebuild". {@code flush()}'s OTHER branch, the one that actually ATTEMPTS a synchronous build (below
+ * {@code ASYNC_REBUILD_MIN_GRAPH_SIZE}), can also leave {@code graphState} at {@code MUTABLE} - a failed persist
+ * ({@code markGraphManifestUnusable()} correctly writes {@code closeDeferredRebuild = false}) or new mutations
+ * arriving mid-build both do. An ungated recheck would overwrite that correct {@code false} with a misleading
+ * {@code true}, reporting "close chose to skip the rebuild" when what actually happened is unrelated to a skip
+ * at all.
+ * <p>
+ * Pinned here at the level of the actual fix - the {@code flushDeferredRebuild} gate - rather than by
+ * reproducing a real failed persist (already covered from a different angle by
+ * {@code CompactIndexGraphPersistFailureTest}/{@code Issue6503GraphPersistOutOfMemoryTest}): the recheck must do
+ * nothing at all when {@code flush()} never ran, regardless of what {@code needsGraphBuild()} says, because
+ * {@code flush()} not having run means it cannot possibly have chosen to skip anything.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6657RecheckDoesNotMislabelUnattemptedFlushTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue6657RecheckDoesNotMislabelUnattemptedFlushTest";
+  private static final int    DIMENSIONS = 8;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void releaseBackgroundResourcesDoesNotMarkDeferredWhenFlushNeverRan() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        final Random rnd = new Random(17);
+        db.transaction(() -> {
+          final var type = db.getSchema().createDocumentType("Doc");
+          type.createProperty("id", Type.INTEGER);
+          type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+          db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+              + ", \"similarity\": \"COSINE\" }");
+        });
+        db.transaction(() -> db.newDocument("Doc").set("id", 0).set("vector", randomVector(rnd)).save());
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE - needsGraphBuild() must be true here, or this test does not exercise the "
+                + "case the old, ungated recheck would have mislabeled")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("closeTimeRebuildPending")).isEqualTo(0L);
+
+        // flush() is deliberately never called - releaseBackgroundResources() alone, standing in for a build
+        // attempt that failed (or any other reason graphState stayed MUTABLE without flush() choosing to skip).
+        index.releaseBackgroundResources();
+
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("the recheck must not fire when flush() never ran - it cannot have skipped a build it never "
+                + "considered, so needsGraphBuild() alone must not be enough to mark a deferral")
+            .isEqualTo(0L);
+      } finally {
+        if (db.isOpen())
+          db.drop();
+      }
+    }
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6713EnsureGraphAvailableUnlockedValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6713EnsureGraphAvailableUnlockedValidationTest.java
@@ -52,22 +52,28 @@ import static org.assertj.core.api.Assertions.assertThat;
  * all, only the validation - the one path #5391 never touched because it predates #5391 and sits in a different
  * method.
  * <p>
- * Reproduction: a large index (200,000 vectors of 1536 dimensions - large enough that the validation loop reliably
- * takes several hundred milliseconds, dimension chosen so the per-vector cost is dominated by the property read
- * and conversion rather than the document lookup alone) is built, persisted and closed cleanly, so the persisted
- * graph and its manifest describe exactly the live set. On reopen, a background thread runs the first search, which
- * drives {@code ensureGraphAvailable()} into the validation loop. While that is in flight, the main thread inserts
- * one more vector - an operation that only ever needs {@code lock.writeLock()} briefly - and times it. Before the
- * fix this insert would queue behind the whole validation loop; after the fix it returns promptly regardless of how
- * long the validation takes, because the loop no longer holds that lock.
+ * Reproduction: a large index (600,000 vectors of 128 dimensions - vector count, not dimension, is what drives the
+ * validation loop long enough to matter here, since each vector still costs one document lookup regardless of its
+ * width; a higher dimension was tried first and reproduced the same locking bug, but its ~7x larger heap footprint
+ * (600,000 x 1536 floats vs x 128) turned out to make the fixed-size validation workload itself GC-pressure-bound on
+ * a memory-constrained CI runner - confirmed locally by reproducing the same order-of-magnitude slowdown, and
+ * outright OutOfMemoryError, under a matching -Xmx2g. 128 dimensions keeps the same reproduction memory-safe) is
+ * built, persisted and closed cleanly, so the persisted graph and its manifest describe exactly the live set. On
+ * reopen, a background thread runs the first search, which drives {@code ensureGraphAvailable()} into the
+ * validation loop. While that is in flight, the main thread inserts one more vector - an operation that only ever
+ * needs {@code lock.writeLock()} briefly - and times it. Before the fix this insert would queue behind the whole
+ * validation loop; after the fix it returns promptly regardless of how long the validation takes, because the loop
+ * no longer holds that lock. The search thread is joined with a generous (not tight) timeout: how long the search
+ * itself takes to finish is a function of hardware speed, not of what this fix changed, so only insert latency -
+ * measured with {@link StallAwareStopwatch} - is asserted against a tight bound.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 @Tag("slow")
 class Issue6713EnsureGraphAvailableUnlockedValidationTest {
   private static final String DB_ROOT         = "target/test-databases/Issue6713EnsureGraphAvailableUnlockedValidationTest";
-  private static final int    DIMENSIONS      = 1536;
-  private static final int    NUM_VECTORS     = 200_000;
+  private static final int    DIMENSIONS      = 128;
+  private static final int    NUM_VECTORS     = 600_000;
   private static final int    MAX_CONNECTIONS = 8;
   private static final int    BEAM_WIDTH      = 16;
 
@@ -122,25 +128,51 @@ class Issue6713EnsureGraphAvailableUnlockedValidationTest {
             searchFailure.set(t);
           }
         }, "issue-6713-first-search");
+        // Measures the search thread's own total duration, not a fixed millisecond guess: how long an
+        // O(NUM_VECTORS) validation loop takes is a function of hardware speed (a >100x gap was measured between a
+        // fast workstation and a memory-constrained CI runner for the identical fixture), so the bound the
+        // concurrent insert below is measured against is a FRACTION of this run's own search duration rather than
+        // an absolute number - self-calibrating to whatever this machine turns out to be.
+        final StallAwareStopwatch searchStopwatch = StallAwareStopwatch.start();
         searchThread.start();
         assertThat(searchStarted.await(10, TimeUnit.SECONDS)).as("the search thread must have started").isTrue();
-        // A head start into ensureGraphAvailable()'s validation loop, which on this fixture reliably takes several
-        // hundred milliseconds - comfortably longer than this fixed wait plus the bound asserted below.
+        // A head start into ensureGraphAvailable()'s validation loop: negligible next to the loop's own total
+        // duration on any hardware where this fixture is even worth running.
         Thread.sleep(50);
 
         // A concurrent insert only ever needs lock.writeLock() briefly. Before the fix, ensureGraphAvailable() held
         // that same lock for its ENTIRE persisted-graph validation, so this insert would queue behind the search
-        // thread for as long as the (multi-hundred-millisecond) validation loop over NUM_VECTORS took.
-        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        // thread for as long as the validation loop over NUM_VECTORS took - effectively all of searchMs below, not
+        // a small fraction of it.
+        final StallAwareStopwatch insertStopwatch = StallAwareStopwatch.start();
         db.transaction(() -> db.command("sql", "INSERT INTO Doc SET id = ?, vector = ?", NUM_VECTORS,
             embedding(NUM_VECTORS)));
-        stopwatch.assertGaveUpWithin(400,
-            "an insert that only ever needs the write lock briefly, from one queued behind the whole persisted-graph "
-                + "validation loop");
+        final long insertMs = insertStopwatch.effectiveMs();
 
-        searchThread.join(TimeUnit.SECONDS.toMillis(30));
-        assertThat(searchThread.isAlive()).as("the search must complete on its own").isFalse();
+        // Generous, not tight: how long the search itself takes to finish is a function of hardware speed for an
+        // O(NUM_VECTORS) validation loop, not of what this fix changed (the fix is about the LOCK, not the loop's
+        // own duration) - a fixed tight bound here previously flaked on a slower CI runner even though nothing was
+        // stuck.
+        searchThread.join(TimeUnit.MINUTES.toMillis(5));
+        assertThat(searchThread.isAlive()).as("the search must complete on its own, not hang").isFalse();
         assertThat(searchFailure.get()).as("the search must not have failed").isNull();
+        final long searchMs = searchStopwatch.effectiveMs();
+
+        assertThat(searchMs)
+            .as("precondition: NUM_VECTORS must be large enough that the validation loop takes real time on this "
+                + "hardware, or the comparison below has no discriminating power")
+            .isGreaterThanOrEqualTo(100L);
+
+        // The self-calibrating tripwire: an insert that only ever needs the write lock briefly must take a small
+        // FRACTION of however long this run's own validation search took - not scale with it the way a lock held
+        // for the whole validation would. A fixed millisecond bound cannot separate the two cases across hardware
+        // that differs by two orders of magnitude on the identical fixture; this ratio does, because both
+        // measurements come from the same run on the same machine (PR #6720 review: the original fixed 400ms/30s
+        // bounds flaked on a CI runner where the whole fixture ran ~100x slower than on a fast workstation).
+        assertThat(insertMs)
+            .as("an insert that only ever needs the write lock briefly, out of a search that took %,d ms on this "
+                + "hardware - not one queued behind the whole persisted-graph validation loop", searchMs)
+            .isLessThan(searchMs / 3);
 
         // Not asserted here: graphRebuildCount. The concurrent insert above is itself a mutation, which - once
         // published - is exactly what schedules the ordinary async rebuild any mutation on a MUTABLE large graph

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6713EnsureGraphAvailableUnlockedValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6713EnsureGraphAvailableUnlockedValidationTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6713, a follow-up from #6712's code review.
+ * <p>
+ * {@code ensureGraphAvailable()}'s persisted-graph reuse path rebuilds {@code ordinalToVectorId} by re-validating
+ * every LIVE vector - for a non-quantized (or PRODUCT-quantized) index this is one document lookup plus one
+ * property read per vector - to make sure the graph on disk still describes exactly the live set (issues #3722,
+ * #6106). That validation is {@code O(live vector count)} and used to run entirely under {@code lock.writeLock()},
+ * the same global lock every insert and every search also needs. On an index large enough that the validation takes
+ * real time, the first search after a reopen that finds a persisted graph therefore stalled every OTHER reader and
+ * writer of the index for the whole scan - exactly the stall issue #5391 already moved
+ * {@code buildGraphFromScratchExclusively}'s own (much larger) full-rebuild validation off of. This test targets the
+ * up-to-date-reuse branch specifically: the persisted graph matches the live set exactly, so no rebuild is needed at
+ * all, only the validation - the one path #5391 never touched because it predates #5391 and sits in a different
+ * method.
+ * <p>
+ * Reproduction: a large index (200,000 vectors of 1536 dimensions - large enough that the validation loop reliably
+ * takes several hundred milliseconds, dimension chosen so the per-vector cost is dominated by the property read
+ * and conversion rather than the document lookup alone) is built, persisted and closed cleanly, so the persisted
+ * graph and its manifest describe exactly the live set. On reopen, a background thread runs the first search, which
+ * drives {@code ensureGraphAvailable()} into the validation loop. While that is in flight, the main thread inserts
+ * one more vector - an operation that only ever needs {@code lock.writeLock()} briefly - and times it. Before the
+ * fix this insert would queue behind the whole validation loop; after the fix it returns promptly regardless of how
+ * long the validation takes, because the loop no longer holds that lock.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6713EnsureGraphAvailableUnlockedValidationTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6713EnsureGraphAvailableUnlockedValidationTest";
+  private static final int    DIMENSIONS      = 1536;
+  private static final int    NUM_VECTORS     = 200_000;
+  private static final int    MAX_CONNECTIONS = 8;
+  private static final int    BEAM_WIDTH      = 16;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void concurrentInsertIsNotBlockedByTheUnlockedPersistedGraphValidation() throws Exception {
+    // Session 1: build and persist a graph over exactly NUM_VECTORS, then close cleanly - the persisted graph and
+    // its manifest end up describing precisely the live set, so the next open's validation finds nothing stale.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db, 0, NUM_VECTORS);
+        vectorIndex(db).buildVectorGraphNow();
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Session 2: reopen. The graph is lazy-loaded on first search (GraphState.LOADING), which is what routes the
+    // first search into ensureGraphAvailable()'s persisted-graph validation - the code path this issue targets.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState")).as("precondition: reopen leaves the graph unloaded")
+            .isEqualTo(0L); // GraphState.LOADING
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: large enough that the validation loop takes real time")
+            .isEqualTo((long) NUM_VECTORS);
+
+        final CountDownLatch searchStarted = new CountDownLatch(1);
+        final AtomicReference<Throwable> searchFailure = new AtomicReference<>();
+        final Thread searchThread = new Thread(() -> {
+          searchStarted.countDown();
+          try {
+            index.findNeighborsFromVector(embedding(0), 5);
+          } catch (final Throwable t) {
+            searchFailure.set(t);
+          }
+        }, "issue-6713-first-search");
+        searchThread.start();
+        assertThat(searchStarted.await(10, TimeUnit.SECONDS)).as("the search thread must have started").isTrue();
+        // A head start into ensureGraphAvailable()'s validation loop, which on this fixture reliably takes several
+        // hundred milliseconds - comfortably longer than this fixed wait plus the bound asserted below.
+        Thread.sleep(50);
+
+        // A concurrent insert only ever needs lock.writeLock() briefly. Before the fix, ensureGraphAvailable() held
+        // that same lock for its ENTIRE persisted-graph validation, so this insert would queue behind the search
+        // thread for as long as the (multi-hundred-millisecond) validation loop over NUM_VECTORS took.
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        db.transaction(() -> db.command("sql", "INSERT INTO Doc SET id = ?, vector = ?", NUM_VECTORS,
+            embedding(NUM_VECTORS)));
+        stopwatch.assertGaveUpWithin(400,
+            "an insert that only ever needs the write lock briefly, from one queued behind the whole persisted-graph "
+                + "validation loop");
+
+        searchThread.join(TimeUnit.SECONDS.toMillis(30));
+        assertThat(searchThread.isAlive()).as("the search must complete on its own").isFalse();
+        assertThat(searchFailure.get()).as("the search must not have failed").isNull();
+
+        // Not asserted here: graphRebuildCount. The concurrent insert above is itself a mutation, which - once
+        // published - is exactly what schedules the ordinary async rebuild any mutation on a MUTABLE large graph
+        // does; whether that background rebuild has completed by the time this line runs is a race against this
+        // test's own write, not a signal about which branch ensureGraphAvailable() took. That branch (reuse over
+        // rebuild, for a persisted graph that still matches the live set) is covered without a concurrent writer by
+        // Issue6106StaleVectorGraphTest.anUntouchedGraphIsStillReusedAcrossARestart().
+        assertThat(index.getStats().get("graphState"))
+            .as("the graph must have been published (either straight to IMMUTABLE, or to MUTABLE if the concurrent "
+                + "insert above raced ahead of the publish) - never left LOADING")
+            .isNotEqualTo(0L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static void populate(final Database db, final int fromInclusive, final int toExclusive) {
+    db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+      if ((i - fromInclusive) % 2000 == 1999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  /** Deterministic per-id embedding, so any record's own vector can be reconstructed independently at query time. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x6713L * 31 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/Issue6459GraphPathfindingCommandTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/Issue6459GraphPathfindingCommandTimeoutTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6459 - {@code arcadedb.command.timeout} is purely cooperative, but the graph
+ * path-finding functions consulted it nowhere: {@code astar()}/{@code dijkstra()} had no deadline or interrupt
+ * check at all, SQL {@code shortestPath()} checked only a thread interrupt (never the deadline), and the Cypher
+ * constrained {@code shortestPath()}/{@code allShortestPaths()} BFS (the edge-property / inline-{@code WHERE}
+ * fallback) did the same - unlike the unconstrained BFS right next to it, which was already guarded.
+ * <p>
+ * Each test below reuses the graph shape proven effective by {@link Issue6266CommandTimeoutCoverageTest}: a
+ * 20,000-node ring with two chords per node (out-degree 3, so every node has both directions once the edges are
+ * made bidirectional). One pass over a graph this size costs seconds, comfortably clearing the 50 ms deadline used
+ * here by orders of magnitude - so a check placed inside the loop aborts almost immediately and one placed nowhere
+ * (or only between unrelated checkpoints) runs to graph exhaustion first, which is exactly the distinction the
+ * issue is about.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6459GraphPathfindingCommandTimeoutTest {
+  private static final int NODES = 20_000;
+  /** A vertex with no edges at all: astar()/dijkstra() can never reach it, so they have to exhaust the whole
+   *  20,000-node component before giving up - unless the deadline stops them first. */
+  private static final int UNREACHABLE_IDX = NODES;
+
+  private static final String DB_PATH = "./target/databases/test-issue-6459-pathfinding-command-timeout";
+
+  private static Database database;
+  private static RID[]     nodeRid;
+  private static RID       unreachableRid;
+  /** A second ring, the same size and shape as the first but sharing no edge with it, so a bidirectional
+   *  meet-in-the-middle BFS between the two components can never meet: each side has to exhaust its own
+   *  20,000-node component before its frontier goes empty. A far-but-reachable pair on ONE chorded ring does
+   *  not do this - the out-degree-3 branching plus the two long chords give it small-world diameter, so a
+   *  bidirectional search finds a real path within a handful of layers regardless of the guard. */
+  private static RID[]     otherComponentRid;
+
+  @BeforeAll
+  static void setup() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node").createProperty("v", Type.INTEGER);
+    database.getSchema().createEdgeType("LINK");
+    database.getSchema().getType("Node").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "v");
+
+    nodeRid = new RID[NODES];
+    otherComponentRid = new RID[NODES];
+
+    database.transaction(() -> {
+      nodeRid = buildRing(NODES, 0);
+      otherComponentRid = buildRing(NODES, NODES + 1);
+
+      unreachableRid = database.newVertex("Node").set("v", UNREACHABLE_IDX).save().getIdentity();
+    });
+  }
+
+  /**
+   * Ring plus two chords per node, exactly as {@link Issue6266CommandTimeoutCoverageTest}: out-degree 3, and
+   * bidirectional (the {@code true} argument) so every node also has in-edges. {@code vBase} offsets the {@code v}
+   * property so two rings built back to back get disjoint values and share no vertex.
+   */
+  private static RID[] buildRing(final int size, final int vBase) {
+    final MutableVertex[] vertices = new MutableVertex[size];
+    for (int i = 0; i < size; i++)
+      vertices[i] = database.newVertex("Node").set("v", vBase + i).save();
+
+    for (int i = 0; i < size; i++) {
+      vertices[i].newEdge("LINK", vertices[(i + 1) % size], true, new Object[] { "w", 1.0 }).save();
+      vertices[i].newEdge("LINK", vertices[(i + 7) % size], true, new Object[] { "w", 1.0 }).save();
+      vertices[i].newEdge("LINK", vertices[(i + 31) % size], true, new Object[] { "w", 1.0 }).save();
+    }
+
+    final RID[] rids = new RID[size];
+    for (int i = 0; i < size; i++)
+      rids[i] = vertices[i].getIdentity();
+    return rids;
+  }
+
+  @AfterAll
+  static void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @AfterEach
+  void resetTimeout() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 0L);
+    // A test that arms the interrupt flag must not leave it set for whatever runs next on this thread.
+    Thread.interrupted();
+  }
+
+  // ── astar() / dijkstra(): had no timeout or interrupt check at all ────────
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void astarHonoursTheCommandTimeoutOnAnUnreachableDestination() {
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drainSql(
+        "select expand(astar(" + nodeRid[0] + ", " + unreachableRid + ", 'w'))"))
+        .as("astar() previously consulted neither the deadline nor a thread interrupt, so it explored the "
+            + "whole reachable component before ever answering")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "astar() aborted from inside its main loop, not after exhausting the graph");
+  }
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void dijkstraHonoursTheCommandTimeoutOnAnUnreachableDestination() {
+    // dijkstra() delegates straight to a fresh SQLFunctionAstar, so it shares the fix as well as the bug.
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drainSql(
+        "select expand(dijkstra(" + nodeRid[0] + ", " + unreachableRid + ", 'w'))"))
+        .as("dijkstra() must not survive its own unreachable-destination search past the deadline")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "dijkstra() aborted from inside astar()'s main loop");
+  }
+
+  @Test
+  void astarStillReturnsTheCorrectPathWhenNothingAborts() {
+    final List<Result> rows = drainSql("select expand(astar(" + nodeRid[0] + ", " + nodeRid[3] + ", 'w'))");
+    assertThat(rows).as("a healthy call must still find a path once the guard is in place").isNotEmpty();
+    assertThat(rows.getFirst().getIdentity()).contains(nodeRid[0]);
+  }
+
+  @Test
+  void dijkstraStillReturnsTheCorrectPathWhenNothingAborts() {
+    final List<Result> rows = drainSql("select expand(dijkstra(" + nodeRid[0] + ", " + nodeRid[3] + ", 'w'))");
+    assertThat(rows).as("a healthy call must still find a path once the guard is in place").isNotEmpty();
+    assertThat(rows.getFirst().getIdentity()).contains(nodeRid[0]);
+  }
+
+  @Test
+  @Timeout(30)
+  void astarStopsOnAThreadInterruptEvenWithoutADeadline() {
+    // Before this fix astar() consulted no interrupt either - a caller had no way at all to cancel a run.
+    Thread.currentThread().interrupt();
+
+    assertThatThrownBy(() -> drainSql("select expand(astar(" + nodeRid[0] + ", " + unreachableRid + ", 'w'))"))
+        .as("astar() must be at least abortable via an explicit cancel")
+        .hasStackTraceContaining("astar() has been interrupted");
+  }
+
+  // ── SQL shortestPath(): checked Thread.interrupted() but never the deadline ─
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void sqlShortestPathHonoursTheCommandTimeoutOnAnUnreachableDestination() {
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    // Both endpoints sit on a fully separate ring: the search can never meet, so walkLeft/walkRight together
+    // have to exhaust both 20,000-node components before the outer loop notices the frontiers are empty -
+    // unless the deadline stops them first.
+    assertThatThrownBy(() -> drainSql(
+        "select expand(shortestPath(" + nodeRid[0] + ", " + otherComponentRid[0] + "))"))
+        .as("shortestPath() checked Thread.interrupted() but never arcadedb.command.timeout")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "the bidirectional BFS aborted from inside walkLeft/walkRight's caller");
+  }
+
+  @Test
+  void sqlShortestPathStillReturnsAPathWhenNothingAborts() {
+    final List<Result> rows = drainSql("select expand(shortestPath(" + nodeRid[0] + ", " + nodeRid[3] + "))");
+    assertThat(rows).as("a healthy call must still find a path once the guard is in place").isNotEmpty();
+  }
+
+  // ── Cypher MATCH shortestPath()/allShortestPaths(): the constrained BFS ────
+  // fallback (an inline WHERE or property map on the relationship) had neither check, unlike the unconstrained
+  // BFS right next to it.
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void cypherConstrainedShortestPathHonoursTheCommandTimeout() {
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = shortestPath((a)-[r:LINK* WHERE r.w > 0]-(b)) RETURN p",
+        Map.of("src", 0, "dst", NODES / 2)))
+        .as("an inline WHERE forces the edge-aware BFS (computeFilteredShortestPath), which consulted neither "
+            + "check before this fix")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "the constrained frontier walk aborted from inside its own loop");
+  }
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void cypherConstrainedAllShortestPathsHonoursTheCommandTimeout() {
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = allShortestPaths((a)-[r:LINK* WHERE r.w > 0]-(b)) RETURN p",
+        Map.of("src", 0, "dst", NODES / 2)))
+        .as("computeFilteredAllShortestPaths shares the same gap as its computeFilteredShortestPath sibling")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "the constrained layered BFS aborted from inside its own loop");
+  }
+
+  @Test
+  void cypherShortestPathFormsStillReturnCorrectPathsWhenNothingAborts() {
+    assertThat(drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = shortestPath((a)-[:LINK*]-(b)) RETURN p",
+        Map.of("src", 0, "dst", 3)))
+        .as("the unconstrained MATCH form must still find a path")
+        .isNotEmpty();
+
+    assertThat(drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = shortestPath((a)-[r:LINK* WHERE r.w > 0]-(b)) RETURN p",
+        Map.of("src", 0, "dst", 3)))
+        .as("the constrained MATCH form (inline WHERE) must still find a path")
+        .isNotEmpty();
+
+    assertThat(drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = allShortestPaths((a)-[r:LINK* WHERE r.w > 0]-(b)) RETURN p",
+        Map.of("src", 0, "dst", 3)))
+        .as("the constrained allShortestPaths() form must still find at least one path")
+        .isNotEmpty();
+
+    assertThat(drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}) RETURN shortestPath((a)-[r:LINK* WHERE r.w > 0]-(b)) AS p",
+        Map.of("src", 0, "dst", 3)))
+        .as("the RETURN-position expression form (ShortestPathExpression) shares the same fix")
+        .isNotEmpty();
+  }
+
+  // ── The default, disabled by default, leaves every form alone ─────────────
+
+  @Test
+  void theDisabledDefaultLeavesEveryFormAlone() {
+    assertThat(database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_TIMEOUT))
+        .as("the setting is off by default, so none of the checks added for this issue may fire")
+        .isZero();
+
+    assertThat(drainSql("select expand(astar(" + nodeRid[0] + ", " + nodeRid[3] + ", 'w'))")).isNotEmpty();
+    assertThat(drainSql("select expand(dijkstra(" + nodeRid[0] + ", " + nodeRid[3] + ", 'w'))")).isNotEmpty();
+    assertThat(drainSql("select expand(shortestPath(" + nodeRid[0] + ", " + nodeRid[3] + "))")).isNotEmpty();
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private static void setTimeout(final long millis) {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, millis);
+  }
+
+  private static List<Result> drainSql(final String query) {
+    return drain("sql", query, Map.of());
+  }
+
+  private static List<Result> drainCypher(final String query) {
+    return drain("opencypher", query, Map.of());
+  }
+
+  private static List<Result> drainCypher(final String query, final Map<String, Object> params) {
+    return drain("opencypher", query, params);
+  }
+
+  private static List<Result> drain(final String language, final String query, final Map<String, Object> params) {
+    final List<Result> rows = new java.util.ArrayList<>();
+    try (final ResultSet rs = params.isEmpty() ? database.query(language, query) : database.query(language, query, params)) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -825,6 +825,22 @@ class CypherBuiltInFunctionsTest extends TestHelper {
   }
 
   @Test
+  void aggSliceDefaultsFromToZeroWhenNull() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.slice");
+    @SuppressWarnings("unchecked")
+    final List<Object> result = (List<Object>) fn.execute(new Object[] { List.of(1, 2, 3, 4, 5), null, 3 }, null);
+    assertThat(result).isEqualTo(List.of(1, 2, 3));
+  }
+
+  @Test
+  void aggSliceDefaultsToToListSizeWhenOmitted() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.slice");
+    @SuppressWarnings("unchecked")
+    final List<Object> result = (List<Object>) fn.execute(new Object[] { List.of(1, 2, 3, 4, 5), 2 }, null);
+    assertThat(result).isEqualTo(List.of(3, 4, 5));
+  }
+
+  @Test
   void aggMedian() {
     final StatelessFunction fn = CypherFunctionRegistry.get("agg.median");
     // Odd number of elements

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -25,8 +25,11 @@ import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.Function;
 import com.arcadedb.function.FunctionRegistry;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.agg.PercentileContFunction;
+import com.arcadedb.function.agg.PercentileDiscFunction;
 import com.arcadedb.function.procedure.Procedure;
 import com.arcadedb.function.procedure.ProcedureRegistry;
+import com.arcadedb.function.vector.VectorCreateFunction;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.function.CypherFunctionRegistry;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
@@ -884,6 +887,96 @@ class CypherBuiltInFunctionsTest extends TestHelper {
     @SuppressWarnings("unchecked")
     final List<Object> items = (List<Object>) result.get("items");
     assertThat(items).hasSize(2).contains("c", "e");
+  }
+
+  // Issue #6672: agg.statistics()/agg.maxItems() seeded their running max with Double.MIN_VALUE, the smallest
+  // POSITIVE double (~4.9E-324), not the most-negative double. For a dataset whose true maximum is <= 0 the seed
+  // was never beaten, so agg.statistics() reported a bogus tiny-positive max and agg.maxItems() returned a bogus
+  // value with an empty items list.
+  @Test
+  void aggStatisticsMaxOfAllNegativeValuesIsTheActualMaximum() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.statistics");
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { List.of(-5.0, -3.0, -1.0) }, null);
+
+    assertThat(result.get("max")).isEqualTo(-1.0);
+    assertThat(result.get("min")).isEqualTo(-5.0);
+  }
+
+  @Test
+  void aggStatisticsMaxOfAllZeroValuesIsZero() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.statistics");
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { List.of(0.0, 0.0, 0.0) }, null);
+
+    assertThat(result.get("max")).isEqualTo(0.0);
+  }
+
+  @Test
+  void aggMaxItemsOfAllNegativeValuesReturnsTheActualMaximumAndItsItems() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.maxItems");
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(
+        new Object[] { List.of(-5.0, -3.0, -1.0), List.of("a", "b", "c") }, null);
+
+    assertThat(result.get("value")).isEqualTo(-1.0);
+    @SuppressWarnings("unchecked")
+    final List<Object> items = (List<Object>) result.get("items");
+    assertThat(items).containsExactly("c");
+  }
+
+  // Issue #6677: several functions cast a positional argument to (Number) with no type check, so a non-numeric
+  // argument threw a raw ClassCastException (HTTP 500) instead of a clean client type error. Fixed by routing
+  // through CypherFunctionHelper.requireNumberArgument(), the same mechanism #6609 introduced for left/right/substring.
+  // (RangeFunction, also named in #6677, already validated its arguments before this issue was filed - see #5909 -
+  // so it is not part of this fix.)
+  @Test
+  void aggNthOfNonNumericIndexIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.nth");
+    assertThatThrownBy(() -> fn.execute(new Object[] { List.of("a", "b", "c"), List.of() }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("agg.nth()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void aggSliceOfNonNumericBoundIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.slice");
+    assertThatThrownBy(() -> fn.execute(new Object[] { List.of(1, 2, 3), "not-a-number", 2 }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("agg.slice()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> fn.execute(new Object[] { List.of(1, 2, 3), 0, "not-a-number" }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("agg.slice()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void percentileContOfNonNumericPercentileIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = new PercentileContFunction();
+    assertThatThrownBy(() -> fn.execute(new Object[] { 3.0, List.of() }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("percentileCont()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void percentileDiscOfNonNumericPercentileIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = new PercentileDiscFunction();
+    assertThatThrownBy(() -> fn.execute(new Object[] { 3.0, List.of() }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("percentileDisc()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void vectorCreateOfNonNumericDimensionIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = new VectorCreateFunction();
+    assertThatThrownBy(() -> fn.execute(new Object[] { List.of(1.0, 2.0), List.of() }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("vector_create()")
+        .hasMessageContaining("LIST");
   }
 
   // ===================== NODE FUNCTION TESTS =====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherDisjunctionAnchorWithRelationshipIssue6482Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherDisjunctionAnchorWithRelationshipIssue6482Test.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6482: a label-disjunction anchor with an incident relationship
+ * ({@code MATCH (n:A|B {id: $x})-[:REL]->(m) RETURN m}) used to bail out of the cost-based optimizer
+ * for the whole statement - {@code CypherExecutionPlanner.shouldUseOptimizer()} refused any path where a
+ * disjunction node had a relationship, even though the disjunction sits on the anchor and only the
+ * anchor is served by {@code NodeByLabelDisjunctionScan}/{@code NodeByLabelDisjunctionIndexSeek} (issue
+ * #6397). The query still returned correct rows through the legacy engine, just without the index-seek
+ * speedup.
+ * <p>
+ * Also pins the safety net this fix adds: when the disjunction is NOT on the anchor - it sits on a node
+ * reached by a relationship instead - the optimizer must still decline (fall back to the legacy engine)
+ * rather than build an {@code ExpandAll}/{@code ExpandInto} that can only filter on the disjunction's
+ * first label. {@link CypherLabelDisjunctionOnExpandedNodeIssue6338Test} already pins the end-to-end
+ * correctness of that shape; the assertions here additionally confirm those queries are not silently
+ * routed through the optimizer now that the AST-level gate has been relaxed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherDisjunctionAnchorWithRelationshipIssue6482Test extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      final var typeA = database.getSchema().createVertexType("Alpha6482");
+      typeA.createProperty("id", String.class);
+      typeA.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+
+      final var typeB = database.getSchema().createVertexType("Bravo6482");
+      typeB.createProperty("id", String.class);
+      typeB.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+
+      database.getSchema().createVertexType("Target6482");
+      database.getSchema().createEdgeType("LINKS6482");
+    });
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Alpha6482 {id: 'a1'})");
+      database.command("opencypher", "CREATE (:Bravo6482 {id: 'b1'})");
+      database.command("opencypher", "CREATE (:Target6482 {id: 't1'})");
+      database.command("opencypher",
+          "MATCH (n:Alpha6482 {id: 'a1'}), (m:Target6482 {id: 't1'}) CREATE (n)-[:LINKS6482]->(m)");
+      database.command("opencypher",
+          "MATCH (n:Bravo6482 {id: 'b1'}), (m:Target6482 {id: 't1'}) CREATE (n)-[:LINKS6482]->(m)");
+    });
+  }
+
+  @Test
+  void disjunctionAnchorWithEqualityPredicateAndRelationshipUsesTheOptimizer() {
+    final String query = "MATCH (n:Alpha6482|Bravo6482 {id: 'a1'})-[:LINKS6482]->(m:Target6482) RETURN m.id AS k";
+    final String plan = profilePlan(query);
+    assertThat(plan).as("plan\n%s", plan)
+        .contains("Execution Plan (Cost-Based Optimizer)")
+        .contains("NodeByLabelDisjunctionIndexSeek");
+
+    assertThat(ids(query)).containsExactly("t1");
+  }
+
+  @Test
+  void disjunctionAnchorViaWhereClauseWithRelationshipUsesTheOptimizer() {
+    final String query = "MATCH (n:Alpha6482|Bravo6482)-[:LINKS6482]->(m:Target6482) WHERE n.id = 'b1' RETURN m.id AS k";
+    final String plan = profilePlan(query);
+    assertThat(plan).as("plan\n%s", plan)
+        .contains("Execution Plan (Cost-Based Optimizer)")
+        .contains("NodeByLabelDisjunctionIndexSeek");
+
+    assertThat(ids(query)).containsExactly("t1");
+  }
+
+  @Test
+  void bothAlternativesStillReachTheSameTargetOverTheRelationship() {
+    assertThat(ids("MATCH (n:Alpha6482|Bravo6482 {id: 'a1'})-[:LINKS6482]->(m:Target6482) RETURN m.id AS k"))
+        .containsExactly("t1");
+    assertThat(ids("MATCH (n:Alpha6482|Bravo6482 {id: 'b1'})-[:LINKS6482]->(m:Target6482) RETURN m.id AS k"))
+        .containsExactly("t1");
+  }
+
+  @Test
+  void aValueNoAlternativeHasReturnsNothingEvenWithARelationship() {
+    assertThat(ids("MATCH (n:Alpha6482|Bravo6482 {id: 'nope'})-[:LINKS6482]->(m:Target6482) RETURN m.id AS k"))
+        .isEmpty();
+  }
+
+  /**
+   * The disjunction sits on the node a relationship expands INTO, not on the anchor. This is the shape
+   * {@link CypherLabelDisjunctionOnExpandedNodeIssue6338Test} already pins end-to-end; this assertion
+   * additionally confirms the optimizer declines it (falls back to the legacy engine) instead of silently
+   * filtering on only the disjunction's first label via {@code addTargetLabelFilter}.
+   */
+  @Test
+  void disjunctionOnTheExpandedNodeDoesNotUseTheOptimizerButStaysCorrect() {
+    final String query = "MATCH (m:Target6482)<-[:LINKS6482]-(n:Alpha6482|Bravo6482) RETURN n.id AS k ORDER BY k";
+    final String plan = profilePlan(query);
+    assertThat(plan).as("plan\n%s", plan).doesNotContain("Execution Plan (Cost-Based Optimizer)");
+
+    assertThat(ids(query)).containsExactly("a1", "b1");
+  }
+
+  private List<String> ids(final String cypher) {
+    final List<String> result = new ArrayList<>();
+    database.transaction(() -> {
+      final ResultSet rs = database.query("opencypher", cypher);
+      while (rs.hasNext())
+        result.add(rs.next().getProperty("k"));
+      rs.close();
+    });
+    return result;
+  }
+
+  private String profilePlan(final String cypher) {
+    final StringBuilder plan = new StringBuilder();
+    database.transaction(() -> {
+      final ResultSet rs = database.command("opencypher", "PROFILE " + cypher);
+      while (rs.hasNext())
+        rs.next();
+      plan.append(rs.getExecutionPlan().orElseThrow().prettyPrint(0, 2));
+      rs.close();
+    });
+    return plan.toString();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLeftRightSubstringFunctionArgumentIssue6609Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLeftRightSubstringFunctionArgumentIssue6609Test.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6609: {@code RETURN left('a', [])} (and the same shape for {@code right()} and
+ * {@code substring()}) reached an unchecked {@code (Number) args[1]} cast, so the {@code java.lang.ClassCastException}
+ * escaped as {@code CommandExecutionException} / HTTP 500 "Error on transaction commit" instead of a client-facing
+ * type error. Handing a LIST to a function declared {@code f(..., length :: INTEGER)} is the client's mistake, not an
+ * internal fault: Neo4j answers {@code Neo.ClientError.Statement.TypeError} (22N27) and ArcadeDB must answer 400.
+ *
+ * <p>Same class of fix as issue #5484 (the numeric family) and issue #5798 (the STRING family): #5901's own
+ * description names {@code left()}/{@code right()} as a follow-up left out of that fix's scope, and {@code substring()}
+ * shares the same unchecked numeric cast path.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherLeftRightSubstringFunctionArgumentIssue6609Test extends TestHelper {
+
+  // ===================== the reproducer =====================
+
+  @Test
+  void leftOfListLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN left('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void rightOfListLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN right('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("right()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void substringOfListLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN substring('aa', 0, []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("substring()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void substringOfListStartIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN substring('aa', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("substring()")
+        .hasMessageContaining("LIST");
+  }
+
+  // ===================== other out-of-domain types =====================
+
+  @Test
+  void leftOfBooleanLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN left('a', true) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("BOOLEAN");
+  }
+
+  @Test
+  void leftOfStringLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN left('a', 'two') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void leftOfMapLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN left('a', {a: 1}) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("MAP");
+  }
+
+  // ===================== runtime path (type known only once the query runs) =====================
+
+  @Test
+  void leftOfListPropertyIsRejectedAtRuntime() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Issue6609 {name: 'a', tags: [1, 2]})"));
+    assertThatThrownBy(() -> consume("MATCH (n:Issue6609) RETURN left(n.name, n.tags) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("LIST");
+  }
+
+  // ===================== a literal fails even when no row matches =====================
+
+  @Test
+  void aListLiteralFailsEvenWhenNoRowMatches() {
+    // Neo4j rejects an out-of-domain literal before running the query, so it fails even where the function would
+    // never be called. Same parse-time guarantee already given to the pure-numeric family (issue #5484).
+    database.transaction(() -> database.command("opencypher", "CREATE (:Issue6609 {name: 'a'})"));
+    assertThatThrownBy(() -> consume("MATCH (n:Issue6609) WHERE n.name = 'nobody' RETURN left('a', [1,2]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("LIST");
+    assertThatThrownBy(() -> consume("MATCH (n:Issue6609) WHERE n.name = 'nobody' RETURN right('a', [1,2]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("right()")
+        .hasMessageContaining("LIST");
+    assertThatThrownBy(() -> consume("MATCH (n:Issue6609) WHERE n.name = 'nobody' RETURN substring('aa', 0, [1]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("substring()")
+        .hasMessageContaining("LIST");
+  }
+
+  // ===================== the primary STRING argument is untouched by this fix =====================
+
+  @Test
+  void thePrimaryStringArgumentIsStillNotTypeChecked() {
+    // Out of scope for #6609 (and for #5798/#5901 before it): left()/right()/substring()'s primary text argument
+    // still converts any value via toString() rather than rejecting it. Locked down so a future fix to that separate
+    // gap is a deliberate, visible change to this test rather than a silent behavior drift.
+    assertThat(single("RETURN left(5, 1) AS r")).isEqualTo("5");
+  }
+
+  // ===================== arguments that are still accepted =====================
+
+  @Test
+  void nullPropagationIsNotATypeError() {
+    assertThat(single("RETURN left('a', null) AS r")).isNull();
+    assertThat(single("RETURN right('a', null) AS r")).isNull();
+    assertThat(single("RETURN substring('a', null) AS r")).isNull();
+    assertThat(single("RETURN substring('a', 0, null) AS r")).isNull();
+  }
+
+  @Test
+  void normalArgumentsStillWork() {
+    assertThat(single("RETURN left('hello', 3) AS r")).isEqualTo("hel");
+    assertThat(single("RETURN right('hello', 3) AS r")).isEqualTo("llo");
+    assertThat(single("RETURN substring('hello', 1, 3) AS r")).isEqualTo("ell");
+    assertThat(single("RETURN substring('hello', 1) AS r")).isEqualTo("ello");
+  }
+
+  @Test
+  void negativeLengthIsStillAClientErrorNotATypeError() {
+    // Regression guard: a well-typed but out-of-range Number (issue #5296/#5793) must still be reported the way it
+    // was before this fix, distinct from the type-mismatch message this issue adds.
+    assertThatThrownBy(() -> consume("RETURN left('a', -1) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("negative length")
+        .hasMessageNotContaining("Type mismatch");
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherNumericFunctionArgumentIssue5484Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherNumericFunctionArgumentIssue5484Test.java
@@ -31,7 +31,10 @@ import com.arcadedb.function.math.MathUnaryFunction;
 import com.arcadedb.function.math.RoundFunction;
 import com.arcadedb.function.math.SignFunction;
 import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
+import com.arcadedb.function.text.LeftFunction;
+import com.arcadedb.function.text.RightFunction;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
+import com.arcadedb.query.opencypher.executor.CypherSubstringFunction;
 import com.arcadedb.query.opencypher.parser.FunctionValidator;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -316,9 +319,13 @@ class CypherNumericFunctionArgumentIssue5484Test extends TestHelper {
   }
 
   private static boolean isNumericExecutor(final StatelessFunction executor) {
+    // left()/right()/substring() (issue #6609) are numeric only from NumericSignature#startArg() onward - their
+    // leading argument is the STRING being sliced - but still belong in NUMERIC_ARGUMENT_FUNCTIONS so their trailing
+    // numeric arguments get the same parse-time guarantee as the rest of the family.
     return executor instanceof AbsFunction || executor instanceof MathUnaryFunction
         || executor instanceof MathBinaryFunction || executor instanceof SignFunction || executor instanceof IsNaNFunction
-        || executor instanceof RoundFunction;
+        || executor instanceof RoundFunction || executor instanceof LeftFunction || executor instanceof RightFunction
+        || executor instanceof CypherSubstringFunction;
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherPlanCacheInvalidationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherPlanCacheInvalidationTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.opencypher.optimizer.plan.PhysicalPlan;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -72,10 +73,16 @@ class CypherPlanCacheInvalidationTest {
   private static final String Q = "MATCH (a:Foo)-[:REL]->(b:Foo) RETURN b.x AS v";
 
   @Test
-  void planCacheIsFlushedOnSchemaChange() {
+  void planCacheIsFlushedOnSchemaChange() throws InterruptedException {
     database.transaction(() -> {
       database.command("cypher", "CREATE (a:Foo {x:1})-[:REL]->(b:Foo {x:2}), (c:Foo {x:1})-[:REL]->(d:Foo {x:2})");
     });
+
+    // put()'s invalidation guard (issue #6671) is millisecond-timestamped: a query planned in the very same
+    // millisecond as a preceding invalidation (here, the implicit "Foo" type creation above) is correctly not
+    // cached. Sleeping past the millisecond boundary before each post-invalidation query, exactly like
+    // ExecutionPlanCacheTest does for the SQL cache, keeps these assertions about "was it cached" deterministic.
+    Thread.sleep(2);
 
     // Populate the plan cache with a node-returning query (its plan depends on the current schema).
     assertThat(matchRows(Q)).isEqualTo(2L);
@@ -85,6 +92,7 @@ class CypherPlanCacheInvalidationTest {
     database.getSchema().getType("Foo").createProperty("x", Type.INTEGER);
     assertThat(database.getCypherPlanCache().size()).as("plan cache flushed after CREATE PROPERTY").isEqualTo(0);
 
+    Thread.sleep(2);
     assertThat(matchRows(Q)).isEqualTo(2L);
     assertThat(database.getCypherPlanCache().size()).isGreaterThan(0);
 
@@ -93,6 +101,7 @@ class CypherPlanCacheInvalidationTest {
     assertThat(database.getCypherPlanCache().size()).as("plan cache flushed after CREATE INDEX").isEqualTo(0);
 
     // Re-plan now can use the index; result must still be correct.
+    Thread.sleep(2);
     assertThat(matchRows(Q)).isEqualTo(2L);
     assertThat(database.getCypherPlanCache().size()).isGreaterThan(0);
 
@@ -102,6 +111,52 @@ class CypherPlanCacheInvalidationTest {
     assertThat(database.getCypherPlanCache().size()).as("plan cache flushed after DROP INDEX").isEqualTo(0);
 
     // Result stays correct with the fresh (scan-based) plan.
+    Thread.sleep(2);
     assertThat(matchRows(Q)).isEqualTo(2L);
+  }
+
+  /**
+   * Issue #6671: {@code CypherPlanCache.put()} used to have no invalidation guard at all - unlike the SQL execution
+   * plan cache, which at least attempted (non-atomically) to check {@code getLastInvalidation() < planningStart}
+   * before inserting. A {@code DROP INDEX}/{@code ALTER TYPE}/create-index landing while a Cypher query was being
+   * planned could therefore always be cached right back in, regardless of timing, leaving a {@code NodeIndexSeek}
+   * plan cached against a dropped index. This test reproduces the exact interleaving deterministically (no real
+   * threads): capture {@code planningStart}, invalidate the cache (standing in for the concurrent DDL), then attempt
+   * to cache a plan built at that {@code planningStart} - the fixed, single-lock {@code put(query, plan,
+   * planningStart)} must refuse it.
+   */
+  @Test
+  void planBuiltBeforeAConcurrentInvalidationIsNeverCached() throws InterruptedException {
+    database.transaction(() -> {
+      database.command("cypher", "CREATE (a:Foo {x:1})-[:REL]->(b:Foo {x:2}), (c:Foo {x:1})-[:REL]->(d:Foo {x:2})");
+    });
+
+    // The implicit "Foo" type creation above already invalidated the cache once; sleep past that millisecond
+    // boundary so the warm-up query below is unambiguously planned afterwards (see the comment in
+    // planCacheIsFlushedOnSchemaChange for why put()'s millisecond-timestamped guard needs this).
+    Thread.sleep(2);
+
+    // Warm the cache once to obtain a real, valid PhysicalPlan instance to fight over.
+    assertThat(matchRows(Q)).isEqualTo(2L);
+    assertThat(database.getCypherPlanCache().contains(Q)).isTrue();
+    final PhysicalPlan plan = database.getCypherPlanCache().get(Q);
+    assertThat(plan).isNotNull();
+
+    // Planning "began" here, before the concurrent DDL below invalidates the cache.
+    final long planningStart = System.currentTimeMillis();
+
+    // Stand in for a concurrent DDL landing on another thread while planning was in flight.
+    database.getCypherPlanCache().invalidate();
+    assertThat(database.getCypherPlanCache().contains(Q)).isFalse();
+
+    // The plan was built against planningStart, which is now older than the invalidation: it must be rejected.
+    database.getCypherPlanCache().put(Q, plan, planningStart);
+    assertThat(database.getCypherPlanCache().contains(Q))
+        .as("a plan built before a concurrent invalidation must never be cached").isFalse();
+
+    // A plan whose planning genuinely started after the invalidation must still be cached normally.
+    final long freshPlanningStart = System.currentTimeMillis() + 1;
+    database.getCypherPlanCache().put(Q, plan, freshPlanningStart);
+    assertThat(database.getCypherPlanCache().contains(Q)).as("a plan planned after the invalidation must be cached").isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStandaloneOptionalMatchPullBatchIssue6668Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStandaloneOptionalMatchPullBatchIssue6668Test.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6668: a standalone {@code OPTIONAL MATCH} used as the first clause
+ * of a query kept its match cursor in a local variable that was re-created on every
+ * {@code fetchMore} call, so once the pattern had more rows than the pull batch size (100) it
+ * re-ran the scan from the beginning on every subsequent batch, emitting the first 100 rows
+ * repeatedly and never terminating.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherStandaloneOptionalMatchPullBatchIssue6668Test {
+  private static final int NODE_COUNT = 250;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/cypher6668").create();
+    database.transaction(() -> {
+      for (int i = 0; i < NODE_COUNT; i++)
+        database.command("opencypher", "CREATE (:Person {id: $id})", java.util.Map.of("id", i));
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  private List<Result> rows(final String query) {
+    final List<Result> rows = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+    return rows;
+  }
+
+  /**
+   * A standalone leading OPTIONAL MATCH whose cardinality exceeds the 100-row pull batch must
+   * terminate and emit each matched node exactly once, not repeat the first batch forever.
+   */
+  @Test
+  void standaloneOptionalMatchExceedingPullBatchTerminatesWithoutDuplicates() {
+    database.transaction(() -> {
+      final List<Result> rows = rows("OPTIONAL MATCH (n:Person) RETURN n.id AS id");
+
+      assertThat(rows).hasSize(NODE_COUNT);
+
+      final Set<Object> ids = new HashSet<>();
+      for (final Result row : rows)
+        ids.add(row.getProperty("id"));
+      assertThat(ids).hasSize(NODE_COUNT);
+    });
+  }
+
+  /**
+   * The no-match case must still resolve to a single all-NULL row once the (empty) pattern scan
+   * is exhausted.
+   */
+  @Test
+  void standaloneOptionalMatchWithNoMatchesEmitsSingleNullRow() {
+    database.transaction(() -> {
+      final List<Result> rows = rows("OPTIONAL MATCH (n:Person {id: -1}) RETURN n");
+
+      assertThat(rows).hasSize(1);
+      assertThat(rows.getFirst().<Object>getProperty("n")).isNull();
+    });
+  }
+
+  /**
+   * A leading OPTIONAL MATCH whose cardinality fits within a single pull batch must still work
+   * (this shape already passed before the fix, it pins the non-regressed case).
+   */
+  @Test
+  void standaloneOptionalMatchWithinPullBatchStillWorks() {
+    database.transaction(() -> {
+      final List<Result> rows = rows("OPTIONAL MATCH (n:Person {id: 0}) RETURN n.id AS id");
+
+      assertThat(rows).hasSize(1);
+      assertThat(rows.getFirst().<Object>getProperty("id")).isEqualTo(0);
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionSecondaryArgumentIssue6608Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionSecondaryArgumentIssue6608Test.java
@@ -168,6 +168,23 @@ class CypherStringFunctionSecondaryArgumentIssue6608Test extends TestHelper {
     assertThat(single("RETURN char_length('ab') AS r")).isEqualTo(2L);
   }
 
+  // ===================== pre-existing ambiguity noted by review, out of scope for this fix =====================
+
+  @Test
+  void btrimCalledWithThreePositionalArgumentsIsAPreExistingAmbiguityNotIntroducedByThisFix() {
+    // btrim() has no dedicated SQL-style grammar rule (only the reserved TRIM keyword does - see
+    // CypherExpressionBuilder#findTrimFunctionRecursive), so a 3-argument call to it is parsed as an
+    // ordinary function call and reaches CypherTrimFunction's args.length == 3 branch positionally:
+    // args[0] is read as "mode" (never LEADING/TRAILING, so it silently falls through to "trim both"),
+    // args[1] as the trim character, and args[2] as the source - NOT args[0] as the source a caller
+    // writing btrim(source, char, somethingElse) by analogy with the 2-arg form would expect. This
+    // predates #6608 (this fix only added the type check on args[1]/args[2], it did not change which
+    // position plays which role) and is pinned here as documented, current behaviour rather than fixed,
+    // since resolving it is a separate, unscoped question of whether btrim() should even accept 3
+    // arguments at all.
+    assertThat(single("RETURN btrim('unused-as-mode', 'x', 'xxabcxx') AS r")).isEqualTo("abc");
+  }
+
   private Object single(final String query) {
     try (final ResultSet rs = database.query("opencypher", query)) {
       assertThat(rs.hasNext()).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionSecondaryArgumentIssue6608Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionSecondaryArgumentIssue6608Test.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6608: issue #5798 (fixed by PR #5901) made several string functions reject a
+ * non-STRING value in their PRIMARY argument position, but the remaining STRING-typed argument positions of
+ * the same functions - {@code split()}'s delimiter, {@code replace()}'s search and replacement text,
+ * {@code trim()}/{@code btrim()}/{@code lTrim()}/{@code rTrim()}'s trim-character argument - still accepted
+ * any value and silently converted it via {@code Object.toString()}. {@code char.length()} (a.k.a.
+ * {@code char_length()}) was not covered by #5798 at all, in any argument position.
+ * <p>
+ * Handing a non-STRING value to one of these positions is the client's mistake and must be a
+ * {@link CommandSemanticException} (400), not a silently "successful" textual conversion, exactly as the
+ * primary argument position already behaves since #5798.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherStringFunctionSecondaryArgumentIssue6608Test extends TestHelper {
+
+  // ===================== the reproducers from the issue =====================
+
+  @Test
+  void replaceOfNonStringSearchOrReplacementArgumentIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN replace('a', 1, 'b') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN replace('a', 1, []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN replace('a', 'x', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void splitOfNonStringDelimiterIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN split('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("split()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void lTrimOfNonStringTrimCharacterIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN lTrim('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("lTrim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void rTrimOfNonStringTrimCharacterIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN rTrim('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("rTrim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void btrimOfNonStringTrimCharacterIsAClientTypeError() {
+    // 2-argument form: btrim(source, trimCharacter).
+    assertThatThrownBy(() -> consume("RETURN btrim('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void theSqlStyleThreeArgumentTrimFormRejectsANonStringTrimCharacter() {
+    // trim(BOTH/LEADING/TRAILING char FROM string): char is args[1], source is args[2].
+    assertThatThrownBy(() -> consume("RETURN trim(BOTH [] FROM 'a') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void charLengthOfANonStringArgumentIsAClientTypeError() {
+    // char.length() and char_length() are aliases resolving to the same executor (CypherFunctionFactory),
+    // so both report under the executor's own getName() spelling, same convention as the toUpper()/upper()
+    // aliases in issue #5798.
+    assertThatThrownBy(() -> consume("RETURN char.length([]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("char_length()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN char_length(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("char_length()")
+        .hasMessageContaining("STRING");
+  }
+
+  // ===================== the internal consistency controls from the issue still pass =====================
+
+  @Test
+  void thePrimaryArgumentPositionsFixedByIssue5798StillReject() {
+    assertThatThrownBy(() -> consume("RETURN split(5, ',') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("split()");
+    assertThatThrownBy(() -> consume("RETURN replace(5, 'a', 'b') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()");
+    assertThatThrownBy(() -> consume("RETURN btrim('a', 1, []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()");
+  }
+
+  // ===================== null propagation is not a type error =====================
+
+  @Test
+  void nullPropagationIsNotATypeError() {
+    assertThat(single("RETURN split('a,b', null) AS r")).isNull();
+    assertThat(single("RETURN replace('a', null, 'b') AS r")).isNull();
+    assertThat(single("RETURN replace('a', 'a', null) AS r")).isNull();
+    assertThat(single("RETURN lTrim('a', null) AS r")).isNull();
+    assertThat(single("RETURN rTrim('a', null) AS r")).isNull();
+    assertThat(single("RETURN btrim('a', null) AS r")).isNull();
+    assertThat(single("RETURN char.length(null) AS r")).isNull();
+  }
+
+  // ===================== explicit conversion still works =====================
+
+  @Test
+  void explicitToStringConversionStillWorks() {
+    assertThat(single("RETURN split('a1b', toString(1)) AS r").toString()).isEqualTo("[a, b]");
+    assertThat(single("RETURN replace('a1b', toString(1), 'x') AS r")).isEqualTo("axb");
+    assertThat(single("RETURN char.length(toString(42)) AS r")).isEqualTo(2L);
+  }
+
+  // ===================== valid arguments still work (no regression) =====================
+
+  @Test
+  void validArgumentsStillWork() {
+    assertThat(single("RETURN split('a,b', ',') AS r").toString()).isEqualTo("[a, b]");
+    assertThat(single("RETURN replace('abc', 'b', 'x') AS r")).isEqualTo("axc");
+    assertThat(single("RETURN lTrim('xxabc', 'x') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN rTrim('abcxx', 'x') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN btrim('xxabcxx', 'x') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN trim(BOTH 'x' FROM 'xxabcxx') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN char.length('ab') AS r")).isEqualTo(2L);
+    assertThat(single("RETURN char_length('ab') AS r")).isEqualTo(2L);
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableUsageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableUsageTest.java
@@ -116,6 +116,28 @@ class CypherVariableUsageTest {
     assertThat(isReferenced("MATCH (a)-[r:KNOWS]->(b) FOREACH (x IN [1] | DELETE r) RETURN a", "r")).isTrue();
   }
 
+  /**
+   * Issue #6573: an inline property expression inside a top-level CREATE or MERGE pattern reads the
+   * variable. The top-level switch had no {@code case CREATE}/{@code case MERGE} - unlike its sibling
+   * {@code foreachReferencesVariable}, which already treats a nested CREATE/MERGE conservatively - so
+   * it fell to {@code default} and the clause was never inspected. That anonymized the edge binding
+   * whenever nothing else in the query mentioned it, so {@code CREATE (c {prop: r.x})} silently read a
+   * missing binding and evaluated to null instead of the real value.
+   */
+  @Test
+  void createReadsItInAnInlineProperty() {
+    assertThat(isReferenced(
+        "MATCH (a)-[r:KNOWS]->(b) CREATE (c:Note {since: r.since}) RETURN c.since", "r"))
+        .isTrue();
+  }
+
+  @Test
+  void mergeReadsItInAnInlineProperty() {
+    assertThat(isReferenced(
+        "MATCH (a)-[r:KNOWS]->(b) MERGE (c:Note {since: r.since}) RETURN c.since", "r"))
+        .isTrue();
+  }
+
   @Test
   void aCallSubqueryReadsItByImportAndInsideItsBody() {
     assertThat(isReferenced("MATCH (a)-[r:KNOWS]->(b) CALL (r) { RETURN 1 AS one } RETURN one", "r")).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6461MergeAnchorStaleEdgeListTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6461MergeAnchorStaleEdgeListTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6461: MERGE of a relationship duplicates it (and, for an unbound far
+ * endpoint, its far endpoint) when the anchor vertex was bound earlier in the same query.
+ * <p>
+ * {@code MergeStep.executeMerge} wraps each row it processes in {@code database.transaction(..., true)}
+ * (see the class Javadoc on that method / issue #6367). When the caller has no outer transaction open -
+ * an unwrapped autocommit call, exactly the shape {@code BoltNetworkExecutor.handleRun} uses, and the
+ * shape a raw engine {@code database.command(...)} call has - each row's MERGE owns and commits its own
+ * transaction. The anchor vertex instance the row carries (bound by an earlier {@code MATCH}, or reused
+ * across {@code UNWIND} rows of the same MERGE) was loaded before that per-row transaction started, so
+ * once a prior row's MERGE appends the FIRST edge in a direction to it - the one write that rewrites the
+ * vertex record's edge-list head pointer - the row's own instance still reflects the pre-append state.
+ * {@code findAllMatchingPaths}/{@code traverseFromNode} trusted that instance and enumerated its edges
+ * directly, missing the edge/node a previous row already created and creating a duplicate.
+ * <p>
+ * Over HTTP this is invisible: {@code DatabaseAbstractHandler.executeInTransaction()} wraps the whole
+ * autocommit command in one outer transaction, so every row's MERGE simply joins it and shares its
+ * transaction-local record cache. These tests reproduce the unwrapped shape directly against the engine.
+ */
+class Issue6461MergeAnchorStaleEdgeListTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-6461-merge-anchor-stale-edge-list").create();
+    database.getSchema().createVertexType("Par");
+    database.getSchema().createVertexType("Chi");
+    database.getSchema().createVertexType("A");
+    database.getSchema().createEdgeType("HAS");
+    database.getSchema().createEdgeType("L");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * Realistic repro from the issue: an anchor bound once by MATCH, then reused by MERGE across several
+   * UNWIND rows, some of which resolve to the same not-yet-existing child. The second `cid=10` row must
+   * see the child/edge the first row created instead of creating a duplicate.
+   */
+  @Test
+  void unwindMergeReusingBoundAnchorDoesNotDuplicateEdgeOrFarEndpoint() {
+    database.command("opencypher", "CREATE (p:Par {id:1})");
+
+    database.command("opencypher",
+        "MATCH (p:Par {id:1}) UNWIND [10,10,20] AS cid MERGE (p)-[:HAS]->(c:Chi {id:cid})");
+
+    final ResultSet edgeCount = database.query("opencypher", "MATCH (:Par)-[r:HAS]->(:Chi) RETURN count(r) AS c");
+    assertThat(edgeCount.next().<Number>getProperty("c").longValue()).isEqualTo(2);
+
+    final Map<Object, Long> childCountsById = new HashMap<>();
+    final ResultSet children = database.query("opencypher", "MATCH (c:Chi) RETURN c.id AS id, count(*) AS c");
+    while (children.hasNext()) {
+      final Result r = children.next();
+      childCountsById.put(r.getProperty("id"), ((Number) r.getProperty("c")).longValue());
+    }
+    assertThat(childCountsById).containsEntry(10L, 1L).containsEntry(20L, 1L);
+  }
+
+  /**
+   * Minimal form from the issue: two MERGE clauses on the same already-bound pair in one query must
+   * match the same edge the second time round, not create a second one.
+   */
+  @Test
+  void repeatedMergeOnSameBoundPairDoesNotDuplicateEdge() {
+    database.command("opencypher", "CREATE (a:A {n:'a'})");
+    database.command("opencypher", "CREATE (b:A {n:'b'})");
+
+    database.command("opencypher",
+        "MATCH (a:A {n:'a'}),(b:A {n:'b'}) MERGE (a)-[:L]->(b) MERGE (a)-[:L]->(b)");
+
+    final ResultSet edgeCount = database.query("opencypher", "MATCH (:A)-[r:L]->(:A) RETURN count(r) AS c");
+    assertThat(edgeCount.next().<Number>getProperty("c").longValue()).isEqualTo(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6540DistinctKeyDelimiterCollisionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6540DistinctKeyDelimiterCollisionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6540: {@code ProjectReturnStep}, {@code UnionStep} and {@code WithStep} built their
+ * DISTINCT/UNION deduplication key by concatenating {@code name=value|} for every projected property
+ * into one string. A projected value whose rendering itself contains {@code =} or {@code |} could make
+ * two genuinely different rows concatenate to the same key string and get wrongly collapsed - e.g. a
+ * single property {@code a = "1|b=2"} and two properties {@code a=1, b=2} both used to render as
+ * {@code "a=1|b=2|"}.
+ * <p>
+ * {@code UNION} is the clearest way to put two differently-shaped rows (one column vs. two columns)
+ * through the same dedup key, since a plain {@code RETURN}/{@code WITH} fixes its column set for every
+ * row of a single branch.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6540DistinctKeyDelimiterCollisionTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/issue-6540-distinct-key-collision");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  /**
+   * The reported case, verbatim: a single string property that happens to look like a rendered
+   * {@code name=value|name=value|} key must not collide with an unrelated two-property row.
+   */
+  @Test
+  void unionDoesNotCollapseDifferentlyShapedRowsThatRenderToTheSameDelimitedString() {
+    // Both branches write "RETURN *", so the parse-time column-name check that UNION otherwise
+    // enforces (all branches must share the same return column names) passes trivially - but the
+    // *actual* per-row property sets still differ at runtime, exactly like the reported example.
+    final List<Result> rows = new ArrayList<>();
+    try (ResultSet rs = database.query("cypher", """
+        WITH '1|b=2' AS a RETURN *
+        UNION
+        WITH 1 AS a, 2 AS b RETURN *""")) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+
+    assertThat(rows).hasSize(2);
+    assertThat(rows).anySatisfy(row -> {
+      assertThat(row.getPropertyNames()).containsExactly("a");
+      assertThat(row.<String>getProperty("a")).isEqualTo("1|b=2");
+    });
+    assertThat(rows).anySatisfy(row -> {
+      assertThat(row.getPropertyNames()).containsExactlyInAnyOrder("a", "b");
+      assertThat(row.<Number>getProperty("a").intValue()).isEqualTo(1);
+      assertThat(row.<Number>getProperty("b").intValue()).isEqualTo(2);
+    });
+  }
+
+  /**
+   * Sanity check: two rows that really do carry equal names/values must still collapse under UNION's
+   * implicit DISTINCT.
+   */
+  @Test
+  void unionStillCollapsesTrueDuplicates() {
+    final List<Result> rows = new ArrayList<>();
+    try (ResultSet rs = database.query("cypher", """
+        RETURN 1 AS a, 2 AS b
+        UNION
+        RETURN 1 AS a, 2 AS b""")) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+    assertThat(rows).hasSize(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6541WithDistinctStarInternalVariablesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6541WithDistinctStarInternalVariablesTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6541: same class of bug as #5444 ({@link Issue5444ReturnStarInternalVariablesTest}), but for
+ * {@code WITH *} instead of {@code RETURN *}. The executor binds anonymous pattern elements to
+ * generated variables ({@code   __anon0}, ...) that a query never named; {@code WithStep}'s
+ * {@code WITH *} branch forwards them unfiltered, and its {@code DISTINCT} key-building loop counted
+ * them too, so two rows that only differ by such a hidden binding wrongly stayed distinct.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6541WithDistinctStarInternalVariablesTest {
+  private static final String DATABASE_PATH = "./target/databases/issue-6541-with-distinct-star";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DATABASE_PATH).create();
+    database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Node").set("id", "hub").save();
+      for (final String id : List.of("a", "b")) {
+        final MutableVertex leaf = database.newVertex("Node").set("id", id).save();
+        leaf.newEdge("LINK", hub, true, (Object[]) null).save();
+      }
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null)
+      database.drop();
+  }
+
+  /**
+   * The anonymous source node differs between the two matched paths, but only {@code hub} is ever
+   * returned: {@code WITH DISTINCT *} must collapse the two rows to one, the same way
+   * {@code RETURN DISTINCT *} already does for #5444.
+   */
+  @Test
+  void withDistinctStarIgnoresTheHiddenVariables() {
+    final List<String> ids = new ArrayList<>();
+    try (ResultSet resultSet = database.query("opencypher",
+        "MATCH (:Node)-[:LINK]->(hub:Node) WHERE hub.id = 'hub' WITH DISTINCT * RETURN hub.id AS id")) {
+      while (resultSet.hasNext())
+        ids.add(resultSet.next().getProperty("id"));
+    }
+    assertThat(ids).containsExactly("hub");
+  }
+
+  /**
+   * {@code WITH *} still forwards every in-scope variable downstream (only the DISTINCT key ignores
+   * the internal ones), so a plain, non-distinct {@code WITH *} keeps behaving exactly as before.
+   */
+  @Test
+  void withStarStillForwardsNamedVariables() {
+    try (ResultSet resultSet = database.query("opencypher",
+        "MATCH (hub:Node) WHERE hub.id = 'hub' WITH * RETURN hub.id AS id")) {
+      assertThat(resultSet.hasNext()).isTrue();
+      assertThat(resultSet.next().<String>getProperty("id")).isEqualTo("hub");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6573CreateMergeEdgeVariableTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6573CreateMergeEdgeVariableTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #6573.
+ * <p>
+ * {@code CypherVariableUsage.isEdgeVariableReferenced} decides whether a MATCH-bound relationship
+ * variable keeps its real binding (vs. being anonymized for the CSR/GAV fast path) by walking every
+ * clause type in {@code statement.getClausesInOrder()}. The top-level switch had no
+ * {@code case CREATE}/{@code case MERGE} - unlike its sibling {@code foreachReferencesVariable} in the
+ * same file, which already treats a nested CREATE/MERGE conservatively - so a top-level CREATE/MERGE
+ * fell to {@code default} and was never inspected. That anonymized the edge whenever nothing else in
+ * the query mentioned it, so an inline property expression like {@code CREATE (c {since: r.since})}
+ * silently read a missing binding and evaluated to null instead of the real value.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6573CreateMergeEdgeVariableTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (a:Person {id: 'a'})-[r:KNOWS {since: 2001}]->(b:Person {id: 'b'})");
+  }
+
+  /** The issue's own reproducer: a relationship read only inside a CREATE inline property. */
+  @Test
+  void createReadsTheEdgePropertyThroughAnInlineExpression() {
+    try (final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person)-[r:KNOWS]->(b:Person) CREATE (c:Note {since: r.since}) RETURN c.since AS s")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("s").intValue()).isEqualTo(2001);
+    }
+  }
+
+  /** Same defect via MERGE instead of CREATE. */
+  @Test
+  void mergeReadsTheEdgePropertyThroughAnInlineExpression() {
+    try (final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person)-[r:KNOWS]->(b:Person) MERGE (c:Note {since: r.since}) RETURN c.since AS s")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("s").intValue()).isEqualTo(2001);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6665CallSubqueryCountEquivalenceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6665CallSubqueryCountEquivalenceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression guard for issue #6665: on ArcadeDB 26.8.1, a read-only {@code CALL (...) { ... RETURN count(*) }}
+ * subquery reported a different {@code count(*)} depending on whether its inner {@code MATCH}/{@code WHERE}
+ * result flowed straight into {@code RETURN count(*)} or was first materialized through {@code collect()}/
+ * {@code UNWIND} before the same {@code count(*)} - two forms that must be equivalent for a read-only subquery.
+ * <p>
+ * This exact repro (verbatim from the issue) no longer reproduces on this branch: both forms agree with each
+ * other and with a ground-truth standalone count of the same pattern. This test pins that down so a future
+ * regression in CALL-subquery / {@code count(*)} evaluation is caught.
+ */
+class Issue6665CallSubqueryCountEquivalenceTest {
+
+  @Test
+  void directCountAndMaterializedCountAgreeInsideCallSubquery() {
+    final Database database = new DatabaseFactory("./target/databases/issue6665-call-count-equivalence").create();
+    try {
+      database.transaction(() -> database.command("cypher", """
+          CREATE (oa:V {klist: [1167157462, -165975848, -164122097]}),
+                 (ob:V {k10: 254370155}),
+                 (oc:V),
+                 (od:V {k2: "CILs3s"}),
+                 (oe:V {k10: -866288821}),
+                 (n0:V {k7: 1994572697, k2: "D5ZqpQB"}),
+                 (n1:V),
+                 (x:V {k10: -1192051958}),
+                 (y:V {k9: "5sm", id: 85}),
+                 (ob)-[:rt6 {k8: "G", k3: true}]->(oa),
+                 (ob)-[:rt8 {k8: "nPemIkbA", k10: -1906562515}]->(oc),
+                 (od)-[:rt9 {k7: -51638479}]->(oe),
+                 (n1)-[:R]->(x)-[:rt8]->(y)-[:rt2 {k11: [1]}]->(n0)
+          """));
+
+      // Query A: the CALL subquery's inner MATCH/WHERE result flows straight into RETURN count(*).
+      final String queryA = """
+          MATCH DIFFERENT RELATIONSHIPS
+            ({klist: [1167157462, -165975848, -164122097]})
+              <-[r0:rt6 {k8: "G"}]-({k10: 254370155})
+              -[r1:rt8 {k8: "nPemIkbA", k10: -1906562515}]->(),
+            p0 = ({k2: "CILs3s"})-[:rt9 {k7: -51638479}]->({k10: -866288821})
+          WHERE r0.k3 = true
+          CALL (r0, r1, p0) {
+            MATCH (n0 {k7: 1994572697, k2: "D5ZqpQB"}),
+                  (n1)-[r3]->({k10: -1192051958})-[:rt8]->
+                    (:V {k9: "5sm", id: 85})-[r2:rt2|rt10|rt9]->(n0)
+            WHERE single(item IN r2.k11 WHERE item IS NOT NULL)
+            RETURN count(*) AS __expr_count
+          }
+          RETURN __expr_count > 0 AS __v
+          """;
+
+      // Query B: identical, but the matched bindings are first materialized through collect()/UNWIND before the
+      // same count(*) - a read-only subquery must report the same answer either way.
+      final String queryB = """
+          MATCH DIFFERENT RELATIONSHIPS
+            ({klist: [1167157462, -165975848, -164122097]})
+              <-[r0:rt6 {k8: "G"}]-({k10: 254370155})
+              -[r1:rt8 {k8: "nPemIkbA", k10: -1906562515}]->(),
+            p0 = ({k2: "CILs3s"})-[:rt9 {k7: -51638479}]->({k10: -866288821})
+          WHERE r0.k3 = true
+          CALL (r0, r1, p0) {
+            MATCH (n0 {k7: 1994572697, k2: "D5ZqpQB"}),
+                  (n1)-[r3]->({k10: -1192051958})-[:rt8]->
+                    (:V {k9: "5sm", id: 85})-[r2:rt2|rt10|rt9]->(n0)
+            WHERE single(item IN r2.k11 WHERE item IS NOT NULL)
+            WITH {r0: r0, r1: r1, p0: p0, n0: n0, n1: n1, r3: r3, r2: r2} AS __row
+            WITH collect(__row) AS __rows
+            UNWIND __rows AS __layer_row
+            RETURN count(*) AS __expr_count
+          }
+          RETURN __expr_count > 0 AS __v
+          """;
+
+      final Object resultA;
+      try (ResultSet rs = database.query("cypher", queryA)) {
+        assertThat(rs.hasNext()).isTrue();
+        resultA = rs.next().getProperty("__v");
+      }
+      final Object resultB;
+      try (ResultSet rs = database.query("cypher", queryB)) {
+        assertThat(rs.hasNext()).isTrue();
+        resultB = rs.next().getProperty("__v");
+      }
+
+      // Ground truth: the same inner pattern, matched standalone (bound to r0/r1/p0 via WITH instead of CALL) and
+      // counted directly, independent of the CALL-subquery machinery under test.
+      final String groundTruth = """
+          MATCH DIFFERENT RELATIONSHIPS
+            ({klist: [1167157462, -165975848, -164122097]})
+              <-[r0:rt6 {k8: "G"}]-({k10: 254370155})
+              -[r1:rt8 {k8: "nPemIkbA", k10: -1906562515}]->(),
+            p0 = ({k2: "CILs3s"})-[:rt9 {k7: -51638479}]->({k10: -866288821})
+          WHERE r0.k3 = true
+          WITH r0, r1, p0
+          MATCH (n0 {k7: 1994572697, k2: "D5ZqpQB"}),
+                (n1)-[r3]->({k10: -1192051958})-[:rt8]->
+                  (:V {k9: "5sm", id: 85})-[r2:rt2|rt10|rt9]->(n0)
+          WHERE single(item IN r2.k11 WHERE item IS NOT NULL)
+          RETURN count(*) AS c
+          """;
+      final long groundTruthCount;
+      try (ResultSet rs = database.query("cypher", groundTruth)) {
+        assertThat(rs.hasNext()).isTrue();
+        final Result row = rs.next();
+        groundTruthCount = ((Number) row.getProperty("c")).longValue();
+      }
+
+      assertThat(groundTruthCount).as("the inner pattern matches exactly one row").isEqualTo(1L);
+      assertThat(resultA).as("direct count(*)").isEqualTo(true);
+      assertThat(resultB).as("collect()/UNWIND-materialized count(*)").isEqualTo(true);
+      assertThat(resultA).as("direct and materialized count(*) must agree").isEqualTo(resultB);
+    } finally {
+      database.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6665CallSubqueryCountEquivalenceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6665CallSubqueryCountEquivalenceTest.java
@@ -73,7 +73,7 @@ class Issue6665CallSubqueryCountEquivalenceTest {
             WHERE single(item IN r2.k11 WHERE item IS NOT NULL)
             RETURN count(*) AS __expr_count
           }
-          RETURN __expr_count > 0 AS __v
+          RETURN __expr_count AS __v
           """;
 
       // Query B: identical, but the matched bindings are first materialized through collect()/UNWIND before the
@@ -95,18 +95,18 @@ class Issue6665CallSubqueryCountEquivalenceTest {
             UNWIND __rows AS __layer_row
             RETURN count(*) AS __expr_count
           }
-          RETURN __expr_count > 0 AS __v
+          RETURN __expr_count AS __v
           """;
 
-      final Object resultA;
+      final long resultA;
       try (ResultSet rs = database.query("cypher", queryA)) {
         assertThat(rs.hasNext()).isTrue();
-        resultA = rs.next().getProperty("__v");
+        resultA = ((Number) rs.next().getProperty("__v")).longValue();
       }
-      final Object resultB;
+      final long resultB;
       try (ResultSet rs = database.query("cypher", queryB)) {
         assertThat(rs.hasNext()).isTrue();
-        resultB = rs.next().getProperty("__v");
+        resultB = ((Number) rs.next().getProperty("__v")).longValue();
       }
 
       // Ground truth: the same inner pattern, matched standalone (bound to r0/r1/p0 via WITH instead of CALL) and
@@ -133,8 +133,8 @@ class Issue6665CallSubqueryCountEquivalenceTest {
       }
 
       assertThat(groundTruthCount).as("the inner pattern matches exactly one row").isEqualTo(1L);
-      assertThat(resultA).as("direct count(*)").isEqualTo(true);
-      assertThat(resultB).as("collect()/UNWIND-materialized count(*)").isEqualTo(true);
+      assertThat(resultA).as("direct count(*) must match the ground-truth count").isEqualTo(groundTruthCount);
+      assertThat(resultB).as("collect()/UNWIND-materialized count(*) must match the ground-truth count").isEqualTo(groundTruthCount);
       assertThat(resultA).as("direct and materialized count(*) must agree").isEqualTo(resultB);
     } finally {
       database.drop();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6673ListPredicateAggregation3vlTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6673ListPredicateAggregation3vlTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #6673.
+ * <p>
+ * The list predicates {@code all()}/{@code any()}/{@code none()}/{@code single()} lose Cypher
+ * three-valued logic (3VL) when evaluated inside a projection that also contains an aggregation:
+ * {@link com.arcadedb.query.opencypher.executor.ExpressionEvaluator} used to special-case
+ * {@code ListPredicateExpression} with its own {@code evaluateListPredicate} that counted only
+ * {@code Boolean.TRUE} matches and could only ever return {@code true} or {@code false}, never
+ * {@code null} - diverging from the primary AST implementation
+ * ({@link com.arcadedb.query.opencypher.ast.ListPredicateExpression#evaluate}) and from the
+ * openCypher truth tables, where a predicate that is {@code null} for every element yields
+ * {@code null}, not {@code false}/{@code true}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6673ListPredicateAggregation3vlTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (:Person {name: 'A'})");
+    database.command("opencypher", "CREATE (:Person {name: 'B'})");
+    database.command("opencypher", "CREATE (:Person {name: 'C'})");
+  }
+
+  @Test
+  void anyReturnsNullWhenEveryElementPredicateIsNullInsideAggregation() {
+    // Every element's predicate is null (x.nonexistent > 0 -> null) over a non-empty collected list.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN any(x IN collect(v) WHERE x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Object>getProperty("r")).isNull();
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
+  void allReturnsNullWhenEveryElementPredicateIsNullInsideAggregation() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN all(x IN collect(v) WHERE x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("r")).isNull();
+  }
+
+  @Test
+  void noneReturnsNullWhenEveryElementPredicateIsNullInsideAggregation() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN none(x IN collect(v) WHERE x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("r")).isNull();
+  }
+
+  @Test
+  void singleReturnsNullWhenEveryElementPredicateIsNullInsideAggregation() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN single(x IN collect(v) WHERE x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("r")).isNull();
+  }
+
+  @Test
+  void anyStillTrueWhenAtLeastOneElementMatchesInsideAggregation() {
+    // Sanity check: the fix must not turn a genuine match into null. Two elements are null, one is true.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN any(x IN collect(v) WHERE x.name = 'A' OR x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat((Boolean) rs.next().getProperty("r")).isTrue();
+  }
+
+  @Test
+  void noneStillFalseWhenAnElementMatchesInsideAggregation() {
+    // Sanity check: a genuine true predicate among nulls must still make none() false, not null.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (v:Person) RETURN none(x IN collect(v) WHERE x.name = 'A' OR x.nonexistent > 0) AS r");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat((Boolean) rs.next().getProperty("r")).isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6676NumericGroupByEqualityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6676NumericGroupByEqualityTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6676: Cypher {@code GROUP BY} (the implicit grouping {@link
+ * com.arcadedb.query.opencypher.executor.steps.GroupByAggregationStep} performs when a RETURN/WITH clause mixes
+ * aggregations with non-aggregated expressions) keyed its groups on the raw boxed grouping value instead of
+ * canonicalizing numeric types the way its sibling DISTINCT paths do (issue #5789, {@link
+ * com.arcadedb.function.DistinctNumericKey}). A value present as different numeric runtime types (Integer 1 vs Long 1
+ * vs Double 1.0) therefore split into separate groups, even though {@code 1 = 1.0} evaluates to {@code true}.
+ */
+class Issue6676NumericGroupByEqualityTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue6676-numeric-groupby").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void singleKeyGroupByCollapsesNumericallyEqualCrossTypeValues() {
+    try (final ResultSet rs = database.query("opencypher", "UNWIND [1, 1.0, 1] AS x RETURN x, count(*) AS c")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("x")).doubleValue()).isEqualTo(1.0);
+      assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(3L);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void singleKeyGroupByStillSeparatesNumericallyDifferentValues() {
+    try (final ResultSet rs = database.query("opencypher", "UNWIND [1, 1.0, 2] AS x RETURN x, count(*) AS c ORDER BY c DESC")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result first = rs.next();
+      assertThat(((Number) first.getProperty("c")).longValue()).isEqualTo(2L);
+      assertThat(rs.hasNext()).isTrue();
+      final Result second = rs.next();
+      assertThat(((Number) second.getProperty("c")).longValue()).isEqualTo(1L);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void multiKeyGroupByCollapsesNumericallyEqualCrossTypeValues() {
+    try (final ResultSet rs = database.query("opencypher",
+        "UNWIND [[1, 'a'], [1.0, 'a'], [2, 'b']] AS pair RETURN pair[0] AS n, pair[1] AS label, count(*) AS c")) {
+      long total = 0;
+      int rows = 0;
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        total += ((Number) row.getProperty("c")).longValue();
+        rows++;
+      }
+      assertThat(rows).isEqualTo(2); // (1/1.0, 'a') collapses into one group, (2, 'b') is the other
+      assertThat(total).isEqualTo(3);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCypher25ClausesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCypher25ClausesTest.java
@@ -161,6 +161,56 @@ class OpenCypherCypher25ClausesTest {
   }
 
   // ---------------------------------------------------------------------------
+  // FILTER clause (issue #6574)
+  // ---------------------------------------------------------------------------
+
+  // Issue #6574: a standalone FILTER with a false predicate must suppress all rows
+  // instead of being silently ignored.
+  @Test
+  void filterFalsePredicateProducesNoRows() {
+    final ResultSet result = database.query("opencypher", "FILTER (0 IN range(12, 1, -1)) RETURN 1 AS x");
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  // Issue #6574: a standalone FILTER with a true predicate must let rows through.
+  @Test
+  void filterTruePredicateProducesRow() {
+    final ResultSet result = database.query("opencypher", "FILTER (1 IN range(12, 1, -1)) RETURN 1 AS x");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(((Number) result.next().getProperty("x")).intValue()).isEqualTo(1);
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  // Issue #6574: the grammar's optional WHERE keyword form (FILTER WHERE <expr>) must also filter.
+  @Test
+  void filterWithWhereKeywordFalsePredicateProducesNoRows() {
+    final ResultSet result = database.query("opencypher", "FILTER WHERE 1 = 2 RETURN 1 AS x");
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  void filterWithWhereKeywordTruePredicateProducesRow() {
+    final ResultSet result = database.query("opencypher", "FILTER WHERE 1 = 1 RETURN 1 AS x");
+    assertThat(result.hasNext()).isTrue();
+  }
+
+  // Issue #6574: FILTER must actually restrict rows produced by a preceding MATCH,
+  // the same way an equivalent WHERE would - not just no-op on a constant.
+  @Test
+  void filterAfterMatchRestrictsRowsByProperty() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name: 'Alice', age: 40})");
+      database.command("opencypher", "CREATE (:Person {name: 'Bob', age: 20})");
+    });
+
+    final ResultSet result = database.query("opencypher", "MATCH (n:Person) FILTER (n.age > 30) RETURN n.name AS name");
+    final List<String> names = new ArrayList<>();
+    while (result.hasNext())
+      names.add(result.next().getProperty("name"));
+    assertThat(names).containsExactly("Alice");
+  }
+
+  // ---------------------------------------------------------------------------
   // INSERT clause (issue #3365 section 1.1)
   // ---------------------------------------------------------------------------
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.executor.steps.DeleteStep;
+import com.arcadedb.query.opencypher.executor.steps.ForeachStep;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
+import com.arcadedb.query.sql.executor.ExecutionStep;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6631: the eager-materialization gate that {@code DeleteStep}/{@code
+ * ForeachStep} use to guard against issue #6491 (a disconnected-pattern MATCH re-observing an
+ * already-deleted entity across output rows) was scoped to the whole statement rather than to the MATCH
+ * clause(s) actually feeding a given DELETE/FOREACH segment. A multi-segment statement (WITH-separated
+ * MATCH/write pairs) where any segment happens to contain an unrelated, incidental disconnected-pattern
+ * MATCH forced every DELETE/FOREACH in the statement onto the eager, whole-row-set-buffered path, even a
+ * bulk delete elsewhere that has nothing to do with the disconnected pattern.
+ * <p>
+ * These tests read the private {@code eagerMaterialize} field off the built {@code DeleteStep}/{@code
+ * ForeachStep} via reflection - the flag has no other externally observable effect short of a memory
+ * measurement, since both the eager and the streaming path delete the same rows and return the same
+ * results.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
+  private Database database;
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+  }
+
+  private static boolean eagerMaterializeOf(final Object step) {
+    try {
+      final Field field = step.getClass().getDeclaredField("eagerMaterialize");
+      field.setAccessible(true);
+      return field.getBoolean(step);
+    } catch (final ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static <T> T findStep(final ResultSet result, final Class<T> type) {
+    final Optional<ExecutionPlan> plan = result.getExecutionPlan();
+    assertThat(plan).isPresent();
+    for (final ExecutionStep step : plan.get().getSteps())
+      if (type.isInstance(step))
+        return type.cast(step);
+    throw new IllegalStateException("No " + type.getSimpleName() + " found in execution plan");
+  }
+
+  @Test
+  void deleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-unrelated").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Tag {name: 'x'})");
+      database.command("opencypher", "CREATE (:Tag {name: 'y'})");
+      database.command("opencypher", "CREATE (:Big {id: 1})");
+      database.command("opencypher", "CREATE (:Big {id: 2})");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (a:Tag {name: 'x'}), (b:Tag {name: 'y'}) WITH a, b "
+              + "MATCH (n:Big) DETACH DELETE n")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("DELETE fed only by a connected MATCH must not pay the eager-materialization "
+                + "cost just because an earlier, unrelated WITH-separated segment has a "
+                + "disconnected-pattern MATCH")
+            .isFalse();
+      }
+    });
+
+    try (ResultSet remaining = database.query("opencypher", "MATCH (n:Big) RETURN n")) {
+      assertThat(remaining.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void deleteDirectlyFedByADisconnectedMatchStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-direct").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "DETACH DELETE n RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("DELETE fed by a disconnected-pattern MATCH in its own segment must keep "
+                + "eagerly materializing - regression guard for issue #6491")
+            .isTrue();
+      }
+    });
+  }
+
+  @Test
+  void foreachDeleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-unrelated").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Tag {name: 'x'})");
+      database.command("opencypher", "CREATE (:Tag {name: 'y'})");
+      database.command("opencypher", "CREATE (:Big {id: 1})");
+      database.command("opencypher", "CREATE (:Big {id: 2})");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (a:Tag {name: 'x'}), (b:Tag {name: 'y'}) WITH a, b "
+              + "MATCH (n:Big) FOREACH (x IN [1] | DETACH DELETE n)")) {
+        while (result.hasNext())
+          result.next();
+
+        final ForeachStep foreachStep = findStep(result, ForeachStep.class);
+        assertThat(eagerMaterializeOf(foreachStep))
+            .withFailMessage("FOREACH DELETE fed only by a connected MATCH must not pay the "
+                + "eager-materialization cost just because an earlier, unrelated WITH-separated segment "
+                + "has a disconnected-pattern MATCH")
+            .isFalse();
+      }
+    });
+
+    try (ResultSet remaining = database.query("opencypher", "MATCH (n:Big) RETURN n")) {
+      assertThat(remaining.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void foreachDeleteDirectlyFedByADisconnectedMatchStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-direct").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "FOREACH (x IN [1] | DETACH DELETE n) RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final ForeachStep foreachStep = findStep(result, ForeachStep.class);
+        assertThat(eagerMaterializeOf(foreachStep))
+            .withFailMessage("FOREACH DELETE fed by a disconnected-pattern MATCH in its own segment must "
+                + "keep eagerly materializing - regression guard for issue #6491")
+            .isTrue();
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -220,6 +220,43 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
     }
   }
 
+  /**
+   * Same hazard as {@link #deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes()},
+   * but the passthrough is spelled {@code WITH *} instead of naming the forwarded variables. {@code
+   * propagateTaintThroughRenames()} explicitly skips star items (there is no single expression/alias pair
+   * to inspect), so this pins down that the direct, same-name taint {@code closeMatchSegment()} already
+   * applies is what covers this shape - not the rename-propagation logic.
+   */
+  @Test
+  void deleteOfADisconnectedMatchsOwnVariableForwardedThroughAStarWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-star").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "WITH * "
+              + "DETACH DELETE n RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH * that forwards everything unchanged does not neutralize the issue "
+                + "#6491 hazard for a disconnected-pattern MATCH's own variable - a DELETE of it "
+                + "downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+  }
+
   @Test
   void foreachDeleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
     database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-unrelated").create();
@@ -311,17 +348,6 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
   }
 
   /**
-   * Backs the comment on {@code CypherExecutionPlan.buildExecutionStepsLegacy()}'s DELETE construction
-   * site, which leaves it using the unscoped, statement-wide {@code matchClausesHaveDisconnectedPatterns
-   * (statement.getMatchClauses())} rather than this issue's segment-scoped fix: that is only safe if a
-   * multi-segment, WITH-separated MATCH/DELETE statement - the shape #6631 is about - can never actually
-   * reach that method, because {@code CypherExecutionPlan.buildExecutionSteps()} only falls back to it
-   * when {@code statement.getClausesInOrder()} is null or empty. Parses the same query shape used by
-   * {@link #deleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized()} through the
-   * real production parser and asserts {@code getClausesInOrder()} is populated, confirming the premise
-   * with an executable check rather than an unverified comment.
-   */
-  /**
    * Same hazard as {@link #deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes()},
    * but the WITH renames the tainted variable ({@code WITH n AS m}) instead of forwarding it under the
    * same name - a rename doesn't change how rows flow either, so it must not lose the taint. Without
@@ -392,6 +418,17 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
     }
   }
 
+  /**
+   * Backs the comment on {@code CypherExecutionPlan.buildExecutionStepsLegacy()}'s DELETE construction
+   * site, which leaves it using the unscoped, statement-wide {@code matchClausesHaveDisconnectedPatterns
+   * (statement.getMatchClauses())} rather than this issue's segment-scoped fix: that is only safe if a
+   * multi-segment, WITH-separated MATCH/DELETE statement - the shape #6631 is about - can never actually
+   * reach that method, because {@code CypherExecutionPlan.buildExecutionSteps()} only falls back to it
+   * when {@code statement.getClausesInOrder()} is null or empty. Parses the same query shape used by
+   * {@link #deleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized()} through the
+   * real production parser and asserts {@code getClausesInOrder()} is populated, confirming the premise
+   * with an executable check rather than an unverified comment.
+   */
   @Test
   void aMultiSegmentWithSeparatedStatementAlwaysPopulatesClausesInOrder() {
     final CypherStatement statement = new Cypher25AntlrParser().parse(

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -20,8 +20,10 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.ast.CypherStatement;
 import com.arcadedb.query.opencypher.executor.steps.DeleteStep;
 import com.arcadedb.query.opencypher.executor.steps.ForeachStep;
+import com.arcadedb.query.opencypher.parser.Cypher25AntlrParser;
 import com.arcadedb.query.sql.executor.ExecutionPlan;
 import com.arcadedb.query.sql.executor.ExecutionStep;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -178,6 +180,46 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
     });
   }
 
+  /**
+   * Same hazard as {@link #deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes()},
+   * but the forwarded, tainted variable is a relationship bound by the disconnected MATCH rather than a
+   * node - {@code closeMatchSegment()} must taint relationship variables too, not just node variables,
+   * since a disconnected MATCH can rebind the same underlying edge across rows exactly as it can a
+   * vertex (see {@code DeleteStep}'s own {@code eagerMaterialize} field doc).
+   */
+  @Test
+  void deleteOfADisconnectedMatchsOwnRelationshipVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-rel-passthrough").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:A)-[:REL]->(:B)");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (a:A)-[r:REL]->(b:B), (o:Other) "
+              + "WITH r, o "
+              + "DELETE r RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH that plainly forwards a disconnected-pattern MATCH's own relationship "
+                + "variable (WITH r, o) does not neutralize the issue #6491 hazard for that variable - a "
+                + "DELETE of it downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+
+    try (ResultSet remaining = database.query("opencypher", "MATCH ()-[r:REL]->() RETURN r")) {
+      assertThat(remaining.hasNext()).isFalse();
+    }
+  }
+
   @Test
   void foreachDeleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
     database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-unrelated").create();
@@ -266,5 +308,30 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
             .isTrue();
       }
     });
+  }
+
+  /**
+   * Backs the comment on {@code CypherExecutionPlan.buildExecutionStepsLegacy()}'s DELETE construction
+   * site, which leaves it using the unscoped, statement-wide {@code matchClausesHaveDisconnectedPatterns
+   * (statement.getMatchClauses())} rather than this issue's segment-scoped fix: that is only safe if a
+   * multi-segment, WITH-separated MATCH/DELETE statement - the shape #6631 is about - can never actually
+   * reach that method, because {@code CypherExecutionPlan.buildExecutionSteps()} only falls back to it
+   * when {@code statement.getClausesInOrder()} is null or empty. Parses the same query shape used by
+   * {@link #deleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized()} through the
+   * real production parser and asserts {@code getClausesInOrder()} is populated, confirming the premise
+   * with an executable check rather than an unverified comment.
+   */
+  @Test
+  void aMultiSegmentWithSeparatedStatementAlwaysPopulatesClausesInOrder() {
+    final CypherStatement statement = new Cypher25AntlrParser().parse(
+        "MATCH (a:Tag {name: 'x'}), (b:Tag {name: 'y'}) WITH a, b MATCH (n:Big) DETACH DELETE n");
+
+    assertThat(statement.getClausesInOrder())
+        .withFailMessage("A multi-segment, WITH-separated MATCH/DELETE statement must populate "
+            + "getClausesInOrder() when parsed through the real parser - otherwise "
+            + "buildExecutionStepsLegacy()'s unscoped DELETE construction site would be reachable for "
+            + "exactly the shape issue #6631 is about")
+        .isNotNull()
+        .isNotEmpty();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -321,6 +321,77 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
    * real production parser and asserts {@code getClausesInOrder()} is populated, confirming the premise
    * with an executable check rather than an unverified comment.
    */
+  /**
+   * Same hazard as {@link #deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes()},
+   * but the WITH renames the tainted variable ({@code WITH n AS m}) instead of forwarding it under the
+   * same name - a rename doesn't change how rows flow either, so it must not lose the taint. Without
+   * {@code propagateTaintThroughRenames()}, {@code closeMatchSegment()} taints {@code n} but a later
+   * {@code DELETE m} checks {@code m} against the taint set and finds nothing.
+   */
+  @Test
+  void deleteOfADisconnectedMatchsOwnVariableRenamedThroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-rename").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "WITH n AS m, o "
+              + "DETACH DELETE m RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH that renames a disconnected-pattern MATCH's own variable "
+                + "(WITH n AS m) does not neutralize the issue #6491 hazard for it - a DELETE of the new "
+                + "name downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+  }
+
+  /** Same as above, but renaming the disconnected MATCH's relationship variable rather than a node. */
+  @Test
+  void deleteOfADisconnectedMatchsOwnRelationshipVariableRenamedThroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-rel-rename").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:A)-[:REL]->(:B)");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (a:A)-[r:REL]->(b:B), (o:Other) "
+              + "WITH r AS r2, o "
+              + "DELETE r2 RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH that renames a disconnected-pattern MATCH's own relationship "
+                + "variable (WITH r AS r2) does not neutralize the issue #6491 hazard for it - a DELETE "
+                + "of the new name downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+
+    try (ResultSet remaining = database.query("opencypher", "MATCH ()-[r:REL]->() RETURN r")) {
+      assertThat(remaining.hasNext()).isFalse();
+    }
+  }
+
   @Test
   void aMultiSegmentWithSeparatedStatementAlwaysPopulatesClausesInOrder() {
     final CypherStatement statement = new Cypher25AntlrParser().parse(

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -42,6 +42,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * MATCH forced every DELETE/FOREACH in the statement onto the eager, whole-row-set-buffered path, even a
  * bulk delete elsewhere that has nothing to do with the disconnected pattern.
  * <p>
+ * The straightforward fix - clear the tracked MATCH clauses at every WITH boundary - has its own gap:
+ * a WITH that plainly forwards a variable bound by a disconnected-pattern MATCH (e.g. {@code WITH n, o})
+ * does not resolve the #6491 hazard for that variable, since rows out of a disconnected-pattern MATCH
+ * still flow one at a time through a non-aggregating WITH. {@code CypherExecutionPlan} guards against
+ * this with a persistent "tainted variable" set: once a segment is found disconnected, its variables stay
+ * tainted for the rest of the statement, and a later DELETE/FOREACH is still eagerly materialized if it
+ * targets one of them - regardless of how many WITH clauses forwarded it in between.
+ * <p>
  * These tests read the private {@code eagerMaterialize} field off the built {@code DeleteStep}/{@code
  * ForeachStep} via reflection - the flag has no other externally observable effect short of a memory
  * measurement, since both the eager and the streaming path delete the same rows and return the same
@@ -141,6 +149,36 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
   }
 
   @Test
+  void deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-passthrough").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "WITH n, o "
+              + "DETACH DELETE n RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH that plainly forwards a disconnected-pattern MATCH's own variable "
+                + "(WITH n, o) does not neutralize the issue #6491 hazard for that variable - a DELETE of "
+                + "it downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+  }
+
+  @Test
   void foreachDeleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
     database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-unrelated").create();
 
@@ -195,6 +233,36 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
         assertThat(eagerMaterializeOf(foreachStep))
             .withFailMessage("FOREACH DELETE fed by a disconnected-pattern MATCH in its own segment must "
                 + "keep eagerly materializing - regression guard for issue #6491")
+            .isTrue();
+      }
+    });
+  }
+
+  @Test
+  void foreachDeleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-passthrough").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "WITH n, o "
+              + "FOREACH (x IN [1] | DETACH DELETE n) RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final ForeachStep foreachStep = findStep(result, ForeachStep.class);
+        assertThat(eagerMaterializeOf(foreachStep))
+            .withFailMessage("A WITH that plainly forwards a disconnected-pattern MATCH's own variable "
+                + "(WITH n, o) does not neutralize the issue #6491 hazard for that variable - a FOREACH "
+                + "DELETE of it downstream of the WITH must still eagerly materialize")
             .isTrue();
       }
     });

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentralityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentralityTest.java
@@ -132,15 +132,17 @@ class AlgoDegreeCentralityTest {
   }
 
   private void assertDegreeOfE(final String query, final long expectedIn, final long expectedOut, final long expectedDegree) {
-    final ResultSet rs = database.query("opencypher", query);
     boolean found = false;
-    while (rs.hasNext()) {
-      final Result r = rs.next();
-      if ("E".equals(r.getProperty("name"))) {
-        found = true;
-        assertThat(((Number) r.getProperty("inDegree")).longValue()).as(query + " inDegree").isEqualTo(expectedIn);
-        assertThat(((Number) r.getProperty("outDegree")).longValue()).as(query + " outDegree").isEqualTo(expectedOut);
-        assertThat(((Number) r.getProperty("degree")).longValue()).as(query + " degree").isEqualTo(expectedDegree);
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        if ("E".equals(r.getProperty("name"))) {
+          found = true;
+          assertThat(((Number) r.getProperty("inDegree")).longValue()).as(query + " inDegree").isEqualTo(expectedIn);
+          assertThat(((Number) r.getProperty("outDegree")).longValue()).as(query + " outDegree").isEqualTo(expectedOut);
+          assertThat(((Number) r.getProperty("degree")).longValue()).as(query + " degree").isEqualTo(expectedDegree);
+          break;
+        }
       }
     }
     assertThat(found).as("node E must be present in the result").isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentralityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentralityTest.java
@@ -104,6 +104,48 @@ class AlgoDegreeCentralityTest {
     }
   }
 
+  /**
+   * Issue #6716: {@code direction} was parsed but never used, so {@code degree}/{@code score} were always the
+   * full IN+OUT total whatever direction was requested. E has a different in-degree and out-degree (2 out, 3
+   * in), which BOTH/IN/OUT must each answer differently once the parameter actually takes effect.
+   */
+  @Test
+  void degreeDirectionParameterIsHonoured() {
+    database.transaction(() -> {
+      final MutableVertex e = database.newVertex("Node").set("name", "E").save();
+      final MutableVertex f = database.newVertex("Node").set("name", "F").save();
+      e.newEdge("LINK", f, true, (Object[]) null).save();
+      e.newEdge("LINK", f, true, (Object[]) null).save();
+      f.newEdge("LINK", e, true, (Object[]) null).save();
+      f.newEdge("LINK", e, true, (Object[]) null).save();
+      f.newEdge("LINK", e, true, (Object[]) null).save();
+    });
+
+    assertDegreeOfE("CALL algo.degree(null, 'OUT') YIELD node, inDegree, outDegree, degree "
+        + "RETURN node.name AS name, inDegree, outDegree, degree", 0L, 2L, 2L);
+    assertDegreeOfE("CALL algo.degree(null, 'IN') YIELD node, inDegree, outDegree, degree "
+        + "RETURN node.name AS name, inDegree, outDegree, degree", 3L, 0L, 3L);
+    assertDegreeOfE("CALL algo.degree(null, 'BOTH') YIELD node, inDegree, outDegree, degree "
+        + "RETURN node.name AS name, inDegree, outDegree, degree", 3L, 2L, 5L);
+    assertDegreeOfE("CALL algo.degree() YIELD node, inDegree, outDegree, degree "
+        + "RETURN node.name AS name, inDegree, outDegree, degree", 3L, 2L, 5L);
+  }
+
+  private void assertDegreeOfE(final String query, final long expectedIn, final long expectedOut, final long expectedDegree) {
+    final ResultSet rs = database.query("opencypher", query);
+    boolean found = false;
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      if ("E".equals(r.getProperty("name"))) {
+        found = true;
+        assertThat(((Number) r.getProperty("inDegree")).longValue()).as(query + " inDegree").isEqualTo(expectedIn);
+        assertThat(((Number) r.getProperty("outDegree")).longValue()).as(query + " outDegree").isEqualTo(expectedOut);
+        assertThat(((Number) r.getProperty("degree")).longValue()).as(query + " degree").isEqualTo(expectedDegree);
+      }
+    }
+    assertThat(found).as("node E must be present in the result").isTrue();
+  }
+
   @Test
   void degreeReturnsFourResults() {
     final ResultSet rs = database.query("opencypher",

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.graph.olap.GraphAnalyticalViewRegistry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -233,6 +234,71 @@ class AlgoPageRankTest {
     assertThat(sum).isBetween(0.9, 1.1);
 
     gav.shutdown();
+  }
+
+  /**
+   * Regression for issue #6641 code review: {@code AbstractAlgoProcedure.findProvider()}'s whole-graph
+   * fallback loop (used when {@code relTypes} is null, e.g. plain {@code algo.pagerank()}) used to call
+   * {@code isReady()} before {@code coversEdgeType()} - the same ordering bug already fixed in
+   * {@link com.arcadedb.graph.GraphTraversalProviderRegistry#findProvider}, just at a second call site.
+   * Since {@code isReady()} now dispatches a {@link GraphAnalyticalView}'s deferred restore-from-disk as a
+   * side effect when one is pending (see #6641), calling it before checking coverage meant a whole-graph
+   * algorithm would eagerly resolve every registered view's deferred restore, not only the one it can
+   * actually use. Verifies the fix with two persisted-CSR views reopened in the same database: one that
+   * does not cover all edge types (registered first, so the loop has to skip past it) and one that does -
+   * running {@code algo.pagerank()} must resolve only the latter, leaving the former's deferred restore
+   * completely untouched.
+   */
+  @Test
+  void pageRankFindProviderDoesNotTriggerUnrelatedViewsDeferredRestore() throws Exception {
+    database.getSchema().createEdgeType("OTHER");
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("Page").set("name", "X").save();
+      final MutableVertex y = database.newVertex("Page").set("name", "Y").save();
+      x.newEdge("OTHER", y, true, (Object[]) null).save();
+    });
+
+    // Registered first, but does not cover every edge type in the schema (LINKS and OTHER) - not a valid
+    // whole-graph candidate, so the fixed loop must skip it without ever calling isReady() on it.
+    GraphAnalyticalView.builder(database)
+        .withName("pagerank-order-other")
+        .withVertexTypes("Page")
+        .withEdgeTypes("OTHER")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+    // No edge-type filter - covers every edge type, the whole-graph candidate algo.pagerank() should use.
+    GraphAnalyticalView.builder(database)
+        .withName("pagerank-order-whole")
+        .withVertexTypes("Page")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    final String dbPath = database.getDatabasePath();
+    database.close();
+    database = new DatabaseFactory(dbPath).open();
+
+    final GraphAnalyticalView other = GraphAnalyticalViewRegistry.get(database, "pagerank-order-other");
+    final GraphAnalyticalView whole = GraphAnalyticalViewRegistry.get(database, "pagerank-order-whole");
+    assertThat(other).isNotNull();
+    assertThat(whole).isNotNull();
+    assertThat(other.getStatus())
+        .as("both persisted CSRs must still be provisionally READY, unresolved, right after reopen")
+        .isEqualTo(GraphAnalyticalView.Status.READY);
+    assertThat(whole.getStatus()).isEqualTo(GraphAnalyticalView.Status.READY);
+
+    try (final ResultSet rs = database.query("opencypher",
+        "CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 5, tolerance: 0.0001}) YIELD node, score RETURN count(*) AS c")) {
+      assertThat(rs.hasNext()).isTrue();
+    }
+
+    assertThat(other.getStatus())
+        .as("issue #6641: a whole-graph algorithm must not eagerly resolve an unrelated view's deferred "
+            + "restore just because it was iterated over while searching for a usable provider")
+        .isEqualTo(GraphAnalyticalView.Status.READY);
+    assertThat(other.isBuilt()).isFalse();
+
+    other.drop();
+    whole.drop();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCCTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCCTest.java
@@ -20,9 +20,12 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -35,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -217,6 +221,51 @@ class AlgoWCCTest {
 
     final Map<String, Long> comp = componentsByName("CALL algo.wcc('EDGE')");
     assertThat(comp.get("D")).isNotEqualTo(comp.get("A"));
+  }
+
+  @Test
+  void wccWithRelTypesStillUsesCSRAccelerationWhenViewCoversTheRequestedType() {
+    // The whole point of restricting the filter to CSR-backed calls: a relType filter must not
+    // fall back to the single-threaded OLTP BFS just because a view happens to be present. The
+    // view here covers both EDGE and OTHER, wider than the 'EDGE' request, so this also re-checks
+    // that CSR acceleration doesn't widen the result the way wccWithRelTypesIsNotWidenedByAViewCoveringMoreTypes
+    // already does for correctness - this test is the counterweight for performance: if the view
+    // were silently bypassed for a filtered call, CSR_ACCELERATED_VAR would never be set.
+    bridgeComponentsWithOtherEdge();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Node")
+        .withEdgeTypes("EDGE", "OTHER")
+        .build();
+    try {
+      assertThat(gav.isBuilt()).isTrue();
+
+      database.begin();
+      try {
+        final BasicCommandContext context = new BasicCommandContext();
+        context.setDatabase(database);
+        final List<Result> rows = new AlgoWCC().execute(new Object[] { "EDGE" }, null, context)
+            .collect(Collectors.toList());
+
+        assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+            .as("a filtered call must still be able to use the view")
+            .isEqualTo(true);
+
+        final Map<String, Long> comp = new HashMap<>();
+        for (final Result row : rows)
+          comp.put(((RID) row.getProperty("node")).asVertex().getString("name"),
+              ((Number) row.getProperty("componentId")).longValue());
+
+        assertThat(comp.get("B")).isEqualTo(comp.get("A"));
+        assertThat(comp.get("C")).isEqualTo(comp.get("A"));
+        assertThat(comp.get("E")).isEqualTo(comp.get("D"));
+        assertThat(comp.get("D")).isNotEqualTo(comp.get("A"));
+      } finally {
+        database.rollback();
+      }
+    } finally {
+      gav.drop();
+    }
   }
 
   private void bridgeComponentsWithOtherEdge() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCCTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCCTest.java
@@ -21,6 +21,8 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -28,8 +30,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +54,7 @@ class AlgoWCCTest {
     database = factory.create();
     database.getSchema().createVertexType("Node");
     database.getSchema().createEdgeType("EDGE");
+    database.getSchema().createEdgeType("OTHER");
 
     // Two disconnected components:
     // Component 1: A -> B -> C
@@ -158,5 +163,80 @@ class AlgoWCCTest {
     } finally {
       db.drop();
     }
+  }
+
+  @Test
+  void wccWithRelTypesRestrictsToThoseEdges() {
+    bridgeComponentsWithOtherEdge();
+
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('EDGE')");
+    assertThat(comp.get("B")).isEqualTo(comp.get("A"));
+    assertThat(comp.get("C")).isEqualTo(comp.get("A"));
+    assertThat(comp.get("E")).isEqualTo(comp.get("D"));
+    assertThat(comp.get("D")).isNotEqualTo(comp.get("A"));
+  }
+
+  @Test
+  void wccWithRelTypesIgnoresOtherEdgeTypes() {
+    bridgeComponentsWithOtherEdge();
+
+    // OTHER holds only C -> D, so A, B and E stay on their own
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('OTHER')");
+    assertThat(comp.get("D")).isEqualTo(comp.get("C"));
+    assertThat(comp.get("A")).isNotEqualTo(comp.get("C"));
+    assertThat(comp.get("B")).isNotEqualTo(comp.get("C"));
+    assertThat(comp.get("E")).isNotEqualTo(comp.get("C"));
+    assertThat(Set.copyOf(List.of(comp.get("A"), comp.get("B"), comp.get("E")))).hasSize(3);
+  }
+
+  @Test
+  void wccWithUnknownRelTypeIsolatesEveryVertex() {
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('NOSUCH')");
+    assertThat(Set.copyOf(comp.values())).hasSize(5);
+  }
+
+  @Test
+  void wccWithCommaSeparatedRelTypesCoversBoth() {
+    bridgeComponentsWithOtherEdge();
+
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('EDGE,OTHER')");
+    assertThat(comp.values()).containsOnly(comp.get("A"));
+  }
+
+  @Test
+  void wccWithRelTypesIsNotWidenedByAViewCoveringMoreTypes() {
+    bridgeComponentsWithOtherEdge();
+
+    // a view covering both types matches a request for either one, so the filter has to be
+    // applied to the traversal rather than inherited from the view's topology
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Node")
+        .withEdgeTypes("EDGE", "OTHER")
+        .build();
+    assertThat(gav.isBuilt()).isTrue();
+
+    final Map<String, Long> comp = componentsByName("CALL algo.wcc('EDGE')");
+    assertThat(comp.get("D")).isNotEqualTo(comp.get("A"));
+  }
+
+  private void bridgeComponentsWithOtherEdge() {
+    database.transaction(() -> {
+      final Vertex c = (Vertex) database.query("sql",
+          "SELECT FROM Node WHERE name = 'C'").next().getElement().get();
+      final Vertex d = (Vertex) database.query("sql",
+          "SELECT FROM Node WHERE name = 'D'").next().getElement().get();
+      c.newEdge("OTHER", d, true, (Object[]) null).save();
+    });
+  }
+
+  private Map<String, Long> componentsByName(final String call) {
+    final ResultSet rs = database.query("opencypher",
+        call + " YIELD node, componentId RETURN node.name AS name, componentId");
+    final Map<String, Long> byName = new HashMap<>();
+    while (rs.hasNext()) {
+      final Result result = rs.next();
+      byName.put(result.getProperty("name"), ((Number) result.getProperty("componentId")).longValue());
+    }
+    return byName;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6715: {@code AbstractAlgoProcedure.GraphData.weightedAdjacencyFromColumns} checkpointed its
+ * {@link com.arcadedb.query.sql.executor.WorkGuard} once per <em>node</em>, but
+ * {@link GraphTraversalProvider#edgeWeightsOf} - the one call each iteration makes to read a node's weighted
+ * edges from a Graph Analytical View's columns - had no checkpoint of its own inside its O(degree) loop. A
+ * supernode's row was therefore one unabortable unit of work: once {@code edgeWeightsOf} was entered for it,
+ * nothing could stop the call until the whole row was built, however large the degree.
+ * <p>
+ * The fix threads the guard into {@code edgeWeightsOf} itself (a new overload taking a per-edge checkpoint
+ * callback) so the walk can be interrupted mid-row, and gives the columnar build the same cumulative memory
+ * reservation {@code adjacency()} already has, closing the second gap the issue's own follow-up comment named:
+ * a supernode's arrays were never charged against {@code CYPHER_ALGO_MAX_WORKING_MEMORY} at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6715EdgeWeightsOfCheckpointTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6715-edgeweightsof-checkpoint");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void teardown() {
+    // A test that arms the interrupt flag must not leave it set for whatever runs next on this thread.
+    Thread.interrupted();
+    if (database != null) {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      GraphTraversalProviderRegistry.clearAll(database);
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * The interrupt is armed from inside the provider itself, once the walk is a handful of edges into the
+   * supernode's row - not before the call, which the outer per-node checkpoint would already catch regardless of
+   * this fix. Before the fix, {@code edgeWeightsOf} has no checkpoint of its own, so the row is built to
+   * completion (all {@code supernodeDegree} calls to {@link WeightedSupernodeProvider#getEdgeProperty}) before
+   * the interrupt is ever observed. After the fix, the per-edge checkpoint restarts at zero for this call and
+   * fires at the next multiple of 1024, so the walk stops within about one checkpoint stride of where the
+   * interrupt was raised - orders of magnitude short of the full degree.
+   */
+  @Test
+  void abortsMidSupernodeRatherThanBuildingTheWholeRow() {
+    final int nodeCount = 10;
+    final int supernodeIndex = 3;
+    final int supernodeDegree = 5_000_000;
+    final WeightedSupernodeProvider provider = new WeightedSupernodeProvider(nodeCount, supernodeIndex,
+        supernodeDegree, "LINK", "w", 5);
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    assertThatThrownBy(() -> drain("CALL algo.maxKCut(2, {weightProperty: 'w', direction: 'OUT'}) YIELD node RETURN node"))
+        .as("a per-edge checkpoint inside edgeWeightsOf must observe the interrupt raised mid-row")
+        .hasStackTraceContaining("algo.maxKCut() has been interrupted");
+
+    assertThat(provider.supernodeEdgeCalls.get())
+        .as("the walk must stop close to where the interrupt was raised, not after building the whole "
+            + supernodeDegree + "-edge row")
+        .isLessThan(2000);
+  }
+
+  /**
+   * The counterweight: a healthy call - nothing armed - still reads every edge of a (much smaller) supernode and
+   * returns its result, so the new checkpoint costs nothing when there is nothing to abort.
+   */
+  @Test
+  void aHealthyCallStillReadsEveryEdgeOfTheSupernode() {
+    final int nodeCount = 10;
+    final int supernodeIndex = 3;
+    final int supernodeDegree = 500;
+    final WeightedSupernodeProvider provider = new WeightedSupernodeProvider(nodeCount, supernodeIndex,
+        supernodeDegree, "LINK", "w", -1);
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    assertThat(drain("CALL algo.maxKCut(2, {weightProperty: 'w', direction: 'OUT'}) YIELD node RETURN node")).isNotEmpty();
+    assertThat(provider.supernodeEdgeCalls.get()).isEqualTo(supernodeDegree);
+  }
+
+  /**
+   * The memory side of the same gap, named in the issue's own follow-up comment: before this fix, the columnar
+   * weighted-adjacency build never reserved anything at all against {@code CYPHER_ALGO_MAX_WORKING_MEMORY}, so
+   * many medium-sized rows could together exceed the budget with nothing to refuse the call. 3000 nodes of 2000
+   * edges each is 6,000,000 entries; a budget that admits the row headers and the first ~525 nodes' worth of
+   * entries (the point {@code ADJACENCY_CHECKPOINT_ENTRIES} is first crossed) but not the whole graph must refuse
+   * partway through, well short of the full 6,000,000.
+   */
+  @Test
+  void manyMediumRowsTogetherExceedTheBudgetAndAreRefused() {
+    final int nodeCount = 3000;
+    final int degreePerNode = 2000;
+    final UniformDegreeProvider provider = new UniformDegreeProvider(nodeCount, degreePerNode, "LINK", "w");
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    // Admits the row-header reservation (3000 nodes * 2 arrays * 32 bytes = 192,000 bytes) but not the full
+    // 6,000,000-entry payload (6,000,000 * (4 + 8) bytes = 72,000,000 bytes).
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 2_000_000L);
+
+    assertThatThrownBy(() -> drain("CALL algo.maxKCut(2, {weightProperty: 'w', direction: 'OUT'}) YIELD node RETURN node"))
+        .as("the cumulative cost of many medium rows must be caught, not only a single oversized one")
+        .hasStackTraceContaining("the weighted adjacency");
+
+    assertThat(provider.edgePropertyCalls.get())
+        .as("the call must be refused well before every node's row was built")
+        .isLessThan(nodeCount * degreePerNode);
+  }
+
+  /**
+   * The counterweight: a budget generous enough for the whole graph must not be refused by the new reservation.
+   */
+  @Test
+  void aBudgetThatFitsTheWholeGraphLetsTheCallThrough() {
+    final int nodeCount = 200;
+    final int degreePerNode = 50;
+    final UniformDegreeProvider provider = new UniformDegreeProvider(nodeCount, degreePerNode, "LINK", "w");
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    assertThat(drain("CALL algo.maxKCut(2, {weightProperty: 'w', direction: 'OUT'}) YIELD node RETURN node")).isNotEmpty();
+    assertThat(provider.edgePropertyCalls.get()).isEqualTo(nodeCount * degreePerNode);
+  }
+
+  private java.util.List<Object> drain(final String query) {
+    final java.util.List<Object> rows = new java.util.ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        rows.add(resultSet.next());
+    }
+    return rows;
+  }
+
+  /**
+   * A minimal {@link GraphTraversalProvider} test double serving one weighted edge type/property: every node is
+   * empty except {@code supernodeIndex}, whose row has {@code supernodeDegree} edges all reachable through
+   * {@code getEdgeProperty}. Self-interrupts the current thread once {@code getEdgeProperty} on the supernode has
+   * been called {@code selfInterruptAfterCalls} times ({@code -1} disables this).
+   */
+  private static final class WeightedSupernodeProvider implements GraphTraversalProvider {
+    private final int    nodeCount;
+    private final int    supernodeIndex;
+    private final int    supernodeDegree;
+    private final String edgeType;
+    private final String weightProperty;
+    private final int    selfInterruptAfterCalls;
+    final AtomicInteger supernodeEdgeCalls = new AtomicInteger();
+
+    WeightedSupernodeProvider(final int nodeCount, final int supernodeIndex, final int supernodeDegree,
+        final String edgeType, final String weightProperty, final int selfInterruptAfterCalls) {
+      this.nodeCount = nodeCount;
+      this.supernodeIndex = supernodeIndex;
+      this.supernodeDegree = supernodeDegree;
+      this.edgeType = edgeType;
+      this.weightProperty = weightProperty;
+      this.selfInterruptAfterCalls = selfInterruptAfterCalls;
+    }
+
+    @Override
+    public int getNodeCount() {
+      return nodeCount;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "test-weighted-supernode-provider";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return -1;
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return new RID(0, nodeId);
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return new int[nodeId == supernodeIndex ? supernodeDegree : 0];
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return nodeId == supernodeIndex ? supernodeDegree : 0;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return false;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+
+    @Override
+    public String[] getMaterializedEdgeTypes() {
+      return new String[] { edgeType };
+    }
+
+    @Override
+    public boolean hasEdgeProperties() {
+      return true;
+    }
+
+    @Override
+    public boolean hasEdgeProperty(final String edgeType, final String propertyName) {
+      return this.edgeType.equals(edgeType) && weightProperty.equals(propertyName);
+    }
+
+    @Override
+    public Object getEdgeProperty(final int nodeId, final int neighborIndex, final Vertex.DIRECTION direction,
+        final String edgeType, final String propertyName) {
+      if (nodeId == supernodeIndex) {
+        final int calls = supernodeEdgeCalls.incrementAndGet();
+        if (selfInterruptAfterCalls >= 0 && calls == selfInterruptAfterCalls)
+          Thread.currentThread().interrupt();
+      }
+      return 1.0;
+    }
+  }
+
+  /**
+   * A {@link GraphTraversalProvider} test double where every node has the same degree, so the cost that has to
+   * be refused is the sum across many nodes rather than one oversized row.
+   */
+  private static final class UniformDegreeProvider implements GraphTraversalProvider {
+    private final int    nodeCount;
+    private final int    degreePerNode;
+    private final String edgeType;
+    private final String weightProperty;
+    final AtomicInteger edgePropertyCalls = new AtomicInteger();
+
+    UniformDegreeProvider(final int nodeCount, final int degreePerNode, final String edgeType, final String weightProperty) {
+      this.nodeCount = nodeCount;
+      this.degreePerNode = degreePerNode;
+      this.edgeType = edgeType;
+      this.weightProperty = weightProperty;
+    }
+
+    @Override
+    public int getNodeCount() {
+      return nodeCount;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "test-uniform-degree-provider";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return -1;
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return new RID(0, nodeId);
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return new int[degreePerNode];
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return degreePerNode;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return false;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+
+    @Override
+    public String[] getMaterializedEdgeTypes() {
+      return new String[] { edgeType };
+    }
+
+    @Override
+    public boolean hasEdgeProperties() {
+      return true;
+    }
+
+    @Override
+    public boolean hasEdgeProperty(final String edgeType, final String propertyName) {
+      return this.edgeType.equals(edgeType) && weightProperty.equals(propertyName);
+    }
+
+    @Override
+    public Object getEdgeProperty(final int nodeId, final int neighborIndex, final Vertex.DIRECTION direction,
+        final String edgeType, final String propertyName) {
+      edgePropertyCalls.incrementAndGet();
+      return 1.0;
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -125,9 +125,10 @@ class Issue6715EdgeWeightsOfCheckpointTest {
    * The memory side of the same gap, named in the issue's own follow-up comment: before this fix, the columnar
    * weighted-adjacency build never reserved anything at all against {@code CYPHER_ALGO_MAX_WORKING_MEMORY}, so
    * many medium-sized rows could together exceed the budget with nothing to refuse the call. 3000 nodes of 2000
-   * edges each is 6,000,000 entries; a budget that admits the row headers and the first ~525 nodes' worth of
-   * entries (the point {@code ADJACENCY_CHECKPOINT_ENTRIES} is first crossed) but not the whole graph must refuse
-   * partway through, well short of the full 6,000,000.
+   * edges each is 6,000,000 entries; a tight 2,000,000-byte budget - which admits the row headers and only a
+   * small fraction of the entries, since the checkpoint interval is capped by {@code MemoryBudget.capacityFor}
+   * against what is actually left of it, not just the coarser {@code ADJACENCY_CHECKPOINT_ENTRIES / 3} - must
+   * refuse within the first few dozen nodes, well short of building all 3000 rows.
    */
   @Test
   void manyMediumRowsTogetherExceedTheBudgetAndAreRefused() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -161,8 +163,8 @@ class Issue6715EdgeWeightsOfCheckpointTest {
     assertThat(provider.edgePropertyCalls.get()).isEqualTo(nodeCount * degreePerNode);
   }
 
-  private java.util.List<Object> drain(final String query) {
-    final java.util.List<Object> rows = new java.util.ArrayList<>();
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
     try (final ResultSet resultSet = database.query("opencypher", query)) {
       while (resultSet.hasNext())
         rows.add(resultSet.next());

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6577OrWithNonCursorBuildableOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6577OrWithNonCursorBuildableOperatorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6577
+ * <p>
+ * {@code SelectExecutor.isTheNodeFullyIndexed()} (used by {@code filterWithIndexesFinalNode()}'s "under an OR, both
+ * sides must be indexed" gate) only excluded {@code is_null}/{@code is_not_null} from "this leaf is indexed" -
+ * every other operator on an indexed property, including {@code neq}/{@code like}/{@code ilike}, was treated as
+ * indexed as long as the property itself had an index. But {@code filterWithIndexesFinalNode()}'s cursor-building
+ * switch only knows how to build a cursor for {@code eq}/{@code in_op}/{@code between}/{@code gt}/{@code ge}/
+ * {@code lt}/{@code le} - a {@code neq}/{@code like}/{@code ilike} leaf silently contributed zero cursors while
+ * still passing the "both sides indexed" gate for its {@code or} sibling. The result: for
+ * {@code a != 'x' OR n = -1}, the {@code eq} leaf's cursor alone became the WHOLE candidate stream, and every
+ * record matching only the {@code neq} branch was silently dropped - not "evaluated less efficiently", genuinely
+ * missing from the result.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6577OrWithNonCursorBuildableOperatorTest extends TestHelper {
+
+  private static final int ROWS = 1000;
+
+  public Issue6577OrWithNonCursorBuildableOperatorTest() {
+    autoStartTx = true;
+  }
+
+  @Override
+  protected void beginTest() {
+    final var t = database.getSchema().createDocumentType("T");
+    t.createProperty("a", Type.STRING);
+    t.createProperty("n", Type.INTEGER);
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "a");
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "n");
+
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newDocument("T").set("a", "x", "n", i).save();
+    });
+  }
+
+  @Test
+  void orWithNeqOnOneSideMustNotDropTheOtherBranch() {
+    // EVERY ROW HAS a = "x" != "nonexistent", SO THE neq BRANCH ALONE ALREADY MATCHES ALL ROWS
+    final long count = database.select().fromType("T").where()//
+        .property("a").neq().value("nonexistent")//
+        .or().property("n").eq().value(-1).count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+
+  @Test
+  void orWithNeqOnOneSideMustNotDropTheOtherBranchReversed() {
+    // SAME SHAPE, neq ON THE RIGHT-HAND SIDE OF THE or INSTEAD OF THE LEFT
+    final long count = database.select().fromType("T").where()//
+        .property("n").eq().value(-1)//
+        .or().property("a").neq().value("nonexistent").count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+
+  @Test
+  void orWithLikeOnOneSideMustNotDropTheOtherBranch() {
+    final long count = database.select().fromType("T").where()//
+        .property("a").like().value("x")//
+        .or().property("n").eq().value(-1).count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+
+  @Test
+  void orWithIlikeOnOneSideMustNotDropTheOtherBranch() {
+    final long count = database.select().fromType("T").where()//
+        .property("a").ilike().value("X")//
+        .or().property("n").eq().value(-1).count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+
+  @Test
+  void orWithNeqOnBothSidesFallsBackToFullScanCorrectly() {
+    // NEITHER SIDE IS CURSOR-BUILDABLE, SO THIS MUST FALL ALL THE WAY BACK TO A FULL SCAN - STILL CORRECT
+    final long count = database.select().fromType("T").where()//
+        .property("a").neq().value("nonexistent")//
+        .or().property("n").neq().value(-999999).count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6592CompactedCompositePrefixDescTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6592CompactedCompositePrefixDescTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Follow-up regression test for https://github.com/ArcadeData/arcadedb/issues/6592: once the composite (multi-property)
+ * index in {@link SelectCompositeIndexTest} is actually used by the native {@link Select} query builder, a genuine bug
+ * surfaces on an index that has gone through LSM compaction (any long-running database) when the query does an
+ * {@code ORDER BY <trailing property> DESC} on a composite-index prefix match.
+ * <p>
+ * Two independent defects in {@link com.arcadedb.index.lsm.LSMTreeIndexCompacted}, both only reachable through a
+ * PARTIAL (prefix) key - i.e. a composite index where not every property is bound by equality - combined to produce
+ * this:
+ * <ol>
+ * <li>{@code compareKey()} never adjusted the binary-search {@code mid} to the boundary of the matching-prefix run
+ * (unlike {@code LSMTreeIndexMutable.compareKey()}, which does), so a descending partial-key scan could start
+ * anywhere inside the group instead of at its highest entry;</li>
+ * <li>{@code searchInCurrentPage()}'s "the search key is outside this data page" fallback always stepped to
+ * {@code firstPageNumber + 1}, which is only correct for an ASCENDING scan (where "outside" only ever means the page
+ * sorts below the search key). For a DESCENDING scan "outside" only ever means the page sorts ABOVE the search key,
+ * so the fallback needs to step to {@code firstPageNumber - 1} instead - stepping the wrong way walked the scan into
+ * an unrelated, higher-keyed page (possibly belonging to a different compacted series entirely) and returned
+ * whatever it found there as if it matched the WHERE clause.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6592CompactedCompositePrefixDescTest extends TestHelper {
+
+  private static final int    NOISE_GROUPS = 12;
+  private static final int    NOISE_ROWS   = 2_500;
+  private static final int    GROUP_SIZE   = 5;
+  private static final String PAD          = "x".repeat(64);
+
+  @Override
+  protected void beginTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+
+    final VertexType supplier = database.getSchema().createVertexType("Supplier", 1);
+    supplier.createProperty("key1", Type.STRING);
+    supplier.createProperty("key2", Type.STRING);
+    supplier.createProperty("orderedAt", Type.LONG);
+    supplier.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "key1", "key2", "orderedAt");
+
+    database.transaction(() -> {
+      // Noise groups both alphabetically BEFORE and AFTER the target "a"/"b" group, spread across enough data to
+      // force several compacted series (see buildMultiSeriesIndex() in Issue5214MultiSeriesRangeTest for the same
+      // RAM-bounded-compaction technique). Groups before "a" exercise the descending "outside" fallback (#6592
+      // follow-up); groups after it exercise the pre-existing ascending fallback, which must stay correct.
+      for (int g = 0; g < NOISE_GROUPS; g++) {
+        final String key1 = (g % 2 == 0 ? "0" : "z") + PAD + g;
+        for (int i = 0; i < NOISE_ROWS; i++)
+          database.newVertex("Supplier").set("key1", key1, "key2", "x", "orderedAt", (long) i).save();
+      }
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("Supplier").set("key1", "a", "key2", "b", "orderedAt", (long) i).save();
+    });
+
+    final TypeIndex typeIndex = database.getSchema().getType("Supplier").getIndexesByProperties("key1", "key2", "orderedAt")
+        .getFirst();
+    try {
+      assertThat(((IndexInternal) typeIndex).scheduleCompaction()).as("compaction scheduled").isTrue();
+      assertThat(((IndexInternal) typeIndex).compact()).as("compaction executed").isTrue();
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void orderByDescLimitOneReturnsTheMatchingGroupAfterCompaction() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", false)//
+          .limit(1)//
+          .compile();
+
+      final Vertex first = select.vertices().nextOrNull();
+
+      assertThat(first).isNotNull();
+      assertThat(first.getString("key1")).isEqualTo("a");
+      assertThat(first.getString("key2")).isEqualTo("b");
+      assertThat(first.getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1);
+    });
+  }
+
+  @Test
+  void orderByAscLimitOneStillReturnsTheMatchingGroupAfterCompaction() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", true)//
+          .limit(1)//
+          .compile();
+
+      final Vertex first = select.vertices().nextOrNull();
+
+      assertThat(first).isNotNull();
+      assertThat(first.getString("key1")).isEqualTo("a");
+      assertThat(first.getString("key2")).isEqualTo("b");
+      assertThat(first.getLong("orderedAt")).isZero();
+    });
+  }
+
+  @Test
+  void descendingScanReturnsExactlyTheMatchingGroupInOrder() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", false)//
+          .compile();
+
+      final List<Vertex> list = select.vertices().toList();
+
+      assertThat(list).hasSize(GROUP_SIZE);
+      for (int i = 0; i < GROUP_SIZE; i++) {
+        assertThat(list.get(i).getString("key1")).isEqualTo("a");
+        assertThat(list.get(i).getString("key2")).isEqualTo("b");
+        assertThat(list.get(i).getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1 - i);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/ArcadeData/arcadedb/issues/6694: {@code LSMTreeIndexCompacted.newIterators()}'s
+ * ROOT-PAGE lookup for a partial (composite-index prefix) key always used purpose=2 (ascending), regardless of the
+ * requested scan direction. #6692 fixed the analogous asymmetry at the DATA-page level ({@code searchInCurrentPage()},
+ * which already used {@code ascendingOrder ? 2 : 3}), but left the coarser root-page probe that PICKS which data page
+ * to start {@code searchInCurrentPage()} from always ascending.
+ * <p>
+ * This only surfaces when the composite-index prefix match ({@code key1='a' AND key2='b'}) itself spans MULTIPLE data
+ * pages within one compacted series - i.e. a group large enough that the root page holds a RUN of several
+ * page-boundary entries that all compare equal under a partial-key comparison. {@code compareKey()}'s "PARTIAL
+ * MATCHING" walk resolves an ambiguous binary-search landing point to the FIRST entry of that run for purpose=2 and
+ * the LAST entry for purpose=3; using purpose=2 unconditionally means a DESCENDING scan's root-page probe always
+ * lands on the FIRST (lowest-keyed) data page of the group instead of the LAST (highest-keyed) one, so the scan
+ * starts multiple pages too low and returns the wrong (or incomplete) rows.
+ * <p>
+ * The existing #6692 regression test ({@code Issue6592CompactedCompositePrefixDescTest}) used a target group small
+ * enough to live in a single data page, so it never exercised this specific branch - confirmed by the automated code
+ * review comment that filed this issue.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
+
+  private static final int GROUP_SIZE = 4_000;
+  private static final int PAGE_SIZE  = 8 * 1024;
+
+  @Override
+  protected void beginTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+
+    final VertexType supplier = database.getSchema().createVertexType("Supplier", 1);
+    supplier.createProperty("key1", Type.STRING);
+    supplier.createProperty("key2", Type.STRING);
+    supplier.createProperty("orderedAt", Type.LONG);
+    database.getSchema()
+        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Supplier", new String[] { "key1", "key2", "orderedAt" }, PAGE_SIZE);
+
+    database.transaction(() -> {
+      // A single prefix group large enough to span several data pages within one compacted series - the root page
+      // then holds a run of multiple page-boundary entries that all compare equal under the partial key (key1,key2).
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("Supplier").set("key1", "a", "key2", "b", "orderedAt", (long) i).save();
+    });
+
+    final TypeIndex typeIndex = database.getSchema().getType("Supplier").getIndexesByProperties("key1", "key2", "orderedAt")
+        .getFirst();
+    try {
+      assertThat(((IndexInternal) typeIndex).scheduleCompaction()).as("compaction scheduled").isTrue();
+      assertThat(((IndexInternal) typeIndex).compact()).as("compaction executed").isTrue();
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void orderByDescLimitOneReturnsTheHighestValueAfterCompaction() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", false)//
+          .limit(1)//
+          .compile();
+
+      final Vertex first = select.vertices().nextOrNull();
+
+      assertThat(first).isNotNull();
+      assertThat(first.getString("key1")).isEqualTo("a");
+      assertThat(first.getString("key2")).isEqualTo("b");
+      assertThat(first.getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1);
+    });
+  }
+
+  @Test
+  void descendingScanReturnsExactlyTheMatchingGroupInOrder() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", false)//
+          .compile();
+
+      final List<Vertex> list = select.vertices().toList();
+
+      assertThat(list).hasSize(GROUP_SIZE);
+      for (int i = 0; i < GROUP_SIZE; i++) {
+        assertThat(list.get(i).getString("key1")).isEqualTo("a");
+        assertThat(list.get(i).getString("key2")).isEqualTo("b");
+        assertThat(list.get(i).getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1 - i);
+      }
+    });
+  }
+
+  @Test
+  void orderByAscLimitOneStillReturnsTheLowestValueAfterCompaction() {
+    database.transaction(() -> {
+      final SelectCompiled select = database.select().fromType("Supplier")//
+          .where().property("key1").eq().value("a")//
+          .and().property("key2").eq().value("b")//
+          .orderBy("orderedAt", true)//
+          .limit(1)//
+          .compile();
+
+      final Vertex first = select.vertices().nextOrNull();
+
+      assertThat(first).isNotNull();
+      assertThat(first.getString("key1")).isEqualTo("a");
+      assertThat(first.getString("key2")).isEqualTo("b");
+      assertThat(first.getLong("orderedAt")).isZero();
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
@@ -68,9 +68,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("slow")
 class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
 
-  private static final int GROUP_SIZE = 4_000;
-  private static final int LOWER_GROUP_SIZE = 4_000;
-  private static final int PAGE_SIZE  = 8 * 1024;
+  private static final int GROUP_SIZE       = 4_000; // target ("a"/"b") group size
+  private static final int LOWER_GROUP_SIZE = 4_000; // independent: the noise ("0"/"x") group below it, sized separately
+  private static final int PAGE_SIZE        = 8 * 1024;
 
   @Override
   protected void beginTest() {

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6694CompactedRootPageDescendingPurposeTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.select;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.Schema;
@@ -30,6 +31,7 @@ import com.arcadedb.schema.VertexType;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,8 +52,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * starts multiple pages too low and returns the wrong (or incomplete) rows.
  * <p>
  * The existing #6692 regression test ({@code Issue6592CompactedCompositePrefixDescTest}) used a target group small
- * enough to live in a single data page, so it never exercised this specific branch - confirmed by the automated code
- * review comment that filed this issue.
+ * enough to live in a single data page, so it never exercised this specific branch.
+ * <p>
+ * A second, independent gap: switching the root-page purpose to 3 for a descending scan also changes which
+ * {@code lookupInPage} boundary branch fires when {@code fromKeys} sorts higher than every entry of an ENTIRE
+ * compacted series (not just one page within it) - the "outside" shortcut that used to emit that whole series as a
+ * single cursor (purpose=2's HIGHER-than-last branch, #5214) now instead routes through
+ * {@code searchInCurrentPage()}'s normal per-page probe via purpose=3's own HIGHER-than-last special case.
+ * {@link #descendingPartialKeyIteratorIncludesAnEntireLowerSeries()} builds a second, alphabetically LOWER prefix
+ * group large enough to compact into its own series and confirms a descending partial-key iterator starting above
+ * it still returns every one of its rows, in order, with none dropped.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -59,6 +69,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
 
   private static final int GROUP_SIZE = 4_000;
+  private static final int LOWER_GROUP_SIZE = 4_000;
   private static final int PAGE_SIZE  = 8 * 1024;
 
   @Override
@@ -75,6 +86,11 @@ class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
         .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Supplier", new String[] { "key1", "key2", "orderedAt" }, PAGE_SIZE);
 
     database.transaction(() -> {
+      // A prefix group alphabetically BELOW the target ("0" < "a"), large enough to compact into its own series -
+      // exercises a descending scan whose fromKeys sorts above this series' ENTIRE key range, not just one page of it.
+      for (int i = 0; i < LOWER_GROUP_SIZE; i++)
+        database.newVertex("Supplier").set("key1", "0", "key2", "x", "orderedAt", (long) i).save();
+
       // A single prefix group large enough to span several data pages within one compacted series - the root page
       // then holds a run of multiple page-boundary entries that all compare equal under the partial key (key1,key2).
       for (int i = 0; i < GROUP_SIZE; i++)
@@ -126,6 +142,38 @@ class Issue6694CompactedRootPageDescendingPurposeTest extends TestHelper {
         assertThat(list.get(i).getString("key1")).isEqualTo("a");
         assertThat(list.get(i).getString("key2")).isEqualTo("b");
         assertThat(list.get(i).getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1 - i);
+      }
+    });
+  }
+
+  @Test
+  void descendingPartialKeyIteratorIncludesAnEntireLowerSeries() {
+    database.transaction(() -> {
+      final TypeIndex typeIndex = database.getSchema().getType("Supplier").getIndexesByProperties("key1", "key2", "orderedAt")
+          .getFirst();
+
+      // Partial (2-of-3 component) descending iterator starting at the target group, with no lower bound: it must
+      // walk straight through the target group and then through the entire "0"/"x" series below it, dropping nothing.
+      final List<Object[]> keys = new ArrayList<>();
+      try (final IndexCursor cursor = typeIndex.iterator(false, new Object[] { "a", "b" }, true)) {
+        while (cursor.hasNext()) {
+          cursor.next();
+          keys.add(cursor.getKeys());
+        }
+      }
+
+      assertThat(keys).as("no rows from either group must be dropped").hasSize(GROUP_SIZE + LOWER_GROUP_SIZE);
+
+      for (int i = 0; i < GROUP_SIZE; i++) {
+        assertThat(keys.get(i)[0]).isEqualTo("a");
+        assertThat(keys.get(i)[1]).isEqualTo("b");
+        assertThat(keys.get(i)[2]).isEqualTo((long) (GROUP_SIZE - 1 - i));
+      }
+      for (int i = 0; i < LOWER_GROUP_SIZE; i++) {
+        final Object[] key = keys.get(GROUP_SIZE + i);
+        assertThat(key[0]).isEqualTo("0");
+        assertThat(key[1]).isEqualTo("x");
+        assertThat(key[2]).isEqualTo((long) (LOWER_GROUP_SIZE - 1 - i));
       }
     });
   }

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
@@ -461,6 +461,59 @@ public class SelectExecutionTest extends TestHelper {
         .where().property("name").eq().value("John").limit(10).count()).isEqualTo(10);
   }
 
+  /**
+   * Issue #6579: {@code limit(0)} must count 0, not 1, when at least one record matches. Covers both the
+   * no-WHERE (unindexed full-type-scan) path and an AND-shaped WHERE (the uncapped fallback path), since
+   * {@code SelectExecutor.executeCount()} used to increment {@code count} before comparing it to
+   * {@code select.limit}, so the very first match was counted before the {@code count >= limit} check
+   * ever saw {@code limit == 0}.
+   */
+  @Test
+  void okCountWithLimitZero() {
+    assertThat(database.select().fromType("Vertex").limit(0).count()).isEqualTo(0);
+
+    assertThat(database.select().fromType("Vertex")//
+        .where().property("name").eq().value("John")//
+        .and().property("name").isNotNull().limit(0).count()).isEqualTo(0);
+
+    // PINS THE ALREADY-SAFE INDEXED-CURSOR PATH TOO (id IS UNIQUE-INDEXED, SEE beginTest()): MultiIndexCursor
+    // ALREADY STOPS BEFORE ANY CANDIDATE IS PULLED FOR limit(0), SO THIS GUARDS AGAINST A FUTURE REGRESSION IN
+    // computeExactCandidateLimit()'S CAP LOGIC, NOT AGAINST THE BUG THIS TEST OTHERWISE EXERCISES
+    assertThat(database.select().fromType("Vertex")//
+        .where().property("id").eq().value(5).limit(0).count()).isEqualTo(0);
+  }
+
+  /**
+   * Issue #6579 review follow-up: the {@code limit == 0} fix must not turn {@code limit > 0} into a full
+   * scan. {@code executeCount()}'s {@code break} only fires from inside the {@code evaluateWhere()} match
+   * branch, so if the pre-increment {@code count >= limit} guard added for {@code limit == 0} were the
+   * <i>only</i> check, the loop could only stop on the <i>next</i> matching record after the limit was
+   * reached - degrading into a full scan whenever no such record exists. This pins the same-iteration
+   * early exit by asserting on {@code evaluatedRecords} directly: with exactly one matching record
+   * followed by 500 non-matching ones (an unindexed, full-type-scan WHERE, so every visited record goes
+   * through {@code evaluateWhere()}), a {@code limit(1)} count must stop right after that one match, not
+   * walk the other 500.
+   */
+  @Test
+  void okCountWithLimitStopsEarlyDespiteReorder() {
+    database.getSchema().createDocumentType("Issue6579EarlyExit");
+    database.transaction(() -> {
+      database.newDocument("Issue6579EarlyExit").set("flag", true).save();
+      for (int i = 0; i < 500; i++)
+        database.newDocument("Issue6579EarlyExit").set("flag", false).save();
+    });
+
+    final Select select = database.select().fromType("Issue6579EarlyExit")//
+        .where().property("flag").eq().value(true).limit(1);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    assertThat(executor.executeCount()).isEqualTo(1);
+    assertThat((Long) executor.metrics().get("evaluatedRecords")).as(
+        "evaluatedRecords must stay near the single match, not walk the 500 non-matching records after it")
+        .isLessThan(10L);
+  }
+
   @Test
   void okCountCompiled() {
     final SelectCompiled compiled = database.select().fromType("Vertex")//

--- a/engine/src/test/java/com/arcadedb/query/select/SelectNotWrappedIndexedLeafTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectNotWrappedIndexedLeafTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.MultiIndexCursor;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6575
+ * <p>
+ * {@code SelectOperator.not} has no fluent entry point on the {@code Select} builder today (no {@code .not()} method
+ * exists on {@code SelectWhereLeftBlock}/{@code SelectWhereOperatorBlock}/etc.), so the where-tree in these tests is
+ * built by hand, the same technique already used by
+ * {@code Issue6565SelectIndexCandidateLimitTest#notLeafIsNeverTreatedAsExactlyIndexed} and
+ * {@code SelectCompositeIndexTest#compositeIndexNotUsedWithNotInTheConjunction} - neither of which happens to cover
+ * this defect: the first only asserts the candidate cap stays {@code -1}, and the second returns a {@code null}
+ * cursor only because neither of its two properties has a standalone index, not because the code excludes a leaf
+ * under {@code not}.
+ * <p>
+ * {@code isTheNodeFullyIndexed()} walks through a {@code not} node the same way it walks through {@code and}/{@code
+ * or}, setting {@code node.index} on the leaf underneath exactly as it would for a plain, un-negated leaf.
+ * {@code filterWithIndexesFinalNode()} then had no special case for a {@code not} parent (only {@code or} and
+ * {@code and} are handled), so for a where-tree shaped {@code NOT (a = 'x')} against a standalone index on
+ * {@code a}, it built {@code node.index.get(new Object[]{"x"})} - a cursor of the records where {@code a = 'x'}
+ * <b>is</b> true, the exact opposite of what {@code NOT (a = 'x')} should select. {@code evaluateWhere()} would then
+ * reject every one of those candidates (they all satisfy the positive condition by construction), so the query
+ * silently returned zero rows instead of "every record where {@code a != 'x'}".
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class SelectNotWrappedIndexedLeafTest extends TestHelper {
+
+  public SelectNotWrappedIndexedLeafTest() {
+    autoStartTx = true;
+  }
+
+  @Override
+  protected void beginTest() {
+    final var t = database.getSchema().createDocumentType("T");
+    t.createProperty("a", Type.STRING);
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "a");
+
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++) {
+        final var d = database.newDocument("T");
+        d.set("a", i == 0 ? "x" : "y");
+        d.save();
+      }
+    });
+  }
+
+  @Test
+  void notWrappedIndexedEqLeafBuildsNoCursor() {
+    // NOT (a = 'x'): 'a' HAS A STANDALONE INDEX, SO isTheNodeFullyIndexed() SETS node.index ON THE LEAF EXACTLY AS
+    // IT WOULD FOR A PLAIN 'a = x'. filterWithIndexesFinalNode() MUST REFUSE TO BUILD A CURSOR FOR IT ANYWAY, SINCE
+    // A CURSOR HERE WOULD YIELD THE RECORDS WHERE a = 'x' IS TRUE - THE OPPOSITE OF WHAT NOT (a = 'x') SELECTS.
+    final Select select = database.select().fromType("T");
+    final SelectTreeNode eqLeaf = new SelectTreeNode(new SelectPropertyValue("a"), SelectOperator.eq, "x");
+    select.rootTreeElement = new SelectTreeNode(eqLeaf, SelectOperator.not, null);
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      // A null CURSOR MEANS execute() FALLS BACK TO A FULL TYPE SCAN, WHICH IS THE ONLY SAFE OPTION HERE - A CAP
+      // WOULD REQUIRE THE (WRONG) POSITIVE CURSOR THIS TEST EXISTS TO REJECT.
+      assertThat((Object) cursor).isNull();
+      assertThat(executor.metrics().get("usedIndexes")).isEqualTo(0);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  @Test
+  void notWrappedIndexedLeafUnderAndStillBuildsNoCursorForTheNegatedSide() {
+    // NOT (a = 'x') AND a = 'y': THE and's LEFT CHILD IS A not NODE, NOT A BARE LEAF - filterWithIndexes() RECURSES
+    // THROUGH IT AND filterWithIndexesFinalNode() MUST STILL REFUSE THE CURSOR FOR THE LEAF UNDERNEATH, WHILE THE
+    // RIGHT (UN-NEGATED) LEAF IS FREE TO GET ITS OWN CURSOR AS USUAL.
+    final Select select = database.select().fromType("T");
+    final SelectTreeNode notEqXLeaf = new SelectTreeNode(new SelectPropertyValue("a"), SelectOperator.eq, "x");
+    final SelectTreeNode notEqX = new SelectTreeNode(notEqXLeaf, SelectOperator.not, null);
+    final SelectTreeNode eqYLeaf = new SelectTreeNode(new SelectPropertyValue("a"), SelectOperator.eq, "y");
+    select.rootTreeElement = new SelectTreeNode(notEqX, SelectOperator.and, eqYLeaf);
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      // ONLY THE RIGHT (UN-NEGATED) LEAF CONTRIBUTED A CURSOR
+      assertThat(executor.metrics().get("usedIndexes")).isEqualTo(1);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DistinctExecutionStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DistinctExecutionStepTest.java
@@ -331,6 +331,33 @@ class DistinctExecutionStepTest extends TestHelper {
     result.close();
   }
 
+  /**
+   * Issue #6676: {@code DISTINCT} keyed on the raw boxed property value, so a schemaless/mixed-type column
+   * carrying the same logical number as different Java numeric types (Integer vs Long) split into separate
+   * rows instead of collapsing, unlike SQL GROUP BY (issue #4516) which already canonicalizes.
+   */
+  @Test
+  void shouldCollapseNumericallyEqualCrossTypeValues() {
+    database.getSchema().createDocumentType("MixedNumeric");
+
+    database.transaction(() -> {
+      database.newDocument("MixedNumeric").set("v", 1).save();   // Integer
+      database.newDocument("MixedNumeric").set("v", 1L).save();  // Long
+      database.newDocument("MixedNumeric").set("v", 2).save();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT DISTINCT v FROM MixedNumeric");
+
+    int count = 0;
+    while (result.hasNext()) {
+      result.next();
+      count++;
+    }
+
+    assertThat(count).isEqualTo(2); // 1 (Integer) and 1 (Long) collapse into one row, plus 2
+    result.close();
+  }
+
   @Test
   void shouldHandleDistinctWithNullValues() {
     database.getSchema().createDocumentType("Data");

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -78,4 +78,95 @@ class ExplainStatementExecutionTest extends TestHelper {
 
     result.close();
   }
+
+  /**
+   * Regression test for issue #6648: {@code EXPLAIN <write statement>} sent through the
+   * {@code sqlscript} language engine used to actually perform the wrapped write, because
+   * {@code SQLScriptQueryEngine} chains whatever {@code Statement.createExecutionPlan()} returns
+   * and pulls it to completion, and {@code ExplainStatement.createExecutionPlan()} used to pass
+   * the wrapped statement's own executable plan straight through. Plain {@code "sql"} was never
+   * affected, since it goes through {@code ExplainStatement.execute()}, which never pulls the
+   * plan it builds.
+   */
+  @Test
+  void explainUpdateInSqlScriptDoesNotExecuteWrite() {
+    final String typeName = "Issue6648UpdateTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sqlscript", "EXPLAIN UPDATE " + typeName + " SET bar = 1;");
+      assertThat(result.hasNext()).isTrue();
+      final Result next = result.next();
+      assertThat(next.<Object>getProperty("executionPlan")).isNotNull();
+      assertThat(next.<String>getProperty("executionPlanAsString")).isNotNull();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
+
+  @Test
+  void explainInsertInSqlScriptDoesNotExecuteWrite() {
+    final String typeName = "Issue6648InsertTarget";
+    database.getSchema().createDocumentType(typeName);
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sqlscript", "EXPLAIN INSERT INTO " + typeName + " SET bar = 1;");
+      assertThat(result.hasNext()).isTrue();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT count(*) as count FROM " + typeName);
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo(0L);
+    rs.close();
+  }
+
+  @Test
+  void explainDeleteInSqlScriptDoesNotExecuteWrite() {
+    final String typeName = "Issue6648DeleteTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sqlscript", "EXPLAIN DELETE FROM " + typeName + ";");
+      assertThat(result.hasNext()).isTrue();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT count(*) as count FROM " + typeName);
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo(1L);
+    rs.close();
+  }
+
+  /**
+   * Same bug, reached through a different chaining caller: {@code IfStep} also chains whatever
+   * {@code Statement.createExecutionPlan()} returns for the statements in its branch. Confirms the
+   * fix lives where it belongs (in {@code ExplainStatement.createExecutionPlan()}), not as a
+   * one-off special case in {@code SQLScriptQueryEngine} alone.
+   */
+  @Test
+  void explainUpdateInsideIfBlockDoesNotExecuteWrite() {
+    final String typeName = "Issue6648IfBlockTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final String script = """
+              IF(true){
+                  EXPLAIN UPDATE %s SET bar = 1;
+              }
+          """.formatted(typeName);
+      final ResultSet result = database.command("sqlscript", script);
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -199,4 +199,85 @@ class ExplainStatementExecutionTest extends TestHelper {
     assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
     rs.close();
   }
+
+  /**
+   * Same bug, reached through {@code ForEachStep}: it chains whatever
+   * {@code Statement.createExecutionPlan()} returns for each statement in the loop body exactly like
+   * {@code ScriptLineStep} does, so it shared the same silent-write hazard before this fix.
+   */
+  @Test
+  void explainUpdateInsideForEachDoesNotExecuteWrite() {
+    final String typeName = "Issue6648ForEachTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final String script = """
+              FOREACH ($i IN [1]) {
+                  EXPLAIN UPDATE %s SET bar = 1;
+              }
+          """.formatted(typeName);
+      final ResultSet result = database.command("sqlscript", script);
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
+
+  /**
+   * Same bug, reached through {@code WhileStep}.
+   */
+  @Test
+  void explainUpdateInsideWhileDoesNotExecuteWrite() {
+    final String typeName = "Issue6648WhileTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final String script = """
+              LET $i = 0;
+              WHILE ($i < 1) {
+                  EXPLAIN UPDATE %s SET bar = 1;
+                  LET $i = $i + 1;
+              }
+          """.formatted(typeName);
+      final ResultSet result = database.command("sqlscript", script);
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
+
+  /**
+   * Same bug, reached through {@code RetryStep}: statements between {@code BEGIN} and
+   * {@code COMMIT RETRY n} are collected into a retry block and chained the same way as a plain
+   * script line.
+   */
+  @Test
+  void explainUpdateInsideRetryBlockDoesNotExecuteWrite() {
+    final String typeName = "Issue6648RetryTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final String script = """
+              BEGIN;
+              EXPLAIN UPDATE %s SET bar = 1;
+              COMMIT RETRY 5;
+          """.formatted(typeName);
+      final ResultSet result = database.command("sqlscript", script);
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -169,4 +169,34 @@ class ExplainStatementExecutionTest extends TestHelper {
     assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
     rs.close();
   }
+
+  /**
+   * {@code PROFILE EXPLAIN <statement>} is a third way to reach the same bug:
+   * {@code ProfileStatement.execute()} is itself a caller that pulls whatever
+   * {@code statement.createExecutionPlan()} hands back (see {@code ProfileStatement.java:58-64}), so
+   * before this fix {@code PROFILE EXPLAIN UPDATE ...} silently ran the update exactly like the
+   * {@code sqlscript} case did. EXPLAIN's non-execution contract is defined to win regardless of what
+   * encloses it, so {@code PROFILE EXPLAIN <statement>} degrades to plan-only output - no execution,
+   * no real cost numbers - rather than PROFILE unwrapping the inner statement and running it for real.
+   */
+  @Test
+  void profileExplainUpdateDoesNotExecuteWrite() {
+    final String typeName = "Issue6648ProfileExplainTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sql", "PROFILE EXPLAIN UPDATE " + typeName + " SET bar = 1");
+      assertThat(result.hasNext()).isTrue();
+      final Result next = result.next();
+      assertThat(next.<Object>getProperty("executionPlan")).isNotNull();
+      assertThat(next.<String>getProperty("executionPlanAsString")).isNotNull();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -280,4 +280,38 @@ class ExplainStatementExecutionTest extends TestHelper {
     assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
     rs.close();
   }
+
+  /**
+   * Same bug, reached through a SELECT's own {@code LET} clause: {@code LetItem.query} is typed as
+   * a generic {@code Statement}, so {@code LET $x = (EXPLAIN <statement>)} parses, and
+   * {@code GlobalLetQueryStep}/{@code LetQueryStep} (built by {@code SelectExecutionPlanner}) chain
+   * whatever {@code query.createExecutionPlan()} returns exactly like every other caller this fix
+   * covers.
+   * <p>
+   * Uses {@code INSERT}, not {@code UPDATE}/{@code DELETE}: reaching this path at all requires
+   * {@code Statement.refersToParent()} on the wrapped statement, which {@code UpdateStatement},
+   * {@code DeleteStatement}, {@code CreateVertexStatement}, {@code CreateEdgeStatement} and
+   * {@code DDLStatement} have never implemented - {@code LET $x = (UPDATE ...)} throws
+   * {@code UnsupportedOperationException} regardless of EXPLAIN, so those aren't a silent-write
+   * risk here, just a pre-existing, unrelated gap out of scope for this fix.
+   * {@code InsertStatement.refersToParent()} already returns {@code false}, so INSERT is the one
+   * write statement that actually reaches {@code ExplainExecutionPlan} through this path today.
+   */
+  @Test
+  void explainInsertInsideSelectLetDoesNotExecuteWrite() {
+    final String typeName = "Issue6648SelectLetTarget";
+    database.getSchema().createDocumentType(typeName);
+
+    database.transaction(() -> {
+      final ResultSet result = database.query("sql",
+          "SELECT $explained AS explained LET $explained = (EXPLAIN INSERT INTO " + typeName + " SET bar = 1)");
+      assertThat(result.hasNext()).isTrue();
+      result.next();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT count(*) as count FROM " + typeName);
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo(0L);
+    rs.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces and verifies the fix for issue #6463: {@code INSERT INTO ... CONTENT :param} silently
+ * inserted only the first element of a {@link List} bound parameter, unlike the equivalent JSON-array
+ * literal form which creates one record per item.
+ */
+public class InsertContentListParamTest extends TestHelper {
+
+  public InsertContentListParamTest() {
+    autoStartTx = true;
+  }
+
+  @Test
+  void insertContentWithListParamCreatesOneRecordPerItem() {
+    final String typeName = "Issue6463Person";
+    database.getSchema().createDocumentType(typeName);
+
+    final List<Map<String, Object>> people = new ArrayList<>();
+    for (final String name : List.of("a", "b", "c")) {
+      final Map<String, Object> item = new LinkedHashMap<>();
+      item.put("name", name);
+      people.add(item);
+    }
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("people", people);
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT :people", params);
+
+    final List<String> insertedNames = new ArrayList<>();
+    while (result.hasNext())
+      insertedNames.add(result.next().<String>getProperty("name"));
+    result.close();
+
+    assertThat(insertedNames).containsExactlyInAnyOrder("a", "b", "c");
+
+    final ResultSet count = database.query("sql", "SELECT count(*) as total FROM " + typeName);
+    assertThat(count.hasNext()).isTrue();
+    assertThat(count.next().<Long>getProperty("total")).isEqualTo(3L);
+    count.close();
+  }
+
+  @Test
+  void insertContentWithSingleElementListParamStillCreatesOneRecord() {
+    final String typeName = "Issue6463SingleItem";
+    database.getSchema().createDocumentType(typeName);
+
+    final Map<String, Object> item = new LinkedHashMap<>();
+    item.put("name", "solo");
+    final List<Map<String, Object>> people = new ArrayList<>(List.of(item));
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("people", people);
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT :people", params);
+
+    assertThat(result.hasNext()).isTrue();
+    final Result inserted = result.next();
+    assertThat(inserted.<String>getProperty("name")).isEqualTo("solo");
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
+  void insertContentWithPositionalListParamCreatesOneRecordPerItem() {
+    final String typeName = "Issue6463PositionalPerson";
+    database.getSchema().createDocumentType(typeName);
+
+    final List<Map<String, Object>> people = new ArrayList<>();
+    for (final String name : List.of("x", "y", "z")) {
+      final Map<String, Object> item = new LinkedHashMap<>();
+      item.put("name", name);
+      people.add(item);
+    }
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT ?", (Object) people);
+
+    final List<String> insertedNames = new ArrayList<>();
+    while (result.hasNext())
+      insertedNames.add(result.next().<String>getProperty("name"));
+    result.close();
+
+    assertThat(insertedNames).containsExactlyInAnyOrder("x", "y", "z");
+
+    final ResultSet count = database.query("sql", "SELECT count(*) as total FROM " + typeName);
+    assertThat(count.hasNext()).isTrue();
+    assertThat(count.next().<Long>getProperty("total")).isEqualTo(3L);
+    count.close();
+  }
+
+  @Test
+  void insertContentWithSingleMapParamStillCreatesOneRecord() {
+    final String typeName = "Issue6463MapParam";
+    database.getSchema().createDocumentType(typeName);
+
+    final Map<String, Object> content = new LinkedHashMap<>();
+    content.put("name", "mapParam");
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("content", content);
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT :content", params);
+
+    assertThat(result.hasNext()).isTrue();
+    final Result inserted = result.next();
+    assertThat(inserted.<String>getProperty("name")).isEqualTo("mapParam");
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  /**
+   * An empty-list {@code CONTENT :param} deliberately keeps the pre-existing {@code tot = 1} sizing of the
+   * equivalent empty JSON-array literal ({@code CONTENT []}), rather than creating zero records. This pins that
+   * documented edge case down (see the PR description for #6463).
+   */
+  @Test
+  void insertContentWithEmptyListParamStillCreatesOneRecord() {
+    final String typeName = "Issue6463EmptyListParam";
+    database.getSchema().createDocumentType(typeName);
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("people", new ArrayList<Map<String, Object>>());
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT :people", params);
+
+    assertThat(result.hasNext()).isTrue();
+    result.next();
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    final ResultSet count = database.query("sql", "SELECT count(*) as total FROM " + typeName);
+    assertThat(count.hasNext()).isTrue();
+    assertThat(count.next().<Long>getProperty("total")).isEqualTo(1L);
+    count.close();
+  }
+
+  /**
+   * {@code CreateVertexExecutionPlanner} extends {@link InsertExecutionPlanner} and reuses its
+   * {@code handleCreateRecord()} unchanged, so {@code CREATE VERTEX ... CONTENT :param} with a {@link List}-valued
+   * parameter must get the same one-record-per-item fix as plain {@code INSERT}.
+   */
+  @Test
+  void createVertexContentWithListParamCreatesOneVertexPerItem() {
+    final String typeName = "Issue6463Vertex";
+    database.getSchema().createVertexType(typeName);
+
+    final List<Map<String, Object>> people = new ArrayList<>();
+    for (final String name : List.of("v1", "v2", "v3")) {
+      final Map<String, Object> item = new LinkedHashMap<>();
+      item.put("name", name);
+      people.add(item);
+    }
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("people", people);
+
+    final ResultSet result = database.command("sql", "CREATE VERTEX " + typeName + " CONTENT :people", params);
+
+    final List<String> insertedNames = new ArrayList<>();
+    while (result.hasNext())
+      insertedNames.add(result.next().<String>getProperty("name"));
+    result.close();
+
+    assertThat(insertedNames).containsExactlyInAnyOrder("v1", "v2", "v3");
+
+    final ResultSet count = database.query("sql", "SELECT count(*) as total FROM " + typeName);
+    assertThat(count.hasNext()).isTrue();
+    assertThat(count.next().<Long>getProperty("total")).isEqualTo(3L);
+    count.close();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6465PlainScanSourcesHonourCommandDeadlineTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6465PlainScanSourcesHonourCommandDeadlineTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.index.RangeIndex;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6465: a WHERE-less aggregation/ORDER BY/DISTINCT over a plain scan drains the whole type
+ * server-side with nothing consulting {@code arcadedb.command.timeout}. {@code ScanWithFilterStep} and
+ * {@code FilterStep} (used when a WHERE exists) already guard their loop with
+ * {@link WorkGuard#forCommandDeadline(CommandContext)}; the plain scan sources - reached whenever there
+ * is no WHERE to build a filtered step from - carried no such guard, so a blocking consumer downstream
+ * (aggregation, {@code ORDER BY}, {@code DISTINCT}) could run past the configured deadline unbounded by
+ * anything but the data size.
+ * <p>
+ * Rather than reproducing that with a dataset large enough to outrun a real deadline under wall-clock
+ * timing (flaky across machines), each test here pins an already-expired deadline directly on the
+ * {@link CommandContext} - the same technique
+ * {@code Issue6266CommandTimeoutCoverageTest#aPinnedDeadlineIsHonouredWhateverItsValue} uses - and drains
+ * the guarded step directly, so the assertion is deterministic: the very first record the step tries to
+ * hand back must instead raise a {@link TimeoutException}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6465PlainScanSourcesHonourCommandDeadlineTest {
+
+  @Test
+  void fetchFromClusterExecutionStepHonoursAnExpiredDeadline() throws Exception {
+    TestHelper.executeInNewDatabase(db -> {
+      final DocumentType type = db.getSchema().createDocumentType("PlainScanType");
+      type.createProperty("value", Long.class);
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          db.newDocument("PlainScanType").set("value", (long) i).save();
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(db);
+      context.setCommandDeadline(System.currentTimeMillis() - 1, "an already expired deadline");
+
+      final FetchFromClusterExecutionStep step = new FetchFromClusterExecutionStep(type.getFirstBucketId(), context);
+      final ResultSet result = step.syncPull(context, 100);
+
+      assertThatThrownBy(() -> drain(result))
+          .as("a plain bucket scan with no WHERE must still stop at the command deadline")
+          .isInstanceOf(TimeoutException.class)
+          .hasMessageContaining("an already expired deadline");
+    });
+  }
+
+  @Test
+  void fetchFromIndexStepHonoursAnExpiredDeadline() throws Exception {
+    TestHelper.executeInNewDatabase(db -> {
+      final DocumentType type = db.getSchema().createDocumentType("PlainScanIndexType");
+      type.createProperty("value", Long.class);
+      final TypeIndex index = type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "value");
+
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          db.newDocument("PlainScanIndexType").set("value", (long) i).save();
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(db);
+      context.setCommandDeadline(System.currentTimeMillis() - 1, "an already expired deadline");
+
+      // No condition: a full, unfiltered ascending scan of the index - the DISTINCT/ORDER BY fast path.
+      final FetchFromIndexValuesStep step = new FetchFromIndexValuesStep((RangeIndex) index, true, context);
+      final ResultSet result = step.syncPull(context, 100);
+
+      assertThatThrownBy(() -> drain(result))
+          .as("a full index scan with no WHERE must still stop at the command deadline")
+          .isInstanceOf(TimeoutException.class)
+          .hasMessageContaining("an already expired deadline");
+    });
+  }
+
+  @Test
+  void fetchFromRidsStepHonoursAnExpiredDeadline() throws Exception {
+    TestHelper.executeInNewDatabase(db -> {
+      final DocumentType type = db.getSchema().createDocumentType("PlainScanRidType");
+      type.createProperty("value", Long.class);
+
+      final List<RID> rids = new ArrayList<>();
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          rids.add(db.newDocument("PlainScanRidType").set("value", (long) i).save().getIdentity());
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(db);
+      context.setCommandDeadline(System.currentTimeMillis() - 1, "an already expired deadline");
+
+      final FetchFromRidsStep step = new FetchFromRidsStep(rids, context);
+      final ResultSet result = step.syncPull(context, 100);
+
+      assertThatThrownBy(() -> drain(result))
+          .as("a RID-list scan with no WHERE must still stop at the command deadline")
+          .isInstanceOf(TimeoutException.class)
+          .hasMessageContaining("an already expired deadline");
+    });
+  }
+
+  /**
+   * Sanity check: with no deadline configured (the default), every guarded step still returns every row -
+   * the guard must cost nothing more than a comparison when disabled, never change the result.
+   */
+  @Test
+  void unguardedScansAreUnaffectedWhenNoDeadlineIsConfigured() throws Exception {
+    TestHelper.executeInNewDatabase(db -> {
+      final DocumentType type = db.getSchema().createDocumentType("PlainScanNoDeadlineType");
+      type.createProperty("value", Long.class);
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          db.newDocument("PlainScanNoDeadlineType").set("value", (long) i).save();
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(db);
+
+      final FetchFromClusterExecutionStep step = new FetchFromClusterExecutionStep(type.getFirstBucketId(), context);
+      assertThat(drain(step.syncPull(context, 100))).hasSize(10);
+    });
+  }
+
+  private static List<Result> drain(final ResultSet resultSet) {
+    final List<Result> rows = new ArrayList<>();
+    while (resultSet.hasNext())
+      rows.add(resultSet.next());
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.parser.MatchExpression;
+import com.arcadedb.query.sql.parser.MatchPathItem;
+import com.arcadedb.query.sql.parser.MatchStatement;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Focused unit tests for the GAV expand-into fast path in {@link MatchEdgeTraverser#init}, reproducing #6670:
+ * the fast path called {@code isConnectedTo()} with no edge type at all (matching on ANY type) and derived
+ * direction from the schedule's forward/reverse split instead of the pattern's actual out/in/both method.
+ * <p>
+ * Driving this from a full SQL MATCH query is unreliable here: the fast path only fires for an edge whose both
+ * endpoints are already bound by earlier edges in the same pattern (a cycle-closing edge), and getting the
+ * planner to schedule one - without it instead getting folded into a {@code MatchGAVFusedStep} chain, which
+ * bypasses {@link MatchEdgeTraverser} entirely - depends on scheduling heuristics that are not part of this
+ * bug. This test instead builds the minimal {@link EdgeTraversal}/bound-source-record scaffolding directly and
+ * drives {@link MatchEdgeTraverser#hasNext} itself, with a {@link GraphTraversalProvider} test double that
+ * records exactly which direction and edge types it was asked about.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MatchEdgeTraverserExpandIntoTest extends TestHelper {
+
+  /**
+   * Records the direction/edge types of the last {@link #isConnectedTo} call and answers a fixed "connected"
+   * verdict, so a test can assert both what the traverser asked and what it did with the answer.
+   */
+  private static final class RecordingProvider implements GraphTraversalProvider {
+    private final Map<RID, Integer> ridToId = new HashMap<>();
+    private final Map<Integer, RID> idToRid = new HashMap<>();
+    private       int               nextId  = 0;
+    private       boolean           connected;
+
+    Vertex.DIRECTION lastDirection;
+    String[]         lastEdgeTypes;
+
+    private int idFor(final RID rid) {
+      return ridToId.computeIfAbsent(rid, r -> {
+        final int id = nextId++;
+        idToRid.put(id, r);
+        return id;
+      });
+    }
+
+    @Override
+    public int getNodeCount() {
+      return ridToId.size();
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "recording-fake";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return idFor(rid);
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return idToRid.get(nodeId);
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return new int[0];
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return 0;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      lastDirection = direction;
+      lastEdgeTypes = edgeTypes;
+      return connected;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+  }
+
+  private RecordingProvider provider;
+
+  @AfterEach
+  void unregisterProvider() {
+    if (provider != null)
+      GraphTraversalProviderRegistry.unregister(database, provider);
+  }
+
+  private MatchPathItem parsePathItem(final String matchPattern) {
+    final MatchStatement stm = (MatchStatement) ((DatabaseInternal) database).getStatementCache()
+        .get("MATCH " + matchPattern + " RETURN a,b");
+    final MatchExpression expr = stm.getMatchExpressions().get(0);
+    return expr.getItems().get(0);
+  }
+
+  private EdgeTraversal edgeTraversal(final MatchPathItem item, final boolean forward) {
+    final PatternNode outNode = new PatternNode();
+    outNode.alias = "a";
+    final PatternNode inNode = new PatternNode();
+    inNode.alias = "b";
+    final PatternEdge patternEdge = new PatternEdge();
+    patternEdge.out = outNode;
+    patternEdge.in = inNode;
+    patternEdge.item = item;
+    return new EdgeTraversal(patternEdge, forward);
+  }
+
+  private ResultInternal boundSourceRecord(final Identifiable a, final Identifiable b) {
+    final ResultInternal sourceRecord = new ResultInternal(database);
+    sourceRecord.setProperty("a", a);
+    sourceRecord.setProperty("b", b);
+    return sourceRecord;
+  }
+
+  @Test
+  void expandIntoPassesPatternEdgeTypeToProvider() {
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isTrue();
+    // Before the fix, isConnectedTo() was called with no edge types at all (any type matches); it must now
+    // receive exactly the pattern's own type.
+    assertThat(provider.lastEdgeTypes).containsExactly("KNOWS");
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.OUT);
+  }
+
+  @Test
+  void expandIntoForwardDirectionMatchesMethodName() {
+    // a.in('KNOWS') must be checked as IN from a's perspective, not OUT: before the fix, the forward traverser
+    // always asked for OUT regardless of the pattern's actual out/in/both method.
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.in('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.IN);
+  }
+
+  @Test
+  void expandIntoReverseTraverserFlipsDirection() {
+    // MatchReverseEdgeTraverser starts from the pattern's in-side and runs the method's *reverse*, so for
+    // a.out('KNOWS') scheduled backward (starting at b) it must ask the provider for IN from b's perspective -
+    // before the fix, the reverse traverser inherited the same OUT-biased formula as the forward one.
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchReverseEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, false));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.IN);
+    assertThat(provider.lastEdgeTypes).containsExactly("KNOWS");
+  }
+
+  @Test
+  void expandIntoBothDirectionStaysBoth() {
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.both('KNOWS'){as:b}");
+
+    final BasicCommandContext forwardContext = new BasicCommandContext();
+    forwardContext.setDatabase(database);
+    final MatchEdgeTraverser forward = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+    assertThat(forward.hasNext(forwardContext)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.BOTH);
+
+    final BasicCommandContext reverseContext = new BasicCommandContext();
+    reverseContext.setDatabase(database);
+    final MatchEdgeTraverser reverse = new MatchReverseEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, false));
+    assertThat(reverse.hasNext(reverseContext)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.BOTH);
+  }
+
+  @Test
+  void expandIntoNotConnectedReturnsEmpty() {
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = false;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
@@ -66,6 +66,7 @@ class MatchEdgeTraverserExpandIntoTest extends TestHelper {
 
     Vertex.DIRECTION lastDirection;
     String[]         lastEdgeTypes;
+    int              isConnectedToCalls;
 
     private int idFor(final RID rid) {
       return ridToId.computeIfAbsent(rid, r -> {
@@ -122,6 +123,7 @@ class MatchEdgeTraverserExpandIntoTest extends TestHelper {
 
     @Override
     public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      isConnectedToCalls++;
       lastDirection = direction;
       lastEdgeTypes = edgeTypes;
       return connected;
@@ -288,5 +290,56 @@ class MatchEdgeTraverserExpandIntoTest extends TestHelper {
     context.setDatabase(database);
 
     assertThat(traverser.hasNext(context)).isFalse();
+  }
+
+  @Test
+  void expandIntoSkipsWhileConditionItems() {
+    // A while-conditioned item is a variable-depth traversal: isConnectedTo() only ever answers whether two
+    // vertices are joined by a single hop, so it must never be consulted here even though both endpoints are
+    // already bound - the recursive executeTraversal() has to run instead.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("KNOWS", b);
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b, while: ($depth < 2)}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    traverser.hasNext(context);
+    assertThat(provider.isConnectedToCalls).isZero();
+  }
+
+  @Test
+  void expandIntoSkipsMaxDepthItems() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("KNOWS", b);
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.out('KNOWS'){as:b, maxDepth: 2}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    traverser.hasNext(context);
+    assertThat(provider.isConnectedToCalls).isZero();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchEdgeTraverserExpandIntoTest.java
@@ -245,6 +245,57 @@ class MatchEdgeTraverserExpandIntoTest extends TestHelper {
   }
 
   @Test
+  void expandIntoReverseInDirectionMapsToOut() {
+    // Same flip as expandIntoReverseTraverserFlipsDirection(), but for the "in" method: a.in('KNOWS') scheduled
+    // backward (starting at b, the method's actual out-side) must ask the provider for OUT from b's perspective.
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.in('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchReverseEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, false));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThat(traverser.hasNext(context)).isTrue();
+    assertThat(provider.lastDirection).isEqualTo(Vertex.DIRECTION.OUT);
+  }
+
+  @Test
+  void expandIntoSkipsUnrecognizedMethod() {
+    // outE()/inE()/bothE()/outV()/inV() return an edge/vertex object the fast path doesn't produce, so
+    // getExpandIntoDirection() must fall through to null (its default case) for any method other than
+    // out/in/both, leaving the provider untouched even though both endpoints are bound.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("KNOWS", b);
+    database.commit();
+
+    provider = new RecordingProvider();
+    provider.connected = true;
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    final MatchPathItem item = parsePathItem("{as:a}.outE('KNOWS'){as:b}");
+    final MatchEdgeTraverser traverser = new MatchEdgeTraverser(boundSourceRecord(a, b), edgeTraversal(item, true));
+
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    traverser.hasNext(context);
+    assertThat(provider.isConnectedToCalls).isZero();
+  }
+
+  @Test
   void expandIntoBothDirectionStaysBoth() {
     database.getSchema().createVertexType("Person");
     database.begin();

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchGAVFusedStepDirectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchGAVFusedStepDirectionTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the {@code MatchGAVFusedStep} sibling of #6670, found during code review: the fused
+ * multi-hop chain step ({@link MatchExecutionPlanner#collectFusibleChain}/{@code isFusibleEdge}) derived each
+ * hop's direction from the schedule's forward/reverse flag ({@code EdgeTraversal.out}) rather than the pattern's
+ * actual out/in/both method - the same root cause this PR fixes for the single-hop expand-into fast path, just
+ * in the chain-fusion path instead. {@code isFusibleEdge} explicitly allows {@code in()}/{@code both()} hops
+ * into a fused chain, so a chain with one of those and a GAV registered silently queried the wrong direction.
+ * <p>
+ * {@code createPlanForPattern} always runs the schedule's first edge through the regular (correct)
+ * {@code MatchStep}/{@code MatchEdgeTraverser} path - {@code collectFusibleChain} only starts looking from the
+ * second edge onward, and only actually uses {@link MatchGAVFusedStep} once it collects 2+ fusible edges there.
+ * A 2-hop pattern therefore never fuses (one edge is always peeled off first, leaving only one to "chain"); these
+ * tests use a 3-hop pattern so the second and third hops - the ones that actually go through
+ * {@code MatchGAVFusedStep} - carry the {@code in()}/{@code both()} method under test.
+ * <p>
+ * {@code MatchGAVFusedStep} does not evaluate each hop's own {@code where} clause (a separate, pre-existing
+ * limitation of the fused path, out of scope here), so each hop in the fixture uses its own edge type -
+ * FOLLOWS/KNOWS/KNOWS2 - to stay unambiguous by graph shape alone rather than relying on a filter the fused step
+ * would silently ignore. Sharing one KNOWS type across both fused hops would let the middle vertex's own
+ * outgoing edge (needed to test the second hop) also satisfy the first hop's direction check, masking exactly
+ * the bug this test exists to catch.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MatchGAVFusedStepDirectionTest extends TestHelper {
+
+  @Test
+  void fusedChainRespectsInMethodDirection() {
+    // Alice -FOLLOWS-> Bob (hop 0, not fused). Eve -KNOWS-> Bob and Eve -KNOWS2-> Dave (hops 1-2, fused):
+    // b.in('KNOWS') must find Eve via the INCOMING edge (Bob has no outgoing KNOWS edge at all, so the buggy
+    // OUT-only fused query finds nothing here), then c.out('KNOWS2') must find Dave.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.getSchema().createEdgeType("KNOWS");
+    database.getSchema().createEdgeType("KNOWS2");
+
+    database.begin();
+    final MutableVertex alice = database.newVertex("Person").set("name", "Alice").save();
+    final MutableVertex bob = database.newVertex("Person").set("name", "Bob").save();
+    final MutableVertex eve = database.newVertex("Person").set("name", "Eve").save();
+    final MutableVertex dave = database.newVertex("Person").set("name", "Dave").save();
+    alice.newEdge("FOLLOWS", bob);
+    eve.newEdge("KNOWS", bob);
+    eve.newEdge("KNOWS2", dave);
+    database.commit();
+
+    // Built via the builder (not `new GraphAnalyticalView(db)`, which never registers itself as a
+    // GraphTraversalProvider) so the query planner actually discovers and fuses this chain.
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS", "KNOWS", "KNOWS2")
+        .build();
+    try {
+      database.begin();
+      final ResultSet rs = database.query("sql",
+          """
+          MATCH {type: Person, as: a, where: (name = 'Alice')}.out('FOLLOWS'){as: b}.in('KNOWS'){as: c}\
+          .out('KNOWS2'){as: d} \
+          RETURN a.name as aName, b.name as bName, c.name as cName, d.name as dName""");
+
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("aName")).isEqualTo("Alice");
+      assertThat(row.<String>getProperty("bName")).isEqualTo("Bob");
+      assertThat(row.<String>getProperty("cName")).isEqualTo("Eve");
+      assertThat(row.<String>getProperty("dName")).isEqualTo("Dave");
+      assertThat(rs.hasNext()).isFalse();
+      database.commit();
+    } finally {
+      gav.drop();
+    }
+  }
+
+  @Test
+  void fusedChainRespectsBothMethodDirection() {
+    // Same shape as fusedChainRespectsInMethodDirection(), but with both() hops: b.both('KNOWS') must find Eve
+    // regardless of edge direction (Bob has only an INCOMING KNOWS edge, so the buggy code - which "both"
+    // degrades to whenever the schedule doesn't happen to reverse this hop - finds nothing here), then
+    // c.both('KNOWS2') must find Dave.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.getSchema().createEdgeType("KNOWS");
+    database.getSchema().createEdgeType("KNOWS2");
+
+    database.begin();
+    final MutableVertex alice = database.newVertex("Person").set("name", "Alice").save();
+    final MutableVertex bob = database.newVertex("Person").set("name", "Bob").save();
+    final MutableVertex eve = database.newVertex("Person").set("name", "Eve").save();
+    final MutableVertex dave = database.newVertex("Person").set("name", "Dave").save();
+    alice.newEdge("FOLLOWS", bob);
+    eve.newEdge("KNOWS", bob);
+    eve.newEdge("KNOWS2", dave);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS", "KNOWS", "KNOWS2")
+        .build();
+    try {
+      database.begin();
+      final ResultSet rs = database.query("sql",
+          """
+          MATCH {type: Person, as: a, where: (name = 'Alice')}.out('FOLLOWS'){as: b}.both('KNOWS'){as: c}\
+          .both('KNOWS2'){as: d} \
+          RETURN a.name as aName, b.name as bName, c.name as cName, d.name as dName""");
+
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("aName")).isEqualTo("Alice");
+      assertThat(row.<String>getProperty("bName")).isEqualTo("Bob");
+      assertThat(row.<String>getProperty("cName")).isEqualTo("Eve");
+      assertThat(row.<String>getProperty("dName")).isEqualTo("Dave");
+      assertThat(rs.hasNext()).isFalse();
+      database.commit();
+    } finally {
+      gav.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/PerTypeAclIndexAndTimeSeriesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/PerTypeAclIndexAndTimeSeriesTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.security.SecurityDatabaseUser;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * A user denied {@code readRecord}/{@code deleteRecord} on a type must not be able to reach that type's data (or
+ * its TimeSeries samples, or its index entries) through a query plan that never loads the record through its
+ * bucket - {@code INDEX:} targets, the {@code MAX}/{@code MIN}/{@code count(*)} index shortcuts, and the TimeSeries
+ * read/count paths all have to apply the same per-type check {@code LocalBucket} applies to a normal record load.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PerTypeAclIndexAndTimeSeriesTest {
+  private static final String PATH        = "target/databases/PerTypeAclIndexAndTimeSeriesTest";
+  private static final String SECRET_TYPE = "Secret";
+  private static final String PUBLIC_TYPE = "Public";
+  private static final String TS_TYPE     = "SecretMetrics";
+
+  private DatabaseFactory factory;
+  private Database        database;
+  private String          secretIndexName;
+
+  @BeforeEach
+  void setUp() {
+    factory = new DatabaseFactory(PATH).setSecurity(db -> {
+    });
+    if (factory.exists())
+      factory.open().drop();
+
+    database = factory.create();
+
+    database.command("sql", "CREATE DOCUMENT TYPE " + SECRET_TYPE);
+    database.command("sql", "CREATE PROPERTY " + SECRET_TYPE + ".ssn STRING");
+    database.command("sql", "CREATE INDEX ON " + SECRET_TYPE + " (ssn) UNIQUE");
+    secretIndexName = database.getSchema().getType(SECRET_TYPE).getPolymorphicIndexByProperties("ssn").getName();
+    database.transaction(() -> database.command("sql", "INSERT INTO " + SECRET_TYPE + " SET ssn = '123-45-6789'"));
+
+    database.command("sql", "CREATE DOCUMENT TYPE " + PUBLIC_TYPE);
+    database.command("sql", "CREATE PROPERTY " + PUBLIC_TYPE + ".code STRING");
+    database.command("sql", "CREATE INDEX ON " + PUBLIC_TYPE + " (code) UNIQUE");
+    database.transaction(() -> database.command("sql", "INSERT INTO " + PUBLIC_TYPE + " SET code = 'ok'"));
+
+    database.command("sql", "CREATE TIMESERIES TYPE " + TS_TYPE + " TIMESTAMP ts FIELDS (value DOUBLE)");
+    database.transaction(() -> database.command("sql", "INSERT INTO " + TS_TYPE + " SET ts = 1000, value = 42.0"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(null);
+    database.drop();
+    factory.close();
+  }
+
+  @Test
+  void indexTargetSelectDeniedOnRestrictedTypeGrantedOnPublicType() {
+    bindUser(Set.of(SECRET_TYPE), Set.of());
+
+    final Throwable thrown = catchThrowable(
+        () -> database.query("sql", "SELECT key, rid FROM INDEX:`" + secretIndexName + "` WHERE key > ''").hasNext());
+    assertThat(thrown).as("reading a denied type's indexed values directly must be gated like a normal record read")
+        .isInstanceOf(SecurityException.class);
+
+    final ResultSet publicRs = database.query("sql", "SELECT key FROM INDEX:`" + publicIndexName() + "` WHERE key > ''");
+    assertThat(publicRs.hasNext()).as("the same query on an authorized type must still work").isTrue();
+  }
+
+  @Test
+  void indexTargetDeleteDeniedOnRestrictedType() {
+    bindUser(Set.of(SECRET_TYPE), Set.of());
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(
+        () -> database.command("sql", "DELETE FROM INDEX:`" + secretIndexName + "` WHERE key = '123-45-6789'")));
+    assertThat(thrown).as("deleting a denied type's index entry must be gated, not silently desync the index")
+        .isInstanceOf(SecurityException.class);
+
+    unbindUser();
+    final long entries = database.getSchema().getIndexByName(secretIndexName).countEntries();
+    assertThat(entries).as("no index entry may have been removed by the rejected delete").isEqualTo(1);
+  }
+
+  @Test
+  void maxMinIndexShortcutDeniedOnRestrictedType() {
+    bindUser(Set.of(SECRET_TYPE), Set.of());
+
+    // MaxMinFromIndexStep (like CountFromIndexStep and the TS count below) computes its single row lazily on the
+    // first next() - hasNext() only reports "not executed yet" - so the scan has to be driven past hasNext() for
+    // the check inside next() to run.
+    final Throwable thrown = catchThrowable(() -> database.query("sql", "SELECT max(ssn) FROM " + SECRET_TYPE).next());
+    assertThat(thrown).as("the MAX/MIN index shortcut must be gated exactly like a full record scan would be")
+        .isInstanceOf(SecurityException.class);
+  }
+
+  @Test
+  void countIndexShortcutDeniedOnRestrictedType() {
+    bindUser(Set.of(SECRET_TYPE), Set.of());
+
+    final Throwable thrown = catchThrowable(
+        () -> database.query("sql", "SELECT count(*) FROM INDEX:`" + secretIndexName + "`").next());
+    assertThat(thrown).as("counting a denied type's index entries must be gated like counting its records")
+        .isInstanceOf(SecurityException.class);
+  }
+
+  @Test
+  void timeSeriesReadAndCountDeniedOnRestrictedType() {
+    bindUser(Set.of(), Set.of(TS_TYPE));
+
+    final Throwable readThrown = catchThrowable(() -> database.query("sql", "SELECT FROM " + TS_TYPE).hasNext());
+    assertThat(readThrown).as("reading a denied TimeSeries type's samples must be gated like a normal record read")
+        .isInstanceOf(SecurityException.class);
+
+    final Throwable countThrown = catchThrowable(() -> database.query("sql", "SELECT count(*) FROM " + TS_TYPE).next());
+    assertThat(countThrown).as("counting a denied TimeSeries type's samples must be gated too")
+        .isInstanceOf(SecurityException.class);
+  }
+
+  @Test
+  void schemaIndexesListingHidesTheDeniedTypeAndKeepsThePublicOne() {
+    bindUser(Set.of(SECRET_TYPE), Set.of());
+
+    final ResultSet rs = database.query("sql", "SELECT FROM schema:indexes");
+    final List<String> visibleIndexNames = new ArrayList<>();
+    while (rs.hasNext())
+      visibleIndexNames.add(rs.next().<String>getProperty("name"));
+
+    assertThat(visibleIndexNames).as("a denied type's index must not even be listed")
+        .doesNotContain(secretIndexName);
+    assertThat(visibleIndexNames).as("an authorized type's index must still be listed")
+        .contains(publicIndexName());
+  }
+
+  private String publicIndexName() {
+    return database.getSchema().getType(PUBLIC_TYPE).getPolymorphicIndexByProperties("code").getName();
+  }
+
+  private void bindUser(final Set<String> deniedTypesByBucket, final Set<String> deniedTypesByName) {
+    DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(restrictedUser(deniedTypesByBucket, deniedTypesByName));
+  }
+
+  private void unbindUser() {
+    DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(null);
+  }
+
+  /**
+   * Denies every {@code ACCESS} on the buckets of {@code deniedTypesByBucket} and, independently, on the type names
+   * in {@code deniedTypesByName} (the only check a bucket-less TimeSeries type can be gated by) - everything else is
+   * granted, so a query succeeding proves the fix is scoped to the denied type and not a blanket lockout.
+   */
+  private SecurityDatabaseUser restrictedUser(final Set<String> deniedTypesByBucket, final Set<String> deniedTypesByName) {
+    final Set<Integer> deniedBucketIds = new HashSet<>();
+    for (final String typeName : deniedTypesByBucket)
+      for (final int bucketId : database.getSchema().getType(typeName).getBucketIds(false))
+        deniedBucketIds.add(bucketId);
+
+    return new SecurityDatabaseUser() {
+      @Override
+      public String getName() {
+        return "restricted";
+      }
+
+      @Override
+      public boolean requestAccessOnDatabase(final DATABASE_ACCESS access) {
+        return true;
+      }
+
+      @Override
+      public boolean requestAccessOnFile(final int fileId, final ACCESS access) {
+        return !deniedBucketIds.contains(fileId);
+      }
+
+      @Override
+      public boolean requestAccessOnType(final String typeName, final ACCESS access) {
+        return !deniedTypesByName.contains(typeName);
+      }
+
+      @Override
+      public long getResultSetLimit() {
+        return -1L;
+      }
+
+      @Override
+      public long getReadTimeout() {
+        return -1L;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SQLExecutorAdditionalCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SQLExecutorAdditionalCoverageTest.java
@@ -357,6 +357,47 @@ class SQLExecutorAdditionalCoverageTest extends TestHelper {
     rs.close();
   }
 
+  /**
+   * Issue #6680: a non-count aggregate (sum/avg/min/max) over an empty input used to return zero rows instead of the
+   * single row with a null/identity value that SQL callers expect (and that count(*) already returns).
+   */
+  @Test
+  void nonCountAggregatesOnEmptyTypeReturnSingleRow() {
+    database.getSchema().createDocumentType("EmptyAggType");
+
+    try (final ResultSet rs = database.query("sql", "SELECT max(x) as m FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result item = rs.next();
+      assertThat(item.<Object>getProperty("m")).isNull();
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT min(x) as m FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("m")).isNull();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT avg(x) as a FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("a")).isNull();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT sum(x) as s FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      // Consistent with a group whose rows are all-null: sum() never sees a non-null value and its identity is 0.
+      assertThat(rs.next().<Number>getProperty("s")).isEqualTo(0);
+    }
+
+    // Mixed with count(*): both aggregates must land in the same synthesized row.
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) as c, max(x) as m FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result item = rs.next();
+      assertThat(item.<Long>getProperty("c")).isEqualTo(0L);
+      assertThat(item.<Object>getProperty("m")).isNull();
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
   // --- EmptyDataGeneratorStep ---
   @Test
   void selectWithoutTarget() {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SQLExecutorAdditionalCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SQLExecutorAdditionalCoverageTest.java
@@ -396,6 +396,16 @@ class SQLExecutorAdditionalCoverageTest extends TestHelper {
       assertThat(item.<Object>getProperty("m")).isNull();
       assertThat(rs.hasNext()).isFalse();
     }
+
+    // A non-aggregate field column mixed with count(*) and no GROUP BY: the field has no group to bind to over an
+    // empty input, so it resolves to null rather than throwing - the synthesized row still carries the aggregate.
+    try (final ResultSet rs = database.query("sql", "SELECT x, count(*) as c FROM EmptyAggType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result item = rs.next();
+      assertThat(item.<Object>getProperty("x")).isNull();
+      assertThat(item.<Long>getProperty("c")).isEqualTo(0L);
+      assertThat(rs.hasNext()).isFalse();
+    }
   }
 
   // --- EmptyDataGeneratorStep ---

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
@@ -75,8 +75,11 @@ class SelectVarTargetCacheTest extends TestHelper {
     assertThat(rs2.next().<String>getProperty("name")).isEqualTo("fromB");
     rs2.close();
 
-    // Third execution: back to TypeA. Also exercises the ExecutionPlanCache path (ctx1's plan may have been
-    // cached), which must not still be pinned to whichever type built the cached plan first.
+    // Third execution: back to TypeA. Reuses the same shared parsed Statement once more (not the
+    // ExecutionPlanCache: a $var target is non-cacheable, so createExecutionPlan() never consults that cache
+    // for this statement at all - see the assertion below), which must not still be pinned to whichever type
+    // built the first execution's plan.
+    assertThat(stmt1.executionPlanCanBeCached()).isFalse();
     final SelectStatement stmt3 = (SelectStatement) db.getStatementCache().get(sqlText);
     final BasicCommandContext ctx3 = new BasicCommandContext();
     ctx3.setDatabase(database);
@@ -85,5 +88,36 @@ class SelectVarTargetCacheTest extends TestHelper {
     assertThat(rs3.hasNext()).isTrue();
     assertThat(rs3.next().<String>getProperty("name")).isEqualTo("fromA");
     rs3.close();
+  }
+
+  @Test
+  void ordinaryTargetStillUsesExecutionPlanCache() {
+    // Companion to the test above: confirms marking a $var target non-cacheable in FromItem.isCacheable()
+    // didn't overreach and disable plan caching for a plain, literal-type target.
+    database.getSchema().createDocumentType("TypeA");
+    database.begin();
+    database.newDocument("TypeA").set("name", "fromA").save();
+    database.commit();
+
+    final String sqlText = "SELECT FROM TypeA";
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final SelectStatement stmt = (SelectStatement) db.getStatementCache().get(sqlText);
+    assertThat(stmt.executionPlanCanBeCached()).isTrue();
+
+    // ExecutionPlanCache.put() discards a plan built before the cache's own invalidation timestamp - both are
+    // millisecond System.currentTimeMillis() reads, so a plan built in the very same millisecond as the schema
+    // DDL above (which invalidates the cache) can lose that race under a busy JVM. Wait past it explicitly
+    // rather than asserting on elapsed time (see StallAwareStopwatch guidance): this loop bounds nothing, it
+    // just guarantees the plan is built strictly after the invalidation it must not lose to.
+    final long lastInvalidation = db.getExecutionPlanCache().getLastInvalidation();
+    while (System.currentTimeMillis() <= lastInvalidation) {
+      Thread.onSpinWait();
+    }
+
+    assertThat(db.getExecutionPlanCache().contains(sqlText)).isFalse();
+    final BasicCommandContext ctx = new BasicCommandContext();
+    ctx.setDatabase(database);
+    stmt.createExecutionPlan(ctx);
+    assertThat(db.getExecutionPlanCache().contains(sqlText)).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
@@ -108,7 +108,9 @@ class SelectVarTargetCacheTest extends TestHelper {
     // millisecond System.currentTimeMillis() reads, so a plan built in the very same millisecond as the schema
     // DDL above (which invalidates the cache) can lose that race under a busy JVM. Wait past it explicitly
     // rather than asserting on elapsed time (see StallAwareStopwatch guidance): this loop bounds nothing, it
-    // just guarantees the plan is built strictly after the invalidation it must not lose to.
+    // just guarantees the plan is built strictly after the invalidation it must not lose to. Deliberately
+    // unbounded rather than a @Timeout-guarded wait: the wall clock is guaranteed to advance, so this cannot
+    // hang - the only way to leave this loop is for time to pass, which it always does.
     final long lastInvalidation = db.getExecutionPlanCache().getLastInvalidation();
     while (System.currentTimeMillis() <= lastInvalidation) {
       Thread.onSpinWait();

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectVarTargetCacheTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.sql.parser.LocalResultSet;
+import com.arcadedb.query.sql.parser.SelectStatement;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6669: {@code SelectExecutionPlanner.init()} aliased the statement's FROM target instead
+ * of copying it, so a later rewrite of a {@code $var} target (from
+ * {@code SelectExecutionPlanner#rewriteIndexChainsAsSubqueries}) mutated the FromClause node in place. That
+ * node is the exact object {@link com.arcadedb.query.sql.parser.StatementCache} hands back for every execution
+ * of the same SQL text, so the first execution's resolved type stuck permanently to the cached statement - and,
+ * via {@link com.arcadedb.query.sql.parser.ExecutionPlanCache} (also keyed purely by SQL text, independent of
+ * any variable binding), to the cached execution plan as well.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SelectVarTargetCacheTest extends TestHelper {
+
+  @Test
+  void reusedStatementWithDifferentVarTargetReturnsFreshType() {
+    database.getSchema().createDocumentType("TypeA");
+    database.getSchema().createDocumentType("TypeB");
+
+    database.begin();
+    database.newDocument("TypeA").set("name", "fromA").save();
+    database.newDocument("TypeB").set("name", "fromB").save();
+    database.commit();
+
+    final String sqlText = "SELECT FROM $t";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // First execution: $t = TypeA
+    final SelectStatement stmt1 = (SelectStatement) db.getStatementCache().get(sqlText);
+    final BasicCommandContext ctx1 = new BasicCommandContext();
+    ctx1.setDatabase(database);
+    ctx1.setVariable("$t", "TypeA");
+    final ResultSet rs1 = new LocalResultSet(stmt1.createExecutionPlan(ctx1));
+    assertThat(rs1.hasNext()).isTrue();
+    assertThat(rs1.next().<String>getProperty("name")).isEqualTo("fromA");
+    rs1.close();
+
+    // Second execution: StatementCache.get() returns the exact same parsed Statement instance for identical
+    // SQL text - proving this reuses the shared, potentially-mutated AST rather than a fresh parse.
+    final SelectStatement stmt2 = (SelectStatement) db.getStatementCache().get(sqlText);
+    assertThat(stmt2).isSameAs(stmt1);
+
+    final BasicCommandContext ctx2 = new BasicCommandContext();
+    ctx2.setDatabase(database);
+    ctx2.setVariable("$t", "TypeB");
+    final ResultSet rs2 = new LocalResultSet(stmt2.createExecutionPlan(ctx2));
+    assertThat(rs2.hasNext()).isTrue();
+    assertThat(rs2.next().<String>getProperty("name")).isEqualTo("fromB");
+    rs2.close();
+
+    // Third execution: back to TypeA. Also exercises the ExecutionPlanCache path (ctx1's plan may have been
+    // cached), which must not still be pinned to whichever type built the cached plan first.
+    final SelectStatement stmt3 = (SelectStatement) db.getStatementCache().get(sqlText);
+    final BasicCommandContext ctx3 = new BasicCommandContext();
+    ctx3.setDatabase(database);
+    ctx3.setVariable("$t", "TypeA");
+    final ResultSet rs3 = new LocalResultSet(stmt3.createExecutionPlan(ctx3));
+    assertThat(rs3.hasNext()).isTrue();
+    assertThat(rs3.next().<String>getProperty("name")).isEqualTo("fromA");
+    rs3.close();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodTransformTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodTransformTest.java
@@ -226,6 +226,10 @@ class SQLMethodTransformTest {
       }
 
       @Override
+      public void checkPermissionsOnType(String typeName, SecurityDatabaseUser.ACCESS access) {
+      }
+
+      @Override
       public boolean checkTransactionIsActive(boolean createTx) {
         return false;
       }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6671ExecutionPlanCacheRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6671ExecutionPlanCacheRaceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6671: {@code ExecutionPlanCache.getLastInvalidation() < planningStart} used to be checked in a separate
+ * lock scope ({@code synchronized(this)}) from the {@code put()} that followed it ({@code synchronized(map)}),
+ * leaving a window in which a concurrent {@code invalidate()} (triggered by a DDL such as {@code DROP INDEX}) could
+ * run between the check and the insert: the check would see "not yet invalidated", the DDL would invalidate and
+ * clear the map, and then the stale plan would be inserted into the freshly-cleared map anyway.
+ * <p>
+ * This test reproduces the race deterministically (no real threads, hence no flakiness) by driving the two
+ * operations - "plan a query" and "invalidate the cache" - in the exact interleaving that used to defeat the
+ * check: capture {@code planningStart}, invalidate the cache (standing in for a concurrent DDL), then attempt to
+ * cache a plan built at that {@code planningStart}. The single-lock, single-call {@code put(statement, plan,
+ * planningStart)} introduced by the fix must refuse to cache it.
+ */
+class Issue6671ExecutionPlanCacheRaceTest {
+  private DatabaseInternal database;
+
+  @BeforeEach
+  void setUp() {
+    database = (DatabaseInternal) new DatabaseFactory("./target/databases/issue6671-execplan-race").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  @Test
+  void planBuiltBeforeAConcurrentInvalidationIsNeverCached() throws InterruptedException {
+    database.getSchema().createDocumentType("Race6671");
+    final String stm = "SELECT FROM Race6671";
+
+    final ExecutionPlanCache cache = database.getExecutionPlanCache();
+    final CommandContext context = new BasicCommandContext().setDatabase(database);
+
+    // put()'s invalidation guard (issue #6671) is millisecond-timestamped: a plan built in the very same
+    // millisecond as a preceding invalidation (here, createDocumentType above) is correctly not cached. Sleeping
+    // past the millisecond boundary before the warm-up query below keeps this assertion deterministic, exactly
+    // like ExecutionPlanCacheTest.cacheInvalidation1 already does for the same reason.
+    Thread.sleep(2);
+
+    // Warm the cache once to obtain a real, valid ExecutionPlan instance to fight over.
+    database.query("sql", stm).close();
+    assertThat(cache.contains(stm)).isTrue();
+    final ExecutionPlan plan = cache.get(stm, context);
+    assertThat(plan).isNotNull();
+
+    // Planning "began" here, before the concurrent DDL below invalidates the cache - exactly the interleaving
+    // that used to slip through the two separately-locked calls.
+    final long planningStart = System.currentTimeMillis();
+
+    // Stand in for a concurrent DDL (e.g. DROP INDEX) landing on another thread while planning was in flight.
+    cache.invalidate();
+    assertThat(cache.contains(stm)).isFalse();
+
+    // The plan was built against planningStart, which is now older than the invalidation: it must be rejected.
+    cache.put(stm, plan, planningStart);
+    assertThat(cache.contains(stm)).as("a plan built before a concurrent invalidation must never be cached").isFalse();
+
+    // A plan whose planning genuinely started after the invalidation must still be cached normally.
+    final long freshPlanningStart = System.currentTimeMillis() + 1;
+    cache.put(stm, plan, freshPlanningStart);
+    assertThat(cache.contains(stm)).as("a plan planned after the invalidation must be cached").isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue6667ReproTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6667ReproTest.java
@@ -1,0 +1,54 @@
+package com.arcadedb.schema;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Standalone reproduction of the exact scenario reported in https://github.com/ArcadeData/arcadedb/issues/6667:
+ * a vertex type rename must not corrupt the type's edge-chunk bucket names, or an edge insert on the renamed
+ * type afterward fails with SchemaException. Kept separate from {@link TypeRenameComponentNamingTest} because it
+ * mirrors the issue's own reproducer verbatim.
+ */
+class Issue6667ReproTest {
+  private static final String DB_PATH = "target/databases/issue6667repro";
+
+  @AfterEach
+  void cleanup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void renamedVertexTypeCanStillInsertEdges() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    try (DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      try (Database db = factory.create()) {
+        db.getSchema().createVertexType("Person");
+        db.getSchema().createEdgeType("Knows");
+
+        db.transaction(() -> {
+          MutableVertex v1 = db.newVertex("Person").set("uid", "a").save();
+          MutableVertex v2 = db.newVertex("Person").set("uid", "b").save();
+          v1.newEdge("Knows", v2).save();
+        });
+
+        db.getSchema().getType("Person").rename("Human");
+
+        db.transaction(() -> {
+          MutableVertex v3 = db.newVertex("Human").set("uid", "c").save();
+          MutableVertex v4 = db.newVertex("Human").set("uid", "d").save();
+          v3.newEdge("Knows", v4).save();
+        });
+
+        assertThat(db.countType("Human", true)).isEqualTo(4L);
+      }
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue6667ReproTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6667ReproTest.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.arcadedb.schema;
 
-import com.arcadedb.database.Database;
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
-import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,40 +29,51 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Standalone reproduction of the exact scenario reported in https://github.com/ArcadeData/arcadedb/issues/6667:
  * a vertex type rename must not corrupt the type's edge-chunk bucket names, or an edge insert on the renamed
  * type afterward fails with SchemaException. Kept separate from {@link TypeRenameComponentNamingTest} because it
- * mirrors the issue's own reproducer verbatim.
+ * mirrors the issue's own reproducer verbatim, including the restart step the issue's suggested fix #4 calls
+ * out ("insert an edge, restart, insert another edge, and assert the bucket names follow the convention").
+ * <p>
+ * Extends {@link TestHelper} so {@code afterTest()} runs {@code CHECK DATABASE} on teardown: the failure mode
+ * this test guards against is bucket/file corruption, which a cached record count would not necessarily surface.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue6667ReproTest {
-  private static final String DB_PATH = "target/databases/issue6667repro";
-
-  @AfterEach
-  void cleanup() {
-    FileUtils.deleteRecursively(new File(DB_PATH));
-  }
+class Issue6667ReproTest extends TestHelper {
 
   @Test
   void renamedVertexTypeCanStillInsertEdges() {
-    FileUtils.deleteRecursively(new File(DB_PATH));
-    try (DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
-      try (Database db = factory.create()) {
-        db.getSchema().createVertexType("Person");
-        db.getSchema().createEdgeType("Knows");
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("Knows");
 
-        db.transaction(() -> {
-          MutableVertex v1 = db.newVertex("Person").set("uid", "a").save();
-          MutableVertex v2 = db.newVertex("Person").set("uid", "b").save();
-          v1.newEdge("Knows", v2).save();
-        });
+    database.transaction(() -> {
+      final MutableVertex v1 = database.newVertex("Person").set("uid", "a").save();
+      final MutableVertex v2 = database.newVertex("Person").set("uid", "b").save();
+      v1.newEdge("Knows", v2).save();
+    });
 
-        db.getSchema().getType("Person").rename("Human");
+    database.getSchema().getType("Person").rename("Human");
 
-        db.transaction(() -> {
-          MutableVertex v3 = db.newVertex("Human").set("uid", "c").save();
-          MutableVertex v4 = db.newVertex("Human").set("uid", "d").save();
-          v3.newEdge("Knows", v4).save();
-        });
+    database.transaction(() -> {
+      final MutableVertex v3 = database.newVertex("Human").set("uid", "c").save();
+      final MutableVertex v4 = database.newVertex("Human").set("uid", "d").save();
+      v3.newEdge("Knows", v4).save();
+    });
 
-        assertThat(db.countType("Human", true)).isEqualTo(4L);
-      }
-    }
+    assertThat(database.query("sql", "select from Human").stream().count()).isEqualTo(4L);
+
+    final String databasePath = database.getDatabasePath();
+    database.close();
+    database = new DatabaseFactory(databasePath).open();
+
+    database.transaction(() -> {
+      final MutableVertex v5 = database.newVertex("Human").set("uid", "e").save();
+      final MutableVertex v6 = database.newVertex("Human").set("uid", "f").save();
+      v5.newEdge("Knows", v6).save();
+    });
+
+    assertThat(database.query("sql", "select from Human").stream().count()).isEqualTo(6L);
+
+    final var edgeBuckets = database.getSchema().getType("Human").getInvolvedBuckets().stream()
+        .map(b -> b.getName()).filter(n -> n.endsWith("_out_edges") || n.endsWith("_in_edges")).toList();
+    assertThat(edgeBuckets).containsExactlyInAnyOrder("Human_0_out_edges", "Human_0_in_edges");
   }
 }

--- a/engine/src/test/java/com/arcadedb/schema/Issue6678PolymorphicBucketCacheVisibilityTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6678PolymorphicBucketCacheVisibilityTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.Bucket;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6678: {@code LocalDocumentType.cachedPolymorphicBuckets}/{@code cachedPolymorphicBucketIds} are published
+ * by copy-on-write reassignment ({@code addBucketInternal}, {@code removeBucket}, {@code updatePolymorphicBucketsCache})
+ * but read lock-free on the query-planning hot path ({@code getBuckets(true)}/{@code getBucketIds(true)}). A plain
+ * (non-{@code volatile}) field gives the Java Memory Model no happens-before edge between a schema-mutation thread's
+ * reassignment and a planning thread's read, so the planner is not guaranteed to ever observe a concurrent
+ * {@code ALTER TYPE ... BUCKET} - the same publication gap the sibling {@code LocalSchema.bucketId2TypeMap} pattern
+ * exists to avoid.
+ * <p>
+ * The fix makes both fields {@code volatile}. The first test pins the fix itself, so a future edit cannot silently
+ * drop the modifier. The second is a functional regression for the concrete scenario: adding/removing a bucket
+ * must be reflected by {@code getBuckets(true)}/{@code getBucketIds(true)} immediately afterward.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6678PolymorphicBucketCacheVisibilityTest extends TestHelper {
+
+  @Test
+  void cachedPolymorphicFieldsMustBeVolatileForCrossThreadPlanningReads() throws NoSuchFieldException {
+    final Field buckets = LocalDocumentType.class.getDeclaredField("cachedPolymorphicBuckets");
+    final Field bucketIds = LocalDocumentType.class.getDeclaredField("cachedPolymorphicBucketIds");
+
+    assertThat(Modifier.isVolatile(buckets.getModifiers()))
+        .as("cachedPolymorphicBuckets is copy-on-write reassigned under schema mutation and read lock-free by "
+            + "query planning - it must be volatile so planning threads have a happens-before edge against the "
+            + "writer (issue #6678)")
+        .isTrue();
+    assertThat(Modifier.isVolatile(bucketIds.getModifiers()))
+        .as("cachedPolymorphicBucketIds is copy-on-write reassigned under schema mutation and read lock-free by "
+            + "query planning - it must be volatile so planning threads have a happens-before edge against the "
+            + "writer (issue #6678)")
+        .isTrue();
+  }
+
+  @Test
+  void addingThenRemovingABucketIsReflectedByThePolymorphicCache() {
+    database.transaction(() -> database.getSchema().createDocumentType("Product", 1));
+
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().getType("Product");
+      final int before = type.getBuckets(true).size();
+
+      final Bucket newBucket = database.getSchema().createBucket("Product_extra");
+      type.addBucket(newBucket);
+
+      assertThat(type.getBuckets(true)).hasSize(before + 1).contains(newBucket);
+      assertThat(type.getBucketIds(true)).contains(newBucket.getFileId());
+
+      type.removeBucket(newBucket);
+
+      assertThat(type.getBuckets(true)).hasSize(before).doesNotContain(newBucket);
+      assertThat(type.getBucketIds(true)).doesNotContain(newBucket.getFileId());
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -914,6 +914,58 @@ class TypeTest extends TestHelper {
     assertThat(result).isNotNull();
   }
 
+  /**
+   * Issue #6469: with the datetime implementation configured as {@code ZonedDateTime}, converting a
+   * {@code java.util.Date} used to return a {@code LocalDateTime} (a copy-paste slip: the {@code Date} arm passed
+   * {@code LocalDateTime.class} instead of {@code ZonedDateTime.class}, unlike the {@code Calendar} arm right below
+   * it which already used the correct target). The underlying instant was preserved, but the runtime type was wrong,
+   * which broke {@code instanceof ZonedDateTime} and {@code equals()} against a {@code ZonedDateTime}.
+   */
+  @Test
+  void convertToZonedDateTimeFromDateReturnsZonedDateTime() {
+    final Date now = new Date();
+    final Object result = Type.convert(database, now, ZonedDateTime.class);
+    assertThat(result).isInstanceOf(ZonedDateTime.class);
+    assertThat(((ZonedDateTime) result).toInstant().toEpochMilli()).isEqualTo(now.getTime());
+  }
+
+  /**
+   * Issue #6469: the {@code ZonedDateTime} target had no {@code Number} branch at all (unlike the
+   * {@code LocalDateTime} target), so an epoch-millis {@code Number} set on such a property fell through
+   * {@code convert} unconverted instead of becoming a {@code ZonedDateTime}.
+   */
+  @Test
+  void convertToZonedDateTimeFromNumber() {
+    final long epochMillis = 1_700_000_000_123L;
+    final Object result = Type.convert(database, epochMillis, ZonedDateTime.class);
+    assertThat(result).isInstanceOf(ZonedDateTime.class);
+    assertThat(((ZonedDateTime) result).toInstant().toEpochMilli()).isEqualTo(epochMillis);
+  }
+
+  /**
+   * Issue #6469: same copy-paste slip as {@link #convertToZonedDateTimeFromDateReturnsZonedDateTime()}, but for the
+   * {@code Instant} target - the {@code Date} arm returned a {@code LocalDateTime} instead of an {@code Instant}.
+   */
+  @Test
+  void convertToInstantFromDateReturnsInstant() {
+    final Date now = new Date();
+    final Object result = Type.convert(database, now, Instant.class);
+    assertThat(result).isInstanceOf(Instant.class);
+    assertThat(((Instant) result).toEpochMilli()).isEqualTo(now.getTime());
+  }
+
+  /**
+   * Issue #6469: the {@code Instant} target had no {@code Number} branch at all, matching the missing branch on the
+   * {@code ZonedDateTime} target.
+   */
+  @Test
+  void convertToInstantFromNumber() {
+    final long epochMillis = 1_700_000_000_123L;
+    final Object result = Type.convert(database, epochMillis, Instant.class);
+    assertThat(result).isInstanceOf(Instant.class);
+    assertThat(((Instant) result).toEpochMilli()).isEqualTo(epochMillis);
+  }
+
   @Test
   void convertToRIDFromString() {
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
@@ -361,6 +361,154 @@ class BinarySerializerTest extends TestHelper {
     });
   }
 
+  /**
+   * Issue #6464: an EMPTY typed primitive-array property used to round-trip to an empty {@code ArrayList} instead
+   * of an array, because {@link BinaryTypes#getTypeFromValue(Object, com.arcadedb.schema.Property)} decided the
+   * binary type of a primitive array from its FIRST element - a {@code null} for an empty array - rather than from
+   * the array's component type. So the runtime type of the same property depended on whether it happened to be
+   * empty. Asserted both via the direct classifier ({@link BinaryTypes#getTypeFromValue}) and via a full
+   * serialize/deserialize round trip.
+   */
+  @Test
+  void emptyPrimitiveArrayKeepsItsArrayType() throws Exception {
+    assertThat(BinaryTypes.getTypeFromValue(new short[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_SHORTS);
+    assertThat(BinaryTypes.getTypeFromValue(new int[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_INTEGERS);
+    assertThat(BinaryTypes.getTypeFromValue(new long[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_LONGS);
+    assertThat(BinaryTypes.getTypeFromValue(new float[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_FLOATS);
+    assertThat(BinaryTypes.getTypeFromValue(new double[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_DOUBLES);
+
+    final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Test");
+      database.commit();
+
+      database.begin();
+      final MutableDocument v = database.newDocument("Test");
+
+      v.set("arrayOfIntegers", new int[0]);
+      v.set("arrayOfLongs", new long[0]);
+      v.set("arrayOfShorts", new short[0]);
+      v.set("arrayOfFloats", new float[0]);
+      v.set("arrayOfDoubles", new double[0]);
+
+      final Binary buffer = serializer.serialize((DatabaseInternal) database, v);
+
+      final ByteBuffer buffer2 = ByteBuffer.allocate((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue());
+      buffer2.put(buffer.toByteArray());
+      buffer2.flip();
+
+      final Binary buffer3 = new Binary(buffer2);
+      buffer3.getByte(); // SKIP RECORD TYPE
+      final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
+
+      assertThat(record2.get("arrayOfIntegers")).isInstanceOf(int[].class);
+      assertThat((int[]) record2.get("arrayOfIntegers")).isEmpty();
+      assertThat(record2.get("arrayOfLongs")).isInstanceOf(long[].class);
+      assertThat((long[]) record2.get("arrayOfLongs")).isEmpty();
+      assertThat(record2.get("arrayOfShorts")).isInstanceOf(short[].class);
+      assertThat((short[]) record2.get("arrayOfShorts")).isEmpty();
+      assertThat(record2.get("arrayOfFloats")).isInstanceOf(float[].class);
+      assertThat((float[]) record2.get("arrayOfFloats")).isEmpty();
+      assertThat(record2.get("arrayOfDoubles")).isInstanceOf(double[].class);
+      assertThat((double[]) record2.get("arrayOfDoubles")).isEmpty();
+    });
+  }
+
+  /**
+   * Issue #6464: a boxed {@code Short[]/Integer[]/Long[]/Float[]/Double[]} value was always classified
+   * {@code TYPE_LIST} regardless of content, so it silently downgraded to a {@code List} on read even though the
+   * equivalent primitive array (or a non-empty one, before the fix above) round-tripped as an array. The array's
+   * wrapper component type is now enough on its own to pick the matching {@code TYPE_ARRAY_OF_*} binary type, and
+   * it deserializes as the canonical primitive array - matching what {@code Type.ARRAY_OF_INTEGERS} et al. already
+   * declare as their Java class ({@code int[].class}, not {@code Integer[].class}).
+   */
+  @Test
+  void boxedPrimitiveArraysSerializeAsTypedArrays() throws Exception {
+    assertThat(BinaryTypes.getTypeFromValue(new Short[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_SHORTS);
+    assertThat(BinaryTypes.getTypeFromValue(new Integer[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_INTEGERS);
+    assertThat(BinaryTypes.getTypeFromValue(new Long[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_LONGS);
+    assertThat(BinaryTypes.getTypeFromValue(new Float[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_FLOATS);
+    assertThat(BinaryTypes.getTypeFromValue(new Double[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_DOUBLES);
+
+    final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Test");
+      database.commit();
+
+      final Short[] boxedShorts = { 1, 2, 3 };
+      final Integer[] boxedIntegers = { 1, 2, 3 };
+      final Long[] boxedLongs = { 1L, 2L, 3L };
+      final Float[] boxedFloats = { 1.1f, 2.2f, 3.3f };
+      final Double[] boxedDoubles = { 1.1, 2.2, 3.3 };
+
+      database.begin();
+      final MutableDocument v = database.newDocument("Test");
+
+      v.set("arrayOfShorts", boxedShorts);
+      v.set("arrayOfIntegers", boxedIntegers);
+      v.set("arrayOfLongs", boxedLongs);
+      v.set("arrayOfFloats", boxedFloats);
+      v.set("arrayOfDoubles", boxedDoubles);
+
+      final Binary buffer = serializer.serialize((DatabaseInternal) database, v);
+
+      final ByteBuffer buffer2 = ByteBuffer.allocate((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue());
+      buffer2.put(buffer.toByteArray());
+      buffer2.flip();
+
+      final Binary buffer3 = new Binary(buffer2);
+      buffer3.getByte(); // SKIP RECORD TYPE
+      final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
+
+      assertThat((short[]) record2.get("arrayOfShorts")).containsExactly((short) 1, (short) 2, (short) 3);
+      assertThat((int[]) record2.get("arrayOfIntegers")).containsExactly(1, 2, 3);
+      assertThat((long[]) record2.get("arrayOfLongs")).containsExactly(1L, 2L, 3L);
+      assertThat((float[]) record2.get("arrayOfFloats")).containsExactly(1.1f, 2.2f, 3.3f);
+      assertThat((double[]) record2.get("arrayOfDoubles")).containsExactly(1.1, 2.2, 3.3);
+    });
+  }
+
+  @Test
+  void boxedPrimitiveArrayWithNullElementFallsBackToListInsteadOfNPE() throws Exception {
+    // A WRAPPER ARRAY CONTAINING A null ELEMENT MUST NOT BE CLASSIFIED AS A TYPE_ARRAY_OF_* BINARY TYPE: THAT
+    // SERIALIZER UNBOXES EACH ELEMENT WITH AN ENHANCED FOR-LOOP AND WOULD NPE ON THE null ENTRY (REGRESSION GUARD
+    // FOR THE REVIEW COMMENT ON ISSUE #6464 / PR #6649).
+    assertThat(BinaryTypes.getTypeFromValue(new Short[] { 1, null, 3 }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+    assertThat(BinaryTypes.getTypeFromValue(new Integer[] { 1, null, 3 }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+    assertThat(BinaryTypes.getTypeFromValue(new Long[] { 1L, null, 3L }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+    assertThat(BinaryTypes.getTypeFromValue(new Float[] { 1.1f, null, 3.3f }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+    assertThat(BinaryTypes.getTypeFromValue(new Double[] { 1.1, null, 3.3 }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+
+    final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Test");
+      database.commit();
+
+      final Integer[] withNull = { 1, null, 3 };
+
+      database.begin();
+      final MutableDocument v = database.newDocument("Test");
+
+      v.set("someIntArrayProp", withNull);
+
+      // MUST NOT THROW: BEFORE THIS FIX, SERIALIZING A BOXED WRAPPER ARRAY WITH A null ELEMENT THREW AN UNCAUGHT NPE
+      final Binary buffer = serializer.serialize((DatabaseInternal) database, v);
+
+      final ByteBuffer buffer2 = ByteBuffer.allocate((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue());
+      buffer2.put(buffer.toByteArray());
+      buffer2.flip();
+
+      final Binary buffer3 = new Binary(buffer2);
+      buffer3.getByte(); // SKIP RECORD TYPE
+      final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
+
+      assertThat((List<Object>) record2.get("someIntArrayProp")).containsExactly(1, null, 3);
+    });
+  }
+
   @Test
   void mapPropertiesInDocument() throws Exception {
     final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());

--- a/engine/src/test/java/com/arcadedb/utility/StringUtilsSplitKeyValueTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/StringUtilsSplitKeyValueTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the contract of {@link StringUtils#splitKeyValue(String)}: split on the FIRST '=' only, so a value
+ * containing further separators (a connection string, a base64 padding) is kept whole. The console's
+ * {@code -D&lt;key&gt;=&lt;value&gt;} arguments and SET command (issue #6392), the Postgres wire's SET command,
+ * and the Studio include directive's parameters (issue #6423) all share this one rule instead of each carrying
+ * its own truncating {@code split("=")}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class StringUtilsSplitKeyValueTest {
+  @Test
+  void theValueIsEverythingAfterTheFirstSeparator() {
+    assertThat(StringUtils.splitKeyValue("a=b")).containsExactly("a", "b");
+    assertThat(StringUtils.splitKeyValue("a=b=c")).containsExactly("a", "b=c");
+    assertThat(StringUtils.splitKeyValue("a===")).containsExactly("a", "==");
+  }
+
+  @Test
+  void anEmptyValueIsAValue() {
+    assertThat(StringUtils.splitKeyValue("a=")).containsExactly("a", "");
+  }
+
+  @Test
+  void anEmptyKeyIsReturnedAsSuchForTheCallerToReject() {
+    assertThat(StringUtils.splitKeyValue("=b")).containsExactly("", "b");
+    assertThat(StringUtils.splitKeyValue("=")).containsExactly("", "");
+  }
+
+  @Test
+  void noSeparatorLeavesTheChoiceToTheCaller() {
+    assertThat(StringUtils.splitKeyValue("a")).isNull();
+    assertThat(StringUtils.splitKeyValue("")).isNull();
+  }
+
+  @Test
+  void surroundingBlanksArePreserved() {
+    assertThat(StringUtils.splitKeyValue(" a = b ")).containsExactly(" a ", " b ");
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -947,26 +947,55 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     proxied.setWrapper(name, instance);
   }
 
+  // Global variables are NOT replicated through Raft: unlike every other mutating method on this class, the five
+  // accessors below (getGlobalVariable, setGlobalVariable, setGlobalVariableIfAbsent, setGlobalVariableIfPresent,
+  // getGlobalVariables) all delegate straight to the local node's own database, with no consensus proposal
+  // involved at all. A value set on one node of an HA cluster is invisible to every other node, including after a
+  // failover, so setGlobalVariableIfAbsent/setGlobalVariableIfPresent's per-node atomicity does NOT make Redis
+  // "SET k v NX" (or any other caller) a real cluster-wide distributed lock. A full fix would mean replicating
+  // global variables through Raft, which none of these five methods attempt (issue #6560). Each accessor below
+  // carries its own Javadoc pointer to the full caveat on DatabaseInternal, since a Javadoc comment attaches only
+  // to the single declaration it precedes and would not otherwise show up in generated docs/IDE hover for the
+  // other four.
+
+  /**
+   * Not replicated in an HA cluster - see the caveat on {@link DatabaseInternal#getGlobalVariable(String)}.
+   */
   @Override
   public Object getGlobalVariable(final String name) {
     return proxied.getGlobalVariable(name);
   }
 
+  /**
+   * Not replicated in an HA cluster - see the caveat on {@link DatabaseInternal#getGlobalVariable(String)}.
+   */
   @Override
   public Object setGlobalVariable(final String name, final Object value) {
     return proxied.setGlobalVariable(name, value);
   }
 
+  /**
+   * Not a cluster-wide distributed lock in an HA cluster - see the caveat on
+   * {@link DatabaseInternal#setGlobalVariableIfAbsent(String, Object)}.
+   */
   @Override
   public Object setGlobalVariableIfAbsent(final String name, final Object value) {
     return proxied.setGlobalVariableIfAbsent(name, value);
   }
 
+  /**
+   * Not a cluster-wide distributed lock in an HA cluster - see the caveat on
+   * {@link DatabaseInternal#setGlobalVariableIfAbsent(String, Object)}.
+   */
   @Override
   public Object setGlobalVariableIfPresent(final String name, final Object value) {
     return proxied.setGlobalVariableIfPresent(name, value);
   }
 
+  /**
+   * Not replicated in an HA cluster - see the caveat on {@link DatabaseInternal#getGlobalVariable(String)}. Each
+   * entry of the returned map is this node's own local value, not a cluster-wide view.
+   */
   @Override
   public Map<String, Object> getGlobalVariables() {
     return proxied.getGlobalVariables();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1012,6 +1012,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   @Override
+  public void checkPermissionsOnType(final String typeName, final SecurityDatabaseUser.ACCESS access) {
+    proxied.checkPermissionsOnType(typeName, access);
+  }
+
+  @Override
   public long getResultSetLimit() {
     return proxied.getResultSetLimit();
   }

--- a/integration/src/main/java/com/arcadedb/integration/exporter/Exporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/Exporter.java
@@ -84,12 +84,18 @@ public class Exporter {
         elapsedInSecs = 1;
 
       final long totalRecords = context.vertices.get() + context.edges.get() + context.documents.get();
+      final long skippedRecords = context.skippedRecords.get();
 
-      logger.logLine(0,//
-          "Database exported successfully: %,d records exported in %s secs (%,d records/secs %,d documents %,d vertices %,d edges)",
+      if (skippedRecords > 0)
+        logger.errorLine(
+            "Database export completed with errors: %,d record(s) could not be serialized and were skipped (see the log above for the per-record errors)",
+            skippedRecords);
+      else
+        logger.logLine(0,//
+            "Database exported successfully: %,d records exported in %s secs (%,d records/secs %,d documents %,d vertices %,d edges)",
 //
-          totalRecords, elapsedInSecs, totalRecords / elapsedInSecs, context.documents.get(), context.vertices.get(),
-          context.edges.get());
+            totalRecords, elapsedInSecs, totalRecords / elapsedInSecs, context.documents.get(), context.vertices.get(),
+            context.edges.get());
 
       // RETURN STATISTICS
       final Map<String, Object> result = new LinkedHashMap<>();
@@ -102,9 +108,21 @@ public class Exporter {
         result.put("vertices", context.vertices.get());
       if (context.edges.get() > 0)
         result.put("edges", context.edges.get());
+      if (skippedRecords > 0)
+        result.put("skippedRecords", skippedRecords);
+
+      // A skipped record means the export file is incomplete: the archive was still written on a best-effort
+      // basis (issue #6471), but the operation as a whole must not report success, or the gap goes unnoticed
+      // until the missing records are needed. Symmetric to the importer's default "abort" outcome on a bad row.
+      if (skippedRecords > 0)
+        throw new ExportException(
+            "Database export completed with %,d record(s) skipped because they could not be serialized: the exported file is incomplete"
+                .formatted(skippedRecords));
 
       return result;
 
+    } catch (final ExportException e) {
+      throw e;
     } catch (final Exception e) {
       throw new ExportException("Error on writing to '" + settings.file + "'", e);
     } finally {

--- a/integration/src/main/java/com/arcadedb/integration/exporter/ExporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/ExporterContext.java
@@ -21,9 +21,15 @@ package com.arcadedb.integration.exporter;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ExporterContext {
-  public final AtomicLong documents = new AtomicLong();
-  public final AtomicLong vertices  = new AtomicLong();
-  public final AtomicLong edges     = new AtomicLong();
+  public final AtomicLong documents      = new AtomicLong();
+  public final AtomicLong vertices       = new AtomicLong();
+  public final AtomicLong edges          = new AtomicLong();
+  /**
+   * Records that threw while being serialized and were skipped rather than aborting the whole export
+   * (issue #6471). Incremented by the format implementation's per-record catch blocks; {@link Exporter}
+   * surfaces a non-zero count as a failing outcome once the export completes.
+   */
+  public final AtomicLong skippedRecords = new AtomicLong();
   public       long       startedOn;
   public       long       lastLapOn;
   public       long       lastDocuments;

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
@@ -156,6 +156,7 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
           writeJsonLine("v", graphSerializer.serializeGraphElement(record));
           context.vertices.incrementAndGet();
         } catch (Exception e) {
+          context.skippedRecords.incrementAndGet();
           LogManager.instance()
               .log(this, Level.SEVERE, "Error on exporting vertex %s", e, record != null ? record.getIdentity() : null);
         }
@@ -176,6 +177,7 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
           writeJsonLine("e", graphSerializer.serializeGraphElement(record));
           context.edges.incrementAndGet();
         } catch (Exception e) {
+          context.skippedRecords.incrementAndGet();
           LogManager.instance()
               .log(this, Level.SEVERE, "Error on exporting vertex %s", e, record != null ? record.getIdentity() : null);
         }
@@ -215,6 +217,7 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
             context.edges.incrementAndGet();
           }
         } catch (Exception e) {
+          context.skippedRecords.incrementAndGet();
           LogManager.instance().log(this, Level.SEVERE, "Error on exporting lightweight edges of vertex %s", e,
               vertex != null ? vertex.getIdentity() : null);
         }
@@ -235,6 +238,7 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
           writeJsonLine("d", graphSerializer.serializeGraphElement(record));
           context.documents.incrementAndGet();
         } catch (Exception e) {
+          context.skippedRecords.incrementAndGet();
           LogManager.instance()
               .log(this, Level.SEVERE, "Error on exporting vertex %s", e, record != null ? record.getIdentity() : null);
         }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -20,8 +20,10 @@ package com.arcadedb.integration.importer.format;
 
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.MutableEmbeddedDocument;
+import com.arcadedb.database.Record;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.LightEdge;
 import com.arcadedb.graph.MutableEdge;
@@ -41,7 +43,9 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalEdgeType;
 import com.arcadedb.schema.LocalVertexType;
+import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
 import com.arcadedb.schema.TypeFullTextIndexBuilder;
 import com.arcadedb.schema.TypeLSMSparseVectorIndexBuilder;
 import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
@@ -54,14 +58,24 @@ import java.io.InputStreamReader;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 
 public class JsonlImporterFormat extends AbstractImporterFormat {
 
   private ConsoleLogger          logger;
   private CompressedRID2RIDIndex ridIndex;
+
+  // Issue #6460: LINK / LIST-of-LINK / MAP-of-LINK property values are remapped through ridIndex as soon as they are
+  // loaded (loadProperties() below). A value that cannot be resolved yet - it references a record appearing LATER in
+  // the source stream - is a forward reference: the referenced record's old-to-new RID mapping does not exist yet.
+  // Rather than leaving it silently wrong (the original bug) or failing the whole record, the record's own new RID
+  // and the names of its still-unresolved properties are remembered here and revisited in a reconciliation pass once
+  // the entire file has been read and every RID mapping is known (see reconcileUnresolvedLinks()).
+  private final Map<RID, Set<String>> pendingLinkReconciliation = new HashMap<>();
 
   @Override
   public void load(SourceSchema sourceSchema,
@@ -85,6 +99,7 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       final BufferedReader reader = new BufferedReader(inputFileReader);
 
       ridIndex = new CompressedRID2RIDIndex(database, 1000, 1000);
+      pendingLinkReconciliation.clear();
 
       if (!database.isTransactionActive())
         database.begin();
@@ -132,6 +147,11 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
           database.begin();
         }
       }
+
+      // Issue #6460: resolve any LINK / LIST-of-LINK / MAP-of-LINK property values that were still forward
+      // references when their owning record was loaded (see the field comment on pendingLinkReconciliation).
+      // Every RID mapping is known by now, so this is the only point where they can be reliably fixed up.
+      reconcileUnresolvedLinks(database, context, skipOnRowError);
     } catch (ImportException e) {
       // A per-record failure in default "abort" mode must fail the whole import loudly (issue #6468): rolling
       // back the in-flight batch here - instead of committing it below - is what keeps a partial import from
@@ -345,9 +365,11 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     var properties = document.getJSONObject("p");
     var oldRid = new RID(document.getString("r"));
     var imported = database.newDocument(document.getString("t"));
-    loadProperties(database, imported, properties);
+    var unresolvedLinks = loadProperties(database, imported, properties);
     imported.save();
     ridIndex.put(oldRid, imported.getIdentity());
+    if (!unresolvedLinks.isEmpty())
+      pendingLinkReconciliation.put(imported.getIdentity(), unresolvedLinks);
     context.createdDocuments.incrementAndGet();
   }
 
@@ -360,9 +382,11 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     var properties = vertex.getJSONObject("p");
     var oldRid = new RID(vertex.getString("r"));
     var imported = database.newVertex(vertex.getString("t"));
-    loadProperties(database, imported, properties);
+    var unresolvedLinks = loadProperties(database, imported, properties);
     imported.save();
     ridIndex.put(oldRid, imported.getIdentity());
+    if (!unresolvedLinks.isEmpty())
+      pendingLinkReconciliation.put(imported.getIdentity(), unresolvedLinks);
     context.createdVertices.incrementAndGet();
   }
 
@@ -390,8 +414,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     if (!(imported instanceof LightEdge)) {
       // A lightweight edge has no record: it is already connected by newEdge, carries no properties, and
       // rejects fromMap()/save() by design.
-      loadProperties(database, imported, properties);
+      var unresolvedLinks = loadProperties(database, imported, properties);
       imported.save();
+      if (!unresolvedLinks.isEmpty())
+        pendingLinkReconciliation.put(imported.getIdentity(), unresolvedLinks);
     }
 
     context.createdEdges.incrementAndGet();
@@ -413,9 +439,221 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
   }
 
   // utility methods from JsonSerializer
-  private void loadProperties(DatabaseInternal database, MutableDocument imported, JSONObject properties) {
+
+  /**
+   * Loads a record's properties and, before they are written, remaps any LINK / LIST-of-LINK / MAP-of-LINK value
+   * from the source RID the exporter emitted to the RID the referenced record was actually recreated at (issue
+   * #6460). Without this, edges are healed through {@code ridIndex} on the endpoint paths ({@link #loadEdge}) but a
+   * regular LINK-typed property was passed through untouched, so after import it silently pointed at the source
+   * database's RID - now a different, unrelated record, or none.
+   *
+   * @return the names of properties whose LINK value(s) could not be resolved yet because they reference a record
+   * that has not been imported so far (a forward reference); empty when every LINK value resolved immediately. The
+   * caller is expected to remember these against the record's own (new) identity so {@link #reconcileUnresolvedLinks}
+   * can revisit them once every RID mapping is known.
+   */
+  private Set<String> loadProperties(DatabaseInternal database, MutableDocument imported, JSONObject properties) {
     Map<String, Object> json2map = json2map(database, properties);
+    final Set<String> unresolved = remapLinkProperties(imported.getType(), json2map);
     imported.fromMap(json2map);
+    return unresolved;
+  }
+
+  /**
+   * Remaps every LINK-typed value in {@code properties} in place, consulting {@code ridIndex} for the schema-declared
+   * LINK properties of {@code type} (scalar LINK, and LIST/MAP declared {@code OF LINK}). A value that {@code
+   * ridIndex} does not (yet) know about is left untouched and its property name is added to the returned set.
+   * <p>
+   * Only schema-declared properties are inspected: without a declared type there is no reliable way to tell a LINK
+   * string ("#12:34") apart from an ordinary string that merely looks like one.
+   */
+  private Set<String> remapLinkProperties(final DocumentType type, final Map<String, Object> properties) {
+    if (type == null || properties.isEmpty())
+      return Set.of();
+
+    Set<String> unresolved = null;
+
+    for (final Map.Entry<String, Object> entry : properties.entrySet()) {
+      final Object value = entry.getValue();
+      if (value == null)
+        continue;
+
+      final Property property = type.getPolymorphicPropertyIfExists(entry.getKey());
+      if (property == null)
+        continue;
+
+      final Type propertyType = property.getType();
+
+      if (propertyType == Type.LINK) {
+        if (unresolved == null)
+          unresolved = new HashSet<>();
+        entry.setValue(remapLinkValue(value, unresolved, entry.getKey()));
+      } else if (propertyType == Type.LIST && "LINK".equalsIgnoreCase(property.getOfType()) && value instanceof List<?> list) {
+        if (unresolved == null)
+          unresolved = new HashSet<>();
+        final List<Object> remapped = new ArrayList<>(list.size());
+        for (final Object item : list)
+          remapped.add(remapLinkValue(item, unresolved, entry.getKey()));
+        entry.setValue(remapped);
+      } else if (propertyType == Type.MAP && "LINK".equalsIgnoreCase(property.getOfType()) && value instanceof Map<?, ?> valueMap) {
+        if (unresolved == null)
+          unresolved = new HashSet<>();
+        final Map<Object, Object> remapped = new HashMap<>();
+        for (final Map.Entry<?, ?> mapEntry : valueMap.entrySet())
+          remapped.put(mapEntry.getKey(), remapLinkValue(mapEntry.getValue(), unresolved, entry.getKey()));
+        entry.setValue(remapped);
+      }
+    }
+
+    return unresolved == null ? Set.of() : unresolved;
+  }
+
+  /**
+   * Resolves a single LINK value (the exported source RID, as a String) to the RID the referenced record was
+   * actually recreated at. If {@code ridIndex} has no mapping yet for it - the referenced record has not been
+   * imported so far - {@code propertyName} is recorded into {@code unresolved} and the original value is returned
+   * unchanged, to be revisited by {@link #reconcileUnresolvedLinks}.
+   */
+  private Object remapLinkValue(final Object value, final Set<String> unresolved, final String propertyName) {
+    if (!(value instanceof String string))
+      return value;
+
+    final RID oldRid;
+    try {
+      oldRid = new RID(string);
+    } catch (final Exception e) {
+      // Not a RID-shaped string. Schema says this is a LINK, but the data disagrees - leave it for the normal
+      // property conversion/validation path to deal with rather than silently swallowing it here.
+      return value;
+    }
+
+    final RID newRid = ridIndex.get(oldRid);
+    if (newRid != null)
+      return newRid.toString();
+
+    unresolved.add(propertyName);
+    return value;
+  }
+
+  /**
+   * Revisits every record that {@link #loadProperties} could not fully resolve LINK values for on first pass (a
+   * forward reference to a record imported later in the source stream), now that the whole file has been read and
+   * every old-to-new RID mapping is known. A property still unresolved after this (the referenced record was never
+   * imported at all - excluded from the export, or a genuinely dangling link in the source database) is left as-is,
+   * matching the pre-fix behavior for that case, and is not treated as an import error.
+   * <p>
+   * <b>Known limitation:</b> until this method runs, an unresolved forward-reference LINK value sits in the record
+   * as the raw <i>source</i>-database RID (see {@link #remapLinkValue}) rather than a null or otherwise-neutral
+   * placeholder. If that property backs a UNIQUE index, this transient value can coincidentally collide with
+   * another record's already-resolved value in the <i>target</i> database, raising a {@code DuplicateKeyException}
+   * for data that would otherwise import cleanly. Accepted as a known limitation for now rather than fixed, since
+   * closing it properly (a null placeholder, a pre-scan of forward references, or documenting it permanently) is a
+   * design choice, not a mechanical patch - see PR #6654's "Review follow-ups" for the options considered.
+   * <p>
+   * A failure reconciling one record (including the {@code DuplicateKeyException} above) is handled exactly like a
+   * per-record failure in the main import loop (issue #6468, {@link #load}): logged, counted into
+   * {@code context.errors}, and either aborted via {@link ImportException} or skipped per {@code skipOnRowError},
+   * rather than propagating raw and uncounted past this method.
+   */
+  private void reconcileUnresolvedLinks(final DatabaseInternal database, final ImporterContext context, final boolean skipOnRowError) {
+    if (pendingLinkReconciliation.isEmpty())
+      return;
+
+    int reconciled = 0;
+    for (final Map.Entry<RID, Set<String>> entry : pendingLinkReconciliation.entrySet()) {
+      try {
+        final Record record = database.lookupByRID(entry.getKey(), true);
+        if (!(record instanceof Document document))
+          continue;
+
+        final DocumentType type = document.getType();
+        final MutableDocument mutable = document.modify();
+        boolean changed = false;
+
+        for (final String propertyName : entry.getValue()) {
+          final Property property = type.getPolymorphicPropertyIfExists(propertyName);
+          if (property == null)
+            continue;
+
+          final Object currentValue = mutable.get(propertyName);
+          if (currentValue == null)
+            continue;
+
+          if (property.getType() == Type.LINK && currentValue instanceof RID currentRid) {
+            final RID newRid = ridIndex.get(currentRid);
+            if (newRid != null) {
+              mutable.set(propertyName, newRid);
+              changed = true;
+            }
+          } else if (currentValue instanceof List<?> list) {
+            final List<Object> updated = new ArrayList<>(list.size());
+            boolean listChanged = false;
+            for (final Object item : list) {
+              if (item instanceof RID itemRid) {
+                final RID newRid = ridIndex.get(itemRid);
+                if (newRid != null) {
+                  updated.add(newRid);
+                  listChanged = true;
+                  continue;
+                }
+              }
+              updated.add(item);
+            }
+            if (listChanged) {
+              mutable.set(propertyName, updated);
+              changed = true;
+            }
+          } else if (currentValue instanceof Map<?, ?> valueMap) {
+            final Map<Object, Object> updated = new HashMap<>();
+            boolean mapChanged = false;
+            for (final Map.Entry<?, ?> mapEntry : valueMap.entrySet()) {
+              Object mapValue = mapEntry.getValue();
+              if (mapValue instanceof RID itemRid) {
+                final RID newRid = ridIndex.get(itemRid);
+                if (newRid != null) {
+                  mapValue = newRid;
+                  mapChanged = true;
+                }
+              }
+              updated.put(mapEntry.getKey(), mapValue);
+            }
+            if (mapChanged) {
+              mutable.set(propertyName, updated);
+              changed = true;
+            }
+          }
+        }
+
+        if (changed)
+          mutable.save();
+      } catch (final Exception e) {
+        // Same per-record failure handling as the main import loop (JsonlImporterFormat.java:113-138, issue
+        // #6468): logged, counted, and either aborts the whole import or is skipped per -onRowError, exactly like
+        // any other record failure, instead of propagating raw and uncounted.
+        LogManager.instance().log(this, Level.SEVERE, "Error on reconciling forward-referenced LINK propert(y/ies) for record '%s'", e, entry.getKey());
+        context.errors.incrementAndGet();
+        if (!skipOnRowError)
+          throw new ImportException("Error on reconciling forward-referenced LINK properties for record " + entry.getKey(), e);
+
+        if (database.isTransactionActive())
+          database.rollback();
+        database.begin();
+        continue;
+      }
+
+      // Mirrors the periodic commit granularity of the main import loop (see load()): without this, every record
+      // touched here rides in the single transaction still open when the main loop finished, on top of the batches
+      // already committed for the initial load, producing one very large WAL transaction for a restore with many
+      // forward-referencing LINK properties. Skip mode commits every record individually, same reasoning as the
+      // main loop: a failed record's rollback must never discard an earlier, already-reconciled one riding in the
+      // same batch.
+      if (skipOnRowError || ++reconciled % 1000 == 0) {
+        database.commit();
+        database.begin();
+      }
+    }
+
+    pendingLinkReconciliation.clear();
   }
 
   private Map<String, Object> json2map(DatabaseInternal database, final JSONObject json) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -93,6 +93,13 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     // failed record's rollback can never discard an earlier, already-successful one riding in the same batch.
     final boolean skipOnRowError = settings.isSkipOnRowError();
 
+    // "skip" mode commits/rolls back per record, so it must own the transaction outright - exactly like
+    // CSVImporterFormat/JSONImporterFormat (see ImporterSettings#isSkipOnRowError() and
+    // ImporterSettings#newExclusiveTransactionRequiredException()). Checked eagerly, before touching the database
+    // at all, so a caller-managed transaction's pending work is never at risk (issue #6561).
+    if (skipOnRowError && context.callerTransactionActiveOnEntry)
+      throw ImporterSettings.newExclusiveTransactionRequiredException();
+
     try (final InputStreamReader inputFileReader = new InputStreamReader(parser.getInputStream(),
         DatabaseFactory.getDefaultCharset())) {
       context.startedOn = System.currentTimeMillis();
@@ -141,8 +148,11 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
         // Skip mode commits every record individually (see above and the field comment on skipOnRowError); the
         // default "abort" mode keeps the coarser periodic commit for throughput, since any failure there aborts
-        // and rolls back the whole in-flight batch anyway (see the ImportException catch below).
-        if (skipOnRowError || context.parsed.get() % 1000 == 0) {
+        // and rolls back the whole in-flight batch anyway (see the ImportException catch below). Neither runs at
+        // all when the caller already owns the active transaction (skip mode never reaches here - see the guard
+        // above): a caller-managed transaction is never ours to commit piecemeal, only to accumulate into and hand
+        // back to whoever owns it (issue #6561).
+        if (!context.callerTransactionActiveOnEntry && (skipOnRowError || context.parsed.get() % 1000 == 0)) {
           database.commit();
           database.begin();
         }
@@ -163,7 +173,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     } finally {
-      if (database.isTransactionActive())
+      // Gated on callerTransactionActiveOnEntry exactly like the ImportException catch above (issue #6561): a
+      // transaction that predates this import is never ours to commit, on success or on failure - it's left open
+      // for whoever owns it to decide.
+      if (!context.callerTransactionActiveOnEntry && database.isTransactionActive())
         database.commit();
     }
     context.lastLapOn = System.currentTimeMillis();
@@ -646,8 +659,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       // already committed for the initial load, producing one very large WAL transaction for a restore with many
       // forward-referencing LINK properties. Skip mode commits every record individually, same reasoning as the
       // main loop: a failed record's rollback must never discard an earlier, already-reconciled one riding in the
-      // same batch.
-      if (skipOnRowError || ++reconciled % 1000 == 0) {
+      // same batch. Same callerTransactionActiveOnEntry gate as load()'s own periodic commit, and for the same
+      // reason (issue #6561): skip mode never reaches here when the caller owns the transaction (rejected eagerly
+      // in load()), and the default mode must not commit a transaction it doesn't own either.
+      if (!context.callerTransactionActiveOnEntry && (skipOnRowError || ++reconciled % 1000 == 0)) {
         database.commit();
         database.begin();
       }

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue6075SnapshotBackupIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue6075SnapshotBackupIT.java
@@ -66,6 +66,18 @@ class Issue6075SnapshotBackupIT {
   private static final int    RECORDS       = 20_000;
   /** Throttled so the backup lasts long enough to sample the flush-suspension state a meaningful number of times. */
   private static final int    MAX_MB_PER_SECOND = 4;
+  /**
+   * Issue #6475: {@code countBefore}/{@code countAfter} are sampled by {@link Database#countType} - the bucket's
+   * O(1) cached record counter (see {@code LocalBucket#count()}) - a few microseconds either side of the backup's
+   * own, separately-established point-in-time cutoff, with no barrier tying the two together. A writer commit
+   * landing in that gap is a genuine, narrow race in the test's sampling (not in the backup/restore path itself):
+   * it can make the counter observed as {@code countBefore} run one ahead of what had actually reached the page
+   * state the backup's cutoff captures, which is otherwise indistinguishable from a real point-in-time violation.
+   * Observed once in CI (run 32220365449, job 95970773131): restored count 20001 one below countBefore 20002,
+   * not reproduced locally since. One record of slack absorbs exactly that gap without weakening the assertion's
+   * actual purpose, which is catching a torn or moving snapshot, not a single-commit sampling race.
+   */
+  private static final long   COUNT_SAMPLING_RACE_TOLERANCE = 1L;
 
   @BeforeEach
   @AfterEach
@@ -111,7 +123,9 @@ class Issue6075SnapshotBackupIT {
 
         try (final Database restored = new DatabaseFactory(RESTORED_PATH).open()) {
           assertThat(restored.command("sql", "check database").nextIfAvailable().<Long>getProperty("totalErrors")).isZero();
-          assertThat(restored.countType(TYPE, false)).isBetween(countBefore, countAfter);
+          // See COUNT_SAMPLING_RACE_TOLERANCE (issue #6475): the lower bound allows for a commit landing in the
+          // unsynchronized gap between sampling countBefore and the backup's own point-in-time cutoff.
+          assertThat(restored.countType(TYPE, false)).isBetween(countBefore - COUNT_SAMPLING_RACE_TOLERANCE, countAfter);
         }
       } finally {
         running.set(false);

--- a/integration/src/test/java/com/arcadedb/integration/exporter/JsonlExporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/JsonlExporterIT.java
@@ -20,6 +20,8 @@ package com.arcadedb.integration.exporter;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Record;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.integration.importer.OrientDBImporter;
 import com.arcadedb.integration.importer.OrientDBImporterIT;
@@ -35,7 +37,10 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.net.URL;
+import java.util.Iterator;
 import java.util.zip.GZIPInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -186,6 +191,96 @@ class JsonlExporterIT {
 
     assertThat(foundNonUniqueIndex).as("Should find the non-unique index on age").isTrue();
     assertThat(foundUniqueIndex).as("Should find the unique index on email").isTrue();
+  }
+
+  /**
+   * Issue #6471: a record that throws while being serialized must not make the export look complete. The
+   * per-record catch in {@code JsonlExporterFormat} still skips the broken record and keeps going (that part
+   * is deliberate, issue #6471's own description), but the export as a whole must now report failure and the
+   * skipped count, instead of silently printing its counters as if nothing were missing.
+   */
+  @Test
+  void exportFailsLoudlyWhenARecordCannotBeSerialized() throws Exception {
+    final File file = new File(FILE);
+
+    try (final Database db = new DatabaseFactory(DATABASE_PATH).create()) {
+      db.transaction(() -> {
+        final DocumentType type = db.getSchema().createVertexType("Widget");
+        type.createProperty("name", String.class);
+      });
+      db.transaction(() -> {
+        db.newVertex("Widget").set("name", "first").save();
+        db.newVertex("Widget").set("name", "second").save();
+      });
+    }
+
+    final DatabaseInternal realDatabase = (DatabaseInternal) new DatabaseFactory(DATABASE_PATH).open();
+    try {
+      // A JDK dynamic proxy that forwards every call to the real, already-open database, except
+      // iterateType("Widget", false): that call still returns a real iterator over the real records, but the
+      // first record it hands back throws once (simulating a record that fails to serialize, e.g. #6471's own
+      // DATE-unit example) before behaving normally for the rest. Forwarding through method.invoke() keeps every
+      // internal self-call running with the REAL database as "this", which matters here: the engine keys its
+      // per-thread transaction context by database identity (LocalDatabase#getTransactionIfExists), so a copied
+      // instance (e.g. a Mockito spy(), which clones state onto a new object) is rejected as "a different db".
+      final DatabaseInternal proxyDatabase = (DatabaseInternal) Proxy.newProxyInstance(
+          DatabaseInternal.class.getClassLoader(), new Class<?>[] { DatabaseInternal.class },
+          (proxy, method, args) -> {
+            if ("iterateType".equals(method.getName()) && "Widget".equals(args[0]) && Boolean.FALSE.equals(args[1])) {
+              final Iterator<Record> real = (Iterator<Record>) method.invoke(realDatabase, args);
+              return new Iterator<Record>() {
+                private boolean thrown = false;
+
+                @Override
+                public boolean hasNext() {
+                  return real.hasNext();
+                }
+
+                @Override
+                public Record next() {
+                  final Record record = real.next();
+                  if (!thrown) {
+                    thrown = true;
+                    throw new RuntimeException("Simulated export serialization failure");
+                  }
+                  return record;
+                }
+              };
+            }
+            try {
+              return method.invoke(realDatabase, args);
+            } catch (final InvocationTargetException e) {
+              throw e.getCause();
+            }
+          });
+
+      final Exporter exporter = new Exporter(proxyDatabase, FILE);
+      exporter.setFormat("jsonl").setOverwrite(true);
+
+      assertThatThrownBy(exporter::exportDatabase)//
+          .isInstanceOf(ExportException.class)//
+          .hasMessageContaining("skipped");
+
+      // Best-effort: the file is still written with whatever did serialize successfully.
+      assertThat(file.exists()).isTrue();
+
+      int vertexLines = 0;
+      try (final BufferedReader in = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(file))))) {
+        while (in.ready()) {
+          final String line = in.readLine();
+          final JSONObject json = new JSONObject(line);
+          if ("v".equals(json.getString("t")))
+            ++vertexLines;
+        }
+      }
+      // Two vertex-type iterations touch "Widget" (exportVertices and exportLightweightEdges), each one skips
+      // its own first record: only the second, unaffected widget makes it into exportVertices' output.
+      assertThat(vertexLines).isEqualTo(1);
+
+    } finally {
+      if (realDatabase.isOpen())
+        realDatabase.close();
+    }
   }
 
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JsonLImporterIT {
@@ -399,6 +400,259 @@ class JsonLImporterIT {
     } finally {
       Files.deleteIfExists(jsonlFile);
     }
+  }
+
+  /**
+   * Issue #6561: {@code -onRowError skip} commits/rolls back per record, so - exactly like CSV/JSON (see
+   * {@code Issue5968ImporterSkipOnRowErrorTest}) - it must own the transaction outright and reject an already-active
+   * caller-managed transaction eagerly, rather than silently committing/discarding whatever the caller had pending
+   * on the first record.
+   */
+  @Test
+  void importDatabaseSkipModeRejectsInsideActiveTransaction() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-skip-active-tx-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, singleVertexJsonl());
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        // The caller starts their own transaction with unrelated pending work before handing the Database to the
+        // importer, exactly like the CSV/JSON counterparts in Issue5968ImporterSkipOnRowErrorTest.
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+        importer.settings.onRowError = "skip";
+
+        assertThatThrownBy(importer::load).isInstanceOf(ImportException.class)
+            .hasRootCauseInstanceOf(IllegalStateException.class);
+
+        // The guard must fire before touching the database at all: the caller's own transaction and its pending
+        // work must still be there for them to decide what to do with.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  /**
+   * Issue #6561: default "abort" mode has no exclusive-transaction-ownership guard (only "skip" mode rejects an
+   * already-active caller transaction, see {@link #importDatabaseSkipModeRejectsInsideActiveTransaction()}), so it
+   * must run directly inside a caller's own transaction without ever committing it - on success, the transaction
+   * must be left open for the caller to commit themselves, exactly like {@code CSVImporterFormat}/
+   * {@code JSONImporterFormat} (see {@code csvDocumentImportOnAllSuccessLeavesCallersExternallyManagedTransactionOpenForThemToCommit}
+   * in {@code Issue5968ImporterSkipOnRowErrorTest}).
+   */
+  @Test
+  void importDatabaseAbortModeInsideActiveTransactionLeavesTransactionOpenOnSuccess() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-abort-success-active-tx-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, singleVertexJsonl());
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+        Map<String, Object> result = importer.load();
+        assertThat(result).doesNotContainKey("errors");
+
+        // The import succeeded, but the transaction was never ours to commit: it must still be active, with the
+        // caller's own pre-existing work not yet durable, for the caller to commit (or roll back) themselves.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+        assertThat(db.countType("Person", true)).isEqualTo(1);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  /**
+   * Issue #6561, symmetric to {@link #importDatabaseAbortModeInsideActiveTransactionLeavesTransactionOpenOnSuccess()}
+   * but for the failure path: a failing record must still abort the import, but must not discard the caller's own
+   * pending work by committing OR rolling back a transaction this import never owned - it must be left exactly as
+   * the caller left it, active, for them alone to decide what happens to it next.
+   */
+  @Test
+  void importDatabaseAbortModeInsideActiveTransactionDoesNotCommitOrRollbackOnFailure() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-abort-failure-active-tx-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2},\"r\":\"#6:1\",\"t\":\"NonExistentType\",\"o\":[],\"i\":[]}}\n");
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+
+        assertThatThrownBy(importer::load).isInstanceOf(ImportException.class);
+
+        // The import failed, but the caller's own transaction - and therefore their pre-existing pending work -
+        // must still be there for them to decide what to do with: neither committed nor rolled back out from under
+        // them by an import that never owned this transaction.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  /**
+   * Issue #6561: the periodic {@code commit()}/{@code begin()} every 1000 records in default "abort" mode must not
+   * run at all while inside a caller-managed transaction - it must not silently commit the caller's transaction (and
+   * whatever unrelated work it holds) out from under them partway through a large import, replacing it with a fresh
+   * one the caller never asked for.
+   */
+  @Test
+  void importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyOnLargeImport() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-abort-periodic-active-tx-", ".jsonl");
+    try {
+      final int vertexCount = 1500; // exceeds the 1000-record periodic commit threshold
+      Files.writeString(jsonlFile, manyVerticesJsonl(vertexCount));
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+        Map<String, Object> result = importer.load();
+        assertThat(result).doesNotContainKey("errors");
+        assertThat(result).containsEntry("createdVertices", (long) vertexCount);
+
+        // If the periodic commit had fired (unguarded), the caller's transaction would have been replaced partway
+        // through - still "active" by the time load() returns, but a DIFFERENT, freshly-begun one that no longer
+        // holds the caller's own pre-existing pending work. Asserting the pending work is still there proves the
+        // ORIGINAL transaction survived intact, not just that some transaction happens to be active.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+        assertThat(db.countType("Person", true)).isEqualTo(vertexCount);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  /**
+   * Issue #6561 review follow-up: symmetric to
+   * {@link #importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyOnLargeImport()} but for
+   * {@code reconcileUnresolvedLinks()}'s own periodic commit rather than the main loop's - the large-import fixture
+   * used there carries no LINK properties, so its reconciliation pass is a no-op and never exercises this gate.
+   * Every vertex here (bar the last) has a forward-referencing {@code next} LINK property pointing at the vertex
+   * imported immediately after it, which is guaranteed unresolved on first pass (the referenced record hasn't been
+   * imported yet) and so lands in {@code pendingLinkReconciliation}, exercising the reconciliation pass's own
+   * periodic commit at the same >1000-entry scale.
+   */
+  @Test
+  void importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyDuringLinkReconciliation() throws IOException {
+    Path jsonlFile = Files.createTempFile("arcadedb-6561-abort-periodic-reconcile-active-tx-", ".jsonl");
+    try {
+      final int vertexCount = 1500; // exceeds the 1000-record periodic commit threshold
+      Files.writeString(jsonlFile, manyVerticesWithForwardLinksJsonl(vertexCount));
+
+      var db = new DatabaseFactory(DATABASE_PATH).create();
+      try {
+        db.command("sql", "CREATE DOCUMENT TYPE CallerWork");
+
+        db.begin();
+        db.newDocument("CallerWork").set("name", "pre-existing").save();
+
+        var importer = new Importer(db, jsonlFile.toAbsolutePath().toString());
+        Map<String, Object> result = importer.load();
+        assertThat(result).doesNotContainKey("errors");
+        assertThat(result).containsEntry("createdVertices", (long) vertexCount);
+
+        // Same reasoning as importDatabaseAbortModeInsideActiveTransactionDoesNotCommitPeriodicallyOnLargeImport:
+        // asserting the caller's own pre-existing pending work is still there proves the ORIGINAL transaction
+        // survived the reconciliation pass intact, not just that some transaction happens to be active.
+        assertThat(db.isTransactionActive()).isTrue();
+        db.commit();
+
+        assertThat(db.countType("CallerWork", true)).isEqualTo(1);
+        assertThat(db.countType("Person", true)).isEqualTo(vertexCount);
+      } finally {
+        db.drop();
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  private static String singleVertexJsonl() {
+    return ""
+        + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+        + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+        + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n"
+        + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n";
+  }
+
+  private static String manyVerticesJsonl(final int vertexCount) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(
+        "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n");
+    sb.append("{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n");
+    sb.append(
+        "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n");
+    for (int i = 0; i < vertexCount; ++i)
+      sb.append("{\"t\":\"v\",\"c\":{\"p\":{\"id\":").append(i).append("},\"r\":\"#6:").append(i)
+          .append("\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+    return sb.toString();
+  }
+
+  private static String manyVerticesWithForwardLinksJsonl(final int vertexCount) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(
+        "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n");
+    sb.append("{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n");
+    sb.append(
+        "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},"
+            + "\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{"
+            + "\"id\":{\"type\":\"INTEGER\",\"custom\":{}},"
+            + "\"next\":{\"type\":\"LINK\",\"custom\":{}}"
+            + "},\"indexes\":{},\"custom\":{}}}}}\n");
+    for (int i = 0; i < vertexCount; ++i) {
+      // Every vertex but the last points forward at the NEXT one in the stream (r="#6:(i+1)"), which hasn't been
+      // imported yet at the point this line is processed - guaranteed unresolved on first pass, so it lands in
+      // pendingLinkReconciliation for reconcileUnresolvedLinks() to fix up afterwards.
+      final String next = i < vertexCount - 1 ? ",\"next\":\"#6:" + (i + 1) + "\"" : "";
+      sb.append("{\"t\":\"v\",\"c\":{\"p\":{\"id\":").append(i).append(next).append("},\"r\":\"#6:").append(i)
+          .append("\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+    }
+    return sb.toString();
   }
 
   private static void checkImportedDatabase() {

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -19,6 +19,9 @@
 package com.arcadedb.integration.importer;
 
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NULL_STRATEGY;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.schema.Schema;
@@ -33,6 +36,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -191,6 +197,204 @@ class JsonLImporterIT {
       try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
         assertThat(db.countType("Person", true)).isEqualTo(2L);
         assertThat(db.countType("Friend", true)).isEqualTo(0L);
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  @Test
+  void importDatabaseRemapsLinkTypedPropertyValues() throws IOException {
+    // Issue #6460: a LINK-typed property (and a LIST-of-LINK one) must be remapped through the same old-RID -> new-RID
+    // index edges already use, not passed through with the source database's RID. The source "r" fields below are
+    // deliberately NOT #6:0, #6:1, ... : a fresh import always allocates sequential positions starting at #6:0 in an
+    // empty bucket, so any "r" that doesn't already follow that sequence is guaranteed to land at a DIFFERENT RID on
+    // import - exactly the "restore into fresh buckets" scenario the issue describes - which is what makes a
+    // still-unremapped (still equal to the old "r") link value observable.
+    //
+    // Person#2.bestFriend -> Person#1 is a BACKWARD reference (Person#1 was already imported): resolved immediately.
+    // Person#3.friends -> [Person#4] is a FORWARD reference (Person#4 is imported LATER in the stream): only the
+    // reconciliation pass fixes this one up, once every RID mapping is known.
+    Path jsonlFile = Files.createTempFile("arcadedb-link-remap-import-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},"
+          + "\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{"
+          + "\"id\":{\"type\":\"INTEGER\",\"custom\":{}},"
+          + "\"bestFriend\":{\"type\":\"LINK\",\"custom\":{}},"
+          + "\"friends\":{\"type\":\"LIST\",\"of\":\"LINK\",\"custom\":{}}"
+          + "},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:5\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2,\"bestFriend\":\"#6:5\"},\"r\":\"#6:7\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":3,\"friends\":[\"#6:9\"]},\"r\":\"#6:8\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":4},\"r\":\"#6:9\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true").split(" "));
+      Map<String, Object> result = importer.load();
+
+      assertThat(result).containsEntry("createdVertices", 4L);
+      assertThat(result).doesNotContainKey("errors");
+
+      try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
+        assertThat(db.countType("Person", true)).isEqualTo(4L);
+
+        final Map<Integer, Document> byId = new HashMap<>();
+        for (final Iterator<Record> it = db.iterateType("Person", true); it.hasNext(); ) {
+          final Document doc = it.next().asDocument(true);
+          byId.put((Integer) doc.get("id"), doc);
+        }
+
+        final RID person1Rid = byId.get(1).getIdentity();
+        final RID person4Rid = byId.get(4).getIdentity();
+
+        // None of the freshly assigned RIDs coincide with the source "r" values used above - proof that a still-wrong
+        // (unremapped) value in either assertion below could not pass by accident.
+        assertThat(person1Rid.toString()).isNotIn("#6:5", "#6:7", "#6:8", "#6:9");
+        assertThat(person4Rid.toString()).isNotIn("#6:5", "#6:7", "#6:8", "#6:9");
+
+        // Backward reference: bestFriend must point at Person#1's NEW identity, not at the source RID "#6:5".
+        assertThat(byId.get(2).get("bestFriend")).isEqualTo(person1Rid);
+
+        // Forward reference, fixed up by the reconciliation pass: friends must point at Person#4's NEW identity,
+        // not at the source RID "#6:9".
+        final List<?> friends = (List<?>) byId.get(3).get("friends");
+        assertThat(friends).hasSize(1);
+        assertThat(friends.get(0)).isEqualTo(person4Rid);
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  @Test
+  void importDatabaseRemapsMapOfLinkPropertyValues() throws IOException {
+    // Issue #6460 follow-up (review on PR #6654): MAP-of-LINK is implemented by the same remapLinkProperties()/
+    // reconcileUnresolvedLinks() code path as LIST-of-LINK, but was not exercised by any test. Same fixture shape
+    // as importDatabaseRemapsLinkTypedPropertyValues: a backward reference resolved on first pass and a forward
+    // reference fixed up only by the reconciliation pass.
+    Path jsonlFile = Files.createTempFile("arcadedb-map-link-remap-import-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},"
+          + "\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{"
+          + "\"id\":{\"type\":\"INTEGER\",\"custom\":{}},"
+          + "\"relations\":{\"type\":\"MAP\",\"of\":\"LINK\",\"custom\":{}}"
+          + "},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:5\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2,\"relations\":{\"parent\":\"#6:5\"}},\"r\":\"#6:7\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":3,\"relations\":{\"child\":\"#6:9\"}},\"r\":\"#6:8\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":4},\"r\":\"#6:9\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true").split(" "));
+      Map<String, Object> result = importer.load();
+
+      assertThat(result).containsEntry("createdVertices", 4L);
+      assertThat(result).doesNotContainKey("errors");
+
+      try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
+        final Map<Integer, Document> byId = new HashMap<>();
+        for (final Iterator<Record> it = db.iterateType("Person", true); it.hasNext(); ) {
+          final Document doc = it.next().asDocument(true);
+          byId.put((Integer) doc.get("id"), doc);
+        }
+
+        final RID person1Rid = byId.get(1).getIdentity();
+        final RID person4Rid = byId.get(4).getIdentity();
+
+        // Backward reference: resolved on first pass.
+        final Map<?, ?> person2Relations = (Map<?, ?>) byId.get(2).get("relations");
+        assertThat(person2Relations.get("parent")).isEqualTo(person1Rid);
+
+        // Forward reference: fixed up only by the reconciliation pass.
+        final Map<?, ?> person3Relations = (Map<?, ?>) byId.get(3).get("relations");
+        assertThat(person3Relations.get("child")).isEqualTo(person4Rid);
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  @Test
+  void importDatabaseLeavesNeverResolvedLinkUnchanged() throws IOException {
+    // Issue #6460 follow-up (review on PR #6654): a LINK value that references a record never present in the
+    // source stream at all (excluded via -includeTypes/-excludeTypes, or a genuinely dangling link) must be left
+    // as-is - matching pre-fix behavior for that case - and must NOT be counted as an import error.
+    Path jsonlFile = Files.createTempFile("arcadedb-link-never-resolves-import-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},"
+          + "\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{"
+          + "\"id\":{\"type\":\"INTEGER\",\"custom\":{}},"
+          + "\"bestFriend\":{\"type\":\"LINK\",\"custom\":{}}"
+          + "},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1,\"bestFriend\":\"#6:99\"},\"r\":\"#6:5\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true").split(" "));
+      Map<String, Object> result = importer.load();
+
+      assertThat(result).containsEntry("createdVertices", 1L);
+      assertThat(result).doesNotContainKey("errors");
+
+      try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
+        final Document person1 = db.iterateType("Person", true).next().asDocument(true);
+        // Never resolved: left as the original (now unreachable) source RID, exactly like pre-fix behavior.
+        assertThat(person1.get("bestFriend")).isEqualTo(new RID("#6:99"));
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  @Test
+  void importDatabaseRemapsLinkPropertyOnEdge() throws IOException {
+    // Issue #6460 follow-up (review on PR #6654): loadVertex/loadDocument were both covered, but loadEdge wires
+    // pendingLinkReconciliation through a different call site with the same shape - a LINK-typed property on a
+    // (non-lightweight) edge must be remapped too, including the forward-reference case fixed up only by the
+    // reconciliation pass.
+    Path jsonlFile = Files.createTempFile("arcadedb-edge-link-remap-import-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},"
+          + "\"types\":{"
+          + "\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}},"
+          + "\"Knows\":{\"type\":\"e\",\"parents\":[],\"buckets\":[\"Knows_0\"],\"properties\":{\"referrer\":{\"type\":\"LINK\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}"
+          + "}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:5\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2},\"r\":\"#6:6\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"e\",\"c\":{\"p\":{\"referrer\":\"#6:7\"},\"t\":\"Knows\",\"o\":\"#6:5\",\"i\":\"#6:6\"}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":3},\"r\":\"#6:7\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true").split(" "));
+      Map<String, Object> result = importer.load();
+
+      assertThat(result).containsEntry("createdVertices", 3L);
+      assertThat(result).containsEntry("createdEdges", 1L);
+      assertThat(result).doesNotContainKey("errors");
+
+      try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
+        Document person3 = null;
+        for (final Iterator<Record> it = db.iterateType("Person", true); it.hasNext(); ) {
+          final Document doc = it.next().asDocument(true);
+          if (Integer.valueOf(3).equals(doc.get("id")))
+            person3 = doc;
+        }
+        assertThat(person3).isNotNull();
+
+        final var knowsEdge = db.iterateType("Knows", true).next().asEdge(true);
+        // Forward reference (Person#3 imported after the edge): fixed up only by the reconciliation pass.
+        assertThat(knowsEdge.get("referrer")).isEqualTo(person3.getIdentity());
       }
     } finally {
       Files.deleteIfExists(jsonlFile);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2050,24 +2050,33 @@ public class PostgresNetworkExecutor extends Thread {
     }
   }
 
+  private static final Pattern SET_TO_SEPARATOR = Pattern.compile("(?i)\\s+TO\\s+");
+
   /**
    * Parses a Postgres {@code SET <param> = <value>} or {@code SET <param> TO <value>} command into its
-   * {@code {paramName, value}} pair. Splits on the FIRST separator only, so a value containing a further
-   * '=' (e.g. a connection string) is kept whole instead of truncated (issue #6423). {@code paramName} is
-   * lower-cased for case-insensitive comparison; a quoted {@code value} has its surrounding quotes
-   * stripped. Returns null when the command has neither a '=' nor a ' TO ' separator.
+   * {@code {paramName, value}} pair. A command can only use one of the two separators, but its value may
+   * legitimately contain the other one as plain text (e.g. {@code SET search_path TO 'a=b'} or
+   * {@code SET x = 'a TO b'}), so this picks whichever separator - the first '=' or the first case-
+   * insensitive ' TO ' - occurs FIRST in the string and splits on that one only, leaving every other
+   * occurrence of either inside the value untouched (issue #6423). {@code paramName} is lower-cased for
+   * case-insensitive comparison; a quoted {@code value} has its surrounding quotes stripped. Returns null
+   * when the command has neither separator.
    */
   static String[] parseSetCommand(final String query) {
     final int setLength = "SET ".length();
     // Use original query to preserve case of values
     final String q = query.substring(setLength);
 
-    String[] parts = StringUtils.splitKeyValue(q);
-    if (parts == null)
-      // Fall back to a case-insensitive " TO " split, also on the first occurrence only
-      parts = q.split("(?i)\\s+TO\\s+", 2);
+    final int eqPos = q.indexOf('=');
+    final Matcher toMatcher = SET_TO_SEPARATOR.matcher(q);
+    final boolean toFound = toMatcher.find();
 
-    if (parts.length < 2)
+    final String[] parts;
+    if (toFound && (eqPos < 0 || toMatcher.start() < eqPos))
+      parts = new String[] { q.substring(0, toMatcher.start()), q.substring(toMatcher.end()) };
+    else if (eqPos >= 0)
+      parts = StringUtils.splitKeyValue(q);
+    else
       return null;
 
     final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2080,6 +2080,10 @@ public class PostgresNetworkExecutor extends Thread {
       return null;
 
     final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);
+    if (paramName.isEmpty())
+      // An empty parameter name (e.g. "SET = somevalue") is as malformed as a missing separator.
+      return null;
+
     String value = parts[1].trim();
     if (value.startsWith("'") || value.startsWith("\"")) {
       // A quoted value needs a matching closing delimiter: a single stray quote (e.g. "SET x = '") is a

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -30,6 +30,7 @@ import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.database.QueryMetricsRecorder;
 import com.arcadedb.exception.ArithmeticErrorException;
 import com.arcadedb.exception.CauseChain;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.ErrorCategory;
@@ -668,7 +669,8 @@ public class PostgresNetworkExecutor extends Thread {
           resultSet = database.command(query.language, query.query, server.getConfiguration());
         }
       }
-      final List<Result> cachedResultSet = browseAndCacheResultSet(resultSet, 0);
+      final List<Result> cachedResultSet = browseAndCacheBoundedResultSet(resultSet,
+          GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.getValueAsInteger());
       profile.addEngineNanos(System.nanoTime() - engineStart);
 
       final long serStart = System.nanoTime();
@@ -764,6 +766,45 @@ public class PostgresNetworkExecutor extends Thread {
             portalSuspendedResponse();
           break;
         }
+      }
+      return cachedResultSet;
+    }
+  }
+
+  /**
+   * Browses and caches a result set for the simple-query ('Q' message) protocol path, refusing (rather than
+   * silently truncating) a result larger than {@code maxRows}.
+   * <p>
+   * Unlike the extended query protocol - where a portal's {@code Execute} message carries its own client-chosen
+   * max-rows and a limit hit is a normal, expected {@code PortalSuspended} the client explicitly asked for by
+   * fetching in batches - the simple-query protocol has no such mechanism: a 'Q' message always means "give me
+   * the complete result", and {@link #browseAndCacheResultSet(ResultSet, int, boolean)}'s silent-truncate-plus-
+   * suspend behaviour would misreport a partial result as the whole answer (a {@code CommandComplete} row count
+   * that undercounts what the query actually matches). This path is also why the whole result had to be held in
+   * memory in the first place: determining the row description (the union of columns and their types across
+   * heterogeneous/schemaless rows) genuinely requires having seen every row before the first one can be sent,
+   * since Postgres's wire protocol fixes the column set in {@code RowDescription}, sent before any {@code
+   * DataRow}. Rather than risk an OutOfMemoryError on an unbounded SELECT (issue #6679), refuse once the result
+   * grows past {@code maxRows} with a clear, actionable error instead: the client should use the extended query
+   * protocol with a bounded portal fetch size for a result set that large.
+   *
+   * @param maxRows the maximum number of rows to buffer, 0 = unlimited (matches {@link GlobalConfiguration#POSTGRES_SIMPLE_QUERY_MAX_ROWS})
+   */
+  private List<Result> browseAndCacheBoundedResultSet(final ResultSet resultSet, final int maxRows) {
+    try (resultSet) {
+      final List<Result> cachedResultSet = new ArrayList<>();
+      while (resultSet.hasNext()) {
+        final Result row = resultSet.next();
+        if (row == null)
+          continue;
+
+        cachedResultSet.add(row);
+
+        if (maxRows > 0 && cachedResultSet.size() > maxRows)
+          throw new CommandExecutionException(
+              "Result set exceeds the configured limit of " + maxRows + " rows for the Postgres simple-query protocol ("
+                  + GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.getKey()
+                  + "); use the extended query protocol with a bounded portal fetch size for large result sets");
       }
       return cachedResultSet;
     }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -385,7 +385,7 @@ public class PostgresNetworkExecutor extends Thread {
         portal.executed = true;
         if (portal.isExpectingResult) {
           portal.cachedResultSet = browseAndCacheResultSet(resultSet, 0);
-          portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal));
+          portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
           if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
             final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                 getParams(portal), portal.sqlStatement);
@@ -484,7 +484,7 @@ public class PostgresNetworkExecutor extends Thread {
               final long serStart = System.nanoTime();
               // A catalog answer already carries the columns it must be announced under.
               if (!portal.catalogQuery || portal.columns == null)
-                portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal));
+                portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
               if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
                 final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                     getParams(portal), portal.sqlStatement);
@@ -503,7 +503,8 @@ public class PostgresNetworkExecutor extends Thread {
         if (portal.isExpectingResult && portal.cachedResultSet != null && !portal.cachedResultSet.isEmpty()) {
           final long serStart = System.nanoTime();
           // Query returned results - send them
-          final Map<String, PostgresType> dataRowColumns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal));
+          final Map<String, PostgresType> dataRowColumns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal),
+              resolveAliasToSourceProperty(portal));
 
           if (DEBUG)
             LogManager.instance().log(this, Level.INFO,
@@ -672,7 +673,7 @@ public class PostgresNetworkExecutor extends Thread {
 
       final long serStart = System.nanoTime();
       Map<String, PostgresType> columns = catalogAnswer != null ? catalogAnswer.columns()
-          : getColumns(cachedResultSet, resolveQueryTargetType(parsedStatement));
+          : getColumns(cachedResultSet, resolveQueryTargetType(parsedStatement), resolveAliasToSourceProperty(parsedStatement));
       if (columns.isEmpty() && cachedResultSet.isEmpty()) {
         final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(query.query, query.language, NO_PARAMETERS,
             parsedStatement);
@@ -859,17 +860,21 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   private Map<String, PostgresType> getColumns(final List<Result> resultSet) {
-    return getColumns(resultSet, null);
+    return getColumns(resultSet, null, Map.of());
   }
 
   /**
-   * @param queryTargetType the schema type the query's FROM target names, or null when it is not a plain
-   *                        "FROM &lt;type&gt;" or was not resolved. Falls back {@link #getDeclaredProperty} to
-   *                        this type when a row is not itself an element - which a query that projects specific
-   *                        columns ("SELECT col FROM Type") produces for every row, since only the projected
-   *                        values travel with it, not the backing element.
+   * @param queryTargetType       the schema type the query's FROM target names, or null when it is not a plain
+   *                              "FROM &lt;type&gt;" or was not resolved. Falls back {@link #getDeclaredProperty}
+   *                              to this type when a row is not itself an element - which a query that projects
+   *                              specific columns ("SELECT col FROM Type") produces for every row, since only the
+   *                              projected values travel with it, not the backing element.
+   * @param aliasToSourceProperty maps an aliased projection's output column name back to the property it reads
+   *                              (issue #6473), e.g. {@code "x" -> "amount"} for {@code SELECT amount AS x}; see
+   *                              {@link #resolveAliasToSourceProperty(Statement)}.
    */
-  private Map<String, PostgresType> getColumns(final List<Result> resultSet, final DocumentType queryTargetType) {
+  private Map<String, PostgresType> getColumns(final List<Result> resultSet, final DocumentType queryTargetType,
+      final Map<String, String> aliasToSourceProperty) {
     final Map<String, PostgresType> columns = new LinkedHashMap<>();
 
     boolean atLeastOneElement = false;
@@ -893,10 +898,10 @@ public class PostgresNetworkExecutor extends Thread {
           // Prefer the declared "LIST OF <type>" (issue #5289) so a column's OID does not depend on whether
           // the first row's list happens to be empty.
           if (value instanceof Collection<?> collection && collection.isEmpty()) {
-            final PostgresType declaredType = getDeclaredListType(row, p, queryTargetType);
+            final PostgresType declaredType = getDeclaredListType(row, p, queryTargetType, aliasToSourceProperty);
             if (declaredType != null)
               pgType = declaredType;
-          } else if (pgType == PostgresType.DATE && isDeclaredAsDatetime(row, p, queryTargetType)) {
+          } else if (pgType == PostgresType.DATE && isDeclaredAsDatetime(row, p, queryTargetType, aliasToSourceProperty)) {
             // java.util.Date is the default Java runtime type of both Type.DATE and Type.DATETIME* (issue
             // #6447), so getTypeForValue cannot tell them apart from the value alone and always answers DATE.
             // Prefer the schema's declared type when it can be found, the same way the empty-list case above
@@ -957,6 +962,55 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   /**
+   * Memoized on the portal, mirroring {@link #resolveQueryTargetType(PostgresPortal)}.
+   */
+  private Map<String, String> resolveAliasToSourceProperty(final PostgresPortal portal) {
+    if (!portal.aliasToSourcePropertyResolved) {
+      portal.aliasToSourceProperty = resolveAliasToSourceProperty(portal.sqlStatement);
+      portal.aliasToSourcePropertyResolved = true;
+    }
+    return portal.aliasToSourceProperty;
+  }
+
+  /**
+   * Maps a SELECT projection's output column name back to the bare property it reads, when the two differ
+   * (issue #6473): {@code SELECT amount AS x} maps {@code "x" -> "amount"}. Used by {@link #getDeclaredProperty}
+   * to resolve the schema-context fallback through an alias instead of missing it, since the row only ever
+   * carries the OUTPUT name ({@code propertyName} there).
+   * <p>
+   * Only a bare property reference ({@link Expression#isBaseIdentifier()}) is mapped - a computed expression
+   * (aliased or not) has no single source property to fall back to, and is correctly left out so the caller
+   * keeps its existing value-only guess for that column. An explicit alias that happens to repeat the source
+   * property name ({@code SELECT amount AS amount}) is also left out: {@code propertyName} already equals it,
+   * so the direct lookup in {@link #getDeclaredProperty} already succeeds without this map.
+   */
+  private Map<String, String> resolveAliasToSourceProperty(final Statement statement) {
+    if (!(statement instanceof SelectStatement select) || select.getProjection() == null)
+      return Map.of();
+
+    final List<ProjectionItem> items = select.getProjection().getItems();
+    if (items == null || items.isEmpty())
+      return Map.of();
+
+    Map<String, String> aliasToProperty = null;
+    for (final ProjectionItem item : items) {
+      if (item.getAlias() == null || item.getExpression() == null || !item.getExpression().isBaseIdentifier())
+        continue;
+
+      final String alias = item.getProjectionAliasAsString();
+      final String sourceProperty = item.getExpression().getDefaultAlias().getStringValue();
+      if (alias.equals(sourceProperty))
+        continue;
+
+      if (aliasToProperty == null)
+        aliasToProperty = new HashMap<>();
+      aliasToProperty.put(alias, sourceProperty);
+    }
+
+    return aliasToProperty != null ? aliasToProperty : Map.of();
+  }
+
+  /**
    * Returns the schema property backing {@code propertyName}, or null when it cannot be found. {@code row}
    * itself is an element - and so carries its own {@link DocumentType} - only for a whole-entity projection
    * ("SELECT FROM Type" or "SELECT *"); a query that projects specific columns ("SELECT col FROM Type") produces
@@ -966,27 +1020,33 @@ public class PostgresNetworkExecutor extends Thread {
    * declared type over a guess made from a single sample value.
    * <p>
    * {@code propertyName} is the row's own column name, which for an aliased or computed projection ({@code
-   * SELECT amount AS x FROM Type}) is the alias, not the source property - so the lookup misses and the caller
-   * falls back to a value-only guess for that column. The "look up by row column name" pattern is inherited
-   * from #5289's {@link #getDeclaredListType}, which has the identical gap for an empty aliased LIST; the
-   * {@code queryTargetType} fallback added here for #6447 does not close it either. Resolving an alias back to
-   * its source property would need to walk the SELECT projection's expression tree, a materially larger piece
-   * of work than either fix.
+   * SELECT amount AS x FROM Type}) is the alias, not the source property - so a direct lookup misses. When the
+   * row is not itself an element (the {@code queryTargetType} fallback case, where this actually matters -
+   * see below), {@code aliasToSourceProperty} - resolved once per query by
+   * {@link #resolveAliasToSourceProperty(Statement)} - is tried next, closing the gap left by #5289's original
+   * {@link #getDeclaredListType} and by #6447's {@code queryTargetType} fallback (issue #6473).
    */
-  private Property getDeclaredProperty(final Result row, final String propertyName, final DocumentType queryTargetType) {
+  private Property getDeclaredProperty(final Result row, final String propertyName, final DocumentType queryTargetType,
+      final Map<String, String> aliasToSourceProperty) {
     final Document element = row.getElement().orElse(null);
     final DocumentType documentType = element != null ? element.getType() : queryTargetType;
     if (documentType == null)
       return null;
 
-    return documentType.getPolymorphicPropertyIfExists(propertyName);
+    final Property declared = documentType.getPolymorphicPropertyIfExists(propertyName);
+    if (declared != null || element != null)
+      return declared;
+
+    final String sourceProperty = aliasToSourceProperty.get(propertyName);
+    return sourceProperty != null ? documentType.getPolymorphicPropertyIfExists(sourceProperty) : null;
   }
 
   /**
    * Returns the array type declared by the schema for a LIST property, or null when it is not a declared LIST.
    */
-  private PostgresType getDeclaredListType(final Result row, final String propertyName, final DocumentType queryTargetType) {
-    final Property property = getDeclaredProperty(row, propertyName, queryTargetType);
+  private PostgresType getDeclaredListType(final Result row, final String propertyName, final DocumentType queryTargetType,
+      final Map<String, String> aliasToSourceProperty) {
+    final Property property = getDeclaredProperty(row, propertyName, queryTargetType, aliasToSourceProperty);
     if (property == null || property.getType() != Type.LIST)
       return null;
 
@@ -998,8 +1058,9 @@ public class PostgresNetworkExecutor extends Thread {
    * disambiguate a sampled {@code java.util.Date} value, which is the default Java runtime type of both
    * Type.DATE and every Type.DATETIME* and so cannot tell them apart on its own.
    */
-  private boolean isDeclaredAsDatetime(final Result row, final String propertyName, final DocumentType queryTargetType) {
-    final Property property = getDeclaredProperty(row, propertyName, queryTargetType);
+  private boolean isDeclaredAsDatetime(final Result row, final String propertyName, final DocumentType queryTargetType,
+      final Map<String, String> aliasToSourceProperty) {
+    final Property property = getDeclaredProperty(row, propertyName, queryTargetType, aliasToSourceProperty);
     if (property == null)
       return false;
 
@@ -1187,7 +1248,7 @@ public class PostgresNetworkExecutor extends Thread {
 
       if (!sampleRows.isEmpty()) {
         // Use the sample row to discover columns
-        final Map<String, PostgresType> cols = getColumns(sampleRows, docType);
+        final Map<String, PostgresType> cols = getColumns(sampleRows, docType, Map.of());
         if (DEBUG)
           LogManager.instance().log(this, Level.INFO,
               "PSQL: getColumnsFromType('%s') -> sampleQuery='%s', found %d rows, columns=%s (thread=%s)",
@@ -1411,7 +1472,7 @@ public class PostgresNetworkExecutor extends Thread {
 
       final ResultSet resultSet = sample.execute(database, parameters != null ? parameters : NO_PARAMETERS, context);
       final List<Result> sampleRows = browseAndCacheResultSet(resultSet, 1, false);
-      return sampleRows.isEmpty() ? null : getColumns(sampleRows, resolveQueryTargetType(select));
+      return sampleRows.isEmpty() ? null : getColumns(sampleRows, resolveQueryTargetType(select), resolveAliasToSourceProperty(select));
     } catch (final Exception e) {
       if (DEBUG)
         LogManager.instance().log(this, Level.WARNING, "PSQL: cannot replay the schema probe '%s': %s", parsed, e.getMessage());

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2081,11 +2081,16 @@ public class PostgresNetworkExecutor extends Thread {
 
     final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);
     String value = parts[1].trim();
-    // Only strip a matching pair of quotes: a single stray quote (e.g. "SET x = '") is not a closed
-    // quoted value and must be left as-is rather than throw StringIndexOutOfBoundsException on the
-    // unconditional substring(1, length - 1) a bare startsWith() check used to attempt.
-    if (value.length() >= 2 && (value.charAt(0) == '\'' || value.charAt(0) == '"') && value.charAt(value.length() - 1) == value.charAt(0))
+    if (value.startsWith("'") || value.startsWith("\"")) {
+      // A quoted value needs a matching closing delimiter: a single stray quote (e.g. "SET x = '") is a
+      // malformed command, not a closed quoted value, so it is rejected the same way a missing separator
+      // is - rather than throw StringIndexOutOfBoundsException on an unconditional substring(1, length - 1),
+      // or silently store a value still carrying its opening quote.
+      final char quote = value.charAt(0);
+      if (value.length() < 2 || value.charAt(value.length() - 1) != quote)
+        return null;
       value = value.substring(1, value.length() - 1);
+    }
 
     return new String[] { paramName, value };
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2081,7 +2081,10 @@ public class PostgresNetworkExecutor extends Thread {
 
     final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);
     String value = parts[1].trim();
-    if (value.startsWith("'") || value.startsWith("\""))
+    // Only strip a matching pair of quotes: a single stray quote (e.g. "SET x = '") is not a closed
+    // quoted value and must be left as-is rather than throw StringIndexOutOfBoundsException on the
+    // unconditional substring(1, length - 1) a bare startsWith() check used to attempt.
+    if (value.length() >= 2 && (value.charAt(0) == '\'' || value.charAt(0) == '"') && value.charAt(value.length() - 1) == value.charAt(0))
       value = value.substring(1, value.length() - 1);
 
     return new String[] { paramName, value };

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -68,6 +68,7 @@ import io.micrometer.core.instrument.Metrics;
 import com.arcadedb.utility.DateUtils;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.StringUtils;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -2049,39 +2050,52 @@ public class PostgresNetworkExecutor extends Thread {
     }
   }
 
-  private void setConfiguration(final String query) {
+  /**
+   * Parses a Postgres {@code SET <param> = <value>} or {@code SET <param> TO <value>} command into its
+   * {@code {paramName, value}} pair. Splits on the FIRST separator only, so a value containing a further
+   * '=' (e.g. a connection string) is kept whole instead of truncated (issue #6423). {@code paramName} is
+   * lower-cased for case-insensitive comparison; a quoted {@code value} has its surrounding quotes
+   * stripped. Returns null when the command has neither a '=' nor a ' TO ' separator.
+   */
+  static String[] parseSetCommand(final String query) {
     final int setLength = "SET ".length();
     // Use original query to preserve case of values
     final String q = query.substring(setLength);
 
-    // Try to split by either '=' or ' TO ' (case-insensitive)
-    String[] parts = q.split("=");
-    if (parts.length < 2) {
-      // Try case-insensitive split for " TO "
-      parts = q.split("(?i)\\s+TO\\s+");
-    }
+    String[] parts = StringUtils.splitKeyValue(q);
+    if (parts == null)
+      // Fall back to a case-insensitive " TO " split, also on the first occurrence only
+      parts = q.split("(?i)\\s+TO\\s+", 2);
 
-    if (parts.length < 2) {
+    if (parts.length < 2)
+      return null;
+
+    final String paramName = parts[0].trim().toLowerCase(Locale.ENGLISH);
+    String value = parts[1].trim();
+    if (value.startsWith("'") || value.startsWith("\""))
+      value = value.substring(1, value.length() - 1);
+
+    return new String[] { paramName, value };
+  }
+
+  private void setConfiguration(final String query) {
+    final String[] parts = parseSetCommand(query);
+    if (parts == null) {
       LogManager.instance().log(this, Level.WARNING, "Invalid SET command format: %s", query);
       return;
     }
 
-    parts[0] = parts[0].trim();
-    parts[1] = parts[1].trim();
+    final String paramName = parts[0];
+    final String value = parts[1];
 
-    if (parts[1].startsWith("'") || parts[1].startsWith("\""))
-      parts[1] = parts[1].substring(1, parts[1].length() - 1);
-
-    // Use case-insensitive comparison for parameter names
-    final String paramName = parts[0].toLowerCase(Locale.ENGLISH);
     if ("datestyle".equals(paramName)) {
-      if ("ISO".equalsIgnoreCase(parts[1]))
+      if ("ISO".equalsIgnoreCase(value))
         database.getSchema().setDateTimeFormat(DateUtils.DATE_TIME_ISO_8601_FORMAT);
       else
-        LogManager.instance().log(this, Level.INFO, "datestyle '%s' not supported", parts[1]);
+        LogManager.instance().log(this, Level.INFO, "datestyle '%s' not supported", value);
     }
 
-    connectionProperties.put(paramName, parts[1]);
+    connectionProperties.put(paramName, value);
   }
 
   /**

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -122,6 +122,12 @@ public class PostgresNetworkExecutor extends Thread {
   private final ChannelBinaryServer         channel;
   private final byte[]                      buffer                = new byte[BUFFER_LENGTH];
   private final Map<String, PostgresPortal> portals               = new HashMap<>();
+  // Prepared statements registered by PARSE, keyed by statement name (issue #6660 / CodeRabbit on #6658).
+  // Read-only after PARSE creates the entry - bindCommand() clones from here via PostgresPortal.bindFrom()
+  // rather than handing out this same instance, so that two portal names bound from one statement (or the
+  // same portal name re-bound without a new Parse) never share mutable per-execution state. `portals` above
+  // holds only the independent, already-bound portals that describeCommand('P')/executeCommand() operate on.
+  private final Map<String, PostgresPortal> preparedStatements    = new HashMap<>();
   private final boolean                     DEBUG                 = GlobalConfiguration.POSTGRES_DEBUG.getValueAsBoolean();
   private final boolean                     QUOTED_IDENTIFIERS    = GlobalConfiguration.POSTGRES_QUOTED_IDENTIFIERS.getValueAsBoolean();
   private final Map<String, Object>         connectionProperties  = new HashMap<>();
@@ -367,7 +373,13 @@ public class PostgresNetworkExecutor extends Thread {
     if (errorInTransaction)
       return;
 
-    final PostgresPortal portal = getPortal(portalName, false);
+    // Describe('S') names a PREPARED STATEMENT (registered by PARSE); Describe('P') names a bound PORTAL
+    // (registered by BIND) - two different registries since #6660 / CodeRabbit split them apart so portals
+    // stop sharing mutable state. A statement's column info, once resolved here from its schema, is a
+    // property of the statement itself (independent of any parameter values), so it is cached directly on
+    // the template - every portal bound from it afterwards inherits it via PostgresPortal.bindFrom(), the
+    // same way queryTargetType/aliasToSourceProperty are already memoized per statement.
+    final PostgresPortal portal = type == 'S' ? preparedStatements.get(portalName) : getPortal(portalName, false);
     if (portal == null) {
       writeNoData();
       return;
@@ -375,19 +387,30 @@ public class PostgresNetworkExecutor extends Thread {
 
     if (type == 'P') {
       if (portal.sqlStatement != null) {
-        final Object[] parameters = portal.parameterValues != null ? portal.parameterValues.toArray() : new Object[0];
-        final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
-        final ResultSet resultSet;
-        try {
-          resultSet = portal.sqlStatement.execute(database, parameters, createCommandContext());
-        } finally {
-          QueryMetricsRecorder.Holder.record(metricsStart, database.getName(), portal.language, "command");
+        if (!portal.executed) {
+          // Guarded so a second Describe('P') on the same portal (or one arriving after an Execute already
+          // ran the statement) reuses the materialized result instead of running the statement again - issue
+          // #6458's follow-up Execute(s) depend on this same fullResultSet being run exactly once.
+          final Object[] parameters = portal.parameterValues != null ? portal.parameterValues.toArray() : new Object[0];
+          final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
+          final ResultSet resultSet;
+          try {
+            resultSet = portal.sqlStatement.execute(database, parameters, createCommandContext());
+          } finally {
+            QueryMetricsRecorder.Holder.record(metricsStart, database.getName(), portal.language, "command");
+          }
+          portal.executed = true;
+          if (portal.isExpectingResult)
+            // Materializes the whole result now (issue #6458): Describe needs every row's columns, not just
+            // the first, to catch a property that only shows up on a later row (documents can be sparse) -
+            // and the portal keeps this list so the Execute(s) that follow slice it by their own row-limit
+            // instead of re-running the statement or losing what Describe already had to read.
+            portal.fullResultSet = browseAndCacheResultSet(resultSet, 0);
         }
-        portal.executed = true;
         if (portal.isExpectingResult) {
-          portal.cachedResultSet = browseAndCacheResultSet(resultSet, 0);
-          portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
-          if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
+          final List<Result> forColumns = portal.fullResultSet != null ? portal.fullResultSet : Collections.emptyList();
+          portal.columns = getColumns(forColumns, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
+          if (portal.columns.isEmpty() && forColumns.isEmpty()) {
             final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                 getParams(portal), portal.sqlStatement);
             if (schemaColumns != null)
@@ -440,7 +463,11 @@ public class PostgresNetworkExecutor extends Thread {
       if (errorInTransaction)
         return;
 
-      portal = getPortal(portalName, true);
+      // Do NOT remove the portal here (issue #6458): a limit-hit Execute suspends rather than finishes, and
+      // the follow-up Execute the client sends to continue fetching looks this same portal name up again.
+      // The portal is only ever discarded by an explicit Close ('C') message or by a later Bind reusing the
+      // name (closeCommand()/bindCommand()).
+      portal = getPortal(portalName, false);
       if (portal == null) {
         writeNoData();
         return;
@@ -477,7 +504,11 @@ public class PostgresNetworkExecutor extends Thread {
           }
           portal.executed = true;
           if (portal.isExpectingResult) {
-            portal.cachedResultSet = browseAndCacheResultSet(resultSet, limit);
+            // Materializes the whole result now (issue #6458), the same way Describe('P') does: a client that
+            // never Described this portal first (it already knows the row shape) reaches this branch instead,
+            // and every Execute on this portal from here on - including this one - slices fullResultSet by its
+            // own row-limit below rather than re-running the statement.
+            portal.fullResultSet = browseAndCacheResultSet(resultSet, 0);
             profile.addEngineNanos(System.nanoTime() - engineStart);
             // Only send RowDescription if not already sent during DESCRIBE
             // But always use columns from actual result for DataRows consistency
@@ -485,8 +516,8 @@ public class PostgresNetworkExecutor extends Thread {
               final long serStart = System.nanoTime();
               // A catalog answer already carries the columns it must be announced under.
               if (!portal.catalogQuery || portal.columns == null)
-                portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
-              if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
+                portal.columns = getColumns(portal.fullResultSet, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
+              if (portal.columns.isEmpty() && portal.fullResultSet.isEmpty()) {
                 final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                     getParams(portal), portal.sqlStatement);
                 if (schemaColumns != null)
@@ -499,6 +530,22 @@ public class PostgresNetworkExecutor extends Thread {
           } else {
             profile.addEngineNanos(System.nanoTime() - engineStart);
           }
+        }
+
+        // Computes this Execute's slice of the portal's materialized result (issue #6458). Runs on every
+        // Execute, not only the one that just populated fullResultSet above: a follow-up Execute continuing a
+        // previously suspended fetch reaches here with portal.executed already true and fullResultSet already
+        // populated - by this same method on an earlier call, or by describeCommand() - and only needs the
+        // next slice, never a re-run of the statement.
+        if (portal.isExpectingResult && portal.fullResultSet != null) {
+          final int total = portal.fullResultSet.size();
+          final int start = portal.resultCursor;
+          final int end = limit > 0 ? Math.min(start + limit, total) : total;
+          portal.cachedResultSet = start < end ? new ArrayList<>(portal.fullResultSet.subList(start, end)) : Collections.emptyList();
+          portal.resultCursor = end;
+          // The protocol allows exactly one terminator after the data rows: PortalSuspended when this slice
+          // stopped on the row-limit with rows still left, CommandComplete once the portal is fully drained.
+          portal.suspended = limit > 0 && end < total;
         }
 
         if (portal.isExpectingResult && portal.cachedResultSet != null && !portal.cachedResultSet.isEmpty()) {
@@ -536,7 +583,17 @@ public class PostgresNetworkExecutor extends Thread {
           // Use the columns that were sent in RowDescription for consistency
           final Map<String, PostgresType> columnsToUse = portal.columns != null ? portal.columns : dataRowColumns;
           writeDataRows(portal.cachedResultSet, columnsToUse, portal.resultFormats);
-          writeCommandComplete(portal.query, portal.cachedResultSet.size());
+          // Exactly one terminator after the data rows (issue #6458), never both, and always after the rows
+          // rather than before them: PortalSuspended when this slice stopped short of fullResultSet with the
+          // row-limit reached, CommandComplete once the portal is fully drained - tagged with resultCursor,
+          // the running total across every slice this portal has sent (matching PostgreSQL's own convention),
+          // when this portal is the paginated fullResultSet-backed kind; a portal whose cachedResultSet was
+          // set directly (a synthetic single-row answer - SHOW/catalog/etc.) never touches resultCursor, so it
+          // keeps reporting its own size exactly as before this fix.
+          if (portal.suspended)
+            portalSuspendedResponse();
+          else
+            writeCommandComplete(portal.query, portal.fullResultSet != null ? portal.resultCursor : portal.cachedResultSet.size());
           profile.addSerializationNanos(System.nanoTime() - serStart);
         } else {
           final long serStart = System.nanoTime();
@@ -735,15 +792,17 @@ public class PostgresNetworkExecutor extends Thread {
   /**
    * Browse a result set and cache results up to the limit, then close the source ResultSet.
    * <p>
-   * <b>Ownership:</b> this method takes ownership of the supplied ResultSet and closes it
-   * before returning, in both the natural-exhaustion and the limit-hit paths. The portal
-   * keeps only the materialized {@code List<Result>} (see {@code PostgresPortal#cachedResultSet}),
-   * never a reference to the underlying ResultSet. Multi-batch portal-suspension fetching
-   * from a partially-consumed ResultSet is therefore not supported by this implementation -
-   * a follow-up Execute on the same portal re-uses the cached list rather than pulling the
-   * next chunk from the source. This is unchanged behaviour from before the #4197 audit; the
-   * audit only made the close explicit, releasing the execution plan and unblocking parallel-scan
-   * worker threads that would otherwise stay parked on a full bounded queue.
+   * <b>Ownership:</b> this method takes ownership of the supplied ResultSet and closes it before returning, in
+   * both the natural-exhaustion and the limit-hit paths. Both callers that matter for issue #6458 - Describe
+   * ('P') and the first Execute of a portal that was never Described - call this with {@code limit=0} to
+   * materialize the whole result into {@link PostgresPortal#fullResultSet}: Describe needs every row to
+   * discover every column (documents can be sparse), and Execute needs the complete list to slice by whatever
+   * row-limit each Execute call declares, including a follow-up one continuing a previously suspended fetch
+   * (see the pagination step in {@code executeCommand()}, which slices {@code fullResultSet} rather than
+   * calling this method again). The {@code limit>0} form remains for the unrelated internal callers that want
+   * a bounded sample and are happy to see the rest of the result set discarded - {@code sendSuspendedOnLimit}
+   * is {@code false} for all of them, so the always-{@code limit=0} callers are the only ones that can still
+   * reach that branch.
    *
    * @param resultSet           The result set to browse (this method closes it)
    * @param limit               Maximum number of results to cache (0 = unlimited)
@@ -1751,16 +1810,49 @@ public class PostgresNetworkExecutor extends Thread {
       final String portalName = readString();
       final String sourcePreparedStatement = readString();
 
-      // Look up the prepared statement (stored during PARSE)
-      // The portal name may be different (often empty for unnamed portal)
-      PostgresPortal portal = getPortal(sourcePreparedStatement, false);
-      if (portal == null) {
-        // Try with portal name as fallback for backwards compatibility
-        portal = getPortal(portalName, false);
-      }
-      if (portal == null) {
+      // Look up the prepared statement (stored during PARSE) and create THIS Bind's own independent portal
+      // from it (issue #6660 / CodeRabbit review on #6658). PARSE's PostgresPortal is a read-only template
+      // from here on - bindFrom() copies what PARSE already fixed for the statement (query, sqlStatement,
+      // parameter types, and any response PARSE precomputed for BEGIN/COMMIT/ROLLBACK or a resolved catalog
+      // answer) into a fresh object, so that two portal names bound from the same statement - or the same
+      // portal name re-bound without a new Parse, which is exactly what asyncpg's/pgjdbc's statement caching
+      // does for a repeated query - never share mutable execution state (parameterValues, fullResultSet,
+      // resultCursor, suspended, rowDescriptionSent...). Without this, a later Bind on one portal name could
+      // silently reset or overwrite another already-bound (possibly suspended) portal from the same statement,
+      // since both names used to point at the very same object.
+      final PostgresPortal preparedStatement = preparedStatements.get(sourcePreparedStatement);
+      final PostgresPortal template = preparedStatement != null ? preparedStatement
+          // Backwards-compatible fallback: portalName may itself already name a bound portal.
+          : portals.get(portalName);
+      if (template == null) {
         writeMessage("bind complete", null, '2', 4);
         return;
+      }
+      PostgresPortal portal = PostgresPortal.bindFrom(template);
+
+      // Only the preparedStatements-map template above is provably never executed for a real query (parseCommand
+      // writes it once and nothing ever mutates it afterwards) - the fallback template just above (portals.get
+      // (portalName), reached when sourcePreparedStatement does not name a real prepared statement) is a normal,
+      // mutable portal that may already have run. bindFrom() copies executed/cachedResultSet from whichever
+      // template it was given but leaves fullResultSet at null, so without this reset a portal cloned from an
+      // already-executed fallback template would skip both executeCommand()'s "not yet executed" branch
+      // (portal.executed is already true) and its fullResultSet-pagination branch (fullResultSet is null), and
+      // would serve the OLD run's stale cachedResultSet instead of running this Bind's own execution. Same reset
+      // #6660 originally applied (105cdbb0b8), reinstated here for this one remaining path that can reach it -
+      // the preparedStatements-only redesign above made the reset a no-op for its own template source, since
+      // that source's `executed` is never true for a real query, but did not make it a no-op for this fallback.
+      // Gated on sqlStatement != null (a real, engine-parsed query) OR catalogQuery (a catalog query whose
+      // filters are bound parameters, deferred by parseCommand to be answered - and genuinely re-executed - in
+      // executeCommand once the values arrive) - both are actually re-run per Execute and can go stale exactly
+      // like #6660. This deliberately excludes BEGIN/COMMIT/ROLLBACK and a RESOLVED (parameter-less) catalog
+      // answer, which precompute their fixed response once during Parse via setEmptyResultSet()/direct
+      // assignment and must not be reset before Execute ever sees them.
+      if (portal.executed && (portal.sqlStatement != null || portal.catalogQuery)) {
+        portal.executed = false;
+        portal.fullResultSet = null;
+        portal.cachedResultSet = null;
+        portal.resultCursor = 0;
+        portal.suspended = false;
       }
 
       if (DEBUG)
@@ -1877,15 +1969,15 @@ public class PostgresNetworkExecutor extends Thread {
         return;
       }
 
-      // Store the portal under the portal name (which may be empty for unnamed portal)
-      // This is necessary because EXECUTE looks up portals by portal name, not prepared statement name
-      // PostgreSQL protocol: PARSE creates "prepared statement", BIND creates "portal" from it
-      if (!portalName.equals(sourcePreparedStatement)) {
-        portals.put(portalName, portal);
-        if (DEBUG)
-          LogManager.instance().log(this, Level.INFO, "PSQL: bind stored portal under name '%s' (thread=%s)",
-              portalName, Thread.currentThread().threadId());
-      }
+      // Store this Bind's own portal under the portal name (which may be empty for unnamed portal) - always,
+      // even when portalName equals sourcePreparedStatement, since this is a fresh clone now rather than the
+      // statement's own template object (issue #6660 / CodeRabbit review on #6658).
+      // This is necessary because EXECUTE looks up portals by portal name, not prepared statement name.
+      // PostgreSQL protocol: PARSE creates "prepared statement", BIND creates "portal" from it.
+      portals.put(portalName, portal);
+      if (DEBUG)
+        LogManager.instance().log(this, Level.INFO, "PSQL: bind stored portal under name '%s' (thread=%s)",
+            portalName, Thread.currentThread().threadId());
 
       writeMessage("bind complete", null, '2', 4);
 
@@ -1994,7 +2086,7 @@ public class PostgresNetworkExecutor extends Thread {
           // regardless of which of the three keywords the client actually sent (see queryCommand()).
           portal.query = "ROLLBACK";
           setEmptyResultSet(portal);
-          portals.put(portalName, portal);
+          preparedStatements.put(portalName, portal);
           writeMessage("parse complete", null, '1', 4);
         }
         return;
@@ -2082,7 +2174,7 @@ public class PostgresNetworkExecutor extends Thread {
         }
       }
 
-      portals.put(portalName, portal);
+      preparedStatements.put(portalName, portal);
 
       // ParseComplete
       writeMessage("parse complete", null, '1', 4);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -773,20 +773,25 @@ public class PostgresNetworkExecutor extends Thread {
 
   /**
    * Browses and caches a result set for the simple-query ('Q' message) protocol path, refusing (rather than
-   * silently truncating) a result larger than {@code maxRows}.
+   * silently truncating) a result larger than {@code maxRows} - and stopping the scan as soon as that is known,
+   * rather than paying to read the rest of an oversized source just to reject it.
    * <p>
    * Unlike the extended query protocol - where a portal's {@code Execute} message carries its own client-chosen
    * max-rows and a limit hit is a normal, expected {@code PortalSuspended} the client explicitly asked for by
    * fetching in batches - the simple-query protocol has no such mechanism: a 'Q' message always means "give me
-   * the complete result", and {@link #browseAndCacheResultSet(ResultSet, int, boolean)}'s silent-truncate-plus-
-   * suspend behaviour would misreport a partial result as the whole answer (a {@code CommandComplete} row count
-   * that undercounts what the query actually matches). This path is also why the whole result had to be held in
-   * memory in the first place: determining the row description (the union of columns and their types across
-   * heterogeneous/schemaless rows) genuinely requires having seen every row before the first one can be sent,
-   * since Postgres's wire protocol fixes the column set in {@code RowDescription}, sent before any {@code
-   * DataRow}. Rather than risk an OutOfMemoryError on an unbounded SELECT (issue #6679), refuse once the result
-   * grows past {@code maxRows} with a clear, actionable error instead: the client should use the extended query
-   * protocol with a bounded portal fetch size for a result set that large.
+   * the complete result". This path is also why the whole result had to be held in memory in the first place:
+   * determining the row description (the union of columns and their types across heterogeneous/schemaless rows)
+   * genuinely requires having seen every row before the first one can be sent, since Postgres's wire protocol
+   * fixes the column set in {@code RowDescription}, sent before any {@code DataRow}.
+   * <p>
+   * Aborting the scan early is safe for a write statement too: {@code UpdateExecutionPlan.executeInternal()} (and
+   * {@code DeleteExecutionPlan}, which extends it) fully executes every matched row's write and buffers the whole
+   * {@code RETURN AFTER}/{@code RETURN BEFORE} result internally <em>before</em> {@code UpdateStatement.execute()}
+   * / {@code DeleteStatement.execute()} ever return a {@link ResultSet} to this method - so by the time this loop
+   * runs, an {@code UPDATE}/{@code DELETE} ... {@code RETURN} statement has already fully applied every write
+   * regardless of how many rows of its result this loop goes on to pull. Stopping early here only shortens how
+   * much of that already-complete result gets copied into {@code cachedResultSet}; it can never leave a write
+   * half-done.
    *
    * @param maxRows the maximum number of rows to buffer, 0 = unlimited (matches {@link GlobalConfiguration#POSTGRES_SIMPLE_QUERY_MAX_ROWS})
    */
@@ -806,6 +811,7 @@ public class PostgresNetworkExecutor extends Thread {
                   + GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.getKey()
                   + "); use the extended query protocol with a bounded portal fetch size for large result sets");
       }
+
       return cachedResultSet;
     }
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -117,6 +117,8 @@ public class PostgresNetworkExecutor extends Thread {
   /** Bind-message parameter length denoting a NULL value (wire value -1, read unsigned). */
   private static final long                                           NULL_PARAM_LENGTH = 0xFFFFFFFFL;
   private static final Object[]                                       NO_PARAMETERS     = new Object[0];
+  /** Case-insensitive {@code TO} separator for the {@code SET <param> TO <value>} syntax. */
+  private static final Pattern                                        SET_TO_SEPARATOR  = Pattern.compile("(?i)\\s+TO\\s+");
 
   private final ArcadeDBServer              server;
   private final ChannelBinaryServer         channel;
@@ -2049,8 +2051,6 @@ public class PostgresNetworkExecutor extends Thread {
       writeError(ERROR_SEVERITY.ERROR, "Error on parsing query: " + e.getMessage(), sqlStateFor(e));
     }
   }
-
-  private static final Pattern SET_TO_SEPARATOR = Pattern.compile("(?i)\\s+TO\\s+");
 
   /**
    * Parses a Postgres {@code SET <param> = <value>} or {@code SET <param> TO <value>} command into its

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
@@ -57,11 +57,73 @@ public class PostgresPortal {
    * its filters are bound parameters, whose values only arrive with the Bind message (issue #6412).
    */
   public boolean                   catalogQuery         = false;
+  /**
+   * The complete materialized result of this portal's statement (issue #6458), set once - by whichever of a
+   * Describe('P') or the first Execute runs the statement first - and read by every Execute after that to
+   * hand out {@code limit}-sized slices via {@link #resultCursor}. {@link #cachedResultSet} holds only the
+   * current slice (what the in-flight Execute is about to write to the wire), matching what every existing
+   * reader of that field already expects; this field is what makes a second slice possible without re-running
+   * the statement or losing the rows a Describe already had to materialize to discover the row's columns.
+   * <p>
+   * <b>Known limitation</b> (tracked as issue #6659): this is eager, in-memory pagination over a fully
+   * materialized list, not a true streaming cursor - the whole result is pulled into memory (and retained for
+   * the portal's whole lifetime) before the first row goes out, regardless of the client's row-limit. A client
+   * that always Describes first (pgjdbc, notably) already got this treatment before #6458, since
+   * {@code describeCommand()} has to read every row to discover a sparse document's full column set - but a
+   * raw wire-protocol client that skips Describe and relies on Execute's row-limit to bound server-side memory
+   * over a large result no longer gets that bound. Real streaming would need the source {@code ResultSet} kept
+   * open across Execute calls instead of closed immediately by {@code browseAndCacheResultSet}.
+   */
+  public List<Result>              fullResultSet;
+  /**
+   * How many rows of {@link #fullResultSet} have already been handed to the client across every Execute so
+   * far (issue #6458). The next Execute's slice starts here.
+   */
+  public int                       resultCursor         = 0;
+  /**
+   * True when the most recently computed slice of {@link #fullResultSet} stopped because Execute's row-limit
+   * was hit while rows remained - i.e. the wire must send PortalSuspended for that slice, not CommandComplete.
+   * The protocol allows exactly one of the two (issue #6458).
+   */
+  public boolean                   suspended            = false;
 
   public PostgresPortal(final String query, String language) {
     this.query = query;
     this.language = language;
     this.isExpectingResult = true;
+  }
+
+  /**
+   * Creates a fresh, independent portal for one Bind of the prepared statement {@code template} (issue
+   * #6660 / CodeRabbit review on #6658). PARSE builds one {@code PostgresPortal} per prepared statement and
+   * it must stay a read-only template from then on: two portal names bound from the same statement, or the
+   * same portal name re-bound without a new Parse (asyncpg's/pgjdbc's statement caching, both), are logically
+   * independent portals and must never share mutable per-execution state - sharing it let a Bind on one
+   * portal name silently reset or overwrite another already-bound (possibly suspended) portal from the same
+   * statement, since both names pointed at the same object.
+   * <p>
+   * This copies only what PARSE already fixed for the statement for good (query text/language/parameter
+   * types, the parsed {@code sqlStatement}, and - for BEGIN/COMMIT/ROLLBACK and a resolved catalog answer -
+   * the response PARSE precomputed into {@code executed}/{@code cachedResultSet}/{@code columns}) and leaves
+   * every per-Bind field (parameter values, {@code fullResultSet}, {@code resultCursor}, {@code suspended},
+   * {@code rowDescriptionSent}, ...) at its fresh default, so each returned portal starts its own independent
+   * lifecycle.
+   */
+  public static PostgresPortal bindFrom(final PostgresPortal template) {
+    final PostgresPortal portal = new PostgresPortal(template.query, template.language);
+    portal.sqlStatement = template.sqlStatement;
+    portal.parameterTypes = template.parameterTypes;
+    portal.ignoreExecution = template.ignoreExecution;
+    portal.isExpectingResult = template.isExpectingResult;
+    portal.catalogQuery = template.catalogQuery;
+    portal.executed = template.executed;
+    portal.cachedResultSet = template.cachedResultSet;
+    portal.columns = template.columns;
+    portal.queryTargetType = template.queryTargetType;
+    portal.queryTargetTypeResolved = template.queryTargetTypeResolved;
+    portal.aliasToSourceProperty = template.aliasToSourceProperty;
+    portal.aliasToSourcePropertyResolved = template.aliasToSourcePropertyResolved;
+    return portal;
   }
 
   @Override

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
@@ -47,6 +47,12 @@ public class PostgresPortal {
   public DocumentType               queryTargetType;
   public boolean                    queryTargetTypeResolved = false;
   /**
+   * Memoizes {@code PostgresNetworkExecutor.resolveAliasToSourceProperty(sqlStatement)} (issue #6473), for the
+   * same reason and on the same lifecycle as {@link #queryTargetType}.
+   */
+  public Map<String, String>        aliasToSourceProperty;
+  public boolean                    aliasToSourcePropertyResolved = false;
+  /**
    * True when the query is about the emulated system catalog and could not be answered at Parse time because
    * its filters are bound parameters, whose values only arrive with the Bind message (issue #6412).
    */

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -728,9 +728,7 @@ public enum PostgresType {
   public void serializeAsText(final PostgresType pgType, final Binary typeBuffer, final Object value) {
     String serializedValue = null;
     final byte[] byteaValue = pgType == BYTEA ? byteaValueOf(value) : null;
-    if (value == null && pgType.code == BOOLEAN.code) {
-      serializedValue = "0";
-    } else if (pgType == JSON && value != null && (value instanceof Collection<?> || value.getClass().isArray())) {
+    if (pgType == JSON && value != null && (value instanceof Collection<?> || value.getClass().isArray())) {
       // The column was announced as a json document holding an array (issue #5366): emit a real JSON array
       // instead of a Postgres array literal, so the payload matches the announced OID.
       serializedValue = serializeCollectionAsJson(
@@ -753,9 +751,13 @@ public enum PostgresType {
       // BigDecimal.toString() switches to scientific notation outside a small exponent range (e.g. "1E+10"),
       // which is not a NUMERIC text value PostgreSQL itself would ever emit or a client would expect to parse.
       serializedValue = bd.toPlainString();
-    } else if (value instanceof Date date) {
+    } else if (value instanceof Date date && pgType == DATE) {
       // DATE (OID 1082) expects "YYYY-MM-DD" in text format
       serializedValue = date.toInstant().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE);
+    } else if (value instanceof Date date) {
+      // TIMESTAMP (or any other non-DATE column) backed by a java.util.Date: keep the time-of-day
+      // instead of truncating to a date-only value (issue #6675)
+      serializedValue = LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).format(POSTGRES_DATETIME_FORMATTER);
     } else if (value instanceof LocalDateTime ldt) {
       // TIMESTAMP (OID 1114) expects "yyyy-MM-dd HH:mm:ss.SSSSSS" in text format
       serializedValue = ldt.format(POSTGRES_DATETIME_FORMATTER);

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6458PortalSuspensionIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6458PortalSuspensionIT.java
@@ -1,0 +1,761 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6458: the extended-query protocol's Execute with a non-zero max-row count
+ * (portal suspension) sent {@code PortalSuspended} before the data rows instead of after, sent it together
+ * with {@code CommandComplete} (the protocol allows exactly one terminator), and removed the portal on the
+ * very Execute that suspended it - so a follow-up Execute meant to continue the fetch found nothing and the
+ * result was silently truncated to the first batch.
+ * <p>
+ * The pgjdbc driver drives exactly this path when {@code autoCommit(false)} and {@code setFetchSize(n)} are
+ * both in play: it opens a server-side cursor (a portal bound once) and issues repeated Execute messages with
+ * a max-row count of {@code n} on that same portal as the application consumes the {@link ResultSet}, relying
+ * on {@code PortalSuspended} vs {@code CommandComplete} to know whether to ask for more. pgjdbc always sends a
+ * Describe('P') before its first Execute, though, which - because {@code describeCommand()} already has to run
+ * the statement in full to discover the portal's columns - means those tests exercise the fix's pagination
+ * behaviour rather than the exact wire defects the issue reports; {@link
+ * #executeMaxRowsSendsRowsBeforeSuspendedNeverBothTerminatorsAndThePortalSurvivesToContinue} crafts the wire
+ * messages directly (no Describe) to reach the code path the report describes and reproduces all three
+ * defects verbatim - confirmed by running it against the pre-fix code, where it fails with
+ * {@code expected: 'D' but was: 's'} on the very first row.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6458PortalSuspensionIT extends PostgresWireProtocolTestBase {
+
+  /**
+   * Reproduces the exact defects the issue reports, at the wire level, on a client that never sends a
+   * Describe('P') for the portal - unlike pgjdbc, which always does and so never actually reaches the buggy
+   * code path the other tests in this class exercise only indirectly (through its end result, not the wire
+   * sequence itself). Crafts Parse/Bind/Execute/Execute directly, the shape the issue's own report describes.
+   */
+  @Test
+  void executeMaxRowsSendsRowsBeforeSuspendedNeverBothTerminatorsAndThePortalSurvivesToContinue() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+
+      // Schema and data setup over the simple query protocol - irrelevant to what this test is checking.
+      runSimpleQueryToCompletion(out, in, "CREATE DOCUMENT TYPE RawSuspend6458 IF NOT EXISTS");
+      runSimpleQueryToCompletion(out, in, "CREATE PROPERTY RawSuspend6458.id IF NOT EXISTS INTEGER");
+      for (int i = 0; i < 10; i++)
+        runSimpleQueryToCompletion(out, in, "INSERT INTO RawSuspend6458 SET id = " + i);
+
+      // Parse + Bind only - deliberately NO Describe('P'), so the portal reaches Execute with
+      // portal.executed == false and this exercises PostgresNetworkExecutor.executeCommand()'s own
+      // first-execution branch directly, exactly as issue #6458 describes.
+      sendParse(out, "SELECT id FROM RawSuspend6458 ORDER BY id");
+      assertThat(readOneMessage(in).type).as("ParseComplete").isEqualTo('1');
+      sendBind(out, "P1");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+
+      // First Execute: limit=4 with 10 rows available - must suspend with 4 rows left unread. No Describe
+      // means the client has not seen the columns yet, so this Execute must lead with its own RowDescription
+      // before any data - PostgresNetworkExecutor.executeCommand()'s own !rowDescriptionSent branch.
+      sendExecute(out, "P1", 4);
+      sendSync(out);
+      assertThat(readOneMessage(in).type).as("RowDescription, since no Describe('P') preceded this Execute").isEqualTo('T');
+      assertThat(readNextBatchOfIds(in, 4))
+          .as("first batch: DataRow x4 in id order, then exactly one terminator (checked by readNextBatchOfIds)")
+          .containsExactly(0, 1, 2, 3);
+      assertThat(readOneMessage(in).type).as("PortalSuspended, not CommandComplete - 6 rows remain unread").isEqualTo('s');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // Second Execute on the SAME portal name, with no Bind or Describe in between: the defect under test
+      // removed the portal on the first Execute, so this would get NoData ('n') instead of the next batch.
+      sendExecute(out, "P1", 4);
+      sendSync(out);
+      assertThat(readNextBatchOfIds(in, 4))
+          .as("second batch continues exactly where the first stopped - the portal was not removed nor re-run")
+          .containsExactly(4, 5, 6, 7);
+      assertThat(readOneMessage(in).type).as("PortalSuspended again - 2 rows remain unread").isEqualTo('s');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // Third Execute drains the remaining 2 rows: this time exhausted, so CommandComplete - not
+      // PortalSuspended, and not both.
+      sendExecute(out, "P1", 4);
+      sendSync(out);
+      assertThat(readNextBatchOfIds(in, 2))
+          .as("final batch: the last 2 rows, in order")
+          .containsExactly(8, 9);
+      assertThat(readOneMessage(in).type).as("CommandComplete - the portal is now fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+    }
+  }
+
+  /**
+   * The counterpart to {@link #executeMaxRowsSendsRowsBeforeSuspendedNeverBothTerminatorsAndThePortalSurvivesToContinue}:
+   * this client DOES send a Describe('P') before its first Execute, like pgjdbc always does - so
+   * {@code describeCommand()} is the one that materializes {@code fullResultSet} and sends the RowDescription,
+   * and {@code executeCommand()} reaches its already-executed branch straight away. The pgjdbc-driven tests in
+   * this class exercise this path indirectly through a JDBC {@link ResultSet}, which cannot observe the wire
+   * sequence itself; this test asserts directly, at the wire level, that a small Execute limit after Describe('P')
+   * still returns only that many rows with exactly one terminator - the more consequential of the two defects
+   * #6458 reports, since {@code describeCommand()} used to run before the row-limit fix and read the query's
+   * result in full regardless of what the first Execute would go on to ask for.
+   */
+  @Test
+  void describePortalThenExecuteWithASmallLimitReturnsOnlyThatManyRowsThenSuspends() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+
+      // Schema and data setup over the simple query protocol - irrelevant to what this test is checking.
+      runSimpleQueryToCompletion(out, in, "CREATE DOCUMENT TYPE DescribeThenSuspend6458 IF NOT EXISTS");
+      runSimpleQueryToCompletion(out, in, "CREATE PROPERTY DescribeThenSuspend6458.id IF NOT EXISTS INTEGER");
+      for (int i = 0; i < 10; i++)
+        runSimpleQueryToCompletion(out, in, "INSERT INTO DescribeThenSuspend6458 SET id = " + i);
+
+      sendParse(out, "SELECT id FROM DescribeThenSuspend6458 ORDER BY id");
+      assertThat(readOneMessage(in).type).as("ParseComplete").isEqualTo('1');
+      sendBind(out, "P2");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+
+      // Describe('P') before any Execute: this is describeCommand()'s branch, not executeCommand()'s - it runs
+      // the statement, materializes portal.fullResultSet in full, and sends the RowDescription on its own.
+      sendDescribe(out, "P2");
+      sendSync(out);
+      assertThat(readOneMessage(in).type).as("RowDescription, sent by describeCommand()").isEqualTo('T');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // First Execute: limit=4 with 10 rows available and portal.executed already true from Describe - this is
+      // executeCommand()'s already-executed branch, which must still slice fullResultSet down to just 4 rows
+      // rather than returning everything Describe had to read.
+      sendExecute(out, "P2", 4);
+      sendSync(out);
+      assertThat(readNextBatchOfIds(in, 4))
+          .as("first batch after Describe('P'): exactly 4 rows, not the full 10 describeCommand() read")
+          .containsExactly(0, 1, 2, 3);
+      assertThat(readOneMessage(in).type).as("PortalSuspended, not CommandComplete - 6 rows remain unread").isEqualTo('s');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // Second Execute on the same portal, no further Bind/Describe: continues exactly where the first left off.
+      sendExecute(out, "P2", 4);
+      sendSync(out);
+      assertThat(readNextBatchOfIds(in, 4))
+          .as("second batch continues from row 4")
+          .containsExactly(4, 5, 6, 7);
+      assertThat(readOneMessage(in).type).as("PortalSuspended again - 2 rows remain unread").isEqualTo('s');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // Third Execute drains the remaining 2 rows.
+      sendExecute(out, "P2", 4);
+      sendSync(out);
+      assertThat(readNextBatchOfIds(in, 2))
+          .as("final batch: the last 2 rows, in order")
+          .containsExactly(8, 9);
+      assertThat(readOneMessage(in).type).as("CommandComplete - the portal is now fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+    }
+  }
+
+  /**
+   * Regression test for issue #6660, surfaced by #6458 itself: keeping a portal alive after it completes
+   * (rather than removing it, which #6458 needed for suspension to work) means a second Bind on the same
+   * portal name with no new Parse in between - what asyncpg's statement cache and pgjdbc's server-side
+   * prepared-statement promotion both do for a repeated identical query - used to reuse the exact same {@link
+   * PostgresPortal} instance from the first run. Before the fix, that instance's {@code executed}/{@code
+   * fullResultSet}/{@code resultCursor} from the first, already-exhausted run survived into the second Bind,
+   * so the second Execute served an empty slice of the old result instead of re-running the query - confirmed
+   * failing pre-fix with the second run's Execute jumping straight to an empty CommandComplete instead of the
+   * RowDescription + 5 rows the first run got. Fixed via {@link PostgresPortal#bindFrom}: every Bind now
+   * creates its own fresh portal from the (never mutated) prepared-statement template, so the second run
+   * starts as clean as the first - including its own RowDescription, since a brand new portal has never sent
+   * one before.
+   */
+  @Test
+  void reBindingAnAlreadyExecutedPortalWithNoNewParseReRunsInsteadOfServingTheExhaustedFirstRun() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+
+      runSimpleQueryToCompletion(out, in, "CREATE DOCUMENT TYPE Rebind6458 IF NOT EXISTS");
+      runSimpleQueryToCompletion(out, in, "CREATE PROPERTY Rebind6458.id IF NOT EXISTS INTEGER");
+      for (int i = 0; i < 5; i++)
+        runSimpleQueryToCompletion(out, in, "INSERT INTO Rebind6458 SET id = " + i);
+
+      // Parse once. A max-rows of 0 (unlimited) drains the whole portal in a single Execute, so this run
+      // completes with CommandComplete rather than suspending - the state the second Bind below reuses.
+      sendParse(out, "SELECT id FROM Rebind6458 ORDER BY id");
+      assertThat(readOneMessage(in).type).as("ParseComplete").isEqualTo('1');
+
+      sendBind(out, "PR1");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+      sendExecute(out, "PR1", 0);
+      sendSync(out);
+      assertThat(readOneMessage(in).type).as("RowDescription - first execution of this portal").isEqualTo('T');
+      assertThat(readNextBatchOfIds(in, 5)).as("first run reads every row").containsExactly(0, 1, 2, 3, 4);
+      assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // Second Bind on the SAME portal name, no new Parse: must re-run the query, not replay the first run's
+      // now-exhausted fullResultSet/resultCursor.
+      sendBind(out, "PR1");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+      sendExecute(out, "PR1", 0);
+      sendSync(out);
+      assertThat(readOneMessage(in).type)
+          .as("RowDescription again - this is a brand new portal, not the exhausted first one; it has never sent one")
+          .isEqualTo('T');
+      assertThat(readNextBatchOfIds(in, 5))
+          .as("second run re-executes and reads every row again, not an empty slice of the exhausted first run")
+          .containsExactly(0, 1, 2, 3, 4);
+      assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+    }
+  }
+
+  /**
+   * Regression test for a review finding on PR #6658 (2026-08-24 cycle): {@code bindCommand()}'s
+   * "backwards-compatible fallback" - reached when a Bind's own {@code sourcePreparedStatement} name is not a
+   * real, Parsed prepared statement, so the lookup falls back to treating {@code portalName} itself as the
+   * template ({@code portals.get(portalName)}) - can pick up an already-executed, real portal as that template.
+   * {@link PostgresPortal#bindFrom} copies {@code executed}/{@code cachedResultSet} from whatever template it
+   * is given (safe for the {@code preparedStatements}-map template, which parseCommand writes once and never
+   * mutates afterwards, so its {@code executed} is never true for a real query) but this fallback template is a
+   * normal, mutable portal that may already have run a real query - without a reset, the clone would inherit a
+   * stale {@code executed=true} and stale {@code cachedResultSet} while {@code fullResultSet} stays at its
+   * fresh {@code null} default, so {@code executeCommand()} would skip both its "not yet executed" branch and
+   * its {@code fullResultSet}-pagination branch and serve the OLD run's stale result instead of re-executing
+   * this Bind. Confirmed failing without the reset (second run replays the stale first-run row count instead
+   * of picking up rows inserted in between).
+   */
+  @Test
+  void bindFallbackOnAnUnknownSourceStatementReRunsInsteadOfServingTheStaleExecutedPortal() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+
+      runSimpleQueryToCompletion(out, in, "CREATE DOCUMENT TYPE FallbackBind6458 IF NOT EXISTS");
+      runSimpleQueryToCompletion(out, in, "CREATE PROPERTY FallbackBind6458.id IF NOT EXISTS INTEGER");
+      for (int i = 0; i < 5; i++)
+        runSimpleQueryToCompletion(out, in, "INSERT INTO FallbackBind6458 SET id = " + i);
+
+      sendParse(out, "SELECT id FROM FallbackBind6458 ORDER BY id");
+      assertThat(readOneMessage(in).type).as("ParseComplete").isEqualTo('1');
+
+      // First Bind+Execute: a normal Bind naming the real (unnamed) statement, fully drained.
+      sendBind(out, "PF1");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+      sendExecute(out, "PF1", 0);
+      sendSync(out);
+      assertThat(readOneMessage(in).type).as("RowDescription - first execution of this portal").isEqualTo('T');
+      assertThat(readNextBatchOfIds(in, 5)).as("first run reads every row").containsExactly(0, 1, 2, 3, 4);
+      assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // Data changes between the two Binds, so a stale vs. fresh cachedResultSet is observable.
+      runSimpleQueryToCompletion(out, in, "INSERT INTO FallbackBind6458 SET id = 5");
+      runSimpleQueryToCompletion(out, in, "INSERT INTO FallbackBind6458 SET id = 6");
+      runSimpleQueryToCompletion(out, in, "INSERT INTO FallbackBind6458 SET id = 7");
+
+      // Second Bind on the SAME portal name, naming a source prepared statement that was never Parsed -
+      // bindCommand()'s preparedStatements.get(...) lookup misses, so it falls back to portals.get(portalName),
+      // which is the already-executed PF1 portal from above.
+      sendBind(out, "PF1", "never-parsed-statement-name");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+      sendExecute(out, "PF1", 0);
+      sendSync(out);
+      assertThat(readOneMessage(in).type)
+          .as("RowDescription again - this must be a fresh execution, not the stale first run replayed")
+          .isEqualTo('T');
+      assertThat(readNextBatchOfIds(in, 8))
+          .as("re-executes against the now-8-row table instead of replaying the first run's stale 5-row result")
+          .containsExactly(0, 1, 2, 3, 4, 5, 6, 7);
+      assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+    }
+  }
+
+  /**
+   * Regression test for a review finding on PR #6658 (2026-08-24, cycle 5): the reset added in {@link
+   * #bindFallbackOnAnUnknownSourceStatementReRunsInsteadOfServingTheStaleExecutedPortal}'s fix was gated on
+   * {@code portal.sqlStatement != null}, which correctly excludes BEGIN/COMMIT/ROLLBACK and a RESOLVED
+   * (parameter-less) catalog answer - both precomputed once during Parse - but also, unintentionally, a
+   * DEFERRED catalog query ({@code portal.catalogQuery = true}, set by {@code parseCommand()} when the query
+   * names an emulated catalog relation - {@code pg_class} here - but its filter is a bound parameter whose
+   * value only arrives with Bind). That case's {@code sqlStatement} is null too, but unlike BEGIN/COMMIT/
+   * ROLLBACK it genuinely re-runs the query per Execute in {@code executeCommand()}'s {@code
+   * if (portal.catalogQuery)} branch, so it can go stale through {@code bindCommand()}'s fallback exactly like
+   * the plain-SQL case, just missed by the original gate. Confirmed failing without {@code || portal
+   * .catalogQuery} in the gate (second run replays the stale one-row answer instead of the two rows a type
+   * created in between should have added).
+   */
+  @Test
+  void bindFallbackOnAnUnknownSourceStatementReRunsADeferredCatalogQueryTooNotJustPlainSql() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+
+      runSimpleQueryToCompletion(out, in, "CREATE DOCUMENT TYPE CatalogFB6458First IF NOT EXISTS");
+
+      // $1 is detected from the query text alone (parseCommand()'s placeholder-detection fallback, since this
+      // Parse declares paramCount=0 like every real client using the simple wire helpers here) and typed
+      // VARCHAR, which is what makes parseCommand() defer this to portal.catalogQuery = true instead of
+      // resolving it immediately: a query naming an emulated catalog relation (pg_class) whose filter is a
+      // bound parameter, mirroring the shape pgjdbc's DatabaseMetaData table/column lookups actually send.
+      sendParse(out, "SELECT relname FROM pg_class WHERE relname LIKE $1");
+      assertThat(readOneMessage(in).type).as("ParseComplete").isEqualTo('1');
+
+      // First Bind+Execute: a normal Bind naming the real (unnamed) statement, filtered to just the one type
+      // created so far.
+      sendBindWithOneTextParam(out, "PCQ1", "", "CatalogFB6458%");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+      sendExecute(out, "PCQ1", 0);
+      sendSync(out);
+      assertThat(readOneMessage(in).type).as("RowDescription - first execution of this portal").isEqualTo('T');
+      assertThat(readNextBatchOfStrings(in, 1)).as("first run matches only the one type created so far")
+          .containsExactly("CatalogFB6458First");
+      assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // A second matching type appears between the two Binds, so a stale vs. fresh catalog answer is observable.
+      runSimpleQueryToCompletion(out, in, "CREATE DOCUMENT TYPE CatalogFB6458Second IF NOT EXISTS");
+
+      // Second Bind on the SAME portal name, naming a source prepared statement that was never Parsed -
+      // bindCommand()'s preparedStatements.get(...) lookup misses, so it falls back to portals.get(portalName),
+      // which is the already-executed PCQ1 catalog-query portal from above.
+      sendBindWithOneTextParam(out, "PCQ1", "never-parsed-statement-name", "CatalogFB6458%");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+      sendExecute(out, "PCQ1", 0);
+      sendSync(out);
+      assertThat(readOneMessage(in).type)
+          .as("RowDescription again - this must be a fresh execution, not the stale first run replayed")
+          .isEqualTo('T');
+      assertThat(readNextBatchOfStrings(in, 2))
+          .as("re-runs the catalog query and picks up the type created in between, instead of replaying the stale one-row answer")
+          .containsExactlyInAnyOrder("CatalogFB6458First", "CatalogFB6458Second");
+      assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+    }
+  }
+
+  /**
+   * Regression test for the CodeRabbit review finding on PR #6658: {@code bindCommand()} used to look up the
+   * portal to bind by the PREPARED STATEMENT's name and store that exact object under the new portal name too
+   * - so two portal names bound from the same statement were not independent portals at all, just two names
+   * for the same mutable object. Binding a second portal ({@code P2}) from a statement that already had a
+   * SUSPENDED portal ({@code P1}, mid-fetch) would silently reset/overwrite {@code P1}'s progress, and a
+   * later {@code Execute(P1)} would resume (or lose) {@code P2}'s state instead of its own. Fixed via {@link
+   * PostgresPortal#bindFrom}: every Bind creates its own fresh portal from the statement's read-only template,
+   * so {@code P1} and {@code P2} never share state no matter how many times the same statement is re-bound.
+   */
+  @Test
+  void twoPortalsFromOneStatementDoNotShareStateEvenWhenOneIsSuspended() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+
+      runSimpleQueryToCompletion(out, in, "CREATE DOCUMENT TYPE AliasedPortals6458 IF NOT EXISTS");
+      runSimpleQueryToCompletion(out, in, "CREATE PROPERTY AliasedPortals6458.id IF NOT EXISTS INTEGER");
+      for (int i = 0; i < 10; i++)
+        runSimpleQueryToCompletion(out, in, "INSERT INTO AliasedPortals6458 SET id = " + i);
+
+      sendParse(out, "SELECT id FROM AliasedPortals6458 ORDER BY id");
+      assertThat(readOneMessage(in).type).as("ParseComplete").isEqualTo('1');
+
+      // P1: bind and partially fetch, leaving it suspended with 6 rows unread.
+      sendBind(out, "P1");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+      sendExecute(out, "P1", 4);
+      sendSync(out);
+      assertThat(readOneMessage(in).type).as("RowDescription for P1's first execution").isEqualTo('T');
+      assertThat(readNextBatchOfIds(in, 4)).as("P1 first batch").containsExactly(0, 1, 2, 3);
+      assertThat(readOneMessage(in).type).as("P1 suspended - 6 rows remain unread").isEqualTo('s');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // P2: bind from the SAME statement (no new Parse) and drain it fully. Before the fix this reused P1's
+      // own object, so this Bind+Execute would corrupt P1's suspended progress.
+      sendBind(out, "P2");
+      assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
+      sendExecute(out, "P2", 0);
+      sendSync(out);
+      assertThat(readOneMessage(in).type).as("RowDescription for P2's own, independent first execution").isEqualTo('T');
+      assertThat(readNextBatchOfIds(in, 10)).as("P2 reads every row, independently of P1's in-progress fetch").containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+      assertThat(readOneMessage(in).type).as("P2 fully drained").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+
+      // P1 must still be resumable from exactly where it left off (row 4) - not empty, not restarted, and not
+      // showing P2's already-exhausted cursor.
+      sendExecute(out, "P1", 10);
+      sendSync(out);
+      assertThat(readNextBatchOfIds(in, 6)).as("P1 continues from row 4, unaffected by P2's Bind+Execute").containsExactly(4, 5, 6, 7, 8, 9);
+      assertThat(readOneMessage(in).type).as("P1 now fully drained too").isEqualTo('C');
+      assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
+    }
+  }
+
+  @Test
+  void aFetchSizeSmallerThanTheResultReturnsEveryRowAcrossSeveralSuspendedBatches() throws Exception {
+    // 23 rows with a fetch size of 7 batches as 7, 7, 7, 2 - the last batch stops short of the limit, so it
+    // exercises both the "limit hit, rows remain" slice (the first three batches) and the "naturally
+    // exhausted before the limit" one (the last) in the pagination step of executeCommand().
+    assertFetchSizeReturnsEveryRow(23, 7);
+  }
+
+  @Test
+  void aFetchSizeThatDividesTheResultExactlyStillReturnsEveryRow() throws Exception {
+    // 20 rows with a fetch size of 5 - every batch, including the last, lands exactly on the limit. This is
+    // the boundary the pagination step has to get right: the final slice must still be reported as exhausted
+    // (CommandComplete), not suspended, even though its size equals the limit - end == total, not end < total.
+    assertFetchSizeReturnsEveryRow(20, 5);
+  }
+
+  private void assertFetchSizeReturnsEveryRow(final int totalRows, final int fetchSize) throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      // Schema and data setup runs with the default autoCommit(true), so each statement commits itself.
+      try (final Statement create = connection.createStatement()) {
+        create.execute("CREATE DOCUMENT TYPE Suspend6458 IF NOT EXISTS");
+        create.execute("CREATE PROPERTY Suspend6458.id IF NOT EXISTS INTEGER");
+        create.execute("CREATE INDEX IF NOT EXISTS ON Suspend6458 (id) UNIQUE");
+      }
+
+      // A plain Statement per row (simple query protocol, not Parse/Bind/Execute) - deliberately not a single
+      // reused PreparedStatement here: pgjdbc promotes a repeatedly-executed PreparedStatement to a named
+      // server-side statement after its default prepareThreshold (5) executions, which would exercise the
+      // portal-reuse-on-rebind path rather than the portal-suspension one this test targets.
+      try (final Statement insert = connection.createStatement()) {
+        for (int i = 0; i < totalRows; i++)
+          insert.execute("INSERT INTO Suspend6458 SET id = " + i);
+      }
+
+      // A server-side cursor requires autoCommit off, matching the JDBC fetch-size-with-Execute-max-rows path
+      // issue #6458 describes.
+      connection.setAutoCommit(false);
+      // pgjdbc piggybacks its own implicit BEGIN on the very first statement after autoCommit turns off. When
+      // that first statement is a PreparedStatement, the BEGIN (simple query protocol) and the Parse/Bind/
+      // Describe/Execute (extended protocol) go out in one pipelined flush - and a plain Statement here first
+      // gives pgjdbc's implicit BEGIN its own round trip, keeping the SELECT below the only thing on the wire
+      // when Execute runs. Unrelated to this issue: pgjdbc reads it back fine either way once the BEGIN gets
+      // its own trip, and CI has no coverage either way of the mixed-flush case's own wire correctness.
+      try (final Statement warmUp = connection.createStatement()) {
+        warmUp.execute("begin");
+      }
+      final List<Integer> fetchedIds = new ArrayList<>();
+      try (final PreparedStatement select = connection.prepareStatement("SELECT id FROM Suspend6458 ORDER BY id")) {
+        select.setFetchSize(fetchSize);
+        try (final ResultSet resultSet = select.executeQuery()) {
+          while (resultSet.next())
+            fetchedIds.add(resultSet.getInt("id"));
+        }
+      }
+      connection.commit();
+      connection.setAutoCommit(true);
+
+      assertThat(fetchedIds)
+          .as("every row must come back exactly once, in order, across every suspended batch - not just the first")
+          .hasSize(totalRows)
+          .containsExactlyElementsOf(IntStream.range(0, totalRows).boxed().toList());
+    }
+  }
+
+  @Test
+  void aPortalThatSuspendsCanStillBeClosedExplicitlyWithoutBreakingTheConnection() throws Exception {
+    // Regression guard for the portal-removal half of the fix (issue #6458's third defect): a portal
+    // suspended mid-fetch (more rows available than were consumed) must be closeable - the client's normal
+    // try-with-resources teardown of its ResultSet/PreparedStatement sends a Close ('C') message for the
+    // portal - without the connection or a later statement on it hanging or erroring.
+    try (final Connection connection = openJdbcConnection()) {
+      try (final Statement create = connection.createStatement()) {
+        create.execute("CREATE DOCUMENT TYPE Suspend6458b IF NOT EXISTS");
+        create.execute("CREATE PROPERTY Suspend6458b.id IF NOT EXISTS INTEGER");
+      }
+
+      try (final Statement insert = connection.createStatement()) {
+        for (int i = 0; i < 10; i++)
+          insert.execute("INSERT INTO Suspend6458b SET id = " + i);
+      }
+
+      connection.setAutoCommit(false);
+      // See the comment on the same pattern in assertFetchSizeReturnsEveryRow: keeps pgjdbc's implicit BEGIN
+      // off the same pipelined flush as the PreparedStatement below, which is unrelated to this issue.
+      try (final Statement warmUp = connection.createStatement()) {
+        warmUp.execute("begin");
+      }
+      try (final PreparedStatement select = connection.prepareStatement("SELECT id FROM Suspend6458b ORDER BY id")) {
+        select.setFetchSize(3);
+        try (final ResultSet resultSet = select.executeQuery()) {
+          // Consume only the first batch, leaving the portal suspended with rows still unread - the
+          // try-with-resources close() below sends a Close ('C') message for the portal while it is in that
+          // state.
+          assertThat(resultSet.next()).isTrue();
+          assertThat(resultSet.getInt("id")).isZero();
+        }
+      }
+      connection.commit();
+      connection.setAutoCommit(true);
+
+      // The connection must still be usable afterwards - proof that closing a suspended portal did not wedge
+      // the session or leak the ResultSet in a way that poisons subsequent statements.
+      try (final Statement count = connection.createStatement();
+          final ResultSet countResult = count.executeQuery("SELECT count() as total FROM Suspend6458b")) {
+        assertThat(countResult.next()).isTrue();
+        assertThat(countResult.getLong("total")).isEqualTo(10L);
+      }
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    return DriverManager.getConnection(
+        "jdbc:postgresql://localhost:" + GlobalConfiguration.POSTGRES_PORT.getValueAsInteger() + "/" + getDatabaseName(), properties);
+  }
+
+  // ---- raw wire-protocol helpers for executeMaxRowsSendsRowsBeforeSuspendedNeverBothTerminatorsAndThePortalSurvivesToContinue ----
+
+  private record Msg(char type, byte[] payload) {
+  }
+
+  private static Msg readOneMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] payload = new byte[length - 4];
+    in.readFully(payload);
+    return new Msg((char) type, payload);
+  }
+
+  /**
+   * Reads exactly {@code expectedCount} DataRow messages and decodes each one's single INTEGER column
+   * (text format - Bind below requests no result-format override), failing immediately, with the offending
+   * message's type, on anything else. The terminator that follows (PortalSuspended or CommandComplete) is
+   * read separately by the caller, so its type is asserted right next to the expectation that explains it.
+   */
+  private static List<Integer> readNextBatchOfIds(final DataInputStream in, final int expectedCount) throws Exception {
+    final List<Integer> ids = new ArrayList<>(expectedCount);
+    for (int i = 0; i < expectedCount; i++) {
+      final Msg m = readOneMessage(in);
+      assertThat(m.type).as("row %d of this batch must be a DataRow ('D'), sent before any terminator", i).isEqualTo('D');
+      ids.add(parseSingleIntColumnDataRow(m.payload));
+    }
+    return ids;
+  }
+
+  private static int parseSingleIntColumnDataRow(final byte[] payload) throws Exception {
+    return Integer.parseInt(parseSingleStringColumnDataRow(payload));
+  }
+
+  /**
+   * Same shape as {@link #readNextBatchOfIds} but for a single VARCHAR column (the catalog-query test's
+   * {@code relname}), read as text rather than parsed into an int.
+   */
+  private static List<String> readNextBatchOfStrings(final DataInputStream in, final int expectedCount) throws Exception {
+    final List<String> values = new ArrayList<>(expectedCount);
+    for (int i = 0; i < expectedCount; i++) {
+      final Msg m = readOneMessage(in);
+      assertThat(m.type).as("row %d of this batch must be a DataRow ('D'), sent before any terminator", i).isEqualTo('D');
+      values.add(parseSingleStringColumnDataRow(m.payload));
+    }
+    return values;
+  }
+
+  private static String parseSingleStringColumnDataRow(final byte[] payload) throws Exception {
+    final DataInputStream p = new DataInputStream(new ByteArrayInputStream(payload));
+    final int fieldCount = p.readUnsignedShort();
+    assertThat(fieldCount).as("this query projects exactly one column").isEqualTo(1);
+    final int len = p.readInt();
+    final byte[] valueBytes = new byte[len];
+    p.readFully(valueBytes);
+    return new String(valueBytes, StandardCharsets.UTF_8);
+  }
+
+  private static void runSimpleQueryToCompletion(final DataOutputStream out, final DataInputStream in, final String sql) throws Exception {
+    final byte[] queryBytes = (sql + "\0").getBytes(StandardCharsets.UTF_8);
+    out.writeByte('Q');
+    out.writeInt(4 + queryBytes.length);
+    out.write(queryBytes);
+    out.flush();
+    readMessageOfType(in, 'Z'); // drains RowDescription/CommandComplete/etc. through ReadyForQuery
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // unnamed statement
+    writeCString(body, query);
+    body.write(0);
+    body.write(0); // int16 numParamDataTypes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('P');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  /**
+   * Binds the unnamed statement to the given named portal, with no parameters and no result-format override
+   * (every column comes back as text) - deliberately sends no Describe('P') afterward, so the portal reaches
+   * Execute exactly as issue #6458's report describes.
+   */
+  private static void sendBind(final DataOutputStream out, final String portalName) throws Exception {
+    sendBind(out, portalName, ""); // unnamed statement
+  }
+
+  /**
+   * Same as {@link #sendBind(DataOutputStream, String)} but lets the caller name an explicit source prepared
+   * statement, so a test can Bind against a statement name that was never Parsed and exercise bindCommand()'s
+   * fallback onto {@code portals.get(portalName)}.
+   */
+  private static void sendBind(final DataOutputStream out, final String portalName, final String sourcePreparedStatement) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, portalName);
+    writeCString(body, sourcePreparedStatement);
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0
+    body.write(0);
+    body.write(0); // int16 numParamValues = 0
+    body.write(0);
+    body.write(0); // int16 numResultFormatCodes = 0 (all text)
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('B');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  /**
+   * Same as {@link #sendBind(DataOutputStream, String, String)} but binds exactly one text-format parameter
+   * value, for a query with a single {@code $1} placeholder.
+   */
+  private static void sendBindWithOneTextParam(final DataOutputStream out, final String portalName,
+      final String sourcePreparedStatement, final String paramValue) throws Exception {
+    final byte[] paramBytes = paramValue.getBytes(StandardCharsets.UTF_8);
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, portalName);
+    writeCString(body, sourcePreparedStatement);
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0 (all text)
+    body.write(0);
+    body.write(1); // int16 numParamValues = 1
+    body.write((paramBytes.length >>> 24) & 0xFF);
+    body.write((paramBytes.length >>> 16) & 0xFF);
+    body.write((paramBytes.length >>> 8) & 0xFF);
+    body.write(paramBytes.length & 0xFF);
+    body.write(paramBytes);
+    body.write(0);
+    body.write(0); // int16 numResultFormatCodes = 0 (all text)
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('B');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  /**
+   * Sends Describe('P') for the given portal name, the message pgjdbc always sends before its first Execute.
+   */
+  private static void sendDescribe(final DataOutputStream out, final String portalName) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    body.write('P');
+    writeCString(body, portalName);
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('D');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendExecute(final DataOutputStream out, final String portalName, final int maxRows) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, portalName);
+    body.write((maxRows >>> 24) & 0xFF);
+    body.write((maxRows >>> 16) & 0xFF);
+    body.write((maxRows >>> 8) & 0xFF);
+    body.write(maxRows & 0xFF);
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('E');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendSync(final DataOutputStream out) throws Exception {
+    out.writeByte('S');
+    out.writeInt(4);
+    out.flush();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6473AliasedColumnTypeResolutionIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6473AliasedColumnTypeResolutionIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6473, the follow-up to #6447/#5289: {@code PostgresNetworkExecutor.getDeclaredProperty()}
+ * looked a projected column's schema property up by the ROW's own column name, which for an aliased projection
+ * ({@code SELECT amount AS x FROM Type}) is the alias, not the source property - so both schema-context
+ * fallbacks it backs (the empty-LIST element type, #5289; the DATE/DATETIME java.util.Date disambiguation,
+ * #6447) missed whenever the projected column carried an alias, and fell back to a value-only guess instead.
+ * <p>
+ * Both scenarios below need a real ROW - not an empty result set - with a narrow (non-whole-entity) aliased
+ * projection: that is exactly the shape that reaches {@code getDeclaredProperty}'s {@code queryTargetType}
+ * fallback. A zero-row probe would instead be answered by {@code getColumnsFromQuerySchema}, an unrelated,
+ * already alias-aware static resolution that does not exercise this code path at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6473AliasedColumnTypeResolutionIT extends PostgresWireProtocolTestBase {
+
+  @Test
+  void anAliasedEmptyListPropertyReportsTheDeclaredElementTypeInsteadOfDefaultingToText() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createTestType(connection);
+
+      try (final Statement insert = connection.createStatement()) {
+        // An empty list carries no element to infer the type from - the value alone cannot tell int4[] from
+        // text[], only the schema's "LIST OF INTEGER" declaration can (issue #5289).
+        insert.execute("INSERT INTO Types6473 SET id = 1, tags = []");
+      }
+
+      final String typeFromRow;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT tags AS x FROM Types6473 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        typeFromRow = resultSet.getMetaData().getColumnTypeName(1);
+      }
+
+      assertThat(typeFromRow)
+          .as("an alias must not defeat the declared-LIST-element-type fallback: without resolving 'x' back to "
+              + "'tags', an empty list reports the default text[] instead of the declared int4[]")
+          .isEqualTo("_int4");
+    }
+  }
+
+  @Test
+  void anAliasedDatetimePropertyRoundTripsAsTimestampWhenDateTimeImplementationIsJavaUtilDate() throws Exception {
+    // Same java.util.Date/DATE ambiguity #6447 disambiguates via the schema (see Issue6447TypeResolutionIT),
+    // but through an alias: "SELECT whenHappened AS x" - x is not a schema property, so getDeclaredProperty
+    // must resolve it back to "whenHappened" before isDeclaredAsDatetime can even run.
+    try (final Connection connection = openJdbcConnection()) {
+      try (final Statement configure = connection.createStatement()) {
+        configure.execute("ALTER DATABASE dateTimeImplementation `java.util.Date`");
+      }
+      createTestType(connection);
+
+      try (final Statement insert = connection.createStatement()) {
+        insert.execute("INSERT INTO Types6473 SET id = 1, whenHappened = '2026-08-19 12:34:56'");
+      }
+
+      final String typeFromRow;
+      try (final PreparedStatement select = connection.prepareStatement(
+          "SELECT whenHappened AS x FROM Types6473 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        typeFromRow = resultSet.getMetaData().getColumnTypeName(1);
+      }
+
+      assertThat(typeFromRow)
+          .as("without resolving the alias back to its source property, a java.util.Date-backed DATETIME "
+              + "sample resolves to plain date instead of timestamp")
+          .isEqualTo("timestamp");
+    }
+  }
+
+  private void createTestType(final Connection connection) throws Exception {
+    try (final Statement statement = connection.createStatement()) {
+      statement.execute("CREATE DOCUMENT TYPE Types6473 IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY Types6473.id IF NOT EXISTS INTEGER");
+      statement.execute("CREATE PROPERTY Types6473.tags IF NOT EXISTS LIST OF INTEGER");
+      statement.execute("CREATE PROPERTY Types6473.whenHappened IF NOT EXISTS DATETIME");
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression test for issue #6679: the Postgres simple-query ('Q' message) protocol path materialized the
+ * entire result set into an unbounded {@code List<Result>} before sending the first row, so a large {@code
+ * SELECT} risked an {@code OutOfMemoryError}. The simple-query protocol has no client-driven cursor/max-rows
+ * mechanism (unlike the extended protocol's portal {@code Execute}), so buffering could not simply be turned
+ * into a silent {@code PortalSuspended} truncation without misreporting a partial result as the whole answer.
+ * The fix instead bounds the buffer with {@link GlobalConfiguration#POSTGRES_SIMPLE_QUERY_MAX_ROWS} and refuses
+ * a SELECT whose result exceeds it with a clear {@code ErrorResponse}, protecting server memory without
+ * silently returning wrong (truncated) data.
+ * <p>
+ * This test speaks the wire protocol directly over a raw socket (rather than through the JDBC driver) so the
+ * exact byte-level response - an {@code ErrorResponse} versus a normal {@code RowDescription}/{@code DataRow}
+ * stream - can be asserted on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
+  private static final int    ROW_CAP  = 5;
+  private static final String TYPE     = "Issue6679Row";
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.setValue(ROW_CAP);
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.reset();
+    super.endTest();
+  }
+
+  private void createRows(final int count) {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    database.transaction(() -> {
+      if (!database.getSchema().existsType(TYPE))
+        database.getSchema().createDocumentType(TYPE);
+      for (int i = 0; i < count; i++)
+        database.newDocument(TYPE).set("id", i).save();
+    });
+  }
+
+  @Test
+  @DisplayName("[#6679] a simple-query SELECT whose result exceeds the configured cap is refused, not silently truncated")
+  void resultOverTheCapIsRefusedWithAnErrorResponse() throws Exception {
+    createRows(ROW_CAP + 10);
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "SELECT FROM " + TYPE);
+        final List<WireMessage> response = readUntilReadyForQuery(in);
+
+        assertThat(messageTypesOf(response)).as("an ErrorResponse instead of a truncated result").contains('E');
+        assertThat(messageTypesOf(response)).as("no CommandComplete for a refused query").doesNotContain('C');
+        final WireMessage error = response.stream().filter(m -> m.type() == 'E').findFirst()
+            .orElseThrow(() -> new AssertionError("expected an ErrorResponse"));
+        assertThat(errorFields(error).get('M')).contains("exceeds the configured limit").contains(String.valueOf(ROW_CAP));
+
+        // The session must stay usable afterwards: not left aborted/wedged by the refusal.
+        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+      });
+    }
+  }
+
+  @Test
+  @DisplayName("[#6679] a simple-query SELECT within the configured cap still returns every row normally")
+  void resultWithinTheCapIsReturnedInFull() throws Exception {
+    createRows(ROW_CAP - 2);
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "SELECT FROM " + TYPE);
+        final List<WireMessage> response = readUntilReadyForQuery(in);
+
+        assertThat(messageTypesOf(response)).as("no ErrorResponse for a result within the cap").doesNotContain('E');
+        final long dataRows = response.stream().filter(m -> m.type() == 'D').count();
+        assertThat(dataRows).isEqualTo(ROW_CAP - 2);
+        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+      });
+    }
+  }
+
+  private void authenticate(final DataOutputStream out, final DataInputStream in) throws Exception {
+    sendStartupMessage(out, "root", getDatabaseName());
+    readMessage(in); // AuthenticationCleartextPassword
+    sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+    readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+  }
+
+  private static void sendSimpleQuery(final DataOutputStream out, final String query) throws Exception {
+    final byte[] queryBytes = query.getBytes(StandardCharsets.UTF_8);
+    out.writeByte('Q');
+    out.writeInt(4 + queryBytes.length + 1);
+    out.write(queryBytes);
+    out.writeByte(0);
+    out.flush();
+  }
+
+  private record WireMessage(char type, byte[] body) {
+  }
+
+  private static WireMessage readWireMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] body = new byte[length - 4];
+    in.readFully(body);
+    return new WireMessage((char) type, body);
+  }
+
+  private static List<WireMessage> readUntilReadyForQuery(final DataInputStream in) throws Exception {
+    final List<WireMessage> messages = new ArrayList<>();
+    WireMessage message;
+    do {
+      message = readWireMessage(in);
+      messages.add(message);
+    } while (message.type() != 'Z');
+    return messages;
+  }
+
+  private static char readyForQueryStatusOf(final List<WireMessage> messages) {
+    final WireMessage last = messages.get(messages.size() - 1);
+    assertThat(last.type()).isEqualTo('Z');
+    return (char) last.body()[0];
+  }
+
+  private static List<Character> messageTypesOf(final List<WireMessage> messages) {
+    final List<Character> types = new ArrayList<>(messages.size());
+    for (final WireMessage message : messages)
+      types.add(message.type());
+    return types;
+  }
+
+  private static Map<Character, String> errorFields(final WireMessage message) {
+    assertThat(message.type()).isEqualTo('E');
+    final Map<Character, String> fields = new LinkedHashMap<>();
+    final byte[] body = message.body();
+    int i = 0;
+    while (i < body.length && body[i] != 0) {
+      final char code = (char) body[i++];
+      final int start = i;
+      while (body[i] != 0)
+        i++;
+      fields.put(code, new String(body, start, i - start, StandardCharsets.UTF_8));
+      i++; // skip this field's terminator
+    }
+    return fields;
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
@@ -20,6 +20,7 @@ package com.arcadedb.postgres;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -129,6 +130,62 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
         assertThat(dataRows).isEqualTo(ROW_CAP - 2);
         assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
       });
+    }
+  }
+
+  @Test
+  @DisplayName("[#6679] a simple-query SELECT of exactly the configured cap is returned in full")
+  void resultAtTheCapIsReturnedInFull() throws Exception {
+    createRows(ROW_CAP);
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "SELECT FROM " + TYPE);
+        final List<WireMessage> response = readUntilReadyForQuery(in);
+
+        assertThat(messageTypesOf(response)).as("a result of exactly the cap must not be refused").doesNotContain('E');
+        final long dataRows = response.stream().filter(m -> m.type() == 'D').count();
+        assertThat(dataRows).isEqualTo(ROW_CAP);
+        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+      });
+    }
+  }
+
+  /**
+   * The row cap must never leave a write statement partially executed: {@code UPDATE ... RETURN} still updates
+   * every matching row even when its RETURN result exceeds the cap, and only the (now fully-applied) result is
+   * refused.
+   */
+  @Test
+  @DisplayName("[#6679] an UPDATE ... RETURN over the cap still updates every row; only the RETURN result is refused")
+  void updateReturnOverTheCapStillAppliesEveryWrite() throws Exception {
+    createRows(ROW_CAP + 10);
+
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendSimpleQuery(out, "UPDATE " + TYPE + " SET touched = true RETURN AFTER");
+        final List<WireMessage> response = readUntilReadyForQuery(in);
+
+        assertThat(messageTypesOf(response)).as("the oversized RETURN result is refused").contains('E');
+        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+      });
+    }
+
+    final Database database = getServerDatabase(0, getDatabaseName());
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM " + TYPE + " WHERE touched = true")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(((Number) rs.next().getProperty("c")).longValue())
+          .as("every matching row must be updated even though the RETURN result was refused").isEqualTo(ROW_CAP + 10);
     }
   }
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
@@ -106,6 +106,14 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
 
         // The session must stay usable afterwards: not left aborted/wedged by the refusal.
         assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+
+        // Prove it, rather than just trusting the status byte: the same socket must still accept and answer a
+        // normal query, not merely report idle while actually closed/wedged.
+        sendSimpleQuery(out, "SELECT 1 AS one");
+        final List<WireMessage> followUp = readUntilReadyForQuery(in);
+        assertThat(messageTypesOf(followUp)).as("a normal query after the refusal must succeed").doesNotContain('E');
+        assertThat(messageTypesOf(followUp)).as("a normal query after the refusal must return its row").contains('D');
+        assertThat(readyForQueryStatusOf(followUp)).isEqualTo('I');
       });
     }
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6679SimpleQueryMaxRowsIT.java
@@ -100,6 +100,7 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
 
         assertThat(messageTypesOf(response)).as("an ErrorResponse instead of a truncated result").contains('E');
         assertThat(messageTypesOf(response)).as("no CommandComplete for a refused query").doesNotContain('C');
+        assertThat(messageTypesOf(response)).as("no DataRow for a refused query").doesNotContain('D');
         final WireMessage error = response.stream().filter(m -> m.type() == 'E').findFirst()
             .orElseThrow(() -> new AssertionError("expected an ErrorResponse"));
         assertThat(errorFields(error).get('M')).contains("exceeds the configured limit").contains(String.valueOf(ROW_CAP));

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -83,15 +83,15 @@ class PostgresSetCommandParsingTest {
   }
 
   @Test
-  void anUnclosedQuoteIsLeftAsIsInsteadOfThrowing() {
+  void anUnclosedQuoteIsRejectedInsteadOfThrowing() {
     // A single stray quote is not a closed quoted value: substring(1, length - 1) on it used to throw
-    // StringIndexOutOfBoundsException instead of leaving the (malformed) value alone.
+    // StringIndexOutOfBoundsException instead of being treated as the malformed command it is.
     assertThatCode(() -> PostgresNetworkExecutor.parseSetCommand("SET x = '")).doesNotThrowAnyException();
-    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = '")).containsExactly("x", "'");
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = '")).isNull();
   }
 
   @Test
-  void mismatchedQuotesAreLeftAsIs() {
-    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = 'abc\"")).containsExactly("x", "'abc\"");
+  void mismatchedQuotesAreRejected() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = 'abc\"")).isNull();
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6423: {@code PostgresNetworkExecutor.setConfiguration()} used to split a
+ * {@code SET <param> = <value>} command on EVERY '=', so a value containing a further '=' (e.g. a connection
+ * string) was silently truncated - and, because the quote-stripping that followed assumed the truncated value
+ * still ended in the closing quote, it chopped off the value's last character too.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresSetCommandParsingTest {
+
+  @Test
+  void valueContainingEqualsIsKeptWhole() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET search_path = 'a=b'")).containsExactly("search_path", "a=b");
+  }
+
+  @Test
+  void simpleEqualsAssignment() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET datestyle = 'ISO'")).containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void toKeywordAssignment() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET datestyle TO 'ISO'")).containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void toKeywordAssignmentIsCaseInsensitiveAndSplitsOnFirstOccurrenceOnly() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET search_path to 'a TO b'")).containsExactly("search_path", "a TO b");
+  }
+
+  @Test
+  void unquotedValueIsNotStripped() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET timezone = UTC")).containsExactly("timezone", "UTC");
+  }
+
+  @Test
+  void paramNameIsLowerCased() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET DateStyle = 'ISO'")).containsExactly("datestyle", "ISO");
+  }
+
+  @Test
+  void noSeparatorReturnsNull() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET justaname")).isNull();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -83,6 +83,11 @@ class PostgresSetCommandParsingTest {
   }
 
   @Test
+  void emptyParamNameIsRejected() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET = somevalue")).isNull();
+  }
+
+  @Test
   void anUnclosedQuoteIsRejectedInsteadOfThrowing() {
     // A single stray quote is not a closed quoted value: substring(1, length - 1) on it used to throw
     // StringIndexOutOfBoundsException instead of being treated as the malformed command it is.

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.postgres;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Regression tests for issue #6423: {@code PostgresNetworkExecutor.setConfiguration()} used to split a
@@ -79,5 +80,18 @@ class PostgresSetCommandParsingTest {
   @Test
   void noSeparatorReturnsNull() {
     assertThat(PostgresNetworkExecutor.parseSetCommand("SET justaname")).isNull();
+  }
+
+  @Test
+  void anUnclosedQuoteIsLeftAsIsInsteadOfThrowing() {
+    // A single stray quote is not a closed quoted value: substring(1, length - 1) on it used to throw
+    // StringIndexOutOfBoundsException instead of leaving the (malformed) value alone.
+    assertThatCode(() -> PostgresNetworkExecutor.parseSetCommand("SET x = '")).doesNotThrowAnyException();
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = '")).containsExactly("x", "'");
+  }
+
+  @Test
+  void mismatchedQuotesAreLeftAsIs() {
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET x = 'abc\"")).containsExactly("x", "'abc\"");
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSetCommandParsingTest.java
@@ -53,6 +53,20 @@ class PostgresSetCommandParsingTest {
   }
 
   @Test
+  void toKeywordAssignmentWithValueContainingEqualsIsKeptWhole() {
+    // The command uses ' TO ' as its separator, so the '=' inside the value must NOT be mistaken for
+    // the (unused) '=' separator - the earlier-occurring separator wins, not '=' unconditionally.
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET search_path TO 'a=b'")).containsExactly("search_path", "a=b");
+  }
+
+  @Test
+  void equalsAssignmentWithValueContainingToIsKeptWhole() {
+    // Symmetric case: the command uses '=' as its separator, so a ' TO ' inside the value must not be
+    // mistaken for the (unused) TO separator.
+    assertThat(PostgresNetworkExecutor.parseSetCommand("SET search_path = 'a TO b'")).containsExactly("search_path", "a TO b");
+  }
+
+  @Test
   void unquotedValueIsNotStripped() {
     assertThat(PostgresNetworkExecutor.parseSetCommand("SET timezone = UTC")).containsExactly("timezone", "UTC");
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -1338,13 +1338,12 @@ class PostgresTypeTest {
 
   @Test
   void serializeAsTextNullBoolean() {
+    // A null BOOLEAN must use the SQL-NULL sentinel (length -1) in text format, exactly like every
+    // other type, not the 1-byte value "0" (which a client would read back as false) - issue #6674
     Binary buffer = new Binary();
     PostgresType.BOOLEAN.serializeAsText(PostgresType.BOOLEAN, buffer, null);
     buffer.flip();
-    int length = buffer.getInt();
-    byte[] data = new byte[length];
-    buffer.getByteBuffer().get(data);
-    assertThat(new String(data)).isEqualTo("0");
+    assertThat(buffer.getInt()).isEqualTo(-1);
   }
 
   @Test
@@ -1395,6 +1394,21 @@ class PostgresTypeTest {
     // DATE (OID 1082) must be serialized as "YYYY-MM-DD" only
     assertThat(result).matches("\\d{4}-\\d{2}-\\d{2}");
     assertThat(result).isEqualTo("2024-05-19");
+  }
+
+  @Test
+  void serializeAsTextTimestampBackedByDate() {
+    // With arcadedb.dateTimeImplementation = java.util.Date, a DATETIME property announced as
+    // TIMESTAMP (OID 1114) must keep its time-of-day in text format, not truncate to a date-only
+    // value the way DATE (OID 1082) does - issue #6675
+    Binary buffer = new Binary();
+    Date date = new Date(1716138311000L); // 2024-05-19 17:05:11 UTC
+    PostgresType.TIMESTAMP.serializeAsText(PostgresType.TIMESTAMP, buffer, date);
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+    assertThat(new String(data)).isEqualTo("2024-05-19 17:05:11.000000");
   }
 
   @Test

--- a/redisw/src/main/java/com/arcadedb/redis/RedisException.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisException.java
@@ -24,11 +24,44 @@ import com.arcadedb.exception.ArcadeDBException;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  **/
 public class RedisException extends ArcadeDBException {
+  private final String kind;
+
   public RedisException(final String message) {
     super(message);
+    this.kind = null;
   }
 
   public RedisException(final String message, final Throwable cause) {
     super(message, cause);
+    this.kind = null;
+  }
+
+  private RedisException(final String kind, final String message) {
+    super(message);
+    this.kind = kind;
+  }
+
+  /**
+   * Creates a {@link RedisException} carrying an explicit RESP error kind - the token right after {@code -} in
+   * the wire reply - separate from its message (issue #6560). Without this, a call site that needs a kind other
+   * than the {@code ErrorCategory}-derived default (e.g. {@code WRONGPASS}, {@code NOAUTH}, {@code NOPROTO}) had
+   * to bake it into the message text itself, which {@code RedisNetworkExecutor}'s dispatch {@code catch} block
+   * then prefixed with its own {@code ErrorCategory}-derived kind (always {@code ERR} for a plain
+   * {@code RedisException}) - producing a doubled/masking reply like {@code -ERR WRONGPASS ...} on the wire, where
+   * the kind a client could actually branch on was always {@code ERR}.
+   * <p>
+   * Example: {@code RedisException.withKind("WRONGPASS", "invalid username-password pair")} replies
+   * {@code -WRONGPASS invalid username-password pair}, not {@code -ERR WRONGPASS invalid username-password pair}.
+   */
+  public static RedisException withKind(final String kind, final String message) {
+    return new RedisException(kind, message);
+  }
+
+  /**
+   * The explicit RESP error kind this exception carries, or {@code null} when none was given - in which case
+   * the kind should be derived from {@link com.arcadedb.exception.ErrorCategory} instead.
+   */
+  public String getKind() {
+    return kind;
   }
 }

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -385,15 +385,20 @@ public class RedisNetworkExecutor extends Thread {
    * which carries no kind at all: a client had nothing to branch on, and an optimistic-concurrency conflict - the
    * one failure worth repeating the command for - looked exactly like a permanent one.
    * <p>
-   * The classification itself lives in {@link ErrorCategory} so every wire protocol answers it the same way. RESP
-   * has no vocabulary for the client-error categories Postgres and Bolt distinguish, so they all keep Redis'
-   * generic {@code ERR}.
+   * A {@link RedisException} carrying an explicit kind (see {@link RedisException#withKind}) wins first - that
+   * covers the kinds {@link ErrorCategory} has no concept of at all, such as {@code WRONGPASS}, {@code NOAUTH} and
+   * {@code NOPROTO} (issue #6560). Everything else falls back to {@link ErrorCategory} so every wire protocol
+   * answers the question the same way. RESP has no vocabulary for the client-error categories Postgres and Bolt
+   * distinguish, so they all keep Redis' generic {@code ERR}.
    * <p>
    * {@code TRYAGAIN} is the closest RESP2 offers, but in real Redis it is a cluster-mode error, so several client
    * libraries will not auto-retry on it. The retry hint is therefore weaker here than Postgres' {@code 40001} or
    * Bolt's transient status - it is the best signal the protocol has, not an equivalent one.
    */
   static String respErrorPrefix(final Throwable error) {
+    if (error instanceof RedisException redisException && redisException.getKind() != null)
+      return redisException.getKind();
+
     return switch (ErrorCategory.of(error)) {
       case RETRY -> "TRYAGAIN";
       case SECURITY -> "NOPERM";
@@ -775,16 +780,17 @@ public class RedisNetworkExecutor extends Thread {
     } else if (list.size() == 2) {
       // Single-argument AUTH targets Redis' "default" user, which ArcadeDB does not model.
       markUnauthenticated();
-      throw new RedisException("WRONGPASS ArcadeDB requires the 'AUTH <username> <password>' form");
+      throw RedisException.withKind("WRONGPASS", "ArcadeDB requires the 'AUTH <username> <password>' form");
     } else
-      throw new RedisException("ERR wrong number of arguments for 'auth' command");
+      // ERR is already respErrorPrefix()'s default kind, so the message no longer needs to repeat it.
+      throw new RedisException("wrong number of arguments for 'auth' command");
 
     try {
       markAuthenticated(server.getSecurity().authenticate(userName, password, null));
       value.append("+OK");
     } catch (final ServerSecurityException e) {
       markUnauthenticated();
-      throw new RedisException("WRONGPASS invalid username-password pair or user is disabled");
+      throw RedisException.withKind("WRONGPASS", "invalid username-password pair or user is disabled");
     }
   }
 
@@ -843,7 +849,7 @@ public class RedisNetworkExecutor extends Thread {
       if (NumberUtils.isIntegerNumber(maybeVersion)) {
         final int proto = Integer.parseInt(maybeVersion);
         if (proto < 2 || proto > 3)
-          throw new RedisException("NOPROTO unsupported protocol version");
+          throw RedisException.withKind("NOPROTO", "unsupported protocol version");
         idx++;
       }
     }
@@ -851,20 +857,21 @@ public class RedisNetworkExecutor extends Thread {
     // Optional AUTH <username> <password> option.
     if (list.size() > idx && "AUTH".equalsIgnoreCase((String) list.get(idx))) {
       if (list.size() < idx + 3)
-        throw new RedisException("ERR Syntax error in HELLO");
+        // ERR is already respErrorPrefix()'s default kind, so the message no longer needs to repeat it.
+        throw new RedisException("Syntax error in HELLO");
       final String userName = (String) list.get(idx + 1);
       final String password = (String) list.get(idx + 2);
       try {
         markAuthenticated(server.getSecurity().authenticate(userName, password, null));
       } catch (final ServerSecurityException e) {
         markUnauthenticated();
-        throw new RedisException("WRONGPASS invalid username-password pair or user is disabled");
+        throw RedisException.withKind("WRONGPASS", "invalid username-password pair or user is disabled");
       }
     }
 
     if (authenticatedUser == null)
-      throw new RedisException(
-          "NOAUTH HELLO must be called with the client already authenticated, otherwise the HELLO <proto> AUTH <user> <pass> option can be used to authenticate the client and select the RESP protocol version at the same time");
+      throw RedisException.withKind("NOAUTH",
+          "HELLO must be called with the client already authenticated, otherwise the HELLO <proto> AUTH <user> <pass> option can be used to authenticate the client and select the RESP protocol version at the same time");
 
     // RESP2 map reply: a flat array of alternating key/value elements (7 pairs = 14 elements).
     value.append("*14");
@@ -908,10 +915,10 @@ public class RedisNetworkExecutor extends Thread {
    */
   private DatabaseInternal getAuthorizedDatabase(final String databaseName) {
     if (authenticatedUser == null)
-      throw new RedisException("NOAUTH Authentication required.");
+      throw RedisException.withKind("NOAUTH", "Authentication required.");
 
     if (!authenticatedUser.canAccessToDatabase(databaseName))
-      throw new RedisException("NOPERM this user has no permissions to access the database '" + databaseName + "'");
+      throw RedisException.withKind("NOPERM", "this user has no permissions to access the database '" + databaseName + "'");
 
     final DatabaseInternal database = (DatabaseInternal) server.getDatabase(databaseName);
     DatabaseContext.INSTANCE.init(database).setCurrentUser(authenticatedUser.getDatabaseUser(database));

--- a/redisw/src/test/java/com/arcadedb/redis/RedisAuthenticationTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisAuthenticationTest.java
@@ -92,6 +92,21 @@ public class RedisAuthenticationTest extends BaseGraphServerTest {
   }
 
   @Test
+  void wrongCredentialsErrorKindIsNotMaskedByErr() {
+    // Issue #6560: respErrorPrefix() used to always report "ERR" for this failure (none of the call sites raise a
+    // real java.lang.SecurityException that ErrorCategory.of() recognises as SECURITY), so the wire reply came out
+    // as "-ERR WRONGPASS ..." - a client branching on the RESP error kind (the token right after '-') saw ERR, not
+    // WRONGPASS, even though the message text happened to still mention WRONGPASS further along.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      final JedisDataException error = catchThrowableOfType(JedisDataException.class, () -> jedis.auth(USER, "wrong-password"));
+      assertThat(error).isNotNull();
+      assertThat(error.getMessage()).as("RESP error kind must be WRONGPASS, not masked by a leading ERR")
+          .startsWith("WRONGPASS")
+          .doesNotStartWith("ERR");
+    }
+  }
+
+  @Test
   void authenticatedCommandsSucceed() {
     try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
       assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
@@ -149,6 +164,36 @@ public class RedisAuthenticationTest extends BaseGraphServerTest {
   }
 
   @Test
+  void helloWithoutAuthErrorKindIsNotMaskedByErr() {
+    // Issue #6560, review follow-up: the WRONGPASS/NOPERM wire-level coverage above did not extend to HELLO's
+    // own NOAUTH and NOPROTO RedisException.withKind() call sites, so exercise them here too rather than only
+    // through the respErrorPrefix() unit test - a future regression in hello()'s dispatch could otherwise slip
+    // through with only the classification logic pinned, not the actual wire reply hello() produces.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      final JedisDataException error = catchThrowableOfType(JedisDataException.class,
+          () -> jedis.sendCommand(Protocol.Command.HELLO, "2"));
+      assertThat(error).isNotNull();
+      assertThat(error.getMessage()).as("RESP error kind must be NOAUTH, not masked by a leading ERR")
+          .startsWith("NOAUTH")
+          .doesNotStartWith("ERR");
+    }
+  }
+
+  @Test
+  void helloWithBadProtocolVersionErrorKindIsNotMaskedByErr() {
+    // Issue #6560, review follow-up: see helloWithoutAuthErrorKindIsNotMaskedByErr() above. HELLO's protocol-
+    // version check runs before the NOAUTH check, so a bad version is reachable on an unauthenticated connection.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      final JedisDataException error = catchThrowableOfType(JedisDataException.class,
+          () -> jedis.sendCommand(Protocol.Command.HELLO, "9"));
+      assertThat(error).isNotNull();
+      assertThat(error.getMessage()).as("RESP error kind must be NOPROTO, not masked by a leading ERR")
+          .startsWith("NOPROTO")
+          .doesNotStartWith("ERR");
+    }
+  }
+
+  @Test
   void helloWithWrongCredentialsIsRejected() {
     try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
       final JedisDataException error = catchThrowableOfType(JedisDataException.class,
@@ -180,6 +225,13 @@ public class RedisAuthenticationTest extends BaseGraphServerTest {
       error = catchThrowableOfType(JedisDataException.class, () -> jedis.get(getDatabaseName() + ".anyKey"));
       assertThat(error).isNotNull();
       assertThat(error.getMessage()).contains("NOPERM");
+
+      // Issue #6560: the RESP error kind itself (the token right after '-') must be NOPERM, not masked by a
+      // leading ERR - getAuthorizedDatabase()'s NOPERM RedisException never raised a real
+      // java.lang.SecurityException, so ErrorCategory.of() never classified it as SECURITY.
+      assertThat(error.getMessage()).as("RESP error kind must be NOPERM, not masked by a leading ERR")
+          .startsWith("NOPERM")
+          .doesNotStartWith("ERR");
     } finally {
       security.dropUser("limited");
     }

--- a/redisw/src/test/java/com/arcadedb/redis/RedisErrorClassificationTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisErrorClassificationTest.java
@@ -59,6 +59,30 @@ class RedisErrorClassificationTest {
   }
 
   @Test
+  void anExplicitKindWinsOverTheDefaultErrCategory() {
+    // Issue #6560: a RedisException whose message already baked in a kind word (e.g. "WRONGPASS ...") used to be
+    // reported with the generic "ERR" kind anyway, since none of WRONGPASS/NOAUTH/NOPROTO/NOPERM's call sites
+    // raise a real java.lang.SecurityException that ErrorCategory.of() would recognise - the wire reply came out
+    // as "-ERR WRONGPASS ..." (or "-ERR NOAUTH ...", "-ERR NOPROTO ...", "-ERR NOPERM ..."), so the RESP error
+    // *kind* (the token right after '-') a client can branch on was always ERR, never the specific one.
+    assertThat(RedisNetworkExecutor.respErrorPrefix(RedisException.withKind("WRONGPASS", "bad credentials")))
+        .isEqualTo("WRONGPASS");
+    assertThat(RedisNetworkExecutor.respErrorPrefix(RedisException.withKind("NOAUTH", "Authentication required.")))
+        .isEqualTo("NOAUTH");
+    assertThat(RedisNetworkExecutor.respErrorPrefix(RedisException.withKind("NOPROTO", "unsupported protocol version")))
+        .isEqualTo("NOPROTO");
+    assertThat(RedisNetworkExecutor.respErrorPrefix(RedisException.withKind("NOPERM", "no permission")))
+        .isEqualTo("NOPERM");
+  }
+
+  @Test
+  void aPlainRedisExceptionWithoutAnExplicitKindKeepsTheDefault() {
+    // A RedisException that never called withKind() (e.g. "syntax error", "Key 'x' is not a number") still falls
+    // back to the ErrorCategory-derived default, exactly as before this exception carried a kind at all.
+    assertThat(RedisNetworkExecutor.respErrorPrefix(new RedisException("syntax error"))).isEqualTo("ERR");
+  }
+
+  @Test
   void anEmptyMessageStillNamesTheFailure() {
     // A bare `-` reply, or `-null`, tells the client nothing at all.
     assertThat(RedisNetworkExecutor.respErrorMessage(new IllegalStateException())).isEqualTo("IllegalStateException");

--- a/redisw/src/test/java/com/arcadedb/redis/RedisQueryLanguageTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisQueryLanguageTest.java
@@ -528,8 +528,15 @@ public class RedisQueryLanguageTest extends BaseGraphServerTest {
   }
 
   protected JSONObject executeQuery(final int serverIndex, final String language, final String command) throws Exception {
+    // Ask the server which port it actually bound (issue #6560), rather than assuming the 2480+serverIndex
+    // default: SERVER_HTTP_INCOMING_PORT is a range (2480-2489 by default) and binds the first free port in
+    // it, so with 2480 already held by anything else - another local ArcadeDB instance, an IDE debug session
+    // for a different project - this test's own server listens elsewhere. A port-less/wrong-port URL would
+    // then reach that foreign server instead, and every test in this class would fail with a confusing
+    // "403 Too many failed authentication attempts" / "User/Password not valid" that reads as an auth bug
+    // rather than a port collision. Same pattern as #6437's fix for ConsoleAsyncInsertTest.
     final HttpURLConnection connection = (HttpURLConnection) new URL(
-        "http://127.0.0.1:248" + serverIndex + "/api/v1/query/" + getDatabaseName()).openConnection();
+        "http://127.0.0.1:" + getServer(serverIndex).getHttpServer().getPort() + "/api/v1/query/" + getDatabaseName()).openConnection();
     connection.setRequestMethod("POST");
     connection.setRequestProperty("Authorization",
         "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
@@ -555,8 +562,10 @@ public class RedisQueryLanguageTest extends BaseGraphServerTest {
   }
 
   protected JSONObject executeCommand(final int serverIndex, final String language, final String command) throws Exception {
+    // See the comment in executeQuery() above: ask the server for its actual bound port instead of assuming
+    // 2480+serverIndex (issue #6560).
     final HttpURLConnection connection = (HttpURLConnection) new URL(
-        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/" + getDatabaseName()).openConnection();
+        "http://127.0.0.1:" + getServer(serverIndex).getHttpServer().getPort() + "/api/v1/command/" + getDatabaseName()).openConnection();
     connection.setRequestMethod("POST");
     connection.setRequestProperty("Authorization",
         "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));

--- a/server/src/main/java/com/arcadedb/server/ServerDatabase.java
+++ b/server/src/main/java/com/arcadedb/server/ServerDatabase.java
@@ -237,6 +237,11 @@ public class ServerDatabase implements DatabaseInternal {
     wrapped.checkPermissionsOnFile(fileId, access);
   }
 
+  @Override
+  public void checkPermissionsOnType(final String typeName, final SecurityDatabaseUser.ACCESS access) {
+    wrapped.checkPermissionsOnType(typeName, access);
+  }
+
   public long getResultSetLimit() {
     return wrapped.getResultSetLimit();
   }

--- a/server/src/main/java/com/arcadedb/server/ai/ToolDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/ai/ToolDispatcher.java
@@ -18,9 +18,11 @@
  */
 package com.arcadedb.server.ai;
 
-import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
@@ -88,34 +90,49 @@ public class ToolDispatcher {
     if (!user.canAccessToDatabase(databaseName))
       return errorJson("User '" + user.getName() + "' is not authorized to access database '" + databaseName + "'");
 
-    final Database database = server.getDatabase(databaseName);
+    final DatabaseInternal database = server.getDatabase(databaseName);
 
-    // Read-only: use query() (not command()). Writes will surface as the engine's
-    // "not idempotent" exception, which the LLM is prompted to recover by returning
-    // the command as a fenced block for the user to review.
-try (ResultSet rs = database.query(language, command)) {
-      final JSONArray records = new JSONArray();
-      long approxBytes = 0;
-      boolean truncated = false;
-      while (rs.hasNext()) {
-        final Result row = rs.next();
-        final JSONObject rowJson = new JSONObject(row.toJSON());
-        final int sz = rowJson.toString().length();
-        // Always allow the first row through so the LLM gets at least one record
-        // even when a single row is bigger than the budget.
-        if (approxBytes + sz > MAX_RESULT_BYTES && records.length() > 0) {
-          truncated = true;
-          break;
+    // Bind the authenticated principal onto this database's DatabaseContext so the engine's per-type/bucket
+    // ACL layer enforces (LocalDatabase.checkPermissionsOnFile is a no-op when no principal is bound) -
+    // mirrors AbstractServerHttpHandler.checkAuthorizationOnDatabase, which every other query path uses.
+    // Bound/restored per call rather than for the whole request: the tool argument above can name a database
+    // other than the chat's default one, and this dispatcher's worker thread is reused across requests, so a
+    // leaked binding must never survive past this single query.
+    DatabaseContext.DatabaseContextTL context = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
+    if (context == null)
+      context = DatabaseContext.INSTANCE.init(database);
+    final SecurityDatabaseUser previousUser = context.getCurrentUser();
+    context.setCurrentUser(user.getDatabaseUser(database));
+    try {
+      // Read-only: use query() (not command()). Writes will surface as the engine's
+      // "not idempotent" exception, which the LLM is prompted to recover by returning
+      // the command as a fenced block for the user to review.
+      try (ResultSet rs = database.query(language, command)) {
+        final JSONArray records = new JSONArray();
+        long approxBytes = 0;
+        boolean truncated = false;
+        while (rs.hasNext()) {
+          final Result row = rs.next();
+          final JSONObject rowJson = new JSONObject(row.toJSON());
+          final int sz = rowJson.toString().length();
+          // Always allow the first row through so the LLM gets at least one record
+          // even when a single row is bigger than the budget.
+          if (approxBytes + sz > MAX_RESULT_BYTES && records.length() > 0) {
+            truncated = true;
+            break;
+          }
+          records.put(rowJson);
+          approxBytes += sz;
         }
-        records.put(rowJson);
-        approxBytes += sz;
+        final JSONObject envelope = new JSONObject();
+        envelope.put("user", user.getName());
+        envelope.put("result", records);
+        if (truncated)
+          envelope.put("truncated", true);
+        return envelope.toString();
       }
-      final JSONObject envelope = new JSONObject();
-      envelope.put("user", user.getName());
-      envelope.put("result", records);
-      if (truncated)
-        envelope.put("truncated", true);
-      return envelope.toString();
+    } finally {
+      context.setCurrentUser(previousUser);
     }
   }
 

--- a/server/src/main/java/com/arcadedb/server/ai/ToolDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/ai/ToolDispatcher.java
@@ -18,16 +18,15 @@
  */
 package com.arcadedb.server.ai;
 
-import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.info.SchemaInfo;
 import com.arcadedb.server.info.ServerInfo;
+import com.arcadedb.server.security.DatabaseUserContext;
 import com.arcadedb.server.security.ServerSecurityUser;
 
 /**
@@ -92,18 +91,12 @@ public class ToolDispatcher {
 
     final DatabaseInternal database = server.getDatabase(databaseName);
 
-    // Bind the authenticated principal onto this database's DatabaseContext so the engine's per-type/bucket
-    // ACL layer enforces (LocalDatabase.checkPermissionsOnFile is a no-op when no principal is bound) -
-    // mirrors AbstractServerHttpHandler.checkAuthorizationOnDatabase, which every other query path uses.
-    // Bound/restored per call rather than for the whole request: the tool argument above can name a database
-    // other than the chat's default one, and this dispatcher's worker thread is reused across requests, so a
-    // leaked binding must never survive past this single query.
-    DatabaseContext.DatabaseContextTL context = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
-    if (context == null)
-      context = DatabaseContext.INSTANCE.init(database);
-    final SecurityDatabaseUser previousUser = context.getCurrentUser();
-    context.setCurrentUser(user.getDatabaseUser(database));
-    try {
+    // Bind the authenticated principal for the duration of the read so the engine's per-type/bucket ACL
+    // layer enforces (LocalDatabase.checkPermissionsOnFile is a no-op when no principal is bound) - mirrors
+    // SchemaInfo.forUser's use of the same helper for the get_schema tool. Scoped per call rather than for
+    // the whole request because the tool argument above can name a database other than the chat's default
+    // one, and this dispatcher's worker thread is reused across requests.
+    return DatabaseUserContext.runAs(database, user, () -> {
       // Read-only: use query() (not command()). Writes will surface as the engine's
       // "not idempotent" exception, which the LLM is prompted to recover by returning
       // the command as a fenced block for the user to review.
@@ -131,9 +124,7 @@ public class ToolDispatcher {
           envelope.put("truncated", true);
         return envelope.toString();
       }
-    } finally {
-      context.setCurrentUser(previousUser);
-    }
+    });
   }
 
   private String executeGetSchema(final JSONObject args) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
@@ -323,8 +323,13 @@ public class GetDynamicContentHandler extends AbstractServerHttpHandler {
    * {@link ArrayIndexOutOfBoundsException} out of the page render (issue #6423).
    */
   static void parseIncludeParameters(final String params, final String include, final Map<String, Object> variables) {
-    final String[] parameterPairs = params.split(" ");
+    // Split on a run of whitespace, not a single space: a run of consecutive spaces between parameters
+    // (or a trailing one) would otherwise produce an empty-string element that logs a spurious "malformed
+    // parameter ''" warning below.
+    final String[] parameterPairs = params.trim().split("\\s+");
     for (final String pair : parameterPairs) {
+      if (pair.isEmpty())
+        continue;
       final String[] kv = StringUtils.splitKeyValue(pair);
       if (kv == null) {
         LogManager.instance().log(GetDynamicContentHandler.class, Level.WARNING,

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
@@ -26,6 +26,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StringUtils;
 import io.micrometer.core.instrument.Metrics;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
@@ -248,11 +249,7 @@ public class GetDynamicContentHandler extends AbstractServerHttpHandler {
 
           include = include.substring(0, sep);
 
-          final String[] parameterPairs = params.split(" ");
-          for (final String pair : parameterPairs) {
-            final String[] kv = pair.split("=");
-            variables.put(kv[0].trim(), kv[1].trim());
-          }
+          parseIncludeParameters(params, include, variables);
         }
 
         final InputStream fis = getClass().getClassLoader().getResourceAsStream("static/" + include);
@@ -317,5 +314,24 @@ public class GetDynamicContentHandler extends AbstractServerHttpHandler {
     buffer.append(file.substring(pos));
 
     return buffer.toString();
+  }
+
+  /**
+   * Parses the space-separated {@code key=value} parameters of an {@code ${include:file.html k=v ...}} directive
+   * into {@code variables}. Each pair is split on the FIRST '=' only, so a value containing a further '=' is kept
+   * whole, and a parameter with no '=' at all is reported and skipped instead of throwing
+   * {@link ArrayIndexOutOfBoundsException} out of the page render (issue #6423).
+   */
+  static void parseIncludeParameters(final String params, final String include, final Map<String, Object> variables) {
+    final String[] parameterPairs = params.split(" ");
+    for (final String pair : parameterPairs) {
+      final String[] kv = StringUtils.splitKeyValue(pair);
+      if (kv == null) {
+        LogManager.instance().log(GetDynamicContentHandler.class, Level.WARNING,
+            "Malformed include parameter '%s' in '%s', ignoring it", pair, include);
+        continue;
+      }
+      variables.put(kv[0].trim(), kv[1].trim());
+    }
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -593,6 +593,17 @@ public class CoreApiSpec implements OpenApiContributor {
         {"$bytes": "<base64>"} for byte[] (standard or URL-safe base64), \
         {"$int8": [v0, v1, ...]} for byte[] from integers in [-128, 127] (used to send \
         INT8-encoded vectors to LSM_VECTOR indexes without a float32 round-trip)."""));
+    // PostQueryHandler extends PostCommandHandler and overrides only executeCommand(), not execute(), so
+    // both /api/v1/query/{database} and /api/v1/command/{database} honor 'limit' identically (issue #6584).
+    schema.addProperty("limit", SpecBuilders.integer(
+        """
+        Maximum number of rows to serialize into the response. When omitted, a LIMIT stated by the query is \
+        honored as written and only a query stating none is capped by the server default \
+        ('arcadedb.server.httpQueryDefaultLimit'). Use -1 for no cap. The response always reports the cap \
+        that was applied ('limit'), how many rows it carries ('returned') and whether rows were left \
+        behind ('truncated'). No value here can widen a single response past the server's hard ceiling \
+        ('arcadedb.server.httpQueryMaxResultRows'): a result that would exceed it is refused with 413 \
+        instead of being truncated.""").example(100));
     schema.setRequired(List.of("command", "language"));
     return schema;
   }

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -27,8 +27,10 @@ import com.arcadedb.security.SecurityManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -40,6 +42,9 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   private final        String      userName;
   private              String[]    groups;
   private volatile     boolean[][] fileAccessMap     = null;
+  // Companion to fileAccessMap, keyed by type name instead of bucket file id: the only way to gate a type that
+  // owns no bucket (a TimeSeries type). See updateFileAccess().
+  private volatile     Map<String, boolean[]> typeAccessMap = null;
   // Written under the updateDatabaseConfiguration() monitor but read by unsynchronized getters on the query
   // path, so they are volatile: without it a reader has no visibility guarantee and a 64-bit read is not
   // required to be atomic, which would let a query observe a torn limit.
@@ -130,6 +135,20 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
       return permissions[index];
     }
     return true;
+  }
+
+  @Override
+  public boolean requestAccessOnType(final String typeName, final ACCESS access) {
+    if (denyAll)
+      return false;
+
+    final Map<String, boolean[]> currentMap = typeAccessMap;
+    if (currentMap == null)
+      return true;
+
+    final boolean[] permissions = currentMap.get(typeName);
+    // Not (yet) in the map: same default-allow policy as requestAccessOnFile() for an unregistered file id.
+    return permissions == null || permissions[access.ordinal()];
   }
 
   public synchronized void updateDatabaseConfiguration(final JSONObject configuredGroups) {
@@ -223,50 +242,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
       if (type == null)
         continue;
 
-      final String typeName = type.getName();
-
-      for (final String groupName : groups) {
-        if (!configuredGroups.has(groupName))
-          // GROUP NOT DEFINED
-          continue;
-
-        final JSONObject group = configuredGroups.getJSONObject(groupName);
-
-        if (!group.has("types"))
-          continue;
-
-        final JSONObject types = group.getJSONObject("types");
-
-        JSONObject groupType = types.has(typeName) ? types.getJSONObject(typeName) : null;
-        if (groupType == null)
-          // GET DEFAULT TYPE FOR THE GROUP IF ANY
-          groupType = types.has(SecurityManager.ANY) ? types.getJSONObject(SecurityManager.ANY) : null;
-
-        if (groupType == null)
-          continue;
-
-        if (newFileAccessMap[i] == null)
-          // FIRST DEFINITION ENCOUNTERED: START FROM ALL REVOKED
-          newFileAccessMap[i] = new boolean[] { false, false, false, false };
-
-        // APPLY THE FOUND TYPE FROM THE FOUND GROUP
-        updateAccessArray(newFileAccessMap[i], groupType.getJSONArray("access"));
-      }
-
-      if (newFileAccessMap[i] == null) {
-        // NO GROUP+TYPE FOUND, APPLY SETTINGS FROM DEFAULT GROUP/TYPE
-        newFileAccessMap[i] = new boolean[] { false, false, false, false };
-
-        final JSONObject t;
-        if (defaultGroupTypes.has(typeName)) {
-          // APPLY THE FOUND TYPE FROM DEFAULT GROUP
-          t = defaultGroupTypes.getJSONObject(typeName);
-        } else
-          // APPLY DEFAULT TYPE FROM DEFAULT GROUP
-          t = defaultType;
-
-        updateAccessArray(newFileAccessMap[i], t.getJSONArray("access"));
-      }
+      newFileAccessMap[i] = resolveTypeAccess(type.getName(), configuredGroups, defaultGroupTypes, defaultType);
     }
 
     // SWAP WITH THE NEW MAP (VOLATILE PROPERTY)
@@ -275,6 +251,70 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
     // #5269: the refreshed map may now cover files previously reported as missing; reset the throttle so a genuinely
     // new file created later can still be reported once.
     warnedNotRegisteredFiles.clear();
+
+    // A TimeSeries type owns no bucket (its data lives in its own engine, not a LocalBucket), so it never gets an
+    // entry in newFileAccessMap above - requestAccessOnType() is the only way to gate it. Covers every type, not
+    // just bucket-less ones, so requestAccessOnType() stays consistent with requestAccessOnFile() for a type that
+    // does have buckets too.
+    final Map<String, boolean[]> newTypeAccessMap = new HashMap<>();
+    for (final DocumentType type : database.getSchema().getTypes())
+      newTypeAccessMap.put(type.getName(), resolveTypeAccess(type.getName(), configuredGroups, defaultGroupTypes, defaultType));
+    typeAccessMap = newTypeAccessMap;
+  }
+
+  /**
+   * Resolves the {@code [createRecord, readRecord, updateRecord, deleteRecord]} access array a type is entitled to
+   * under {@code configuredGroups}: the first group (in {@link #groups} order) that names the type, or failing
+   * that the group's {@code "*"} default type, or failing that the configuration's default group/type.
+   */
+  private boolean[] resolveTypeAccess(final String typeName, final JSONObject configuredGroups,
+      final JSONObject defaultGroupTypes, final JSONObject defaultType) {
+    boolean[] access = null;
+
+    for (final String groupName : groups) {
+      if (!configuredGroups.has(groupName))
+        // GROUP NOT DEFINED
+        continue;
+
+      final JSONObject group = configuredGroups.getJSONObject(groupName);
+
+      if (!group.has("types"))
+        continue;
+
+      final JSONObject types = group.getJSONObject("types");
+
+      JSONObject groupType = types.has(typeName) ? types.getJSONObject(typeName) : null;
+      if (groupType == null)
+        // GET DEFAULT TYPE FOR THE GROUP IF ANY
+        groupType = types.has(SecurityManager.ANY) ? types.getJSONObject(SecurityManager.ANY) : null;
+
+      if (groupType == null)
+        continue;
+
+      if (access == null)
+        // FIRST DEFINITION ENCOUNTERED: START FROM ALL REVOKED
+        access = new boolean[] { false, false, false, false };
+
+      // APPLY THE FOUND TYPE FROM THE FOUND GROUP
+      updateAccessArray(access, groupType.getJSONArray("access"));
+    }
+
+    if (access == null) {
+      // NO GROUP+TYPE FOUND, APPLY SETTINGS FROM DEFAULT GROUP/TYPE
+      access = new boolean[] { false, false, false, false };
+
+      final JSONObject t;
+      if (defaultGroupTypes.has(typeName)) {
+        // APPLY THE FOUND TYPE FROM DEFAULT GROUP
+        t = defaultGroupTypes.getJSONObject(typeName);
+      } else
+        // APPLY DEFAULT TYPE FROM DEFAULT GROUP
+        t = defaultType;
+
+      updateAccessArray(access, t.getJSONArray("access"));
+    }
+
+    return access;
   }
 
   private static boolean[] updateAccessArray(final boolean[] array, final JSONArray access) {

--- a/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerIncludeParametersTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerIncludeParametersTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression tests for issue #6423: an {@code ${include:file.html k=v ...}} parameter with no '=' used to throw
+ * {@link ArrayIndexOutOfBoundsException} out of the page render, and a value containing a further '=' was
+ * silently truncated.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GetDynamicContentHandlerIncludeParametersTest {
+
+  @Test
+  void wellFormedParametersArePutIntoVariables() {
+    final Map<String, Object> variables = new HashMap<>();
+    GetDynamicContentHandler.parseIncludeParameters("a=1 b=2", "test.html", variables);
+    assertThat(variables).containsEntry("a", "1").containsEntry("b", "2");
+  }
+
+  @Test
+  void valueContainingEqualsIsKeptWhole() {
+    final Map<String, Object> variables = new HashMap<>();
+    GetDynamicContentHandler.parseIncludeParameters("flag=x=y", "test.html", variables);
+    assertThat(variables).containsEntry("flag", "x=y");
+  }
+
+  @Test
+  void parameterWithNoSeparatorIsSkippedInsteadOfThrowing() {
+    final Map<String, Object> variables = new HashMap<>();
+    assertThatCode(() -> GetDynamicContentHandler.parseIncludeParameters("a=1 noequals b=2", "test.html", variables))
+        .doesNotThrowAnyException();
+    assertThat(variables).containsEntry("a", "1").containsEntry("b", "2").doesNotContainKey("noequals");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerIncludeParametersTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerIncludeParametersTest.java
@@ -56,4 +56,13 @@ class GetDynamicContentHandlerIncludeParametersTest {
         .doesNotThrowAnyException();
     assertThat(variables).containsEntry("a", "1").containsEntry("b", "2").doesNotContainKey("noequals");
   }
+
+  @Test
+  void repeatedOrTrailingSpacesDoNotProduceAMalformedParameter() {
+    // A run of whitespace between parameters (or a trailing one) used to split into an empty-string
+    // element that logged a spurious "malformed parameter ''" warning.
+    final Map<String, Object> variables = new HashMap<>();
+    GetDynamicContentHandler.parseIncludeParameters("a=1   b=2  ", "test.html", variables);
+    assertThat(variables).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "b", "2"));
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -301,6 +301,34 @@ class CoreApiSpecTest {
   }
 
   @Test
+  void commandRequestDeclaresLimitMatchingQueryRequest() {
+    // Issue #6584: PostQueryHandler extends PostCommandHandler and overrides only executeCommand(),
+    // so both /api/v1/query/{database} and /api/v1/command/{database} run through the very same
+    // execute() and honor an optional 'limit' field identically. QueryRequest documents it; CommandRequest
+    // did not, leaving a client generated strictly from the contract with no typed way to cap a command's
+    // result set even though the server supports it.
+    final Schema<?> commandRequest = openAPI.getComponents().getSchemas().get("CommandRequest");
+    final Schema<?> queryRequest = openAPI.getComponents().getSchemas().get("QueryRequest");
+
+    assertThat(commandRequest.getProperties())
+        .as("PostCommandHandler.execute() reads an optional 'limit' field for both the command and "
+            + "query endpoints, so CommandRequest must declare it exactly like QueryRequest does")
+        .containsKey("limit");
+
+    final Schema<?> commandLimit = (Schema<?>) commandRequest.getProperties().get("limit");
+    final Schema<?> queryLimit = (Schema<?>) queryRequest.getProperties().get("limit");
+
+    assertThat(commandLimit.getType())
+        .as("CommandRequest.limit must be typed the same as QueryRequest.limit: both feed the same "
+            + "optionalIntField(requestMap, \"limit\") call")
+        .isEqualTo(queryLimit.getType());
+    assertThat(commandLimit.getDescription())
+        .as("the two endpoints share the exact same limit/truncation semantics, so the contract text "
+            + "must not diverge and confuse a reader of the generated docs")
+        .isEqualTo(queryLimit.getDescription());
+  }
+
+  @Test
   void getQuery404DoesNotClaimTheStaleSessionCasePostAndCommandDo() {
     final Operation get = openAPI.getPaths().get("/api/v1/query/{database}/{language}/{command}").getGet();
 

--- a/server/src/test/java/com/arcadedb/server/security/AiChatToolDispatcherPerTypeAclIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/AiChatToolDispatcherPerTypeAclIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.ai.ToolDispatcher;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the AI chat {@code query_database} tool bypassing per-type/bucket ACL enforcement:
+ * {@link ToolDispatcher#executeQuery} ran the user-supplied query with only the coarse
+ * {@code canAccessToDatabase} check and never bound the authenticated principal onto the query thread's
+ * {@code DatabaseContext}. The engine's fine-grained per-type ACL layer
+ * ({@code LocalDatabase.checkPermissionsOnFile}) is deliberately a no-op when no principal is bound, so a
+ * user with database-level access but no per-type rights on a given type could read it anyway through the
+ * AI chat tool, even though the identical query is rejected on every other query path
+ * ({@code POST /api/v1/query/{db}}).
+ * <p>
+ * The test drives {@link ToolDispatcher} directly (bypassing the AI gateway/HTTP plumbing, which is
+ * external infrastructure not under test) with a user granted {@code readRecord} on every type except
+ * {@code SecretDoc}. On the vulnerable build {@code query_database} returned the {@code SecretDoc} row; with
+ * the principal bound the per-type READ_RECORD gate rejects it, while the same user's query against an
+ * authorized type still succeeds.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class AiChatToolDispatcherPerTypeAclIT extends BaseGraphServerTest {
+
+  private static final String SCOPED_USER = "aichat-pertype-scoped-user";
+  private static final String SCOPED_PWD  = "aichatpertypeuser1";
+  private static final String PUBLIC_TYPE = "PublicDoc";
+  private static final String SECRET_TYPE = "SecretDoc";
+
+  @Test
+  void queryDatabaseToolEnforcesPerTypeAcl() throws Exception {
+    testEachServer((serverIndex) -> {
+      command(serverIndex, "CREATE VERTEX TYPE " + PUBLIC_TYPE);
+      command(serverIndex, "CREATE VERTEX TYPE " + SECRET_TYPE);
+      command(serverIndex, "CREATE VERTEX " + PUBLIC_TYPE + " SET x = 1");
+      command(serverIndex, "CREATE VERTEX " + SECRET_TYPE + " SET x = 1");
+
+      createScopedUser(serverIndex);
+      try {
+        final ServerSecurity security = getServer(serverIndex).getSecurity();
+        final ServerSecurityUser scopedUser = security.authenticate(SCOPED_USER, SCOPED_PWD, getDatabaseName());
+
+        final ToolDispatcher dispatcher = new ToolDispatcher(getServer(serverIndex), scopedUser, getDatabaseName());
+
+        // Attack: query a per-type forbidden type through the AI chat tool. On the vulnerable build this
+        // returned the SecretDoc row (no principal bound -> per-type READ_RECORD check skipped).
+        final JSONObject secretResult = new JSONObject(dispatcher.execute("query_database",
+            new JSONObject().put("language", "sql").put("command", "SELECT FROM " + SECRET_TYPE)));
+        assertThat(secretResult.has("error"))
+            .as("query_database on a per-type forbidden type must be rejected").isTrue();
+
+        // Positive control: the same user may query an authorized type - proving the rejection above is
+        // per-type authorization, not a blanket tool failure.
+        final JSONObject publicResult = new JSONObject(dispatcher.execute("query_database",
+            new JSONObject().put("language", "sql").put("command", "SELECT FROM " + PUBLIC_TYPE)));
+        assertThat(publicResult.has("error"))
+            .as("query_database on an authorized type must succeed").isFalse();
+        assertThat(publicResult.getJSONArray("result")).hasSize(1);
+      } finally {
+        deleteUser(serverIndex, SCOPED_USER);
+      }
+    });
+  }
+
+  private void createScopedUser(final int serverIndex) throws Exception {
+    final ServerSecurity security = getServer(serverIndex).getSecurity();
+
+    // Grant readRecord on every type via the "*" default, but explicitly REVOKE all access on SECRET_TYPE.
+    // A listed type overrides the "*" default in the per-type map resolution.
+    ServerSecurityTestAccess.databaseGroups(security, getDatabaseName()).put("aiChatPerTypeScoped",
+        new JSONObject().put("access", new JSONArray())
+            .put("types", new JSONObject()
+                .put("*", new JSONObject().put("access", new JSONArray().put("readRecord")))
+                .put(SECRET_TYPE, new JSONObject().put("access", new JSONArray()))));
+    security.saveGroups();
+
+    if (security.existsUser(SCOPED_USER))
+      security.dropUser(SCOPED_USER);
+
+    security.createUser(new JSONObject()
+        .put("name", SCOPED_USER)
+        .put("password", security.encodePassword(SCOPED_PWD))
+        .put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put("aiChatPerTypeScoped"))));
+  }
+
+  private void deleteUser(final int serverIndex, final String name) {
+    final ServerSecurity security = getServer(serverIndex).getSecurity();
+    if (security.existsUser(name))
+      security.dropUser(name);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/BatchParallelFlushPerTypeAclIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/BatchParallelFlushPerTypeAclIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the incomplete fix of GHSA-c23x-pqcj-7hfm: the c23x fix bound the authenticated
+ * principal on the batch handler's HTTP worker thread and gated {@code LocalBucket.createRecordsBulk} for the
+ * edge-record creation phase, but left {@code DatabaseAsyncTransaction} - the task type
+ * {@link com.arcadedb.graph.GraphBatch}'s parallel edge-connect phase submits to the async executor when
+ * {@code parallelFlush} is left at its default {@code true} - binding no principal at all. The engine's
+ * per-type ACL ({@code LocalDatabase.checkPermissionsOnFile}) is a no-op when no principal is bound, so a user
+ * with {@code CREATE_RECORD} on an edge type but {@code CREATE_RECORD}/{@code UPDATE_RECORD} revoked on the
+ * target vertex type could still durably connect edges to that vertex type's buckets through the parallel
+ * connect phase, while the same write was already correctly rejected with {@code parallelFlush=false}.
+ * <p>
+ * The user in this test may create edges of {@code PfEdge} but has only {@code readRecord} on {@code PfVertex}.
+ * On the vulnerable build the parallel-flush batch below durably connected the edge (2xx); with the principal
+ * bound on the async worker, the per-type {@code CREATE_RECORD}/{@code UPDATE_RECORD} gate rejects it (403),
+ * matching the {@code parallelFlush=false} behaviour that was already correct.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BatchParallelFlushPerTypeAclIT extends BaseGraphServerTest {
+
+  private static final String SCOPED_USER = "parallelflush-scoped-user";
+  private static final String SCOPED_PWD  = "parallelflushuser1";
+  private static final String VERTEX_TYPE = "PfVertex";
+  private static final String EDGE_TYPE   = "PfEdge";
+
+  @Test
+  void perTypeAclEnforcedOnParallelFlushEdgeConnect() throws Exception {
+    testEachServer((serverIndex) -> {
+      // Types must exist BEFORE the scoped user's per-type ACL map is built, so the map segments PfVertex.
+      command(serverIndex, "CREATE VERTEX TYPE " + VERTEX_TYPE);
+      command(serverIndex, "CREATE EDGE TYPE " + EDGE_TYPE);
+
+      final String v1 = createVertex(serverIndex);
+      final String v2 = createVertex(serverIndex);
+      final String v3 = createVertex(serverIndex);
+      final String v4 = createVertex(serverIndex);
+
+      // Seed one edge per attack target BEFORE the ACL is narrowed, as root: this durably allocates v1's and
+      // v3's out-edge chunk. GraphBatch only defers a vertex's chunk head update to the async connect phase
+      // when the chunk already exists with spare room (a brand-new vertex's first chunk is instead created
+      // synchronously on the bound thread, which the earlier GHSA-c23x fix already gates) - so without a seed
+      // edge here the attack below would only re-exercise the already-fixed path.
+      command(serverIndex, "CREATE EDGE " + EDGE_TYPE + " FROM " + v1 + " TO " + v2);
+      command(serverIndex, "CREATE EDGE " + EDGE_TYPE + " FROM " + v3 + " TO " + v2);
+
+      createScopedUser(serverIndex);
+      try {
+        final String auth = basicAuth(SCOPED_USER, SCOPED_PWD);
+
+        // Attack: connect a further edge from a per-type-forbidden vertex with an EXISTING, ROOMY edge chunk,
+        // through the batch handler's default (parallelFlush=true) edge-connect phase. On the vulnerable build
+        // this was durably written despite the revoked ACL, because the async worker that runs the connect
+        // phase binds no principal.
+        final String parallelEdgeLine =
+            "{\"@type\":\"edge\",\"@class\":\"" + EDGE_TYPE + "\",\"@from\":\"" + v1 + "\",\"@to\":\"" + v2 + "\"}\n";
+        final int parallelStatus = postBatch(serverIndex, getDatabaseName(), auth, parallelEdgeLine, null);
+        assertThat(parallelStatus).as("parallel-flush edge connect to a per-type forbidden vertex type must be rejected")
+            .isEqualTo(403);
+
+        // Differential control: the identical write (on the OTHER seeded vertex, so it starts from the same
+        // one-edge state) with parallelFlush=false runs the connect phase inline on the bound HTTP thread
+        // (already gated since GHSA-c23x). Asserting it here proves the 403 above is per-type authorization
+        // enforced consistently on both paths, not some unrelated failure.
+        final String sequentialEdgeLine =
+            "{\"@type\":\"edge\",\"@class\":\"" + EDGE_TYPE + "\",\"@from\":\"" + v3 + "\",\"@to\":\"" + v4 + "\"}\n";
+        final int sequentialStatus = postBatch(serverIndex, getDatabaseName(), auth, sequentialEdgeLine, "parallelFlush=false");
+        assertThat(sequentialStatus).as("sequential edge connect to a per-type forbidden vertex type must be rejected")
+            .isEqualTo(403);
+
+        // Decisive check (as root): each attack target's adjacency must still show only the one seeded edge -
+        // the exact bucket the advisory says a bypass leaves durably mutated. On the vulnerable build the
+        // parallel-flush attempt connected a second edge to v1 despite the revoked ACL. (A flush that fails
+        // after its edge record was already committed on the bound thread, as here, may still leave that
+        // lone, UNCONNECTED PfEdge record behind if the user also lacks deleteRecord to let GraphBatch reclaim
+        // it - that is a data-hygiene side effect of the correctly-rejected write, not a re-opening of the ACL
+        // bypass, so it is not what this assertion checks.)
+        assertThat(countConnectedEdges(serverIndex, v1)).as("no forbidden-type edge connection may have been added via the parallel path")
+            .isEqualTo(1);
+        assertThat(countConnectedEdges(serverIndex, v3)).as("no forbidden-type edge connection may have been added via the sequential path")
+            .isEqualTo(1);
+      } finally {
+        deleteUser(serverIndex, SCOPED_USER);
+      }
+    });
+  }
+
+  private String createVertex(final int serverIndex) throws Exception {
+    final String response = command(serverIndex, "CREATE VERTEX " + VERTEX_TYPE);
+    final JSONObject json = new JSONObject(response);
+    return json.getJSONArray("result").getJSONObject(0).getString("@rid");
+  }
+
+  private long countConnectedEdges(final int serverIndex, final String vertexRid) throws Exception {
+    final String response = command(serverIndex, "SELECT bothE('" + EDGE_TYPE + "').size() AS c FROM " + vertexRid);
+    final JSONObject json = new JSONObject(response);
+    return json.getJSONArray("result").getJSONObject(0).getLong("c");
+  }
+
+  private void createScopedUser(final int serverIndex) throws Exception {
+    final ServerSecurity security = getServer(serverIndex).getSecurity();
+
+    // Grant readRecord/createRecord/updateRecord on every type via the "*" default (covers PfEdge), but
+    // narrow PfVertex down to readRecord only - createRecord/updateRecord REVOKED, mirroring the attack
+    // precondition. A listed type overrides the "*" default in the per-type map resolution.
+    security.getDatabaseGroupsConfiguration(getDatabaseName()).put("parallelFlushScoped",
+        new JSONObject().put("access", new JSONArray())
+            .put("types", new JSONObject()
+                .put("*", new JSONObject().put("access",
+                    new JSONArray().put("readRecord").put("createRecord").put("updateRecord")))
+                .put(VERTEX_TYPE, new JSONObject().put("access", new JSONArray().put("readRecord")))));
+    security.saveGroups();
+
+    if (security.existsUser(SCOPED_USER))
+      security.dropUser(SCOPED_USER);
+
+    final JSONObject payload = new JSONObject()
+        .put("name", SCOPED_USER)
+        .put("password", SCOPED_PWD)
+        .put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put("parallelFlushScoped")));
+
+    final HttpURLConnection connection = openPost(serverIndex, "/api/v1/server/users",
+        basicAuth("root", DEFAULT_PASSWORD_FOR_TESTS));
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream().write(payload.toString().getBytes());
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(201);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void deleteUser(final int serverIndex, final String name) throws Exception {
+    final HttpURLConnection connection = openPost(serverIndex,
+        "/api/v1/server/users?name=" + URLEncoder.encode(name, StandardCharsets.UTF_8),
+        basicAuth("root", DEFAULT_PASSWORD_FOR_TESTS));
+    connection.setRequestMethod("DELETE");
+    connection.connect();
+    try {
+      connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int postBatch(final int serverIndex, final String db, final String auth, final String jsonl,
+      final String extraQueryParam) throws Exception {
+    final String query = extraQueryParam != null ? "?" + extraQueryParam : "";
+    final HttpURLConnection connection = openPost(serverIndex, "/api/v1/batch/" + db + query, auth);
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/x-ndjson");
+    connection.getOutputStream().write(jsonl.getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private HttpURLConnection openPost(final int serverIndex, final String path, final String auth) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + path).openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", auth);
+    return connection;
+  }
+
+  private String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+  }
+}


### PR DESCRIPTION
## What does this PR do?

`LSMVectorIndex.getStats()` gains a `closeTimeRebuildPending` entry (`1`/`0`) that answers whether
the most recent `close()` deferred a graph rebuild it would otherwise have run, instead of an
operator having to go find the `FINE` log line that says the same thing.

## Stacked on #6653 - read this first

**This PR targets `fix/6067-flush-redoes-cancelled-build` (#6653), not `main`.** The deferral branch
this issue is about - `flush()`'s size-threshold skip, added by #6653 - does not exist on `main` yet;
#6653 is still open. #6657 was explicitly filed as a non-blocking follow-up to #6653 ("doesn't belong
bundled into that PR"), so this branches from #6653's branch to build the follow-up on the code it
actually follows up on, rather than duplicating #6653's still-unmerged changes here.

**Diff note:** because of the stacking, this PR's diff will show #6653's changes too until #6653
merges. Once it does, GitHub retargets this PR to `main` automatically (base-branch deletion
retargeting) and the diff narrows to just this PR's own commit. Nothing to do on this PR's part.

## Motivation

Issue #6657, filed by @lvca from #6653's third review round: "an ops team debugging 'why is my first
query after reopen slow' would currently have to find that `FINE` log line rather than being able to
check it directly" - suggested exposing a "graph rebuild pending" boolean or timestamp via
`getStats()`, alongside the existing `graphState`/`graphRebuildCount`/`mutationsSinceRebuild` entries.

## Design decision worth a second look: persisted, not in-memory

The issue's own "possible direction" (explicitly "not investigated") proposes a plain in-memory
boolean, "set only in `flush()`'s new deferral branch (and cleared once
`ensureGraphAvailable()`/`buildGraphFromScratch()` actually catches up)".

That does not actually work as described: `flush()` only ever runs from
`LocalDatabase.closeDurableParts()`, i.e. only at `close()`/`drop()`, and a **fresh** `LSMVectorIndex`
instance is constructed on every `open()`/`create()` (see the two factory methods). A plain field set
by one instance's `flush()` would already be gone by the time any later instance - the one from the
next `open()` - could read or clear it. That's precisely the scenario the issue names as the point of
the feature: checking the stat right after reopen, before the first search. An in-memory field would
misreport `false` at exactly that moment.

Implemented instead as a small persisted flag on the graph's existing manifest sidecar
(`LSMVectorIndexGraphManifest` - a few dozen bytes, already read once per graph load / written once
per persist):

- `Content` gained a `closeDeferredRebuild` boolean, defaulting to `false` on read (old manifests
  without the field read as `false`, no format-version bump needed).
- New `markCloseDeferred()`: preserves whatever `vectorCount`/`fingerprint` are already on disk (or
  falls back to `UNUSABLE_VECTOR_COUNT`/`0` when nothing has ever been persisted - the never-built
  arm), writes `closeDeferredRebuild = true`. It does **not** touch the existing
  staleness-detection fields, so it cannot interfere with `ensureGraphAvailable()`'s fingerprint-based
  reuse check.
- The two existing write paths - `write(int, long)` (normal post-build persist) and
  `markUnusable(String)` - now clear `closeDeferredRebuild` back to `false` explicitly: reaching
  either means a build completed (successfully or not), so whatever a previous close deferred has now
  been paid for.
- `LSMVectorIndex.flush()` calls the new `markCloseTimeRebuildDeferred(gf)` helper from **both**
  existing "skip the build" branches - the size-threshold deferral (#6653) and the pre-existing
  `!valid` "background resources already released" branch - but not from the "nothing needed" branch,
  which must never clear an already-true flag just because a later, uneventful close found nothing new
  pending.
- `getStats()` reads the manifest fresh each call (guarded by `graphFile != null`) and reports
  `closeTimeRebuildPending`.

**Known, deliberate gaps** (both documented at their call sites, neither chased further):
- A large index closed before its first-ever graph file was even created, and closed *again* without a
  build in between (two-or-more-session never-built case), has no manifest path to write to
  (`graphFile == null`) - `markCloseTimeRebuildDeferred()` is a no-op there. The index itself is
  unaffected (still lazily rebuilt on next search); only the stats signal for that narrow window is
  unavailable.
- `releaseBackgroundResources()`'s post-cancellation recheck (added addressing review round 2) can
  still lose to a **straggler build thread**: one that outlived `shutdownNow()`'s 5s budget - already
  logged as a WARNING a few lines above the recheck - and happens to still hold `graphBuildLock` at the
  exact moment the recheck's own `tryLock()` runs. Narrow (needs both an unresponsive build *and* it
  specifically being the lock holder right then), and unlike the cancellation case the recheck exists
  for, there is no later "the build is definitely done by now" moment left inside this method to retry
  from. Flagged by review round 3.

Both kept out of scope deliberately, per the issue's own framing ("keeps the addition scoped to the
exact question ops teams would ask").

## Related issues

Closes #6657
Depends on #6653 (base branch)
Relates to #6067

## Additional Notes

- Not touched: the manifest's `vectorCount`/`fingerprint` staleness-detection logic, which several
  other tests (`Issue6106StaleVectorGraphTest`, `LSMVectorIndexGraphManifestTest`,
  `Issue6503GraphPersistOutOfMemoryTest`) exercise directly - all still green.

## Test plan

- New regression test `Issue6657CloseTimeRebuildPendingStatTest` (`@Tag("slow")`, ~1000 vectors,
  small dimensions/build params for speed). In one flow: the stat turns on the moment `close()`
  defers; it still reads `1` on a **freshly reopened, different** `LSMVectorIndex` instance, before
  that instance has searched (the assertion that specifically rules out the in-memory design); it
  clears back to `0` once the deferred rebuild actually runs via the triggering search; a clean build
  with nothing deferred reports `0` (no false positive).
- Confirmed the test can fail: temporarily disabled both `markCloseTimeRebuildDeferred(gf)` call
  sites and reran - failed at the expected assertion. Restored before committing.
- `mvn -pl engine -am test -Dtest=Issue6657CloseTimeRebuildPendingStatTest` - 1/1 pass.
- `mvn -pl engine -am test -Dtest=Issue6657CloseTimeRebuildPendingStatTest,Issue6067DeferredCloseRebuildTest,LSMVectorIndexGraphManifestTest,Issue6503GraphPersistOutOfMemoryTest`
  - 12/12 pass (the two suites that reference `LSMVectorIndexGraphManifest.Content` directly, plus
  #6067's own tests, plus the OOM-simulation test exercising `markUnusable`).
- Broader sweep of close/rebuild/manifest-adjacent vector-index tests (`VectorIndexRebuildsOnEveryCloseTest`,
  `VectorIndexNoRebuildOnUnusedCloseTest`, `LSMVectorIndexCloseCancelsInFlightBuildTest`,
  `Issue6518CloseDoesNotLeakBuildPoolTest`, `CompactIndexGraphPersistFailureTest`,
  `CompactIndexKeepsGraphReusableTest`, `Issue6106StaleVectorGraphTest`,
  `LSMVectorIndexGraphFileToctouTest`, `LSMVectorIndexGraphFileVisibilityTest`,
  `LSMVectorIndexGraphStorageTest`, `LSMVectorIndexPersistenceTest`, `LSMVectorIndexRecoveryTest`,
  `LSMVectorIndexRebuildTest`, `Issue5870VectorIndexIdRenumberingTest`) - 68/68 pass.

**Review round 2** (concurrency + missing branch coverage):
- New `Issue6657InvalidPathRebuildPendingStatTest` covers the second `markCloseTimeRebuildDeferred()`
  call site (the `needsBuild && !valid` branch).
- New `Issue6657CancelledBuildRecheckTest` deterministically pins the cancelled-build false-negative
  the round-2 review found: a helper thread holds `graphBuildLock` directly (rather than racing a real
  JVector build's timing, which `LSMVectorIndexCloseCancelsInFlightBuildTest` already shows is hard to
  pin reliably) and releases it only after `flush()` has observed it contended, mirroring what a real
  cancellation would do without ever writing the manifest.
- Confirmed both new tests can fail: reverted each fix in turn, reran, confirmed the expected failure,
  restored.
- Full sweep re-run after both fixes (82 tests, including the two new ones) - all pass.

**Review round 3** (documentation-only ask, no blocking issues): documented the residual
straggler-build-thread gap (see "Known, deliberate gaps" above) at its code site and here; added a
cheap already-`true` short-circuit to `markCloseDeferred()` per the minor I/O nit. 30-test focused
re-run after - all pass.

**Review round 4** (real correctness finding, addressed): the `releaseBackgroundResources()` recheck
fired on `needsGraphBuild()` alone, which is `true` whenever `graphState == MUTABLE` for *any* reason -
not only "flush() skipped an owed rebuild". `flush()`'s *other* branch, the one that actually attempts
a synchronous build (below `ASYNC_REBUILD_MIN_GRAPH_SIZE`), can also leave `graphState` at `MUTABLE` -
a failed persist (which correctly writes `closeDeferredRebuild = false`) or new mutations arriving
mid-build both do - and the ungated recheck would overwrite that correct `false` with a misleading
`true`. New `flushDeferredRebuild` field, set only inside `flush()`'s two skip branches and reset at
the top of every `flush()`, gates the recheck so it fires only when *this* close's `flush()` itself
chose to defer; as a side effect this also stops the recheck from running on `LocalDatabase.kill()`/
whole-database-drop, which call `releaseBackgroundResources()` without ever calling `flush()` (round
4's second finding). New `Issue6657RecheckDoesNotMislabelUnattemptedFlushTest` pins the gate directly;
confirmed it fails against the ungated code. Also fixed the `@param` indentation nit. 31-test focused
re-run after - all pass.

**This PR has reached its configured review-cycle limit (4).** Round 4's fixes above are pushed but
have not themselves been through a fifth automated review pass. Given the pattern across all four
rounds - real, specific, verifiable findings each time, all addressed with a matching regression test
that was confirmed to fail pre-fix - a human pass over this last commit specifically (the
`flushDeferredRebuild` gating) is the recommended next step before merge, rather than assuming a clean
bill of health by default.

## Checklist

- [x] I have run the build using `mvn clean package` command (module-scoped: `mvn -pl engine -am test`, per project convention for a change scoped to one module)
- [x] My unit tests cover both failure and success scenarios


