### PR TITLE
fix(#6732): Issue6657CloseTimeRebuildPendingStatTest awaits the async prefix-reuse rebuild

### DIFF
--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.index.vector;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.utility.FileUtils;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,10 +44,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  * stat must turn on exactly when {@code close()} defers a rebuild, it must still read {@code 1} on a <b>freshly
  * reopened</b> index - i.e. a brand-new {@link LSMVectorIndex} instance, not the one that set it - before that
  * index has been searched (the whole point: answering the question BEFORE the next search silently pays for it),
- * and it must clear back to {@code 0} once that search actually runs the deferred rebuild.
+ * and it must clear back to {@code 0} once the deferred rebuild that search triggers actually completes.
  * <p>
  * A normal close that never deferred anything (below the async-rebuild threshold) is also pinned at {@code 0}, to
  * catch a stat that reads "true" unconditionally.
+ * <p>
+ * The search that pays for the deferral does not itself run the rebuild synchronously: the fixture's reopened
+ * state - a persisted graph short by exactly one vector, both above {@code ASYNC_REBUILD_MIN_GRAPH_SIZE} - is
+ * exactly what issue #6655's stale-prefix-reuse fix ({@link LSMVectorIndex#ensureGraphAvailable()}) now reuses
+ * as a verified prefix instead of rebuilding, so the search answers immediately from the reused graph plus the
+ * queued gap vector and only kicks the rebuild asynchronously. The stat therefore has to be awaited, not read
+ * the instant the search returns.
  *
  * @author Roberto Franchini (r.franchini@arcadedata.com)
  */
@@ -144,17 +153,24 @@ class Issue6657CloseTimeRebuildPendingStatTest {
             .as("precondition: nothing has rebuilt yet in this fresh instance")
             .isZero();
 
-        // The search that finally pays for the deferred rebuild (ensureGraphAvailable() -> buildGraphFromScratch(),
-        // synchronous on this call since the graph is not yet loaded this session).
+        // The search that finally pays for the deferral: ensureGraphAvailable() finds the persisted graph short
+        // by exactly the one vector written above - a stale-prefix-reuse candidate under issue #6655's fix - so
+        // it answers immediately from the reused graph plus the queued gap vector and only kicks the rebuild
+        // asynchronously (reuseStalePrefixGraph() -> startAsyncGraphRebuild()), rather than running it inline.
         final var results = reopenedIndex.findNeighborsFromVector(extraVector(), 5, 64);
         assertThat(results)
-            .as("the deferred rebuild must still make the vector written right before the deferring close() "
-                + "reachable by search")
+            .as("the queued gap vector must already be searchable via the reused prefix graph's delta buffer, "
+                + "before the deferred rebuild it kicked off has even finished")
             .hasSize(5);
 
-        assertThat(reopenedIndex.getStats().get("graphRebuildCount"))
-            .as("the search above must be what finally runs the deferred build")
-            .isEqualTo(1L);
+        // The async rebuild kicked off by the search above eventually folds the gap into the graph proper - the
+        // same deferred rebuild the deferring close() owed, now actually paid.
+        Awaitility.await("the async rebuild kicked off by the deferred-rebuild search completes")
+            .atMost(Duration.ofSeconds(60))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted(() -> assertThat(reopenedIndex.getStats().get("graphRebuildCount"))
+                .as("the search above must be what finally runs the deferred build")
+                .isEqualTo(1L));
         assertThat(reopenedIndex.getStats().get("closeTimeRebuildPending"))
             .as("the deferred rebuild caught up - the stat must clear")
             .isEqualTo(0L);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
@@ -20,7 +20,10 @@ package com.arcadedb.index.vector;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.Pair;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -157,11 +160,16 @@ class Issue6657CloseTimeRebuildPendingStatTest {
         // by exactly the one vector written above - a stale-prefix-reuse candidate under issue #6655's fix - so
         // it answers immediately from the reused graph plus the queued gap vector and only kicks the rebuild
         // asynchronously (reuseStalePrefixGraph() -> startAsyncGraphRebuild()), rather than running it inline.
+        final RID gapDocRid = ridOf(db, NUM_VECTORS);
         final var results = reopenedIndex.findNeighborsFromVector(extraVector(), 5, 64);
         assertThat(results)
             .as("the queued gap vector must already be searchable via the reused prefix graph's delta buffer, "
                 + "before the deferred rebuild it kicked off has even finished")
             .hasSize(5);
+        assertThat(results.stream().map(Pair::getFirst))
+            .as("the gap record must actually be found by its own embedding - a record is always its own "
+                + "nearest neighbour - not merely that the search returned five OTHER results")
+            .contains(gapDocRid);
 
         // The async rebuild kicked off by the search above eventually folds the gap into the graph proper - the
         // same deferred rebuild the deferring close() owed, now actually paid.
@@ -216,5 +224,12 @@ class Issue6657CloseTimeRebuildPendingStatTest {
   private static LSMVectorIndex vectorIndex(final Database db) {
     return (LSMVectorIndex) db.getSchema().getType("Doc")
         .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+
+  private static RID ridOf(final Database db, final int id) {
+    try (final ResultSet rs = db.query("sql", "SELECT @rid FROM Doc WHERE id = ?", id)) {
+      assertThat(rs.hasNext()).as("the gap record must exist").isTrue();
+      return rs.next().getProperty("@rid");
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
@@ -172,16 +172,24 @@ class Issue6657CloseTimeRebuildPendingStatTest {
             .contains(gapDocRid);
 
         // The async rebuild kicked off by the search above eventually folds the gap into the graph proper - the
-        // same deferred rebuild the deferring close() owed, now actually paid.
+        // same deferred rebuild the deferring close() owed, now actually paid. Both stats are awaited TOGETHER,
+        // not graphRebuildCount first and closeTimeRebuildPending as a separate synchronous check right after:
+        // incrementGraphRebuildCount() runs in-memory under lock.writeLock() the moment the rebuilt graph is
+        // swapped in, but closeTimeRebuildPending is derived from the manifest, which writeGraphManifest() does
+        // not write until AFTER the graph is persisted to disk and its transaction committed - a later point in
+        // time, not an atomic one. Reading closeTimeRebuildPending synchronously right after graphRebuildCount
+        // turns green would race that gap.
         Awaitility.await("the async rebuild kicked off by the deferred-rebuild search completes")
             .atMost(Duration.ofSeconds(60))
             .pollInterval(Duration.ofMillis(200))
-            .untilAsserted(() -> assertThat(reopenedIndex.getStats().get("graphRebuildCount"))
-                .as("the search above must be what finally runs the deferred build")
-                .isEqualTo(1L));
-        assertThat(reopenedIndex.getStats().get("closeTimeRebuildPending"))
-            .as("the deferred rebuild caught up - the stat must clear")
-            .isEqualTo(0L);
+            .untilAsserted(() -> {
+              assertThat(reopenedIndex.getStats().get("graphRebuildCount"))
+                  .as("the search above must be what finally runs the deferred build")
+                  .isEqualTo(1L);
+              assertThat(reopenedIndex.getStats().get("closeTimeRebuildPending"))
+                  .as("the deferred rebuild caught up - the stat must clear")
+                  .isEqualTo(0L);
+            });
       } finally {
         db.drop();
       }


### PR DESCRIPTION
Closes #6732

## Summary

- `Issue6657CloseTimeRebuildPendingStatTest` failed deterministically on main (`engine/target/surefire-reports/TEST-com.arcadedb.index.vector.Issue6657CloseTimeRebuildPendingStatTest.xml: 1 failure`), reproducible standalone and in the full vector slow lane: 100% (multiple runs).
- Root cause: PR #6712 (issue #6655) generalized `LSMVectorIndex.ensureGraphAvailable()` to reuse a persisted graph as a verified prefix - and kick an *async* rebuild - whenever it is stale only because vectors were added since it was built, above `ASYNC_REBUILD_MIN_GRAPH_SIZE`. The #6657 test's fixture (one vector written on top of an already-built graph, 1,006 live vectors total) is exactly that shape. Before #6712 it hit the old synchronous `buildGraphFromScratch()` path on the first search after reopen; now it hits the new async prefix-reuse path, so `graphRebuildCount` isn't incremented until the async rebuild the search kicked off actually finishes - the test asserted on it immediately after the search returned.
- This is a test/product interaction gap between #6712 and #6724 (merged back to back), not a functional regression - the async-prefix-reuse behavior is #6655's intended fix. Fixed the test to await the async rebuild (`Awaitility`), the same pattern already used by `Issue6655StaleGraphPrefixReuseTest`.
- `Issue6655StaleGraphPrefixReuseTest` was also reported failing in the same run, but did not reproduce: 7/7 clean standalone runs and 0 failures across 416 tests when run together with the rest of the vector package's slow+vector-tagged suites. No change made for it; noted in #6732 in case it recurs.

## Test plan

- [x] `mvn -o -pl engine test -Dgroups=slow -DexcludedGroups=vector -Dtest=Issue6657CloseTimeRebuildPendingStatTest` - reproduced the failure on main, passes 3/3 after the fix (~0.8-1.2s each)
- [x] `mvn -o -pl engine test -Dgroups=slow -DexcludedGroups=vector -Dtest=Issue6655StaleGraphPrefixReuseTest` - 7/7 clean (isolated)
- [x] Full `com.arcadedb.index.vector` package (slow + vector tagged, `-DexcludedGroups=benchmark`, 82 classes / 416 tests) - all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage for vector searches after reopening an index.
  * Verified newly added vectors are returned immediately while background rebuilding continues.
  * Confirmed related records appear in search results during asynchronous processing.
  * Added validation that rebuilding and pending-status indicators update correctly after processing completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->