### PR TITLE
fix(#6655): reuse a stale persisted vector graph as a prefix instead of a synchronous rebuild

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1337,6 +1337,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * A persisted graph {@link #ensureGraphAvailable()} decided is eligible for reuse as a prefix (issue #6655),
+   * carrying exactly what {@link #reuseStalePrefixGraph} needs to act on that decision after the write lock
+   * detecting it has been released.
+   *
+   * @param loadedGraph              the graph loaded from disk, already verified against the manifest
+   * @param liveOrdinalToVectorId    every live vector's id, in ordinal order - not only the ones the graph covers
+   * @param graphSize                how many of {@code liveOrdinalToVectorId}'s leading entries the graph covers
+   * @param vectorProp               the vector property name, for reading the gap vectors back
+   */
+  private record ReuseCandidate(ImmutableGraphIndex loadedGraph, int[] liveOrdinalToVectorId, int graphSize,
+                                 String vectorProp) {
+  }
+
+  /**
    * Ensure graph is available for searching. Lazy-loads from disk if needed.
    * This is the entry point for all search operations.
    */
@@ -1360,10 +1374,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // lock.writeLock() is held - it would stall every other reader and writer of this index for as long as the
     // read takes, exactly the stall buildGraphFromScratchWithRetry()'s own javadoc moved the (much larger)
     // full-rebuild validation off this same lock for (issue #5391; PR #6712 review).
-    ImmutableGraphIndex prefixReuseGraph      = null;
-    int[]               prefixReuseOrdinals   = null;
-    int                 prefixReuseGraphSize  = 0;
-    String              prefixReuseVectorProp = null;
+    ReuseCandidate prefixReuseCandidate = null;
 
     graphBuildLock.lock();
     try {
@@ -1519,6 +1530,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
             // deferred-close one. A missing manifest cannot support this: the weak node-count comparison above
             // proves nothing about WHICH records a same-sized graph describes, and a prefix of it proves even
             // less. Below the async-rebuild threshold a synchronous rebuild is already cheap, so it is left alone.
+            // vectorIndex.size(), not graphIndex.size() as rebuildGraphBeforeSearch()'s analogous check uses:
+            // graphIndex is not yet set on this path (that is the whole point - the persisted graph has not been
+            // published to it yet), so the only live-vector count available here is the index's, which is also
+            // the more conservative of the two whenever they would differ (rebuiltOrdinalToVectorId.length can
+            // be smaller after validation filtering, never larger) - "is this worth deferring" errs towards yes.
             final int[] prefix = persistedManifest != null && graphSize == persistedManifest.vectorCount()
                 && graphSize < rebuiltOrdinalToVectorId.length && graphSize > 0
                 && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE
@@ -1530,10 +1546,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
               // Deliberately not done here: reuseStalePrefixGraph() does real I/O for the gap and must run
               // unlocked (see the field javadoc above). Only the decision - not the read - belongs under this
               // lock, same as every other branch in this method.
-              prefixReuseGraph = loadedGraph;
-              prefixReuseOrdinals = prefix;
-              prefixReuseGraphSize = graphSize;
-              prefixReuseVectorProp = vectorProp;
+              prefixReuseCandidate = new ReuseCandidate(loadedGraph, prefix, graphSize, vectorProp);
             } else
               LogManager.instance().log(this, Level.INFO,
                   "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
@@ -1589,16 +1602,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // while already holding it. Skipped when the stale graph was instead reused as a prefix above (issue
       // #6655): that already put the index to work as MUTABLE, and a synchronous rebuild here would throw
       // that work away and pay for it again.
-      if (prefixReuseGraph == null)
+      if (prefixReuseCandidate == null)
         buildGraphFromScratch();
     } finally {
       graphBuildLock.unlock();
     }
 
-    if (prefixReuseGraph != null) {
+    if (prefixReuseCandidate != null) {
       // Unlocked with respect to lock.writeLock(): reuseStalePrefixGraph() does its own graphBuildLock-serialized
       // I/O and a brief re-lock only to publish (see its javadoc).
-      reuseStalePrefixGraph(prefixReuseGraph, prefixReuseOrdinals, prefixReuseGraphSize, prefixReuseVectorProp);
+      reuseStalePrefixGraph(prefixReuseCandidate);
     }
   }
 
@@ -1627,15 +1640,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * the ordinary delta scan, rather than trading this fix's latency win for a window where they silently do not
    * come back.
    *
-   * @param loadedGraph              the graph loaded from disk, already verified against the manifest by the
-   *                                 caller
-   * @param rebuiltOrdinalToVectorId every live vector's id, in ordinal order - not only the ones the graph covers
-   * @param graphSize                how many of {@code rebuiltOrdinalToVectorId}'s leading entries the graph
-   *                                 covers; the manifest-verified prefix
-   * @param vectorProp               the vector property name, for reading the gap vectors back
+   * @param candidate the eligibility decision {@link #ensureGraphAvailable()} made under its write lock
    */
-  private void reuseStalePrefixGraph(final ImmutableGraphIndex loadedGraph, final int[] rebuiltOrdinalToVectorId,
-      final int graphSize, final String vectorProp) {
+  private void reuseStalePrefixGraph(final ReuseCandidate candidate) {
+    final ImmutableGraphIndex loadedGraph = candidate.loadedGraph();
+    final int[] rebuiltOrdinalToVectorId = candidate.liveOrdinalToVectorId();
+    final int graphSize = candidate.graphSize();
+    final String vectorProp = candidate.vectorProp();
+
     graphBuildLock.lock();
     try {
       // Double-check: graphState is volatile and this is the same fast-path re-check ensureGraphAvailable()

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1354,10 +1354,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // here does not reintroduce the stall. graphBuildLock is reentrant, so the fallback call to
     // buildGraphFromScratch() at the end of this method - which acquires the same lock - is safe from here.
     //
-    // Set below when a stale persisted graph is instead reused as a prefix (issue #6655); read after
-    // graphBuildLock is released, so the async rebuild and inactivity-timer kicks that follow can run without
-    // holding it (same convention insert() follows for scheduleInactivityRebuild()).
-    boolean deferredPrefixReuse = false;
+    // Populated below when a stale persisted graph qualifies for reuse as a prefix (issue #6655) instead of
+    // falling through to a synchronous buildGraphFromScratch(); consumed after graphBuildLock is released.
+    // reuseStalePrefixGraph() does real per-vector I/O for the gap past graphSize, and that must not run while
+    // lock.writeLock() is held - it would stall every other reader and writer of this index for as long as the
+    // read takes, exactly the stall buildGraphFromScratchWithRetry()'s own javadoc moved the (much larger)
+    // full-rebuild validation off this same lock for (issue #5391; PR #6712 review).
+    ImmutableGraphIndex prefixReuseGraph      = null;
+    int[]               prefixReuseOrdinals   = null;
+    int                 prefixReuseGraphSize  = 0;
+    String              prefixReuseVectorProp = null;
 
     graphBuildLock.lock();
     try {
@@ -1521,14 +1527,19 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 rebuiltOrdinalToVectorId : null;
 
             if (prefix != null) {
-              reuseStalePrefixGraph(loadedGraph, prefix, graphSize, vectorProp);
-              deferredPrefixReuse = true;
+              // Deliberately not done here: reuseStalePrefixGraph() does real I/O for the gap and must run
+              // unlocked (see the field javadoc above). Only the decision - not the read - belongs under this
+              // lock, same as every other branch in this method.
+              prefixReuseGraph = loadedGraph;
+              prefixReuseOrdinals = prefix;
+              prefixReuseGraphSize = graphSize;
+              prefixReuseVectorProp = vectorProp;
             } else
               LogManager.instance().log(this, Level.INFO,
                   "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
                   indexName, staleReason);
             // Don't use the stale graph as IMMUTABLE — fall through to buildGraphFromScratch() below unless the
-            // prefix reuse above already put it to work as MUTABLE
+            // prefix reuse above already queued a deferred reuse
           } else {
             // Graph is up to date — publish it under a brief write lock (issue #6713), then finish PQ
             // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
@@ -1578,20 +1589,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // while already holding it. Skipped when the stale graph was instead reused as a prefix above (issue
       // #6655): that already put the index to work as MUTABLE, and a synchronous rebuild here would throw
       // that work away and pay for it again.
-      if (!deferredPrefixReuse)
+      if (prefixReuseGraph == null)
         buildGraphFromScratch();
     } finally {
       graphBuildLock.unlock();
     }
 
-    if (deferredPrefixReuse) {
-      // Kick the same async rebuild rebuildGraphBeforeSearch() would eventually trigger anyway, so the gap left
-      // by the reused prefix is closed promptly instead of waiting on the ordinary mutation threshold - and also
-      // arm the inactivity timer as a fallback for when the async attempt is skipped (already in progress, or
-      // still cooling down from a prior OOM deferral - see isCoolingDownFromRebuildDeferral()). Both outside
-      // graphBuildLock, just released, the same convention insert() follows.
-      startAsyncGraphRebuild();
-      scheduleInactivityRebuild();
+    if (prefixReuseGraph != null) {
+      // Unlocked with respect to lock.writeLock(): reuseStalePrefixGraph() does its own graphBuildLock-serialized
+      // I/O and a brief re-lock only to publish (see its javadoc).
+      reuseStalePrefixGraph(prefixReuseGraph, prefixReuseOrdinals, prefixReuseGraphSize, prefixReuseVectorProp);
     }
   }
 
@@ -1600,6 +1607,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * since it was built - no deletions, and its manifest-verified ordinals {@code [0, graphSize)} still resolve to
    * exactly the records they were built from - instead of discarding it for a synchronous full rebuild (issue
    * #6655).
+   * <p>
+   * Called UNLOCKED with respect to {@link #lock}: the gap past {@code graphSize} is read from disk (a page read,
+   * or a document lookup for the non-quantized case) via {@link ArcadePageVectorValues}, real per-vector I/O that
+   * must not run while {@code lock.writeLock()} is held - that would stall every other reader and writer of this
+   * index for as long as the read takes, exactly the stall {@link #buildGraphFromScratchWithRetry} moved the
+   * (much larger) full-rebuild validation off this same lock for (issue #5391). {@link #graphBuildLock} is what
+   * makes running unlocked safe here: it serializes this method against a concurrent {@code buildGraphFromScratch}
+   * and against a second concurrent caller that reached the same reuse decision (both publish
+   * {@link #graphIndex}/{@link #ordinalToVectorId}/{@link #graphState}, so they cannot be allowed to interleave),
+   * the identical role it already plays for {@code buildGraphFromScratchWithRetry}. Only the brief publish step at
+   * the end takes {@code lock.writeLock()}, to make the state change visible/consistent to concurrent readers -
+   * not to protect the read.
    * <p>
    * The vectors past {@code graphSize} are not yet in the graph, and are not in {@link #deltaVectors} either:
    * that buffer is in-memory only (issue #3722) and this is a session that never wrote them, it is only now
@@ -1617,44 +1636,76 @@ public class LSMVectorIndex implements Index, IndexInternal {
    */
   private void reuseStalePrefixGraph(final ImmutableGraphIndex loadedGraph, final int[] rebuiltOrdinalToVectorId,
       final int graphSize, final String vectorProp) {
-    // Trimmed to the gap before it is handed anywhere else: snapshotOf() and computeGraphBuildCacheCapacity() both
-    // size their work off whatever array they are given, and only ordinals [graphSize, length) are ever read
-    // below. Handing them the full live-vector array (as an earlier version of this fix did) made the snapshot
-    // and the build reader's cache scale with the WHOLE index - exactly the O(index size) cost this fix exists to
-    // avoid on the calling search thread - rather than with how much is actually missing from the graph (PR
-    // #6712 review).
-    final int[] gapOrdinalToVectorId = Arrays.copyOfRange(rebuiltOrdinalToVectorId, graphSize,
-        rebuiltOrdinalToVectorId.length);
+    graphBuildLock.lock();
+    try {
+      // Double-check: graphState is volatile and this is the same fast-path re-check ensureGraphAvailable()
+      // itself does after acquiring a lock. Another thread may have already published - a concurrent
+      // buildGraphFromScratch(), or a second reuseStalePrefixGraph() call that queued behind this same mutex and
+      // ran first - while this call waited for graphBuildLock.
+      if (graphState != GraphState.LOADING)
+        return;
 
-    final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
-        metadata.dimensions, vectorProp,
-        snapshotOf(vectorIndex, gapOrdinalToVectorId), gapOrdinalToVectorId, this,
-        computeGraphBuildCacheCapacity(gapOrdinalToVectorId.length, false));
+      // Trimmed to the gap before it is handed anywhere else: snapshotOf() and computeGraphBuildCacheCapacity()
+      // both size their work off whatever array they are given, and only ordinals [graphSize, length) are ever
+      // read below. Handing them the full live-vector array (as an earlier version of this fix did) made the
+      // snapshot and the build reader's cache scale with the WHOLE index - exactly the O(index size) cost this
+      // fix exists to avoid - rather than with how much is actually missing from the graph (PR #6712 review).
+      final int[] gapOrdinalToVectorId = Arrays.copyOfRange(rebuiltOrdinalToVectorId, graphSize,
+          rebuiltOrdinalToVectorId.length);
 
-    int queued = 0;
-    for (int ordinal = 0; ordinal < gapOrdinalToVectorId.length; ordinal++) {
-      final int vectorId = gapOrdinalToVectorId[ordinal];
-      final RID rid = vectorIndex.getRid(vectorId);
-      if (rid == null)
-        continue; // gone since the array above was built; the next mutation or rebuild picks it up
-      final VectorFloat<?> vector = vectors.getVector(ordinal);
-      if (vector == null || (vectors instanceof final ArcadePageVectorValues pageValues
-          && pageValues.isDeletedSentinel(vector)))
-        continue;
-      deltaVectors.add(new DeltaVectorEntry(vectorId, rid, vector));
-      queued++;
+      final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
+          metadata.dimensions, vectorProp,
+          snapshotOf(vectorIndex, gapOrdinalToVectorId), gapOrdinalToVectorId, this,
+          computeGraphBuildCacheCapacity(gapOrdinalToVectorId.length, false));
+
+      // Collected into a local list first, exactly the way buildGraphFromScratchExclusively collects its own
+      // unreachable-node re-queue before its publish step: appended into the shared deltaVectors only once this
+      // method holds lock.writeLock() below, never while unlocked.
+      final List<DeltaVectorEntry> gapEntries = new ArrayList<>(gapOrdinalToVectorId.length);
+      for (int ordinal = 0; ordinal < gapOrdinalToVectorId.length; ordinal++) {
+        final int vectorId = gapOrdinalToVectorId[ordinal];
+        final RID rid = vectorIndex.getRid(vectorId);
+        if (rid == null)
+          continue; // gone since the array above was built; the next mutation or rebuild picks it up
+        final VectorFloat<?> vector = vectors.getVector(ordinal);
+        if (vector == null || (vectors instanceof final ArcadePageVectorValues pageValues
+            && pageValues.isDeletedSentinel(vector)))
+          continue;
+        gapEntries.add(new DeltaVectorEntry(vectorId, rid, vector));
+      }
+
+      // Publish. graphState stays LOADING for the whole unlocked read above - insert() does not wait on it - so
+      // a concurrent write could have landed on this index in the meantime and already appended its own entries
+      // to deltaVectors and its own count to mutationsSinceSerialize. addAll()/addAndGet() rather than a replace
+      // or a plain set() is what keeps those, instead of silently dropping them.
+      lock.writeLock().lock();
+      try {
+        this.graphIndex = loadedGraph;
+        this.ordinalToVectorId = Arrays.copyOf(rebuiltOrdinalToVectorId, graphSize);
+        this.deltaVectors.addAll(gapEntries);
+        this.graphState = GraphState.MUTABLE;
+        this.mutationsSinceSerialize.addAndGet(gapEntries.size());
+      } finally {
+        lock.writeLock().unlock();
+      }
+
+      metrics.incrementStalePrefixGraphReuses();
+      LogManager.instance().log(this, Level.INFO,
+          "Reusing persisted graph for index %s as a stale prefix: %d of %d live vectors are already in the "
+              + "graph, %d queued into the delta buffer pending an async rebuild (issue #6655)",
+          indexName, graphSize, rebuiltOrdinalToVectorId.length, gapEntries.size());
+    } finally {
+      graphBuildLock.unlock();
     }
 
-    this.graphIndex = loadedGraph;
-    this.ordinalToVectorId = Arrays.copyOf(rebuiltOrdinalToVectorId, graphSize);
-    this.graphState = GraphState.MUTABLE;
-    this.mutationsSinceSerialize.set(queued);
-    metrics.incrementStalePrefixGraphReuses();
-
-    LogManager.instance().log(this, Level.INFO,
-        "Reusing persisted graph for index %s as a stale prefix: %d of %d live vectors are already in the graph, "
-            + "%d queued into the delta buffer pending an async rebuild (issue #6655)",
-        indexName, graphSize, rebuiltOrdinalToVectorId.length, queued);
+    // Outside graphBuildLock, the same scope buildGraphFromScratchWithRetry leaves for what runs after it
+    // publishes: only the build/reuse itself needs to be serialized, not its follow-up work. Kicks the same
+    // async rebuild rebuildGraphBeforeSearch() would eventually trigger anyway, so the gap just queued above is
+    // closed promptly instead of waiting on the ordinary mutation threshold, and arms the inactivity timer as a
+    // fallback for when the async attempt is skipped (already in progress, or still cooling down from a prior
+    // OOM deferral - see isCoolingDownFromRebuildDeferral()).
+    startAsyncGraphRebuild();
+    scheduleInactivityRebuild();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1617,14 +1617,23 @@ public class LSMVectorIndex implements Index, IndexInternal {
    */
   private void reuseStalePrefixGraph(final ImmutableGraphIndex loadedGraph, final int[] rebuiltOrdinalToVectorId,
       final int graphSize, final String vectorProp) {
+    // Trimmed to the gap before it is handed anywhere else: snapshotOf() and computeGraphBuildCacheCapacity() both
+    // size their work off whatever array they are given, and only ordinals [graphSize, length) are ever read
+    // below. Handing them the full live-vector array (as an earlier version of this fix did) made the snapshot
+    // and the build reader's cache scale with the WHOLE index - exactly the O(index size) cost this fix exists to
+    // avoid on the calling search thread - rather than with how much is actually missing from the graph (PR
+    // #6712 review).
+    final int[] gapOrdinalToVectorId = Arrays.copyOfRange(rebuiltOrdinalToVectorId, graphSize,
+        rebuiltOrdinalToVectorId.length);
+
     final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
         metadata.dimensions, vectorProp,
-        snapshotOf(vectorIndex, rebuiltOrdinalToVectorId), rebuiltOrdinalToVectorId, this,
-        computeGraphBuildCacheCapacity(rebuiltOrdinalToVectorId.length, false));
+        snapshotOf(vectorIndex, gapOrdinalToVectorId), gapOrdinalToVectorId, this,
+        computeGraphBuildCacheCapacity(gapOrdinalToVectorId.length, false));
 
     int queued = 0;
-    for (int ordinal = graphSize; ordinal < rebuiltOrdinalToVectorId.length; ordinal++) {
-      final int vectorId = rebuiltOrdinalToVectorId[ordinal];
+    for (int ordinal = 0; ordinal < gapOrdinalToVectorId.length; ordinal++) {
+      final int vectorId = gapOrdinalToVectorId[ordinal];
       final RID rid = vectorIndex.getRid(vectorId);
       if (rid == null)
         continue; // gone since the array above was built; the next mutation or rebuild picks it up

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1353,6 +1353,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // validation loop off of. Builders wait on this mutex; searches and inserts never touch it, so serializing
     // here does not reintroduce the stall. graphBuildLock is reentrant, so the fallback call to
     // buildGraphFromScratch() at the end of this method - which acquires the same lock - is safe from here.
+    //
+    // Set below when a stale persisted graph is instead reused as a prefix (issue #6655); read after
+    // graphBuildLock is released, so the async rebuild and inactivity-timer kicks that follow can run without
+    // holding it (same convention insert() follows for scheduleInactivityRebuild()).
+    boolean deferredPrefixReuse = false;
+
     graphBuildLock.lock();
     try {
       // Double-check after acquiring the lock
@@ -1496,10 +1502,33 @@ public class LSMVectorIndex implements Index, IndexInternal {
             staleReason = null;
 
           if (staleReason != null) {
-            LogManager.instance().log(this, Level.INFO,
-                "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
-                indexName, staleReason);
-            // Don't use the stale graph — fall through to buildGraphFromScratch() below
+            // ISSUE #6655: a graph stale ONLY because more vectors were added since it was built - no deletions
+            // (guaranteed by the !hasDeletedVectors guard above) and, when a manifest is present, its fingerprint
+            // proves the graph's own ordinals [0, graphSize) still resolve to exactly the records they were built
+            // from - is not wrong, only behind. That is the identical staleness rebuildGraphBeforeSearch()'s async
+            // policy already tolerates mid-session (a graph missing the newest vectors, not one describing the
+            // wrong ones), so it is reused immediately instead of paying a synchronous full rebuild on the calling
+            // search thread for however large the WHOLE index has become - the reopen-time counterpart of #6067's
+            // close-time deferral, reached through the general stale-persisted-graph path rather than only the
+            // deferred-close one. A missing manifest cannot support this: the weak node-count comparison above
+            // proves nothing about WHICH records a same-sized graph describes, and a prefix of it proves even
+            // less. Below the async-rebuild threshold a synchronous rebuild is already cheap, so it is left alone.
+            final int[] prefix = persistedManifest != null && graphSize == persistedManifest.vectorCount()
+                && graphSize < rebuiltOrdinalToVectorId.length && graphSize > 0
+                && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE
+                && persistedManifest.fingerprint() == LSMVectorIndexGraphManifest.fingerprintOf(
+                Arrays.copyOf(rebuiltOrdinalToVectorId, graphSize), vectorIndex::getRid) ?
+                rebuiltOrdinalToVectorId : null;
+
+            if (prefix != null) {
+              reuseStalePrefixGraph(loadedGraph, prefix, graphSize, vectorProp);
+              deferredPrefixReuse = true;
+            } else
+              LogManager.instance().log(this, Level.INFO,
+                  "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
+                  indexName, staleReason);
+            // Don't use the stale graph as IMMUTABLE — fall through to buildGraphFromScratch() below unless the
+            // prefix reuse above already put it to work as MUTABLE
           } else {
             // Graph is up to date — publish it under a brief write lock (issue #6713), then finish PQ
             // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
@@ -1544,12 +1573,79 @@ public class LSMVectorIndex implements Index, IndexInternal {
         }
       }
 
-      // No persisted graph, load failed, or it was stale - build from scratch. buildGraphFromScratch()
-      // acquires graphBuildLock itself; since it is reentrant this is safe to call while already holding it.
-      buildGraphFromScratch();
+      // No persisted graph, load failed, or it was stale with no usable prefix - build from scratch.
+      // buildGraphFromScratch() acquires graphBuildLock itself; since it is reentrant this is safe to call
+      // while already holding it. Skipped when the stale graph was instead reused as a prefix above (issue
+      // #6655): that already put the index to work as MUTABLE, and a synchronous rebuild here would throw
+      // that work away and pay for it again.
+      if (!deferredPrefixReuse)
+        buildGraphFromScratch();
     } finally {
       graphBuildLock.unlock();
     }
+
+    if (deferredPrefixReuse) {
+      // Kick the same async rebuild rebuildGraphBeforeSearch() would eventually trigger anyway, so the gap left
+      // by the reused prefix is closed promptly instead of waiting on the ordinary mutation threshold - and also
+      // arm the inactivity timer as a fallback for when the async attempt is skipped (already in progress, or
+      // still cooling down from a prior OOM deferral - see isCoolingDownFromRebuildDeferral()). Both outside
+      // graphBuildLock, just released, the same convention insert() follows.
+      startAsyncGraphRebuild();
+      scheduleInactivityRebuild();
+    }
+  }
+
+  /**
+   * Reuse a persisted graph that {@link #ensureGraphAvailable()} found stale only because more vectors were added
+   * since it was built - no deletions, and its manifest-verified ordinals {@code [0, graphSize)} still resolve to
+   * exactly the records they were built from - instead of discarding it for a synchronous full rebuild (issue
+   * #6655).
+   * <p>
+   * The vectors past {@code graphSize} are not yet in the graph, and are not in {@link #deltaVectors} either:
+   * that buffer is in-memory only (issue #3722) and this is a session that never wrote them, it is only now
+   * discovering them on reopen. Queuing them here - the same re-queue {@link #buildGraphFromScratch()} performs
+   * for a node its own build left unreachable - is what keeps every live vector searchable immediately through
+   * the ordinary delta scan, rather than trading this fix's latency win for a window where they silently do not
+   * come back.
+   *
+   * @param loadedGraph              the graph loaded from disk, already verified against the manifest by the
+   *                                 caller
+   * @param rebuiltOrdinalToVectorId every live vector's id, in ordinal order - not only the ones the graph covers
+   * @param graphSize                how many of {@code rebuiltOrdinalToVectorId}'s leading entries the graph
+   *                                 covers; the manifest-verified prefix
+   * @param vectorProp               the vector property name, for reading the gap vectors back
+   */
+  private void reuseStalePrefixGraph(final ImmutableGraphIndex loadedGraph, final int[] rebuiltOrdinalToVectorId,
+      final int graphSize, final String vectorProp) {
+    final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
+        metadata.dimensions, vectorProp,
+        snapshotOf(vectorIndex, rebuiltOrdinalToVectorId), rebuiltOrdinalToVectorId, this,
+        computeGraphBuildCacheCapacity(rebuiltOrdinalToVectorId.length, false));
+
+    int queued = 0;
+    for (int ordinal = graphSize; ordinal < rebuiltOrdinalToVectorId.length; ordinal++) {
+      final int vectorId = rebuiltOrdinalToVectorId[ordinal];
+      final RID rid = vectorIndex.getRid(vectorId);
+      if (rid == null)
+        continue; // gone since the array above was built; the next mutation or rebuild picks it up
+      final VectorFloat<?> vector = vectors.getVector(ordinal);
+      if (vector == null || (vectors instanceof final ArcadePageVectorValues pageValues
+          && pageValues.isDeletedSentinel(vector)))
+        continue;
+      deltaVectors.add(new DeltaVectorEntry(vectorId, rid, vector));
+      queued++;
+    }
+
+    this.graphIndex = loadedGraph;
+    this.ordinalToVectorId = Arrays.copyOf(rebuiltOrdinalToVectorId, graphSize);
+    this.graphState = GraphState.MUTABLE;
+    this.mutationsSinceSerialize.set(queued);
+    metrics.incrementStalePrefixGraphReuses();
+
+    LogManager.instance().log(this, Level.INFO,
+        "Reusing persisted graph for index %s as a stale prefix: %d of %d live vectors are already in the graph, "
+            + "%d queued into the delta buffer pending an async rebuild (issue #6655)",
+        indexName, graphSize, rebuiltOrdinalToVectorId.length, queued);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
@@ -71,6 +71,11 @@ class LSMVectorIndexMetrics {
   // number that keeps climbing is the signal to give the JVM more heap, lower graphBuildCacheMaxHeapPercent, or
   // split the index; one that climbed once and stopped is a transient the next trigger already recovered from.
   private final AtomicLong rebuildsDeferredForMemory = new AtomicLong(0);
+  // Times a stale persisted graph (more live vectors than it covers, no deletions) was reused as a prefix instead
+  // of being discarded for a synchronous full rebuild on the calling search thread (issue #6655). Each one traded
+  // a blocking rebuild sized to the whole index for an immediate answer plus a background rebuild; the gap
+  // vectors stay searchable meanwhile through the delta buffer they were queued into.
+  private final AtomicLong stalePrefixGraphReuses = new AtomicLong(0);
 
   // Vector fetch source tracking
   private final AtomicLong vectorFetchFromQuantized = new AtomicLong(0);
@@ -125,6 +130,10 @@ class LSMVectorIndexMetrics {
 
   void incrementRebuildsDeferredForMemory() {
     rebuildsDeferredForMemory.incrementAndGet();
+  }
+
+  void incrementStalePrefixGraphReuses() {
+    stalePrefixGraphReuses.incrementAndGet();
   }
 
   // Vector fetch source tracking methods
@@ -234,6 +243,7 @@ class LSMVectorIndexMetrics {
     stats.put("groupedSearchesMergingDelta", groupedSearchesMergingDelta.get());
     stats.put("unverifiedGraphReuses", unverifiedGraphReuses.get());
     stats.put("rebuildsDeferredForMemory", rebuildsDeferredForMemory.get());
+    stats.put("stalePrefixGraphReuses", stalePrefixGraphReuses.get());
     stats.put("compactionCount", compactionCount.get());
 
     stats.put("vectorFetchFromQuantized", vectorFetchFromQuantized.get());
@@ -257,6 +267,7 @@ class LSMVectorIndexMetrics {
     groupedSearchesMergingDelta.set(0);
     unverifiedGraphReuses.set(0);
     rebuildsDeferredForMemory.set(0);
+    stalePrefixGraphReuses.set(0);
     compactionCount.set(0);
     vectorFetchFromQuantized.set(0);
     vectorFetchFromDocuments.set(0);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6655: a follow-up to #6067's close-time deferral. {@code ensureGraphAvailable()}'s
+ * stale-persisted-graph fallback (issue #3722 - a persisted graph with fewer nodes than there are live vectors,
+ * because vectors were added after the graph was last built and persisted) called {@code buildGraphFromScratch()}
+ * unconditionally and SYNCHRONOUSLY, with no size-based deferral of its own - unlike
+ * {@link LSMVectorIndex#rebuildGraphBeforeSearch()}, which already prefers an async rebuild above
+ * {@code ASYNC_REBUILD_MIN_GRAPH_SIZE} (1000) vectors for the identical staleness reached mid-session.
+ * <p>
+ * Net effect before the fix: for a large index, the FIRST search after a reopen that finds a stale persisted graph
+ * pays the full rebuild cost inline, on the calling search thread - the same wall-clock cost #6067 moved off
+ * {@code close()}, just relocated to whichever query happens to run first. The fix reuses the persisted graph
+ * immediately as a verified PREFIX of the live set (manifest-verified, no deletions) instead, queues the vectors
+ * past it into the delta buffer so nothing is silently missing from the answer, and kicks the same async rebuild
+ * {@code rebuildGraphBeforeSearch()} would use mid-session.
+ * <p>
+ * Two things are pinned, because either alone would pass against a half-fix: the first search must return promptly
+ * (not merely "eventually", which an async-but-still-blocking variant could also satisfy) AND it must already
+ * answer correctly for a vector written after the persisted build - proving the fix does not trade away the very
+ * data the synchronous rebuild used to guarantee was found.
+ * <p>
+ * Same per-vector build parameters and vector count as {@code Issue6067DeferredCloseRebuildTest} (128 dimensions,
+ * {@code maxConnections=64}, {@code beamWidth=400}, 20,000 vectors), for the same reason: a full rebuild has to
+ * reliably take multiple real seconds, or the timing tripwire below cannot fail on the pre-fix code by accident.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6655StaleGraphPrefixReuseTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6655StaleGraphPrefixReuseTest";
+  private static final int    DIMENSIONS      = 128;
+  private static final int    NUM_VECTORS     = 20_000;
+  private static final int    GAP_VECTORS     = 200;
+  private static final int    MAX_CONNECTIONS = 64;
+  private static final int    BEAM_WIDTH      = 400;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void reopenWithMoreVectorsThanThePersistedGraphReusesItAsAPrefixInsteadOfBlockingOnAFullRebuild() throws Exception {
+    // Session 1: build and persist a graph over exactly NUM_VECTORS, then close cleanly - the persisted graph and
+    // its manifest end up describing precisely the first NUM_VECTORS records.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db, 0, NUM_VECTORS);
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState")).as("precondition: graph must be built and IMMUTABLE first")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Session 2: write GAP_VECTORS more records (committed, so WAL-durable), then crash instead of closing
+    // cleanly. On main, close()/flush() would rebuild the graph synchronously and erase the very staleness this
+    // test needs; kill() skips that, leaving the persisted graph and manifest exactly as session 1 left them -
+    // still describing only the first NUM_VECTORS records - while the live vector count is now NUM_VECTORS +
+    // GAP_VECTORS.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        populate(db, NUM_VECTORS, NUM_VECTORS + GAP_VECTORS);
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise this session never reaches a state kill() can usefully crash")
+            .isEqualTo(2L); // GraphState.MUTABLE
+
+        // Crash: the on-disk state (files, WAL) is left exactly as an abrupt kill leaves it - the persisted graph
+        // and manifest untouched, the extra records only in the WAL. close() right after, on this same already-
+        // killed instance, only clears the process-wide active-instance bookkeeping DatabaseFactory.open() checks
+        // (issue #6655's test setup, same pattern as UnflushedDictionaryRecoveryTest) - it does not get a chance
+        // to flush or rebuild anything the crash already bypassed.
+        ((DatabaseInternal) db).kill();
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Session 3: reopen. WAL recovery restores all NUM_VECTORS + GAP_VECTORS records; the persisted graph and
+    // manifest still describe only the first NUM_VECTORS. This is the reproduction: a stale persisted graph, more
+    // live vectors than it covers, no deletions, a manifest-verifiable prefix.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("cnt"))
+              .as("precondition: WAL recovery must have restored every record from the crashed session")
+              .isEqualTo((long) (NUM_VECTORS + GAP_VECTORS));
+        }
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("precondition: nothing must have rebuilt yet in this fresh session").isZero();
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: above the async-rebuild threshold, otherwise this is the pre-existing small-graph "
+                + "synchronous path, unaffected by this fix")
+            .isGreaterThanOrEqualTo(1000L);
+
+        // The query is one of the gap records' own embedding: a record is always its own nearest neighbour, so
+        // finding it in the answer proves the gap vectors are searchable from the very first query - not only
+        // once the deferred rebuild eventually runs.
+        final int gapDocId = NUM_VECTORS; // first record written after the persisted build
+        final RID gapDocRid = ridOf(db, gapDocId);
+
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        final List<Pair<RID, Float>> results = index.findNeighborsFromVector(embedding(gapDocId), 5, 64);
+        // Measured on this fixture: a prefix reuse returns in well under a second; a full synchronous rebuild of
+        // 20,200 vectors at these build parameters takes several real seconds (see Issue6067DeferredCloseRebuildTest
+        // for the same measurement on an equivalent fixture). The bound is a tripwire between the two, wide on
+        // both sides.
+        stopwatch.assertGaveUpWithin(2_000,
+            "a search that reuses a stale prefix graph from one that ran a full synchronous rebuild to completion");
+
+        assertThat(results.stream().map(Pair::getFirst))
+            .as("the gap record must be found by its own embedding on the very first query, proving the queued "
+                + "delta entries - not only the reused graph - are already searchable")
+            .contains(gapDocRid);
+
+        assertThat(index.getStats().get("graphState"))
+            .as("the reuse must leave the index MUTABLE (graph + queued delta), not a synchronously-rebuilt "
+                + "IMMUTABLE graph")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("stalePrefixGraphReuses"))
+            .as("the reuse path introduced by this fix must be the one that actually ran").isEqualTo(1L);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("no synchronous rebuild may have run on the calling thread for this search to have returned "
+                + "already").isZero();
+
+        // The async rebuild kicked off by the reuse eventually folds the gap into the graph proper.
+        Awaitility.await("the async rebuild kicked off by the stale-prefix reuse completes")
+            .atMost(Duration.ofSeconds(60))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isEqualTo(1L));
+
+        assertThat(index.getStats().get("graphState"))
+            .as("once the deferred rebuild completes the graph goes back to IMMUTABLE").isEqualTo(1L);
+
+        final List<Pair<RID, Float>> afterRebuild = index.findNeighborsFromVector(embedding(gapDocId), 5, 64);
+        assertThat(afterRebuild.stream().map(Pair::getFirst))
+            .as("the gap record must still be found once it is folded into the graph proper, not only while it "
+                + "sat in the delta buffer")
+            .contains(gapDocRid);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static void populate(final Database db, final int fromInclusive, final int toExclusive) {
+    db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+      if ((i - fromInclusive) % 1000 == 999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  /** Deterministic per-id embedding, so any record's own vector can be reconstructed independently at query time. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x6655L * 31 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static RID ridOf(final Database db, final int id) {
+    try (final ResultSet rs = db.query("sql", "SELECT @rid FROM Doc WHERE id = ?", id)) {
+      assertThat(rs.hasNext()).as("the gap record must exist").isTrue();
+      return rs.next().getProperty("@rid");
+    }
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}


### PR DESCRIPTION
Closes #6655

## Summary

`ensureGraphAvailable()`'s stale-persisted-graph fallback (issue #3722/#6106 - a persisted graph with fewer nodes than there are live vectors) called `buildGraphFromScratch()` unconditionally and **synchronously**, on the calling search thread, with no size-based deferral of its own - unlike `rebuildGraphBeforeSearch()`, which already prefers an async rebuild above `ASYNC_REBUILD_MIN_GRAPH_SIZE` (1000) vectors for the identical staleness reached mid-session.

Net effect: for a large index, the **first search** after a reopen that finds a stale persisted graph paid the full rebuild cost inline - the same wall-clock cost issue #6067 moved off `close()`, just relocated to whichever query happened to run first. This was filed as a follow-up from #6653's code review (#6067's fix), but the underlying `ensureGraphAvailable()` staleness path it points at is reachable independently of #6067/#6653 (which are still open) - any reopen that finds a stale persisted graph hits it, for example after a crash that leaves the graph behind the WAL-recovered vector set.

## Fix

When the staleness is *provably* safe to reuse, the persisted graph is now reused immediately as a verified prefix instead of being discarded for a synchronous full rebuild:

- a manifest is present (a missing manifest can't support this - see the existing #6106 weak-comparison path, left untouched),
- no vectors were deleted (already excluded from this whole code path by the existing `hasDeletedVectors` guard), and
- the manifest's fingerprint proves the graph's own ordinals `[0, graphSize)` still resolve to *exactly* the records it was built from - i.e. the graph is only missing vectors added afterward, the same staleness `rebuildGraphBeforeSearch()`'s async policy already tolerates mid-session.

The vectors past `graphSize` are queued into the in-memory delta buffer - the same re-queue `buildGraphFromScratch()` already performs for a node its own build left unreachable - so they stay immediately searchable through the ordinary delta scan, rather than trading this fix's latency win for a window where they silently don't come back (that buffer is in-memory only, and this is a session that never wrote them - it's only now discovering them on reopen, so nothing else would have populated it). The same async rebuild `rebuildGraphBeforeSearch()` would use mid-session is kicked off in the background to fold the gap into the graph proper, with the inactivity timer armed as a fallback for when that async attempt is skipped (already in progress, or cooling down from a prior OOM deferral).

A missing manifest, a same-size mismatch, a graph larger than the live set, or any deletion all still fall through to the existing synchronous rebuild, unchanged.

A new `stalePrefixGraphReuses` stat (`LSMVectorIndex.getStats()`) counts how often the new path fires, alongside the existing `unverifiedGraphReuses`/`rebuildsDeferredForMemory` counters.

## Test plan

- [x] New regression test `Issue6655StaleGraphPrefixReuseTest` (tagged `slow`, mirrors `Issue6067DeferredCloseRebuildTest`'s fixture: 128 dims, 20,000+200 vectors, `maxConnections=64`, `beamWidth=400`):
  - builds and persists a graph over 20,000 vectors, closes cleanly;
  - reopens, writes 200 more vectors, then crashes (`DatabaseInternal.kill()`) instead of closing cleanly, so the persisted graph/manifest are left describing only the first 20,000 while WAL recovery on the next open restores all 20,200;
  - asserts the first search returns within a tripwire bound that a full synchronous rebuild of 20,200 vectors cannot meet (measured pre-fix: ~4.5s; bound: 2s) **and** already finds one of the 200 gap vectors by its own embedding - pinning both "fast" and "correct" so a half-fix (async-but-still-blocking, or fast-but-missing-data) cannot pass;
  - asserts `graphState` is `MUTABLE` and `stalePrefixGraphReuses == 1` immediately after that search, and `graphRebuildCount == 0` (nothing ran synchronously on the calling thread);
  - awaits the background async rebuild completing (`graphRebuildCount == 1`, `graphState` back to `IMMUTABLE`) and re-verifies the gap vector is still found once folded into the graph proper.
  - Verified the test fails without the fix (reverted the two source files, reran): fails at the same timing tripwire, `measured 4489 ms` vs. the `2000 ms` bound - i.e. it genuinely exercises the synchronous-rebuild-on-search-thread behavior being fixed here, not a vacuous pass.
- [x] `mvn -pl engine -am compile` / `test-compile` - clean.
- [x] Full regression pass, all green, no failures:
  - `Issue6106StaleVectorGraphTest` (7), `LSMVectorIndexRecoveryTest` (23), `GraphSearcherPoolStaleGraphTest` (5), `LSMVectorIndexBruteForceScanTest` (3), `CompactIndexGraphPersistFailureTest` (1), `Issue6655StaleGraphPrefixReuseTest` (1)
  - `LSMVectorIndexGraphManifestTest` (8), `LSMVectorIndexRebuildTest` (15), `VectorIndexRebuildsOnEveryCloseTest` (1), `VectorIndexNoRebuildOnUnusedCloseTest` (1), `LSMVectorIndexTest` (29), `LSMVectorIndexPersistenceTest` (2), `Issue6501GroupedDeltaMergeTest` (8), `Issue6502VectorPrefilterTest` (9), `Issue5558DeletedRegionSearchTest` (11), `Issue6496InactivityRebuildThresholdTest` (2), `Issue6503RebuildAdmissionControlTest` (8)
  - 134 tests total, 0 failures, 0 errors.

## Notes for the reviewer

- Scope is deliberately narrow: only the manifest-verified, no-deletions, growth-only case is reused; every other staleness reason (#6106's cross-generation mismatch, a truncated persist, a graph larger than the live set, no manifest) is untouched and still falls through to the pre-existing synchronous `buildGraphFromScratch()`.
- Locking is unchanged: the new logic runs inside the same `lock.writeLock()` section the existing stale-graph check already holds, and the extra work (reading the gap vectors) is a strict subset of the I/O the pre-existing code already does under that same lock to build `rebuiltOrdinalToVectorId` in the first place.
- The issue's own text flagged this as needing "its own careful look at `ensureGraphAvailable()`'s locking" for the general "serve a stale-but-good-enough graph while async-replacing it" design. This PR does not adopt that general design - it stays within the *existing* MUTABLE-graph-plus-delta-buffer contract the class already has (the same one `rebuildGraphBeforeSearch()`'s async path relies on), rather than introducing a new "hot-swap while serving reads" contract. Happy to discuss if a broader design is wanted instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved vector search availability after reopening with a partially outdated persisted index.
  - Existing searchable data can be reused immediately while newly added vectors are incorporated in the background.
  - Large indexes now avoid unnecessary synchronous rebuilds, reducing delays for the first search.

- **Metrics**
  - Added statistics for tracking reuse of persisted vector graphs.

- **Bug Fixes**
  - Improved recovery behavior after interruptions or crashes during vector index updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->