### PR TITLE
fix(#6316,#6265,#6318,#6705): algo.* CSR routing, influenceMaximization allocation, LCC CSR abortability, stale avg() tests

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -1233,6 +1233,14 @@ public final class GraphAlgorithms {
 
     final int maxDeg = maxDegree;
 
+    // One buffer per thread that ever runs a chunk of this call, reused across every batch
+    // parallelForRangeCheckpointed splits a pass into and every iteration of the outer loop - not
+    // reallocated per chunk invocation. Before issue #6318 threaded checkpointing through this loop's
+    // parallel phase, a fresh neighborBuf per chunk cost PARALLELISM allocations per iteration; batching
+    // into up to CHECKPOINT_BATCHES chunks-of-chunks would have multiplied that up to CHECKPOINT_BATCHES x
+    // without this (PR #6714 review round 9).
+    final ThreadLocal<int[]> neighborBufTL = new ThreadLocal<>();
+
     for (int iter = 0; iter < maxIters; iter++) {
       checkpoint.check();
       System.arraycopy(labels, 0, newLabels, 0, n);
@@ -1240,7 +1248,11 @@ public final class GraphAlgorithms {
       final AtomicBoolean anyChanged = new AtomicBoolean(false);
 
       parallelForRangeCheckpointed(n, checkpoint, (start, end) -> {
-        final int[] neighborBuf = new int[maxDeg];
+        int[] neighborBuf = neighborBufTL.get();
+        if (neighborBuf == null || neighborBuf.length < maxDeg) {
+          neighborBuf = new int[maxDeg];
+          neighborBufTL.set(neighborBuf);
+        }
         boolean localChanged = false;
 
         for (int u = start; u < end; u++) {

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -61,10 +61,11 @@ public final class GraphAlgorithms {
   private static final int PARALLEL_THRESHOLD     = 8192;
   /** How many checkpointed batches {@link #parallelForRangeCheckpointed} splits a full range into, at most. */
   private static final int CHECKPOINT_BATCHES     = 16;
-  /** How often {@link #lccBuildAndIntersect}'s sequential prep passes check in: cheap enough per node that
-   *  checking every one would cost more than the check saves, same tradeoff {@code GraphData.adjacency}'s
-   *  node-count checkpoint strikes. */
-  private static final int LCC_PREP_CHECKPOINT_STRIDE = 4095;
+  /** Bitmask for how often {@link #lccBuildAndIntersect}'s sequential prep passes check in - {@code (u & MASK) ==
+   *  MASK} is true every 4096th node, not every {@code MASK}th one. Cheap enough per node that checking every one
+   *  would cost more than the check saves, same tradeoff {@code GraphData.adjacency}'s node-count checkpoint
+   *  strikes. */
+  private static final int LCC_PREP_CHECKPOINT_MASK = 4095;
   private static final int PARALLEL_BFS_THRESHOLD = 4096;
   private static final double ALPHA              = 8.0;  // edge ratio for push->pull switch
   private static final int PULL_ENTER_DIVISOR    = 8;    // push->pull when frontier > n/8
@@ -1365,7 +1366,7 @@ public final class GraphAlgorithms {
       if (csr == null)
         continue;
       for (int u = 0; u < n; u++) {
-        if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+        if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
           checkpoint.check();
         degree[u] += csr.outDegree(u) + csr.inDegree(u);
       }
@@ -1390,7 +1391,7 @@ public final class GraphAlgorithms {
       final int[] bwdOffsets = csr.getBackwardOffsets();
       final int[] bwdNeighbors = csr.getBackwardNeighbors();
       for (int u = 0; u < n; u++) {
-        if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+        if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
           checkpoint.check();
         int ia = fwdOffsets[u], aEnd = fwdOffsets[u + 1];
         int ib = bwdOffsets[u], bEnd = bwdOffsets[u + 1];
@@ -1415,7 +1416,7 @@ public final class GraphAlgorithms {
         final int[] fwdOffsets = csr.getForwardOffsets();
         final int[] fwdNeighbors = csr.getForwardNeighbors();
         for (int u = 0; u < n; u++) {
-          if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+          if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
             checkpoint.check();
           for (int j = fwdOffsets[u]; j < fwdOffsets[u + 1]; j++)
             neighbors[pos[u]++] = fwdNeighbors[j];
@@ -1423,7 +1424,7 @@ public final class GraphAlgorithms {
         final int[] bwdOffsets = csr.getBackwardOffsets();
         final int[] bwdNeighbors = csr.getBackwardNeighbors();
         for (int u = 0; u < n; u++) {
-          if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+          if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
             checkpoint.check();
           for (int j = bwdOffsets[u]; j < bwdOffsets[u + 1]; j++)
             neighbors[pos[u]++] = bwdNeighbors[j];
@@ -1445,7 +1446,7 @@ public final class GraphAlgorithms {
     // checkpointed the same periodic way as the prep passes above.
     int write = 0;
     for (int u = 0; u < n; u++) {
-      if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+      if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
         checkpoint.check();
       final int readStart = offsets[u];
       final int readEnd = offsets[u + 1];

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -143,6 +143,31 @@ public final class GraphAlgorithms {
     }
   }
 
+  /** How many checkpointed batches {@link #parallelForRangeCheckpointed} splits a full range into, at most. */
+  private static final int CHECKPOINT_BATCHES = 16;
+
+  /**
+   * As {@link #parallelForRange}, but for a kernel with no natural per-iteration checkpoint of its own: the range
+   * is split into up to {@link #CHECKPOINT_BATCHES} batches, each run through {@link #parallelForRange} in turn,
+   * with {@code checkpoint} called on the calling thread between batches - never from inside a worker chunk, same
+   * contract as {@link WorkCheckpoint#check()} documents.
+   * <p>
+   * A batch is never smaller than {@link #PARALLEL_THRESHOLD}, so a graph too small to parallelise still runs as
+   * one batch with one checkpoint call, exactly like a plain {@link #parallelForRange} call would have. On a large
+   * graph this is what gives {@link #localClusteringCoefficient} intra-pass abortability at all (issue #6318: its
+   * one-shot triangle count had no iteration boundary to hang a checkpoint on the way {@link #pageRank} and
+   * {@link #labelPropagation} do), and it narrows their own between-iterations latency to within a single pass.
+   */
+  static void parallelForRangeCheckpointed(final int n, final WorkCheckpoint checkpoint, final BiConsumer<Integer, Integer> work) {
+    final int batchSize = Math.max(PARALLEL_THRESHOLD, (n + CHECKPOINT_BATCHES - 1) / CHECKPOINT_BATCHES);
+    for (int start = 0; start < n; start += batchSize) {
+      checkpoint.check();
+      final int batchStart = start;
+      final int batchEnd = Math.min(start + batchSize, n);
+      parallelForRange(batchEnd - batchStart, (s, e) -> work.accept(batchStart + s, batchStart + e));
+    }
+  }
+
   // --- PageRank (Pull-based, Parallel) ---
 
   /**
@@ -171,14 +196,14 @@ public final class GraphAlgorithms {
    * <p>
    * This kernel has no convergence test - it always runs the full {@code iterations} count - and that count comes
    * straight from a caller-supplied knob, so without a checkpoint {@code algo.pageRank({maxIterations: 2000000000})}
-   * spins with nothing able to stop it. The hook is called once per power iteration, which bounds abort latency by
-   * one sweep of the graph and costs one virtual call per O(n + m) of work.
+   * spins with nothing able to stop it. The hook is called once per power iteration at minimum, which bounds abort
+   * latency by one sweep of the graph and costs one virtual call per O(n + m) of work.
    * <p>
-   * One sweep is deliberately coarser than the ~1024-node latency the inline OLTP loops of the {@code algo.*}
-   * procedures achieve, and it is as fine as this kernel can be: the per-node work here runs inside
-   * {@link #parallelForRange}, on worker threads that would not observe an interrupt aimed at the calling thread,
-   * and throwing out of a chunk closure would leave its siblings running. So the checkpoint stays on the calling
-   * thread, between the parallel phases.
+   * The per-node work here runs inside {@link #parallelForRange}, on worker threads that would not observe an
+   * interrupt aimed at the calling thread, and throwing out of a chunk closure would leave its siblings running.
+   * So the checkpoint stays on the calling thread, between parallel phases - via {@link #parallelForRangeCheckpointed}
+   * rather than {@link #parallelForRange} directly, which narrows abort latency to within a single large phase
+   * rather than only between iterations (issue #6318).
    *
    * @param checkpoint called between iterations; throws to abort. {@link WorkCheckpoint#NONE} to run unbounded
    */
@@ -253,13 +278,13 @@ public final class GraphAlgorithms {
       // Pre-compute contribution per node: rank[v] / outDeg[v].
       // This turns the inner loop into a single gather+accumulate with no arithmetic.
       final double[] contrib = new double[n];
-      parallelForRange(n, (s, e) -> {
+      parallelForRangeCheckpointed(n, checkpoint, (s, e) -> {
         for (int u = s; u < e; u++)
           contrib[u] = currentRank[u] * invDeg[u];
       });
 
       // PULL: each node sums contributions from neighbors — parallel, zero sync
-      parallelForRange(n, (start, end) -> {
+      parallelForRangeCheckpointed(n, checkpoint, (start, end) -> {
         for (int u = start; u < end; u++) {
           double sum = 0;
           for (int t = 0; t < typeCount; t++) {
@@ -286,7 +311,7 @@ public final class GraphAlgorithms {
         danglingSum += currentRank[danglingNodes[i]];
       if (danglingSum > 0.0) {
         final double danglingContrib = damping * danglingSum / n;
-        parallelForRange(n, (s, e) -> {
+        parallelForRangeCheckpointed(n, checkpoint, (s, e) -> {
           for (int u = s; u < e; u++)
             nextRank[u] += danglingContrib;
         });
@@ -1147,9 +1172,10 @@ public final class GraphAlgorithms {
    * <p>
    * The convergence test ({@code break} once no label moved) is not a bound on {@code maxIters}: a graph that
    * oscillates between two labellings never converges, so the caller-supplied knob is what decides when the run
-   * ends. The hook is called once per iteration, which bounds abort latency by one sweep of the graph - coarser than
-   * the inline OLTP loops of the {@code algo.*} procedures, and as fine as this kernel can be, for the reason given
-   * on {@link #pageRank(GraphAnalyticalView, double, int, DIRECTION, WorkCheckpoint, String...)}.
+   * ends. The hook is called once per iteration at minimum, which bounds abort latency by one sweep of the graph;
+   * the per-node work inside that sweep runs through {@link #parallelForRangeCheckpointed} for the same
+   * intra-phase latency {@link #pageRank(GraphAnalyticalView, double, int, DIRECTION, WorkCheckpoint, String...)}
+   * gets from it.
    *
    * @param checkpoint called between iterations; throws to abort. {@link WorkCheckpoint#NONE} to run unbounded
    */
@@ -1204,7 +1230,7 @@ public final class GraphAlgorithms {
 
       final AtomicBoolean anyChanged = new AtomicBoolean(false);
 
-      parallelForRange(n, (start, end) -> {
+      parallelForRangeCheckpointed(n, checkpoint, (start, end) -> {
         final int[] neighborBuf = new int[maxDeg];
         boolean localChanged = false;
 
@@ -1289,14 +1315,35 @@ public final class GraphAlgorithms {
    * @return double[] of LCC values indexed by dense node ID
    */
   public static double[] localClusteringCoefficient(final GraphAnalyticalView view, final String... edgeTypes) {
+    return localClusteringCoefficient(view, WorkCheckpoint.NONE, edgeTypes);
+  }
+
+  /**
+   * {@link #localClusteringCoefficient(GraphAnalyticalView, String...)} with a cooperative abort hook.
+   * <p>
+   * Unlike {@link #pageRank} and {@link #labelPropagation}, this kernel has no iteration loop to hang a
+   * once-per-iteration checkpoint on: it is one O(m x sqrt(m)) pass with nothing but the graph sizing it (issue
+   * #6318). {@code checkpoint} is called periodically through the sequential prep passes (degree count, adjacency
+   * build, compaction) and, via {@link #parallelForRangeCheckpointed}, between the batches its two parallel
+   * phases - the multi-type sort and the triangle count - are now split into, so the CSR path gets the same
+   * abortability the OLTP path (whole node per {@code guard.check()}) already had.
+   *
+   * @param checkpoint called periodically; throws to abort. {@link WorkCheckpoint#NONE} to run unbounded
+   */
+  public static double[] localClusteringCoefficient(final GraphAnalyticalView view, final WorkCheckpoint checkpoint,
+      final String... edgeTypes) {
     final int n = view.getNodeMapping().size();
     if (n == 0)
       return new double[0];
 
     final String[] types = resolveEdgeTypes(view, edgeTypes);
 
-    return lccBuildAndIntersect(view, types, n);
+    return lccBuildAndIntersect(view, types, n, checkpoint);
   }
+
+  /** How often the sequential prep passes below check in: cheap enough per node that checking every one would
+   *  cost more than the check saves, same tradeoff {@code GraphData.adjacency}'s node-count checkpoint strikes. */
+  private static final int LCC_PREP_CHECKPOINT_STRIDE = 4095;
 
   /**
    * Builds a flat merged undirected adjacency from CSR arrays, then counts triangles via
@@ -1304,7 +1351,8 @@ public final class GraphAlgorithms {
    * since CSR forward and backward arrays are already individually sorted.
    * Multi-type sort phase and triangle counting are both parallelized.
    */
-  private static double[] lccBuildAndIntersect(final GraphAnalyticalView view, final String[] types, final int n) {
+  private static double[] lccBuildAndIntersect(final GraphAnalyticalView view, final String[] types, final int n,
+      final WorkCheckpoint checkpoint) {
     final boolean singleType = types.length == 1;
     // First pass: compute degree per node
     final int[] degree = new int[n];
@@ -1312,8 +1360,11 @@ public final class GraphAlgorithms {
       final CSRAdjacencyIndex csr = view.getCSRIndex(edgeType);
       if (csr == null)
         continue;
-      for (int u = 0; u < n; u++)
+      for (int u = 0; u < n; u++) {
+        if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+          checkpoint.check();
         degree[u] += csr.outDegree(u) + csr.inDegree(u);
+      }
     }
 
     // Build offsets from degrees
@@ -1335,6 +1386,8 @@ public final class GraphAlgorithms {
       final int[] bwdOffsets = csr.getBackwardOffsets();
       final int[] bwdNeighbors = csr.getBackwardNeighbors();
       for (int u = 0; u < n; u++) {
+        if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+          checkpoint.check();
         int ia = fwdOffsets[u], aEnd = fwdOffsets[u + 1];
         int ib = bwdOffsets[u], bEnd = bwdOffsets[u + 1];
         int p = offsets[u];
@@ -1357,17 +1410,23 @@ public final class GraphAlgorithms {
           continue;
         final int[] fwdOffsets = csr.getForwardOffsets();
         final int[] fwdNeighbors = csr.getForwardNeighbors();
-        for (int u = 0; u < n; u++)
+        for (int u = 0; u < n; u++) {
+          if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+            checkpoint.check();
           for (int j = fwdOffsets[u]; j < fwdOffsets[u + 1]; j++)
             neighbors[pos[u]++] = fwdNeighbors[j];
+        }
         final int[] bwdOffsets = csr.getBackwardOffsets();
         final int[] bwdNeighbors = csr.getBackwardNeighbors();
-        for (int u = 0; u < n; u++)
+        for (int u = 0; u < n; u++) {
+          if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+            checkpoint.check();
           for (int j = bwdOffsets[u]; j < bwdOffsets[u + 1]; j++)
             neighbors[pos[u]++] = bwdNeighbors[j];
+        }
       }
-      // Sort each adjacency list — parallel for large graphs
-      parallelForRange(n, (start, end) -> {
+      // Sort each adjacency list — parallel for large graphs, checkpointed between batches (issue #6318)
+      parallelForRangeCheckpointed(n, checkpoint, (start, end) -> {
         for (int u = start; u < end; u++)
           Arrays.sort(neighbors, offsets[u], offsets[u + 1]);
       });
@@ -1377,9 +1436,13 @@ public final class GraphAlgorithms {
     // duplicates from reciprocal edges (same neighbour in both the fwd and bwd CSR lists), so the
     // undirected neighbour set used for the simple-graph LCC holds each distinct neighbour once.
     // offsets[u] is captured before being overwritten, and the write cursor never overtakes the
-    // read cursor, so the mutation is safe in place with no extra allocation.
+    // read cursor, so the mutation is safe in place with no extra allocation. Sequential (the write
+    // cursor carries across nodes), so it cannot go through parallelForRangeCheckpointed and is
+    // checkpointed the same periodic way as the prep passes above.
     int write = 0;
     for (int u = 0; u < n; u++) {
+      if ((u & LCC_PREP_CHECKPOINT_STRIDE) == LCC_PREP_CHECKPOINT_STRIDE)
+        checkpoint.check();
       final int readStart = offsets[u];
       final int readEnd = offsets[u + 1];
       offsets[u] = write;
@@ -1397,8 +1460,9 @@ public final class GraphAlgorithms {
     // Each triangle {u, v, w} is found exactly once (u < v < w), then credited to all 3 nodes.
     // This halves the intersection work compared to counting from both directions.
     // Uses AtomicLongArray for thread-safe increments on shared triangle counts.
+    // Checkpointed between batches (issue #6318): this is the dominant O(m x sqrt(m)) phase.
     final AtomicLongArray triangles = new AtomicLongArray(n);
-    parallelForRange(n, (start, end) -> {
+    parallelForRangeCheckpointed(n, checkpoint, (start, end) -> {
       for (int u = start; u < end; u++) {
         final int uStart = offsets[u];
         final int uEnd = offsets[u + 1];

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -64,9 +64,9 @@ public final class GraphAlgorithms {
    * dividing it by this count still keeps every batch at least {@link #PARALLEL_THRESHOLD} large (below that,
    * fewer, larger-than-this-count batches are used instead, down to a single one). Above
    * {@link #MAX_CHECKPOINT_BATCH_SIZE} nodes this count is no longer the driver: batch size is capped there
-   * instead, so batch count keeps growing with the range and abort latency per batch stays bounded (issue
-   * PR #6714 review round 11 - without the cap, batch size grew unboundedly with the range for any n above
-   * {@code CHECKPOINT_BATCHES x PARALLEL_THRESHOLD}, since batch count was pinned at exactly this many).
+   * instead, so batch count keeps growing with the range and abort latency per batch stays bounded - without
+   * the cap, batch size grew unboundedly with the range for any n above
+   * {@code CHECKPOINT_BATCHES x PARALLEL_THRESHOLD}, since batch count was pinned at exactly this many.
    */
   private static final int CHECKPOINT_BATCHES     = 16;
   /** Upper bound on a single checkpointed batch's size, so abort latency stays bounded as the range grows past
@@ -75,12 +75,12 @@ public final class GraphAlgorithms {
   /** Bitmask for how often {@link #lccBuildAndIntersect}'s sequential prep passes check in between nodes -
    *  {@code (u & MASK) == MASK} is true every 1024th node, not every {@code MASK}th one. Matches the 1024-node
    *  stride {@code WorkGuard.checkPeriodically} and {@code GraphData.adjacency} both use elsewhere in the
-   *  codebase (PR #6714 review round 11: this used to be 4x coarser, with no reason for the difference). */
+   *  codebase. */
   private static final int LCC_PREP_CHECKPOINT_MASK = 1023;
   /** Entry-count threshold at which {@link #lccBuildAndIntersect}'s per-node prep passes checkpoint mid-row,
    *  inside a single node's own edge walk rather than only between nodes - otherwise one supernode row is an
    *  unabortable unit regardless of its own size, the same class of gap issue #6715 names for
-   *  {@code weightedAdjacencyFromColumns} (PR #6714 review round 11). Same magnitude as
+   *  {@code weightedAdjacencyFromColumns}. Same magnitude as
    *  {@code AbstractAlgoProcedure.ADJACENCY_CHECKPOINT_ENTRIES}, duplicated here rather than shared because
    *  that constant is {@code protected} on a class in a different package with no public accessor. */
   private static final int LCC_ROW_CHECKPOINT_ENTRIES = 1_048_576;
@@ -1262,15 +1262,15 @@ public final class GraphAlgorithms {
 
       final AtomicBoolean anyChanged = new AtomicBoolean(false);
 
-      // A fresh neighborBuf per chunk invocation rather than a shared/pooled one: PR #6714 review round 9
-      // found parallelForRangeCheckpointed's batching (issue #6318) multiplies how often this closure runs per
-      // iteration - up to CHECKPOINT_BATCHES x, versus once per parallelForRange chunk before. A round-9 fix
-      // moved this into a ThreadLocal to reuse across batches/iterations, but round 11 found that trades a
-      // small, bounded per-call allocation for unbounded retention on the engine's long-lived shared thread
-      // pool: a ThreadLocal set on a pool thread outlives this call, so a supernode-sized maxDeg (e.g. a
-      // 10M-degree hub, ~40 MB) stays retained on every thread that ever ran a chunk, indefinitely, until that
-      // thread happens to touch an unrelated ThreadLocal and expunges the stale entry. A retained-indefinitely
-      // large buffer is worse than a reallocated-but-GC'd small one, so this reverts to the simpler shape.
+      // A fresh neighborBuf per chunk invocation rather than a shared/pooled one: parallelForRangeCheckpointed's
+      // batching (issue #6318) multiplies how often this closure runs per iteration - up to CHECKPOINT_BATCHES
+      // x, versus once per parallelForRange chunk before. A ThreadLocal to reuse the buffer across batches/
+      // iterations was tried and rejected: it trades a small, bounded per-call allocation for unbounded
+      // retention on the engine's long-lived shared thread pool - a ThreadLocal set on a pool thread outlives
+      // this call, so a supernode-sized maxDeg (e.g. a 10M-degree hub, ~40 MB) stays retained on every thread
+      // that ever ran a chunk, indefinitely, until that thread happens to touch an unrelated ThreadLocal and
+      // expunges the stale entry. A retained-indefinitely large buffer is worse than a reallocated-but-GC'd
+      // small one, so this keeps the simpler shape.
       parallelForRangeCheckpointed(n, checkpoint, (start, end) -> {
         final int[] neighborBuf = new int[maxDeg];
         boolean localChanged = false;
@@ -1431,7 +1431,7 @@ public final class GraphAlgorithms {
         while (ia < aEnd && ib < bEnd) {
           // Checkpointed on entries written for THIS node, not just between nodes: a single supernode row
           // (millions of entries) is otherwise one unabortable unit regardless of its own size, the same class
-          // of gap issue #6715 names for weightedAdjacencyFromColumns (PR #6714 review round 11).
+          // of gap issue #6715 names for weightedAdjacencyFromColumns.
           if (((p - offsets[u]) & (LCC_ROW_CHECKPOINT_ENTRIES - 1)) == 0)
             checkpoint.check();
           if (fwdNeighbors[ia] <= bwdNeighbors[ib])

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -59,6 +59,12 @@ public final class GraphAlgorithms {
 
   private static final int PARALLELISM           = Runtime.getRuntime().availableProcessors();
   private static final int PARALLEL_THRESHOLD     = 8192;
+  /** How many checkpointed batches {@link #parallelForRangeCheckpointed} splits a full range into, at most. */
+  private static final int CHECKPOINT_BATCHES     = 16;
+  /** How often {@link #lccBuildAndIntersect}'s sequential prep passes check in: cheap enough per node that
+   *  checking every one would cost more than the check saves, same tradeoff {@code GraphData.adjacency}'s
+   *  node-count checkpoint strikes. */
+  private static final int LCC_PREP_CHECKPOINT_STRIDE = 4095;
   private static final int PARALLEL_BFS_THRESHOLD = 4096;
   private static final double ALPHA              = 8.0;  // edge ratio for push->pull switch
   private static final int PULL_ENTER_DIVISOR    = 8;    // push->pull when frontier > n/8
@@ -142,9 +148,6 @@ public final class GraphAlgorithms {
       throw new RuntimeException(firstError);
     }
   }
-
-  /** How many checkpointed batches {@link #parallelForRangeCheckpointed} splits a full range into, at most. */
-  private static final int CHECKPOINT_BATCHES = 16;
 
   /**
    * As {@link #parallelForRange}, but for a kernel with no natural per-iteration checkpoint of its own: the range
@@ -1340,10 +1343,6 @@ public final class GraphAlgorithms {
 
     return lccBuildAndIntersect(view, types, n, checkpoint);
   }
-
-  /** How often the sequential prep passes below check in: cheap enough per node that checking every one would
-   *  cost more than the check saves, same tradeoff {@code GraphData.adjacency}'s node-count checkpoint strikes. */
-  private static final int LCC_PREP_CHECKPOINT_STRIDE = 4095;
 
   /**
    * Builds a flat merged undirected adjacency from CSR arrays, then counts triangles via

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -59,13 +59,31 @@ public final class GraphAlgorithms {
 
   private static final int PARALLELISM           = Runtime.getRuntime().availableProcessors();
   private static final int PARALLEL_THRESHOLD     = 8192;
-  /** How many checkpointed batches {@link #parallelForRangeCheckpointed} splits a full range into, at most. */
+  /**
+   * How many checkpointed batches {@link #parallelForRangeCheckpointed} aims for on a range small enough that
+   * dividing it by this count still keeps every batch at least {@link #PARALLEL_THRESHOLD} large (below that,
+   * fewer, larger-than-this-count batches are used instead, down to a single one). Above
+   * {@link #MAX_CHECKPOINT_BATCH_SIZE} nodes this count is no longer the driver: batch size is capped there
+   * instead, so batch count keeps growing with the range and abort latency per batch stays bounded (issue
+   * PR #6714 review round 11 - without the cap, batch size grew unboundedly with the range for any n above
+   * {@code CHECKPOINT_BATCHES x PARALLEL_THRESHOLD}, since batch count was pinned at exactly this many).
+   */
   private static final int CHECKPOINT_BATCHES     = 16;
-  /** Bitmask for how often {@link #lccBuildAndIntersect}'s sequential prep passes check in - {@code (u & MASK) ==
-   *  MASK} is true every 4096th node, not every {@code MASK}th one. Cheap enough per node that checking every one
-   *  would cost more than the check saves, same tradeoff {@code GraphData.adjacency}'s node-count checkpoint
-   *  strikes. */
-  private static final int LCC_PREP_CHECKPOINT_MASK = 4095;
+  /** Upper bound on a single checkpointed batch's size, so abort latency stays bounded as the range grows past
+   *  it instead of scaling with the range - see {@link #CHECKPOINT_BATCHES}. */
+  private static final int MAX_CHECKPOINT_BATCH_SIZE = CHECKPOINT_BATCHES * PARALLEL_THRESHOLD;
+  /** Bitmask for how often {@link #lccBuildAndIntersect}'s sequential prep passes check in between nodes -
+   *  {@code (u & MASK) == MASK} is true every 1024th node, not every {@code MASK}th one. Matches the 1024-node
+   *  stride {@code WorkGuard.checkPeriodically} and {@code GraphData.adjacency} both use elsewhere in the
+   *  codebase (PR #6714 review round 11: this used to be 4x coarser, with no reason for the difference). */
+  private static final int LCC_PREP_CHECKPOINT_MASK = 1023;
+  /** Entry-count threshold at which {@link #lccBuildAndIntersect}'s per-node prep passes checkpoint mid-row,
+   *  inside a single node's own edge walk rather than only between nodes - otherwise one supernode row is an
+   *  unabortable unit regardless of its own size, the same class of gap issue #6715 names for
+   *  {@code weightedAdjacencyFromColumns} (PR #6714 review round 11). Same magnitude as
+   *  {@code AbstractAlgoProcedure.ADJACENCY_CHECKPOINT_ENTRIES}, duplicated here rather than shared because
+   *  that constant is {@code protected} on a class in a different package with no public accessor. */
+  private static final int LCC_ROW_CHECKPOINT_ENTRIES = 1_048_576;
   private static final int PARALLEL_BFS_THRESHOLD = 4096;
   private static final double ALPHA              = 8.0;  // edge ratio for push->pull switch
   private static final int PULL_ENTER_DIVISOR    = 8;    // push->pull when frontier > n/8
@@ -157,7 +175,10 @@ public final class GraphAlgorithms {
    * contract as {@link WorkCheckpoint#check()} documents.
    * <p>
    * A batch is never smaller than {@link #PARALLEL_THRESHOLD}, so a small-but-nonzero range still runs as one
-   * batch with one checkpoint call, exactly like a plain {@link #parallelForRange} call would have. {@code n == 0}
+   * batch with one checkpoint call, exactly like a plain {@link #parallelForRange} call would have. A batch is
+   * also never larger than {@link #MAX_CHECKPOINT_BATCH_SIZE}, so a range large enough to need more than
+   * {@link #CHECKPOINT_BATCHES} of them gets more, smaller batches instead of {@link #CHECKPOINT_BATCHES} ever-
+   * larger ones - otherwise abort latency would grow with the range without bound. {@code n == 0}
    * is the one exception: the batch loop never runs at all, so {@code checkpoint} is never called - harmless
    * today because every current caller ({@link #pageRank}, {@link #labelPropagation}, the LCC kernel) already
    * returns before reaching a checkpointed loop on an empty graph, but a future caller without that guarantee
@@ -168,7 +189,9 @@ public final class GraphAlgorithms {
    * and {@link #labelPropagation} do), and it narrows their own between-iterations latency to within a single pass.
    */
   static void parallelForRangeCheckpointed(final int n, final WorkCheckpoint checkpoint, final BiConsumer<Integer, Integer> work) {
-    final int batchSize = Math.max(PARALLEL_THRESHOLD, (n + CHECKPOINT_BATCHES - 1) / CHECKPOINT_BATCHES);
+    final int batchSize = Math.min(
+        Math.max(PARALLEL_THRESHOLD, (n + CHECKPOINT_BATCHES - 1) / CHECKPOINT_BATCHES),
+        MAX_CHECKPOINT_BATCH_SIZE);
     for (int start = 0; start < n; start += batchSize) {
       checkpoint.check();
       final int batchStart = start;
@@ -1233,26 +1256,23 @@ public final class GraphAlgorithms {
 
     final int maxDeg = maxDegree;
 
-    // One buffer per thread that ever runs a chunk of this call, reused across every batch
-    // parallelForRangeCheckpointed splits a pass into and every iteration of the outer loop - not
-    // reallocated per chunk invocation. Before issue #6318 threaded checkpointing through this loop's
-    // parallel phase, a fresh neighborBuf per chunk cost PARALLELISM allocations per iteration; batching
-    // into up to CHECKPOINT_BATCHES chunks-of-chunks would have multiplied that up to CHECKPOINT_BATCHES x
-    // without this (PR #6714 review round 9).
-    final ThreadLocal<int[]> neighborBufTL = new ThreadLocal<>();
-
     for (int iter = 0; iter < maxIters; iter++) {
       checkpoint.check();
       System.arraycopy(labels, 0, newLabels, 0, n);
 
       final AtomicBoolean anyChanged = new AtomicBoolean(false);
 
+      // A fresh neighborBuf per chunk invocation rather than a shared/pooled one: PR #6714 review round 9
+      // found parallelForRangeCheckpointed's batching (issue #6318) multiplies how often this closure runs per
+      // iteration - up to CHECKPOINT_BATCHES x, versus once per parallelForRange chunk before. A round-9 fix
+      // moved this into a ThreadLocal to reuse across batches/iterations, but round 11 found that trades a
+      // small, bounded per-call allocation for unbounded retention on the engine's long-lived shared thread
+      // pool: a ThreadLocal set on a pool thread outlives this call, so a supernode-sized maxDeg (e.g. a
+      // 10M-degree hub, ~40 MB) stays retained on every thread that ever ran a chunk, indefinitely, until that
+      // thread happens to touch an unrelated ThreadLocal and expunges the stale entry. A retained-indefinitely
+      // large buffer is worse than a reallocated-but-GC'd small one, so this reverts to the simpler shape.
       parallelForRangeCheckpointed(n, checkpoint, (start, end) -> {
-        int[] neighborBuf = neighborBufTL.get();
-        if (neighborBuf == null || neighborBuf.length < maxDeg) {
-          neighborBuf = new int[maxDeg];
-          neighborBufTL.set(neighborBuf);
-        }
+        final int[] neighborBuf = new int[maxDeg];
         boolean localChanged = false;
 
         for (int u = start; u < end; u++) {
@@ -1409,6 +1429,11 @@ public final class GraphAlgorithms {
         int ib = bwdOffsets[u], bEnd = bwdOffsets[u + 1];
         int p = offsets[u];
         while (ia < aEnd && ib < bEnd) {
+          // Checkpointed on entries written for THIS node, not just between nodes: a single supernode row
+          // (millions of entries) is otherwise one unabortable unit regardless of its own size, the same class
+          // of gap issue #6715 names for weightedAdjacencyFromColumns (PR #6714 review round 11).
+          if (((p - offsets[u]) & (LCC_ROW_CHECKPOINT_ENTRIES - 1)) == 0)
+            checkpoint.check();
           if (fwdNeighbors[ia] <= bwdNeighbors[ib])
             neighbors[p++] = fwdNeighbors[ia++];
           else
@@ -1430,16 +1455,22 @@ public final class GraphAlgorithms {
         for (int u = 0; u < n; u++) {
           if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
             checkpoint.check();
-          for (int j = fwdOffsets[u]; j < fwdOffsets[u + 1]; j++)
+          for (int j = fwdOffsets[u]; j < fwdOffsets[u + 1]; j++) {
+            if (((j - fwdOffsets[u]) & (LCC_ROW_CHECKPOINT_ENTRIES - 1)) == 0)
+              checkpoint.check();
             neighbors[pos[u]++] = fwdNeighbors[j];
+          }
         }
         final int[] bwdOffsets = csr.getBackwardOffsets();
         final int[] bwdNeighbors = csr.getBackwardNeighbors();
         for (int u = 0; u < n; u++) {
           if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
             checkpoint.check();
-          for (int j = bwdOffsets[u]; j < bwdOffsets[u + 1]; j++)
+          for (int j = bwdOffsets[u]; j < bwdOffsets[u + 1]; j++) {
+            if (((j - bwdOffsets[u]) & (LCC_ROW_CHECKPOINT_ENTRIES - 1)) == 0)
+              checkpoint.check();
             neighbors[pos[u]++] = bwdNeighbors[j];
+          }
         }
       }
       // Sort each adjacency list — parallel for large graphs, checkpointed between batches (issue #6318)
@@ -1465,6 +1496,8 @@ public final class GraphAlgorithms {
       offsets[u] = write;
       int last = -1; // node IDs are non-negative sequential integers, so -1 never matches
       for (int j = readStart; j < readEnd; j++) {
+        if (((j - readStart) & (LCC_ROW_CHECKPOINT_ENTRIES - 1)) == 0)
+          checkpoint.check();
         final int neighbor = neighbors[j];
         if (neighbor != u && neighbor != last)
           neighbors[write++] = last = neighbor;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -155,11 +155,16 @@ public final class GraphAlgorithms {
    * with {@code checkpoint} called on the calling thread between batches - never from inside a worker chunk, same
    * contract as {@link WorkCheckpoint#check()} documents.
    * <p>
-   * A batch is never smaller than {@link #PARALLEL_THRESHOLD}, so a graph too small to parallelise still runs as
-   * one batch with one checkpoint call, exactly like a plain {@link #parallelForRange} call would have. On a large
-   * graph this is what gives {@link #localClusteringCoefficient} intra-pass abortability at all (issue #6318: its
-   * one-shot triangle count had no iteration boundary to hang a checkpoint on the way {@link #pageRank} and
-   * {@link #labelPropagation} do), and it narrows their own between-iterations latency to within a single pass.
+   * A batch is never smaller than {@link #PARALLEL_THRESHOLD}, so a small-but-nonzero range still runs as one
+   * batch with one checkpoint call, exactly like a plain {@link #parallelForRange} call would have. {@code n == 0}
+   * is the one exception: the batch loop never runs at all, so {@code checkpoint} is never called - harmless
+   * today because every current caller ({@link #pageRank}, {@link #labelPropagation}, the LCC kernel) already
+   * returns before reaching a checkpointed loop on an empty graph, but a future caller without that guarantee
+   * would not get even one check-in.
+   * <p>
+   * On a large graph this is what gives {@link #localClusteringCoefficient} intra-pass abortability at all (issue
+   * #6318: its one-shot triangle count had no iteration boundary to hang a checkpoint on the way {@link #pageRank}
+   * and {@link #labelPropagation} do), and it narrows their own between-iterations latency to within a single pass.
    */
   static void parallelForRangeCheckpointed(final int n, final WorkCheckpoint checkpoint, final BiConsumer<Integer, Integer> work) {
     final int batchSize = Math.max(PARALLEL_THRESHOLD, (n + CHECKPOINT_BATCHES - 1) / CHECKPOINT_BATCHES);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -788,6 +788,37 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       return provider != null ? provider.getNeighborView(dir, relTypes) : null;
     }
 
+    /**
+     * Per-node degree in the given direction, for callers that need only the count - not the neighbour ids
+     * {@link #adjacency} would materialise to get it.
+     * <p>
+     * CSR-backed, this reads the count straight off {@link GraphTraversalProvider#getDegrees}, which for a
+     * {@code GraphAnalyticalView} is an O(1)-per-node offset subtraction rather than an O(degree) walk - no
+     * neighbour-id array is ever allocated. {@code getDegrees} takes one edge type at a time (issue #6316:
+     * it has exactly one caller, {@code DegreeProductOp}, and always with a single type), so an "all/several
+     * types" request is resolved to the provider's materialised types and summed per type, the same resolution
+     * {@link #weightedAdjacency} uses for its columnar path.
+     */
+    public int[] degrees(final Vertex.DIRECTION dir, final String... relTypes) {
+      final int[] degrees = new int[nodeCount];
+      memory.reserve(saturatingProduct(nodeCount, INT_BYTES), "the degree buffer", nodeCount + " nodes");
+      if (provider != null) {
+        final String[] types = relTypes != null && relTypes.length > 0 ? relTypes : provider.getMaterializedEdgeTypes();
+        if (types != null && types.length > 0) {
+          final int[] perType = new int[nodeCount];
+          for (final String type : types) {
+            provider.getDegrees(perType, dir, type);
+            for (int i = 0; i < nodeCount; i++)
+              degrees[i] += perType[i];
+          }
+        }
+        return degrees;
+      }
+      for (int i = 0; i < nodeCount; i++)
+        degrees[i] = (int) vertices.get(i).countEdges(dir, relTypes);
+      return degrees;
+    }
+
     public Vertex getVertex(final int i) {
       if (provider != null) {
         final RID rid = provider.getRID(i);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -800,11 +800,16 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * {@link #weightedAdjacency} uses for its columnar path.
      */
     public int[] degrees(final Vertex.DIRECTION dir, final String... relTypes) {
-      final int[] degrees = new int[nodeCount];
+      // Reserved before allocating, not after (issue #6714 review round 4: this used to allocate first, the
+      // same "reserve after the fact" ordering the round-3 review found and fixed for weightedAdjacency).
       memory.reserve(saturatingProduct(nodeCount, INT_BYTES), "the degree buffer", nodeCount + " nodes");
+      final int[] degrees = new int[nodeCount];
       if (provider != null) {
         final String[] types = relTypes != null && relTypes.length > 0 ? relTypes : provider.getMaterializedEdgeTypes();
         if (types != null && types.length > 0) {
+          // perType is a second nodeCount-sized scratch buffer, previously allocated with no reservation of its
+          // own at all - reserved here, separately, right before it is actually needed.
+          memory.reserve(saturatingProduct(nodeCount, INT_BYTES), "the per-type degree scratch buffer", nodeCount + " nodes");
           final int[] perType = new int[nodeCount];
           for (final String type : types) {
             // getDegrees() overwrites perType (it Arrays.fill(..., 0)s it before writing), never accumulates

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -963,6 +963,14 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * per-type, per-direction slicing that keeps a weight with its own edge lives. Nothing about that pairing is
      * re-derived here, so the CSR path of an {@code algo.*} procedure, of {@code astar} and of
      * {@code bellmanFord} cannot drift apart from one another.
+     * <p>
+     * {@code guard.checkPeriodically(i)} is throttled per <em>node</em>, not per edge: {@code edgeWeightsOf}'s
+     * only implementation (the default method; no provider overrides it) is O(degree) with no checkpoint inside
+     * its own loop, so one call for a supernode is a single unabortable unit of work regardless of how large its
+     * fan-out is - unlike {@link #weightedAdjacencyFromRecords}, which still throttles per edge. This is a
+     * pre-existing property of this shared helper (issue #6316 review, PR #6714): a proper fix needs a checkpoint
+     * hook inside {@code edgeWeightsOf} itself, which is an SPI change tracked separately as issue #6715 rather
+     * than folded into this PR.
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -794,9 +794,9 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * <p>
      * CSR-backed, this reads the count straight off {@link GraphTraversalProvider#getDegrees}, which for a
      * {@code GraphAnalyticalView} is an O(1)-per-node offset subtraction rather than an O(degree) walk - no
-     * neighbour-id array is ever allocated. {@code getDegrees} takes one edge type at a time (issue #6316:
-     * it has exactly one caller, {@code DegreeProductOp}, and always with a single type), so an "all/several
-     * types" request is resolved to the provider's materialised types and summed per type, the same resolution
+     * neighbour-id array is ever allocated. {@code getDegrees} takes one edge type at a time (issue #6316: its
+     * other caller, {@code DegreeProductOp}, also calls it once per type), so an "all/several types" request is
+     * resolved to the provider's materialised types and summed per type, the same resolution
      * {@link #weightedAdjacency} uses for its columnar path.
      */
     public int[] degrees(final Vertex.DIRECTION dir, final String... relTypes) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -806,6 +806,10 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       final int[] degrees = new int[nodeCount];
       if (provider != null) {
         final String[] types = relTypes != null && relTypes.length > 0 ? relTypes : provider.getMaterializedEdgeTypes();
+        // types empty/null here means the graph genuinely has no materialised edges of any type - loadGraph's
+        // findProvider already required this provider to be isReady() and to cover every requested type before
+        // selecting it, so an empty result is "no edges exist", not "the provider couldn't answer": degrees
+        // staying all-zero is the correct answer for that graph, not a silent wrong one.
         if (types != null && types.length > 0) {
           // perType is a second nodeCount-sized scratch buffer, previously allocated with no reservation of its
           // own at all - reserved here, separately, right before it is actually needed.
@@ -821,6 +825,11 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         }
         return degrees;
       }
+      // countEdges() returns long, narrowed here without an overflow check: this array is int[] because every
+      // CSR-backed caller of GraphData is already int-indexed (dense node ids, CSR neighbour arrays), so the
+      // OLTP fallback matches that contract rather than carrying a long a single degree() consumer would need.
+      // A vertex with more than Integer.MAX_VALUE edges in one direction would already be precluded by the
+      // engine's other structural limits well before this cast could matter.
       for (int i = 0; i < nodeCount; i++)
         degrees[i] = (int) vertices.get(i).countEdges(dir, relTypes);
       return degrees;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -897,7 +897,18 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     public WeightedAdjacency weightedAdjacency(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String... relTypes) {
       if (weightProperty == null) {
+        // adjacency() already reserved neighbors' own footprint (issue #6317); what is new here is the parallel
+        // weights array beside it, one double per entry. Its total entry count is already known from neighbors,
+        // so unlike the columnar/record builds below - where entries accumulate as the walk goes - this can be
+        // reserved in one shot before allocating it, rather than incrementally.
         final int[][] neighbors = adjacency(dir, relTypes);
+        long totalEntries = 0;
+        for (int i = 0; i < nodeCount; i++)
+          totalEntries += neighbors[i].length;
+        memory.reserve(saturatingSum(saturatingProduct(nodeCount, MATRIX_ROW_OVERHEAD_BYTES),
+                saturatingProduct(totalEntries, DOUBLE_BYTES)), "the unit-weight array",
+            nodeCount + " nodes, " + totalEntries + " edge entries");
+
         final double[][] weights = new double[nodeCount][];
         for (int i = 0; i < nodeCount; i++) {
           guard.checkPeriodically(i);
@@ -924,6 +935,25 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     }
 
     /**
+     * Charges {@code rows} row-header pairs (one each for {@code neighbors[i]} and {@code weights[i]}) and
+     * {@code entries} {@code (neighbour id, weight)} pairs to the call's budget.
+     * <p>
+     * {@code weightedAdjacency} used to reserve nothing for its own columnar/record builds at all - #6300's
+     * edge-count budget was {@code algo.mst}/{@code algo.msa}'s only protection against an oversized graph, and
+     * routing them onto this shared helper (issue #6316) silently lost it: the full {@code int[][]}/{@code
+     * double[][]} pair was materialised before either procedure's own {@code reserve()} call ran. This is the
+     * same "reserve while counting, not after" placement {@link #reserveAdjacency} uses for the plain adjacency
+     * build, so a graph too large for the weighted working set is refused mid-walk rather than after it.
+     */
+    private void reserveWeightedAdjacency(final long rows, final long entries) {
+      if (rows == 0 && entries == 0)
+        return;
+      memory.reserve(saturatingSum(saturatingProduct(rows, 2 * MATRIX_ROW_OVERHEAD_BYTES),
+              saturatingProduct(entries, INT_BYTES + DOUBLE_BYTES)), "the weighted adjacency list",
+          rows > 0 ? rows + " nodes, " + entries + " edge entries" : entries + " edge entries");
+    }
+
+    /**
      * Columnar build: one call per node into {@link GraphTraversalProvider#edgeWeightsOf}, which is where the
      * per-type, per-direction slicing that keeps a weight with its own edge lives. Nothing about that pairing is
      * re-derived here, so the CSR path of an {@code algo.*} procedure, of {@code astar} and of
@@ -931,14 +961,22 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
+      reserveWeightedAdjacency(nodeCount, 0);
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
+      long entries = 0;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
         final NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, types);
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
+        entries += neighbors[i].length;
+        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
+          reserveWeightedAdjacency(0, entries);
+          entries = 0;
+        }
       }
+      reserveWeightedAdjacency(0, entries);
       return new WeightedAdjacency(neighbors, weights);
     }
 
@@ -949,6 +987,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      */
     private WeightedAdjacency weightedAdjacencyFromRecords(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] relTypes) {
+      reserveWeightedAdjacency(nodeCount, 0);
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
       // One growable pair of scratch buffers for the whole graph rather than a list per node: the degree is
@@ -956,6 +995,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       int[] scratchNeighbors = new int[16];
       double[] scratchWeights = new double[16];
       int edgeStep = 0;
+      long entries = 0;
 
       for (int i = 0; i < nodeCount; i++) {
         final Vertex vertex = getVertex(i);
@@ -995,7 +1035,13 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         }
         neighbors[i] = Arrays.copyOf(scratchNeighbors, degree);
         weights[i] = Arrays.copyOf(scratchWeights, degree);
+        entries += degree;
+        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
+          reserveWeightedAdjacency(0, entries);
+          entries = 0;
+        }
       }
+      reserveWeightedAdjacency(0, entries);
       return new WeightedAdjacency(neighbors, weights);
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -800,8 +800,8 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * {@link #weightedAdjacency} uses for its columnar path.
      */
     public int[] degrees(final Vertex.DIRECTION dir, final String... relTypes) {
-      // Reserved before allocating, not after (issue #6714 review round 4: this used to allocate first, the
-      // same "reserve after the fact" ordering the round-3 review found and fixed for weightedAdjacency).
+      // Reserved before allocating, not after - the same "reserve while counting, not after" ordering
+      // weightedAdjacency uses for its own buffers.
       memory.reserve(saturatingProduct(nodeCount, INT_BYTES), "the degree buffer", nodeCount + " nodes");
       final int[] degrees = new int[nodeCount];
       if (provider != null) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -807,6 +807,8 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         if (types != null && types.length > 0) {
           final int[] perType = new int[nodeCount];
           for (final String type : types) {
+            // getDegrees() overwrites perType (it Arrays.fill(..., 0)s it before writing), never accumulates
+            // into it, so summing its result per type here is correct rather than double-counting.
             provider.getDegrees(perType, dir, type);
             for (int i = 0; i < nodeCount; i++)
               degrees[i] += perType[i];

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
@@ -19,9 +19,6 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.exception.RecordNotFoundException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -31,7 +28,6 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -100,14 +96,11 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
-    if (vertices.isEmpty())
+    final GraphData graph = loadGraph(db, null, null, context);
+    final int n = graph.nodeCount;
+    if (n == 0)
       return Stream.empty();
-
-    final int n = vertices.size();
-    final Map<Vertex, Integer> vertexIndex = new HashMap<>(n);
-    for (int i = 0; i < n; i++)
-      vertexIndex.put(vertices.get(i), i);
+    final int[][] adj = graph.adjacency(Vertex.DIRECTION.OUT);
 
     final double[] betweenness = new double[n];
 
@@ -117,7 +110,6 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
     // (issue #6302). The inner checkpoints keep the abort latency below one whole source's pass.
     for (int s = 0; s < n; s++) {
       guard.check();
-      final Vertex source = vertices.get(s);
 
       final Deque<Integer> stack = new ArrayDeque<>();
       final List<List<Integer>> predecessors = new ArrayList<>(n);
@@ -140,26 +132,16 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
         final int v = queue.poll();
         stack.push(v);
 
-        final Vertex vVertex = vertices.get(v);
-        for (final Edge edge : vVertex.getEdges(Vertex.DIRECTION.OUT)) {
-          try {
-            final Vertex neighbor = edge.getInVertex();
-            final Integer w = vertexIndex.get(neighbor);
-            if (w == null)
-              continue;
-
-            // First time visiting w?
-            if (dist[w] < 0) {
-              queue.add(w);
-              dist[w] = dist[v] + 1;
-            }
-            // Shortest path to w via v?
-            if (dist[w] == dist[v] + 1) {
-              sigma[w] += sigma[v];
-              predecessors.get(w).add(v);
-            }
-          } catch (final RecordNotFoundException e) {
-            GhostEdgeReporter.reportSkipped(e);
+        for (final int w : adj[v]) {
+          // First time visiting w?
+          if (dist[w] < 0) {
+            queue.add(w);
+            dist[w] = dist[v] + 1;
+          }
+          // Shortest path to w via v?
+          if (dist[w] == dist[v] + 1) {
+            sigma[w] += sigma[v];
+            predecessors.get(w).add(v);
           }
         }
       }
@@ -187,7 +169,7 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
 
     return IntStream.range(0, n).mapToObj(i -> {
       final ResultInternal result = new ResultInternal();
-      result.setProperty("node", vertices.get(i).getIdentity());
+      result.setProperty("node", graph.getRID(i));
       result.setProperty("score", betweenness[i]);
       return (Result) result;
     });

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentrality.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentrality.java
@@ -25,13 +25,17 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
 import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
  * Procedure: algo.degree(relTypes?, direction?)
  * <p>
  * Computes degree centrality for every vertex: the normalized fraction of nodes connected to it.
- * Uses {@code vertex.countEdges()} for maximum efficiency — no edge objects are materialised.
+ * Routes through {@link #loadGraph} like the rest of the {@code algo.*} package (issue #6316), so a Graph
+ * Analytical View covering the graph is used when one is ready. CSR-backed, {@link GraphData#degrees} reads
+ * the count straight off the view's offset arrays in O(1) per node rather than materialising and counting a
+ * neighbour list, which is the same {@code vertex.countEdges()}-style efficiency the OLTP path already had.
  * </p>
  * <p>
  * Example:
@@ -80,24 +84,23 @@ public class AlgoDegreeCentrality extends AbstractAlgoProcedure {
     final String dirArg = args.length > 1 ? extractString(args[1], "direction") : "BOTH";
 
     final Database db = context.getDatabase();
-    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
+    final GraphData graph = loadGraph(db, null, relTypes, context);
 
-    final int n = vertices.size();
+    final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
 
     final double norm = n > 1 ? (double) (n - 1) : 1.0;
 
-    return vertices.stream().map(v -> {
-      final long in = relTypes != null && relTypes.length > 0 ?
-          v.countEdges(Vertex.DIRECTION.IN, relTypes) :
-          v.countEdges(Vertex.DIRECTION.IN);
-      final long out = relTypes != null && relTypes.length > 0 ?
-          v.countEdges(Vertex.DIRECTION.OUT, relTypes) :
-          v.countEdges(Vertex.DIRECTION.OUT);
+    final int[] inDegrees = graph.degrees(Vertex.DIRECTION.IN, relTypes);
+    final int[] outDegrees = graph.degrees(Vertex.DIRECTION.OUT, relTypes);
+
+    return IntStream.range(0, n).mapToObj(i -> {
+      final long in = inDegrees[i];
+      final long out = outDegrees[i];
       final long total = in + out;
       final ResultInternal r = new ResultInternal();
-      r.setProperty("node", v.getIdentity());
+      r.setProperty("node", graph.getRID(i));
       r.setProperty("inDegree", in);
       r.setProperty("outDegree", out);
       r.setProperty("degree", total);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximization.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximization.java
@@ -139,7 +139,7 @@ public class AlgoInfluenceMaximization extends AbstractAlgoProcedure {
           // #6265). Throttling to checkPeriodically(1024) would instead make abort latency
           // 1024 x O(n + m) cascades, worst on exactly the large graphs where the deadline matters most.
           guard.check();
-          totalSpread += simulateIC(adj, seeds, round, candidate, n, propagationProbability, rng, activated, queue);
+          totalSpread += simulateIC(adj, seeds, round, candidate, propagationProbability, rng, activated, queue);
         }
         final double avgSpread = totalSpread / simulations;
 
@@ -177,7 +177,7 @@ public class AlgoInfluenceMaximization extends AbstractAlgoProcedure {
    * rather than reallocating and zero-filling {@code n}-sized arrays on every call.
    */
   private int simulateIC(final int[][] adj, final int[] seeds, final int seedCount,
-      final int candidate, final int n, final double p, final Random rng,
+      final int candidate, final double p, final Random rng,
       final boolean[] activated, final int[] queue) {
     int head = 0;
     int tail = 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximization.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximization.java
@@ -112,6 +112,12 @@ public class AlgoInfluenceMaximization extends AbstractAlgoProcedure {
     final Random rng = new Random(42L);
     final WorkGuard guard = newWorkGuard(context);
 
+    // Hoisted out of simulateIC() and reused across every Monte Carlo call (k x n x simulations of them).
+    // simulateIC() resets only the entries it touched, turning what used to be an O(n) allocate-and-zero
+    // per call into an O(activated) reset (issue #6265).
+    final boolean[] activated = new boolean[n];
+    final int[]     queue     = new int[n];
+
     final List<Result> results = new ArrayList<>(seedCount);
     double prevSpread = 0.0;
 
@@ -127,12 +133,13 @@ public class AlgoInfluenceMaximization extends AbstractAlgoProcedure {
         double totalSpread = 0.0;
         for (int sim = 0; sim < simulations; sim++) {
           // Deliberately the unthrottled check(), not checkPeriodically(), unlike node2vec's and maxKCut's
-          // inner loops. Throttling pays off only where one iteration can be cheaper than the check itself,
-          // and simulateIC allocates and zero-fills two arrays of size n before the cascade starts, so it is
-          // never O(1) on any graph shape. Throttling to 1024 would instead make abort latency
+          // inner loops. guard.check() costs one flag test when no timeout is configured, so paying it once
+          // per simulation is cheap even now that simulateIC's buffers are hoisted to the caller and a
+          // simulation on a sparse graph with a low propagationProbability can be close to O(1) (issue
+          // #6265). Throttling to checkPeriodically(1024) would instead make abort latency
           // 1024 x O(n + m) cascades, worst on exactly the large graphs where the deadline matters most.
           guard.check();
-          totalSpread += simulateIC(adj, seeds, round, candidate, n, propagationProbability, rng);
+          totalSpread += simulateIC(adj, seeds, round, candidate, n, propagationProbability, rng, activated, queue);
         }
         final double avgSpread = totalSpread / simulations;
 
@@ -163,12 +170,15 @@ public class AlgoInfluenceMaximization extends AbstractAlgoProcedure {
   /**
    * Simulates one IC cascade from the current seed set plus a candidate node.
    * Returns the number of activated nodes.
+   * <p>
+   * {@code activated} and {@code queue} are owned by the caller and reused across every simulation
+   * (issue #6265): both are guaranteed all-{@code false}/scratch on entry and are restored to that state
+   * before returning, by resetting only the entries this call touched (recorded in {@code queue[0..tail)})
+   * rather than reallocating and zero-filling {@code n}-sized arrays on every call.
    */
   private int simulateIC(final int[][] adj, final int[] seeds, final int seedCount,
-      final int candidate, final int n, final double p, final Random rng) {
-    final boolean[] activated = new boolean[n];
-    // BFS queue (int[] with head/tail pointers — zero boxing)
-    final int[] queue = new int[n];
+      final int candidate, final int n, final double p, final Random rng,
+      final boolean[] activated, final int[] queue) {
     int head = 0;
     int tail = 0;
 
@@ -197,6 +207,10 @@ public class AlgoInfluenceMaximization extends AbstractAlgoProcedure {
         }
       }
     }
+
+    // Reset only the touched entries so the shared buffers are clean for the next call (issue #6265).
+    for (int i = 0; i < tail; i++)
+      activated[queue[i]] = false;
 
     return count;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.stream.Stream;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -20,9 +20,6 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
-import com.arcadedb.exception.RecordNotFoundException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -95,18 +92,15 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final MemoryBudget memory = newMemoryBudget(db);
-    final List<Vertex> vertices = loadVertices(db, null, memory);
+    final GraphData graph = loadGraph(db, null, relTypes, context);
 
-    final int n = vertices.size();
+    final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
 
-    final Map<RID, Integer> ridToIdx = buildRidIndex(vertices);
-
-    final Integer startIdx = ridToIdx.get(startNode.getIdentity());
-    final Integer endIdx   = ridToIdx.get(endNode.getIdentity());
-    if (startIdx == null || endIdx == null)
+    final int startIdx = graph.indexOf(startNode.getIdentity());
+    final int endIdx   = graph.indexOf(endNode.getIdentity());
+    if (startIdx < 0 || endIdx < 0)
       return Stream.empty();
 
     // Yen's algorithm is dense here: a nodeCount x nodeCount weight matrix for the whole run - 800 MB at
@@ -114,38 +108,35 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
     // dense formulation is a client error naming the node count and the budget, rather than an
     // OutOfMemoryError. The two spur masks beside it are nodeCount-sized and allocated once for the whole call
     // (see below), so they are a rounding error next to the matrix and are priced with it rather than apart.
+    final MemoryBudget memory = graph.memory();
     memory.reserve(saturatingSum(matrixBytes(n, n, DOUBLE_BYTES), matrixBytes(2, n, BOOLEAN_BYTES)),
         "the weight matrix and the spur masks",
         "a double matrix of " + n + " x " + n + " nodes and two boolean masks of " + n + " nodes");
 
-    // Build weighted adjacency matrix (OUT direction)
+    // Build weighted adjacency matrix (OUT direction). Edge collection and weight extraction go through
+    // GraphData.weightedAdjacency (issue #6316), the same shared helper algo.steinerTree and algo.mst read
+    // weights through, rather than a hand-rolled getEdges() walk. Parallel edges collapse to the cheapest one,
+    // same as before.
     final double[][] weightMatrix = new double[n][n];
     for (double[] row : weightMatrix)
       Arrays.fill(row, Double.MAX_VALUE);
+
+    final String weightProp = weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null;
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProp, relTypes);
+    final int[][] neighbors = weighted.neighbors();
+    final double[][] edgeWeights = weighted.weights();
 
     for (int i = 0; i < n; i++) {
       // One row of the matrix is O(n) and one vertex's edges are O(degree); either is more than a flag test.
       guard.check();
       weightMatrix[i][i] = 0.0;
-      final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge e : edges) {
-        try {
-          final Integer j = ridToIdx.get(e.getIn());
-          if (j == null)
-            continue;
-          double w = 1.0;
-          if (weightProperty != null && !weightProperty.isEmpty()) {
-            final Object wObj = e.get(weightProperty);
-            if (wObj instanceof Number num)
-              w = num.doubleValue();
-          }
-          if (w < weightMatrix[i][j])
-            weightMatrix[i][j] = w;
-        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
-          GhostEdgeReporter.reportSkipped(rnf);
-        }
+      final int[] row = neighbors[i];
+      final double[] rowWeights = edgeWeights[i];
+      for (int e = 0; e < row.length; e++) {
+        final int j = row[e];
+        final double w = rowWeights[e];
+        if (w < weightMatrix[i][j])
+          weightMatrix[i][j] = w;
       }
     }
 
@@ -272,7 +263,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
       final int[] path = kPaths.get(i);
       final List<RID> pathRids = new ArrayList<>(path.length);
       for (final int idx : path)
-        pathRids.add(vertices.get(idx).getIdentity());
+        pathRids.add(graph.getRID(idx));
 
       final ResultInternal r = new ResultInternal();
       r.setProperty("path", buildPath(pathRids, db));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLocalClusteringCoefficient.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLocalClusteringCoefficient.java
@@ -111,9 +111,12 @@ public class AlgoLocalClusteringCoefficient extends AbstractAlgoProcedure {
     if (n == 0)
       return Stream.empty();
 
+    // The CSR path is now abortable the same way the OLTP path is (issue #6318): the kernel's two parallel
+    // phases and its sequential prep passes are all checkpointed via this guard.
+    final WorkGuard guard = newWorkGuard(context);
     final double[] lcc = relTypes != null ?
-        GraphAlgorithms.localClusteringCoefficient(gav, relTypes) :
-        GraphAlgorithms.localClusteringCoefficient(gav);
+        GraphAlgorithms.localClusteringCoefficient(gav, guard::check, relTypes) :
+        GraphAlgorithms.localClusteringCoefficient(gav, guard::check);
     context.setVariable(CommandContext.RESULT_COUNT_HINT_VAR, (long) n);
 
     return IntStream.range(0, n).mapToObj(i -> {
@@ -141,13 +144,9 @@ public class AlgoLocalClusteringCoefficient extends AbstractAlgoProcedure {
     final long[] triangles = new long[n];
     for (int u = 0; u < n; u++) {
       // One node intersects its neighbour list against each of its neighbours', which is O(degree²) on a
-      // supernode and O(m x sqrt(m)) over the graph - nothing but the graph sizes it (issue #6302).
-      //
-      // Only the OLTP path is covered here. The CSR path hands the whole computation to
-      // GraphAlgorithms#localClusteringCoefficient, which counts triangles across a thread pool, and the
-      // WorkCheckpoint hook #6264 introduced is specified to be called between iterations on the calling
-      // thread rather than from inside a parallel chunk - so covering that kernel is a change to how it
-      // partitions its work, not a checkpoint that can be dropped in here.
+      // supernode and O(m x sqrt(m)) over the graph - nothing but the graph sizes it (issue #6302). The CSR
+      // path below is checkpointed too (issue #6318), via the same guard, threaded into
+      // GraphAlgorithms#localClusteringCoefficient as a WorkCheckpoint.
       guard.check();
       final int[] neighborsU = adj[u];
       for (final int v : neighborsU) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLocalClusteringCoefficient.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLocalClusteringCoefficient.java
@@ -145,7 +145,7 @@ public class AlgoLocalClusteringCoefficient extends AbstractAlgoProcedure {
     for (int u = 0; u < n; u++) {
       // One node intersects its neighbour list against each of its neighbours', which is O(degree²) on a
       // supernode and O(m x sqrt(m)) over the graph - nothing but the graph sizes it (issue #6302). The CSR
-      // path below is checkpointed too (issue #6318), via the same guard, threaded into
+      // path (executeWithCSR, above) is checkpointed too (issue #6318), via the same guard, threaded into
       // GraphAlgorithms#localClusteringCoefficient as a WorkCheckpoint.
       guard.check();
       final int[] neighborsU = adj[u];

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -145,6 +145,11 @@ public class AlgoMST extends AbstractAlgoProcedure {
         ev[ec] = row[j];
         ew[ec] = rowWeights[j];
         ec++;
+        // Round 14 review: the old pass-2 fill loop this replaced checked in per edge (guard.checkPeriodically
+        // (edgeStep++)); this flattening copy is pure in-memory work with no DB touch, but it is still O(edges)
+        // over a count nothing bounds, so it keeps the same throttled checkpoint rather than being the one
+        // silent gap in an otherwise consistently-guarded pass.
+        guard.checkPeriodically(ec);
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -121,10 +121,11 @@ public class AlgoMST extends AbstractAlgoProcedure {
     // magnitude above the node count - and linear was never the criterion (issue #6300).
     //
     // 24 bytes per edge: the endpoints eu/ev and the weight ew, plus the two int arrays sortedIndexesByWeight
-    // works over (the order and the merge scratch). This reservation happens after weightedAdjacency has already
-    // materialised its own neighbour/weight arrays rather than ahead of a counting pass this procedure no longer
-    // runs itself - the same tradeoff algo.steinerTree already makes for the working sets it reserves around its
-    // own weightedAdjacency call.
+    // works over (the order and the merge scratch). weightedAdjacency's own neighbour/weight arrays are reserved
+    // incrementally as it builds them, not after the fact (issue #6714 review: routing MST/MSA onto the shared
+    // helper had silently dropped their #6300 edge-count protection, since weightedAdjacency reserved nothing of
+    // its own) - what is reserved here, after that call returns, is only this procedure's own flat eu/ev/ew
+    // arrays, which are additional to and smaller than what weightedAdjacency already gated.
     final MemoryBudget memory = graph.memory();
     memory.reserve(saturatingProduct(edgeCount, EDGE_BYTES), "the edge arrays", edgeCount + " edges");
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -19,10 +19,6 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.RID;
-import com.arcadedb.exception.RecordNotFoundException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -30,7 +26,6 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -101,96 +96,50 @@ public class AlgoMST extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final MemoryBudget memory = newMemoryBudget(db);
-    final List<Vertex> vertices = loadVertices(db, null, memory);
+    final GraphData graph = loadGraph(db, null, relTypes, context);
 
-    final int n = vertices.size();
+    final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
 
-    final Map<RID, Integer> ridToIdx = buildRidIndex(vertices);
+    // Edge collection and weight extraction now go through GraphData.weightedAdjacency (issue #6316), the same
+    // shared helper algo.steinerTree and algo.bellmanFord read weights through: neighbour and weight come off
+    // the same walk, so they cannot be mismatched the way #6301 found here independently of them. It also
+    // resolves via the CSR when a Graph Analytical View is ready, which the old hand-rolled getEdges() walk
+    // never did.
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProperty, relTypes);
+    final int[][] neighbors = weighted.neighbors();
+    final double[][] weights = weighted.weights();
+
+    int edgeCount = 0;
+    for (int i = 0; i < n; i++)
+      edgeCount += neighbors[i].length;
 
     // The working set here is sized by the EDGE count, which is the one dense shape #6263 did not price: its
     // criterion was "knob-sized or quadratic in the node count", and edge-linear reads like the graph paying for
     // itself. It is not small - the edge count is the largest linear dimension a graph has, usually an order of
-    // magnitude above the node count - and linear was never the criterion. What matters is whether the caller can
-    // predict a ceiling, and here there is none: 100M edges ask for ~2.4 GB with nothing between them and the
-    // allocator (issue #6300).
+    // magnitude above the node count - and linear was never the criterion (issue #6300).
     //
     // 24 bytes per edge: the endpoints eu/ev and the weight ew, plus the two int arrays sortedIndexesByWeight
-    // works over (the order and the merge scratch).
-    //
-    // The budget is consulted as pass 1 counts rather than once it is done. Both refuse the same calls, but a
-    // check afterwards first pays in full for a traversal it will throw away - the same argument that puts
-    // algo.steinerTree's reservation ahead of its adjacency build.
-    final long maxEdges = memory.capacityFor(EDGE_BYTES);
-
-    // Collect edges — two passes to allocate primitive arrays without reallocation. Ghost edges are
-    // skipped identically in both passes (same getEdges() order), so the pass-2 fill never exceeds the
-    // pass-1 count and the arrays are always sized correctly. This is safe because an edge record is
-    // only ever deleted, never resurrected, during a read query: a ghost in pass 1 is still a ghost in
-    // pass 2.
-    // Pass 1: count
-    int edgeCount = 0;
-    int edgeStep = 0;
-    for (int i = 0; i < n; i++) {
-      final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge e : edges) {
-        // Both passes deserialise every edge record of the graph, so each is O(V + E) of real work with nothing
-        // but the graph to bound it (issue #6302). Throttled by EDGE rather than by vertex: a near-star graph
-        // puts millions of edges inside a single vertex iteration, and a per-vertex checkpoint would leave that
-        // whole node unabortable - which is exactly the case the budget cannot catch when it is disabled.
-        guard.checkPeriodically(edgeStep++);
-        try {
-          if (ridToIdx.containsKey(e.getIn())) {
-            edgeCount++;
-            if (edgeCount > maxEdges)
-              // Over budget: reserve() is what refuses, so the message names the same component, figure and
-              // setting it would have named had the count finished first.
-              memory.reserve(saturatingProduct(edgeCount, EDGE_BYTES), "the edge arrays",
-                  "more than " + maxEdges + " edges");
-          }
-        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
-          GhostEdgeReporter.reportSkipped(rnf);
-        }
-      }
-    }
-    // Succeeds by construction - the loop above stopped the walk the moment the count passed what the budget
-    // allows - and is made anyway so the reservation is recorded against the call rather than only tested. What
-    // it costs is one comparison; what it buys is that `reserved` describes the heap this call actually holds,
-    // which is the invariant every other component priced here relies on.
+    // works over (the order and the merge scratch). This reservation happens after weightedAdjacency has already
+    // materialised its own neighbour/weight arrays rather than ahead of a counting pass this procedure no longer
+    // runs itself - the same tradeoff algo.steinerTree already makes for the working sets it reserves around its
+    // own weightedAdjacency call.
+    final MemoryBudget memory = graph.memory();
     memory.reserve(saturatingProduct(edgeCount, EDGE_BYTES), "the edge arrays", edgeCount + " edges");
 
-    // Pass 2: fill primitive arrays
     final int[]    eu = new int[edgeCount];
     final int[]    ev = new int[edgeCount];
     final double[] ew = new double[edgeCount];
     int ec = 0;
-    edgeStep = 0;
     for (int i = 0; i < n; i++) {
-      final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge e : edges) {
-        guard.checkPeriodically(edgeStep++);
-        try {
-          final Integer j = ridToIdx.get(e.getIn());
-          if (j == null)
-            continue;
-          eu[ec] = i;
-          ev[ec] = j;
-          if (weightProperty != null) {
-            final Object w = e.get(weightProperty);
-            ew[ec] = w instanceof Number num ? num.doubleValue() : 1.0;
-          } else {
-            ew[ec] = 1.0;
-          }
-          ec++;
-        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
-          GhostEdgeReporter.reportSkipped(rnf);
-        }
+      final int[] row = neighbors[i];
+      final double[] rowWeights = weights[i];
+      for (int j = 0; j < row.length; j++) {
+        eu[ec] = i;
+        ev[ec] = row[j];
+        ew[ec] = rowWeights[j];
+        ec++;
       }
     }
 
@@ -231,8 +180,8 @@ public class AlgoMST extends AbstractAlgoProcedure {
     final int finalSize = mstSize;
     return IntStream.range(0, finalSize).mapToObj(i -> {
       final ResultInternal r = new ResultInternal();
-      r.setProperty("source", vertices.get(mstU[i]).getIdentity());
-      r.setProperty("target", vertices.get(mstV[i]).getIdentity());
+      r.setProperty("source", graph.getRID(mstU[i]));
+      r.setProperty("target", graph.getRID(mstV[i]));
       r.setProperty("weight", mstW[i]);
       r.setProperty("totalWeight", finalTotal);
       return (Result) r;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -106,8 +106,12 @@ public class AlgoMST extends AbstractAlgoProcedure {
     // shared helper algo.steinerTree and algo.bellmanFord read weights through: neighbour and weight come off
     // the same walk, so they cannot be mismatched the way #6301 found here independently of them. It also
     // resolves via the CSR when a Graph Analytical View is ready, which the old hand-rolled getEdges() walk
-    // never did.
-    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProperty, relTypes);
+    // never did. A blank weightProperty is normalised to null first (matching algo.maxFlow's capacityProperty
+    // handling), so both mean "no property, every edge weighs 1.0" - otherwise a blank string would still take
+    // the record-backed fallback in weightedAdjacency instead of the CSR path even when a view is ready, since
+    // weightedAdjacency only special-cases a null weightProperty, not an empty one (PR #6714 review round 12).
+    final String weightProp = weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null;
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProp, relTypes);
     final int[][] neighbors = weighted.neighbors();
     final double[][] weights = weighted.weights();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -109,7 +109,7 @@ public class AlgoMST extends AbstractAlgoProcedure {
     // never did. A blank weightProperty is normalised to null first (matching algo.maxFlow's capacityProperty
     // handling), so both mean "no property, every edge weighs 1.0" - otherwise a blank string would still take
     // the record-backed fallback in weightedAdjacency instead of the CSR path even when a view is ready, since
-    // weightedAdjacency only special-cases a null weightProperty, not an empty one (PR #6714 review round 12).
+    // weightedAdjacency only special-cases a null weightProperty, not an empty one.
     final String weightProp = weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null;
     final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProp, relTypes);
     final int[][] neighbors = weighted.neighbors();
@@ -126,10 +126,9 @@ public class AlgoMST extends AbstractAlgoProcedure {
     //
     // 24 bytes per edge: the endpoints eu/ev and the weight ew, plus the two int arrays sortedIndexesByWeight
     // works over (the order and the merge scratch). weightedAdjacency's own neighbour/weight arrays are reserved
-    // incrementally as it builds them, not after the fact (issue #6714 review: routing MST/MSA onto the shared
-    // helper had silently dropped their #6300 edge-count protection, since weightedAdjacency reserved nothing of
-    // its own) - what is reserved here, after that call returns, is only this procedure's own flat eu/ev/ew
-    // arrays, which are additional to and smaller than what weightedAdjacency already gated.
+    // incrementally as it builds them, not after the fact - what is reserved here, after that call returns, is
+    // only this procedure's own flat eu/ev/ew arrays, which are additional to and smaller than what
+    // weightedAdjacency already gates.
     final MemoryBudget memory = graph.memory();
     memory.reserve(saturatingProduct(edgeCount, EDGE_BYTES), "the edge arrays", edgeCount + " edges");
 
@@ -145,10 +144,10 @@ public class AlgoMST extends AbstractAlgoProcedure {
         ev[ec] = row[j];
         ew[ec] = rowWeights[j];
         ec++;
-        // Round 14 review: the old pass-2 fill loop this replaced checked in per edge (guard.checkPeriodically
-        // (edgeStep++)); this flattening copy is pure in-memory work with no DB touch, but it is still O(edges)
-        // over a count nothing bounds, so it keeps the same throttled checkpoint rather than being the one
-        // silent gap in an otherwise consistently-guarded pass.
+        // The old pass-2 fill loop this replaced checked in per edge (guard.checkPeriodically(edgeStep++)); this
+        // flattening copy is pure in-memory work with no DB touch, but it is still O(edges) over a count
+        // nothing bounds, so it keeps the same throttled checkpoint rather than being the one silent gap in an
+        // otherwise consistently-guarded pass.
         guard.checkPeriodically(ec);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
@@ -19,10 +19,6 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.RID;
-import com.arcadedb.exception.RecordNotFoundException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -31,7 +27,6 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -92,51 +87,44 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final MemoryBudget memory = newMemoryBudget(db);
-    final List<Vertex> vertices = loadVertices(db, null, memory);
+    final GraphData graph = loadGraph(db, null, relTypes, context);
 
-    final int n = vertices.size();
+    final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
 
-    final Map<RID, Integer> ridToIdx = buildRidIndex(vertices);
-
-    final Integer srcIdx = ridToIdx.get(sourceNode.getIdentity());
-    final Integer snkIdx = ridToIdx.get(sinkNode.getIdentity());
-    if (srcIdx == null || snkIdx == null)
+    final int srcIdx = graph.indexOf(sourceNode.getIdentity());
+    final int snkIdx = graph.indexOf(sinkNode.getIdentity());
+    if (srcIdx < 0 || snkIdx < 0)
       return Stream.empty();
 
     // Edmonds-Karp keeps a dense capacity matrix and a dense residual matrix, both nodeCount x nodeCount and
     // both alive to the end: 1.6 GB at 10 000 nodes, with no knob involved. Reserved before the first is
     // allocated so that a graph too large for the dense formulation is a client error naming the node count and
     // the budget, rather than an OutOfMemoryError.
+    final MemoryBudget memory = graph.memory();
     memory.reserve(saturatingProduct(2L, matrixBytes(n, n, DOUBLE_BYTES)),
         "the capacity and residual matrices", "2 matrices of " + n + " x " + n + " nodes");
 
-    // Build capacity matrix as n×n array
-    final double[][] capacity = new double[n][n];
+    // Build capacity matrix as n×n array. Capacity extraction goes through GraphData.weightedAdjacency (issue
+    // #6316), the same shared helper the other weighted algo.* procedures read edge weights through, rather
+    // than a hand-rolled getEdges() walk. A blank capacityProperty is normalised to null first so both mean
+    // "no property, every edge has capacity 1.0" exactly as before.
+    final String capacityProp = capacityProperty != null && !capacityProperty.isEmpty() ? capacityProperty : null;
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, capacityProp, relTypes);
+    final int[][] neighbors = weighted.neighbors();
+    final double[][] weights = weighted.weights();
 
+    final double[][] capacity = new double[n][n];
     for (int i = 0; i < n; i++) {
-      final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge e : edges) {
-        try {
-          final Integer j = ridToIdx.get(e.getIn());
-          if (j == null)
-            continue;
-          double cap = 1.0;
-          if (capacityProperty != null && !capacityProperty.isEmpty()) {
-            final Object w = e.get(capacityProperty);
-            if (w instanceof Number num)
-              cap = num.doubleValue();
-          }
-          capacity[i][j] += cap;
-          // For undirected: also add reverse capacity
-          capacity[j][i] += cap;
-        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
-          GhostEdgeReporter.reportSkipped(rnf);
-        }
+      final int[] row = neighbors[i];
+      final double[] rowWeights = weights[i];
+      for (int k = 0; k < row.length; k++) {
+        final int j = row[k];
+        final double cap = rowWeights[k];
+        capacity[i][j] += cap;
+        // For undirected: also add reverse capacity
+        capacity[j][i] += cap;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -55,6 +55,15 @@ import java.util.stream.Stream;
  */
 public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
 
+  /**
+   * Heap this procedure spends per edge for its own flat {@code eFrom}/{@code eTo}/{@code eW} copy, on top of
+   * whatever {@code weightedAdjacency} already reserved for its own {@code int[][]}/{@code double[][]} pair
+   * (issue #6714 review: this procedure allocated that copy with no reservation of its own at all, unlike
+   * {@code algo.mst}'s equivalent {@code eu}/{@code ev}/{@code ew} arrays - no sort scratch here, since Edmonds'
+   * algorithm has no Kruskal-style weight ordering to allocate for).
+   */
+  private static final long EDGE_BYTES = 2 * INT_BYTES + DOUBLE_BYTES;
+
   @Override
   public String getName() {
     return "algo.msa";
@@ -110,6 +119,11 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     int edgeCount = 0;
     for (int i = 0; i < n; i++)
       edgeCount += neighbors[i].length;
+
+    // This procedure's own flat copy of the edges, priced separately from what weightedAdjacency already
+    // reserved for its int[][]/double[][] pair - the same "additional to and smaller than" accounting algo.mst
+    // uses for its equivalent eu/ev/ew arrays.
+    graph.memory().reserve(saturatingProduct(edgeCount, EDGE_BYTES), "the edge arrays", edgeCount + " edges");
 
     final int[] eFrom = new int[edgeCount];
     final int[] eTo = new int[edgeCount];

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -114,7 +114,7 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     // getEdges() walk. OUT direction = directed edges, matching the arborescence semantics. A blank
     // weightProperty is normalised to null first (matching algo.maxFlow's capacityProperty handling), so a
     // blank string does not avoidably fall onto weightedAdjacency's record-backed fallback instead of the CSR
-    // path when a view is ready (PR #6714 review round 12).
+    // path when a view is ready.
     final String weightProp = weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null;
     final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProp, relTypes);
     final int[][] neighbors = weighted.neighbors();
@@ -141,8 +141,8 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
         eTo[ec] = row[j];
         eW[ec] = rowWeights[j];
         ec++;
-        // Round 14 review: same throttled checkpoint as algo.mst's equivalent flattening copy - pure in-memory
-        // work, but still O(edges) over a count nothing bounds.
+        // Same throttled checkpoint as algo.mst's equivalent flattening copy - pure in-memory work, but still
+        // O(edges) over a count nothing bounds.
         guard.checkPeriodically(ec);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -111,8 +111,12 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
 
     // Edge collection and weight extraction go through GraphData.weightedAdjacency (issue #6316), the same
     // shared helper algo.steinerTree and algo.mst read weights through, rather than a hand-rolled two-pass
-    // getEdges() walk. OUT direction = directed edges, matching the arborescence semantics.
-    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProperty, relTypes);
+    // getEdges() walk. OUT direction = directed edges, matching the arborescence semantics. A blank
+    // weightProperty is normalised to null first (matching algo.maxFlow's capacityProperty handling), so a
+    // blank string does not avoidably fall onto weightedAdjacency's record-backed fallback instead of the CSR
+    // path when a view is ready (PR #6714 review round 12).
+    final String weightProp = weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null;
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProp, relTypes);
     final int[][] neighbors = weighted.neighbors();
     final double[][] weights = weighted.weights();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -141,6 +141,9 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
         eTo[ec] = row[j];
         eW[ec] = rowWeights[j];
         ec++;
+        // Round 14 review: same throttled checkpoint as algo.mst's equivalent flattening copy - pure in-memory
+        // work, but still O(edges) over a count nothing bounds.
+        guard.checkPeriodically(ec);
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -19,10 +19,6 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.RID;
-import com.arcadedb.exception.RecordNotFoundException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -32,7 +28,6 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -96,64 +91,38 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
-    final int n = vertices.size();
+    final GraphData graph = loadGraph(db, null, relTypes, context);
+    final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
 
-    final Map<RID, Integer> ridToIdx = buildRidIndex(vertices);
-    final Integer rootIdxObj = ridToIdx.get(root.getIdentity());
-    if (rootIdxObj == null)
+    final int rootIdx = graph.indexOf(root.getIdentity());
+    if (rootIdx < 0)
       return Stream.empty();
-    final int rootIdx = rootIdxObj;
 
-    // Collect all directed edges as primitive arrays (two-pass, OUT direction = directed edges). Ghost
-    // edges are skipped identically in both passes, so the pass-2 fill never exceeds the pass-1 count and
-    // the arrays are always sized correctly. This rests on two read-query invariants: (1) an edge record is
-    // only ever deleted, never resurrected, so a pass-1 ghost is still a ghost in pass 2; (2) the two
-    // getEdges() calls per vertex iterate the same edges in the same order, so counting and filling agree.
-    // Pass 1: count
+    // Edge collection and weight extraction go through GraphData.weightedAdjacency (issue #6316), the same
+    // shared helper algo.steinerTree and algo.mst read weights through, rather than a hand-rolled two-pass
+    // getEdges() walk. OUT direction = directed edges, matching the arborescence semantics.
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProperty, relTypes);
+    final int[][] neighbors = weighted.neighbors();
+    final double[][] weights = weighted.weights();
+
     int edgeCount = 0;
-    for (int i = 0; i < n; i++) {
-      final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge e : edges) {
-        try {
-          if (ridToIdx.containsKey(e.getIn()))
-            edgeCount++;
-        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
-          GhostEdgeReporter.reportSkipped(rnf);
-        }
-      }
-    }
+    for (int i = 0; i < n; i++)
+      edgeCount += neighbors[i].length;
 
-    // Pass 2: fill
     final int[] eFrom = new int[edgeCount];
     final int[] eTo = new int[edgeCount];
     final double[] eW = new double[edgeCount];
     int ec = 0;
     for (int i = 0; i < n; i++) {
-      final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
-          vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge e : edges) {
-        try {
-          final Integer j = ridToIdx.get(e.getIn());
-          if (j == null)
-            continue;
-          eFrom[ec] = i;
-          eTo[ec] = j;
-          if (weightProperty != null) {
-            final Object w = e.get(weightProperty);
-            eW[ec] = w instanceof Number num ? num.doubleValue() : 1.0;
-          } else {
-            eW[ec] = 1.0;
-          }
-          ec++;
-        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
-          GhostEdgeReporter.reportSkipped(rnf);
-        }
+      final int[] row = neighbors[i];
+      final double[] rowWeights = weights[i];
+      for (int j = 0; j < row.length; j++) {
+        eFrom[ec] = i;
+        eTo[ec] = row[j];
+        eW[ec] = rowWeights[j];
+        ec++;
       }
     }
 
@@ -170,8 +139,8 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     final List<Result> results = new ArrayList<>(msaEdges.length);
     for (final int ei : msaEdges) {
       final ResultInternal r = new ResultInternal();
-      r.setProperty("source", vertices.get(eFrom[ei]).getIdentity());
-      r.setProperty("target", vertices.get(eTo[ei]).getIdentity());
+      r.setProperty("source", graph.getRID(eFrom[ei]));
+      r.setProperty("target", graph.getRID(eTo[ei]));
       r.setProperty("weight", eW[ei]);
       r.setProperty("totalWeight", totalWeight);
       results.add(r);

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue5414LastPointTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue5414LastPointTest.java
@@ -368,14 +368,21 @@ class Issue5414LastPointTest extends TestHelper {
   }
 
   @Test
-  void descendingScanOnAnEmptySeriesReturnsNothing() {
+  void descendingScanOnAnEmptySeriesReturnsNoOrNullRows() {
     database.command("sql", "CREATE TIMESERIES TYPE Empty TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE)");
 
     assertThat(query("SELECT ts FROM Empty WHERE host = 'a' ORDER BY ts DESC LIMIT 1")).isEmpty();
 
-    // Same as any other aggregate over an empty time series: no row at all.
-    assertThat(query("SELECT avg(value) AS v FROM Empty WHERE host = 'a'")).isEmpty();
-    assertThat(query("SELECT ts.last(value, ts) AS v FROM Empty WHERE host = 'a'")).isEmpty();
+    // A no-GROUP-BY aggregate over an empty input always returns exactly one row with a null value
+    // (issue #6680), same as SELECT avg(x) FROM AnyEmptyType. ts.last() is itself an aggregate
+    // function (SQLFunctionTsLast extends SQLAggregatedFunction), so it follows the same rule.
+    final List<Result> avg = query("SELECT avg(value) AS v FROM Empty WHERE host = 'a'");
+    assertThat(avg).hasSize(1);
+    assertThat(avg.getFirst().<Object>getProperty("v")).isNull();
+
+    final List<Result> last = query("SELECT ts.last(value, ts) AS v FROM Empty WHERE host = 'a'");
+    assertThat(last).hasSize(1);
+    assertThat(last.getFirst().<Object>getProperty("v")).isNull();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionSumAverageMultiArgTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionSumAverageMultiArgTest.java
@@ -155,8 +155,11 @@ class SQLFunctionSumAverageMultiArgTest {
         assertThat(((Number) rs.next().getProperty("s")).doubleValue()).isEqualTo(1.5);
       }
 
-      // EMPTY GROUP RETURNS NO ROW (NO DIVISION BY ZERO)
+      // EMPTY GROUP RETURNS ONE ROW WITH A NULL AVERAGE (NO DIVISION BY ZERO), consistent with any other
+      // no-GROUP-BY aggregate over an empty input (issue #6680) rather than zero rows.
       try (final ResultSet rs = db.query("sql", "SELECT avg(a) AS s FROM Nums WHERE a > 1000")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Object>getProperty("s")).isNull();
         assertThat(rs.hasNext()).isFalse();
       }
     });

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6318ParallelForRangeCheckpointedTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6318ParallelForRangeCheckpointedTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6318 - {@code GraphAlgorithms.localClusteringCoefficient}'s CSR path had no
+ * checkpoint of its own to give it the abortability the OLTP path already had, because its two parallel phases
+ * had no per-iteration boundary the way {@code pageRank}/{@code labelPropagation} do to hang one on.
+ * {@code parallelForRangeCheckpointed} is the fix: it splits a range into batches and calls the checkpoint
+ * between them, on the calling thread, the same contract {@link WorkCheckpoint#check()} documents.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6318ParallelForRangeCheckpointedTest {
+
+  @Test
+  void everyIndexInTheRangeIsVisitedExactlyOnce() {
+    for (final int n : new int[] { 0, 1, 100, 8192, 20_000, 100_000 }) {
+      final AtomicIntegerArray hits = new AtomicIntegerArray(Math.max(n, 1));
+      GraphAlgorithms.parallelForRangeCheckpointed(n, WorkCheckpoint.NONE, (start, end) -> {
+        for (int i = start; i < end; i++)
+          hits.incrementAndGet(i);
+      });
+      for (int i = 0; i < n; i++)
+        assertThat(hits.get(i)).as("index " + i + " for n=" + n).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void aSmallRangeChecksInExactlyOnce() {
+    final AtomicInteger checkpointCalls = new AtomicInteger();
+    GraphAlgorithms.parallelForRangeCheckpointed(10, checkpointCalls::incrementAndGet, (s, e) -> {
+    });
+    assertThat(checkpointCalls.get())
+        .as("a range too small to parallelise must still check in once, like a plain parallelForRange call would")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void aLargeRangeChecksInMoreThanOnce() {
+    final AtomicInteger checkpointCalls = new AtomicInteger();
+    GraphAlgorithms.parallelForRangeCheckpointed(200_000, checkpointCalls::incrementAndGet, (s, e) -> {
+    });
+    assertThat(checkpointCalls.get())
+        .as("a large range must be split into more than one batch, or the CSR LCC path this backs is exactly as "
+            + "unabortable mid-pass as it was before issue #6318")
+        .isGreaterThan(1);
+  }
+
+  @Test
+  void aThrowingCheckpointAbortsBeforeLaterBatchesRun() {
+    // Fires on the 3rd call: the first batch's work must have already run (checkpoint.check() happens before a
+    // batch's work in the loop, so batch 1 and 2 run, batch 3 is where the throw happens before its own work).
+    final AtomicInteger calls = new AtomicInteger();
+    final int n = 200_000;
+    final AtomicInteger processed = new AtomicInteger();
+
+    final WorkCheckpoint checkpoint = () -> {
+      if (calls.incrementAndGet() == 3)
+        throw new IllegalStateException("aborted for the test");
+    };
+
+    assertThatThrownBy(() -> GraphAlgorithms.parallelForRangeCheckpointed(n, checkpoint, (s, e) -> processed.addAndGet(e - s)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("aborted for the test");
+
+    assertThat(calls.get()).as("must not keep checking in after the throw").isEqualTo(3);
+    assertThat(processed.get())
+        .as("batches after the one that threw must never run their work")
+        .isLessThan(n);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6318ParallelForRangeCheckpointedTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6318ParallelForRangeCheckpointedTest.java
@@ -18,6 +18,9 @@
  */
 package com.arcadedb.graph.olap;
 
+import com.arcadedb.utility.StallAwareStopwatch;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,5 +95,66 @@ class Issue6318ParallelForRangeCheckpointedTest {
     assertThat(processed.get())
         .as("batches after the one that threw must never run their work")
         .isLessThan(n);
+  }
+
+  /**
+   * Code review counterweight for issue #6318 (PR #6714): splitting a range into up to {@code CHECKPOINT_BATCHES}
+   * batches means up to that many separate {@link GraphAlgorithms#parallelForRange} dispatches - each with its
+   * own thread-pool submission round-trip - where {@code pageRank}/{@code labelPropagation}'s hot parallel phases
+   * used to issue exactly one. This measures that the added dispatch overhead stays small relative to a
+   * pageRank-shaped amount of per-node work (a handful of flops over a small fixed-size neighbour array, not a
+   * bare store - a trivial per-node body would be dispatch-dominated and overstate the overhead in a way real
+   * kernels never see), rather than asserting it from the shape of the code alone.
+   * <p>
+   * {@link StallAwareStopwatch#effectiveMs()} discounts JVM-wide stalls from each of the two measurements before
+   * they are compared, so the ratio is not a raw wall-clock reading (#6260) - a shared stop-the-world pause moves
+   * both sides together and the ratio is unaffected either way.
+   */
+  @Test
+  @Tag("benchmark")
+  void checkpointedBatchingOverheadIsSmallRelativeToPageRankShapedWork() {
+    final int n = 2_000_000;
+    final int neighborsPerNode = 4;
+    final double[] contrib = new double[n];
+    final double[] next = new double[n];
+    for (int i = 0; i < n; i++)
+      contrib[i] = 1.0 / (i + 1);
+
+    // A stand-in for pageRank's pull phase: each node sums a small fixed number of neighbours' contributions,
+    // the same order of magnitude of work per node as the real kernel does.
+    final java.util.function.BiConsumer<Integer, Integer> pageRankShapedWork = (start, end) -> {
+      for (int u = start; u < end; u++) {
+        double sum = 0.0;
+        for (int k = 0; k < neighborsPerNode; k++)
+          sum += contrib[(u + k * 7919) % n];
+        next[u] = 0.15 + 0.85 * sum;
+      }
+    };
+
+    // Warm up the JIT for both call shapes before any measurement is taken.
+    for (int i = 0; i < 3; i++) {
+      GraphAlgorithms.parallelForRange(n, pageRankShapedWork);
+      GraphAlgorithms.parallelForRangeCheckpointed(n, WorkCheckpoint.NONE, pageRankShapedWork);
+    }
+
+    long plainMs = Long.MAX_VALUE;
+    long checkpointedMs = Long.MAX_VALUE;
+    for (int round = 0; round < 3; round++) {
+      final StallAwareStopwatch plainWatch = StallAwareStopwatch.start();
+      GraphAlgorithms.parallelForRange(n, pageRankShapedWork);
+      plainMs = Math.min(plainMs, plainWatch.effectiveMs());
+
+      final StallAwareStopwatch checkpointedWatch = StallAwareStopwatch.start();
+      GraphAlgorithms.parallelForRangeCheckpointed(n, WorkCheckpoint.NONE, pageRankShapedWork);
+      checkpointedMs = Math.min(checkpointedMs, checkpointedWatch.effectiveMs());
+    }
+
+    // Generous on purpose - the point separated is "a handful of extra thread-pool round-trips" from "something
+    // pathological", not a tight throughput budget. 50ms floors the comparison so two sub-millisecond, noise-
+    // dominated readings cannot fail this by chance.
+    assertThat(checkpointedMs)
+        .as("up to CHECKPOINT_BATCHES=16 dispatches instead of 1 must not multiply wall-clock time on "
+            + "pageRank-shaped work (best-of-3: unbatched=" + plainMs + "ms, batched=" + checkpointedMs + "ms)")
+        .isLessThan(Math.max(50L, plainMs * 3));
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6318ParallelForRangeCheckpointedTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6318ParallelForRangeCheckpointedTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -51,6 +52,20 @@ class Issue6318ParallelForRangeCheckpointedTest {
       for (int i = 0; i < n; i++)
         assertThat(hits.get(i)).as("index " + i + " for n=" + n).isEqualTo(1);
     }
+  }
+
+  @Test
+  void aZeroLengthRangeNeverChecksIn() {
+    // PR #6714 review round 11: documented in the javadoc as the one exception to "checks in at least once",
+    // but not previously pinned by a test - the batch loop's condition (start < n) is false immediately for
+    // n == 0, so the loop body (and therefore checkpoint.check()) never runs at all.
+    final AtomicInteger checkpointCalls = new AtomicInteger();
+    GraphAlgorithms.parallelForRangeCheckpointed(0, checkpointCalls::incrementAndGet, (s, e) -> {
+    });
+    assertThat(checkpointCalls.get())
+        .as("n == 0 has no batch to run, so the checkpoint is never consulted - harmless only because every "
+            + "current caller already returns before reaching a checkpointed loop on an empty graph")
+        .isZero();
   }
 
   @Test
@@ -122,7 +137,7 @@ class Issue6318ParallelForRangeCheckpointedTest {
 
     // A stand-in for pageRank's pull phase: each node sums a small fixed number of neighbours' contributions,
     // the same order of magnitude of work per node as the real kernel does.
-    final java.util.function.BiConsumer<Integer, Integer> pageRankShapedWork = (start, end) -> {
+    final BiConsumer<Integer, Integer> pageRankShapedWork = (start, end) -> {
       for (int u = start; u < end; u++) {
         double sum = 0.0;
         for (int k = 0; k < neighborsPerNode; k++)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6264AlgoIterationKnobGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6264AlgoIterationKnobGuardTest.java
@@ -317,17 +317,25 @@ class Issue6264AlgoIterationKnobGuardTest {
    * {@code algo.pageRank} hands a CSR-backed graph straight to {@link GraphAlgorithms#pageRank}, which lives below
    * the query layer and knew nothing about deadlines. That kernel has no convergence test at all, so it always ran
    * the full {@code maxIterations}: the knob alone decided when it stopped, and nothing could interrupt it.
+   * <p>
+   * Since issue #6318 threaded {@code parallelForRangeCheckpointed} through pageRank's parallel phases (contrib,
+   * pull, and dangling-node redistribution when the graph has dangling nodes), the checkpoint is called more than
+   * once per iteration: the original once-per-iteration call at the top of the loop, plus one more per parallel
+   * phase actually run - more still on a graph large enough for a phase to split into several batches. This
+   * fixture is a directed cycle with no dangling nodes, so the dangling phase never runs and every iteration
+   * checks in exactly 3 times: the loop-top call, then contrib, then pull.
    */
   @Test
-  void thePageRankKernelCallsTheCheckpointOncePerIteration() {
+  void thePageRankKernelCallsTheCheckpointAtLeastOncePerParallelPhaseEachIteration() {
     final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
         .withVertexTypes("Node").withEdgeTypes("LINK").build();
 
     final AtomicInteger calls = new AtomicInteger();
     GraphAlgorithms.pageRank(gav, 0.85, 7, Vertex.DIRECTION.OUT, calls::incrementAndGet, "LINK");
 
-    assertThat(calls.get()).as("one checkpoint per power iteration bounds abort latency by one graph sweep")
-        .isEqualTo(7);
+    assertThat(calls.get())
+        .as("loop-top call + contrib phase + pull phase (no dangling nodes on this cycle), x 7 iterations")
+        .isEqualTo(3 * 7);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6265InfluenceMaximizationBufferReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6265InfluenceMaximizationBufferReuseTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.Result;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression tests for issue #6265 - {@code algo.influenceMaximization}'s {@code simulateIC} used to allocate
+ * and zero-fill a {@code boolean[nodeCount]} and an {@code int[nodeCount]} on every one of its
+ * {@code k x nodeCount x simulations} calls. Both buffers are now hoisted to the caller and reused across every
+ * call, with {@code simulateIC} resetting only the entries it touched (recorded in {@code queue[0..tail)})
+ * instead of reallocating.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6265InfluenceMaximizationBufferReuseTest {
+  private Database database;
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  // ── 1. Correctness: reused buffers must not leak activation state across calls ──────────────
+
+  /**
+   * A hub-and-spoke graph (H -> L1, H -> L2, H -> L3) with {@code propagationProbability = 1.0}, so every
+   * cascade is fully deterministic: whichever node(s) a simulation starts from, the reachable set is exactly
+   * what BFS from those nodes finds, with no randomness involved.
+   * <p>
+   * This is the shape that catches a broken reset: {@code simulateIC}'s very first call (candidate H in round
+   * 1) activates all four nodes. If the shared {@code activated}/{@code queue} buffers were not cleared back to
+   * their touched entries afterward, every following call would see H (and every other previously-visited node)
+   * as already activated and skip re-adding it to the queue - silently undercounting every simulation after the
+   * first, and producing a negative marginal gain in round 2 instead of the correct zero (the graph is already
+   * fully covered by H alone, so adding any second seed contributes nothing).
+   */
+  @Test
+  void reusedBuffersDoNotLeakActivationStateBetweenSimulations() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6265-buffer-reuse");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final MutableVertex h = database.newVertex("Node").set("name", "H").save();
+      final MutableVertex l1 = database.newVertex("Node").set("name", "L1").save();
+      final MutableVertex l2 = database.newVertex("Node").set("name", "L2").save();
+      final MutableVertex l3 = database.newVertex("Node").set("name", "L3").save();
+      h.newEdge("LINK", l1, true, (Object[]) null).save();
+      h.newEdge("LINK", l2, true, (Object[]) null).save();
+      h.newEdge("LINK", l3, true, (Object[]) null).save();
+    });
+
+    // k = 4 (all nodes), a single simulation per candidate (p = 1.0 makes every cascade deterministic, so
+    // more simulations would only repeat the same outcome), and propagationProbability = 1.0.
+    final List<Result> rows = drain(influenceMaximization(4, "LINK", 1, 1.0));
+    assertThat(rows).hasSize(4);
+
+    // Round 1 must pick the hub: it is the only node whose cascade reaches all four nodes.
+    assertThat(rows.getFirst().<Object>getProperty("nodeId").toString()).contains(vertexRid("H"));
+    assertThat(rows.getFirst().<Number>getProperty("marginalGain").doubleValue()).isEqualTo(4.0);
+
+    // Every following round adds a leaf to an already-fully-covered graph: the correct marginal gain is 0,
+    // never negative. A leaked `activated` bit from an earlier call would undercount the cascade and drive
+    // this negative instead.
+    for (int i = 1; i < rows.size(); i++)
+      assertThat(rows.get(i).<Number>getProperty("marginalGain").doubleValue())
+          .as("round " + (i + 1) + " marginal gain must not be negative")
+          .isEqualTo(0.0);
+  }
+
+  private String vertexRid(final String name) {
+    return database.query("sql", "SELECT FROM Node WHERE name = ?", name).next().getElement().orElseThrow().getIdentity().toString();
+  }
+
+  // ── 2. Allocation: no more per-simulation churn ──────────────────────────────────────────────
+
+  private static final int CHAIN_NODES = 300;
+  private static final int SIMULATIONS = 300;
+
+  private void openChainDatabase() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6265-allocation");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      MutableVertex previous = null;
+      for (int i = 0; i < CHAIN_NODES; i++) {
+        final MutableVertex v = database.newVertex("Node").set("name", "A" + i).save();
+        if (previous != null)
+          previous.newEdge("LINK", v, true, (Object[]) null).save();
+        previous = v;
+      }
+    });
+  }
+
+  @Test
+  @Tag("performance")
+  void simulateICNoLongerAllocatesPerCall() {
+    // Measured on the thread's own allocation counter, which no GC and no other test can move.
+    //
+    // k = 1 evaluates every one of the ~299 non-seed candidates, each run through 300 simulations: ~89,700
+    // simulateIC calls. Before this fix each call allocated a boolean[300] (~324 bytes with header/padding)
+    // plus an int[300] (~1216 bytes) - about 1500 bytes/call, ~134 MB total for this one procedure call. Now
+    // both buffers are allocated once for the whole call and simulateIC only flips bits it already touched, so
+    // the bound below (1% of the old per-call estimate) separates "reused" from "reallocated every call" by
+    // two orders of magnitude while leaving headroom for the rest of the procedure's one-time allocations
+    // (adjacency lists, Result objects, boxed doubles for k=1 round's single output row).
+    final com.sun.management.ThreadMXBean threads = threadAllocationBean();
+    assumeTrue(threads != null, "JVM does not expose per-thread allocation counters");
+
+    openChainDatabase();
+
+    // Warm up so class loading / JIT compilation is not attributed to the measured call.
+    for (int i = 0; i < 2; i++)
+      assertThat(drain(influenceMaximization(1, "LINK", SIMULATIONS, 0.1))).isNotEmpty();
+
+    final long oldPerCallEstimate = 1500L * (long) (CHAIN_NODES - 1) * SIMULATIONS;
+    final long allocated = measure(threads, () -> assertThat(drain(influenceMaximization(1, "LINK", SIMULATIONS, 0.1))).isNotEmpty());
+
+    assertThat(allocated)
+        .as("a boolean[n]+int[n] pair per simulateIC call is what this bound separates from buffers reused "
+            + "across the whole procedure call (allocated=" + allocated + " bytes, old per-call estimate=" + oldPerCallEstimate + " bytes)")
+        .isLessThan(oldPerCallEstimate / 100);
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private Stream<Result> influenceMaximization(final int k, final String relTypes, final int simulations, final double p) {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    return new AlgoInfluenceMaximization().execute(new Object[] { k, relTypes, simulations, p }, null, context);
+  }
+
+  private static List<Result> drain(final Stream<Result> rows) {
+    final List<Result> results = new ArrayList<>();
+    for (final Iterator<Result> it = rows.iterator(); it.hasNext(); )
+      results.add(it.next());
+    return results;
+  }
+
+  private static long measure(final com.sun.management.ThreadMXBean threads, final Runnable body) {
+    final long id = Thread.currentThread().threadId();
+    final long before = threads.getThreadAllocatedBytes(id);
+    body.run();
+    return threads.getThreadAllocatedBytes(id) - before;
+  }
+
+  private static com.sun.management.ThreadMXBean threadAllocationBean() {
+    if (!(ManagementFactory.getThreadMXBean() instanceof final com.sun.management.ThreadMXBean bean))
+      return null;
+    if (!bean.isThreadAllocatedMemorySupported())
+      return null;
+    bean.setThreadAllocatedMemoryEnabled(true);
+    return bean.isThreadAllocatedMemoryEnabled() ? bean : null;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6265InfluenceMaximizationBufferReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6265InfluenceMaximizationBufferReuseTest.java
@@ -146,9 +146,15 @@ class Issue6265InfluenceMaximizationBufferReuseTest {
     // simulateIC calls. Before this fix each call allocated a boolean[300] (~324 bytes with header/padding)
     // plus an int[300] (~1216 bytes) - about 1500 bytes/call, ~134 MB total for this one procedure call. Now
     // both buffers are allocated once for the whole call and simulateIC only flips bits it already touched, so
-    // the bound below (1% of the old per-call estimate) separates "reused" from "reallocated every call" by
-    // two orders of magnitude while leaving headroom for the rest of the procedure's one-time allocations
-    // (adjacency lists, Result objects, boxed doubles for k=1 round's single output row).
+    // the bound below separates "reused" from "reallocated every call" by close to two orders of magnitude
+    // while leaving headroom for the rest of the procedure's one-time allocations (adjacency lists, Result
+    // objects, boxed doubles for k=1 round's single output row).
+    //
+    // PR #6714 review: a 1% bound (1,345,500 bytes) passed locally across repeated runs but failed once in CI
+    // at 1,443,080 bytes - about 7% over, still ~93x below the ~134MB unfixed-behaviour baseline it exists to
+    // catch. The one-time overhead this measures is not itself bounded by anything the fix controls (JIT/JVM
+    // allocation noise on the CI runner's shared hardware, not GC - the thread-local counter is immune to
+    // that), so 5% keeps ~20x separation from the pathological case while absorbing that margin.
     final com.sun.management.ThreadMXBean threads = threadAllocationBean();
     assumeTrue(threads != null, "JVM does not expose per-thread allocation counters");
 
@@ -164,7 +170,7 @@ class Issue6265InfluenceMaximizationBufferReuseTest {
     assertThat(allocated)
         .as("a boolean[n]+int[n] pair per simulateIC call is what this bound separates from buffers reused "
             + "across the whole procedure call (allocated=" + allocated + " bytes, old per-call estimate=" + oldPerCallEstimate + " bytes)")
-        .isLessThan(oldPerCallEstimate / 100);
+        .isLessThan(oldPerCallEstimate / 20);
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSAEdgeBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSAEdgeBudgetTest.java
@@ -22,7 +22,12 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,7 +63,11 @@ class Issue6300AlgoMSAEdgeBudgetTest {
       factory.open().drop();
     database = factory.create();
     database.getSchema().createVertexType("Node");
-    database.getSchema().createEdgeType("LINK");
+    // Declared so a Graph Analytical View can materialise "w" as an edge property column (Issue6301's setup
+    // note: without a schema-known property the view falls back to edge records, which would leave the
+    // columnar reservation path - weightedAdjacencyFromColumns - untested by
+    // theWeightedAdjacencyRowHeadersAreRefusedOnTheCSRColumnarPathToo).
+    database.getSchema().createEdgeType("LINK").createProperty("w", Type.DOUBLE);
 
     // A directed chain of EDGE_COUNT + 1 nodes rooted at node 0: every non-root vertex has exactly one incoming
     // edge, so the arborescence is the whole chain and no edge is redundant.
@@ -96,6 +105,53 @@ class Issue6300AlgoMSAEdgeBudgetTest {
         .hasStackTraceContaining("algo.msa(): the edge arrays would need")
         .hasStackTraceContaining(EDGE_COUNT + " edges")
         .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+  }
+
+  /**
+   * PR #6714 review round 13: the tests around this one only exercise {@code weightedAdjacencyFromRecords}
+   * (the OLTP fallback) since no Graph Analytical View is built - {@code weightedAdjacencyFromColumns}, the
+   * path actually used once a view is ready, was never exercised by a budget-refusal test on the {@code
+   * algo.msa} side either (see {@code Issue6300AlgoMSTEdgeBudgetTest#theWeightedAdjacencyRowHeadersAreRefusedOnTheCSRColumnarPathToo}
+   * for the {@code algo.mst} counterpart and the reasoning behind the budget). {@code CSR_ACCELERATED_VAR}
+   * confirms the columnar path was actually taken.
+   * <p>
+   * A CSR-backed {@code GraphData} pays none of {@link #theEdgeArraysAreRefusedWhenTheyDoNotFitTheBudget}'s
+   * 1056-byte OLTP_VERTEX_BYTES graph-loading charge, so the budget here is sized only to the row headers common
+   * to both paths - 11 nodes x 2 x 32 bytes/node = 704 bytes.
+   */
+  @Test
+  void theWeightedAdjacencyRowHeadersAreRefusedOnTheCSRColumnarPathToo() {
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("msa-budget-csr-view")
+        .withVertexTypes("Node")
+        .withEdgeTypes("LINK")
+        .withEdgeProperties("w")
+        .build();
+    try {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 500L);
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      database.begin();
+      try {
+        final Vertex root;
+        try (final ResultSet rs = database.query("sql", "SELECT FROM Node WHERE idx = 0")) {
+          root = rs.next().getVertex().orElseThrow();
+        }
+        assertThatThrownBy(() -> new AlgoMinSpanningArborescence().execute(new Object[] { root, "LINK", "w" }, null, context))
+            .as("weightedAdjacencyFromColumns must be priced the same way weightedAdjacencyFromRecords is")
+            .hasStackTraceContaining("algo.msa(): the weighted adjacency list would need")
+            .hasStackTraceContaining("0 edge entries")
+            .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+        assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+            .as("the view must actually back the call, or this test pins nothing beyond the OLTP path already covered above")
+            .isEqualTo(true);
+      } finally {
+        database.rollback();
+      }
+    } finally {
+      view.drop();
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSAEdgeBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSAEdgeBudgetTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6300, the {@code algo.msa} half of a PR #6714 review round-6 finding: this
+ * procedure allocates its own flat {@code eFrom}/{@code eTo}/{@code eW} copy of the edges - the same shape as
+ * {@code algo.mst}'s {@code eu}/{@code ev}/{@code ew} - but, unlike {@code algo.mst}, never reserved anything for
+ * it. {@code weightedAdjacency}'s own incremental reservation (added in an earlier round of this same PR, see
+ * {@link Issue6300AlgoMSTEdgeBudgetTest}) prices its own {@code int[][]}/{@code double[][]} pair, but says
+ * nothing about a caller's additional copy on top of it - so a graph sized just under that threshold could still
+ * take an unpriced ~16 bytes/edge, the same "OutOfMemoryError instead of a clean refusal" failure mode #6300 was
+ * written to close.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6300AlgoMSAEdgeBudgetTest {
+  /** Ten edges in a rooted chain, so the arborescence spans every node and no edge is redundant. */
+  private static final int EDGE_COUNT = 10;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6300-msa-edge-budget");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    // A directed chain of EDGE_COUNT + 1 nodes rooted at node 0: every non-root vertex has exactly one incoming
+    // edge, so the arborescence is the whole chain and no edge is redundant.
+    database.transaction(() -> {
+      final List<MutableVertex> nodes = new ArrayList<>(EDGE_COUNT + 1);
+      for (int i = 0; i <= EDGE_COUNT; i++)
+        nodes.add(database.newVertex("Node").set("idx", i).save());
+      for (int i = 0; i < EDGE_COUNT; i++)
+        nodes.get(i).newEdge("LINK", nodes.get(i + 1), true, new Object[] { "w", (double) (i + 1) }).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void theEdgeArraysAreRefusedWhenTheyDoNotFitTheBudget() {
+    // 11 nodes at OLTP_VERTEX_BYTES=96 is 1056, weightedAdjacency's row headers (2 x 32 bytes/node) are 704, and
+    // its 10 edge entries (12 bytes each) are 120 - 1880 total, all of which fits comfortably below this budget.
+    // What does not fit is algo.msa's own eFrom/eTo/eW copy on top: 10 edges x 16 bytes = 160, taking the total
+    // to 2040 - over a 1900-byte budget, refusing at this procedure's own reservation rather than
+    // weightedAdjacency's.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1900L);
+
+    assertThatThrownBy(() -> drain("MATCH (r:Node {idx: 0}) CALL algo.msa(r, 'LINK', 'w') YIELD source RETURN source"))
+        .as("algo.msa's own edge arrays are additional working set on top of weightedAdjacency's and must be priced too")
+        .hasStackTraceContaining("algo.msa(): the edge arrays would need")
+        .hasStackTraceContaining(EDGE_COUNT + " edges")
+        .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+  }
+
+  @Test
+  void aBudgetThatFitsLetsTheCallThrough() {
+    // The counterweight: the reservation must not refuse a graph it can serve. 1056 (graph) + 704 (row headers)
+    // + 120 (weightedAdjacency entries) + 160 (this procedure's own copy) = 2040, comfortable under 4 KB.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 4096L);
+
+    final List<Object> rows = drain(
+        "MATCH (r:Node {idx: 0}) CALL algo.msa(r, 'LINK', 'w') YIELD source, weight, totalWeight RETURN source, weight, totalWeight");
+    assertThat(rows).hasSize(EDGE_COUNT);
+  }
+
+  @Test
+  void aDisabledBudgetPricesNothing() {
+    // A negative limit means "no limit" throughout the budget, and it must reach this procedure's own edge-array
+    // capacity too - a capacity computed by dividing a negative limit would refuse every graph instead of
+    // accepting them all.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, -1L);
+
+    assertThat(drain("MATCH (r:Node {idx: 0}) CALL algo.msa(r, 'LINK', 'w') YIELD source RETURN source")).hasSize(EDGE_COUNT);
+  }
+
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
+    final ResultSet rs = database.query("opencypher", query);
+    while (rs.hasNext())
+      rows.add(rs.next());
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
@@ -22,7 +22,11 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -74,7 +78,11 @@ class Issue6300AlgoMSTEdgeBudgetTest {
       factory.open().drop();
     database = factory.create();
     database.getSchema().createVertexType("Node");
-    database.getSchema().createEdgeType("LINK");
+    // Declared so a Graph Analytical View can materialise "w" as an edge property column (Issue6301's setup
+    // note: without a schema-known property the view falls back to edge records, which would leave the
+    // columnar reservation path - weightedAdjacencyFromColumns - untested by
+    // theWeightedAdjacencyRowHeadersAreRefusedOnTheCSRColumnarPathToo).
+    database.getSchema().createEdgeType("LINK").createProperty("w", Type.DOUBLE);
 
     // A path of EDGE_COUNT + 1 nodes: connected, so the MST spans every node and no edge is redundant.
     database.transaction(() -> {
@@ -110,6 +118,50 @@ class Issue6300AlgoMSTEdgeBudgetTest {
         .hasStackTraceContaining("algo.mst(): the weighted adjacency list would need")
         .hasStackTraceContaining("0 edge entries")
         .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+  }
+
+  /**
+   * PR #6714 review round 13: the tests around this one only exercise {@code weightedAdjacencyFromRecords}
+   * (the OLTP fallback) since no Graph Analytical View is built - {@code weightedAdjacencyFromColumns}, the
+   * path actually used once a view is ready and the one repeatedly patched for reservation-ordering bugs across
+   * this PR's earlier review rounds, was never exercised by a budget-refusal test. {@code CSR_ACCELERATED_VAR}
+   * confirms the columnar path was actually taken, not silently the OLTP one the test above already covers.
+   * <p>
+   * The budget cannot reuse {@link #theWeightedAdjacencyRowHeadersAreRefusedWhenTheyDoNotFitTheBudget}'s 1156:
+   * a CSR-backed {@code GraphData} is built straight from the view's node count with no {@code loadVertices}
+   * walk, so it never pays that test's 1056-byte OLTP_VERTEX_BYTES graph-loading charge. Only the row headers
+   * (2 x 32 bytes/node) are common to both paths - 11 nodes is 704 bytes - so the budget here is sized to that
+   * alone.
+   */
+  @Test
+  void theWeightedAdjacencyRowHeadersAreRefusedOnTheCSRColumnarPathToo() {
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("mst-budget-csr-view")
+        .withVertexTypes("Node")
+        .withEdgeTypes("LINK")
+        .withEdgeProperties("w")
+        .build();
+    try {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 500L);
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      database.begin();
+      try {
+        assertThatThrownBy(() -> new AlgoMST().execute(new Object[] { "w" }, null, context))
+            .as("weightedAdjacencyFromColumns must be priced the same way weightedAdjacencyFromRecords is")
+            .hasStackTraceContaining("algo.mst(): the weighted adjacency list would need")
+            .hasStackTraceContaining("0 edge entries")
+            .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+        assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+            .as("the view must actually back the call, or this test pins nothing beyond the OLTP path already covered above")
+            .isEqualTo(true);
+      } finally {
+        database.rollback();
+      }
+    } finally {
+      view.drop();
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
@@ -45,9 +45,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * naming what asked for it. "Linear" was never the criterion; the criterion is whether the caller can predict a
  * ceiling, and here there is none.
  * <p>
- * The reservation is made as the counting pass runs rather than once it has finished. Both refuse the same calls,
- * but a check afterwards first pays in full for a traversal it will then throw away - the same argument that puts
- * {@code algo.steinerTree}'s reservation ahead of its adjacency build. The refusal itself still goes through
+ * Originally the reservation was made as a dedicated counting pass ran, rather than once it had finished, so a
+ * refusal could stop before materialising a traversal it would then throw away. Since issue #6316 moved edge
+ * collection onto {@code GraphData.weightedAdjacency} - the shared helper every other weighted {@code algo.*}
+ * procedure already reads edges through - that dedicated pass is gone: the reservation is made once
+ * {@code weightedAdjacency} has materialised the graph's actual edge count, the same tradeoff
+ * {@code algo.steinerTree} already made for its own working sets. The refusal itself still goes through
  * {@code MemoryBudget.reserve}, so the message names the same component and the same setting either way.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -102,14 +105,18 @@ class Issue6300AlgoMSTEdgeBudgetTest {
   }
 
   @Test
-  void theRefusalNamesTheEdgeCountItStoppedAt() {
-    // The message quotes the count reached, not the graph's total: the walk stops when the budget runs out, so
-    // there is no total to quote yet. That is the observable difference between reserving during the counting
-    // pass and reserving after it - and it is the whole point of the placement.
+  void theRefusalNamesTheActualEdgeCount() {
+    // Since issue #6316 routed edge collection through GraphData.weightedAdjacency (the same shared helper
+    // algo.steinerTree and algo.bellmanFord read weights through), the walk that used to stop counting the
+    // moment the running total crossed the budget no longer has that granularity to stop at: weightedAdjacency
+    // materialises every edge of the graph in one pass with no counting checkpoint of its own, the same
+    // tradeoff every other weightedAdjacency caller already makes. The refusal message now quotes the graph's
+    // actual edge count rather than the count the old walk happened to have reached when it gave up.
     database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1156L);
 
     assertThatThrownBy(() -> drain("CALL algo.mst('w') YIELD source RETURN source"))
-        .hasStackTraceContaining("more than 4 edges");
+        .hasStackTraceContaining("more than the 1156 bytes allowed")
+        .hasStackTraceContaining(EDGE_COUNT + " edges");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
@@ -25,13 +25,16 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Regression tests for issue #6300 - {@code algo.mst} was the one dense {@code algo.*} path the #6263
@@ -46,12 +49,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * ceiling, and here there is none.
  * <p>
  * Originally the reservation was made as a dedicated counting pass ran, rather than once it had finished, so a
- * refusal could stop before materialising a traversal it would then throw away. Since issue #6316 moved edge
- * collection onto {@code GraphData.weightedAdjacency} - the shared helper every other weighted {@code algo.*}
- * procedure already reads edges through - that dedicated pass is gone: the reservation is made once
- * {@code weightedAdjacency} has materialised the graph's actual edge count, the same tradeoff
- * {@code algo.steinerTree} already made for its own working sets. The refusal itself still goes through
- * {@code MemoryBudget.reserve}, so the message names the same component and the same setting either way.
+ * refusal could stop before materialising a traversal it would then throw away. Issue #6316 moved edge collection
+ * onto {@code GraphData.weightedAdjacency} - the shared helper every other weighted {@code algo.*} procedure
+ * already reads edges through - and that dedicated pass went with it. A PR #6714 review round found this had
+ * silently dropped the protection: {@code weightedAdjacency} itself reserved nothing, so the (potentially huge)
+ * neighbour/weight arrays were fully materialised before {@code algo.mst}'s own {@code reserve()} call ever ran.
+ * {@code weightedAdjacency} now reserves incrementally as it builds - a row-header reservation up front, then
+ * per-edge-entry reservations as the walk proceeds, mirroring {@code GraphData.adjacency()}'s existing
+ * {@code reserveAdjacency} pattern - so the refusal happens inside {@code weightedAdjacency} itself, and for a
+ * graph this small it fires at the row-header reservation, before a single edge is read.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -92,31 +98,34 @@ class Issue6300AlgoMSTEdgeBudgetTest {
   }
 
   @Test
-  void theEdgeArraysAreRefusedWhenTheyDoNotFitTheBudget() {
-    // The graph is priced first since #6317 - 11 nodes at OLTP_VERTEX_BYTES is 1056 bytes - and what is left
-    // over is what buys edges: 24 bytes each, so the 100 bytes above the graph buy four of them and the fifth
-    // is over.
+  void theWeightedAdjacencyRowHeadersAreRefusedWhenTheyDoNotFitTheBudget() {
+    // The graph is priced first since #6317 - 11 nodes at OLTP_VERTEX_BYTES is 1056 bytes. weightedAdjacency
+    // reserves its row headers next, up front, before reading a single edge: 2 row headers per node (one for
+    // neighbors[i], one for weights[i]) at MATRIX_ROW_OVERHEAD_BYTES=32 each, so 11 nodes cost 704 bytes -
+    // 1056 + 704 = 1760, over the 1156-byte budget before any edge is even looked at.
     database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1156L);
 
     assertThatThrownBy(() -> drain("CALL algo.mst('w') YIELD source, target RETURN source, target"))
-        .as("the edge arrays are the dense working set of an algo.mst call and must be priced like any other")
-        .hasStackTraceContaining("algo.mst(): the edge arrays would need")
+        .as("the weighted adjacency list is the dense working set of an algo.mst call and must be priced like any other")
+        .hasStackTraceContaining("algo.mst(): the weighted adjacency list would need")
+        .hasStackTraceContaining("0 edge entries")
         .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
   }
 
   @Test
-  void theRefusalNamesTheActualEdgeCount() {
-    // Since issue #6316 routed edge collection through GraphData.weightedAdjacency (the same shared helper
-    // algo.steinerTree and algo.bellmanFord read weights through), the walk that used to stop counting the
-    // moment the running total crossed the budget no longer has that granularity to stop at: weightedAdjacency
-    // materialises every edge of the graph in one pass with no counting checkpoint of its own, the same
-    // tradeoff every other weightedAdjacency caller already makes. The refusal message now quotes the graph's
-    // actual edge count rather than the count the old walk happened to have reached when it gave up.
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1156L);
+  void theRefusalNamesTheActualEdgeCountOnceTheRowHeadersFit() {
+    // A budget wide enough for the graph (1056) plus the row headers (704) - 1760 - but not for the 10 edges'
+    // entries on top of that (12 bytes each: an int neighbour id plus a double weight, 120 bytes total) fires the
+    // second reservation, which quotes the edge count it actually reached: for an 11-node graph the per-edge
+    // checkpoint stride (every 1024 nodes, or 1_048_576 entries) never triggers mid-walk, so every edge has
+    // already been read into the arrays by the time this fires - the same "counted then refused" shape the old
+    // MST-local counting pass had, now living in the shared helper instead.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1800L);
 
     assertThatThrownBy(() -> drain("CALL algo.mst('w') YIELD source RETURN source"))
-        .hasStackTraceContaining("more than the 1156 bytes allowed")
-        .hasStackTraceContaining(EDGE_COUNT + " edges");
+        .hasStackTraceContaining("algo.mst(): the weighted adjacency list would need")
+        .hasStackTraceContaining("more than the 1800 bytes allowed")
+        .hasStackTraceContaining(EDGE_COUNT + " edge entries");
   }
 
   @Test
@@ -166,5 +175,95 @@ class Issue6300AlgoMSTEdgeBudgetTest {
     while (rs.hasNext())
       rows.add(rs.next());
     return rows;
+  }
+
+  /**
+   * PR #6714 review round 3 coverage gap: none of the tests above exercise a graph large enough for
+   * {@code weightedAdjacency}'s incremental checkpoint (every 1024 nodes, or every {@code ADJACENCY_CHECKPOINT_ENTRIES}
+   * entries) to fire mid-walk rather than only at the row-header reservation or the final one. A 3000-node chain
+   * is enough: the checkpoint right after node 1023 reserves only the ~1024 edges read so far, and a budget sized
+   * to admit the row headers plus that first batch but not the full 2999 edges refuses there - which this test
+   * confirms not by timing but by measuring the call's own allocation (issue #6289's approach): if the refusal
+   * actually happened partway through the walk rather than after materialising the whole graph, the allocated
+   * bytes stay a small fraction (roughly 1024/3000) of what building the full {@code int[][]}/{@code double[][]}
+   * pair for all 2999 edges would cost.
+   */
+  @Test
+  @Tag("performance")
+  void aLargeGraphIsRefusedPartwayThroughTheWalkNotAfterMaterialisingAllOfIt() {
+    final com.sun.management.ThreadMXBean threads = threadAllocationBean();
+    assumeTrue(threads != null, "JVM does not expose per-thread allocation counters");
+
+    final int nodeCount = 3000;
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6300-mst-large-graph-refusal");
+    if (factory.exists())
+      factory.open().drop();
+    final Database large = factory.create();
+    try {
+      large.getSchema().createVertexType("Node");
+      large.getSchema().createEdgeType("LINK");
+      large.transaction(() -> {
+        final List<MutableVertex> nodes = new ArrayList<>(nodeCount);
+        for (int i = 0; i < nodeCount; i++)
+          nodes.add(large.newVertex("Node").set("idx", i).save());
+        for (int i = 0; i < nodeCount - 1; i++)
+          nodes.get(i).newEdge("LINK", nodes.get(i + 1), true, new Object[] { "w", (double) (i + 1) }).save();
+      });
+
+      // Graph load (96 bytes/node) plus weightedAdjacency's row headers (64 bytes/node) is 480 000 bytes; the
+      // checkpoint right after node 1023 adds ~1024 edges x 12 bytes = ~12 288 more. 490 000 sits between the
+      // two, so the call refuses right there - after ~1024 of 3000 nodes, not after all of them.
+      final long refusalBudget = 490_000L;
+
+      // Warm up both call shapes (JIT, class loading) before either measurement, so neither is biased by being
+      // the first invocation.
+      large.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, refusalBudget);
+      assertThatThrownBy(() -> drain(large, "CALL algo.mst('w') YIELD source RETURN source"))
+          .hasStackTraceContaining("algo.mst(): the weighted adjacency list would need");
+      large.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, -1L);
+      assertThat(drain(large, "CALL algo.mst('w') YIELD source RETURN source")).isNotEmpty();
+
+      large.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, -1L);
+      final long unboundedAllocated = measure(threads, () -> assertThat(drain(large, "CALL algo.mst('w') YIELD source RETURN source")).isNotEmpty());
+
+      large.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, refusalBudget);
+      final long refusedAllocated = measure(threads, () -> assertThatThrownBy(() -> drain(large, "CALL algo.mst('w') YIELD source RETURN source"))
+          .hasStackTraceContaining("algo.mst(): the weighted adjacency list would need"));
+
+      // A refusal partway through the walk must allocate much less than materialising the whole graph does - if
+      // it did not stop mid-walk, the two would be close to equal instead.
+      assertThat(refusedAllocated)
+          .as("a refusal partway through the walk (refused=" + refusedAllocated + " bytes) must allocate much "
+              + "less than materialising the whole graph does (unbounded=" + unboundedAllocated + " bytes)")
+          .isLessThan(unboundedAllocated / 2);
+    } finally {
+      large.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      large.drop();
+    }
+  }
+
+  private static List<Object> drain(final Database db, final String query) {
+    final List<Object> rows = new ArrayList<>();
+    final ResultSet rs = db.query("opencypher", query);
+    while (rs.hasNext())
+      rows.add(rs.next());
+    return rows;
+  }
+
+  private static long measure(final com.sun.management.ThreadMXBean threads, final Runnable body) {
+    final long id = Thread.currentThread().threadId();
+    final long before = threads.getThreadAllocatedBytes(id);
+    body.run();
+    return threads.getThreadAllocatedBytes(id) - before;
+  }
+
+  private static com.sun.management.ThreadMXBean threadAllocationBean() {
+    if (!(ManagementFactory.getThreadMXBean() instanceof final com.sun.management.ThreadMXBean bean))
+      return null;
+    if (!bean.isThreadAllocatedMemorySupported())
+      return null;
+    bean.setThreadAllocatedMemoryEnabled(true);
+    return bean.isThreadAllocatedMemoryEnabled() ? bean : null;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6316AlgoLoadGraphAdoptionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6316AlgoLoadGraphAdoptionTest.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6316 - six {@code algo.*} procedures (kShortestPaths, mst, msa, maxFlow,
+ * betweenness, degree) never resolved a {@link GraphTraversalProvider} at all: each hand-rolled vertex loading
+ * and RID resolution with {@code getAllVertices}/{@code buildRidIndex}, and the two weighted ones re-derived the
+ * neighbour/weight pairing {@code GraphData.weightedAdjacency} already owns (issue #6301 fixed that pairing bug
+ * independently in each of them).
+ * <p>
+ * All six now route through {@code loadGraph}, so a Graph Analytical View accelerates them like every other
+ * procedure in the package. Each test here pins the CSR-vs-OLTP equivalence the switch has to preserve: build
+ * the same graph, run once without a view and once with one, and assert (a) the answer does not change and (b)
+ * {@link CommandContext#CSR_ACCELERATED_VAR} was actually set - so a broken conversion that silently kept
+ * pinning the OLTP path could not pass by comparing a result against itself.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6316AlgoLoadGraphAdoptionTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6316-loadgraph-adoption");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    // Declared property so a Graph Analytical View materialises a columnar weight (issue #6301's setup note):
+    // without the column the view falls back to edge records, which would leave the columnar path untested.
+    database.getSchema().createEdgeType("E").createProperty("w", Type.DOUBLE);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  private Vertex node(final String name) {
+    return database.newVertex("N").set("name", name).save();
+  }
+
+  private Vertex named(final String name) {
+    return database.query("sql", "SELECT FROM N WHERE name = ?", name).next().getElement().orElseThrow().asVertex();
+  }
+
+  private GraphAnalyticalView buildView(final String name) {
+    return GraphAnalyticalView.builder(database)
+        .withName(name)
+        .withVertexTypes("N")
+        .withEdgeTypes("E")
+        .withEdgeProperties("w")
+        .build();
+  }
+
+  private BasicCommandContext newContext() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    return context;
+  }
+
+  private static List<Result> drain(final Stream<Result> rows) {
+    final List<Result> results = new ArrayList<>();
+    for (final Iterator<Result> it = rows.iterator(); it.hasNext(); )
+      results.add(it.next());
+    return results;
+  }
+
+  private void assertCSRAccelerated(final CommandContext context) {
+    assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+        .as("the view must actually back the call, or this comparison pins the OLTP path against itself")
+        .isEqualTo(true);
+  }
+
+  // ── algo.degree ──────────────────────────────────────────────────────────
+
+  @Test
+  void degreeCentralityMatchesBetweenOLTPAndCSR() {
+    // Star with one extra edge, asymmetric on purpose: A: out=3 in=0; B: out=1 in=1; C: out=0 in=2; D: out=0 in=1.
+    database.transaction(() -> {
+      final Vertex a = node("A"), b = node("B"), c = node("C"), d = node("D");
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("E", c, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("E", d, true, new Object[] { "w", 1.0 }).save();
+      b.newEdge("E", c, true, new Object[] { "w", 1.0 }).save();
+    });
+
+    final Map<RID, long[]> oltp = degreeMap(newContext());
+    assertThat(oltp).hasSize(4);
+
+    final GraphAnalyticalView view = buildView("degree-view");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Map<RID, long[]> csr = degreeMap(csrContext);
+      assertCSRAccelerated(csrContext);
+      assertThat(csr.keySet()).isEqualTo(oltp.keySet());
+      for (final RID rid : oltp.keySet())
+        assertThat(csr.get(rid)).as("in/out/total for " + rid).isEqualTo(oltp.get(rid));
+    } finally {
+      view.drop();
+    }
+  }
+
+  private Map<RID, long[]> degreeMap(final CommandContext context) {
+    final Map<RID, long[]> result = new HashMap<>();
+    for (final Result row : drain(new AlgoDegreeCentrality().execute(new Object[0], null, context))) {
+      final RID node = ((RID) row.getProperty("node"));
+      result.put(node, new long[] {
+          ((Number) row.getProperty("inDegree")).longValue(),
+          ((Number) row.getProperty("outDegree")).longValue(),
+          ((Number) row.getProperty("degree")).longValue() });
+    }
+    return result;
+  }
+
+  // ── algo.betweenness ────────────────────────────────────────────────────
+
+  @Test
+  void betweennessMatchesBetweenOLTPAndCSR() {
+    // A path A-B-C-D-E with each hop inserted in both directions, so Brandes' OUT-only walk sees an
+    // undirected path: B, C and D sit on shortest paths between other pairs, A and E do not.
+    database.transaction(() -> {
+      final Vertex a = node("A"), b = node("B"), c = node("C"), d = node("D"), e = node("E");
+      for (final Vertex[] hop : new Vertex[][] { { a, b }, { b, c }, { c, d }, { d, e } }) {
+        hop[0].newEdge("E", hop[1], true, new Object[] { "w", 1.0 }).save();
+        hop[1].newEdge("E", hop[0], true, new Object[] { "w", 1.0 }).save();
+      }
+    });
+
+    final Map<RID, Double> oltp = betweennessMap(newContext());
+    assertThat(oltp).hasSize(5);
+    // Sanity: the middle node is on strictly more shortest paths than either endpoint.
+    assertThat(oltp.get(named("C").getIdentity())).isGreaterThan(oltp.get(named("A").getIdentity()));
+
+    final GraphAnalyticalView view = buildView("betweenness-view");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Map<RID, Double> csr = betweennessMap(csrContext);
+      assertCSRAccelerated(csrContext);
+      assertThat(csr.keySet()).isEqualTo(oltp.keySet());
+      for (final RID rid : oltp.keySet())
+        assertThat(csr.get(rid)).as("score for " + rid).isEqualTo(oltp.get(rid));
+    } finally {
+      view.drop();
+    }
+  }
+
+  private Map<RID, Double> betweennessMap(final CommandContext context) {
+    final Map<RID, Double> result = new HashMap<>();
+    for (final Result row : drain(new AlgoBetweenness().execute(new Object[0], null, context)))
+      result.put((RID) row.getProperty("node"), ((Number) row.getProperty("score")).doubleValue());
+    return result;
+  }
+
+  // ── algo.mst ─────────────────────────────────────────────────────────────
+
+  @Test
+  void mstMatchesBetweenOLTPAndCSR() {
+    // A->B(1), B->C(2), A->C(3), C->D(1), B->D(4): the MST is {A-B, C-D, B-C} at total weight 4, and A-C/B-D
+    // are the redundant, more expensive edges Kruskal's must reject.
+    database.transaction(() -> {
+      final Vertex a = node("A"), b = node("B"), c = node("C"), d = node("D");
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save();
+      b.newEdge("E", c, true, new Object[] { "w", 2.0 }).save();
+      a.newEdge("E", c, true, new Object[] { "w", 3.0 }).save();
+      c.newEdge("E", d, true, new Object[] { "w", 1.0 }).save();
+      b.newEdge("E", d, true, new Object[] { "w", 4.0 }).save();
+    });
+
+    final Set<String> oltp = mstEdgeSet(newContext());
+    assertThat(oltp).containsExactlyInAnyOrder("A-B:1.0", "B-C:2.0", "C-D:1.0");
+
+    final GraphAnalyticalView view = buildView("mst-view");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Set<String> csr = mstEdgeSet(csrContext);
+      assertCSRAccelerated(csrContext);
+      assertThat(csr).isEqualTo(oltp);
+    } finally {
+      view.drop();
+    }
+  }
+
+  private Set<String> mstEdgeSet(final CommandContext context) {
+    final Set<String> result = new HashSet<>();
+    for (final Result row : drain(new AlgoMST().execute(new Object[] { "w" }, null, context))) {
+      final Vertex source = ((RID) row.getProperty("source")).asVertex();
+      final Vertex target = ((RID) row.getProperty("target")).asVertex();
+      result.add(source.getString("name") + "-" + target.getString("name") + ":" + row.<Number>getProperty("weight").doubleValue());
+    }
+    return result;
+  }
+
+  // ── algo.msa ─────────────────────────────────────────────────────────────
+
+  @Test
+  void msaMatchesBetweenOLTPAndCSRAndContractsACycle() {
+    // Textbook Chu-Liu/Edmonds shape: R->A(10), R->B(8), A->B(1), B->A(1), B->C(9). Cheapest incoming edges
+    // form a cycle A<->B (B->A(1) and A->B(1)); R must break in through the cheapest adjusted entry, R->B at
+    // adjusted cost 8-1=7 versus R->A at 10-1=9. Expected MSA: R->B(8), B->A(1), B->C(9), total 18.
+    database.transaction(() -> {
+      final Vertex r = node("R"), a = node("A"), b = node("B"), c = node("C");
+      r.newEdge("E", a, true, new Object[] { "w", 10.0 }).save();
+      r.newEdge("E", b, true, new Object[] { "w", 8.0 }).save();
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save();
+      b.newEdge("E", a, true, new Object[] { "w", 1.0 }).save();
+      b.newEdge("E", c, true, new Object[] { "w", 9.0 }).save();
+    });
+
+    final Set<String> oltp = msaEdgeSet(newContext());
+    assertThat(oltp).containsExactlyInAnyOrder("R-B:8.0", "B-A:1.0", "B-C:9.0");
+
+    final GraphAnalyticalView view = buildView("msa-view");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Set<String> csr = msaEdgeSet(csrContext);
+      assertCSRAccelerated(csrContext);
+      assertThat(csr).isEqualTo(oltp);
+    } finally {
+      view.drop();
+    }
+  }
+
+  private Set<String> msaEdgeSet(final CommandContext context) {
+    final Set<String> result = new HashSet<>();
+    for (final Result row : drain(new AlgoMinSpanningArborescence().execute(new Object[] { named("R"), null, "w" }, null, context))) {
+      final Vertex source = ((RID) row.getProperty("source")).asVertex();
+      final Vertex target = ((RID) row.getProperty("target")).asVertex();
+      result.add(source.getString("name") + "-" + target.getString("name") + ":" + row.<Number>getProperty("weight").doubleValue());
+    }
+    return result;
+  }
+
+  // ── algo.maxFlow ─────────────────────────────────────────────────────────
+
+  @Test
+  void maxFlowMatchesBetweenOLTPAndCSR() {
+    // Classic small flow network: S->A(3), S->B(2), A->B(1), A->T(2), B->T(3).
+    database.transaction(() -> {
+      final Vertex s = node("S"), a = node("A"), b = node("B"), t = node("T");
+      s.newEdge("E", a, true, new Object[] { "w", 3.0 }).save();
+      s.newEdge("E", b, true, new Object[] { "w", 2.0 }).save();
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("E", t, true, new Object[] { "w", 2.0 }).save();
+      b.newEdge("E", t, true, new Object[] { "w", 3.0 }).save();
+    });
+
+    final double oltp = maxFlowValue(newContext());
+    assertThat(oltp).isGreaterThan(0.0);
+
+    final GraphAnalyticalView view = buildView("maxflow-view");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final double csr = maxFlowValue(csrContext);
+      assertCSRAccelerated(csrContext);
+      assertThat(csr).isEqualTo(oltp);
+    } finally {
+      view.drop();
+    }
+  }
+
+  private double maxFlowValue(final CommandContext context) {
+    final List<Result> rows = drain(new AlgoMaxFlow().execute(new Object[] { named("S"), named("T"), null, "w" }, null, context));
+    assertThat(rows).hasSize(1);
+    return rows.getFirst().<Number>getProperty("maxFlow").doubleValue();
+  }
+
+  // ── algo.kShortestPaths ──────────────────────────────────────────────────
+
+  @Test
+  void kShortestPathsMatchesBetweenOLTPAndCSR() {
+    // A->B(1), A->C(4), B->C(2), B->D(5), C->D(1). The two cheapest A-D paths are A-B-C-D (4) and A-C-D (5).
+    database.transaction(() -> {
+      final Vertex a = node("A"), b = node("B"), c = node("C"), d = node("D");
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("E", c, true, new Object[] { "w", 4.0 }).save();
+      b.newEdge("E", c, true, new Object[] { "w", 2.0 }).save();
+      b.newEdge("E", d, true, new Object[] { "w", 5.0 }).save();
+      c.newEdge("E", d, true, new Object[] { "w", 1.0 }).save();
+    });
+
+    final List<String> oltp = kShortestPathsSummary(newContext());
+    assertThat(oltp).containsExactly("A,B,C,D:4.0", "A,C,D:5.0");
+
+    final GraphAnalyticalView view = buildView("kshortest-view");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final List<String> csr = kShortestPathsSummary(csrContext);
+      assertCSRAccelerated(csrContext);
+      assertThat(csr).isEqualTo(oltp);
+    } finally {
+      view.drop();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> kShortestPathsSummary(final CommandContext context) {
+    final List<Result> rows = drain(new AlgoKShortestPaths().execute(
+        new Object[] { named("A"), named("D"), 2, null, "w" }, null, context));
+    return rows.stream()
+        .map(row -> {
+          final Map<String, Object> path = (Map<String, Object>) row.getProperty("path");
+          final List<Vertex> nodes = (List<Vertex>) path.get("nodes");
+          final String names = nodes.stream().map(v -> v.getString("name")).collect(Collectors.joining(","));
+          return names + ":" + row.<Number>getProperty("weight").doubleValue();
+        })
+        .sorted(Comparator.naturalOrder())
+        .collect(Collectors.toList());
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6316AlgoLoadGraphAdoptionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6316AlgoLoadGraphAdoptionTest.java
@@ -356,4 +356,70 @@ class Issue6316AlgoLoadGraphAdoptionTest {
         .sorted(Comparator.naturalOrder())
         .collect(Collectors.toList());
   }
+
+  // ── parallel edges & self-loops ──────────────────────────────────────────
+
+  /**
+   * PR #6714 review round 13's second finding: every equivalence test above builds a graph with no parallel
+   * edges or self-loops, so an OLTP/CSR mismatch specific to either shape - {@code GraphData.degrees} summing
+   * a provider's per-type buffer versus {@code Vertex.countEdges}, or {@code weightedAdjacency}'s neighbour/
+   * weight pairing - could pass every test above and still disagree once one occurred. These two tests do not
+   * hand-derive the OLTP side's expected numbers the way the tests above do (self-loop counting conventions in
+   * particular are not this test's concern, and the algorithms' own correctness is pinned elsewhere - e.g.
+   * issue #6301 for weight pairing); they only assert OLTP and CSR agree with each other, which is exactly what
+   * a shared-plumbing regression specific to either shape would break.
+   */
+  @Test
+  void degreeCentralityMatchesBetweenOLTPAndCSRWithAParallelEdgeAndASelfLoop() {
+    database.transaction(() -> {
+      final Vertex a = node("A"), b = node("B"), c = node("C");
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save(); // parallel edge, same pair as above
+      a.newEdge("E", a, true, new Object[] { "w", 1.0 }).save(); // self-loop
+      b.newEdge("E", c, true, new Object[] { "w", 1.0 }).save();
+    });
+
+    final Map<RID, long[]> oltp = degreeMap(newContext());
+    assertThat(oltp).hasSize(3);
+
+    final GraphAnalyticalView view = buildView("degree-parallel-selfloop-view");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Map<RID, long[]> csr = degreeMap(csrContext);
+      assertCSRAccelerated(csrContext);
+      assertThat(csr.keySet()).isEqualTo(oltp.keySet());
+      for (final RID rid : oltp.keySet())
+        assertThat(csr.get(rid)).as("in/out/total for " + rid).isEqualTo(oltp.get(rid));
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void mstMatchesBetweenOLTPAndCSRWithAParallelEdgeAndASelfLoop() {
+    // A-B twice at different weights (the cheaper one must win) plus a self-loop on A, which Kruskal's
+    // union-find already excludes on both paths (a self-loop's two endpoints share a root from the start, so
+    // it is never added, the same way #6300's own dedicated tests never needed to special-case one).
+    database.transaction(() -> {
+      final Vertex a = node("A"), b = node("B"), c = node("C");
+      a.newEdge("E", b, true, new Object[] { "w", 5.0 }).save();
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save(); // cheaper parallel edge, must be the one kept
+      a.newEdge("E", a, true, new Object[] { "w", 0.5 }).save(); // self-loop, must not appear in the MST
+      b.newEdge("E", c, true, new Object[] { "w", 2.0 }).save();
+    });
+
+    final Set<String> oltp = mstEdgeSet(newContext());
+    assertThat(oltp).as("the self-loop must not appear and the cheaper parallel edge must win")
+        .containsExactlyInAnyOrder("A-B:1.0", "B-C:2.0");
+
+    final GraphAnalyticalView view = buildView("mst-parallel-selfloop-view");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Set<String> csr = mstEdgeSet(csrContext);
+      assertCSRAccelerated(csrContext);
+      assertThat(csr).isEqualTo(oltp);
+    } finally {
+      view.drop();
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6318AlgoGuardCoverageBackstopTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6318AlgoGuardCoverageBackstopTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Backstop for issue #6318 part 2 - {@code Issue6302AlgoGraphDrivenWorkGuardTest}'s parameterised table is the
+ * only thing that notices an {@code algo.*} procedure shipping without a {@link com.arcadedb.query.sql.executor.WorkGuard}/
+ * {@link com.arcadedb.graph.olap.WorkCheckpoint}, and only if somebody remembers to add a row for it. This test
+ * instead discovers every procedure source file on disk, so a new one is caught automatically rather than by
+ * memory.
+ * <p>
+ * The judgement call this cannot make mechanically is whether a procedure's dominant loop is actually superlinear
+ * in the graph (needs a guard) or a single O(V + E) pass (does not - "one pass costs what loading the graph and
+ * emitting the rows already cost", per {@code Issue6302AlgoGraphDrivenWorkGuardTest}). That judgement is recorded
+ * once, here, as {@link #SINGLE_PASS_EXEMPT}: every procedure file that references no guard at all must be either
+ * self-guarded (the common case: {@code WorkGuard}/{@code newWorkGuard}/{@code guard.check}/{@code guard::check}
+ * somewhere in its source) or explicitly listed with a one-line reason. A new procedure that is neither fails this
+ * test, which is the point - it turns "someone has to remember" into "the build says so".
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6318AlgoGuardCoverageBackstopTest {
+
+  /**
+   * Procedures whose dominant work is a single O(V + E) pass (each vertex visited once, each edge read off that
+   * vertex's own adjacency - never a second sweep of all vertices per vertex), a knob-bounded computation with no
+   * graph-driven multiplier, or a query against a caller-supplied pair rather than the whole graph. Verified by
+   * reading each file's {@code execute()} at the time this test was written (issue #6318); a procedure whose shape
+   * changes to something superlinear must move off this list and gain a guard, not the other way round.
+   */
+  private static final Map<String, String> SINGLE_PASS_EXEMPT = Map.ofEntries(
+      Map.entry("AlgoAdamicAdar.java", "one node's own adjacency plus each neighbour's own adjacency: O(deg + sum of neighbour degrees), not the graph"),
+      Map.entry("AlgoArticulationPoints.java", "Tarjan-style single DFS, O(V + E)"),
+      Map.entry("AlgoAssortativity.java", "two O(V + E) passes: degree computation, then one edge-endpoint-degree sum"),
+      Map.entry("AlgoAStar.java", "single priority-queue search bounded by the path found, not the whole graph"),
+      Map.entry("AlgoBFS.java", "single breadth-first traversal, O(V + E)"),
+      Map.entry("AlgoBiconnectedComponents.java", "DFS forest over unvisited starts, each vertex/edge visited once overall, O(V + E)"),
+      Map.entry("AlgoBipartiteCheck.java", "single two-colouring BFS/DFS, O(V + E)"),
+      Map.entry("AlgoBridges.java", "single low-link DFS, O(V + E)"),
+      Map.entry("AlgoCommonNeighbors.java", "one node's own adjacency plus one other node's own adjacency: O(deg(a) + deg(b))"),
+      Map.entry("AlgoConductance.java", "a handful of O(V) / O(V + E) passes over precomputed degree and community arrays"),
+      Map.entry("AlgoCycleDetection.java", "single DFS with a recursion-stack colour array, O(V + E)"),
+      Map.entry("AlgoDegreeCentrality.java", "one degree lookup per node, O(V) (or O(1) per node CSR-backed, issue #6316)"),
+      Map.entry("AlgoDFS.java", "single depth-first traversal, O(V + E)"),
+      Map.entry("AlgoDijkstra.java", "single priority-queue shortest path, O((V + E) log V)"),
+      Map.entry("AlgoDijkstraSingleSource.java", "single priority-queue search from one source, O((V + E) log V)"),
+      Map.entry("AlgoGraphColoring.java", "single greedy pass, one node's own adjacency scanned once each, O(V + E)"),
+      Map.entry("AlgoGraphSummary.java", "a handful of O(V) / O(V + E) aggregate passes over the loaded graph"),
+      Map.entry("AlgoJaccardSimilarity.java", "one node's own adjacency plus one other node's own adjacency: O(deg(a) + deg(b))"),
+      Map.entry("AlgoKCore.java", "bucket-queue peeling, each vertex removed once and each edge relaxed once, O(V + E)"),
+      Map.entry("AlgoLongestPathDAG.java", "topological order plus one relaxation pass over each vertex's own adjacency, O(V + E)"),
+      Map.entry("AlgoModularityScore.java", "a handful of O(V) / O(V + E) passes over precomputed degree and community arrays"),
+      Map.entry("AlgoPreferentialAttachment.java", "O(1) product of two precomputed degrees"),
+      Map.entry("AlgoResourceAllocation.java", "one node's own adjacency plus one other node's own adjacency: O(deg(a) + deg(b))"),
+      Map.entry("AlgoSameCommunity.java", "O(1) lookup of two precomputed community labels"),
+      Map.entry("AlgoSCC.java", "single Tarjan/Kosaraju pass, O(V + E)"),
+      Map.entry("AlgoTopologicalSort.java", "single Kahn's-algorithm pass, O(V + E)"),
+      Map.entry("AlgoTotalNeighbors.java", "one node's own adjacency plus one other node's own adjacency: O(deg(a) + deg(b))"),
+      Map.entry("AlgoWCC.java", "single union-find pass over every edge, O(V + E)")
+  );
+
+  private static final Pattern GUARD_REFERENCE = Pattern.compile("WorkGuard|WorkCheckpoint|guard\\.|guard::");
+
+  @Test
+  void everyAlgoProcedureIsEitherSelfGuardedOrAJustifiedSinglePassExemption() throws IOException {
+    final Path dir = algoProcedurePackageDir();
+
+    final List<String> unguardedAndUnlisted = new ArrayList<>();
+    try (Stream<Path> files = Files.list(dir)) {
+      for (final Path file : files.sorted().toList()) {
+        final String name = file.getFileName().toString();
+        if (!name.startsWith("Algo") || !name.endsWith(".java") || name.equals("AbstractAlgoProcedure.java"))
+          continue;
+
+        final String source = Files.readString(file);
+        if (GUARD_REFERENCE.matcher(source).find())
+          continue; // self-guarded (directly, or by delegating to a GraphAlgorithms(..., checkpoint, ...) kernel)
+
+        if (!SINGLE_PASS_EXEMPT.containsKey(name))
+          unguardedAndUnlisted.add(name);
+      }
+    }
+
+    assertThat(unguardedAndUnlisted)
+        .as("every algo.* procedure must either reference a WorkGuard/WorkCheckpoint or be added to "
+            + "SINGLE_PASS_EXEMPT with a one-line reason its dominant loop is not superlinear in the graph (issue #6318)")
+        .isEmpty();
+  }
+
+  /**
+   * Also pins the allow-list itself against drift: an entry for a file that no longer exists, or that has since
+   * grown a guard of its own, is dead weight nobody will notice needs removing.
+   */
+  @Test
+  void everyExemptEntryNamesAFileThatExistsAndIsStillUnguarded() throws IOException {
+    final Path dir = algoProcedurePackageDir();
+    final List<String> stale = new ArrayList<>();
+    for (final Map.Entry<String, String> entry : SINGLE_PASS_EXEMPT.entrySet()) {
+      final Path file = dir.resolve(entry.getKey());
+      if (!Files.exists(file)) {
+        stale.add(entry.getKey() + " (file no longer exists)");
+        continue;
+      }
+      if (GUARD_REFERENCE.matcher(Files.readString(file)).find())
+        stale.add(entry.getKey() + " (now references a guard - remove from the exemption list)");
+    }
+    assertThat(stale).as("SINGLE_PASS_EXEMPT entries that no longer apply").isEmpty();
+  }
+
+  private static Path algoProcedurePackageDir() {
+    // Resolved relative to the module root, the way surefire runs (working directory = engine/), rather than
+    // hard-coding an absolute path that would break outside this checkout.
+    return Path.of("src/main/java/com/arcadedb/query/opencypher/procedures/algo");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6318AlgoGuardCoverageBackstopTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6318AlgoGuardCoverageBackstopTest.java
@@ -88,7 +88,12 @@ class Issue6318AlgoGuardCoverageBackstopTest {
       Map.entry("AlgoWCC.java", "single union-find pass over every edge, O(V + E)")
   );
 
-  private static final Pattern GUARD_REFERENCE = Pattern.compile("WorkGuard|WorkCheckpoint|guard\\.|guard::");
+  // Call-site patterns, not bare "WorkGuard"/"WorkCheckpoint" tokens (PR #6714 review round 11): the earlier,
+  // looser regex would have passed a procedure that merely mentions "WorkGuard" in a comment without actually
+  // wiring a checkpoint into its dominant loop. newWorkGuard(/guard.check cover a procedure guarding itself
+  // directly; delegating to a checkpointed GraphAlgorithms kernel (the LCC CSR path) passes the guard as a
+  // WorkCheckpoint-shaped lambda, which the guard::check method-reference pattern already matches.
+  private static final Pattern GUARD_REFERENCE = Pattern.compile("newWorkGuard\\(|guard\\.check|guard::check");
 
   @Test
   void everyAlgoProcedureIsEitherSelfGuardedOrAJustifiedSinglePassExemption() throws IOException {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6318LocalClusteringCoefficientCsrAbortabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6318LocalClusteringCoefficientCsrAbortabilityTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6318 part 1 - {@code algo.localClusteringCoefficient} was abortable on its OLTP
+ * path (a {@code guard.check()} per node, already covered by {@code Issue6302AlgoGraphDrivenWorkGuardTest}, whose
+ * fixture never builds a {@link GraphAnalyticalView}) and not on its CSR path, which handed the whole computation
+ * to {@code GraphAlgorithms#localClusteringCoefficient} with nothing threaded through to stop it.
+ * <p>
+ * Same deterministic technique as {@code Issue6302AlgoGraphDrivenWorkGuardTest}: the interrupt is armed before the
+ * call starts, so the first checkpoint the procedure reaches must observe it regardless of the machine's speed.
+ * Before this fix, the CSR path's checkpoint did not exist at all, so this call ran to completion and returned a
+ * result despite the pending interrupt.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6318LocalClusteringCoefficientCsrAbortabilityTest {
+  private Database             database;
+  private GraphAnalyticalView  view;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6318-lcc-csr-abortability");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    // A small triangle-bearing graph is enough: the point is whether the checkpoint is consulted at all, not
+    // how much work the kernel does before finding it.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      final MutableVertex d = database.newVertex("Node").set("name", "D").save();
+      a.newEdge("LINK", b, true, (Object[]) null).save();
+      b.newEdge("LINK", c, true, (Object[]) null).save();
+      c.newEdge("LINK", a, true, (Object[]) null).save();
+      c.newEdge("LINK", d, true, (Object[]) null).save();
+    });
+
+    view = GraphAnalyticalView.builder(database)
+        .withName("lcc-abortability-view")
+        .withVertexTypes("Node")
+        .withEdgeTypes("LINK")
+        .build();
+  }
+
+  @AfterEach
+  void teardown() {
+    // A test that arms the interrupt flag must not leave it set for whatever runs next on this thread.
+    Thread.interrupted();
+    if (view != null)
+      view.drop();
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  @Timeout(60)
+  void theCSRPathStopsOnAThreadInterrupt() {
+    Thread.currentThread().interrupt();
+
+    assertThatThrownBy(() -> drain("CALL algo.localClusteringCoefficient() YIELD node RETURN node"))
+        .as("a Graph Analytical View must not make algo.localClusteringCoefficient any less abortable than its "
+            + "OLTP path")
+        .hasStackTraceContaining("algo.localClusteringCoefficient() has been interrupted");
+  }
+
+  /**
+   * The counterweight: with nothing armed, the CSR path still answers, and still through the view rather than
+   * silently falling back to OLTP - a guard wired in wrong could break either half.
+   */
+  @Test
+  void anUninterruptedCallStillReturnsItsResultThroughTheView() {
+    assertThat(drain("CALL algo.localClusteringCoefficient() YIELD node RETURN node")).hasSize(4);
+  }
+
+  private List<Result> drain(final String query) {
+    final List<Result> results = new ArrayList<>();
+    final ResultSet rs = database.query("opencypher", query);
+    while (rs.hasNext())
+      results.add(rs.next());
+    return results;
+  }
+}


### PR DESCRIPTION
Fixes #6316
Fixes #6265
Fixes #6318
Fixes #6705

## Summary

- **#6316** - `algo.kShortestPaths`, `algo.mst`, `algo.msa`, `algo.maxFlow`, `algo.betweenness` and `algo.degree` never resolved a Graph Analytical View at all, hand-rolling vertex loading and RID resolution instead of `loadGraph`/`GraphData`. All six now route through the shared helper; the two weighted ones (`kShortestPaths`, `msa`) read edges through `GraphData.weightedAdjacency`. `algo.betweenness` also moves its RID index off `HashMap<Vertex, Integer>` onto the RID-keyed scheme every other procedure uses. `algo.degree` gains `GraphData.degrees()`, an O(1)-per-node CSR degree lookup via `GraphTraversalProvider.getDegrees` instead of materialising a neighbour list just to count it. New CSR-vs-OLTP equivalence tests assert `CommandContext.CSR_ACCELERATED_VAR` so the comparison can't silently pin the OLTP path twice.
- **#6265** - `algo.influenceMaximization`'s `simulateIC` allocated a `boolean[n]` and an `int[n]` on every one of its `k x n x simulations` calls. Both buffers are now hoisted to the caller and reused, with `simulateIC` resetting only the entries it touched.
- **#6318** - `algo.localClusteringCoefficient`'s CSR path had no checkpoint at all (its OLTP path did). `GraphAlgorithms` gains `parallelForRangeCheckpointed`, which batches a range and checks in between batches; LCC's two parallel phases plus its sequential prep passes now use it, as do `pageRank`/`labelPropagation`'s own parallel phases for finer intra-iteration abort latency. A new backstop test discovers every `algo.*` procedure file on disk and fails if one is neither self-guarded nor in a justified single-pass exemption list.
- **#6705** - Not a real bug: two regression tests asserted the pre-#6680 "empty aggregate returns zero rows" behaviour for `avg()` with no `GROUP BY`. #6680 deliberately made that return one row with a null value (matching ANSI SQL scalar-aggregate semantics and `count(*)`'s own behaviour); the two tests were never updated. Fixed the tests, not the production code.
- **#6672** - Investigated and found already fixed by #6687 (merged); closed separately with no further change needed.

## Known limitations (tracked separately)

- **#6715** - `weightedAdjacencyFromColumns` (used by the columnar CSR path of `algo.mst`/`algo.msa`/`algo.maxFlow`/`algo.kShortestPaths`, and pre-existing for `algo.steinerTree`/`algo.bellmanFord`) throttles its `WorkGuard` checkpoint per node, not per edge, because `GraphTraversalProvider#edgeWeightsOf`'s only implementation has no checkpoint hook inside its own O(degree) loop. A single supernode is one unabortable unit of work regardless of fan-out. This is not new to this PR - the four newly-routed procedures previously always used a hand-rolled OLTP walk with genuine per-edge throttling, so it is a narrow, traded-off abortability regression for graphs with a very large supernode. A proper fix needs to widen the `GraphTraversalProvider` SPI itself, which is out of scope for this PR; documented in place and tracked in #6715.
- **#6716** - `algo.degree(relTypes?, direction?)` parses its `direction` argument but never uses it (pre-existing, predates this PR's conversion of the procedure onto `loadGraph`/`GraphData`).

## Test plan

- [x] `mvn -o -pl engine -am compile test-compile` - clean
- [x] New regression tests for each issue: `Issue6265InfluenceMaximizationBufferReuseTest`, `Issue6316AlgoLoadGraphAdoptionTest`, `Issue6318ParallelForRangeCheckpointedTest`, `Issue6318LocalClusteringCoefficientCsrAbortabilityTest`, `Issue6318AlgoGuardCoverageBackstopTest`
- [x] Verified `Issue6318LocalClusteringCoefficientCsrAbortabilityTest` genuinely fails against pre-fix code (stashed the production changes, confirmed the interrupt test failed with "no throwable raised")
- [x] Full `com.arcadedb.query.opencypher.**`, `com.arcadedb.graph.**`, `com.arcadedb.function.**`, `com.arcadedb.engine.timeseries.**`, `com.arcadedb.query.sql.executor.**` suites: 12900 tests, 0 failures caused by this change (3 pre-existing flakes confirmed unrelated - pass in isolation, fail only under a specific concurrent test-class ordering)
- [x] Fixed two other tests whose assertions pinned now-superseded implementation details: `Issue6300AlgoMSTEdgeBudgetTest` (edge-count refusal message shape) and `Issue6264AlgoIterationKnobGuardTest` (pageRank checkpoint call count)

https://claude.ai/code/session_013az14F8gvbcYips5GqiZfy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded analytical-view support across centrality, pathfinding, spanning-tree, flow, and arborescence algorithms.
  - Added more responsive interruption support for long-running graph algorithms, including clustering calculations.

- **Bug Fixes**
  - Improved graph algorithm memory usage and execution efficiency, including influence maximization.
  - Strengthened working-memory budget enforcement.
  - Improved consistency between standard and analytical-view results.
  - Empty-input averages and time-series aggregates now consistently return one row containing `null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
