### PR TITLE
feat(opencypher): add db.index.fulltext.queryNodes/queryRelationships (Neo4j-compatible)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/CypherProcedureRegistry.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/CypherProcedureRegistry.java
@@ -20,6 +20,8 @@ package com.arcadedb.query.opencypher.procedures;
 
 import com.arcadedb.function.procedure.ProcedureRegistry;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.query.opencypher.procedures.db.DbIndexFulltextQueryNodes;
+import com.arcadedb.query.opencypher.procedures.db.DbIndexFulltextQueryRelationships;
 import com.arcadedb.query.opencypher.procedures.db.DbIndexVectorQueryNodes;
 import com.arcadedb.query.opencypher.procedures.db.DbLabels;
 import com.arcadedb.query.opencypher.procedures.db.DbPropertyKeys;
@@ -392,6 +394,8 @@ public final class CypherProcedureRegistry {
 
   private static void registerDbProcedures() {
     register(new DbIndexVectorQueryNodes());
+    register(new DbIndexFulltextQueryNodes());
+    register(new DbIndexFulltextQueryRelationships());
     register(new DbLabels());
     register(new DbRelationshipTypes());
     register(new DbPropertyKeys());

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexFulltextQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexFulltextQueryNodes.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.db;
+
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.fulltext.FullTextSearch;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.EdgeType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Neo4j-compatible procedure: db.index.fulltext.queryNodes(indexName, queryString)
+ * <p>
+ * Searches a BM25 full-text index (ArcadeDB's native {@code FULL_TEXT} index type) and returns matching nodes ranked
+ * by relevance. This provides compatibility with Neo4j's full-text search API, letting text search and graph pattern
+ * matching live in the same Cypher statement instead of requiring a separate SQL {@code SEARCH_INDEX()} query.
+ * </p>
+ * <p>
+ * The index is identified in ArcadeDB's {@code Type[property]} format, exactly as returned by the schema and as
+ * accepted by the SQL {@code SEARCH_INDEX()} function - there is no separate "index name" concept to reconcile.
+ * </p>
+ * <p>
+ * Example (Neo4j-compatible):
+ * <pre>
+ * CALL db.index.fulltext.queryNodes('Article[content]', 'java AND database')
+ * YIELD node, score
+ * RETURN node.title AS title, score
+ * ORDER BY score DESC
+ * </pre>
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ * @see DbIndexFulltextQueryRelationships
+ */
+public class DbIndexFulltextQueryNodes implements CypherProcedure {
+  public static final String NAME = "db.index.fulltext.querynodes";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Searches a full-text index and returns matching nodes ranked by BM25 relevance score (Neo4j-compatible)";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("node", "score");
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    validateArgs(args);
+
+    final String indexName = args[0].toString();
+    final String queryText = args[1].toString();
+
+    final TypeIndex typeIndex = FullTextSearch.resolveFullTextIndex(context.getDatabase(), indexName);
+
+    final DocumentType type = context.getDatabase().getSchema().getType(typeIndex.getTypeName());
+    if (type instanceof EdgeType)
+      throw new CommandSQLParsingException(
+          "db.index.fulltext.queryNodes(): index '" + indexName + "' is a full-text index on relationship type '"
+              + type.getName() + "', use db.index.fulltext.queryRelationships() instead");
+
+    final Map<RID, Float> matches = FullTextSearch.search(typeIndex, queryText, -1);
+
+    final List<Map.Entry<RID, Float>> sorted = new ArrayList<>(matches.entrySet());
+    sorted.sort((a, b) -> Float.compare(b.getValue(), a.getValue()));
+
+    final List<Result> results = new ArrayList<>(sorted.size());
+    for (final Map.Entry<RID, Float> entry : sorted) {
+      try {
+        final Document node = entry.getKey().asDocument(true);
+        final ResultInternal r = new ResultInternal();
+        r.setProperty("node", node);
+        r.setProperty("score", entry.getValue());
+        results.add(r);
+      } catch (final RecordNotFoundException e) {
+        // Stale posting: the record was deleted since the index was last updated, skip it (same handling as the
+        // SEARCH_INDEX() SQL function's searchFromTarget()).
+      }
+    }
+
+    return results.stream();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexFulltextQueryRelationships.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexFulltextQueryRelationships.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.db;
+
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.fulltext.FullTextSearch;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.EdgeType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Neo4j-compatible procedure: db.index.fulltext.queryRelationships(indexName, queryString)
+ * <p>
+ * Searches a BM25 full-text index declared on an edge type and returns matching relationships ranked by relevance.
+ * The relationship counterpart of {@link DbIndexFulltextQueryNodes}, mirroring Neo4j's
+ * {@code db.index.fulltext.queryRelationships()}.
+ * </p>
+ * <p>
+ * Example (Neo4j-compatible):
+ * <pre>
+ * CALL db.index.fulltext.queryRelationships('Cites[note]', 'java')
+ * YIELD relationship, score
+ * RETURN relationship.note AS note, score
+ * ORDER BY score DESC
+ * </pre>
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ * @see DbIndexFulltextQueryNodes
+ */
+public class DbIndexFulltextQueryRelationships implements CypherProcedure {
+  public static final String NAME = "db.index.fulltext.queryrelationships";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Searches a full-text index and returns matching relationships ranked by BM25 relevance score (Neo4j-compatible)";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("relationship", "score");
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    validateArgs(args);
+
+    final String indexName = args[0].toString();
+    final String queryText = args[1].toString();
+
+    final TypeIndex typeIndex = FullTextSearch.resolveFullTextIndex(context.getDatabase(), indexName);
+
+    final DocumentType type = context.getDatabase().getSchema().getType(typeIndex.getTypeName());
+    if (!(type instanceof EdgeType))
+      throw new CommandSQLParsingException(
+          "db.index.fulltext.queryRelationships(): index '" + indexName + "' is a full-text index on node type '"
+              + type.getName() + "', use db.index.fulltext.queryNodes() instead");
+
+    final Map<RID, Float> matches = FullTextSearch.search(typeIndex, queryText, -1);
+
+    final List<Map.Entry<RID, Float>> sorted = new ArrayList<>(matches.entrySet());
+    sorted.sort((a, b) -> Float.compare(b.getValue(), a.getValue()));
+
+    final List<Result> results = new ArrayList<>(sorted.size());
+    for (final Map.Entry<RID, Float> entry : sorted) {
+      try {
+        final Edge relationship = entry.getKey().asEdge(true);
+        final ResultInternal r = new ResultInternal();
+        r.setProperty("relationship", relationship);
+        r.setProperty("score", entry.getValue());
+        results.add(r);
+      } catch (final RecordNotFoundException e) {
+        // Stale posting: the record was deleted since the index was last updated, skip it (same handling as the
+        // SEARCH_INDEX() SQL function's searchFromTarget()).
+      }
+    }
+
+    return results.stream();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherFullTextSearchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherFullTextSearchTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduces issue #6729 / discussion #6728: full-text search over a BM25 {@code FULL_TEXT} index was reachable only
+ * from SQL ({@code SEARCH_INDEX()}), with no native way to combine it with graph pattern matching in Cypher, the way
+ * Neo4j exposes {@code db.index.fulltext.queryNodes()}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherFullTextSearchTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Article IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY Article.title IF NOT EXISTS STRING");
+      database.command("sql", "CREATE PROPERTY Article.content IF NOT EXISTS STRING");
+      database.command("sql", "CREATE INDEX IF NOT EXISTS ON Article (content) FULL_TEXT");
+
+      database.command("sql", "CREATE EDGE TYPE Cites IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY Cites.note IF NOT EXISTS STRING");
+      database.command("sql", "CREATE INDEX IF NOT EXISTS ON Cites (note) FULL_TEXT");
+    });
+
+    database.transaction(() -> {
+      database.newVertex("Article").set("title", "Doc1").set("content", "java programming language").save();
+      database.newVertex("Article").set("title", "Doc2").set("content", "java database systems").save();
+      database.newVertex("Article").set("title", "Doc3").set("content", "python scripting").save();
+    });
+  }
+
+  /**
+   * Reproduces the feature request itself: Neo4j's {@code db.index.fulltext.queryNodes(indexName, query) YIELD node,
+   * score} has no ArcadeDB equivalent, so full-text results cannot be ranked and fed into further graph pattern
+   * matching within one Cypher statement.
+   */
+  @Test
+  void queryNodesNeo4jCompatibleProcedureRanksResultsByScore() {
+    try (ResultSet result = database.query("opencypher",
+        "CALL db.index.fulltext.queryNodes('Article[content]', 'java') YIELD node, score "
+            + "RETURN node.title AS title, score ORDER BY score DESC")) {
+
+      final List<String> titles = new ArrayList<>();
+      final List<Double> scores = new ArrayList<>();
+      while (result.hasNext()) {
+        final Result row = result.next();
+        titles.add(row.getProperty("title"));
+        scores.add(((Number) row.getProperty("score")).doubleValue());
+      }
+
+      assertThat(titles).containsExactlyInAnyOrder("Doc1", "Doc2");
+      for (int i = 1; i < scores.size(); i++)
+        assertThat(scores.get(i)).isLessThanOrEqualTo(scores.get(i - 1));
+    }
+  }
+
+  @Test
+  void queryNodesYieldsAnActualNode() {
+    try (ResultSet result = database.query("opencypher",
+        "CALL db.index.fulltext.queryNodes('Article[content]', 'python') YIELD node, score RETURN node, score")) {
+
+      assertThat(result.hasNext()).isTrue();
+      final Result row = result.next();
+
+      final Object node = row.getProperty("node");
+      assertThat(node).isInstanceOf(Document.class);
+      assertThat(((Document) node).getString("title")).isEqualTo("Doc3");
+      assertThat(((Number) row.getProperty("score")).doubleValue()).isGreaterThan(0.0);
+    }
+  }
+
+  @Test
+  void queryNodesWithNoMatchesReturnsNoRows() {
+    try (ResultSet result = database.query("opencypher",
+        "CALL db.index.fulltext.queryNodes('Article[content]', 'nonexistentterm') YIELD node, score RETURN node")) {
+
+      assertThat(result.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void queryNodesRejectsAnIndexThatIsNotFullText() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE INDEX IF NOT EXISTS ON Article (title) UNIQUE");
+    });
+
+    assertThatThrownBy(() -> {
+      try (ResultSet result = database.query("opencypher",
+          "CALL db.index.fulltext.queryNodes('Article[title]', 'Doc1') YIELD node, score RETURN node")) {
+        while (result.hasNext())
+          result.next();
+      }
+    }).hasStackTraceContaining("full-text");
+  }
+
+  /**
+   * Neo4j-compatible relationship counterpart, {@code db.index.fulltext.queryRelationships}: a full-text index can be
+   * declared on an edge type in ArcadeDB just as on a vertex type, so the same YIELD-node/score shape applies to
+   * relationships.
+   */
+  @Test
+  void queryRelationshipsRanksResultsByScore() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE EDGE Cites FROM (SELECT FROM Article WHERE title = 'Doc1') "
+          + "TO (SELECT FROM Article WHERE title = 'Doc2') SET note = 'cites java database work'");
+      database.command("sql", "CREATE EDGE Cites FROM (SELECT FROM Article WHERE title = 'Doc2') "
+          + "TO (SELECT FROM Article WHERE title = 'Doc3') SET note = 'unrelated scripting note'");
+    });
+
+    try (ResultSet result = database.query("opencypher",
+        "CALL db.index.fulltext.queryRelationships('Cites[note]', 'java') YIELD relationship, score "
+            + "RETURN relationship.note AS note, score")) {
+
+      assertThat(result.hasNext()).isTrue();
+      final Result row = result.next();
+      assertThat((String) row.getProperty("note")).isEqualTo("cites java database work");
+      assertThat(((Number) row.getProperty("score")).doubleValue()).isGreaterThan(0.0);
+      assertThat(result.hasNext()).isFalse();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherFullTextSearchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherFullTextSearchTest.java
@@ -56,6 +56,9 @@ class CypherFullTextSearchTest extends TestHelper {
       database.newVertex("Article").set("title", "Doc1").set("content", "java programming language").save();
       database.newVertex("Article").set("title", "Doc2").set("content", "java database systems").save();
       database.newVertex("Article").set("title", "Doc3").set("content", "python scripting").save();
+      // Same token count as Doc1/Doc2 (so BM25 length normalization is equal) but "java" repeated 3x instead of
+      // once, so it must score strictly higher - used to verify the procedure's own ranking below.
+      database.newVertex("Article").set("title", "Doc4").set("content", "java java java repository").save();
     });
   }
 
@@ -63,12 +66,15 @@ class CypherFullTextSearchTest extends TestHelper {
    * Reproduces the feature request itself: Neo4j's {@code db.index.fulltext.queryNodes(indexName, query) YIELD node,
    * score} has no ArcadeDB equivalent, so full-text results cannot be ranked and fed into further graph pattern
    * matching within one Cypher statement.
+   * <p>
+   * Deliberately has no {@code ORDER BY} in the query: sorting there would mask the procedure returning results in
+   * the wrong order, since Cypher would silently re-sort them. This asserts the order {@code execute()} itself
+   * produces.
    */
   @Test
   void queryNodesNeo4jCompatibleProcedureRanksResultsByScore() {
     try (ResultSet result = database.query("opencypher",
-        "CALL db.index.fulltext.queryNodes('Article[content]', 'java') YIELD node, score "
-            + "RETURN node.title AS title, score ORDER BY score DESC")) {
+        "CALL db.index.fulltext.queryNodes('Article[content]', 'java') YIELD node, score RETURN node.title AS title, score")) {
 
       final List<String> titles = new ArrayList<>();
       final List<Double> scores = new ArrayList<>();
@@ -78,7 +84,9 @@ class CypherFullTextSearchTest extends TestHelper {
         scores.add(((Number) row.getProperty("score")).doubleValue());
       }
 
-      assertThat(titles).containsExactlyInAnyOrder("Doc1", "Doc2");
+      assertThat(titles).containsExactlyInAnyOrder("Doc1", "Doc2", "Doc4");
+      assertThat(titles.getFirst()).isEqualTo("Doc4");
+      assertThat(scores.getFirst()).isGreaterThan(scores.get(1));
       for (int i = 1; i < scores.size(); i++)
         assertThat(scores.get(i)).isLessThanOrEqualTo(scores.get(i - 1));
     }
@@ -127,14 +135,18 @@ class CypherFullTextSearchTest extends TestHelper {
    * Neo4j-compatible relationship counterpart, {@code db.index.fulltext.queryRelationships}: a full-text index can be
    * declared on an edge type in ArcadeDB just as on a vertex type, so the same YIELD-node/score shape applies to
    * relationships.
+   * <p>
+   * Two matching edges with the same note length but different "java" term frequency (1x vs 3x), so BM25 ranks them
+   * distinctly; no {@code ORDER BY} in the query, so this asserts the procedure's own output order rather than
+   * Cypher re-sorting a single/unordered result.
    */
   @Test
   void queryRelationshipsRanksResultsByScore() {
     database.transaction(() -> {
       database.command("sql", "CREATE EDGE Cites FROM (SELECT FROM Article WHERE title = 'Doc1') "
-          + "TO (SELECT FROM Article WHERE title = 'Doc2') SET note = 'cites java database work'");
+          + "TO (SELECT FROM Article WHERE title = 'Doc2') SET note = 'cites java work today'");
       database.command("sql", "CREATE EDGE Cites FROM (SELECT FROM Article WHERE title = 'Doc2') "
-          + "TO (SELECT FROM Article WHERE title = 'Doc3') SET note = 'unrelated scripting note'");
+          + "TO (SELECT FROM Article WHERE title = 'Doc3') SET note = 'java java java focus'");
     });
 
     try (ResultSet result = database.query("opencypher",
@@ -142,9 +154,17 @@ class CypherFullTextSearchTest extends TestHelper {
             + "RETURN relationship.note AS note, score")) {
 
       assertThat(result.hasNext()).isTrue();
-      final Result row = result.next();
-      assertThat((String) row.getProperty("note")).isEqualTo("cites java database work");
-      assertThat(((Number) row.getProperty("score")).doubleValue()).isGreaterThan(0.0);
+      final Result first = result.next();
+      assertThat((String) first.getProperty("note")).isEqualTo("java java java focus");
+      final double firstScore = ((Number) first.getProperty("score")).doubleValue();
+      assertThat(firstScore).isGreaterThan(0.0);
+
+      assertThat(result.hasNext()).isTrue();
+      final Result second = result.next();
+      assertThat((String) second.getProperty("note")).isEqualTo("cites java work today");
+      final double secondScore = ((Number) second.getProperty("score")).doubleValue();
+
+      assertThat(firstScore).isGreaterThan(secondScore);
       assertThat(result.hasNext()).isFalse();
     }
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherFullTextSearchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherFullTextSearchTest.java
@@ -58,7 +58,7 @@ class CypherFullTextSearchTest extends TestHelper {
       database.newVertex("Article").set("title", "Doc3").set("content", "python scripting").save();
       // Same token count as Doc1/Doc2 (so BM25 length normalization is equal) but "java" repeated 3x instead of
       // once, so it must score strictly higher - used to verify the procedure's own ranking below.
-      database.newVertex("Article").set("title", "Doc4").set("content", "java java java repository").save();
+      database.newVertex("Article").set("title", "Doc4").set("content", "java java java").save();
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds `db.index.fulltext.queryNodes(indexName, query) YIELD node, score` and `db.index.fulltext.queryRelationships(indexName, query) YIELD relationship, score` as Cypher `CALL` procedures, mirroring Neo4j's full-text search API and the existing `db.index.vector.queryNodes` procedure.
- Both delegate to ArcadeDB's existing native BM25 `FULL_TEXT` index engine (`FullTextSearch`) - no new dependency, no change to the SQL-side `SEARCH_INDEX()` function.
- Lets full-text search results be ranked by relevance and combined with graph pattern matching in a single Cypher statement, closing the gap described in the discussion.

## Design notes
- Investigated exposing full-text search as an inline Cypher `WHERE` predicate too (e.g. `WHERE search_index(...)`), since that path is nominally reachable through Cypher's generic SQL-function bridge. Found that bridge always passes a `null` current-record to the wrapped SQL function, so `SEARCH_INDEX`'s per-row boolean semantics can't work through it - and Neo4j itself does not expose full-text search as an inline predicate either, only via `CALL ... YIELD`. Scoped this PR to the `CALL` procedures only, which is both the actual feature request and true Neo4j parity.
- `queryRelationships` rejects an index resolved to a node type (and vice versa) with an actionable message pointing at the right procedure, since ArcadeDB allows `FULL_TEXT` indexes on any document type including edge types.

## Test plan
- [x] New regression test `CypherFullTextSearchTest` (5 tests): ranked `queryNodes` results, actual node yield, no-match case, non-full-text-index rejection, `queryRelationships` ranked results.
- [x] `mvn -pl engine test` on the new test class and all fulltext-adjacent suites (`SQLFunctionSearchIndexTest`, `SQLFunctionSearchIndexFuzzyStressTest`, `FullTextQuerySyntaxTest`, `FullTextBM25Test`, `LSMTreeFullTextIndexTest`, `FullTextIndexMetadataTest`, `TypeFullTextIndexBuilderTest`, `FullTextEdgeCasesTest`, `FullTextPersistenceTest`, `FullTextAnalyzerConfigTest`, `FullTextBackwardCompatibilityTest`, `Issue6382ContainsTextColonTest`, `PlainLuceneFullTextIndexTest`) and the existing `CypherProcedureRegistryTest` / `CypherCallVectorNeighborsTest` - all green, no regressions.

Fixes #6729

https://claude.ai/code/session_01PMNdRidHNTwhNAeWoFt6NF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Neo4j-compatible full-text search procedures for querying nodes and relationships through Cypher.
  * Results include matching records and BM25 relevance scores, ordered by relevance.
  * Invalid index types and deleted records are handled appropriately.
  * Full-text search procedures are available as built-in database procedures.

* **Tests**
  * Added coverage for node and relationship searches, score ordering, empty results, and invalid indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->