### PR TITLE
fix(#6715, #6716): per-edge checkpoint in edgeWeightsOf, honour algo.degree's direction param

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -293,12 +293,19 @@ public interface GraphTraversalProvider {
    * A caller that does not visit many nodes in a row - a single-source search that reads one node's edges per
    * step, already bounded by its own outer loop - passes {@code null} and pays nothing beyond one comparison per
    * edge.
+   * <p>
+   * {@code edgeTypes} is a plain array here rather than the other overload's varargs, deliberately: a fifth
+   * argument of a bare {@code null} would otherwise be ambiguous between binding to {@code edgeCheckpoint} here
+   * and to the other overload's {@code String... edgeTypes} (both are reference types, and neither overload is
+   * more specific than the other from a {@code null} literal), breaking any existing five-argument call this
+   * SPI already has. Requiring six arguments to reach this overload at all keeps every four- and five-argument
+   * call - including a bare {@code null} - resolving to the other one, unchanged.
    *
    * @param edgeCheckpoint called with the edge index within this call (0-based), or {@code null} to skip it
    */
   default NodeEdgeWeights edgeWeightsOf(final int nodeId, final Vertex.DIRECTION direction,
       final String propertyName, final double defaultWeight, final IntConsumer edgeCheckpoint,
-      final String... edgeTypes) {
+      final String[] edgeTypes) {
     if (!servesEdgeProperty(propertyName, edgeTypes))
       return null;
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -20,6 +20,8 @@ package com.arcadedb.graph;
 
 import com.arcadedb.database.RID;
 
+import java.util.function.IntConsumer;
+
 /**
  * SPI for accelerated graph traversal providers (e.g., Graph Analytical Views backed by CSR).
  * <p>
@@ -270,6 +272,33 @@ public interface GraphTraversalProvider {
    */
   default NodeEdgeWeights edgeWeightsOf(final int nodeId, final Vertex.DIRECTION direction,
       final String propertyName, final double defaultWeight, final String... edgeTypes) {
+    return edgeWeightsOf(nodeId, direction, propertyName, defaultWeight, null, edgeTypes);
+  }
+
+  /**
+   * Same as {@link #edgeWeightsOf(int, Vertex.DIRECTION, String, double, String...)}, with one addition:
+   * {@code edgeCheckpoint}, if not {@code null}, is called once per edge as the per-(type, direction) slices are
+   * copied into the returned arrays, with a counter that restarts at zero for every call to this method.
+   * <p>
+   * A caller that visits every node of the graph in turn - {@code AbstractAlgoProcedure}'s columnar adjacency
+   * build does, once per node - has no other way to stay abortable mid-node: this method already returns one
+   * fully-built {@link NodeEdgeWeights} per call, so a single node with a very large degree (a supernode) is
+   * otherwise one unabortable unit of work regardless of how often the caller checkpoints between nodes (issue
+   * #6715). Restarting the counter at zero rather than threading a running total through is deliberate, the same
+   * choice {@link com.arcadedb.query.sql.executor.WorkGuard#checkPeriodically} documents for a loop whose counter
+   * restarts: it bounds the worst-case latency to about one checkpoint stride into the largest node, whatever the
+   * node before it looked like, and it keeps this method free of any dependency on where the caller's own count
+   * comes from.
+   * <p>
+   * A caller that does not visit many nodes in a row - a single-source search that reads one node's edges per
+   * step, already bounded by its own outer loop - passes {@code null} and pays nothing beyond one comparison per
+   * edge.
+   *
+   * @param edgeCheckpoint called with the edge index within this call (0-based), or {@code null} to skip it
+   */
+  default NodeEdgeWeights edgeWeightsOf(final int nodeId, final Vertex.DIRECTION direction,
+      final String propertyName, final double defaultWeight, final IntConsumer edgeCheckpoint,
+      final String... edgeTypes) {
     if (!servesEdgeProperty(propertyName, edgeTypes))
       return null;
 
@@ -291,11 +320,14 @@ public interface GraphTraversalProvider {
     final int[] neighbors = new int[degree];
     final double[] weights = new double[degree];
     int pos = 0;
+    int edgeCount = 0;
     s = 0;
     for (final String type : types)
       for (final Vertex.DIRECTION d : directions) {
         final int[] slice = slices[s++];
         for (int j = 0; j < slice.length; j++) {
+          if (edgeCheckpoint != null)
+            edgeCheckpoint.accept(edgeCount++);
           neighbors[pos] = slice[j];
           final Object value = getEdgeProperty(nodeId, j, d, type, propertyName);
           weights[pos] = value instanceof Number num ? num.doubleValue() : defaultWeight;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -917,9 +917,11 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
+      // Reserved before the row-header arrays are allocated, matching adjacency()'s own ordering: the budget
+      // is refused before a single byte of them is on the heap, not after (issue #6715 review).
+      reserveWeightedAdjacency(nodeCount, 0);
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
-      reserveWeightedAdjacency(nodeCount, 0);
       final long maxEntryCheckpoint = ADJACENCY_CHECKPOINT_ENTRIES / 3;
       long entries = 0;
       for (int i = 0; i < nodeCount; i++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -904,12 +904,19 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * dependency on {@link MemoryBudget}, so what is priced here is the cumulative cost across nodes, the same
      * bound {@link #reserveAdjacency} already gives the unweighted adjacency build; a single node whose row alone
      * exceeds the budget is still refused, just after that one row is built rather than during it.
+     * <p>
+     * The entries-seen checkpoint interval is capped by {@link MemoryBudget#capacityFor} against what is
+     * actually left of the configured budget, not only by {@code ADJACENCY_CHECKPOINT_ENTRIES / 3} (a third of
+     * {@link #adjacency}'s own constant, since a weighted entry costs {@code INT_BYTES + DOUBLE_BYTES} rather
+     * than {@code INT_BYTES} alone): reusing the unweighted constant outright would let a tight budget be
+     * overshot by three times as many bytes before a checkpoint ever fires (issue #6715 review).
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
       reserveWeightedAdjacency(nodeCount, 0);
+      final long entryCheckpoint = Math.min(ADJACENCY_CHECKPOINT_ENTRIES / 3, memory.capacityFor(INT_BYTES + DOUBLE_BYTES));
       long entries = 0;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
@@ -917,7 +924,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
         entries += edges.neighbors().length;
-        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
+        if (entries >= entryCheckpoint || (i & 1023) == 1023) {
           reserveWeightedAdjacency(0, entries);
           entries = 0;
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -905,18 +905,22 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * bound {@link #reserveAdjacency} already gives the unweighted adjacency build; a single node whose row alone
      * exceeds the budget is still refused, just after that one row is built rather than during it.
      * <p>
-     * The entries-seen checkpoint interval is capped by {@link MemoryBudget#capacityFor} against what is
-     * actually left of the configured budget, not only by {@code ADJACENCY_CHECKPOINT_ENTRIES / 3} (a third of
-     * {@link #adjacency}'s own constant, since a weighted entry costs {@code INT_BYTES + DOUBLE_BYTES} rather
-     * than {@code INT_BYTES} alone): reusing the unweighted constant outright would let a tight budget be
-     * overshot by three times as many bytes before a checkpoint ever fires (issue #6715 review).
+     * The entries-seen checkpoint interval is capped by {@link MemoryBudget#capacityFor}, recomputed after every
+     * reservation, against what is actually left of the configured budget - not only by
+     * {@code ADJACENCY_CHECKPOINT_ENTRIES / 3} (a third of {@link #adjacency}'s own constant, since a weighted
+     * entry costs {@code INT_BYTES + DOUBLE_BYTES} rather than {@code INT_BYTES} alone: reusing the unweighted
+     * constant outright would let a tight budget be overshot by three times as many bytes before a checkpoint
+     * ever fires). Capping only once before the loop would go stale as the budget fills up: capacity keeps
+     * shrinking with every reservation, so a threshold computed against the very first, most generous reading
+     * of it could let a later batch through that the remaining budget no longer has room for (issue #6715
+     * review).
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
       reserveWeightedAdjacency(nodeCount, 0);
-      final long entryCheckpoint = Math.min(ADJACENCY_CHECKPOINT_ENTRIES / 3, memory.capacityFor(INT_BYTES + DOUBLE_BYTES));
+      final long maxEntryCheckpoint = ADJACENCY_CHECKPOINT_ENTRIES / 3;
       long entries = 0;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
@@ -924,6 +928,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
         entries += edges.neighbors().length;
+        final long entryCheckpoint = Math.min(maxEntryCheckpoint, memory.capacityFor(INT_BYTES + DOUBLE_BYTES));
         if (entries >= entryCheckpoint || (i & 1023) == 1023) {
           reserveWeightedAdjacency(0, entries);
           entries = 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -895,18 +895,48 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * per-type, per-direction slicing that keeps a weight with its own edge lives. Nothing about that pairing is
      * re-derived here, so the CSR path of an {@code algo.*} procedure, of {@code astar} and of
      * {@code bellmanFord} cannot drift apart from one another.
+     * <p>
+     * {@code guard::checkPeriodically} is threaded into {@code edgeWeightsOf} itself rather than only checked
+     * between two calls to it: one call already returns a fully-built row for one node, so a single supernode
+     * would otherwise be one unabortable unit of work regardless of how tightly the per-node loop below is
+     * checkpointed (issue #6715). The memory side of the same gap - a supernode's row is fully allocated before
+     * {@link #reserveWeightedAdjacency} ever runs - cannot be closed the same way without handing this SPI a
+     * dependency on {@link MemoryBudget}, so what is priced here is the cumulative cost across nodes, the same
+     * bound {@link #reserveAdjacency} already gives the unweighted adjacency build; a single node whose row alone
+     * exceeds the budget is still refused, just after that one row is built rather than during it.
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
+      reserveWeightedAdjacency(nodeCount, 0);
+      long entries = 0;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
-        final NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, types);
+        final NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, guard::checkPeriodically, types);
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
+        entries += edges.neighbors().length;
+        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
+          reserveWeightedAdjacency(0, entries);
+          entries = 0;
+        }
       }
+      reserveWeightedAdjacency(0, entries);
       return new WeightedAdjacency(neighbors, weights);
+    }
+
+    /**
+     * Charges {@code rows} neighbour/weight row-header pairs and {@code entries} (neighbour id + weight) pairs to
+     * the call's budget - the weighted counterpart of {@link #reserveAdjacency}, doubled because a
+     * {@link WeightedAdjacency} holds a neighbour array AND a weight array per node rather than one.
+     */
+    private void reserveWeightedAdjacency(final long rows, final long entries) {
+      if (rows == 0 && entries == 0)
+        return;
+      memory.reserve(saturatingSum(saturatingProduct(rows, MATRIX_ROW_OVERHEAD_BYTES * 2),
+              saturatingProduct(entries, INT_BYTES + DOUBLE_BYTES)), "the weighted adjacency",
+          rows > 0 ? rows + " nodes, " + entries + " edge entries" : entries + " edge entries");
     }
 
     /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentrality.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentrality.java
@@ -34,6 +34,11 @@ import java.util.stream.Stream;
  * Uses {@code vertex.countEdges()} for maximum efficiency — no edge objects are materialised.
  * </p>
  * <p>
+ * {@code direction} (default {@code BOTH}) selects which edges count towards {@code degree}/{@code score}: with
+ * {@code IN} or {@code OUT}, only that direction is counted (and the other of {@code inDegree}/{@code outDegree}
+ * is 0, since it was never read), rather than always summing both regardless of what was requested.
+ * </p>
+ * <p>
  * Example:
  * <pre>
  * CALL algo.degree()
@@ -77,7 +82,7 @@ public class AlgoDegreeCentrality extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final String dirArg = args.length > 1 ? extractString(args[1], "direction") : "BOTH";
+    final Vertex.DIRECTION dir = args.length > 1 ? parseDirection(extractString(args[1], "direction")) : Vertex.DIRECTION.BOTH;
 
     final Database db = context.getDatabase();
     final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
@@ -89,12 +94,10 @@ public class AlgoDegreeCentrality extends AbstractAlgoProcedure {
     final double norm = n > 1 ? (double) (n - 1) : 1.0;
 
     return vertices.stream().map(v -> {
-      final long in = relTypes != null && relTypes.length > 0 ?
-          v.countEdges(Vertex.DIRECTION.IN, relTypes) :
-          v.countEdges(Vertex.DIRECTION.IN);
-      final long out = relTypes != null && relTypes.length > 0 ?
-          v.countEdges(Vertex.DIRECTION.OUT, relTypes) :
-          v.countEdges(Vertex.DIRECTION.OUT);
+      // Only the requested direction(s) are counted: a caller that filters to IN or OUT is asking to skip the
+      // cost of the other one too, not only to have it excluded from the total.
+      final long in = dir != Vertex.DIRECTION.OUT ? countEdges(v, Vertex.DIRECTION.IN, relTypes) : 0;
+      final long out = dir != Vertex.DIRECTION.IN ? countEdges(v, Vertex.DIRECTION.OUT, relTypes) : 0;
       final long total = in + out;
       final ResultInternal r = new ResultInternal();
       r.setProperty("node", v.getIdentity());
@@ -104,5 +107,9 @@ public class AlgoDegreeCentrality extends AbstractAlgoProcedure {
       r.setProperty("score", total / norm);
       return (Result) r;
     });
+  }
+
+  private static long countEdges(final Vertex v, final Vertex.DIRECTION direction, final String[] relTypes) {
+    return relTypes != null && relTypes.length > 0 ? v.countEdges(direction, relTypes) : v.countEdges(direction);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentralityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentralityTest.java
@@ -132,15 +132,17 @@ class AlgoDegreeCentralityTest {
   }
 
   private void assertDegreeOfE(final String query, final long expectedIn, final long expectedOut, final long expectedDegree) {
-    final ResultSet rs = database.query("opencypher", query);
     boolean found = false;
-    while (rs.hasNext()) {
-      final Result r = rs.next();
-      if ("E".equals(r.getProperty("name"))) {
-        found = true;
-        assertThat(((Number) r.getProperty("inDegree")).longValue()).as(query + " inDegree").isEqualTo(expectedIn);
-        assertThat(((Number) r.getProperty("outDegree")).longValue()).as(query + " outDegree").isEqualTo(expectedOut);
-        assertThat(((Number) r.getProperty("degree")).longValue()).as(query + " degree").isEqualTo(expectedDegree);
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        if ("E".equals(r.getProperty("name"))) {
+          found = true;
+          assertThat(((Number) r.getProperty("inDegree")).longValue()).as(query + " inDegree").isEqualTo(expectedIn);
+          assertThat(((Number) r.getProperty("outDegree")).longValue()).as(query + " outDegree").isEqualTo(expectedOut);
+          assertThat(((Number) r.getProperty("degree")).longValue()).as(query + " degree").isEqualTo(expectedDegree);
+          break;
+        }
       }
     }
     assertThat(found).as("node E must be present in the result").isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentralityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentralityTest.java
@@ -104,6 +104,48 @@ class AlgoDegreeCentralityTest {
     }
   }
 
+  /**
+   * Issue #6716: {@code direction} was parsed but never used, so {@code degree}/{@code score} were always the
+   * full IN+OUT total whatever direction was requested. E has a different in-degree and out-degree (2 out, 3
+   * in), which BOTH/IN/OUT must each answer differently once the parameter actually takes effect.
+   */
+  @Test
+  void degreeDirectionParameterIsHonoured() {
+    database.transaction(() -> {
+      final MutableVertex e = database.newVertex("Node").set("name", "E").save();
+      final MutableVertex f = database.newVertex("Node").set("name", "F").save();
+      e.newEdge("LINK", f, true, (Object[]) null).save();
+      e.newEdge("LINK", f, true, (Object[]) null).save();
+      f.newEdge("LINK", e, true, (Object[]) null).save();
+      f.newEdge("LINK", e, true, (Object[]) null).save();
+      f.newEdge("LINK", e, true, (Object[]) null).save();
+    });
+
+    assertDegreeOfE("CALL algo.degree(null, 'OUT') YIELD node, inDegree, outDegree, degree "
+        + "RETURN node.name AS name, inDegree, outDegree, degree", 0L, 2L, 2L);
+    assertDegreeOfE("CALL algo.degree(null, 'IN') YIELD node, inDegree, outDegree, degree "
+        + "RETURN node.name AS name, inDegree, outDegree, degree", 3L, 0L, 3L);
+    assertDegreeOfE("CALL algo.degree(null, 'BOTH') YIELD node, inDegree, outDegree, degree "
+        + "RETURN node.name AS name, inDegree, outDegree, degree", 3L, 2L, 5L);
+    assertDegreeOfE("CALL algo.degree() YIELD node, inDegree, outDegree, degree "
+        + "RETURN node.name AS name, inDegree, outDegree, degree", 3L, 2L, 5L);
+  }
+
+  private void assertDegreeOfE(final String query, final long expectedIn, final long expectedOut, final long expectedDegree) {
+    final ResultSet rs = database.query("opencypher", query);
+    boolean found = false;
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      if ("E".equals(r.getProperty("name"))) {
+        found = true;
+        assertThat(((Number) r.getProperty("inDegree")).longValue()).as(query + " inDegree").isEqualTo(expectedIn);
+        assertThat(((Number) r.getProperty("outDegree")).longValue()).as(query + " outDegree").isEqualTo(expectedOut);
+        assertThat(((Number) r.getProperty("degree")).longValue()).as(query + " degree").isEqualTo(expectedDegree);
+      }
+    }
+    assertThat(found).as("node E must be present in the result").isTrue();
+  }
+
   @Test
   void degreeReturnsFourResults() {
     final ResultSet rs = database.query("opencypher",

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6715: {@code AbstractAlgoProcedure.GraphData.weightedAdjacencyFromColumns} checkpointed its
+ * {@link com.arcadedb.query.sql.executor.WorkGuard} once per <em>node</em>, but
+ * {@link GraphTraversalProvider#edgeWeightsOf} - the one call each iteration makes to read a node's weighted
+ * edges from a Graph Analytical View's columns - had no checkpoint of its own inside its O(degree) loop. A
+ * supernode's row was therefore one unabortable unit of work: once {@code edgeWeightsOf} was entered for it,
+ * nothing could stop the call until the whole row was built, however large the degree.
+ * <p>
+ * The fix threads the guard into {@code edgeWeightsOf} itself (a new overload taking a per-edge checkpoint
+ * callback) so the walk can be interrupted mid-row, and gives the columnar build the same cumulative memory
+ * reservation {@code adjacency()} already has, closing the second gap the issue's own follow-up comment named:
+ * a supernode's arrays were never charged against {@code CYPHER_ALGO_MAX_WORKING_MEMORY} at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6715EdgeWeightsOfCheckpointTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6715-edgeweightsof-checkpoint");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void teardown() {
+    // A test that arms the interrupt flag must not leave it set for whatever runs next on this thread.
+    Thread.interrupted();
+    if (database != null) {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      GraphTraversalProviderRegistry.clearAll(database);
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * The interrupt is armed from inside the provider itself, once the walk is a handful of edges into the
+   * supernode's row - not before the call, which the outer per-node checkpoint would already catch regardless of
+   * this fix. Before the fix, {@code edgeWeightsOf} has no checkpoint of its own, so the row is built to
+   * completion (all {@code supernodeDegree} calls to {@link WeightedSupernodeProvider#getEdgeProperty}) before
+   * the interrupt is ever observed. After the fix, the per-edge checkpoint restarts at zero for this call and
+   * fires at the next multiple of 1024, so the walk stops within about one checkpoint stride of where the
+   * interrupt was raised - orders of magnitude short of the full degree.
+   */
+  @Test
+  void abortsMidSupernodeRatherThanBuildingTheWholeRow() {
+    final int nodeCount = 10;
+    final int supernodeIndex = 3;
+    final int supernodeDegree = 5_000_000;
+    final WeightedSupernodeProvider provider = new WeightedSupernodeProvider(nodeCount, supernodeIndex,
+        supernodeDegree, "LINK", "w", 5);
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    assertThatThrownBy(() -> drain("CALL algo.maxKCut(2, {weightProperty: 'w', direction: 'OUT'}) YIELD node RETURN node"))
+        .as("a per-edge checkpoint inside edgeWeightsOf must observe the interrupt raised mid-row")
+        .hasStackTraceContaining("algo.maxKCut() has been interrupted");
+
+    assertThat(provider.supernodeEdgeCalls.get())
+        .as("the walk must stop close to where the interrupt was raised, not after building the whole "
+            + supernodeDegree + "-edge row")
+        .isLessThan(2000);
+  }
+
+  /**
+   * The counterweight: a healthy call - nothing armed - still reads every edge of a (much smaller) supernode and
+   * returns its result, so the new checkpoint costs nothing when there is nothing to abort.
+   */
+  @Test
+  void aHealthyCallStillReadsEveryEdgeOfTheSupernode() {
+    final int nodeCount = 10;
+    final int supernodeIndex = 3;
+    final int supernodeDegree = 500;
+    final WeightedSupernodeProvider provider = new WeightedSupernodeProvider(nodeCount, supernodeIndex,
+        supernodeDegree, "LINK", "w", -1);
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    assertThat(drain("CALL algo.maxKCut(2, {weightProperty: 'w', direction: 'OUT'}) YIELD node RETURN node")).isNotEmpty();
+    assertThat(provider.supernodeEdgeCalls.get()).isEqualTo(supernodeDegree);
+  }
+
+  /**
+   * The memory side of the same gap, named in the issue's own follow-up comment: before this fix, the columnar
+   * weighted-adjacency build never reserved anything at all against {@code CYPHER_ALGO_MAX_WORKING_MEMORY}, so
+   * many medium-sized rows could together exceed the budget with nothing to refuse the call. 3000 nodes of 2000
+   * edges each is 6,000,000 entries; a budget that admits the row headers and the first ~525 nodes' worth of
+   * entries (the point {@code ADJACENCY_CHECKPOINT_ENTRIES} is first crossed) but not the whole graph must refuse
+   * partway through, well short of the full 6,000,000.
+   */
+  @Test
+  void manyMediumRowsTogetherExceedTheBudgetAndAreRefused() {
+    final int nodeCount = 3000;
+    final int degreePerNode = 2000;
+    final UniformDegreeProvider provider = new UniformDegreeProvider(nodeCount, degreePerNode, "LINK", "w");
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    // Admits the row-header reservation (3000 nodes * 2 arrays * 32 bytes = 192,000 bytes) but not the full
+    // 6,000,000-entry payload (6,000,000 * (4 + 8) bytes = 72,000,000 bytes).
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 2_000_000L);
+
+    assertThatThrownBy(() -> drain("CALL algo.maxKCut(2, {weightProperty: 'w', direction: 'OUT'}) YIELD node RETURN node"))
+        .as("the cumulative cost of many medium rows must be caught, not only a single oversized one")
+        .hasStackTraceContaining("the weighted adjacency");
+
+    assertThat(provider.edgePropertyCalls.get())
+        .as("the call must be refused well before every node's row was built")
+        .isLessThan(nodeCount * degreePerNode);
+  }
+
+  /**
+   * The counterweight: a budget generous enough for the whole graph must not be refused by the new reservation.
+   */
+  @Test
+  void aBudgetThatFitsTheWholeGraphLetsTheCallThrough() {
+    final int nodeCount = 200;
+    final int degreePerNode = 50;
+    final UniformDegreeProvider provider = new UniformDegreeProvider(nodeCount, degreePerNode, "LINK", "w");
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    assertThat(drain("CALL algo.maxKCut(2, {weightProperty: 'w', direction: 'OUT'}) YIELD node RETURN node")).isNotEmpty();
+    assertThat(provider.edgePropertyCalls.get()).isEqualTo(nodeCount * degreePerNode);
+  }
+
+  private java.util.List<Object> drain(final String query) {
+    final java.util.List<Object> rows = new java.util.ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        rows.add(resultSet.next());
+    }
+    return rows;
+  }
+
+  /**
+   * A minimal {@link GraphTraversalProvider} test double serving one weighted edge type/property: every node is
+   * empty except {@code supernodeIndex}, whose row has {@code supernodeDegree} edges all reachable through
+   * {@code getEdgeProperty}. Self-interrupts the current thread once {@code getEdgeProperty} on the supernode has
+   * been called {@code selfInterruptAfterCalls} times ({@code -1} disables this).
+   */
+  private static final class WeightedSupernodeProvider implements GraphTraversalProvider {
+    private final int    nodeCount;
+    private final int    supernodeIndex;
+    private final int    supernodeDegree;
+    private final String edgeType;
+    private final String weightProperty;
+    private final int    selfInterruptAfterCalls;
+    final AtomicInteger supernodeEdgeCalls = new AtomicInteger();
+
+    WeightedSupernodeProvider(final int nodeCount, final int supernodeIndex, final int supernodeDegree,
+        final String edgeType, final String weightProperty, final int selfInterruptAfterCalls) {
+      this.nodeCount = nodeCount;
+      this.supernodeIndex = supernodeIndex;
+      this.supernodeDegree = supernodeDegree;
+      this.edgeType = edgeType;
+      this.weightProperty = weightProperty;
+      this.selfInterruptAfterCalls = selfInterruptAfterCalls;
+    }
+
+    @Override
+    public int getNodeCount() {
+      return nodeCount;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "test-weighted-supernode-provider";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return -1;
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return new RID(0, nodeId);
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return new int[nodeId == supernodeIndex ? supernodeDegree : 0];
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return nodeId == supernodeIndex ? supernodeDegree : 0;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return false;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+
+    @Override
+    public String[] getMaterializedEdgeTypes() {
+      return new String[] { edgeType };
+    }
+
+    @Override
+    public boolean hasEdgeProperties() {
+      return true;
+    }
+
+    @Override
+    public boolean hasEdgeProperty(final String edgeType, final String propertyName) {
+      return this.edgeType.equals(edgeType) && weightProperty.equals(propertyName);
+    }
+
+    @Override
+    public Object getEdgeProperty(final int nodeId, final int neighborIndex, final Vertex.DIRECTION direction,
+        final String edgeType, final String propertyName) {
+      if (nodeId == supernodeIndex) {
+        final int calls = supernodeEdgeCalls.incrementAndGet();
+        if (selfInterruptAfterCalls >= 0 && calls == selfInterruptAfterCalls)
+          Thread.currentThread().interrupt();
+      }
+      return 1.0;
+    }
+  }
+
+  /**
+   * A {@link GraphTraversalProvider} test double where every node has the same degree, so the cost that has to
+   * be refused is the sum across many nodes rather than one oversized row.
+   */
+  private static final class UniformDegreeProvider implements GraphTraversalProvider {
+    private final int    nodeCount;
+    private final int    degreePerNode;
+    private final String edgeType;
+    private final String weightProperty;
+    final AtomicInteger edgePropertyCalls = new AtomicInteger();
+
+    UniformDegreeProvider(final int nodeCount, final int degreePerNode, final String edgeType, final String weightProperty) {
+      this.nodeCount = nodeCount;
+      this.degreePerNode = degreePerNode;
+      this.edgeType = edgeType;
+      this.weightProperty = weightProperty;
+    }
+
+    @Override
+    public int getNodeCount() {
+      return nodeCount;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "test-uniform-degree-provider";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return -1;
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return new RID(0, nodeId);
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return new int[degreePerNode];
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return degreePerNode;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return false;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+
+    @Override
+    public String[] getMaterializedEdgeTypes() {
+      return new String[] { edgeType };
+    }
+
+    @Override
+    public boolean hasEdgeProperties() {
+      return true;
+    }
+
+    @Override
+    public boolean hasEdgeProperty(final String edgeType, final String propertyName) {
+      return this.edgeType.equals(edgeType) && weightProperty.equals(propertyName);
+    }
+
+    @Override
+    public Object getEdgeProperty(final int nodeId, final int neighborIndex, final Vertex.DIRECTION direction,
+        final String edgeType, final String propertyName) {
+      edgePropertyCalls.incrementAndGet();
+      return 1.0;
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -125,9 +125,10 @@ class Issue6715EdgeWeightsOfCheckpointTest {
    * The memory side of the same gap, named in the issue's own follow-up comment: before this fix, the columnar
    * weighted-adjacency build never reserved anything at all against {@code CYPHER_ALGO_MAX_WORKING_MEMORY}, so
    * many medium-sized rows could together exceed the budget with nothing to refuse the call. 3000 nodes of 2000
-   * edges each is 6,000,000 entries; a budget that admits the row headers and the first ~525 nodes' worth of
-   * entries (the point {@code ADJACENCY_CHECKPOINT_ENTRIES} is first crossed) but not the whole graph must refuse
-   * partway through, well short of the full 6,000,000.
+   * edges each is 6,000,000 entries; a tight 2,000,000-byte budget - which admits the row headers and only a
+   * small fraction of the entries, since the checkpoint interval is capped by {@code MemoryBudget.capacityFor}
+   * against what is actually left of it, not just the coarser {@code ADJACENCY_CHECKPOINT_ENTRIES / 3} - must
+   * refuse within the first few dozen nodes, well short of building all 3000 rows.
    */
   @Test
   void manyMediumRowsTogetherExceedTheBudgetAndAreRefused() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -161,8 +163,8 @@ class Issue6715EdgeWeightsOfCheckpointTest {
     assertThat(provider.edgePropertyCalls.get()).isEqualTo(nodeCount * degreePerNode);
   }
 
-  private java.util.List<Object> drain(final String query) {
-    final java.util.List<Object> rows = new java.util.ArrayList<>();
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
     try (final ResultSet resultSet = database.query("opencypher", query)) {
       while (resultSet.hasNext())
         rows.add(resultSet.next());


### PR DESCRIPTION
## Summary

Fixes #6715 and #6716.

**#6715** - `AbstractAlgoProcedure.GraphData.weightedAdjacencyFromColumns` checkpointed its `WorkGuard` once per node, but `GraphTraversalProvider#edgeWeightsOf`'s O(degree) inner loop had no checkpoint of its own. A single supernode's row was therefore one unabortable unit of work, whatever `arcadedb.command.timeout` or a thread interrupt said.

- Adds an `edgeWeightsOf` overload taking a per-edge checkpoint callback (`IntConsumer`), called once per edge inside the walk. The counter restarts at zero on every call - the same convention `WorkGuard`'s own javadoc documents for a restarting loop counter - which bounds the worst-case latency to about one checkpoint stride into the largest node's row, independent of the caller's own per-node count. This is additive: the existing 5-arg method delegates to the new one with a `null` checkpoint, so `SQLFunctionAstar` and `SQLFunctionBellmanFord` (the other two call sites) are unaffected.
- `weightedAdjacencyFromColumns` now passes `guard::checkPeriodically` as that checkpoint.
- Also closes the memory side the issue's own follow-up comment named: the columnar build never reserved anything against `CYPHER_ALGO_MAX_WORKING_MEMORY` before this change. It now gets the same cumulative, entries-plus-node-count-checkpointed reservation the unweighted `adjacency()` build already has. A single node whose row alone blows the budget is still refused only after that one row is built (closing this fully would mean handing the `GraphTraversalProvider` SPI a dependency on `AbstractAlgoProcedure.MemoryBudget`, which felt like the wrong tradeoff for this fix - flagging in case there's a different call here).

**#6716** - `AlgoDegreeCentrality` parsed its `direction` argument but never used it: `degree`/`score` were always the full IN+OUT total regardless of what was requested. Now only the requested direction(s) are counted (and the other of `inDegree`/`outDegree` is 0, since it's no longer read), keeping today's IN+OUT behavior for `BOTH`/unset.

## Test plan
- [x] `Issue6715EdgeWeightsOfCheckpointTest`: a pre-armed self-interrupting stub provider proves the walk now aborts within ~1 checkpoint stride of a supernode row rather than building the whole thing (was: ran to completion); a cumulative multi-node budget test proves many medium rows are now refused (was: never reserved anything at all); counterweights confirm a healthy run is unaffected.
- [x] `AlgoDegreeCentralityTest#degreeDirectionParameterIsHonoured`: a node with distinct in/out degree confirms `BOTH`/`IN`/`OUT`/unset each answer correctly.
- [x] `mvn -o -pl engine -am test` over the full `algo` procedure package, `GraphTraversalProvider`-adjacent tests, and the affected `function.sql.graph` tests: all green, no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direction-aware degree calculations for incoming, outgoing, both, and default directions.
  * Added optional progress checkpoints for weighted graph traversals.

* **Bug Fixes**
  * Corrected direction-specific degree results while preserving relationship-type filtering.
  * Improved handling of large weighted traversals with interruption checks and memory-limit enforcement.

* **Tests**
  * Added coverage for degree directions, traversal interruption, progress tracking, and cumulative memory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->