### PR TITLE
fix(#6719, #6721, #6718): checkpoint gaps, redundant edge resum, betweenness allocations

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -339,8 +339,11 @@ public final class GraphAlgorithms {
 
       // Handle dangling nodes: distribute their rank evenly
       double danglingSum = 0.0;
-      for (int i = 0; i < danglingNodes.length; i++)
+      for (int i = 0; i < danglingNodes.length; i++) {
+        if ((i & 1023) == 1023)
+          checkpoint.check();
         danglingSum += currentRank[danglingNodes[i]];
+      }
       if (danglingSum > 0.0) {
         final double danglingContrib = damping * danglingSum / n;
         parallelForRangeCheckpointed(n, checkpoint, (s, e) -> {
@@ -1406,14 +1409,20 @@ public final class GraphAlgorithms {
 
     // Build offsets from degrees
     final int[] offsets = new int[n + 1];
-    for (int i = 0; i < n; i++)
+    for (int i = 0; i < n; i++) {
+      if ((i & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+        checkpoint.check();
       offsets[i + 1] = offsets[i] + degree[i];
+    }
 
     final int totalEdges = offsets[n];
     final int[] neighbors = new int[totalEdges];
     final int[] pos = new int[n];
-    for (int i = 0; i < n; i++)
+    for (int i = 0; i < n; i++) {
+      if ((i & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+        checkpoint.check();
       pos[i] = offsets[i];
+    }
 
     if (singleType) {
       // Single edge type: merge forward + backward (both already sorted) -> O(d) per node
@@ -1551,6 +1560,8 @@ public final class GraphAlgorithms {
     // With forward counting, each triangle is found once and credited to all 3 nodes
     final double[] lcc = new double[n];
     for (int u = 0; u < n; u++) {
+      if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+        checkpoint.check();
       final long deg = offsets[u + 1] - offsets[u];
       if (deg >= 2)
         lcc[u] = (2.0 * triangles.get(u)) / (double) (deg * (deg - 1));

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -72,11 +72,13 @@ public final class GraphAlgorithms {
   /** Upper bound on a single checkpointed batch's size, so abort latency stays bounded as the range grows past
    *  it instead of scaling with the range - see {@link #CHECKPOINT_BATCHES}. */
   private static final int MAX_CHECKPOINT_BATCH_SIZE = CHECKPOINT_BATCHES * PARALLEL_THRESHOLD;
-  /** Bitmask for how often {@link #lccBuildAndIntersect}'s sequential prep passes check in between nodes -
-   *  {@code (u & MASK) == MASK} is true every 1024th node, not every {@code MASK}th one. Matches the 1024-node
-   *  stride {@code WorkGuard.checkPeriodically} and {@code GraphData.adjacency} both use elsewhere in the
-   *  codebase. */
-  private static final int LCC_PREP_CHECKPOINT_MASK = 1023;
+  /** Bitmask for how often a sequential pass with no other natural checkpoint of its own - {@link #pageRank}'s
+   *  dangling-sum loop and {@link #lccBuildAndIntersect}'s sequential prep/materialization passes - checks in
+   *  between elements: {@code (i & MASK) == MASK} is true every 1024th element, not every {@code MASK}th one.
+   *  Matches the 1024-node stride {@code WorkGuard.checkPeriodically} and {@code GraphData.adjacency} both use
+   *  elsewhere in the codebase. Shared across every such loop in this class rather than given a narrower,
+   *  per-caller name, so the checkpoint cadence has exactly one source of truth to tune. */
+  private static final int PERIODIC_CHECKPOINT_MASK = 1023;
   /** Entry-count threshold at which {@link #lccBuildAndIntersect}'s per-node prep passes checkpoint mid-row,
    *  inside a single node's own edge walk rather than only between nodes - otherwise one supernode row is an
    *  unabortable unit regardless of its own size, the same class of gap issue #6715 names for
@@ -340,7 +342,7 @@ public final class GraphAlgorithms {
       // Handle dangling nodes: distribute their rank evenly
       double danglingSum = 0.0;
       for (int i = 0; i < danglingNodes.length; i++) {
-        if ((i & 1023) == 1023)
+        if ((i & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
           checkpoint.check();
         danglingSum += currentRank[danglingNodes[i]];
       }
@@ -1401,7 +1403,7 @@ public final class GraphAlgorithms {
       if (csr == null)
         continue;
       for (int u = 0; u < n; u++) {
-        if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+        if ((u & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
           checkpoint.check();
         degree[u] += csr.outDegree(u) + csr.inDegree(u);
       }
@@ -1410,7 +1412,7 @@ public final class GraphAlgorithms {
     // Build offsets from degrees
     final int[] offsets = new int[n + 1];
     for (int i = 0; i < n; i++) {
-      if ((i & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+      if ((i & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
         checkpoint.check();
       offsets[i + 1] = offsets[i] + degree[i];
     }
@@ -1419,7 +1421,7 @@ public final class GraphAlgorithms {
     final int[] neighbors = new int[totalEdges];
     final int[] pos = new int[n];
     for (int i = 0; i < n; i++) {
-      if ((i & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+      if ((i & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
         checkpoint.check();
       pos[i] = offsets[i];
     }
@@ -1432,7 +1434,7 @@ public final class GraphAlgorithms {
       final int[] bwdOffsets = csr.getBackwardOffsets();
       final int[] bwdNeighbors = csr.getBackwardNeighbors();
       for (int u = 0; u < n; u++) {
-        if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+        if ((u & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
           checkpoint.check();
         int ia = fwdOffsets[u], aEnd = fwdOffsets[u + 1];
         int ib = bwdOffsets[u], bEnd = bwdOffsets[u + 1];
@@ -1462,7 +1464,7 @@ public final class GraphAlgorithms {
         final int[] fwdOffsets = csr.getForwardOffsets();
         final int[] fwdNeighbors = csr.getForwardNeighbors();
         for (int u = 0; u < n; u++) {
-          if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+          if ((u & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
             checkpoint.check();
           for (int j = fwdOffsets[u]; j < fwdOffsets[u + 1]; j++) {
             if (((j - fwdOffsets[u]) & (LCC_ROW_CHECKPOINT_ENTRIES - 1)) == 0)
@@ -1473,7 +1475,7 @@ public final class GraphAlgorithms {
         final int[] bwdOffsets = csr.getBackwardOffsets();
         final int[] bwdNeighbors = csr.getBackwardNeighbors();
         for (int u = 0; u < n; u++) {
-          if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+          if ((u & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
             checkpoint.check();
           for (int j = bwdOffsets[u]; j < bwdOffsets[u + 1]; j++) {
             if (((j - bwdOffsets[u]) & (LCC_ROW_CHECKPOINT_ENTRIES - 1)) == 0)
@@ -1498,7 +1500,7 @@ public final class GraphAlgorithms {
     // checkpointed the same periodic way as the prep passes above.
     int write = 0;
     for (int u = 0; u < n; u++) {
-      if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+      if ((u & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
         checkpoint.check();
       final int readStart = offsets[u];
       final int readEnd = offsets[u + 1];
@@ -1560,7 +1562,7 @@ public final class GraphAlgorithms {
     // With forward counting, each triangle is found once and credited to all 3 nodes
     final double[] lcc = new double[n];
     for (int u = 0; u < n; u++) {
-      if ((u & LCC_PREP_CHECKPOINT_MASK) == LCC_PREP_CHECKPOINT_MASK)
+      if ((u & PERIODIC_CHECKPOINT_MASK) == PERIODIC_CHECKPOINT_MASK)
         checkpoint.check();
       final long deg = offsets[u + 1] - offsets[u];
       if (deg >= 2)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -517,6 +517,28 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
   }
 
   /**
+   * Narrows a {@code long} entry count to {@code int}, refusing rather than wrapping when it does not fit.
+   * <p>
+   * {@code GraphData.weightedAdjacency()}'s {@code totalEntries} is summed in {@code long} precisely so a graph
+   * whose edge count exceeds {@link Integer#MAX_VALUE} is caught here, at the one point a caller narrows it to
+   * size its own flat {@code int[]}/{@code double[]} edge arrays (issue #6721 review) - rather than silently
+   * wrapping to a small or negative value that then either passes a downstream {@code memory.reserve()} check it
+   * should have failed, or surfaces many calls later as a confusing {@code NegativeArraySizeException}, the same
+   * shape issue #6289's siblings ({@link AlgoNode2Vec}, {@link AlgoRandomWalk}, {@link AlgoSteinerTree}) already
+   * guard the same way for their own knob-derived counts.
+   *
+   * @param procedureName the calling procedure's {@link #getName()}, for the exception message
+   * @param nodeCount     the graph's node count, for the exception message
+   * @param totalEntries  the entry count to narrow
+   */
+  protected static int checkedEdgeCount(final String procedureName, final int nodeCount, final long totalEntries) {
+    if (totalEntries > Integer.MAX_VALUE)
+      throw new IllegalArgumentException(procedureName + "(): " + nodeCount + " nodes make " + totalEntries
+          + " edge entries, more than the " + Integer.MAX_VALUE + " a Java array can hold");
+    return (int) totalEntries;
+  }
+
+  /**
    * Creates a {@link WorkGuard} sharing this command's {@link GlobalConfiguration#COMMAND_TIMEOUT} deadline.
    * <p>
    * The knobs that drive the CPU-bound loops of the algorithm procedures ({@code iterations}, {@code restarts},

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -884,10 +884,14 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * the pairing wrong. That is the whole point of returning the two together rather than offering weights
      * "aligned with" an adjacency the caller obtained separately - issue #6301 is what the second shape costs.
      *
-     * @param neighbors dense neighbour ids per node
-     * @param weights   weight of the edge to the neighbour at the same index
+     * @param neighbors    dense neighbour ids per node
+     * @param weights      weight of the edge to the neighbour at the same index
+     * @param totalEntries the edge count summed across every node's row - computed once here, while the rows are
+     *                     already being walked to build or price them, so a caller that needs it (issue #6721:
+     *                     {@code algo.mst}/{@code algo.msa} size their own flat edge arrays from it) reads it
+     *                     instead of re-summing {@code neighbors[i].length} over the whole graph a second time
      */
-    public record WeightedAdjacency(int[][] neighbors, double[][] weights) {
+    public record WeightedAdjacency(int[][] neighbors, double[][] weights, long totalEntries) {
     }
 
     /**
@@ -929,7 +933,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
           weights[i] = new double[neighbors[i].length];
           Arrays.fill(weights[i], 1.0);
         }
-        return new WeightedAdjacency(neighbors, weights);
+        return new WeightedAdjacency(neighbors, weights, totalEntries);
       }
 
       // getEdgeProperty() addresses an edge by (type, direction, position), so "all types" has to be resolved
@@ -1001,12 +1005,14 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       final double[][] weights = new double[nodeCount][];
       final long maxEntryCheckpoint = ADJACENCY_CHECKPOINT_ENTRIES / 3;
       long entries = 0;
+      long totalEntries = 0;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
         final NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, guard::checkPeriodically, types);
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
         entries += edges.neighbors().length;
+        totalEntries += edges.neighbors().length;
         final long entryCheckpoint = Math.min(maxEntryCheckpoint, memory.capacityFor(INT_BYTES + DOUBLE_BYTES));
         if (entries >= entryCheckpoint || (i & 1023) == 1023) {
           reserveWeightedAdjacency(0, entries);
@@ -1014,7 +1020,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         }
       }
       reserveWeightedAdjacency(0, entries);
-      return new WeightedAdjacency(neighbors, weights);
+      return new WeightedAdjacency(neighbors, weights, totalEntries);
     }
 
     /**
@@ -1033,6 +1039,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       double[] scratchWeights = new double[16];
       int edgeStep = 0;
       long entries = 0;
+      long totalEntries = 0;
 
       for (int i = 0; i < nodeCount; i++) {
         final Vertex vertex = getVertex(i);
@@ -1073,13 +1080,14 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         neighbors[i] = Arrays.copyOf(scratchNeighbors, degree);
         weights[i] = Arrays.copyOf(scratchWeights, degree);
         entries += degree;
+        totalEntries += degree;
         if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
           reserveWeightedAdjacency(0, entries);
           entries = 0;
         }
       }
       reserveWeightedAdjacency(0, entries);
-      return new WeightedAdjacency(neighbors, weights);
+      return new WeightedAdjacency(neighbors, weights, totalEntries);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
@@ -25,13 +25,9 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.WorkGuard;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.LinkedList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -108,55 +104,80 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
     //
     // A forward BFS and a backward accumulation per source node, so O(V x E) sized by nothing but the graph
     // (issue #6302). The inner checkpoints keep the abort latency below one whole source's pass.
+    //
+    // Every per-source working structure below is allocated once, outside the loop, and reused across all n
+    // sources - issue #6718: the previous version allocated n fresh ArrayList<Integer> instances (predecessors)
+    // per source, n times over, an O(n^2) allocation-and-boxing cost cutting against the project's "prefer arrays
+    // of primitives" guidance. stack/queue/dist/sigma/delta/predCount are reset only over the nodes a source's
+    // BFS actually touches - the same "reset only what you touched" pattern issue #6265 used for
+    // AlgoInfluenceMaximization's activated/queue buffers - rather than a full O(n) clear per source, which would
+    // have only traded the ArrayList allocations for an equally O(n^2) fill.
+    final int[]    stack         = new int[n];
+    final int[]    queue         = new int[n];
+    final int[][]  predNeighbors = new int[n][];
+    final int[]    predCount     = new int[n];
+    final double[] sigma         = new double[n];
+    final int[]    dist          = new int[n];
+    final double[] delta         = new double[n];
+    Arrays.fill(dist, -1);
+
     for (int s = 0; s < n; s++) {
       guard.check();
 
-      final Deque<Integer> stack = new ArrayDeque<>();
-      final List<List<Integer>> predecessors = new ArrayList<>(n);
-      for (int i = 0; i < n; i++)
-        predecessors.add(new ArrayList<>());
+      int stackSize = 0;
+      int qHead = 0, qTail = 0;
 
-      final double[] sigma = new double[n];
-      final int[] dist = new int[n];
       sigma[s] = 1.0;
-      for (int i = 0; i < n; i++)
-        dist[i] = -1;
       dist[s] = 0;
-
-      final Queue<Integer> queue = new LinkedList<>();
-      queue.add(s);
+      queue[qTail++] = s;
 
       int visited = 0;
-      while (!queue.isEmpty()) {
+      while (qHead < qTail) {
         guard.checkPeriodically(visited++);
-        final int v = queue.poll();
-        stack.push(v);
+        final int v = queue[qHead++];
+        stack[stackSize++] = v;
 
         for (final int w : adj[v]) {
           // First time visiting w?
           if (dist[w] < 0) {
-            queue.add(w);
+            queue[qTail++] = w;
             dist[w] = dist[v] + 1;
           }
           // Shortest path to w via v?
           if (dist[w] == dist[v] + 1) {
             sigma[w] += sigma[v];
-            predecessors.get(w).add(v);
+            if (predNeighbors[w] == null)
+              predNeighbors[w] = new int[4];
+            else if (predCount[w] == predNeighbors[w].length)
+              predNeighbors[w] = Arrays.copyOf(predNeighbors[w], predNeighbors[w].length * 2);
+            predNeighbors[w][predCount[w]++] = v;
           }
         }
       }
 
-      // Back-propagation
-      final double[] delta = new double[n];
+      // Back-propagation, in the same reverse-BFS-order that draining a LIFO stack would give - here just a
+      // descending walk of the array the forward BFS above already filled in that order.
       int accumulated = 0;
-      while (!stack.isEmpty()) {
+      for (int idx = stackSize - 1; idx >= 0; idx--) {
         guard.checkPeriodically(accumulated++);
-        final int w = stack.pop();
-        for (final int v : predecessors.get(w)) {
+        final int w = stack[idx];
+        final int[] preds = predNeighbors[w];
+        final int predN = predCount[w];
+        for (int k = 0; k < predN; k++) {
+          final int v = preds[k];
           delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w]);
         }
         if (w != s)
           betweenness[w] += delta[w];
+      }
+
+      // Reset only the nodes this source's BFS touched, not the full n-sized buffers.
+      for (int idx = 0; idx < stackSize; idx++) {
+        final int node = stack[idx];
+        dist[node] = -1;
+        sigma[node] = 0.0;
+        delta[node] = 0.0;
+        predCount[node] = 0;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -116,8 +116,10 @@ public class AlgoMST extends AbstractAlgoProcedure {
     final double[][] weights = weighted.weights();
 
     // weightedAdjacency() already summed this once while building/pricing the rows (issue #6721) - reused here
-    // rather than walking neighbors[] a second time for the same total.
-    final int edgeCount = (int) weighted.totalEntries();
+    // rather than walking neighbors[] a second time for the same total. Narrowed through checkedEdgeCount rather
+    // than a plain cast, so a total that does not fit an int is refused here instead of silently wrapping into
+    // memory.reserve() below with a wrong, non-negative-looking value that defeats the guard instead of tripping it.
+    final int edgeCount = checkedEdgeCount(getName(), n, weighted.totalEntries());
 
     // The working set here is sized by the EDGE count, which is the one dense shape #6263 did not price: its
     // criterion was "knob-sized or quadratic in the node count", and edge-linear reads like the graph paying for

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -115,9 +115,9 @@ public class AlgoMST extends AbstractAlgoProcedure {
     final int[][] neighbors = weighted.neighbors();
     final double[][] weights = weighted.weights();
 
-    int edgeCount = 0;
-    for (int i = 0; i < n; i++)
-      edgeCount += neighbors[i].length;
+    // weightedAdjacency() already summed this once while building/pricing the rows (issue #6721) - reused here
+    // rather than walking neighbors[] a second time for the same total.
+    final int edgeCount = (int) weighted.totalEntries();
 
     // The working set here is sized by the EDGE count, which is the one dense shape #6263 did not price: its
     // criterion was "knob-sized or quadratic in the node count", and edge-linear reads like the graph paying for

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -121,8 +121,10 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     final double[][] weights = weighted.weights();
 
     // weightedAdjacency() already summed this once while building/pricing the rows (issue #6721) - reused here
-    // rather than walking neighbors[] a second time for the same total.
-    final int edgeCount = (int) weighted.totalEntries();
+    // rather than walking neighbors[] a second time for the same total. Narrowed through checkedEdgeCount rather
+    // than a plain cast, so a total that does not fit an int is refused here instead of silently wrapping into
+    // memory.reserve() below with a wrong, non-negative-looking value that defeats the guard instead of tripping it.
+    final int edgeCount = checkedEdgeCount(getName(), n, weighted.totalEntries());
 
     // This procedure's own flat copy of the edges, priced separately from what weightedAdjacency already
     // reserved for its int[][]/double[][] pair - the same "additional to and smaller than" accounting algo.mst

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -120,9 +120,9 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     final int[][] neighbors = weighted.neighbors();
     final double[][] weights = weighted.weights();
 
-    int edgeCount = 0;
-    for (int i = 0; i < n; i++)
-      edgeCount += neighbors[i].length;
+    // weightedAdjacency() already summed this once while building/pricing the rows (issue #6721) - reused here
+    // rather than walking neighbors[] a second time for the same total.
+    final int edgeCount = (int) weighted.totalEntries();
 
     // This procedure's own flat copy of the edges, priced separately from what weightedAdjacency already
     // reserved for its int[][]/double[][] pair - the same "additional to and smaller than" accounting algo.mst

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6719CheckpointGapsTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6719CheckpointGapsTest.java
@@ -73,7 +73,7 @@ class Issue6719CheckpointGapsTest extends TestHelper {
       final AtomicInteger calls = new AtomicInteger();
       final WorkCheckpoint abortOn5thCall = () -> {
         if (calls.incrementAndGet() == 5)
-          throw new RuntimeException("checkpoint reached — dangling-sum loop is checkpointed");
+          throw new RuntimeException("checkpoint reached - dangling-sum loop is checkpointed");
       };
 
       assertThatThrownBy(() -> GraphAlgorithms.pageRank(gav, 0.85, 1, DIRECTION.OUT, abortOn5thCall, "LINK"))

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6719CheckpointGapsTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6719CheckpointGapsTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex.DIRECTION;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6719: three cheap O(n) sequential loops in {@link GraphAlgorithms} - {@code pageRank}'s dangling-node sum
+ * accumulation, {@code lccBuildAndIntersect}'s {@code offsets}/{@code pos} array-fill loops and its final
+ * {@code lcc[u]} coefficient-materialization loop - had no {@link WorkCheckpoint#check()} call at all, unlike every
+ * other sequential pass in this file. Each is cheap per element (a double add or an int assign), so on a huge graph
+ * it is not a correctness bug, just a small abortability gap: a caller that armed the checkpoint to stop a runaway
+ * call could still be made to wait out one of these loops in full.
+ * <p>
+ * Both tests below rely on precise checkpoint-call accounting rather than timing: a graph shape and node count are
+ * chosen so the checkpoint calls contributed by phases that already had a checkpoint before this fix are known
+ * exactly, and the assertion is set just past that known baseline - so it can only be satisfied if the previously
+ * unchecked loop calls the checkpoint too.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6719CheckpointGapsTest extends TestHelper {
+
+  /**
+   * {@code pageRank}'s dangling-sum loop, isolated with an all-dangling graph (no edges at all, so every node's
+   * out-degree is zero) run for a single iteration. Without the loop's own checkpoint, one iteration makes exactly
+   * 4 checkpoint calls (top-of-iteration, the contrib phase, the pull phase, the dangling-distribute phase - each
+   * of the two {@code parallelForRangeCheckpointed} phases collapses to a single batch since {@code n} is below
+   * {@code PARALLEL_THRESHOLD}), and {@code iterations == 1} means the loop never comes back around for a 5th. A
+   * checkpoint that throws on its 5th call therefore only fires if the dangling-sum loop calls it too - which,
+   * with 5000 dangling nodes and a periodic check every 1024 of them, it does well before the 4-call baseline
+   * would otherwise finish the iteration.
+   */
+  @Test
+  void danglingSumLoopIsCheckpointed() {
+    final int n = 5000;
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.begin();
+    for (int i = 0; i < n; i++)
+      database.newVertex("Node").save();
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Node").withEdgeTypes("LINK").build();
+    try {
+      final AtomicInteger calls = new AtomicInteger();
+      final WorkCheckpoint abortOn5thCall = () -> {
+        if (calls.incrementAndGet() == 5)
+          throw new RuntimeException("checkpoint reached — dangling-sum loop is checkpointed");
+      };
+
+      assertThatThrownBy(() -> GraphAlgorithms.pageRank(gav, 0.85, 1, DIRECTION.OUT, abortOn5thCall, "LINK"))
+          .as("the dangling-sum loop must call the checkpoint before an all-dangling, single-iteration pageRank "
+              + "run would otherwise finish (only 4 checkpoint calls without it)")
+          .hasMessageContaining("dangling-sum loop is checkpointed");
+    } finally {
+      gav.drop();
+    }
+  }
+
+  /**
+   * The three previously-unchecked {@code lccBuildAndIntersect} loops (offsets build, pos build, final {@code
+   * lcc[]} materialization), isolated together against the loops that already had a checkpoint before this fix.
+   * <p>
+   * One edge on an otherwise edgeless 5000-node graph keeps the CSR non-null (avoiding a null CSR on the
+   * single-edge-type path) while leaving every degree at 0 or 1 - checkpoint call counts depend only on the node
+   * count crossing the 1024-node periodic-check boundary, not on degree, so the single edge does not change the
+   * count. For n = 5000 that boundary is crossed 4 times (at node indices 1023, 2047, 3071, 4095) in each of:
+   * degree computation, the single-edge-type merge loop and the compact-in-place loop - all three checkpointed
+   * before this fix, 12 calls total - plus one more from the triangle-counting phase's single batch, 13 without
+   * the fix. The three newly-checkpointed loops each add 4 more, so a fixed run makes 25 calls; asserting at least
+   * 25 fails against the pre-fix 13 and passes only once all three loops are checkpointed.
+   */
+  @Test
+  void lccPrepAndFinalMaterializationLoopsAreCheckpointed() {
+    final int n = 5000;
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.begin();
+    MutableVertex first = null, second = null;
+    for (int i = 0; i < n; i++) {
+      final MutableVertex v = database.newVertex("Node").save();
+      if (i == 0)
+        first = v;
+      else if (i == 1)
+        second = v;
+    }
+    first.newEdge("LINK", second);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Node").withEdgeTypes("LINK").build();
+    try {
+      final AtomicInteger calls = new AtomicInteger();
+      final WorkCheckpoint counting = calls::incrementAndGet;
+
+      final double[] lcc = GraphAlgorithms.localClusteringCoefficient(gav, counting, "LINK");
+
+      assertThat(lcc).hasSize(n);
+      assertThat(calls.get())
+          .as("13 checkpoint calls come from the phases already checkpointed before issue #6719; the three "
+              + "newly-checkpointed loops must contribute at least 4 more each")
+          .isGreaterThanOrEqualTo(25);
+    } finally {
+      gav.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6718BetweennessPrimitiveArraysTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6718BetweennessPrimitiveArraysTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+/**
+ * Issue #6718: {@code AlgoBetweenness.execute()}'s Brandes algorithm allocated {@code n} fresh
+ * {@code ArrayList<Integer>} predecessor lists per source node, {@code n} times over - O(n^2) boxed-list
+ * allocations. The fix replaces {@code predecessors}, and the equally boxed {@code stack}/{@code queue}, with
+ * primitive {@code int[]} buffers allocated once and reused across every source, reset only over the nodes each
+ * source's BFS actually touches.
+ * <p>
+ * Reusing per-source buffers across sources is exactly the kind of change that can leak stale state from one
+ * source's round into the next if a reset is missed anywhere - a bug that would not show up on a small, fully
+ * connected graph where every source touches every node anyway. So {@link #matchesNaiveReferenceOnAnIrregularGraph}
+ * runs the algorithm on a graph deliberately shaped to touch very different, and sometimes disjoint, subsets of
+ * nodes from one source to the next (a cycle, a path and a star bridged into one component, plus a node no other
+ * source ever reaches) and compares every score against a naive reference Brandes implementation - the same
+ * fresh-allocation-per-source shape the old code used, so it cannot share the bug being tested for - computed
+ * independently in this test from the same edge list.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6718BetweennessPrimitiveArraysTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6718-betweenness-primitive-arrays");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  /**
+   * Two triangles sharing vertex C ("bowtie"): every cross-triangle pair (A-D, A-E, B-D, B-E) has a unique
+   * shortest path of length 2 through C, while every same-triangle pair is a direct edge. Hand-computable exactly:
+   * C sits on 4 unordered pairs' unique shortest path; running Brandes from every node as source over a
+   * bidirectionally-represented (undirected) graph counts each such pair twice (once per direction), so the raw,
+   * non-normalized score for C is 8 and 0 for every other node. Normalizing by {@code 2/((n-1)(n-2))} with n = 5
+   * gives {@code 8 * 2/(4*3) = 4/3}.
+   */
+  @Test
+  void bowtieGraphMatchesHandComputedScores() {
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      final MutableVertex d = database.newVertex("Node").set("name", "D").save();
+      final MutableVertex e = database.newVertex("Node").set("name", "E").save();
+      for (final MutableVertex[] edge : new MutableVertex[][] {
+          { a, b }, { b, c }, { c, a }, { c, d }, { d, e }, { e, c } }) {
+        edge[0].newEdge("LINK", edge[1]).save();
+        edge[1].newEdge("LINK", edge[0]).save();
+      }
+    });
+
+    final Map<String, Double> raw = scoresByName("CALL algo.betweenness({normalized: false}) YIELD node, score "
+        + "RETURN node.name AS name, score");
+    assertThat(raw.get("C")).isEqualTo(8.0);
+    for (final String leaf : List.of("A", "B", "D", "E"))
+      assertThat(raw.get(leaf)).isEqualTo(0.0);
+
+    final Map<String, Double> normalized = scoresByName("CALL algo.betweenness({normalized: true}) YIELD node, score "
+        + "RETURN node.name AS name, score");
+    assertThat(normalized.get("C")).isCloseTo(4.0 / 3.0, offset(1e-9));
+    for (final String leaf : List.of("A", "B", "D", "E"))
+      assertThat(normalized.get(leaf)).isCloseTo(0.0, offset(1e-9));
+  }
+
+  /**
+   * Cycle (0-5) bridged to a path (6-10) bridged to a star (center 11, leaves 12-16), plus node 17 which no edge
+   * ever touches. 18 sources in total, with wildly different reachable sets and BFS-tree shapes between them -
+   * exactly the condition under which a missed reset in the reused per-source buffers would surface as a wrong
+   * score, not a crash.
+   */
+  @Test
+  void matchesNaiveReferenceOnAnIrregularGraph() {
+    final int n = 18;
+    final List<int[]> edges = new ArrayList<>();
+    // Cycle: 0-1-2-3-4-5-0
+    for (int i = 0; i < 6; i++)
+      edges.add(new int[] { i, (i + 1) % 6 });
+    // Path: 6-7-8-9-10
+    for (int i = 6; i < 10; i++)
+      edges.add(new int[] { i, i + 1 });
+    // Star: center 11, leaves 12-16
+    for (int leaf = 12; leaf <= 16; leaf++)
+      edges.add(new int[] { 11, leaf });
+    // Bridges: cycle -> path, path -> star. Node 17 stays isolated.
+    edges.add(new int[] { 3, 6 });
+    edges.add(new int[] { 10, 11 });
+
+    final MutableVertex[] vertices = new MutableVertex[n];
+    database.transaction(() -> {
+      for (int i = 0; i < n; i++)
+        vertices[i] = database.newVertex("Node").set("name", "N" + i).save();
+      for (final int[] edge : edges) {
+        vertices[edge[0]].newEdge("LINK", vertices[edge[1]]).save();
+        vertices[edge[1]].newEdge("LINK", vertices[edge[0]]).save();
+      }
+    });
+
+    final int[][] adj = buildUndirectedAdjacency(n, edges);
+    final double[] expected = naiveBrandes(n, adj);
+
+    final Map<String, Double> actual = scoresByName("CALL algo.betweenness({normalized: false}) YIELD node, score "
+        + "RETURN node.name AS name, score");
+    assertThat(actual).hasSize(n);
+    for (int i = 0; i < n; i++)
+      assertThat(actual.get("N" + i)).as("score for N" + i).isCloseTo(expected[i], offset(1e-9));
+  }
+
+  private Map<String, Double> scoresByName(final String query) {
+    final Map<String, Double> result = new HashMap<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        result.put(row.<String>getProperty("name"), row.<Number>getProperty("score").doubleValue());
+      }
+    }
+    return result;
+  }
+
+  private static int[][] buildUndirectedAdjacency(final int n, final List<int[]> edges) {
+    final int[] degree = new int[n];
+    for (final int[] edge : edges) {
+      degree[edge[0]]++;
+      degree[edge[1]]++;
+    }
+    final int[][] adj = new int[n][];
+    for (int i = 0; i < n; i++)
+      adj[i] = new int[degree[i]];
+    final int[] cursor = new int[n];
+    for (final int[] edge : edges) {
+      adj[edge[0]][cursor[edge[0]]++] = edge[1];
+      adj[edge[1]][cursor[edge[1]]++] = edge[0];
+    }
+    return adj;
+  }
+
+  /**
+   * Textbook Brandes, unoptimized on purpose: fresh {@code ArrayList}/{@code ArrayDeque}/{@code LinkedList} per
+   * source, exactly the shape issue #6718 replaced in the production code - so this reference cannot share a
+   * buffer-reuse bug with the code it is checking.
+   */
+  private static double[] naiveBrandes(final int n, final int[][] adj) {
+    final double[] betweenness = new double[n];
+    for (int s = 0; s < n; s++) {
+      final Deque<Integer> stack = new ArrayDeque<>();
+      final List<List<Integer>> predecessors = new ArrayList<>(n);
+      for (int i = 0; i < n; i++)
+        predecessors.add(new ArrayList<>());
+      final double[] sigma = new double[n];
+      final int[] dist = new int[n];
+      sigma[s] = 1.0;
+      for (int i = 0; i < n; i++)
+        dist[i] = -1;
+      dist[s] = 0;
+
+      final Queue<Integer> queue = new LinkedList<>();
+      queue.add(s);
+      while (!queue.isEmpty()) {
+        final int v = queue.poll();
+        stack.push(v);
+        for (final int w : adj[v]) {
+          if (dist[w] < 0) {
+            queue.add(w);
+            dist[w] = dist[v] + 1;
+          }
+          if (dist[w] == dist[v] + 1) {
+            sigma[w] += sigma[v];
+            predecessors.get(w).add(v);
+          }
+        }
+      }
+
+      final double[] delta = new double[n];
+      while (!stack.isEmpty()) {
+        final int w = stack.pop();
+        for (final int v : predecessors.get(w))
+          delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w]);
+        if (w != s)
+          betweenness[w] += delta[w];
+      }
+    }
+    return betweenness;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6721WeightedAdjacencyTotalEntriesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6721WeightedAdjacencyTotalEntriesTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.opencypher.procedures.algo.AbstractAlgoProcedure.GraphData;
+import com.arcadedb.query.opencypher.procedures.algo.AbstractAlgoProcedure.GraphData.WeightedAdjacency;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.WorkGuard;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6721: {@code GraphData.weightedAdjacency()}'s unit-weight branch summed {@code neighbors[i].length} across
+ * every node to size its own memory reservation, even though {@code adjacency()}/{@code reserveAdjacency} had
+ * already computed (and discarded) that same total while building the array. {@code AlgoMST}/{@code
+ * AlgoMinSpanningArborescence} then each summed it again after {@code weightedAdjacency()} returned, to size their
+ * own flat edge arrays - the same node-count-sized total recomputed two or three times per call.
+ * <p>
+ * The fix threads a {@code totalEntries} field through {@link WeightedAdjacency} itself, computed once - in the
+ * same walk that already builds or prices the rows, on whichever of the three internal paths runs (unit-weight,
+ * CSR-backed columnar edge properties, or OLTP edge records) - so callers read it instead of re-summing. These
+ * tests pin that value against an independently-counted expected total on each of the three paths, and
+ * {@code AlgoMST}/{@code AlgoMinSpanningArborescence}'s own tests (unchanged by this fix) continue to cover that
+ * the edge arrays sized from it are the right size.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6721WeightedAdjacencyTotalEntriesTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6721-weightedadjacency-totalentries");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    database.getSchema().createEdgeType("E").createProperty("w", Type.DOUBLE);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  private BasicCommandContext newContext() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    return context;
+  }
+
+  /**
+   * Asymmetric out-degrees (3 + 1 + 0 + 1 = 5 total OUT edges), so a totalEntries that accidentally summed IN
+   * degree, or double-counted a row, would not go unnoticed.
+   */
+  private void buildGraph() {
+    database.transaction(() -> {
+      final Vertex a = database.newVertex("N").set("name", "A").save();
+      final Vertex b = database.newVertex("N").set("name", "B").save();
+      final Vertex c = database.newVertex("N").set("name", "C").save();
+      final Vertex d = database.newVertex("N").set("name", "D").save();
+      a.newEdge("E", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("E", c, true, new Object[] { "w", 2.0 }).save();
+      a.newEdge("E", d, true, new Object[] { "w", 3.0 }).save();
+      b.newEdge("E", c, true, new Object[] { "w", 4.0 }).save();
+      c.newEdge("E", d, true, new Object[] { "w", 5.0 }).save();
+    });
+  }
+
+  @Test
+  void unitWeightBranchReportsTheCorrectTotal() {
+    buildGraph();
+    final CommandContext context = newContext();
+    final AlgoMST algo = new AlgoMST();
+    final GraphData graph = algo.loadGraph(database, null, null, context);
+    final WorkGuard guard = algo.newWorkGuard(context);
+
+    final WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, null);
+
+    assertThat(weighted.totalEntries()).isEqualTo(sumOfRowLengths(weighted));
+    assertThat(weighted.totalEntries()).isEqualTo(5L);
+  }
+
+  @Test
+  void recordBackedBranchReportsTheCorrectTotal() {
+    buildGraph();
+    final CommandContext context = newContext();
+    final AlgoMST algo = new AlgoMST();
+    final GraphData graph = algo.loadGraph(database, null, null, context);
+    final WorkGuard guard = algo.newWorkGuard(context);
+
+    // No Graph Analytical View registered, so this falls onto the edge-record path (servesEdgeProperty has
+    // nothing to consult) rather than the columnar one.
+    final WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, "w");
+
+    assertThat(weighted.totalEntries()).isEqualTo(sumOfRowLengths(weighted));
+    assertThat(weighted.totalEntries()).isEqualTo(5L);
+  }
+
+  @Test
+  void columnarCsrBackedBranchReportsTheCorrectTotal() {
+    buildGraph();
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("issue-6721-view")
+        .withVertexTypes("N")
+        .withEdgeTypes("E")
+        .withEdgeProperties("w")
+        .build();
+    try {
+      final CommandContext context = newContext();
+      final AlgoMST algo = new AlgoMST();
+      final GraphData graph = algo.loadGraph(database, null, null, context);
+      final WorkGuard guard = algo.newWorkGuard(context);
+
+      assertThat(graph.isCSRBacked()).as("the view must actually back this call, or the columnar path is untested").isTrue();
+
+      final WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, "w");
+
+      assertThat(weighted.totalEntries()).isEqualTo(sumOfRowLengths(weighted));
+      assertThat(weighted.totalEntries()).isEqualTo(5L);
+    } finally {
+      view.drop();
+    }
+  }
+
+  private static long sumOfRowLengths(final WeightedAdjacency weighted) {
+    long sum = 0;
+    for (final int[] row : weighted.neighbors())
+      sum += row.length;
+    return sum;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6721WeightedAdjacencyTotalEntriesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6721WeightedAdjacencyTotalEntriesTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #6721: {@code GraphData.weightedAdjacency()}'s unit-weight branch summed {@code neighbors[i].length} across
@@ -158,5 +159,31 @@ class Issue6721WeightedAdjacencyTotalEntriesTest {
     for (final int[] row : weighted.neighbors())
       sum += row.length;
     return sum;
+  }
+
+  /**
+   * Code-review follow-up on this same PR: {@code AlgoMST}/{@code AlgoMinSpanningArborescence} narrowed
+   * {@code totalEntries()} to {@code int} with a plain cast and no bounds check - harmless in practice (the
+   * pre-existing code had the identical ceiling, and the working-memory budget refuses long before a real graph
+   * could reach anywhere near {@link Integer#MAX_VALUE} edges), but a silent wraparound is still the wrong failure
+   * mode for a total that does not fit. Both procedures now narrow through the shared
+   * {@link AbstractAlgoProcedure#checkedEdgeCount}, tested directly here since driving a real graph to
+   * 2+ billion edges is not practical in a unit test.
+   */
+  @Test
+  void checkedEdgeCountNarrowsAFittingTotal() {
+    assertThat(AbstractAlgoProcedure.checkedEdgeCount("algo.mst", 4, 5L)).isEqualTo(5);
+    assertThat(AbstractAlgoProcedure.checkedEdgeCount("algo.mst", 4, 0L)).isEqualTo(0);
+    assertThat(AbstractAlgoProcedure.checkedEdgeCount("algo.mst", 4, (long) Integer.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  void checkedEdgeCountRefusesATotalThatDoesNotFitAnInt() {
+    final long tooBig = (long) Integer.MAX_VALUE + 1;
+    assertThatThrownBy(() -> AbstractAlgoProcedure.checkedEdgeCount("algo.mst", 4, tooBig))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("algo.mst")
+        .hasMessageContaining(String.valueOf(tooBig))
+        .hasMessageContaining(String.valueOf(Integer.MAX_VALUE));
   }
 }


### PR DESCRIPTION
## Summary

Three small follow-ups raised during PR #6714's review, deliberately not folded into that PR and tracked as separate issues.

- Fixes #6719: `pageRank`'s dangling-sum loop and three `lccBuildAndIntersect` loops (offsets/pos build, final `lcc[]` materialization) had no checkpoint call at all, unlike every other sequential pass in `GraphAlgorithms`. Added the same periodic checkpoint the rest of the file already uses.
- Fixes #6721: `GraphData.weightedAdjacency()`'s unit-weight branch, and each of `algo.mst`/`algo.msa`, re-summed `neighbors[i].length` across the whole graph to get an edge count already computed once while building/pricing the rows. `WeightedAdjacency` now carries that total as a field, computed once on whichever of the three internal paths (unit-weight, CSR columns, edge records) runs, so callers read it instead of re-summing.
- Fixes #6718: `algo.betweenness`'s Brandes algorithm allocated `n` fresh `ArrayList<Integer>` predecessor lists per source node, `n` times over - O(n²) boxed-list allocations, cutting against the project's "prefer arrays of primitives" guidance. Replaced `predecessors`, and the equally boxed `stack`/`queue`, with primitive `int[]` buffers allocated once and reused across every source, reset only over the nodes each source's BFS actually touches (the same pattern issue #6265 used for `AlgoInfluenceMaximization`).

#6716 (`algo.degree`'s `direction` parameter being ignored) was already fixed and merged in #6717 - closed without further changes in this PR.

## Test plan

- [x] New regression test `Issue6719CheckpointGapsTest` - verifies the checkpoint call count for `pageRank`'s dangling-sum loop and the three `lccBuildAndIntersect` loops via precise checkpoint-call accounting; confirmed red (13 vs required 25 calls) against the pre-fix code, green after.
- [x] New regression test `Issue6721WeightedAdjacencyTotalEntriesTest` - verifies `WeightedAdjacency.totalEntries()` against an independently-computed sum on all three internal build paths (unit-weight, CSR columns, edge records).
- [x] New regression test `Issue6718BetweennessPrimitiveArraysTest` - a hand-computed "bowtie" graph (two triangles sharing a vertex) with known betweenness scores, plus an independent-oracle comparison (unoptimized, boxed-list reference Brandes implementation) run on an irregular graph (cycle + path + star bridged together, plus an isolated node) deliberately shaped to stress the reused per-source buffers across very different BFS-touched subsets; confirmed this test catches a deliberately-injected missed-reset bug.
- [x] `mvn -o -pl engine -am test` on `com.arcadedb.query.opencypher.procedures.algo.**` and `com.arcadedb.graph.olap.**` (784 tests) - all green.
- [x] `mvn -o -pl engine -am test` on `com.arcadedb.query.opencypher.**` excluding benchmark/slow/vector lanes (9004 tests) - all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved betweenness centrality processing to reduce memory usage and repeated initialization.
  * Streamlined minimum spanning tree and arborescence calculations for efficient edge-count handling.

* **Reliability**
  * Added cancellation checkpoints to long-running PageRank and local clustering coefficient operations.
  * Added safeguards to prevent incorrect processing when weighted graph edge totals are too large.

* **Tests**
  * Added coverage for cancellation behavior, betweenness centrality accuracy, and weighted graph edge counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->