### PR TITLE
fix(#6713, #6566): unlock ensureGraphAvailable() validation + surface sparse-vector epochUntrusted

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -563,10 +563,24 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
    * Delegated rather than left at the interface default: a sparse-vector posting key is a dimension identifier, so
    * the key-order mismatch of #5802 should never arise here - but that is an invariant about the keys, not a property
    * of this class, and answering {@code null} unconditionally would hide the mismatch if it ever did.
+   * <p>
+   * Also folds in {@link PaginatedSparseVectorEngine#untrustedSegmentCount()} (issue #6566): a segment merged before
+   * the recency-epoch fix of #6379 can still return a document that was deleted, and until now the only way to learn
+   * that was the once-per-instance WARNING log line at open/refresh time - unqueryable once the moment passed, and
+   * with no way to confirm a {@code REBUILD INDEX} actually cleared it. This makes the same condition answer through
+   * the surface every other index upgrade warning already uses: {@code schema:indexes}, {@code schema:index:<name>},
+   * Studio, and the HTTP admin API, all of which read {@link IndexInternal#getUpgradeWarning()} today.
    */
   @Override
   public String getUpgradeWarning() {
-    return underlyingIndex.getUpgradeWarning();
+    final String delegated = underlyingIndex.getUpgradeWarning();
+    final int untrustedSegments = engine.untrustedSegmentCount();
+    if (untrustedSegments == 0)
+      return delegated;
+    final String own = "%d of %d segment(s) carry a precedence that predates the recency-epoch fix (issue #6379); a "
+        + "document deleted before those segments were merged may still be returned by queries. Run 'REBUILD INDEX %s' "
+        + "once to rewrite them in the correct order.".formatted(untrustedSegments, engine.segmentCount(), getName());
+    return delegated == null ? own : delegated + " " + own;
   }
 
   @Override
@@ -653,6 +667,9 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     stats.put("memtablePostings", engine.memtablePostings());
     stats.put("totalPostings", engine.totalPostings());
     stats.put("segmentCount", (long) engine.segmentCount());
+    // Issue #6566: a queryable counterpart to the once-per-instance WARNING log line, so a monitoring system (or an
+    // operator re-checking after a REBUILD INDEX) can ask "is this index still affected" rather than grep for it.
+    stats.put("untrustedSegments", (long) engine.untrustedSegmentCount());
     return stats;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -564,22 +564,30 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
    * the key-order mismatch of #5802 should never arise here - but that is an invariant about the keys, not a property
    * of this class, and answering {@code null} unconditionally would hide the mismatch if it ever did.
    * <p>
-   * Also folds in {@link PaginatedSparseVectorEngine#untrustedSegmentCount()} (issue #6566): a segment merged before
-   * the recency-epoch fix of #6379 can still return a document that was deleted, and until now the only way to learn
+   * Also folds in {@link PaginatedSparseVectorEngine#segmentTrust()} (issue #6566): a segment merged before the
+   * recency-epoch fix of #6379 can still return a document that was deleted, and until now the only way to learn
    * that was the once-per-instance WARNING log line at open/refresh time - unqueryable once the moment passed, and
    * with no way to confirm a {@code REBUILD INDEX} actually cleared it. This makes the same condition answer through
    * the surface every other index upgrade warning already uses: {@code schema:indexes}, {@code schema:index:<name>},
    * Studio, and the HTTP admin API, all of which read {@link IndexInternal#getUpgradeWarning()} today.
+   * <p>
+   * Deliberately says nothing about WHAT to run: {@link #getName()} on this class is the physical per-bucket
+   * sub-index name, not the logical index {@code REBUILD INDEX} takes, and the contract on
+   * {@link IndexInternal#getUpgradeWarning()} is explicit that implementations say what is lost and why, not what to
+   * type - the caller ({@code LocalSchema.reportUpgradeWarning()}) resolves the logical name itself and appends the
+   * actual command, the same way {@link com.arcadedb.index.geospatial.LSMTreeGeoIndex#getUpgradeWarning()} leaves it
+   * (PR #6720 review: embedding a second, physical-named "Run 'REBUILD INDEX ...'" here would have shown an operator
+   * two different targets in the same message).
    */
   @Override
   public String getUpgradeWarning() {
     final String delegated = underlyingIndex.getUpgradeWarning();
-    final int untrustedSegments = engine.untrustedSegmentCount();
-    if (untrustedSegments == 0)
+    final PaginatedSparseVectorEngine.SegmentTrustSnapshot trust = engine.segmentTrust();
+    if (trust.untrusted() == 0)
       return delegated;
     final String own = "%d of %d segment(s) carry a precedence that predates the recency-epoch fix (issue #6379); a "
-        + "document deleted before those segments were merged may still be returned by queries. Run 'REBUILD INDEX %s' "
-        + "once to rewrite them in the correct order.".formatted(untrustedSegments, engine.segmentCount(), getName());
+        + "document deleted before those segments were merged may still be returned by queries.".formatted(
+        trust.untrusted(), trust.total());
     return delegated == null ? own : delegated + " " + own;
   }
 
@@ -666,10 +674,12 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     final Map<String, Long> stats = new HashMap<>();
     stats.put("memtablePostings", engine.memtablePostings());
     stats.put("totalPostings", engine.totalPostings());
-    stats.put("segmentCount", (long) engine.segmentCount());
+    // One snapshot for both, so the two numbers can never straddle a compaction landing in between (PR #6720 review).
+    final PaginatedSparseVectorEngine.SegmentTrustSnapshot trust = engine.segmentTrust();
+    stats.put("segmentCount", (long) trust.total());
     // Issue #6566: a queryable counterpart to the once-per-instance WARNING log line, so a monitoring system (or an
     // operator re-checking after a REBUILD INDEX) can ask "is this index still affected" rather than grep for it.
-    stats.put("untrustedSegments", (long) engine.untrustedSegmentCount());
+    stats.put("untrustedSegments", (long) trust.untrusted());
     return stats;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetrics.java
@@ -73,19 +73,24 @@ public final class LSMSparseVectorIndexMetrics {
       final TypeIndex typeIndex = sparse.getTypeIndex();
       final String key = typeIndex != null ? typeIndex.getName() : sparse.getName();
 
+      // One snapshot per engine for both counts, so a compaction landing between two separate reads cannot make a
+      // single bucket's own pair inconsistent (PR #6720 review); the sum across buckets below is still only as
+      // atomic as scraping several independent engines ever is, same as every other field aggregated here.
+      final PaginatedSparseVectorEngine.SegmentTrustSnapshot trust = engine.segmentTrust();
+
       final JSONObject entry;
       if (out.has(key)) {
         entry = out.getJSONObject(key);
         entry.put("memtablePostings", entry.getLong("memtablePostings", 0L) + engine.memtablePostings());
-        entry.put("segmentCount", entry.getInt("segmentCount", 0) + engine.segmentCount());
+        entry.put("segmentCount", entry.getInt("segmentCount", 0) + trust.total());
         entry.put("totalPostings", entry.getLong("totalPostings", 0L) + engine.totalPostings());
-        entry.put("untrustedSegments", entry.getInt("untrustedSegments", 0) + engine.untrustedSegmentCount());
+        entry.put("untrustedSegments", entry.getInt("untrustedSegments", 0) + trust.untrusted());
       } else {
         entry = new JSONObject();
         entry.put("memtablePostings", engine.memtablePostings());
-        entry.put("segmentCount", engine.segmentCount());
+        entry.put("segmentCount", trust.total());
         entry.put("totalPostings", engine.totalPostings());
-        entry.put("untrustedSegments", engine.untrustedSegmentCount());
+        entry.put("untrustedSegments", trust.untrusted());
         out.put(key, entry);
       }
     }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetrics.java
@@ -25,19 +25,23 @@ import com.arcadedb.serializer.json.JSONObject;
 
 /**
  * Builds a Studio-friendly snapshot of every {@link LSMSparseVectorIndex} live on a database:
- * memtable posting count, sealed segment count, and total postings. Operators read this on the
- * Server tab to spot a memtable that is not draining (compaction lag) or a runaway segment count
- * (size-tiered cascade jammed) without log-grepping or a JMX detour.
+ * memtable posting count, sealed segment count, total postings, and how many of those segments
+ * are still untrusted. Operators read this on the Server tab to spot a memtable that is not
+ * draining (compaction lag), a runaway segment count (size-tiered cascade jammed), or a segment
+ * whose precedence predates the recency-epoch fix (issue #6379) - without log-grepping or a JMX
+ * detour.
  * <p>
  * The shape returned is keyed by the user-facing {@link TypeIndex} name (e.g.
  * {@code Doc[tokens,weights]}) so Studio shows one row per logical index. Per-bucket physical
  * sub-indexes are summed under their parent {@code TypeIndex}, which is what an operator
  * thinks of as "the sparse-vector index". Values are pulled directly from the live engines -
- * no extra book-keeping; each counter is an O(1) read.
+ * no extra book-keeping; each counter is a cheap read bounded by the (small) active segment count.
  *
  * <pre>{
- *   "Doc[tokens,weights]":   { "memtablePostings": 12345, "segmentCount": 3, "totalPostings": 987654 },
- *   "Other[tokens,weights]": { "memtablePostings": 0,     "segmentCount": 1, "totalPostings": 543210 }
+ *   "Doc[tokens,weights]":   { "memtablePostings": 12345, "segmentCount": 3, "totalPostings": 987654,
+ *                               "untrustedSegments": 0 },
+ *   "Other[tokens,weights]": { "memtablePostings": 0,     "segmentCount": 1, "totalPostings": 543210,
+ *                               "untrustedSegments": 1 }
  * }</pre>
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -75,11 +79,13 @@ public final class LSMSparseVectorIndexMetrics {
         entry.put("memtablePostings", entry.getLong("memtablePostings", 0L) + engine.memtablePostings());
         entry.put("segmentCount", entry.getInt("segmentCount", 0) + engine.segmentCount());
         entry.put("totalPostings", entry.getLong("totalPostings", 0L) + engine.totalPostings());
+        entry.put("untrustedSegments", entry.getInt("untrustedSegments", 0) + engine.untrustedSegmentCount());
       } else {
         entry = new JSONObject();
         entry.put("memtablePostings", engine.memtablePostings());
         entry.put("segmentCount", engine.segmentCount());
         entry.put("totalPostings", engine.totalPostings());
+        entry.put("untrustedSegments", engine.untrustedSegmentCount());
         out.put(key, entry);
       }
     }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -1364,6 +1364,24 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
   }
 
   /**
+   * Count of currently active segments whose persisted precedence predates the recency-epoch fix (issue #6379) - the
+   * same condition {@link #warnOnPreRecencyEpochSegments} logs once at open/refresh time, re-derived from the live
+   * {@link #segments} snapshot on every call instead of latched by {@link #untrustedEpochWarned}. A log line can only
+   * be read once, at the moment it is emitted; this can be asked again at any time - including after a
+   * {@code REBUILD INDEX}, to confirm the remedy actually worked (issue #6566). O(active segment count), the same
+   * cost as {@link #segmentCount()} - cheap enough for {@link com.arcadedb.index.IndexInternal#getUpgradeWarning()}'s
+   * "called on every listing" contract, which is what surfaces this to {@code schema:indexes} / Studio / the HTTP
+   * admin API.
+   */
+  public int untrustedSegmentCount() {
+    int count = 0;
+    for (final PaginatedSegmentReader r : segments.get())
+      if (r.epochUntrusted())
+        count++;
+    return count;
+  }
+
+  /**
    * Ids of the active segments, sorted ascending.
    * <p>
    * <b>Not parallel to {@link #segmentEpochs()}.</b> This one sorts; that one preserves the array's

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -1364,21 +1364,39 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
   }
 
   /**
-   * Count of currently active segments whose persisted precedence predates the recency-epoch fix (issue #6379) - the
-   * same condition {@link #warnOnPreRecencyEpochSegments} logs once at open/refresh time, re-derived from the live
-   * {@link #segments} snapshot on every call instead of latched by {@link #untrustedEpochWarned}. A log line can only
-   * be read once, at the moment it is emitted; this can be asked again at any time - including after a
-   * {@code REBUILD INDEX}, to confirm the remedy actually worked (issue #6566). O(active segment count), the same
+   * A consistent point-in-time pairing of the active segment count and how many of those segments are untrusted,
+   * taken from a single {@link #segments} snapshot. Reading the two counters separately (as an earlier version of
+   * this fix did) can observe them straddling a compaction that lands in between the two reads - harmless for either
+   * number alone, but a formatted message that combines them ("N of M segments...") could then say something that
+   * was never true at any instant, such as more untrusted segments than active ones (PR #6720 review).
+   *
+   * @param total     active segment count, matching {@link #segmentCount()}
+   * @param untrusted how many of those carry a persisted precedence that predates the recency-epoch fix (issue #6379)
+   */
+  public record SegmentTrustSnapshot(int total, int untrusted) {
+  }
+
+  /**
+   * {@link #segmentTrust()}'s untrusted half, re-derived from the live {@link #segments} snapshot on every call
+   * instead of latched by {@link #untrustedEpochWarned} the way {@link #warnOnPreRecencyEpochSegments} is. A log
+   * line can only be read once, at the moment it is emitted; this can be asked again at any time - including after
+   * a {@code REBUILD INDEX}, to confirm the remedy actually worked (issue #6566). O(active segment count), the same
    * cost as {@link #segmentCount()} - cheap enough for {@link com.arcadedb.index.IndexInternal#getUpgradeWarning()}'s
    * "called on every listing" contract, which is what surfaces this to {@code schema:indexes} / Studio / the HTTP
    * admin API.
    */
   public int untrustedSegmentCount() {
-    int count = 0;
-    for (final PaginatedSegmentReader r : segments.get())
+    return segmentTrust().untrusted();
+  }
+
+  /** See {@link SegmentTrustSnapshot}. */
+  public SegmentTrustSnapshot segmentTrust() {
+    final PaginatedSegmentReader[] active = segments.get();
+    int untrusted = 0;
+    for (final PaginatedSegmentReader r : active)
       if (r.epochUntrusted())
-        count++;
-    return count;
+        untrusted++;
+    return new SegmentTrustSnapshot(active.length, untrusted);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -1960,6 +1960,17 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
    * and would otherwise say nothing, leaving only the leader's log to go on. That path runs on
    * every query, so {@link #untrustedEpochWarned} latches the line to once per engine instance
    * instead of once per refresh.
+   * <p>
+   * Deliberately says nothing about WHAT to run: {@link #indexName} here is the physical per-bucket
+   * sub-index name (as passed from {@code LSMSparseVectorIndex.openEngine()}), not the logical
+   * index {@code REBUILD INDEX} takes - the same distinction issue #6566's PR #6720 review fixed on
+   * {@link com.arcadedb.index.sparsevector.LSMSparseVectorIndex#getUpgradeWarning()}. This class has
+   * no access to the logical {@code TypeIndex} name to get that right, so it leaves the remedy to
+   * the surface that does: {@code getUpgradeWarning()} folds in {@link #untrustedSegmentCount()} for
+   * exactly this condition, and {@code LocalSchema.reportUpgradeWarning()} logs it - separately from
+   * this line - with the correct logical name and command (PR #6720 review, second round: an earlier
+   * version of this fix left this WARNING's own remedy clause wrong, so a reopen logged two lines for
+   * the same condition, one with a target that does not work).
    */
   private void warnOnPreRecencyEpochSegments(final List<PaginatedSegmentReader> readers) {
     int stale = 0;
@@ -1972,9 +1983,8 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
       return;
     LogManager.instance().log(this, Level.WARNING,
         "Sparse-vector index '%s' holds %d segment(s) whose precedence predates the recency-epoch fix (issue #6379); a "
-            + "document deleted before those segments were merged may still be returned by queries. Run "
-            + "'REBUILD INDEX %s' once to rewrite them in the correct order.",
-        null, indexName, stale, indexName);
+            + "document deleted before those segments were merged may still be returned by queries.",
+        null, indexName, stale);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1344,11 +1344,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (graphState != GraphState.LOADING)
       return; // Graph already available or being built
 
-    lock.writeLock().lock();
+    // Serialize against buildGraphFromScratch() and other concurrent callers of this method, the same way
+    // buildGraphFromScratchWithRetry() serializes builders against each other (issue #6713). The persisted-graph
+    // validation below is O(live vector count) - for quantization types without inline storage it is one document
+    // lookup plus one property read per live vector - and used to run entirely under lock.writeLock(), stalling
+    // every reader and writer of the index for the whole scan on a session's first search that finds a persisted
+    // graph after a reopen, exactly the stall issue #5391 already moved buildGraphFromScratchExclusively's own
+    // validation loop off of. Builders wait on this mutex; searches and inserts never touch it, so serializing
+    // here does not reintroduce the stall. graphBuildLock is reentrant, so the fallback call to
+    // buildGraphFromScratch() at the end of this method - which acquires the same lock - is safe from here.
+    graphBuildLock.lock();
     try {
-      // Double-check after acquiring lock
+      // Double-check after acquiring the lock
       if (graphState != GraphState.LOADING)
-        return; // Another thread already started building
+        return; // Another thread already resolved this while we waited for graphBuildLock
 
       // Try to load persisted graph from disk
       // IMPORTANT: If PRODUCT quantization is enabled but PQ file doesn't exist, we need to rebuild
@@ -1492,10 +1501,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 indexName, staleReason);
             // Don't use the stale graph — fall through to buildGraphFromScratch() below
           } else {
-            // Graph is up to date — use it
-            this.graphIndex = loadedGraph;
-            this.graphState = GraphState.IMMUTABLE;
-            this.ordinalToVectorId = rebuiltOrdinalToVectorId;
+            // Graph is up to date — publish it under a brief write lock (issue #6713), then finish PQ
+            // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
+            lock.writeLock().lock();
+            try {
+              this.graphIndex = loadedGraph;
+              this.ordinalToVectorId = rebuiltOrdinalToVectorId;
+              if (graphState == GraphState.LOADING)
+                this.graphState = GraphState.IMMUTABLE;
+              // else: a concurrent put()/putBatch()/remove() already advanced graphState to MUTABLE while
+              // this validation ran unlocked. The freshly loaded graph is still a correct base for
+              // mergeWithDeltaScan() to merge against - it was built from a vectorIndex snapshot taken during
+              // that validation, and whatever changed since then is already in deltaVectors - but overwriting
+              // MUTABLE back to IMMUTABLE here would hide those pending deltas from search.
+            } finally {
+              lock.writeLock().unlock();
+            }
 
             // Build PQ if PRODUCT quantization is enabled but PQ file doesn't exist
             // This handles the case where graph was built before PRODUCT quantization was added
@@ -1523,12 +1544,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
         }
       }
 
+      // No persisted graph, load failed, or it was stale - build from scratch. buildGraphFromScratch()
+      // acquires graphBuildLock itself; since it is reentrant this is safe to call while already holding it.
+      buildGraphFromScratch();
     } finally {
-      lock.writeLock().unlock();
+      graphBuildLock.unlock();
     }
-
-    // No persisted graph or load failed - build from scratch
-    buildGraphFromScratch();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
@@ -180,6 +180,15 @@ class Issue6566UntrustedSegmentSurfaceTest extends TestHelper {
             + "physical per-bucket sub-index name (%s) this fix used to embed a second time", engineName)
         .anyMatch(w -> w.contains("#6379") && w.contains(remedyLine) && countOccurrences(w, "REBUILD INDEX") == 1
             && !w.contains(engineName));
+
+    // Exhaustive, not anyMatch: a second, wrongly-targeted WARNING could coexist with the correct one above and
+    // an anyMatch-only assertion would not notice (PR #6720 review, round 2 - PaginatedSparseVectorEngine's own
+    // warnOnPreRecencyEpochSegments() log line had exactly this bug, undetected by this test's first version).
+    // Every captured line is checked, not just the one this test is looking for.
+    assertThat(warnings)
+        .as("no captured WARNING may pair 'REBUILD INDEX' with the physical per-bucket sub-index name (%s)",
+            engineName)
+        .noneMatch(w -> w.contains("REBUILD INDEX") && w.contains(engineName));
   }
 
   private LSMSparseVectorIndex sparseSubIndex(final String typeName) {

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6566: whether a sparse-vector index still holds a segment whose
+ * precedence predates the recency-epoch fix (issue #6379) used to be observable only as a
+ * once-per-instance {@code WARNING} log line - nothing could alert on it, and once a node had been
+ * up for a while there was no way to ask "is this index still affected" without restarting it, nor
+ * to confirm a {@code REBUILD INDEX} actually cleared it.
+ * <p>
+ * {@link PaginatedSparseVectorEngine#untrustedSegmentCount()} re-derives the same condition
+ * {@code warnOnPreRecencyEpochSegments} logs, but from the live segment snapshot on every call
+ * instead of latching it once - so it is what {@link LSMSparseVectorIndex#getStats()},
+ * {@link LSMSparseVectorIndex#getUpgradeWarning()} (the same surface {@code schema:indexes},
+ * {@code schema:index:<name>}, Studio and the HTTP admin API already read for every other index
+ * upgrade warning) and {@link LSMSparseVectorIndexMetrics#buildJSON} now expose.
+ * <p>
+ * "Legacy-shaped" segments are synthesised the way a pre-#6379 build actually left them on disk:
+ * parents recorded, recency epoch left at 0 - the same fixture
+ * {@code PaginatedSparseVectorEngineCompactionRecencyTest#preRecencyEpochMergedSegmentIsReportedAtOpen}
+ * uses to pin the WARNING log line itself.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6566UntrustedSegmentSurfaceTest extends TestHelper {
+
+  private static final int DIM = 0;
+
+  @Test
+  void untrustedSegmentCountReportsALegacyShapedSegmentAndConfirmsARebuildClearsIt() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // A legacy merge: parents recorded, epoch never set - the on-disk shape a pre-#6379 build left behind.
+    database.transaction(() -> {
+      final SparseSegmentComponent component = newComponent(db, "UntrustedSurfaceTest_seg99");
+      try (final SparseSegmentBuilder b = new SparseSegmentBuilder(component, SegmentParameters.defaults())) {
+        b.setSegmentId(99L);
+        b.setRecencyEpoch(0L); // what a pre-fix builder left in the slot
+        b.setParentSegments(new long[] { 90L, 91L });
+        b.startDim(DIM);
+        b.appendPosting(new RID(0, 500L), 0.5f);
+        b.endDim();
+        b.finish();
+      }
+    });
+
+    try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine(db, "UntrustedSurfaceTest",
+        SegmentParameters.defaults(), /* memtableFlushThreshold */ 100_000L, /* tierFanout */ 1_000_000,
+        /* tierBasePostings */ 1L)) {
+      assertThat(engine.segmentCount()).isEqualTo(1);
+      assertThat(engine.untrustedSegmentCount())
+          .as("the legacy-shaped segment must be counted, not only logged").isEqualTo(1);
+    }
+
+    // The remedy: drop the legacy segment and rebuild the index content from scratch, exactly what
+    // REBUILD INDEX does at the storage level - a fresh segment with no parents.
+    final var legacyComponent = ((LocalSchema) db.getSchema().getEmbedded()).getFileByName("UntrustedSurfaceTest_seg99");
+    assertThat(legacyComponent).isNotNull();
+    db.getFileManager().dropFile(legacyComponent.getFileId());
+
+    try (final PaginatedSparseVectorEngine rebuilt = new PaginatedSparseVectorEngine(db, "UntrustedSurfaceTest",
+        SegmentParameters.defaults(), /* memtableFlushThreshold */ 100_000L, /* tierFanout */ 1_000_000,
+        /* tierBasePostings */ 1L)) {
+      assertThat(rebuilt.segmentCount())
+          .as("the legacy segment must be gone, not merely outnumbered").isZero();
+      rebuilt.put(DIM, new RID(0, 501L), 0.7f);
+      rebuilt.flush();
+      assertThat(rebuilt.untrustedSegmentCount())
+          .as("a queryable stat, not only a latched log line: it must be able to go back to zero and say so, "
+              + "confirming the remedy actually worked").isZero();
+    }
+  }
+
+  /**
+   * End-to-end through the {@link LSMSparseVectorIndex} an ordinary {@code CREATE INDEX ... LSM_SPARSE_VECTOR}
+   * produces: the surface a monitoring system or Studio would actually read, not only the engine underneath it.
+   */
+  @Test
+  void upgradeWarningAndStatsSurfaceTheUntrustedSegmentThroughTheRealIndex() throws Exception {
+    final String typeName = "UntrustedSurfaceDoc";
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(typeName);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+      database.getSchema().buildTypeIndex(typeName, new String[] { "tokens", "weights" })
+          .withSparseVectorType().withDimensions(100).create();
+
+      final MutableDocument doc = database.newDocument(typeName);
+      doc.set("tokens", new int[] { 1, 5 });
+      doc.set("weights", new float[] { 0.3f, 0.7f });
+      doc.save();
+    });
+
+    final LSMSparseVectorIndex sparse = sparseSubIndex(typeName);
+    sparse.getEngine().flush();
+    final String engineName = sparse.getName(); // the per-bucket physical index name the engine's segments are keyed under
+
+    assertThat(sparse.getUpgradeWarning())
+        .as("nothing has been merged from a pre-#6379 segment yet").isNull();
+    assertThat(sparse.getStats().get("untrustedSegments")).isZero();
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    database.transaction(() -> {
+      final SparseSegmentComponent component = newComponent(db, engineName + "_seg999");
+      try (final SparseSegmentBuilder b = new SparseSegmentBuilder(component, SegmentParameters.defaults())) {
+        b.setSegmentId(999L);
+        b.setRecencyEpoch(0L);
+        b.setParentSegments(new long[] { 900L, 901L });
+        b.startDim(DIM);
+        b.appendPosting(new RID(0, 500L), 0.5f);
+        b.endDim();
+        b.finish();
+      }
+    });
+
+    reopenDatabase();
+
+    final LSMSparseVectorIndex reopened = sparseSubIndex(typeName);
+    assertThat(reopened.getStats().get("untrustedSegments"))
+        .as("the reopened index must count the legacy segment now on disk").isEqualTo(1L);
+    assertThat(reopened.getUpgradeWarning())
+        .as("the same surface every other index upgrade warning uses (schema:indexes, Studio, HTTP admin) "
+            + "must name both the issue and the remedy")
+        .contains("#6379").contains("REBUILD INDEX");
+  }
+
+  private LSMSparseVectorIndex sparseSubIndex(final String typeName) {
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName(typeName + "[tokens,weights]");
+    return (LSMSparseVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+  }
+
+  private static SparseSegmentComponent newComponent(final DatabaseInternal db, final String name) {
+    try {
+      final SparseSegmentComponent c = new SparseSegmentComponent(db, name, db.getDatabasePath() + "/" + name,
+          ComponentFile.MODE.READ_WRITE, SparseSegmentComponent.DEFAULT_PAGE_SIZE);
+      ((LocalSchema) db.getSchema().getEmbedded()).registerFile(c);
+      return c;
+    } catch (final IOException e) {
+      throw new RuntimeException("failed to create sparse segment component '" + name + "'", e);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6566UntrustedSegmentSurfaceTest.java
@@ -24,6 +24,8 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.Type;
@@ -31,6 +33,10 @@ import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -146,15 +152,34 @@ class Issue6566UntrustedSegmentSurfaceTest extends TestHelper {
       }
     });
 
-    reopenDatabase();
+    // Capture what the schema-load warning actually says on reopen (PR #6720 review): getUpgradeWarning() must
+    // describe the problem only, and LocalSchema.reportUpgradeWarning() - the sole caller that knows the LOGICAL
+    // TypeIndex name - must be the one and only place "REBUILD INDEX" is appended, naming that logical index and
+    // not the physical per-bucket sub-index name this test's own engineName variable holds.
+    final List<String> warnings = Collections.synchronizedList(new ArrayList<>());
+    final Logger originalLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(new CapturingLogger(warnings, originalLogger));
+    try {
+      reopenDatabase();
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
 
     final LSMSparseVectorIndex reopened = sparseSubIndex(typeName);
     assertThat(reopened.getStats().get("untrustedSegments"))
         .as("the reopened index must count the legacy segment now on disk").isEqualTo(1L);
     assertThat(reopened.getUpgradeWarning())
-        .as("the same surface every other index upgrade warning uses (schema:indexes, Studio, HTTP admin) "
-            + "must name both the issue and the remedy")
-        .contains("#6379").contains("REBUILD INDEX");
+        .as("getUpgradeWarning() itself must say what is lost, not what to type - the physical sub-index name "
+            + "must never appear in a 'REBUILD INDEX' clause it assembles")
+        .contains("#6379").doesNotContain("REBUILD INDEX");
+
+    final String logicalName = typeName + "[tokens,weights]";
+    final String remedyLine = "REBUILD INDEX `" + logicalName + "`";
+    assertThat(warnings)
+        .as("the schema-load WARNING must name the LOGICAL index for REBUILD INDEX exactly once, never the "
+            + "physical per-bucket sub-index name (%s) this fix used to embed a second time", engineName)
+        .anyMatch(w -> w.contains("#6379") && w.contains(remedyLine) && countOccurrences(w, "REBUILD INDEX") == 1
+            && !w.contains(engineName));
   }
 
   private LSMSparseVectorIndex sparseSubIndex(final String typeName) {
@@ -170,6 +195,67 @@ class Issue6566UntrustedSegmentSurfaceTest extends TestHelper {
       return c;
     } catch (final IOException e) {
       throw new RuntimeException("failed to create sparse segment component '" + name + "'", e);
+    }
+  }
+
+  private static int countOccurrences(final String haystack, final String needle) {
+    int count = 0;
+    for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length()))
+      count++;
+    return count;
+  }
+
+  /**
+   * Captures WARNING-and-above messages while forwarding everything to the real logger, matching the pattern
+   * {@code PaginatedSparseVectorEngineCompactionRecencyTest} uses for the same purpose. The fixed-arity overload
+   * must NOT delegate to the varargs one: the fixed arity is the exact match, so it would recurse until the stack
+   * dies.
+   */
+  private static final class CapturingLogger implements Logger {
+    private final List<String> warnings;
+    private final Logger       delegate;
+
+    CapturingLogger(final List<String> warnings, final Logger delegate) {
+      this.warnings = warnings;
+      this.delegate = delegate;
+    }
+
+    private void capture(final Level level, final String message, final Object... args) {
+      if (message == null || level.intValue() < Level.WARNING.intValue())
+        return;
+      String formatted = message;
+      if (args != null && args.length > 0) {
+        try {
+          formatted = message.formatted(args);
+        } catch (final Exception ignored) {
+          // Raw template is good enough for the substring matching the assertions do.
+        }
+      }
+      warnings.add(formatted);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+        final Object arg15, final Object arg16, final Object arg17) {
+      capture(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
+          arg15, arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      capture(level, message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetricsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexMetricsTest.java
@@ -101,9 +101,13 @@ class LSMSparseVectorIndexMetricsTest extends TestHelper {
         .as("entry must expose segmentCount").isTrue();
     assertThat(entry.has("totalPostings"))
         .as("entry must expose totalPostings").isTrue();
+    assertThat(entry.has("untrustedSegments"))
+        .as("entry must expose untrustedSegments (issue #6566)").isTrue();
     assertThat(entry.getLong("memtablePostings")).isGreaterThanOrEqualTo(0L);
     assertThat(entry.getInt("segmentCount")).isGreaterThanOrEqualTo(0);
     // 5 docs * 3 nnz = 15 postings, summed across however many buckets exist.
     assertThat(entry.getLong("totalPostings")).isEqualTo(15L);
+    // Nothing here was merged from a pre-#6379 segment, so the fresh index must read as trusted.
+    assertThat(entry.getInt("untrustedSegments")).isZero();
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngineCompactionRecencyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngineCompactionRecencyTest.java
@@ -506,9 +506,13 @@ class PaginatedSparseVectorEngineCompactionRecencyTest extends TestHelper {
         b.finish();
       }
     });
+    // No "Run 'REBUILD INDEX ...'" clause: this class only knows the physical per-bucket sub-index
+    // name, not the logical one the command actually takes, so it leaves the remedy to
+    // LocalSchema.reportUpgradeWarning() (PR #6720 review) - not exercised here, which opens the
+    // engine directly rather than through a full database/schema load.
     assertThat(warningsWhileOpening(db, "LegacyScanStaleTest"))
         .as("a segment with parents whose epoch equals its id predates the fix and must be reported")
-        .anyMatch(w -> w.contains("#6379") && w.contains("REBUILD INDEX"));
+        .anyMatch(w -> w.contains("#6379") && !w.contains("REBUILD INDEX"));
   }
 
   /**
@@ -560,7 +564,7 @@ class PaginatedSparseVectorEngineCompactionRecencyTest extends TestHelper {
 
     assertThat(warningsWhileOpening(db, "LegacyAbsorbTest"))
         .as("the doubt must be inherited by the merge, not erased by it")
-        .anyMatch(w -> w.contains("#6379") && w.contains("REBUILD INDEX"));
+        .anyMatch(w -> w.contains("#6379"));
   }
 
   /** Open an engine over {@code indexName} with a capturing logger installed, and return what it warned. */

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6713EnsureGraphAvailableUnlockedValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6713EnsureGraphAvailableUnlockedValidationTest.java
@@ -52,22 +52,28 @@ import static org.assertj.core.api.Assertions.assertThat;
  * all, only the validation - the one path #5391 never touched because it predates #5391 and sits in a different
  * method.
  * <p>
- * Reproduction: a large index (200,000 vectors of 1536 dimensions - large enough that the validation loop reliably
- * takes several hundred milliseconds, dimension chosen so the per-vector cost is dominated by the property read
- * and conversion rather than the document lookup alone) is built, persisted and closed cleanly, so the persisted
- * graph and its manifest describe exactly the live set. On reopen, a background thread runs the first search, which
- * drives {@code ensureGraphAvailable()} into the validation loop. While that is in flight, the main thread inserts
- * one more vector - an operation that only ever needs {@code lock.writeLock()} briefly - and times it. Before the
- * fix this insert would queue behind the whole validation loop; after the fix it returns promptly regardless of how
- * long the validation takes, because the loop no longer holds that lock.
+ * Reproduction: a large index (600,000 vectors of 128 dimensions - vector count, not dimension, is what drives the
+ * validation loop long enough to matter here, since each vector still costs one document lookup regardless of its
+ * width; a higher dimension was tried first and reproduced the same locking bug, but its ~7x larger heap footprint
+ * (600,000 x 1536 floats vs x 128) turned out to make the fixed-size validation workload itself GC-pressure-bound on
+ * a memory-constrained CI runner - confirmed locally by reproducing the same order-of-magnitude slowdown, and
+ * outright OutOfMemoryError, under a matching -Xmx2g. 128 dimensions keeps the same reproduction memory-safe) is
+ * built, persisted and closed cleanly, so the persisted graph and its manifest describe exactly the live set. On
+ * reopen, a background thread runs the first search, which drives {@code ensureGraphAvailable()} into the
+ * validation loop. While that is in flight, the main thread inserts one more vector - an operation that only ever
+ * needs {@code lock.writeLock()} briefly - and times it. Before the fix this insert would queue behind the whole
+ * validation loop; after the fix it returns promptly regardless of how long the validation takes, because the loop
+ * no longer holds that lock. The search thread is joined with a generous (not tight) timeout: how long the search
+ * itself takes to finish is a function of hardware speed, not of what this fix changed, so only insert latency -
+ * measured with {@link StallAwareStopwatch} - is asserted against a tight bound.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 @Tag("slow")
 class Issue6713EnsureGraphAvailableUnlockedValidationTest {
   private static final String DB_ROOT         = "target/test-databases/Issue6713EnsureGraphAvailableUnlockedValidationTest";
-  private static final int    DIMENSIONS      = 1536;
-  private static final int    NUM_VECTORS     = 200_000;
+  private static final int    DIMENSIONS      = 128;
+  private static final int    NUM_VECTORS     = 600_000;
   private static final int    MAX_CONNECTIONS = 8;
   private static final int    BEAM_WIDTH      = 16;
 
@@ -122,25 +128,51 @@ class Issue6713EnsureGraphAvailableUnlockedValidationTest {
             searchFailure.set(t);
           }
         }, "issue-6713-first-search");
+        // Measures the search thread's own total duration, not a fixed millisecond guess: how long an
+        // O(NUM_VECTORS) validation loop takes is a function of hardware speed (a >100x gap was measured between a
+        // fast workstation and a memory-constrained CI runner for the identical fixture), so the bound the
+        // concurrent insert below is measured against is a FRACTION of this run's own search duration rather than
+        // an absolute number - self-calibrating to whatever this machine turns out to be.
+        final StallAwareStopwatch searchStopwatch = StallAwareStopwatch.start();
         searchThread.start();
         assertThat(searchStarted.await(10, TimeUnit.SECONDS)).as("the search thread must have started").isTrue();
-        // A head start into ensureGraphAvailable()'s validation loop, which on this fixture reliably takes several
-        // hundred milliseconds - comfortably longer than this fixed wait plus the bound asserted below.
+        // A head start into ensureGraphAvailable()'s validation loop: negligible next to the loop's own total
+        // duration on any hardware where this fixture is even worth running.
         Thread.sleep(50);
 
         // A concurrent insert only ever needs lock.writeLock() briefly. Before the fix, ensureGraphAvailable() held
         // that same lock for its ENTIRE persisted-graph validation, so this insert would queue behind the search
-        // thread for as long as the (multi-hundred-millisecond) validation loop over NUM_VECTORS took.
-        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        // thread for as long as the validation loop over NUM_VECTORS took - effectively all of searchMs below, not
+        // a small fraction of it.
+        final StallAwareStopwatch insertStopwatch = StallAwareStopwatch.start();
         db.transaction(() -> db.command("sql", "INSERT INTO Doc SET id = ?, vector = ?", NUM_VECTORS,
             embedding(NUM_VECTORS)));
-        stopwatch.assertGaveUpWithin(400,
-            "an insert that only ever needs the write lock briefly, from one queued behind the whole persisted-graph "
-                + "validation loop");
+        final long insertMs = insertStopwatch.effectiveMs();
 
-        searchThread.join(TimeUnit.SECONDS.toMillis(30));
-        assertThat(searchThread.isAlive()).as("the search must complete on its own").isFalse();
+        // Generous, not tight: how long the search itself takes to finish is a function of hardware speed for an
+        // O(NUM_VECTORS) validation loop, not of what this fix changed (the fix is about the LOCK, not the loop's
+        // own duration) - a fixed tight bound here previously flaked on a slower CI runner even though nothing was
+        // stuck.
+        searchThread.join(TimeUnit.MINUTES.toMillis(5));
+        assertThat(searchThread.isAlive()).as("the search must complete on its own, not hang").isFalse();
         assertThat(searchFailure.get()).as("the search must not have failed").isNull();
+        final long searchMs = searchStopwatch.effectiveMs();
+
+        assertThat(searchMs)
+            .as("precondition: NUM_VECTORS must be large enough that the validation loop takes real time on this "
+                + "hardware, or the comparison below has no discriminating power")
+            .isGreaterThanOrEqualTo(100L);
+
+        // The self-calibrating tripwire: an insert that only ever needs the write lock briefly must take a small
+        // FRACTION of however long this run's own validation search took - not scale with it the way a lock held
+        // for the whole validation would. A fixed millisecond bound cannot separate the two cases across hardware
+        // that differs by two orders of magnitude on the identical fixture; this ratio does, because both
+        // measurements come from the same run on the same machine (PR #6720 review: the original fixed 400ms/30s
+        // bounds flaked on a CI runner where the whole fixture ran ~100x slower than on a fast workstation).
+        assertThat(insertMs)
+            .as("an insert that only ever needs the write lock briefly, out of a search that took %,d ms on this "
+                + "hardware - not one queued behind the whole persisted-graph validation loop", searchMs)
+            .isLessThan(searchMs / 3);
 
         // Not asserted here: graphRebuildCount. The concurrent insert above is itself a mutation, which - once
         // published - is exactly what schedules the ordinary async rebuild any mutation on a MUTABLE large graph

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6713EnsureGraphAvailableUnlockedValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6713EnsureGraphAvailableUnlockedValidationTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6713, a follow-up from #6712's code review.
+ * <p>
+ * {@code ensureGraphAvailable()}'s persisted-graph reuse path rebuilds {@code ordinalToVectorId} by re-validating
+ * every LIVE vector - for a non-quantized (or PRODUCT-quantized) index this is one document lookup plus one
+ * property read per vector - to make sure the graph on disk still describes exactly the live set (issues #3722,
+ * #6106). That validation is {@code O(live vector count)} and used to run entirely under {@code lock.writeLock()},
+ * the same global lock every insert and every search also needs. On an index large enough that the validation takes
+ * real time, the first search after a reopen that finds a persisted graph therefore stalled every OTHER reader and
+ * writer of the index for the whole scan - exactly the stall issue #5391 already moved
+ * {@code buildGraphFromScratchExclusively}'s own (much larger) full-rebuild validation off of. This test targets the
+ * up-to-date-reuse branch specifically: the persisted graph matches the live set exactly, so no rebuild is needed at
+ * all, only the validation - the one path #5391 never touched because it predates #5391 and sits in a different
+ * method.
+ * <p>
+ * Reproduction: a large index (200,000 vectors of 1536 dimensions - large enough that the validation loop reliably
+ * takes several hundred milliseconds, dimension chosen so the per-vector cost is dominated by the property read
+ * and conversion rather than the document lookup alone) is built, persisted and closed cleanly, so the persisted
+ * graph and its manifest describe exactly the live set. On reopen, a background thread runs the first search, which
+ * drives {@code ensureGraphAvailable()} into the validation loop. While that is in flight, the main thread inserts
+ * one more vector - an operation that only ever needs {@code lock.writeLock()} briefly - and times it. Before the
+ * fix this insert would queue behind the whole validation loop; after the fix it returns promptly regardless of how
+ * long the validation takes, because the loop no longer holds that lock.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6713EnsureGraphAvailableUnlockedValidationTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6713EnsureGraphAvailableUnlockedValidationTest";
+  private static final int    DIMENSIONS      = 1536;
+  private static final int    NUM_VECTORS     = 200_000;
+  private static final int    MAX_CONNECTIONS = 8;
+  private static final int    BEAM_WIDTH      = 16;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void concurrentInsertIsNotBlockedByTheUnlockedPersistedGraphValidation() throws Exception {
+    // Session 1: build and persist a graph over exactly NUM_VECTORS, then close cleanly - the persisted graph and
+    // its manifest end up describing precisely the live set, so the next open's validation finds nothing stale.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db, 0, NUM_VECTORS);
+        vectorIndex(db).buildVectorGraphNow();
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Session 2: reopen. The graph is lazy-loaded on first search (GraphState.LOADING), which is what routes the
+    // first search into ensureGraphAvailable()'s persisted-graph validation - the code path this issue targets.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState")).as("precondition: reopen leaves the graph unloaded")
+            .isEqualTo(0L); // GraphState.LOADING
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: large enough that the validation loop takes real time")
+            .isEqualTo((long) NUM_VECTORS);
+
+        final CountDownLatch searchStarted = new CountDownLatch(1);
+        final AtomicReference<Throwable> searchFailure = new AtomicReference<>();
+        final Thread searchThread = new Thread(() -> {
+          searchStarted.countDown();
+          try {
+            index.findNeighborsFromVector(embedding(0), 5);
+          } catch (final Throwable t) {
+            searchFailure.set(t);
+          }
+        }, "issue-6713-first-search");
+        searchThread.start();
+        assertThat(searchStarted.await(10, TimeUnit.SECONDS)).as("the search thread must have started").isTrue();
+        // A head start into ensureGraphAvailable()'s validation loop, which on this fixture reliably takes several
+        // hundred milliseconds - comfortably longer than this fixed wait plus the bound asserted below.
+        Thread.sleep(50);
+
+        // A concurrent insert only ever needs lock.writeLock() briefly. Before the fix, ensureGraphAvailable() held
+        // that same lock for its ENTIRE persisted-graph validation, so this insert would queue behind the search
+        // thread for as long as the (multi-hundred-millisecond) validation loop over NUM_VECTORS took.
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        db.transaction(() -> db.command("sql", "INSERT INTO Doc SET id = ?, vector = ?", NUM_VECTORS,
+            embedding(NUM_VECTORS)));
+        stopwatch.assertGaveUpWithin(400,
+            "an insert that only ever needs the write lock briefly, from one queued behind the whole persisted-graph "
+                + "validation loop");
+
+        searchThread.join(TimeUnit.SECONDS.toMillis(30));
+        assertThat(searchThread.isAlive()).as("the search must complete on its own").isFalse();
+        assertThat(searchFailure.get()).as("the search must not have failed").isNull();
+
+        // Not asserted here: graphRebuildCount. The concurrent insert above is itself a mutation, which - once
+        // published - is exactly what schedules the ordinary async rebuild any mutation on a MUTABLE large graph
+        // does; whether that background rebuild has completed by the time this line runs is a race against this
+        // test's own write, not a signal about which branch ensureGraphAvailable() took. That branch (reuse over
+        // rebuild, for a persisted graph that still matches the live set) is covered without a concurrent writer by
+        // Issue6106StaleVectorGraphTest.anUntouchedGraphIsStillReusedAcrossARestart().
+        assertThat(index.getStats().get("graphState"))
+            .as("the graph must have been published (either straight to IMMUTABLE, or to MUTABLE if the concurrent "
+                + "insert above raced ahead of the publish) - never left LOADING")
+            .isNotEqualTo(0L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static void populate(final Database db, final int fromInclusive, final int toExclusive) {
+    db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+      if ((i - fromInclusive) % 2000 == 1999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  /** Deterministic per-id embedding, so any record's own vector can be reconstructed independently at query time. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x6713L * 31 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}


### PR DESCRIPTION
## Summary

Two independent, small fixes that came out of other issues' analysis:

**#6713** - `LSMVectorIndex.ensureGraphAvailable()`'s persisted-graph validation loop (one document
lookup plus one property read per live vector, for quantization types without inline storage) ran
entirely under `lock.writeLock()` - the same lock every insert and every search needs. On a large
index this stalled every other reader and writer of the index for the whole scan, on the first
search after a reopen that finds a persisted graph - exactly the stall issue #5391 already fixed
for `buildGraphFromScratchExclusively`'s own (larger) validation loop, but never applied to this
method. Follow-up from #6712's review.

Fix: serialize `ensureGraphAvailable()` against builders via the existing (reentrant) `graphBuildLock`,
same as `buildGraphFromScratchWithRetry()`, and only take `lock.writeLock()` briefly to publish the
result. Handles the case where a concurrent `put()`/`putBatch()`/`remove()` already advanced
`graphState` from `LOADING` to `MUTABLE` while the validation ran unlocked - the freshly loaded graph
is still published as a valid base for `mergeWithDeltaScan()`, but `graphState` is left `MUTABLE`
rather than being forced back to `IMMUTABLE`, so the pending deltas are not hidden from search.

**#6566** - A sparse-vector segment merged before #6379's recency-epoch fix (`epochUntrusted`) can
still return a deleted document, and the only way to learn that was a `WARNING` log line emitted
once per engine instance - unqueryable once the moment passed, with no way to confirm a
`REBUILD INDEX` actually cleared it.

Fix (reusing the existing per-index upgrade-warning surface instead of inventing a new one):
- `PaginatedSparseVectorEngine.untrustedSegmentCount()` re-derives the same condition
  `warnOnPreRecencyEpochSegments` logs, from the live segment snapshot, on every call.
- `LSMSparseVectorIndex.getUpgradeWarning()` now folds this in, alongside the existing delegated
  key-order warning - so it surfaces through `schema:indexes` / `schema:index:<name>` / Studio / the
  HTTP admin API, the same surface every other index upgrade warning already uses
  (`IndexInternal#getUpgradeWarning()`), rather than a bespoke endpoint.
- `LSMSparseVectorIndex.getStats()` and the Studio "Server tab" card
  (`LSMSparseVectorIndexMetrics.buildJSON()`) both gained an `untrustedSegments` count.

A per-index Micrometer gauge (the issue's "ideally" ask) is deliberately not included: there is no
existing per-index Micrometer registration anywhere in the codebase today (`EngineMetricsBinder` is
JVM-global, sourced from the `Profiler` singleton) - building one means a new create/drop lifecycle
for per-index meters, which is a bigger, separately-reviewable change. The `getUpgradeWarning()` /
`getStats()` surface added here answers the issue's primary ask (an index-stats/metadata surface
reporting per-index whether any segment is untrusted, and how many) using infrastructure that
already exists and that Studio already renders.

**Docs**: worth a follow-up note in `arcadedb-docs` (`concepts/vector-search.adoc`, the doc PR #6564
staged) that the untrusted-segment condition is now also visible via `schema:index:<name>` /
`getStats()`, not only the startup log line. Not touched in this PR.

## Test plan

- `Issue6713EnsureGraphAvailableUnlockedValidationTest` (`@Tag("slow")`): builds and persists a
  200,000-vector / 1536-dim graph, reopens, and while a background thread's first search drives
  `ensureGraphAvailable()`'s validation loop (several hundred ms on this fixture), times a
  concurrent insert on the main thread. Fails on pre-fix code (measured ~845ms against a 400ms
  bound); passes after the fix. Verified both directions locally.
- `Issue6566UntrustedSegmentSurfaceTest`: synthesises a legacy-shaped segment (parents recorded,
  epoch never set - the same fixture `PaginatedSparseVectorEngineCompactionRecencyTest` uses for the
  log-line test), confirms `untrustedSegmentCount()` counts it, confirms dropping the legacy segment
  and rebuilding from scratch brings the count back to zero (the "did the remedy work" case the
  issue calls out), and end-to-end through a real SQL-created `LSM_SPARSE_VECTOR` index confirms
  `getUpgradeWarning()`/`getStats()` surface it after a reopen.
- `LSMSparseVectorIndexMetricsTest` updated for the new `untrustedSegments` field in the Studio card
  JSON shape it pins.
- `mvn -o -pl engine -am compile` clean.
- Full `com.arcadedb.index.sparsevector.*Test` and the touched `com.arcadedb.index.vector.*Test`
  classes (`Issue6106StaleVectorGraphTest`, `LSMVectorIndexRebuildTest`,
  `LSMVectorIndexConcurrentUpdateTest`, `LSMVectorIndexConcurrentRebuildVisibilityTest`,
  `LSMVectorIndexConcurrentMultiPageUpdateTest`, `PQSearchDebugTest`, `LSMVectorIndexSmallPQTest`)
  green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sparse-vector index statistics and metrics now report untrusted segment counts.
  * Upgrade warnings provide clearer visibility into legacy segments and a single logical-index rebuild recommendation.
* **Bug Fixes**
  * Improved detection and recovery of legacy sparse-vector segments.
  * Segment reporting is now more consistent across index statistics and metrics.
  * Vector graph validation no longer unnecessarily blocks searches or writes.
  * Concurrent updates are preserved while vector graphs are loaded or rebuilt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->