### PR TITLE
fix(#6657): expose close-time deferred graph rebuild via getStats()

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3942,3 +3942,16 @@ index may be noticeably slower than the queries that follow it, where `close()` 
 instead. Below the 1,000-vector threshold, `close()` keeps rebuilding synchronously as before, unaffected.
 
 [#6067](https://github.com/ArcadeData/arcadedb/issues/6067)
+
+## `LSMVectorIndex.getStats()` reports whether the last close deferred a graph rebuild (#6657)
+
+The deferral above (#6067) is only visible in the log, at `FINE` level, unless an operator goes looking for it.
+`getStats()` now also carries a `closeTimeRebuildPending` entry: `1` when the most recent `close()` chose to skip a
+rebuild it would otherwise have run, `0` otherwise. It answers a narrower question than the existing `graphState`/
+`mutationsSinceRebuild` entries, which cannot by themselves distinguish "pending mutations because a session is
+mid-flight" from "pending mutations because close() chose not to pay for them" - and, unlike a plain in-memory
+counter would, it still reads `1` on a freshly reopened index, before that index has been searched again, which is
+the moment the question is actually useful: right before a query pays the deferred cost, not after. It clears back
+to `0` the moment that rebuild - deferred or not - actually completes.
+
+[#6657](https://github.com/ArcadeData/arcadedb/issues/6657)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3914,3 +3914,31 @@ option through `awaitReady()` (and, at `open()` time, `GAV_RESTORE_AWAIT_TIMEOUT
 deferred restore explicitly and are unaffected by this change.
 
 [#6641](https://github.com/ArcadeData/arcadedb/issues/6641)
+
+## Closing a database no longer blocks on a full vector graph rebuild for large indexes (#6067)
+
+`LSMVectorIndex.close()` persists the graph before shutting down, so that a fast restart finds a ready-to-search
+graph rather than rebuilding on first open. For an index with any pending write (`graphState == MUTABLE`, or a
+first-ever build that never persisted), that persist has always meant a full `buildGraphFromScratch()` - there is
+no incremental update, so any rebuild reindexes every vector in the index, not just the ones written since the
+last build. That cost was paid synchronously on the closing thread regardless of index size: a single write to a
+200,000-vector index measured `close()` blocking for roughly 43 seconds, the same cost as writing a thousand
+vectors, because the rebuild's cost tracks total index size rather than what was actually written.
+
+`close()` now defers that rebuild instead of running it, for any index at or above the same size threshold the
+search path already uses to decide between a synchronous and an asynchronous rebuild (1,000 vectors,
+`arcadedb.vectorIndex.mutationsBeforeRebuild`'s sibling knob is unaffected). The vectors themselves are unaffected
+by any of this - they go through ordinary page/WAL persistence independent of the graph file, so nothing is lost
+by skipping the rebuild - only the graph's on-disk topology is left stale or absent. The next time that index is
+actually searched, after any reopen, the existing stale-persisted-graph detection (the same manifest/node-count
+check that already handles a persisted graph left behind by an unrelated shutdown) notices and rebuilds it lazily
+before answering the query.
+
+**Upgrading:** a session that writes to a large vector index and closes without ever searching it again no longer
+pays the rebuild cost at all - not at close, and not later, since nothing forces it until a search actually needs
+the graph. A session that does go on to search that index pays the same total rebuild cost as before, just moved
+from `close()` to that first query instead - so a query immediately after reopening a large, recently-written
+index may be noticeably slower than the queries that follow it, where `close()` used to absorb that latency
+instead. Below the 1,000-vector threshold, `close()` keeps rebuilding synchronously as before, unaffected.
+
+[#6067](https://github.com/ArcadeData/arcadedb/issues/6067)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3167,6 +3167,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
   /**
    * Minimum graph size to use async rebuild. Below this, synchronous rebuild is fast enough.
    * Above this threshold, a full rebuild can take seconds to minutes, so async is preferred.
+   * <p>
+   * Also the threshold {@link #flush()} uses to decide whether a close-time rebuild is cheap enough to run
+   * synchronously or should be deferred to the next open instead (issue #6067).
    */
   private static final int ASYNC_REBUILD_MIN_GRAPH_SIZE = 1000;
   private static final int[] EMPTY_ORDINALS             = new int[0];
@@ -6441,6 +6444,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 + "stay on disk and are re-indexed on the next open. This means flush() was called after "
                 + "releaseBackgroundResources() - both close paths are supposed to do the reverse",
             indexName, mutationsSinceSerialize.get());
+      } else if (needsBuild && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
+        // A synchronous full rebuild here would block close() for as long as the whole rebuild takes - measured
+        // (issue #6067) at 43s for a single write to a 200k-vector index, scaling with total index size rather
+        // than with what was actually written, because there is no incremental persist: any rebuild is a full
+        // rebuild. The vectors themselves are already durably persisted (ordinary page/WAL writes, unrelated to
+        // the graph); only the graph TOPOLOGY is stale or absent. Leave graphState as-is - MUTABLE, or LOADING
+        // with no persisted graph - and defer the rebuild to whenever this index is next actually searched,
+        // reusing the exact lazy-load/staleness-detection path (ensureGraphAvailable()) that already handles a
+        // stale persisted graph on every ordinary reopen. A session that closes and reopens without searching
+        // this index never pays the cost at all; one that does pays it at the query instead of at close().
+        LogManager.instance().log(this, Level.FINE,
+            "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
+                + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",
+            indexName, vectorIndex.size(), ASYNC_REBUILD_MIN_GRAPH_SIZE);
       } else if (needsBuild) {
         try {
           LogManager.instance()

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6505,12 +6505,33 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * recoverable - {@link #ensureGraphAvailable()} builds it from scratch on the next search - only the stats
    * signal for the gap between reopen and that search is unavailable, which is the narrower of the two arms this
    * covers.
-   *
-   * @param gf the graph file captured at the top of {@link #flush()}, before this close decided to skip the build
+   * <p>
+   * Guarded by {@link #graphBuildLock} - {@code tryLock()}, not {@code lock()} - because every other writer of
+   * this manifest (the normal post-build persist, both {@code markUnusable} failure paths) already holds it via
+   * {@code buildGraphFromScratchWithRetry()}, and {@code LSMVectorIndexGraphManifest}'s own class javadoc requires
+   * callers not to write one manifest concurrently: {@code markCloseDeferred()}'s read-then-write is not atomic,
+   * so racing it against an in-flight build's completion write could clobber a just-persisted fresh
+   * manifest with stale pre-build values. An async rebuild can still be running when {@code close()} calls
+   * {@code flush()} - {@code releaseBackgroundResources()} is what cancels it, and {@code close()} runs that
+   * AFTER {@code flush()} (see the "flush FIRST, release SECOND" note below) - so the race is real, not
+   * theoretical. A plain {@code lock()} would fix that only by blocking this close on whatever that other build
+   * still has left to do, which is exactly the synchronous-close cost issue #6067/#6653 exists to avoid; skipping
+   * the write when the lock is already held is safe instead of merely convenient - a build holding the lock is,
+   * by definition, about to run its own completion write, which clears this same flag on its own.
    */
   private void markCloseTimeRebuildDeferred(final LSMVectorIndexGraphFile gf) {
-    if (gf != null)
-      gf.getManifest().markCloseDeferred();
+    if (gf == null)
+      return;
+    if (graphBuildLock.tryLock()) {
+      try {
+        gf.getManifest().markCloseDeferred();
+      } finally {
+        graphBuildLock.unlock();
+      }
+    } else
+      LogManager.instance().log(this, Level.FINE,
+          "Not recording the close-time rebuild deferral for index %s: a graph build already holds the build "
+              + "lock and its own completion will supersede this note anyway", indexName);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6418,20 +6418,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
   public void flush() {
     if (status.compareAndSet(INDEX_STATUS.AVAILABLE, INDEX_STATUS.UNAVAILABLE)) {
 
-      // Build and persist graph if it hasn't been built yet
-      // This ensures the graph is available on next database open (fast restart)
-      // Build graph if it's in LOADING (never built) or MUTABLE (has pending changes) state
-      //
-      // LOADING means "not loaded into memory", which is not the same as "not
-      // persisted on disk": the graph loads lazily on the first search, so a
-      // session that never searched leaves it LOADING even when a complete
-      // graph is already on disk, and rebuilding then only reproduces a file
-      // that already exists. initializeGraphIndex() already draws exactly this
-      // distinction with the same predicate.
+      // Build and persist graph if it hasn't been built yet. This ensures the graph is available on next
+      // database open (fast restart). See needsGraphBuild() for exactly which states count as "needs one".
       final LSMVectorIndexGraphFile gf = graphFile;
-      final boolean graphAlreadyOnDisk = gf != null && gf.hasPersistedGraph();
-      final boolean needsBuild = vectorIndex.size() > 0 && (graphState == GraphState.MUTABLE
-          || (graphState == GraphState.LOADING && !graphAlreadyOnDisk));
+      final boolean needsBuild = needsGraphBuild(gf);
 
       if (needsBuild && !valid) {
         // Background resources are already gone, so there is no build pool to run this on - and asking for one
@@ -6492,6 +6482,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * {@code true} when the graph is behind the live vector set and a build has not been persisted for it yet.
+   * Shared between {@link #flush()} and {@link #releaseBackgroundResources()} (issue #6657's post-cancellation
+   * recheck) so the two cannot silently drift onto different predicates.
+   * <p>
+   * LOADING means "not loaded into memory", which is not the same as "not persisted on disk": the graph loads
+   * lazily on the first search, so a session that never searched leaves it LOADING even when a complete graph is
+   * already on disk, and rebuilding then only reproduces a file that already exists.
+   * {@code initializeGraphIndex()} already draws exactly this distinction with the same predicate.
+   */
+  private boolean needsGraphBuild(final LSMVectorIndexGraphFile gf) {
+    final boolean graphAlreadyOnDisk = gf != null && gf.hasPersistedGraph();
+    return vectorIndex.size() > 0 && (graphState == GraphState.MUTABLE
+        || (graphState == GraphState.LOADING && !graphAlreadyOnDisk));
+  }
+
+  /**
    * Records, in the graph's manifest sidecar, that this close chose to skip a rebuild it would otherwise have run
    * (issue #6657) - so {@link #getStats()} can answer "did the last close defer a rebuild" directly instead of an
    * operator having to go looking for the {@code FINE} log line above. Deliberately a manifest write rather than an
@@ -6515,9 +6521,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * {@code flush()} - {@code releaseBackgroundResources()} is what cancels it, and {@code close()} runs that
    * AFTER {@code flush()} (see the "flush FIRST, release SECOND" note below) - so the race is real, not
    * theoretical. A plain {@code lock()} would fix that only by blocking this close on whatever that other build
-   * still has left to do, which is exactly the synchronous-close cost issue #6067/#6653 exists to avoid; skipping
-   * the write when the lock is already held is safe instead of merely convenient - a build holding the lock is,
-   * by definition, about to run its own completion write, which clears this same flag on its own.
+   * still has left to do, which is exactly the synchronous-close cost issue #6067/#6653 exists to avoid, so a
+   * held lock is skipped here rather than waited for. That skip is not the full story on its own, though: a build
+   * holding the lock might go on to complete (its own write then correctly clears this flag) or might instead be
+   * CANCELLED by {@link #releaseBackgroundResources()} right after this method returns - and a cancelled build's
+   * {@code CancellationException} path does not touch the manifest at all. {@link #releaseBackgroundResources()}
+   * calls this method again, unconditionally, after it has cancelled and joined any in-flight build, by which
+   * point {@code graphState} reliably says which of the two happened - that second call is the actual backstop
+   * for a skip here, not "the build's completion write" alone.
    */
   private void markCloseTimeRebuildDeferred(final LSMVectorIndexGraphFile gf) {
     if (gf == null)
@@ -6636,6 +6647,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final GraphSearcherPool searchers = searcherPool;
     if (searchers != null)
       searchers.clear();
+
+    // Issue #6657, closing a false-negative gap in the deferral flag above: flush() runs BEFORE this method, so
+    // an async rebuild that flush() found already holding graphBuildLock - and therefore skipped marking, trusting
+    // "its own completion write" to account for it - may have been CANCELLED by the shutdown just above rather
+    // than actually completing. A cancelled build's CancellationException path (see the catch block around it)
+    // does not touch the manifest at all, successful or not, so the flag would otherwise sit wherever the last
+    // real build left it - typically false - even though a rebuild is now genuinely owed. By this point that
+    // build has been cancelled and joined (or logged above as a rare straggler that outlived the join), so
+    // graphState reliably distinguishes "it finished" (no longer MUTABLE, needsGraphBuild() now false - that
+    // build's own write already cleared the flag, nothing to do) from "it did not" (still MUTABLE, mark it now).
+    // Idempotent with flush()'s own attempt above: on the ordinary path where that one already succeeded, this
+    // re-write repeats the same true, at the cost of one extra small file read+write on the close of a large,
+    // recently-mutated index - not on every close.
+    final LSMVectorIndexGraphFile gfAfterRelease = graphFile;
+    if (needsGraphBuild(gfAfterRelease))
+      markCloseTimeRebuildDeferred(gfAfterRelease);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6446,6 +6446,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 + "stay on disk and are re-indexed on the next open. This means flush() was called after "
                 + "releaseBackgroundResources() - both close paths are supposed to do the reverse",
             indexName, mutationsSinceSerialize.get());
+        markCloseTimeRebuildDeferred(gf);
       } else if (needsBuild && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
         // A synchronous full rebuild here would block close() for as long as the whole rebuild takes - measured
         // (issue #6067) at 43s for a single write to a 200k-vector index, scaling with total index size rather
@@ -6463,6 +6464,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
                 + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",
             indexName, vectorIndex.size(), ASYNC_REBUILD_MIN_GRAPH_SIZE);
+        markCloseTimeRebuildDeferred(gf);
       } else if (needsBuild) {
         try {
           LogManager.instance()
@@ -6487,6 +6489,28 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 graphState);
       }
     }
+  }
+
+  /**
+   * Records, in the graph's manifest sidecar, that this close chose to skip a rebuild it would otherwise have run
+   * (issue #6657) - so {@link #getStats()} can answer "did the last close defer a rebuild" directly instead of an
+   * operator having to go looking for the {@code FINE} log line above. Deliberately a manifest write rather than an
+   * in-memory field: a fresh {@link LSMVectorIndex} instance is constructed on every database open (see the two
+   * {@code open()}/{@code create()} factory methods), so a plain field set here would be gone by the time anyone
+   * could read it - the whole point is to answer the question the moment BEFORE the next search would otherwise
+   * silently pay for it.
+   * <p>
+   * A no-op when {@code gf} is {@code null}: a never-yet-built index that was also never discovered on a previous
+   * load has no manifest path to write to. That index has no on-disk graph either, so the deferral is still fully
+   * recoverable - {@link #ensureGraphAvailable()} builds it from scratch on the next search - only the stats
+   * signal for the gap between reopen and that search is unavailable, which is the narrower of the two arms this
+   * covers.
+   *
+   * @param gf the graph file captured at the top of {@link #flush()}, before this close decided to skip the build
+   */
+  private void markCloseTimeRebuildDeferred(final LSMVectorIndexGraphFile gf) {
+    if (gf != null)
+      gf.getManifest().markCloseDeferred();
   }
 
   /**
@@ -6695,6 +6719,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
     stats.put("mutationsSinceRebuild", (long) mutationsSinceSerialize.get());
     stats.put("asyncRebuildInProgress", asyncRebuildInProgress ? 1L : 0L);
     stats.put("rebuildSnapshotGeneration", rebuildSnapshotGeneration);
+
+    // Whether the LAST close() skipped a rebuild it would otherwise have run (issue #6657), as opposed to
+    // graphState/mutationsSinceRebuild above, which cannot tell that apart from ordinary mid-session mutations.
+    // A small manifest read rather than a cached field: unlike the other stats above, this one specifically has
+    // to survive being read on a freshly reopened index, before that index's own first search - see
+    // markCloseTimeRebuildDeferred() for why a field would not.
+    final LSMVectorIndexGraphFile statsGraphFile = graphFile;
+    final LSMVectorIndexGraphManifest.Content manifestContent =
+        statsGraphFile != null ? statsGraphFile.getManifest().read() : null;
+    stats.put("closeTimeRebuildPending", manifestContent != null && manifestContent.closeDeferredRebuild() ? 1L : 0L);
 
     // Calculate mutations threshold (use configured value or default)
     final int defaultMutationsThreshold = getDatabase().getConfiguration()

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6657,9 +6657,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // build has been cancelled and joined (or logged above as a rare straggler that outlived the join), so
     // graphState reliably distinguishes "it finished" (no longer MUTABLE, needsGraphBuild() now false - that
     // build's own write already cleared the flag, nothing to do) from "it did not" (still MUTABLE, mark it now).
-    // Idempotent with flush()'s own attempt above: on the ordinary path where that one already succeeded, this
-    // re-write repeats the same true, at the cost of one extra small file read+write on the close of a large,
-    // recently-mutated index - not on every close.
+    // Idempotent with flush()'s own attempt above: on the ordinary path where that one already succeeded,
+    // markCloseDeferred()'s own already-true short-circuit turns this into a single extra read, not a rewrite -
+    // and only on the close of a large, recently-mutated index, not on every close.
+    //
+    // Known residual gap, same shape one layer further out: markCloseTimeRebuildDeferred()'s own tryLock() can
+    // still lose to a STRAGGLER build thread - one that outlived shutdownNow()'s 5s budget and the pool's
+    // awaitTermination() above (see the WARNING logged a few lines up) - if that straggler happens to be the one
+    // holding graphBuildLock at the exact moment this recheck runs. Narrow (needs both an unresponsive build AND
+    // it specifically being the lock holder right now) and not chased further: unlike the cancellation case this
+    // recheck exists for, there is no later "the build is definitely done by now" moment available to retry from
+    // inside this method. Same acceptance as the gf == null case in markCloseTimeRebuildDeferred()'s javadoc -
+    // documented rather than solved.
     final LSMVectorIndexGraphFile gfAfterRelease = graphFile;
     if (needsGraphBuild(gfAfterRelease))
       markCloseTimeRebuildDeferred(gfAfterRelease);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3169,7 +3169,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Above this threshold, a full rebuild can take seconds to minutes, so async is preferred.
    * <p>
    * Also the threshold {@link #flush()} uses to decide whether a close-time rebuild is cheap enough to run
-   * synchronously or should be deferred to the next open instead (issue #6067).
+   * synchronously or should be deferred to the next SEARCH on this index instead (issue #6067) - opening the
+   * database alone never triggers it, only {@link #ensureGraphAvailable()}/{@link #rebuildGraphBeforeSearch()}
+   * do, and that deferred rebuild is itself still synchronous on whichever search first reaches it, not async.
    */
   private static final int ASYNC_REBUILD_MIN_GRAPH_SIZE = 1000;
   private static final int[] EMPTY_ORDINALS             = new int[0];
@@ -6453,7 +6455,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // with no persisted graph - and defer the rebuild to whenever this index is next actually searched,
         // reusing the exact lazy-load/staleness-detection path (ensureGraphAvailable()) that already handles a
         // stale persisted graph on every ordinary reopen. A session that closes and reopens without searching
-        // this index never pays the cost at all; one that does pays it at the query instead of at close().
+        // this index never pays the cost at all; one that does pays it at the query instead of at close() - that
+        // follow-up rebuild is itself still synchronous on the search that triggers it (ensureGraphAvailable()'s
+        // stale-graph fallback is not gated by this same threshold), so this trades an unconditional cost on
+        // EVERY close() for a conditional one paid by at most one search, not for a non-blocking one.
         LogManager.instance().log(this, Level.FINE,
             "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
                 + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -236,6 +236,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // Serializes graph builds for this index (issue #5391). Held only by builders, never by readers or writers.
   private final ReentrantLock graphBuildLock = new ReentrantLock();
 
+  // Set only inside flush()'s two SKIP branches (issue #6657) - never by the branch that actually attempts a
+  // synchronous build, successfully or not - so releaseBackgroundResources()'s recheck of the same flag (see
+  // there) can tell "flush() chose not to pay for a rebuild" apart from "flush() tried and either failed or got
+  // re-mutated mid-build", which also leaves graphState at MUTABLE but is a different story the recheck must not
+  // relabel as a deferral. Reset at the top of every flush(), so a stale true from an earlier close on this same
+  // instance can never leak into a later, unrelated one. Plain instance field, not persisted: unlike the manifest
+  // flag it gates, its only job is to bridge flush() and releaseBackgroundResources() within ONE close() call on
+  // ONE instance, which is exactly the lifetime a field has.
+  private volatile boolean flushDeferredRebuild = false;
+
   // Index-scoped cache of materialized vectors, shared by every search on this index (issue #5412).
   // Beam search resolves one vector per distance evaluation; before this cache lived at index scope, each
   // query built its own 1024-entry map and discarded it on completion, so every query paid a full record
@@ -6423,6 +6433,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final LSMVectorIndexGraphFile gf = graphFile;
       final boolean needsBuild = needsGraphBuild(gf);
 
+      // Reset before deciding: see the field javadoc for why releaseBackgroundResources() needs this to
+      // distinguish "this flush() skipped" from "this flush() attempted (and possibly failed)".
+      flushDeferredRebuild = false;
+
       if (needsBuild && !valid) {
         // Background resources are already gone, so there is no build pool to run this on - and asking for one
         // would not fail, it would quietly BUILD one: getOrCreateGraphBuildPool() replaces a shut-down pool, and
@@ -6436,6 +6450,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 + "stay on disk and are re-indexed on the next open. This means flush() was called after "
                 + "releaseBackgroundResources() - both close paths are supposed to do the reverse",
             indexName, mutationsSinceSerialize.get());
+        flushDeferredRebuild = true;
         markCloseTimeRebuildDeferred(gf);
       } else if (needsBuild && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
         // A synchronous full rebuild here would block close() for as long as the whole rebuild takes - measured
@@ -6454,6 +6469,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
                 + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",
             indexName, vectorIndex.size(), ASYNC_REBUILD_MIN_GRAPH_SIZE);
+        flushDeferredRebuild = true;
         markCloseTimeRebuildDeferred(gf);
       } else if (needsBuild) {
         try {
@@ -6657,6 +6673,19 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // build has been cancelled and joined (or logged above as a rare straggler that outlived the join), so
     // graphState reliably distinguishes "it finished" (no longer MUTABLE, needsGraphBuild() now false - that
     // build's own write already cleared the flag, nothing to do) from "it did not" (still MUTABLE, mark it now).
+    //
+    // Gated on flushDeferredRebuild, not on needsGraphBuild() alone (review round 4): flush()'s OTHER branch -
+    // the one that actually ATTEMPTS a synchronous build rather than skipping - can also leave graphState at
+    // MUTABLE, either because the attempt failed (buildGraphFromScratchExclusively() then correctly writes
+    // closeDeferredRebuild=false via markUnusable()) or because new mutations arrived mid-build. Neither of those
+    // is "flush() chose to defer", and rechecking unconditionally would overwrite that correct false with a
+    // misleading true - mislabeling "close attempted a rebuild and it failed" as "close skipped the rebuild for
+    // performance". flushDeferredRebuild is set only inside flush()'s two skip branches and reset at the top of
+    // every flush(), so it answers exactly the question this recheck needs: did THIS close's flush() skip, not
+    // just "is a rebuild still owed for some reason". As a side effect this also keeps the recheck from ever
+    // firing on a path that never called flush() at all - LocalDatabase.closeInternal(true) (whole-database
+    // drop) and LocalDatabase.kill() (crash simulation) both call releaseBackgroundResources() without one.
+    //
     // Idempotent with flush()'s own attempt above: on the ordinary path where that one already succeeded,
     // markCloseDeferred()'s own already-true short-circuit turns this into a single extra read, not a rewrite -
     // and only on the close of a large, recently-mutated index, not on every close.
@@ -6669,9 +6698,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // recheck exists for, there is no later "the build is definitely done by now" moment available to retry from
     // inside this method. Same acceptance as the gf == null case in markCloseTimeRebuildDeferred()'s javadoc -
     // documented rather than solved.
-    final LSMVectorIndexGraphFile gfAfterRelease = graphFile;
-    if (needsGraphBuild(gfAfterRelease))
-      markCloseTimeRebuildDeferred(gfAfterRelease);
+    if (flushDeferredRebuild) {
+      final LSMVectorIndexGraphFile gfAfterRelease = graphFile;
+      if (needsGraphBuild(gfAfterRelease))
+        markCloseTimeRebuildDeferred(gfAfterRelease);
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -88,12 +88,12 @@ public class LSMVectorIndexGraphManifest {
    * @param vectorCount         number of ordinals the graph was built over, or {@link #UNUSABLE_VECTOR_COUNT}
    * @param fingerprint         fingerprint of the ordinal &rarr; (vector id, RID) correspondence
    * @param closeDeferredRebuild {@code true} when the pages this manifest describes are known stale because the
-   *                            most recent {@code close()} chose to defer the rebuild that would otherwise have
-   *                            brought them up to date (issue #6657), rather than run it synchronously. Always
-   *                            {@code false} again once a build actually completes - {@link #write(int, long)} and
-   *                            {@link #markUnusable(String)} both clear it - so it answers specifically "did the
-   *                            last close skip a rebuild", not the broader "is a rebuild owed" that
-   *                            {@code vectorCount}/{@code fingerprint} against the live index already answers.
+   *                             most recent {@code close()} chose to defer the rebuild that would otherwise have
+   *                             brought them up to date (issue #6657), rather than run it synchronously. Always
+   *                             {@code false} again once a build actually completes - {@link #write(int, long)} and
+   *                             {@link #markUnusable(String)} both clear it - so it answers specifically "did the
+   *                             last close skip a rebuild", not the broader "is a rebuild owed" that
+   *                             {@code vectorCount}/{@code fingerprint} against the live index already answers.
    */
   public record Content(int formatVersion, int vectorCount, long fingerprint, boolean closeDeferredRebuild) {
   }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -84,11 +84,18 @@ public class LSMVectorIndexGraphManifest {
   /**
    * What a persisted manifest says about the graph next to it.
    *
-   * @param formatVersion version of this file's own layout
-   * @param vectorCount   number of ordinals the graph was built over, or {@link #UNUSABLE_VECTOR_COUNT}
-   * @param fingerprint   fingerprint of the ordinal &rarr; (vector id, RID) correspondence
+   * @param formatVersion       version of this file's own layout
+   * @param vectorCount         number of ordinals the graph was built over, or {@link #UNUSABLE_VECTOR_COUNT}
+   * @param fingerprint         fingerprint of the ordinal &rarr; (vector id, RID) correspondence
+   * @param closeDeferredRebuild {@code true} when the pages this manifest describes are known stale because the
+   *                            most recent {@code close()} chose to defer the rebuild that would otherwise have
+   *                            brought them up to date (issue #6657), rather than run it synchronously. Always
+   *                            {@code false} again once a build actually completes - {@link #write(int, long)} and
+   *                            {@link #markUnusable(String)} both clear it - so it answers specifically "did the
+   *                            last close skip a rebuild", not the broader "is a rebuild owed" that
+   *                            {@code vectorCount}/{@code fingerprint} against the live index already answers.
    */
-  public record Content(int formatVersion, int vectorCount, long fingerprint) {
+  public record Content(int formatVersion, int vectorCount, long fingerprint, boolean closeDeferredRebuild) {
   }
 
   private final Path path;
@@ -175,15 +182,34 @@ public class LSMVectorIndexGraphManifest {
    * @param reason human-readable note stored in the file; nothing reads it back
    */
   public void markUnusable(final String reason) {
-    write(UNUSABLE_VECTOR_COUNT, 0L, reason);
+    write(UNUSABLE_VECTOR_COUNT, 0L, reason, false);
   }
 
   /**
    * Records the correspondence the just-committed graph was built over. Written through a temporary file so a
-   * crash mid-write cannot leave a truncated manifest that reads as a valid one.
+   * crash mid-write cannot leave a truncated manifest that reads as a valid one. Always clears
+   * {@link Content#closeDeferredRebuild()}: a build that reached this call completed, so whatever a previous
+   * {@code close()} deferred has now been paid for.
    */
   public void write(final int vectorCount, final long fingerprint) {
-    write(vectorCount, fingerprint, null);
+    write(vectorCount, fingerprint, null, false);
+  }
+
+  /**
+   * Marks the currently-described graph as stale because {@code close()} deferred the rebuild that would have
+   * refreshed it (issue #6657), rather than running it. Preserves whatever {@code vectorCount}/{@code fingerprint}
+   * are already on disk - this is not a new build, just a note that the existing pages are now known outdated -
+   * or falls back to {@link #UNUSABLE_VECTOR_COUNT} when nothing has ever been persisted here, so a first-ever
+   * build that a large index's close deferred is recorded too.
+   * <p>
+   * Cleared automatically the next time {@link #write(int, long)} or {@link #markUnusable(String)} runs, which is
+   * exactly when a rebuild - deferred or not - actually completes.
+   */
+  public void markCloseDeferred() {
+    final Content existing = read();
+    final int vectorCount = existing != null ? existing.vectorCount() : UNUSABLE_VECTOR_COUNT;
+    final long fingerprint = existing != null ? existing.fingerprint() : 0L;
+    write(vectorCount, fingerprint, null, true);
   }
 
   /**
@@ -193,7 +219,8 @@ public class LSMVectorIndexGraphManifest {
    * two different places, and a shared temp name would turn a future change to either of them into a corrupted
    * manifest. A unique name costs nothing and removes the assumption.
    */
-  private void write(final int vectorCount, final long fingerprint, final String reason) {
+  private void write(final int vectorCount, final long fingerprint, final String reason,
+      final boolean closeDeferredRebuild) {
     final Path temporary = path.resolveSibling(
         path.getFileName() + "." + Long.toHexString(System.nanoTime()) + ".tmp");
     try {
@@ -213,6 +240,7 @@ public class LSMVectorIndexGraphManifest {
       json.put("vectorCount", vectorCount);
       // As a string: a 64-bit fingerprint is not representable in the double a JSON number decodes to.
       json.put("fingerprint", Long.toString(fingerprint));
+      json.put("closeDeferredRebuild", closeDeferredRebuild);
       if (reason != null)
         json.put("reason", reason);
 
@@ -272,7 +300,8 @@ public class LSMVectorIndexGraphManifest {
         return null;
       }
       return new Content(formatVersion, json.getInt("vectorCount", -1),
-          Long.parseLong(json.getString("fingerprint", "0")));
+          Long.parseLong(json.getString("fingerprint", "0")),
+          json.getBoolean("closeDeferredRebuild", false));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "Could not read the vector graph manifest '%s': %s", path,
           e.getMessage());

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -210,9 +210,16 @@ public class LSMVectorIndexGraphManifest {
    * WARNING by {@link #read()}, not thrown) - indistinguishable from here. Accepted rather than plumbed through:
    * the fallback only downgrades an otherwise-valid manifest to "not usable", which forces one extra rebuild on
    * the next load and self-heals from there, the same cost a genuinely corrupt manifest would already pay.
+   * <p>
+   * Short-circuits to a single {@link #read()} (no write at all) when the flag already reads {@code true}: a
+   * large index left with pending mutations and closed repeatedly with no intervening search - each close still
+   * seeing the same {@code needsGraphBuild()} - would otherwise re-persist an identical manifest (temp file,
+   * write, atomic rename) on every single one of those closes for no observable change.
    */
   public void markCloseDeferred() {
     final Content existing = read();
+    if (existing != null && existing.closeDeferredRebuild())
+      return;
     final int vectorCount = existing != null ? existing.vectorCount() : UNUSABLE_VECTOR_COUNT;
     final long fingerprint = existing != null ? existing.fingerprint() : 0L;
     write(vectorCount, fingerprint, null, true);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -204,6 +204,12 @@ public class LSMVectorIndexGraphManifest {
    * <p>
    * Cleared automatically the next time {@link #write(int, long)} or {@link #markUnusable(String)} runs, which is
    * exactly when a rebuild - deferred or not - actually completes.
+   * <p>
+   * {@code read() == null} is treated as "nothing persisted yet" and takes the {@link #UNUSABLE_VECTOR_COUNT}
+   * fallback, which is also what a transient read failure or a format-version mismatch report (both logged as
+   * WARNING by {@link #read()}, not thrown) - indistinguishable from here. Accepted rather than plumbed through:
+   * the fallback only downgrades an otherwise-valid manifest to "not usable", which forces one extra rebuild on
+   * the next load and self-heals from there, the same cost a genuinely corrupt manifest would already pay.
    */
   public void markCloseDeferred() {
     final Content existing = read();

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
@@ -141,6 +141,96 @@ class Issue6067DeferredCloseRebuildTest {
     }
   }
 
+  /**
+   * Sibling of the test above, covering the OTHER arm of the same {@code needsBuild} condition:
+   * {@code graphState == LOADING && !graphAlreadyOnDisk} (a graph never built at all, as opposed to one rebuilt
+   * after an existing build). Both arms reach the identical deferral branch in {@code flush()} and the identical
+   * fallback in {@code ensureGraphAvailable()}, but only the rebuilt-index arm was covered above.
+   * <p>
+   * {@code graphState} starts as {@code LOADING} on every constructed instance (both "new index" and "load
+   * existing index"), but a fresh insert into a never-built index flips it straight to {@code MUTABLE} - so a
+   * single populate-then-close session actually exercises the MUTABLE arm, same as the test above, not this one.
+   * Reaching {@code LOADING} at {@code flush()} time needs a session that touches the index NEITHER by writing
+   * NOR by searching: reopen a large index that a previous session already left un-built (deferred by the fix
+   * under test), and close it again immediately - {@code graphState} then stays exactly what the constructor set
+   * it to.
+   * <p>
+   * Unlike the test above, this one is NOT a fails-before/passes-after timing pin: the pre-fix code always builds
+   * and persists a graph on every close that has one to do, so the very state this test needs (a large index,
+   * closed twice, with no persisted graph either time) is only reachable once the fix exists - pre-fix, the
+   * first close already does the build, and the second close then finds nothing left to do and is trivially
+   * fast for an unrelated reason. So instead of timing, this pins {@code graphRebuildCount} directly: zero
+   * rebuilds across both closes, exactly one once the deferred data is finally searched.
+   */
+  @Test
+  void closeDefersTheFirstEverBuildForALargeIndexToo() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        // Closes with graphState == MUTABLE (see javadoc above) - the fix under test defers this build too, so
+        // no graph is persisted yet. That is the starting condition this test actually needs, not its subject.
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: LOADING - reopening alone (with no write or search in this session) must not "
+                + "advance graphState, otherwise this does not exercise the "
+                + "graphState == LOADING && !graphAlreadyOnDisk arm")
+            .isEqualTo(0L); // GraphState.LOADING
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: above the async-rebuild threshold, otherwise close() takes the pre-existing "
+                + "small-graph synchronous path unaffected by this fix")
+            .isGreaterThanOrEqualTo(1000L);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("precondition: the previous session's close must not have built anything either, or this test "
+                + "is not exercising the LOADING && !graphAlreadyOnDisk arm at all")
+            .isZero();
+
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("neither close() above must have built anything: this pins the actual behaviour under test, "
+                + "since a timing bound alone cannot distinguish 'deferred' from 'nothing was ever built', see "
+                + "the class javadoc")
+            .isZero();
+
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("cnt")).isEqualTo((long) NUM_VECTORS);
+        }
+
+        final var results = index.findNeighborsFromVector(randomVector(new Random(7)), 5, 64);
+        assertThat(results)
+            .as("the deferred first-ever build must still make every vector reachable by search after reopen")
+            .hasSize(5);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("the search above must be what finally triggers the deferred build - it was owed since the "
+                + "first close two sessions ago")
+            .isEqualTo(1L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
   private static float[] extraVector() {
     return randomVector(new Random(5));
   }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6067: {@code flush()}'s rebuild-before-close condition (triggered whenever
+ * {@code graphState == MUTABLE}, i.e. any write since the last graph build) always calls
+ * {@code buildGraphFromScratch()} SYNCHRONOUSLY on the closing thread, with no size-based deferral - unlike the
+ * search path's {@code rebuildGraphBeforeSearch()}, which already runs an async rebuild above 1000 vectors
+ * ({@code ASYNC_REBUILD_MIN_GRAPH_SIZE}).
+ * <p>
+ * Measured on the issue (comment from 2026-08-23): a single write to a 200,000-vector index made {@code close()}
+ * block for ~43 seconds - the same cost whether one vector or a thousand were written, because the rebuild is
+ * always a full one. The fix defers the close-time rebuild to the next search on the index once the index is at
+ * or above {@code ASYNC_REBUILD_MIN_GRAPH_SIZE}, reusing {@code ensureGraphAvailable()}'s existing
+ * stale-persisted-graph detection (already exercised on every ordinary reopen) rather than paying the full cost
+ * synchronously inside {@code close()}.
+ * <p>
+ * Two things are pinned here, because either alone would pass against a half-fix: {@code close()} itself must
+ * return promptly (not merely "eventually", which a half-fixed async-but-still-blocking-close variant could also
+ * satisfy), and no data may be lost - a later reopen and search must still find every vector, including the one
+ * written after the last full build, once the deferred rebuild actually runs.
+ * <p>
+ * Same per-vector build parameters as {@code LSMVectorIndexCloseCancelsInFlightBuildTest} (128 dimensions,
+ * {@code maxConnections=64}, {@code beamWidth=400}), scaled up to 20,000 vectors so a full rebuild reliably takes
+ * multiple real seconds - long enough that the tripwire bound below cannot pass by accident.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6067DeferredCloseRebuildTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6067DeferredCloseRebuildTest";
+  private static final int    DIMENSIONS      = 128;
+  private static final int    NUM_VECTORS     = 20_000;
+  private static final int    MAX_CONNECTIONS = 64;
+  private static final int    BEAM_WIDTH      = 400;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void closeDefersTheRebuildForALargeMutatedIndexInsteadOfBlockingOnAFullRebuild() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        // Force one complete, persisted build so the index starts IMMUTABLE rather than LOADING - isolates the
+        // case under test (a single write after an already-built graph) from the separate first-ever-build case.
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState")).as("precondition: graph must be built and IMMUTABLE first")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+
+        // One more write - mirrors the issue's own measurement that cost does not scale with what was written.
+        db.transaction(
+            () -> db.newDocument("Doc").set("id", NUM_VECTORS).set("vector", extraVector()).save());
+
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise flush()'s rebuild-before-close condition is never reached")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: above the async-rebuild threshold, otherwise close() takes the pre-existing "
+                + "small-graph synchronous path unaffected by this fix")
+            .isGreaterThanOrEqualTo(1000L);
+
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        db.close();
+        // Measured on this fixture: ~50ms deferred vs. ~2.4s for a full synchronous rebuild - the bound below
+        // is a tripwire between the two (see StallAwareStopwatch), with wide margin on both sides.
+        stopwatch.assertGaveUpWithin(1_000,
+            "a close() that defers the graph rebuild from one that runs a full synchronous rebuild to completion");
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Reopen and verify nothing was lost: the deferred rebuild must still make every vector - including the one
+    // written after the last full build - reachable by search once it actually runs, proving the fix trades
+    // promptness for a lazily-paid rebuild, not for correctness.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("cnt")).isEqualTo((long) (NUM_VECTORS + 1));
+        }
+
+        final LSMVectorIndex index = vectorIndex(db);
+        final var results = index.findNeighborsFromVector(extraVector(), 5, 64);
+        assertThat(results)
+            .as("the deferred rebuild must still make the vector written right before close() reachable by "
+                + "search after reopen")
+            .hasSize(5);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static float[] extraVector() {
+    return randomVector(new Random(5));
+  }
+
+  private static void populate(final Database db) {
+    final Random rnd = new Random(7);
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = 0; i < NUM_VECTORS; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+      if (i % 1000 == 999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657CancelledBuildRecheckTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657CancelledBuildRecheckTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the gap review found in issue #6657's own fix: {@code markCloseTimeRebuildDeferred()} skips
+ * the manifest write when {@code graphBuildLock.tryLock()} fails, reasoning that a build holding the lock is
+ * "about to run its own completion write, which clears this same flag on its own". That is only true if the build
+ * actually COMPLETES. When {@code close()} instead CANCELS an in-flight async rebuild -
+ * {@code releaseBackgroundResources()} does exactly that, and runs right after {@code flush()} - the cancelled
+ * build's {@code CancellationException} path never touches the manifest, so without a backstop the flag would be
+ * left wherever it was before this close (typically {@code false}), even though a rebuild is now genuinely owed:
+ * a false negative in the exact "why is my first query after reopen slow" moment the stat exists to answer.
+ * <p>
+ * Deterministic rather than racing a real JVector build's timing (which {@code LSMVectorIndexCloseCancelsInFlightBuildTest}
+ * already shows is a legitimate but non-trivial thing to pin reliably): a helper thread holds
+ * {@code graphBuildLock} directly, standing in for "a build is genuinely in progress", and releases it only after
+ * {@code flush()} has already observed it contended - simulating the point at which a real cancellation would have
+ * freed the lock without ever writing the manifest. The test then checks that the SECOND attempt, inside
+ * {@code releaseBackgroundResources()}, catches what the first one had to skip.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6657CancelledBuildRecheckTest {
+  private static final String DB_ROOT     = "target/test-databases/Issue6657CancelledBuildRecheckTest";
+  private static final int    DIMENSIONS  = 8;
+  private static final int    NUM_VECTORS = 1_005; // at/above ASYNC_REBUILD_MIN_GRAPH_SIZE (1000)
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void releaseBackgroundResourcesRecordsTheDeferralThatFlushHadToSkipBecauseABuildHeldTheLock() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        final Random rnd = new Random(13);
+        db.transaction(() -> {
+          final var type = db.getSchema().createDocumentType("Doc");
+          type.createProperty("id", Type.INTEGER);
+          type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+          db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+              + ", \"similarity\": \"COSINE\" }");
+        });
+        db.begin();
+        for (int i = 0; i < NUM_VECTORS; i++) {
+          db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+          if (i % 500 == 499) {
+            db.commit();
+            db.begin();
+          }
+        }
+        db.commit();
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise flush() never reaches the deferral branch at all")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: at/above the async-rebuild threshold, the exact branch the reviewed race is about")
+            .isGreaterThanOrEqualTo(1000L);
+
+        final ReentrantLock graphBuildLock = graphBuildLock(index);
+        final CountDownLatch lockHeld = new CountDownLatch(1);
+        final CountDownLatch releaseLock = new CountDownLatch(1);
+        final Thread lockHolder = new Thread(() -> {
+          graphBuildLock.lock();
+          try {
+            lockHeld.countDown();
+            releaseLock.await();
+          } catch (final InterruptedException ignored) {
+            // test teardown path only
+          } finally {
+            graphBuildLock.unlock();
+          }
+        }, "test-graph-build-lock-holder");
+        lockHolder.setDaemon(true);
+        lockHolder.start();
+
+        assertThat(lockHeld.await(5, TimeUnit.SECONDS))
+            .as("the helper thread must genuinely hold graphBuildLock before flush() runs, otherwise this test "
+                + "does not exercise the contended tryLock() at all")
+            .isTrue();
+
+        // flush()'s ASYNC_REBUILD_MIN_GRAPH_SIZE branch: needsBuild is true, but markCloseTimeRebuildDeferred()'s
+        // tryLock() must fail while the helper thread holds the lock - standing in for a real async rebuild still
+        // running at this exact point in close().
+        index.flush();
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("flush() must have skipped the write while the lock was held - this is the state a cancelled "
+                + "build would otherwise leave behind uncorrected")
+            .isEqualTo(0L);
+
+        // Stand-in for cancellation freeing the lock without ever writing the manifest (a real CancellationException
+        // path does not call writeGraphManifest()/markGraphManifestUnusable() either).
+        releaseLock.countDown();
+        lockHolder.join(5_000);
+        assertThat(lockHolder.isAlive()).as("the helper thread must have released the lock before proceeding").isFalse();
+
+        // This is the call under test: its tail recheck must catch what flush() had to skip, now that the lock is
+        // free and graphState still says a build is genuinely owed.
+        index.releaseBackgroundResources();
+
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("releaseBackgroundResources()'s recheck must record the deferral flush() could not - this is the "
+                + "false-negative the review comment identified")
+            .isEqualTo(1L);
+      } finally {
+        if (db.isOpen())
+          db.drop();
+      }
+    }
+  }
+
+  private static ReentrantLock graphBuildLock(final LSMVectorIndex index) throws ReflectiveOperationException {
+    final Field field = LSMVectorIndex.class.getDeclaredField("graphBuildLock");
+    field.setAccessible(true);
+    return (ReentrantLock) field.get(index);
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6657: {@code getStats()} did not say whether the last {@code close()} deferred a
+ * graph rebuild (issue #6067/#6653) - an operator debugging "why is my first query after reopen slow" had to go
+ * looking for the {@code FINE} log line {@code LSMVectorIndex.flush()} emits, rather than checking a stat
+ * alongside the existing {@code graphState}/{@code graphRebuildCount}/{@code mutationsSinceRebuild} entries.
+ * <p>
+ * Three things are pinned, because a half-fix could satisfy any two on its own: the {@code closeTimeRebuildPending}
+ * stat must turn on exactly when {@code close()} defers a rebuild, it must still read {@code 1} on a <b>freshly
+ * reopened</b> index - i.e. a brand-new {@link LSMVectorIndex} instance, not the one that set it - before that
+ * index has been searched (the whole point: answering the question BEFORE the next search silently pays for it),
+ * and it must clear back to {@code 0} once that search actually runs the deferred rebuild.
+ * <p>
+ * A normal close that never deferred anything (below the async-rebuild threshold) is also pinned at {@code 0}, to
+ * catch a stat that reads "true" unconditionally.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6657CloseTimeRebuildPendingStatTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6657CloseTimeRebuildPendingStatTest";
+  private static final int    DIMENSIONS      = 16;
+  private static final int    NUM_VECTORS     = 1_005; // just above ASYNC_REBUILD_MIN_GRAPH_SIZE (1000)
+  private static final int    MAX_CONNECTIONS = 8;
+  private static final int    BEAM_WIDTH      = 32;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void closeTimeRebuildPendingTurnsOnAtDeferralSurvivesReopenAndClearsOnceTheDeferredRebuildRuns() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        // Force one complete, persisted build so the index starts IMMUTABLE - isolates the deferral this test is
+        // about (a write after an already-built graph) from the separate first-ever-build arm.
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("a graph that has just been built cleanly must not report a pending close-time deferral")
+            .isEqualTo(0L);
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // One more write on top of the already-built graph - the exact shape flush()'s ASYNC_REBUILD_MIN_GRAPH_SIZE
+    // branch defers instead of rebuilding synchronously.
+    final LSMVectorIndex indexAtDeferralTime;
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        indexAtDeferralTime = vectorIndex(db);
+        db.transaction(() -> db.newDocument("Doc").set("id", NUM_VECTORS).set("vector", extraVector()).save());
+
+        assertThat(indexAtDeferralTime.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise flush()'s deferral branch is never reached")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(indexAtDeferralTime.getStats().get("totalVectors"))
+            .as("precondition: at or above the async-rebuild threshold, otherwise close() rebuilds synchronously "
+                + "and never sets the stat at all")
+            .isGreaterThanOrEqualTo(1000L);
+        assertThat(indexAtDeferralTime.getStats().get("closeTimeRebuildPending"))
+            .as("precondition: not yet deferred - nothing has closed yet this session")
+            .isEqualTo(0L);
+
+        db.close();
+
+        // Same object reference the deferring close() ran on: confirms flush() itself set the stat, before even
+        // checking whether it is observable on a later, different instance (asserted below).
+        assertThat(indexAtDeferralTime.getStats().get("closeTimeRebuildPending"))
+            .as("close() deferred a rebuild above the threshold - the stat must say so immediately")
+            .isEqualTo(1L);
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Reopen: a brand-new LSMVectorIndex instance is constructed here (LSMVectorIndex.open() factory), with none
+    // of indexAtDeferralTime's in-memory state. If the stat were a plain instance field it would read 0 here no
+    // matter what the previous session did - this is the assertion that rules that design out.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex reopenedIndex = vectorIndex(db);
+        assertThat(reopenedIndex).as("reopen must hand back a different Java instance").isNotSameAs(indexAtDeferralTime);
+
+        assertThat(reopenedIndex.getStats().get("graphState"))
+            .as("precondition: LOADING - nothing in this session has searched or written yet")
+            .isEqualTo(0L); // GraphState.LOADING
+        assertThat(reopenedIndex.getStats().get("closeTimeRebuildPending"))
+            .as("the deferral from the previous session's close() must still read 1 on this fresh instance, "
+                + "before this session's first search - this is the actual "
+                + "\"why is my first query after reopen slow\" moment the issue is about")
+            .isEqualTo(1L);
+        assertThat(reopenedIndex.getStats().get("graphRebuildCount"))
+            .as("precondition: nothing has rebuilt yet in this fresh instance")
+            .isZero();
+
+        // The search that finally pays for the deferred rebuild (ensureGraphAvailable() -> buildGraphFromScratch(),
+        // synchronous on this call since the graph is not yet loaded this session).
+        final var results = reopenedIndex.findNeighborsFromVector(extraVector(), 5, 64);
+        assertThat(results)
+            .as("the deferred rebuild must still make the vector written right before the deferring close() "
+                + "reachable by search")
+            .hasSize(5);
+
+        assertThat(reopenedIndex.getStats().get("graphRebuildCount"))
+            .as("the search above must be what finally runs the deferred build")
+            .isEqualTo(1L);
+        assertThat(reopenedIndex.getStats().get("closeTimeRebuildPending"))
+            .as("the deferred rebuild caught up - the stat must clear")
+            .isEqualTo(0L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static float[] extraVector() {
+    return randomVector(new Random(5));
+  }
+
+  private static void populate(final Database db) {
+    final Random rnd = new Random(7);
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", com.arcadedb.schema.Type.INTEGER);
+      type.createProperty("vector", com.arcadedb.schema.Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = 0; i < NUM_VECTORS; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+      if (i % 500 == 499) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657InvalidPathRebuildPendingStatTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657InvalidPathRebuildPendingStatTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Companion to {@link Issue6657CloseTimeRebuildPendingStatTest}, covering the OTHER call site of
+ * {@code markCloseTimeRebuildDeferred()} inside {@code flush()}: the {@code needsBuild && !valid} branch, taken
+ * when {@code flush()} runs after {@code releaseBackgroundResources()} instead of before it - its own WARNING log
+ * says this "should not be reachable" through the ordinary {@code close()} path, since both close paths flush
+ * BEFORE releasing. Reaching it here means calling {@code flush()}/{@code releaseBackgroundResources()} directly,
+ * out of {@code close()}'s order, the same inversion the WARNING log guards against.
+ * <p>
+ * Small and fast on purpose - unlike the size-threshold branch, this one does not need
+ * {@code ASYNC_REBUILD_MIN_GRAPH_SIZE} vectors to reach, only {@code graphState == MUTABLE}.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6657InvalidPathRebuildPendingStatTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue6657InvalidPathRebuildPendingStatTest";
+  private static final int    DIMENSIONS = 8;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void flushAfterBackgroundResourcesAreReleasedStillRecordsTheDeferral() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        final Random rnd = new Random(11);
+        db.transaction(() -> {
+          final var type = db.getSchema().createDocumentType("Doc");
+          type.createProperty("id", Type.INTEGER);
+          type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+          db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+              + ", \"similarity\": \"COSINE\" }");
+        });
+        db.transaction(() -> db.newDocument("Doc").set("id", 0).set("vector", randomVector(rnd)).save());
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise needsBuild is false and flush() takes neither deferral branch")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("closeTimeRebuildPending")).isEqualTo(0L);
+
+        // The inversion the WARNING log in flush() describes: release BEFORE flush, not after. Exercised directly
+        // rather than through db.close(), which always does these two in the safe order.
+        index.releaseBackgroundResources();
+        index.flush();
+
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("the !valid branch of flush() must record the deferral exactly like the size-threshold branch does")
+            .isEqualTo(1L);
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657RecheckDoesNotMislabelUnattemptedFlushTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657RecheckDoesNotMislabelUnattemptedFlushTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the mislabeling gap review round 4 found in {@code releaseBackgroundResources()}'s
+ * post-cancellation recheck (added addressing round 2): the recheck used to key off {@code needsGraphBuild()}
+ * alone, which is {@code true} whenever {@code graphState == MUTABLE} for ANY reason - not only "flush() skipped
+ * an owed rebuild". {@code flush()}'s OTHER branch, the one that actually ATTEMPTS a synchronous build (below
+ * {@code ASYNC_REBUILD_MIN_GRAPH_SIZE}), can also leave {@code graphState} at {@code MUTABLE} - a failed persist
+ * ({@code markGraphManifestUnusable()} correctly writes {@code closeDeferredRebuild = false}) or new mutations
+ * arriving mid-build both do. An ungated recheck would overwrite that correct {@code false} with a misleading
+ * {@code true}, reporting "close chose to skip the rebuild" when what actually happened is unrelated to a skip
+ * at all.
+ * <p>
+ * Pinned here at the level of the actual fix - the {@code flushDeferredRebuild} gate - rather than by
+ * reproducing a real failed persist (already covered from a different angle by
+ * {@code CompactIndexGraphPersistFailureTest}/{@code Issue6503GraphPersistOutOfMemoryTest}): the recheck must do
+ * nothing at all when {@code flush()} never ran, regardless of what {@code needsGraphBuild()} says, because
+ * {@code flush()} not having run means it cannot possibly have chosen to skip anything.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6657RecheckDoesNotMislabelUnattemptedFlushTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue6657RecheckDoesNotMislabelUnattemptedFlushTest";
+  private static final int    DIMENSIONS = 8;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void releaseBackgroundResourcesDoesNotMarkDeferredWhenFlushNeverRan() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        final Random rnd = new Random(17);
+        db.transaction(() -> {
+          final var type = db.getSchema().createDocumentType("Doc");
+          type.createProperty("id", Type.INTEGER);
+          type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+          db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+              + ", \"similarity\": \"COSINE\" }");
+        });
+        db.transaction(() -> db.newDocument("Doc").set("id", 0).set("vector", randomVector(rnd)).save());
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE - needsGraphBuild() must be true here, or this test does not exercise the "
+                + "case the old, ungated recheck would have mislabeled")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("closeTimeRebuildPending")).isEqualTo(0L);
+
+        // flush() is deliberately never called - releaseBackgroundResources() alone, standing in for a build
+        // attempt that failed (or any other reason graphState stayed MUTABLE without flush() choosing to skip).
+        index.releaseBackgroundResources();
+
+        assertThat(index.getStats().get("closeTimeRebuildPending"))
+            .as("the recheck must not fire when flush() never ran - it cannot have skipped a build it never "
+                + "considered, so needsGraphBuild() alone must not be enough to mark a deferral")
+            .isEqualTo(0L);
+      } finally {
+        if (db.isOpen())
+          db.drop();
+      }
+    }
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}


### PR DESCRIPTION
## What does this PR do?

`LSMVectorIndex.getStats()` gains a `closeTimeRebuildPending` entry (`1`/`0`) that answers whether
the most recent `close()` deferred a graph rebuild it would otherwise have run, instead of an
operator having to go find the `FINE` log line that says the same thing.

## Supersedes #6711 - targets `main` directly

#6711 targeted `fix/6067-flush-redoes-cancelled-build` (#6653, still open/unmerged), since this
issue's target code (flush()'s size-threshold deferral branch) only existed on that branch. #6653
fell behind `main` and GitHub's native PR-stack linking blocked retargeting #6711 to `main`
directly ("Cannot change the base branch because the pull request is part of a stack" - both the
GraphQL and REST APIs refuse it while the stack link exists).

This PR is the same branch, rebased onto current `main` and opened fresh against `main` instead.
Because #6653 still hasn't merged, this PR's diff necessarily carries #6653's 3 commits verbatim
(content-identical, replayed cleanly, engine module recompiled clean after rebase) in addition to
this issue's own 5 commits - there was no `main`-only way to express "#6657 depends on #6653's
code" once the stack link made retargeting unavailable.

**Consequence for #6653**: once this PR merges, `main` will already contain #6653's changes, so
PR #6653 will show an empty/redundant diff against `main`. Its author (@lvca) should close it (or
it will auto-resolve as empty) rather than merge it separately, to avoid two records of the same
change.

## Motivation

Issue #6657, filed by @lvca from #6653's third review round: "an ops team debugging 'why is my first
query after reopen slow' would currently have to find that `FINE` log line rather than being able to
check it directly" - suggested exposing a "graph rebuild pending" boolean or timestamp via
`getStats()`, alongside the existing `graphState`/`graphRebuildCount`/`mutationsSinceRebuild` entries.

## Design decision worth a second look: persisted, not in-memory

The issue's own "possible direction" (explicitly "not investigated") proposes a plain in-memory
boolean, "set only in `flush()`'s new deferral branch (and cleared once
`ensureGraphAvailable()`/`buildGraphFromScratch()` actually catches up)".

That does not actually work as described: `flush()` only ever runs from
`LocalDatabase.closeDurableParts()`, i.e. only at `close()`/`drop()`, and a **fresh** `LSMVectorIndex`
instance is constructed on every `open()`/`create()` (see the two factory methods). A plain field set
by one instance's `flush()` would already be gone by the time any later instance - the one from the
next `open()` - could read or clear it. That's precisely the scenario the issue names as the point of
the feature: checking the stat right after reopen, before the first search. An in-memory field would
misreport `false` at exactly that moment.

Implemented instead as a small persisted flag on the graph's existing manifest sidecar
(`LSMVectorIndexGraphManifest` - a few dozen bytes, already read once per graph load / written once
per persist):

- `Content` gained a `closeDeferredRebuild` boolean, defaulting to `false` on read (old manifests
  without the field read as `false`, no format-version bump needed).
- New `markCloseDeferred()`: preserves whatever `vectorCount`/`fingerprint` are already on disk (or
  falls back to `UNUSABLE_VECTOR_COUNT`/`0` when nothing has ever been persisted - the never-built
  arm), writes `closeDeferredRebuild = true`. It does **not** touch the existing
  staleness-detection fields, so it cannot interfere with `ensureGraphAvailable()`'s fingerprint-based
  reuse check.
- The two existing write paths - `write(int, long)` (normal post-build persist) and
  `markUnusable(String)` - now clear `closeDeferredRebuild` back to `false` explicitly: reaching
  either means a build completed (successfully or not), so whatever a previous close deferred has now
  been paid for.
- `LSMVectorIndex.flush()` calls the new `markCloseTimeRebuildDeferred(gf)` helper from **both**
  existing "skip the build" branches - the size-threshold deferral (#6653) and the pre-existing
  `!valid` "background resources already released" branch - but not from the "nothing needed" branch,
  which must never clear an already-true flag just because a later, uneventful close found nothing new
  pending.
- `getStats()` reads the manifest fresh each call (guarded by `graphFile != null`) and reports
  `closeTimeRebuildPending`.

**Known, deliberate gaps** (both documented at their call sites, neither chased further):
- A large index closed before its first-ever graph file was even created, and closed *again* without a
  build in between (two-or-more-session never-built case), has no manifest path to write to
  (`graphFile == null`) - `markCloseTimeRebuildDeferred()` is a no-op there. The index itself is
  unaffected (still lazily rebuilt on next search); only the stats signal for that narrow window is
  unavailable.
- `releaseBackgroundResources()`'s post-cancellation recheck (added addressing review round 2) can
  still lose to a **straggler build thread**: one that outlived `shutdownNow()`'s 5s budget - already
  logged as a WARNING a few lines above the recheck - and happens to still hold `graphBuildLock` at the
  exact moment the recheck's own `tryLock()` runs. Narrow (needs both an unresponsive build *and* it
  specifically being the lock holder right then), and unlike the cancellation case the recheck exists
  for, there is no later "the build is definitely done by now" moment left inside this method to retry
  from. Flagged by review round 3.

Both kept out of scope deliberately, per the issue's own framing ("keeps the addition scoped to the
exact question ops teams would ask").

## Related issues

Closes #6657
Supersedes #6711
Relates to #6067, #6653

## Additional Notes

- Not touched: the manifest's `vectorCount`/`fingerprint` staleness-detection logic, which several
  other tests (`Issue6106StaleVectorGraphTest`, `LSMVectorIndexGraphManifestTest`,
  `Issue6503GraphPersistOutOfMemoryTest`) exercise directly - all still green.

## Test plan

- New regression test `Issue6657CloseTimeRebuildPendingStatTest` (`@Tag("slow")`, ~1000 vectors,
  small dimensions/build params for speed). In one flow: the stat turns on the moment `close()`
  defers; it still reads `1` on a **freshly reopened, different** `LSMVectorIndex` instance, before
  that instance has searched (the assertion that specifically rules out the in-memory design); it
  clears back to `0` once the deferred rebuild actually runs via the triggering search; a clean build
  with nothing deferred reports `0` (no false positive).
- Confirmed the test can fail: temporarily disabled both `markCloseTimeRebuildDeferred(gf)` call
  sites and reran - failed at the expected assertion. Restored before committing.
- `mvn -pl engine -am test -Dtest=Issue6657CloseTimeRebuildPendingStatTest` - 1/1 pass.
- `mvn -pl engine -am test -Dtest=Issue6657CloseTimeRebuildPendingStatTest,Issue6067DeferredCloseRebuildTest,LSMVectorIndexGraphManifestTest,Issue6503GraphPersistOutOfMemoryTest`
  - 12/12 pass (the two suites that reference `LSMVectorIndexGraphManifest.Content` directly, plus
  #6067's own tests, plus the OOM-simulation test exercising `markUnusable`).
- Broader sweep of close/rebuild/manifest-adjacent vector-index tests (`VectorIndexRebuildsOnEveryCloseTest`,
  `VectorIndexNoRebuildOnUnusedCloseTest`, `LSMVectorIndexCloseCancelsInFlightBuildTest`,
  `Issue6518CloseDoesNotLeakBuildPoolTest`, `CompactIndexGraphPersistFailureTest`,
  `CompactIndexKeepsGraphReusableTest`, `Issue6106StaleVectorGraphTest`,
  `LSMVectorIndexGraphFileToctouTest`, `LSMVectorIndexGraphFileVisibilityTest`,
  `LSMVectorIndexGraphStorageTest`, `LSMVectorIndexPersistenceTest`, `LSMVectorIndexRecoveryTest`,
  `LSMVectorIndexRebuildTest`, `Issue5870VectorIndexIdRenumberingTest`) - 68/68 pass.

**Review round 2** (concurrency + missing branch coverage):
- New `Issue6657InvalidPathRebuildPendingStatTest` covers the second `markCloseTimeRebuildDeferred()`
  call site (the `needsBuild && !valid` branch).
- New `Issue6657CancelledBuildRecheckTest` deterministically pins the cancelled-build false-negative
  the round-2 review found: a helper thread holds `graphBuildLock` directly (rather than racing a real
  JVector build's timing, which `LSMVectorIndexCloseCancelsInFlightBuildTest` already shows is hard to
  pin reliably) and releases it only after `flush()` has observed it contended, mirroring what a real
  cancellation would do without ever writing the manifest.
- Confirmed both new tests can fail: reverted each fix in turn, reran, confirmed the expected failure,
  restored.
- Full sweep re-run after both fixes (82 tests, including the two new ones) - all pass.

**Review round 3** (documentation-only ask, no blocking issues): documented the residual
straggler-build-thread gap (see "Known, deliberate gaps" above) at its code site and here; added a
cheap already-`true` short-circuit to `markCloseDeferred()` per the minor I/O nit. 30-test focused
re-run after - all pass.

**Review round 4** (real correctness finding, addressed): the `releaseBackgroundResources()` recheck
fired on `needsGraphBuild()` alone, which is `true` whenever `graphState == MUTABLE` for *any* reason -
not only "flush() skipped an owed rebuild". `flush()`'s *other* branch, the one that actually attempts
a synchronous build (below `ASYNC_REBUILD_MIN_GRAPH_SIZE`), can also leave `graphState` at `MUTABLE` -
a failed persist (which correctly writes `closeDeferredRebuild = false`) or new mutations arriving
mid-build both do - and the ungated recheck would overwrite that correct `false` with a misleading
`true`. New `flushDeferredRebuild` field, set only inside `flush()`'s two skip branches and reset at
the top of every `flush()`, gates the recheck so it fires only when *this* close's `flush()` itself
chose to defer; as a side effect this also stops the recheck from running on `LocalDatabase.kill()`/
whole-database-drop, which call `releaseBackgroundResources()` without ever calling `flush()` (round
4's second finding). New `Issue6657RecheckDoesNotMislabelUnattemptedFlushTest` pins the gate directly;
confirmed it fails against the ungated code. Also fixed the `@param` indentation nit. 31-test focused
re-run after - all pass.

**#6711 reached its configured review-cycle limit (4) before this retarget.** Round 4's fixes above
were pushed but have not themselves been through a fifth automated review pass. Given the pattern
across all four rounds on #6711 - real, specific, verifiable findings each time, all addressed with a
matching regression test confirmed to fail pre-fix - a human pass over that last commit specifically
(the `flushDeferredRebuild` gating) is still the recommended next step before merge, rather than
assuming a clean bill of health by default.

## Checklist

- [x] I have run the build using `mvn clean package` command (module-scoped: `mvn -pl engine -am test`, per project convention for a change scoped to one module)
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Large vector indexes now close faster by deferring graph rebuilding until a subsequent search requires it.
  * Vector data remains safely persisted during close operations.

* **New Features**
  * Added the `closeTimeRebuildPending` statistic to indicate when graph rebuilding is deferred.
  * The statistic clears automatically after the graph is rebuilt.

* **Bug Fixes**
  * Improved tracking of deferred rebuilds when background processing is interrupted or resources are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->