### PR TITLE
fix(#6559): grouped-search shortfall signal, PQ delta scoring scale, per-query INFO log

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -205,7 +205,10 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
    * out of candidate budget (#5761), and the {@link GroupAdmissionState} below re-applies the same cap once
    * across every index so the caller never sees a {@code (limit + 1)}-th group. Still best-effort: an index
    * whose nearest group is denser than its candidate budget returns fewer groups and counts the query in
-   * {@code groupedSearchesShortOfLimit}, which is the signal to raise the index's {@code efSearch}.
+   * {@code groupedSearchesShortOfLimit}, which is the signal to raise the index's {@code efSearch}. A short answer
+   * for the other reason - the corpus or the allow-list simply has fewer than {@code limit} distinct groups to give,
+   * which no beam width can change - counts in {@code groupedSearchesGroupsUnavailable} instead (issue #6559), so
+   * the {@code efSearch} signal stays actionable rather than firing on every query over low-cardinality data.
    * <p>
    * Adding {@code groupBy} to a query changes how its rows are capped and nothing else about what the index can see:
    * both branches below are answered from the graph <em>and</em> the delta buffer of vectors written since it was

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -75,12 +75,14 @@ import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
+import io.github.jbellis.jvector.quantization.ImmutablePQVectors;
 import io.github.jbellis.jvector.quantization.MutablePQVectors;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
@@ -4572,6 +4574,131 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * The {@link #findNeighborsFromVectorApproximate} counterpart of {@link #mergeWithDeltaScan}: same merge, but the
+   * rows it contributes are scored on the <em>same PQ scale</em> as the graph rows they are ranked against (issue
+   * #6559 item 2).
+   * <p>
+   * <b>The defect.</b> The PQ path scores every graph candidate from the in-memory PQ codes - approximately, by
+   * design, that being the whole point of a search that never touches a page. {@code mergeWithDeltaScan} scores the
+   * delta buffer <em>exactly</em>. Merging the two and sorting them against each other ranked two different
+   * measurements in one list: a delta row and a graph row at the same true distance did not get the same number, and
+   * which of them won was decided by the graph row's quantization error rather than by the data - systematically,
+   * since PQ error has structure, not as random noise that averages out. A caller thresholding on distance
+   * ({@code maxDistance}, or its own cut-off) was applying one bar to two scales.
+   * <p>
+   * <b>The fix, and why it is shaped this way.</b> Both sides must carry the same error, and only the delta side can
+   * be moved: making the graph side exact means reading the real vectors, which is precisely the disk I/O this path
+   * exists to avoid. So a delta row is quantized with the index's own codebooks and then scored through the
+   * <em>same</em> {@link PQVectors#precomputedScoreFunctionFor} decoder the graph rows were scored by, over a
+   * scratch store holding just those rows. Going through that decoder rather than reconstructing the vector and
+   * comparing it directly is deliberate: the two are the same quantity in exact arithmetic, but the decoder
+   * assembles it from a partial-sums table in a different order and - for {@code COSINE}, against the global
+   * centroid - so a hand-rolled equivalent lands a few parts in ten thousand away and puts the two sides back on
+   * measurably different scales, which is the whole defect.
+   * <p>
+   * <b>Why the exact scan still runs first.</b> Encoding costs a comparison against all {@code clusterCount}
+   * centroids of every subspace - order 256x one exact comparison - so quantizing the whole buffer would cost more
+   * than the search it feeds, on the one path whose contract is microseconds, and would scale with a buffer that
+   * runs to hundreds of thousands of entries under sustained ingestion. The cheap exact scan is therefore kept as a
+   * <em>pruner</em> - it already ran here before this fix, at the same cost - and only the at-most-{@code k}
+   * survivors are re-scored on the PQ scale. Cost is bounded by {@code k} regardless of buffer size, and is exactly
+   * zero when the buffer is empty, which is the steady state this path is built for.
+   * <p>
+   * <b>The residue.</b> Selecting the head exactly and then ranking it approximately can admit a row that the PQ
+   * scale would have placed just outside {@code k}, or drop one it would have placed just inside. That window is
+   * bounded by the PQ error already present in every graph candidate on this path, and it moves rows between
+   * adjacent ranks rather than between right and wrong - which is the trade an approximate search is, by contract.
+   * The alternative - quantizing every candidate to remove it - costs the buffer scan described above.
+   */
+  private void mergeWithDeltaScanApproximate(final VectorFloat<?> queryVectorFloat, final int k,
+      final Set<RID> allowedRIDs, final List<Pair<RID, Float>> results) {
+    // Pin the quantizer for the whole merge: a concurrent rebuild may swap the volatile field, and every row below
+    // has to be scored through the same codebooks the caller's graph beam is using.
+    final ProductQuantization pq = productQuantization;
+    if (pq == null) {
+      // No quantizer to score through - the caller checked isPQSearchAvailable(), but a rebuild can discard it
+      // between that check and here. Exact scoring is the honest fallback: it is what the graph side degrades to
+      // as well once PQ is gone, so the two stay on one scale either way.
+      mergeWithDeltaScan(queryVectorFloat, k, allowedRIDs, results);
+      return;
+    }
+
+    // The graph rows, captured BEFORE the merge: mergeWithDeltaScan rebuilds `results` from its own heap, so a
+    // position - or a prefix length - taken now means nothing afterwards. Identity by RID is what survives it.
+    final RidHashSet graphRIDs = new RidHashSet(results.size());
+    for (final Pair<RID, Float> row : results)
+      graphRIDs.add(row.getFirst());
+
+    // Stage 1 - the cheap exact prune, unchanged. Whatever it contributes is a superset of the rows that can matter.
+    mergeWithDeltaScan(queryVectorFloat, k, allowedRIDs, results);
+    if (results.isEmpty())
+      return;
+
+    // Stage 2 - re-score, on the PQ scale, only the rows stage 1 admitted from the buffer. The graph rows already
+    // carry PQ scores and must be left exactly as they are.
+    final List<DeltaVectorEntry> currentDelta = deltaVectors; // volatile snapshot
+    // Parallel primitive/reference arrays rather than a list of holder objects: this runs on the microsecond path,
+    // and both are at most `results.size()` long.
+    final int[] positions = new int[results.size()];
+    final DeltaVectorEntry[] entries = new DeltaVectorEntry[results.size()];
+    int rescored = 0;
+
+    for (int i = 0; i < results.size(); i++) {
+      final RID rid = results.get(i).getFirst();
+      if (graphRIDs.contains(rid))
+        continue;
+      final DeltaVectorEntry entry = findDeltaEntry(currentDelta, rid);
+      if (entry == null)
+        // The buffer moved under us (a rebuild drained it between the two stages). The row's exact score is the
+        // best information left, and it is still a live row, so it stays rather than being dropped.
+        continue;
+      positions[rescored] = i;
+      entries[rescored] = entry;
+      rescored++;
+    }
+
+    if (rescored == 0)
+      return;
+
+    // A scratch PQ store holding exactly these rows, so the decoder below is the same class, over the same
+    // codebooks, assembling the same partial sums as the one that scored the graph beam - which is what makes the
+    // two sides genuinely one scale rather than merely two similar ones. Sized to `rescored`, with every row in a
+    // single chunk, so the allocation is `rescored * compressedVectorSize()` bytes and nothing like the
+    // 1024-vectors-per-chunk a growable store would round up to.
+    final ByteSequence<?>[] chunk = { vts.createByteSequence(rescored * pq.compressedVectorSize()) };
+    final PQVectors scratch = new ImmutablePQVectors(pq, chunk, rescored, rescored);
+    for (int j = 0; j < rescored; j++)
+      pq.encodeTo(entries[j].vector, scratch.get(j));
+
+    final ScoreFunction.ApproximateScoreFunction pqScore =
+        scratch.precomputedScoreFunctionFor(queryVectorFloat, metadata.similarityFunction);
+    for (int j = 0; j < rescored; j++) {
+      final int position = positions[j];
+      results.set(position, new Pair<>(results.get(position).getFirst(),
+          scoreToDistance(metadata.similarityFunction, pqScore.similarityTo(j))));
+    }
+
+    // Re-sort: rescoring moved rows on the axis the list is ordered by, so the ascending-distance contract this
+    // method inherits from mergeWithDeltaScan has to be re-established before the caller sees it.
+    results.sort((a, b) -> Float.compare(a.getSecond(), b.getSecond()));
+  }
+
+  /**
+   * The delta entry for {@code rid}, or {@code null} if the buffer no longer holds one. Linear, which is what the
+   * buffer supports - it is an append-ordered list with no index by RID - and called at most once per row of a
+   * {@code k}-sized result, never once per buffer entry.
+   * <p>
+   * {@code rid} arrives here in its {@link #bindRid} form while the buffer stores the raw one; comparing them
+   * directly is correct because {@link RID#equals} is decided on bucket and offset, which binding does not change.
+   */
+  private static DeltaVectorEntry findDeltaEntry(final List<DeltaVectorEntry> delta, final RID rid) {
+    for (final DeltaVectorEntry entry : delta)
+      if (rid.equals(entry.rid))
+        return entry;
+    return null;
+  }
+
+  /**
    * Brute-force scan of all indexed vectors to supplement graph search results.
    * Called as a fallback when graph search returns too few results (issue #3722),
    * e.g., after a rebuild with corrupted pages produced a poorly connected graph.
@@ -5080,6 +5207,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * cap returns fewer than {@code limit} groups and increments {@code groupedSearchesShortOfLimit} in
    * {@link #getStats()}. Raise {@code efSearch} when that counter moves.
    * <p>
+   * <b>A short answer is not always that case</b> (issue #6559). Coming back with fewer than {@code limit} groups
+   * also happens when the walk simply ran out of graph to visit: the corpus holds fewer than {@code limit} distinct
+   * group keys, the allow-list cannot reach that many, or the graph is degraded. No beam width conjures a group that
+   * is not there, so those queries increment {@code groupedSearchesGroupsUnavailable} instead - which keeps
+   * {@code groupedSearchesShortOfLimit} a counter an operator can act on, rather than one pinned high on every
+   * query forever by ordinary low-cardinality {@code groupBy} data.
+   * <p>
    * <b>The delta buffer is merged into the stream, not appended to the answer</b> (issue #6501). Every
    * vector written since the graph was last built lives in the delta buffer and is invisible to the
    * walk above, so a grouped query that ignored it answered from the corpus as of the last rebuild -
@@ -5211,6 +5345,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
         final GraphSearcher searcher = pool.borrow(pooledGraph, poolEpoch);
         final int graphSize = graphIndex.size();
         int passes = 1;
+        // Issue #6559 item 1: whether a short answer is actionable depends on whether the candidate budget cut the
+        // walk short while the graph still had more to give - the case raising efSearch actually fixes - or the
+        // walk simply ran out of graph to visit, whether because the corpus genuinely holds fewer than `limit`
+        // distinct groupBy values (the common, expected case) or because the graph is degraded (issue #3722's case,
+        // for which the plain k-NN path self-heals via bruteForceScan but the grouped path deliberately does not -
+        // see this method's javadoc for why). Either way "raise efSearch" is the wrong advice there.
+        //
+        // Two independent signals feed that, both needed:
+        //  - a pass that came back short of the beam (returned < effectiveEfSearch) means the walk hit dead ends -
+        //    true even with plenty of candidateBudget left, e.g. a graph with unreachable islands (issue #3722);
+        //  - examined >= graphSize after the loop, because candidateBudget is capped at graphSize (Math.min below):
+        //    whenever the corpus is small enough that graphSize is the binding constraint, hitting the budget and
+        //    exhausting the graph are the same event, and the last pass can still return a full beam if graphSize
+        //    happens to be an exact multiple of the beam width - so a short final pass is not reliable on its own.
+        boolean walkRanDry = false;
+        int examined = 0;
         try {
           final ScoreFunction.ExactScoreFunction exactScoreFunction = liveOnlyScoreFunction(queryVectorFloat, vectors);
           final DefaultSearchScoreProvider ssp = new DefaultSearchScoreProvider(exactScoreFunction, exactScoreFunction);
@@ -5237,7 +5387,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // them - topK never reaches the layer-0 traversal (searchLayer0 passes only rerankK to searchOneLayer) and
           // reranking is driven by rerankK too, so every one of these was already scored and reranked.
           SearchResult searchResult = searcher.search(ssp, effectiveEfSearch, effectiveEfSearch, 0.0f, 0.0f, bitsFilter);
-          int examined = 0;
           while (true) {
             final int returned = searchResult.getNodes().length;
             examined += returned;
@@ -5248,8 +5397,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
             // A pass that could not fill its beam ran the candidate queue dry: the reachable graph is
             // exhausted and no further pass can add anything. This is also what makes the loop terminate -
             // every pass that does not break here grew `examined` by a full beam.
-            if (returned < effectiveEfSearch)
+            if (returned < effectiveEfSearch) {
+              walkRanDry = true;
               break;
+            }
             if (examined >= candidateBudget)
               break;
 
@@ -5261,6 +5412,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
         } finally {
           pool.release(searcher, pooledGraph, poolEpoch);
         }
+        // examined can never exceed graphSize - every pass contributes only nodes resume() had not already visited -
+        // so reaching it here means every reachable node was walked, whichever break fired.
+        final boolean graphExhausted = walkRanDry || examined >= graphSize;
 
         // The walk is over - the groups filled, the reachable graph ran out, or the candidate budget did. Whatever
         // is left in the cursor is further from the query than every graph candidate examined, so it is exactly what
@@ -5272,11 +5426,23 @@ public class LSMVectorIndex implements Index, IndexInternal {
         final List<Pair<RID, Float>> results = state.finish();
 
         if (state.distinctGroups() < limit) {
-          metrics.incrementGroupedSearchesShortOfLimit();
-          LogManager.instance()
-              .log(this, Level.FINE,
-                  "Vector grouped search on index %s filled only %d of %d groups after %d pass(es) - raise efSearch for wider group coverage",
-                  indexName, state.distinctGroups(), limit, passes);
+          if (graphExhausted) {
+            // Issue #6559 item 1/4: the walk ran the reachable graph dry rather than hitting the candidate budget -
+            // raising efSearch cannot add candidates that do not exist. Counted separately so it does not pin the
+            // actionable counter high on ordinary low-cardinality groupBy data, and so a degraded graph (issue
+            // #3722) that quietly starves a grouped query leaves a trace instead of none at all.
+            metrics.incrementGroupedSearchesGroupsUnavailable();
+            LogManager.instance()
+                .log(this, Level.FINE,
+                    "Vector grouped search on index %s filled only %d of %d groups after %d pass(es) - the reachable graph ran out of candidates rather than the candidate budget, so raising efSearch will not help; either the corpus/allow-list has fewer than %d distinct groups, or REBUILD INDEX if that is unexpected",
+                    indexName, state.distinctGroups(), limit, passes, limit);
+          } else {
+            metrics.incrementGroupedSearchesShortOfLimit();
+            LogManager.instance()
+                .log(this, Level.FINE,
+                    "Vector grouped search on index %s filled only %d of %d groups after %d pass(es) - raise efSearch for wider group coverage",
+                    indexName, state.distinctGroups(), limit, passes);
+          }
         }
 
         LogManager.instance()
@@ -5388,7 +5554,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
       metrics.incrementGroupedSearchesMergingDelta();
 
     if (state.distinctGroups() < limit) {
-      metrics.incrementGroupedSearchesShortOfLimit();
+      // Issue #6559 item 1: this plan has no efSearch/candidate-budget concept at all - every allow-listed candidate
+      // is scored up front - so a shortfall here is never the "raise efSearch" case groupedSearchesShortOfLimit
+      // means on the graph-walk plan. It counts under groupedSearchesGroupsUnavailable instead, alongside that
+      // plan's own non-actionable exhaustion case.
+      metrics.incrementGroupedSearchesGroupsUnavailable();
       // Deliberately not claiming this is "expected": that is only true when the scored set itself is under limit.
       // An allow-list wide enough to clear limit can still land here if its candidates cluster into fewer than
       // limit distinct groups, or enough of them fail group-key resolution - the summary log line below breaks the
@@ -5693,7 +5863,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
       lock.readLock().lock();
       try {
         if (graphIndex == null || vectorIndex().size() == 0) {
-          // No graph yet — still return delta-only results if available
+          // No graph yet - still return delta-only results if available.
+          //
+          // Scored exactly, and deliberately not through mergeWithDeltaScanApproximate (issue #6559 item 2): there
+          // is no graph here, so every row in this answer comes from the buffer and is already on one scale. The
+          // reason to quantize a delta row is to make it comparable to a PQ-scored graph row, and there are none to
+          // be comparable to - degrading these scores would lose accuracy to buy a consistency that already holds.
           if (!deltaVectors.isEmpty()) {
             final VectorFloat<?> qvf = vts.createFloatVector(queryVector);
             final List<Pair<RID, Float>> results = new ArrayList<>(k);
@@ -5732,7 +5907,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
             GlobalConfiguration.VECTOR_INDEX_PREFILTER_APPROXIMATE_MAX_SELECTIVITY)) {
           metrics.incrementPreFilterSearches();
           final List<Pair<RID, Float>> results = new ArrayList<>(k);
-          mergeWithDeltaScan(queryVectorFloat, k, allowedRIDs, results);
+          // PQ-scaled, not exact (issue #6559 item 2): preFilterApproximate scores its ordinals from the PQ codes,
+          // so delta rows merged here are ranked against - and returned alongside - approximate scores.
+          mergeWithDeltaScanApproximate(queryVectorFloat, k, allowedRIDs, results);
           preFilterApproximate(scoreFunction, k, allowedRIDs, results, ordinalMap);
           return results;
         }
@@ -5777,12 +5954,17 @@ public class LSMVectorIndex implements Index, IndexInternal {
           }
         }
 
-        // Merge with delta vectors inserted since last graph rebuild
-        mergeWithDeltaScan(queryVectorFloat, k, allowedRIDs, results);
+        // Merge with delta vectors inserted since last graph rebuild, scored on the same PQ scale as the graph rows
+        // above rather than exactly (issue #6559 item 2) - see mergeWithDeltaScanApproximate for why ranking the two
+        // against each other on different scales let quantization error, not the data, decide which row won.
+        mergeWithDeltaScanApproximate(queryVectorFloat, k, allowedRIDs, results);
 
-        // Log performance metrics
+        // Log performance metrics. FINE, not INFO (issue #6559 item 3): this path's entire reason to exist is
+        // microsecond latency, so an unconditional per-query INFO line - on the query rate this path is built for -
+        // costs more to format and write than the search itself reports, and floods the log. Every comparable
+        // per-query summary on the neighbouring search paths is already FINE.
         final long elapsedNanos = System.nanoTime() - startTime;
-        LogManager.instance().log(this, Level.INFO,
+        LogManager.instance().log(this, Level.FINE,
             "Zero-disk-I/O PQ search returned %d results in %.2f µs (skipped: %d out of bounds, %d deleted/null)",
             results.size(), elapsedNanos / 1000.0, skippedOutOfBounds, skippedDeletedOrNull);
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4601,8 +4601,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * than the search it feeds, on the one path whose contract is microseconds, and would scale with a buffer that
    * runs to hundreds of thousands of entries under sustained ingestion. The cheap exact scan is therefore kept as a
    * <em>pruner</em> - it already ran here before this fix, at the same cost - and only the at-most-{@code k}
-   * survivors are re-scored on the PQ scale. Cost is bounded by {@code k} regardless of buffer size, and is exactly
-   * zero when the buffer is empty, which is the steady state this path is built for.
+   * survivors are re-scored on the PQ scale.
+   * <p>
+   * <b>What that costs.</b> The <em>quantization</em> - the expensive part - is bounded by {@code k} and does not
+   * grow with the buffer. Resolving those survivors back to their buffer entries adds one more walk of the buffer,
+   * so the stage as a whole is O(buffer + k) on top of the O(buffer) scan stage 1 already performed; it is
+   * emphatically not a buffer search per row, which would be O(k * buffer) and would reintroduce exactly the
+   * scaling this design exists to avoid. The whole method returns before allocating anything when the buffer is
+   * empty, which is the steady state this path is built for.
    * <p>
    * <b>The residue.</b> Selecting the head exactly and then ranking it approximately can admit a row that the PQ
    * scale would have placed just outside {@code k}, or drop one it would have placed just inside. That window is
@@ -4623,6 +4629,17 @@ public class LSMVectorIndex implements Index, IndexInternal {
       return;
     }
 
+    // Nothing in the buffer means nothing to rescore, and this has to be checked before anything is allocated: on
+    // the pre-filter branch `results` arrives empty and every structure below would be built only to be thrown
+    // away. mergeWithDeltaScan makes the same early return on the same condition, so skipping it changes nothing.
+    //
+    // One snapshot, used for both the guard and the resolve pass below. mergeWithDeltaScan takes its own, so a
+    // rebuild landing between the two can leave it merging rows this one no longer holds; that is the case the
+    // unresolved-row branch below already covers, and it degrades to an exact score rather than a wrong one.
+    final List<DeltaVectorEntry> currentDelta = deltaVectors; // volatile snapshot
+    if (currentDelta.isEmpty())
+      return;
+
     // The graph rows, captured BEFORE the merge: mergeWithDeltaScan rebuilds `results` from its own heap, so a
     // position - or a prefix length - taken now means nothing afterwards. Identity by RID is what survives it.
     final RidHashSet graphRIDs = new RidHashSet(results.size());
@@ -4636,35 +4653,53 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     // Stage 2 - re-score, on the PQ scale, only the rows stage 1 admitted from the buffer. The graph rows already
     // carry PQ scores and must be left exactly as they are.
-    final List<DeltaVectorEntry> currentDelta = deltaVectors; // volatile snapshot
-    // Parallel primitive/reference arrays rather than a list of holder objects: this runs on the microsecond path,
-    // and both are at most `results.size()` long.
-    final int[] positions = new int[results.size()];
-    final DeltaVectorEntry[] entries = new DeltaVectorEntry[results.size()];
-    int rescored = 0;
-
+    //
+    // Resolved by walking the buffer ONCE against a map of the rows that still need an entry, rather than searching
+    // the buffer per row. The buffer has no index by RID, so a per-row search is a full scan of it, and doing that
+    // for each of up-to-k rows would cost O(k * buffer) - which under the sustained ingestion this method's javadoc
+    // describes is precisely the scaling the "prune first, quantize only the survivors" design exists to avoid.
+    // One pass keeps the whole stage O(buffer + k), on top of the O(buffer) scan stage 1 already paid.
+    //
+    // Keyed on RID across the two forms deliberately: `results` holds bound RIDs and the buffer holds raw ones, and
+    // RID's equals/hashCode are decided on bucket and offset alone, which binding does not change.
+    final Map<RID, Integer> unresolved = new HashMap<>();
     for (int i = 0; i < results.size(); i++) {
       final RID rid = results.get(i).getFirst();
-      if (graphRIDs.contains(rid))
+      if (!graphRIDs.contains(rid))
+        unresolved.put(rid, i);
+    }
+    if (unresolved.isEmpty())
+      return;
+
+    // Parallel primitive/reference arrays rather than a list of holder objects: this runs on the microsecond path,
+    // and both are at most `unresolved.size()` long.
+    final int[] positions = new int[unresolved.size()];
+    final DeltaVectorEntry[] entries = new DeltaVectorEntry[unresolved.size()];
+    int rescored = 0;
+
+    for (final DeltaVectorEntry entry : currentDelta) {
+      final Integer position = unresolved.remove(entry.rid);
+      if (position == null)
         continue;
-      final DeltaVectorEntry entry = findDeltaEntry(currentDelta, rid);
-      if (entry == null)
-        // The buffer moved under us (a rebuild drained it between the two stages). The row's exact score is the
-        // best information left, and it is still a live row, so it stays rather than being dropped.
-        continue;
-      positions[rescored] = i;
+      positions[rescored] = position;
       entries[rescored] = entry;
       rescored++;
+      if (unresolved.isEmpty())
+        break;
     }
 
+    // Anything still unresolved is a row the buffer no longer holds - a rebuild drained it between the two stages.
+    // Its exact score is the best information left and it is still a live row, so it keeps that score rather than
+    // being dropped; only its scale is off, which is strictly better than losing the row.
     if (rescored == 0)
       return;
 
     // A scratch PQ store holding exactly these rows, so the decoder below is the same class, over the same
     // codebooks, assembling the same partial sums as the one that scored the graph beam - which is what makes the
     // two sides genuinely one scale rather than merely two similar ones. Sized to `rescored`, with every row in a
-    // single chunk, so the allocation is `rescored * compressedVectorSize()` bytes and nothing like the
-    // 1024-vectors-per-chunk a growable store would round up to.
+    // single chunk, so the allocation is `rescored * compressedVectorSize()` bytes: the MutablePQVectors used on
+    // the build path (see buildAndPersistPQ) is the higher-level way to do this, but it rounds its backing store up
+    // to 1024 vectors per chunk, which for the handful of rows here is the larger cost by far.
     final ByteSequence<?>[] chunk = { vts.createByteSequence(rescored * pq.compressedVectorSize()) };
     final PQVectors scratch = new ImmutablePQVectors(pq, chunk, rescored, rescored);
     for (int j = 0; j < rescored; j++)
@@ -4681,21 +4716,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // Re-sort: rescoring moved rows on the axis the list is ordered by, so the ascending-distance contract this
     // method inherits from mergeWithDeltaScan has to be re-established before the caller sees it.
     results.sort((a, b) -> Float.compare(a.getSecond(), b.getSecond()));
-  }
-
-  /**
-   * The delta entry for {@code rid}, or {@code null} if the buffer no longer holds one. Linear, which is what the
-   * buffer supports - it is an append-ordered list with no index by RID - and called at most once per row of a
-   * {@code k}-sized result, never once per buffer entry.
-   * <p>
-   * {@code rid} arrives here in its {@link #bindRid} form while the buffer stores the raw one; comparing them
-   * directly is correct because {@link RID#equals} is decided on bucket and offset, which binding does not change.
-   */
-  private static DeltaVectorEntry findDeltaEntry(final List<DeltaVectorEntry> delta, final RID rid) {
-    for (final DeltaVectorEntry entry : delta)
-      if (rid.equals(entry.rid))
-        return entry;
-    return null;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
@@ -51,7 +51,22 @@ class LSMVectorIndexMetrics {
   // distinct groups, so the caller got a correct but short answer. Finding the limit-th nearest group costs however
   // many candidates the data puts between it and the query, which no fixed budget can guarantee (issue #5761), so
   // this is the signal to raise efSearch on the index or the query.
+  //
+  // Issue #6559: this counter is deliberately narrow - it fires ONLY when the walk stopped because the candidate
+  // budget ran out while the graph still had more to give. It must NOT fire when the reachable graph (or, on the
+  // pre-filter plan, the allow-list) was exhausted on its own: a corpus that genuinely holds fewer than `limit`
+  // distinct groupBy values, or an allow-list that cannot reach `limit` groups, trips that on every query forever and
+  // "raise efSearch" cannot manufacture a group that does not exist. See groupedSearchesGroupsUnavailable for that
+  // case.
   private final AtomicLong groupedSearchesShortOfLimit = new AtomicLong(0);
+  // Grouped searches that came back with fewer than `limit` distinct groups because the reachable graph (or the
+  // allow-list, on the pre-filter plan) ran out on its own - not because a fixed candidate budget cut the walk short.
+  // Raising efSearch cannot help here: there is nothing further to find. A steady, non-zero rate is expected and
+  // requires no action when the groupBy cardinality is genuinely below `limit`. It is also the signal issue #6559
+  // item 4 asked for: a grouped query that comes up short for a reason other than "the cap is doing its job" - e.g. a
+  // degraded graph after a corrupted rebuild (issue #3722) - shows up here rather than nowhere at all, since a
+  // grouped search deliberately skips the brute-force fallback the plain k-NN path uses to self-heal from that case.
+  private final AtomicLong groupedSearchesGroupsUnavailable = new AtomicLong(0);
   // Grouped searches that merged at least one row out of the delta buffer into their answer (issue #6501). Before
   // that issue the grouped path skipped the buffer outright, so a groupBy query silently answered from the corpus as
   // of the last graph rebuild while the same query without groupBy returned the newer rows; the merge is what closed
@@ -118,6 +133,10 @@ class LSMVectorIndexMetrics {
 
   void incrementGroupedSearchesShortOfLimit() {
     groupedSearchesShortOfLimit.incrementAndGet();
+  }
+
+  void incrementGroupedSearchesGroupsUnavailable() {
+    groupedSearchesGroupsUnavailable.incrementAndGet();
   }
 
   void incrementGroupedSearchesMergingDelta() {
@@ -190,6 +209,10 @@ class LSMVectorIndexMetrics {
     return groupedSearchesShortOfLimit.get();
   }
 
+  long getGroupedSearchesGroupsUnavailable() {
+    return groupedSearchesGroupsUnavailable.get();
+  }
+
   long getGroupedSearchesMergingDelta() {
     return groupedSearchesMergingDelta.get();
   }
@@ -240,6 +263,7 @@ class LSMVectorIndexMetrics {
     stats.put("bruteForceScans", bruteForceScans.get());
     stats.put("preFilterSearches", preFilterSearches.get());
     stats.put("groupedSearchesShortOfLimit", groupedSearchesShortOfLimit.get());
+    stats.put("groupedSearchesGroupsUnavailable", groupedSearchesGroupsUnavailable.get());
     stats.put("groupedSearchesMergingDelta", groupedSearchesMergingDelta.get());
     stats.put("unverifiedGraphReuses", unverifiedGraphReuses.get());
     stats.put("rebuildsDeferredForMemory", rebuildsDeferredForMemory.get());
@@ -264,6 +288,7 @@ class LSMVectorIndexMetrics {
     bruteForceScans.set(0);
     preFilterSearches.set(0);
     groupedSearchesShortOfLimit.set(0);
+    groupedSearchesGroupsUnavailable.set(0);
     groupedSearchesMergingDelta.set(0);
     unverifiedGraphReuses.set(0);
     rebuildsDeferredForMemory.set(0);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue5761GroupedSearchGroupChoiceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue5761GroupedSearchGroupChoiceTest.java
@@ -214,13 +214,17 @@ class Issue5761GroupedSearchGroupChoiceTest extends TestHelper {
   /**
    * When the data cannot supply {@code limit} groups, the walk has to stop rather than resume forever. Every vertex
    * here carries the same group key, so no pass will ever open a second group; the search must come back with the one
-   * group it can fill, and say so through {@code groupedSearchesShortOfLimit}.
+   * group it can fill, and say so through {@code groupedSearchesGroupsUnavailable} - NOT
+   * {@code groupedSearchesShortOfLimit}, which issue #6559 narrowed to the case where the candidate budget cut the
+   * walk short. A corpus with only one distinct group exhausts the reachable graph on its own instead: raising
+   * efSearch could never manufacture a second group that does not exist, so this is the non-actionable counter.
    */
   @Test
   void aGroupKeyWithOneValueStopsInsteadOfWalkingTheWholeGraph() {
     createSchema();
     insertVertices();
 
+    final long unavailableBefore = vectorIndex().getStats().get("groupedSearchesGroupsUnavailable");
     final long shortBefore = vectorIndex().getStats().get("groupedSearchesShortOfLimit");
 
     final List<Pair<RID, Float>> neighbors = vectorIndex().findNeighborsFromVectorGrouped(embedding(centerOf(1)), LIMIT,
@@ -228,9 +232,12 @@ class Issue5761GroupedSearchGroupChoiceTest extends TestHelper {
 
     assertThat(neighbors).as("the one group it can fill still has to come back, filled to groupSize")
         .hasSize(GROUP_SIZE);
+    assertThat(vectorIndex().getStats().get("groupedSearchesGroupsUnavailable"))
+        .as("a search that could not open limit groups because the graph ran out on its own has to be visible to the operator")
+        .isEqualTo(unavailableBefore + 1);
     assertThat(vectorIndex().getStats().get("groupedSearchesShortOfLimit"))
-        .as("a search that could not open limit groups has to be visible to the operator")
-        .isEqualTo(shortBefore + 1);
+        .as("this shortfall is not a candidate-budget problem, so it must not pin the efSearch-actionable counter")
+        .isEqualTo(shortBefore);
   }
 
   /** A whitelist has to keep holding across the pass boundary, not just on the first beam. */

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6514GroupedVectorPrefilterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6514GroupedVectorPrefilterTest.java
@@ -176,11 +176,19 @@ class Issue6514GroupedVectorPrefilterTest extends TestHelper {
     for (int i = 0; i < PER_CLUSTER; i++)
       allowed.add(ridOf("doc" + i));
 
+    // Issue #6559 item 1: the pre-filter plan has no efSearch/candidate-budget concept at all - every allow-listed
+    // candidate is scored up front - so this shortfall is never the "raise efSearch" case
+    // groupedSearchesShortOfLimit means on the graph-walk plan. It must count under groupedSearchesGroupsUnavailable
+    // instead.
+    final long unavailableBefore = index.getStats().getOrDefault("groupedSearchesGroupsUnavailable", 0L);
     final long shortfallBefore = index.getStats().getOrDefault("groupedSearchesShortOfLimit", 0L);
     final List<Pair<RID, Float>> results = grouped(query, 5, 3, allowed);
 
+    assertThat(index.getStats().get("groupedSearchesGroupsUnavailable"))
+        .as("an allow-list confined to one cluster cannot open 5 groups").isEqualTo(unavailableBefore + 1);
     assertThat(index.getStats().get("groupedSearchesShortOfLimit"))
-        .as("an allow-list confined to one cluster cannot open 5 groups").isEqualTo(shortfallBefore + 1);
+        .as("the pre-filter plan cannot hit a candidate-budget shortfall, so this counter must stay untouched")
+        .isEqualTo(shortfallBefore);
     for (final Pair<RID, Float> r : results)
       assertThat(r.getFirst().asDocument().getInteger("cluster")).isEqualTo(0);
     assertThat(results.size()).as("groupSize still caps the one group that could be opened").isLessThanOrEqualTo(3);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6559ApproximateDeltaScoringScaleTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6559ApproximateDeltaScoringScaleTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.utility.Pair;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6559 item 2: {@link LSMVectorIndex#findNeighborsFromVectorApproximate} - the zero-disk-I/O PQ path - scored
+ * every graph candidate approximately from the in-memory PQ codes, but merged in delta-buffer rows scored
+ * <em>exactly</em>, then sorted the two against each other as one list.
+ * <p>
+ * The fixture puts the defect in its purest form: a row is inserted into the delta buffer carrying a vector that is
+ * <em>bit-identical</em> to one already in the graph. The two are the same point in space, at the same true distance
+ * from any query, so whatever number the search hands back for one it has to hand back for the other. Before the fix
+ * the graph row came back with its PQ distance (carrying quantization error) and the delta row with an exact 0, so
+ * the delta twin outranked its own graph copy every time - not by being nearer, but by being the only one of the two
+ * measured without error.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6559ApproximateDeltaScoringScaleTest extends TestHelper {
+
+  private static final int DIMENSIONS = 32;
+  private static final int VECTORS    = 400;
+  private static final int PQ_CLUSTERS = 16;
+  // The graph vector the delta row is made a twin of. Any indexed vector does; this one is simply not at an edge.
+  private static final int TWINNED    = 17;
+  // Wide enough that the twinned vector and its delta copy are both comfortably inside the answer.
+  private static final int TOP_K      = 25;
+
+  @BeforeEach
+  void freezeTheGraph() {
+    GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.setValue(1_000_000);
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO.setValue(0f);
+    GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS.setValue(0);
+  }
+
+  @AfterEach
+  void thawTheGraph() {
+    GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.reset();
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO.reset();
+    GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS.reset();
+  }
+
+  /**
+   * Two rows, one vector, one query: the graph copy and its delta twin must come back with the same distance. The
+   * guard below is what keeps this from passing vacuously - it pins that PQ really is lossy on this fixture, so a
+   * build that scored the delta side exactly would produce two visibly different numbers and fail here.
+   */
+  @Test
+  void aDeltaRowIsScoredOnTheSamePqScaleAsItsGraphTwin() {
+    createSchemaAndData();
+
+    final LSMVectorIndex index = vectorIndex();
+    assertThat(index.isPQSearchAvailable()).as("the fixture is only meaningful while the PQ path is really taken")
+        .isTrue();
+
+    final float[] query = vector(TWINNED);
+
+    // The graph row's own PQ distance to a query that IS its vector. Non-zero exactly to the extent PQ is lossy.
+    final List<Pair<RID, Float>> beforeInsert = index.findNeighborsFromVectorApproximate(query, TOP_K, null);
+    final float graphDistance = distanceOf(beforeInsert, "doc" + TWINNED);
+    assertThat(graphDistance)
+        .as("guard against a vacuous test: PQ has to be lossy here, or scoring the delta side exactly would agree "
+            + "with the graph side by accident and this test could never fail")
+        .isGreaterThan(1e-6f);
+
+    // The twin: same vector, new record, and it stays in the delta buffer because the graph is frozen.
+    database.transaction(() -> database.newDocument("Doc").set("id", "twin").set("embedding", vector(TWINNED)).save());
+    assertThat(index.getStats().get("deltaVectorsCount"))
+        .as("the fixture is only a regression test while the twin is still in the delta buffer").isEqualTo(1L);
+
+    final List<Pair<RID, Float>> results = index.findNeighborsFromVectorApproximate(query, TOP_K, null);
+    final float twinDistance = distanceOf(results, "twin");
+
+    assertThat(twinDistance)
+        .as("a delta row and its bit-identical graph twin are the same point, so the PQ path has to score them on "
+            + "the same scale - before the fix the twin came back exact (0) against the graph row's PQ distance")
+        .isCloseTo(graphDistance, org.assertj.core.data.Offset.offset(1e-5f));
+  }
+
+  /**
+   * The other surface with the same merge, and the same defect: the issue #6514 pre-filter plan scores its
+   * allow-listed ordinals from the PQ codes too, so the delta rows merged alongside them need the same treatment.
+   */
+  @Test
+  void thePreFilterPlanAlsoScoresDeltaRowsOnThePqScale() {
+    createSchemaAndData();
+
+    final LSMVectorIndex index = vectorIndex();
+    final float[] query = vector(TWINNED);
+
+    final float graphDistance = distanceOf(index.findNeighborsFromVectorApproximate(query, TOP_K, null), "doc" + TWINNED);
+    assertThat(graphDistance).as("guard against a vacuous test: PQ has to be lossy here").isGreaterThan(1e-6f);
+
+    database.transaction(() -> database.newDocument("Doc").set("id", "twin").set("embedding", vector(TWINNED)).save());
+
+    // Narrow enough to take the pre-filter plan rather than the graph walk.
+    final java.util.Set<RID> allowed = new java.util.HashSet<>();
+    allowed.add(ridOf("doc" + TWINNED));
+    allowed.add(ridOf("twin"));
+
+    final long preFilterBefore = index.getStats().get("preFilterSearches");
+    final List<Pair<RID, Float>> results = index.findNeighborsFromVectorApproximate(query, TOP_K, allowed);
+    assertThat(index.getStats().get("preFilterSearches")).as("the fixture has to actually reach the pre-filter plan")
+        .isGreaterThan(preFilterBefore);
+
+    assertThat(distanceOf(results, "twin"))
+        .as("the pre-filter plan ranks its ordinals on the PQ scale, so its merged delta rows must be there too")
+        .isCloseTo(distanceOf(results, "doc" + TWINNED), org.assertj.core.data.Offset.offset(1e-5f));
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private float distanceOf(final List<Pair<RID, Float>> results, final String id) {
+    for (final Pair<RID, Float> r : results)
+      if (id.equals(((Document) database.lookupByRID(r.getFirst(), true)).getString("id")))
+        return r.getSecond();
+    throw new AssertionError("row '" + id + "' is missing from the answer: " + results);
+  }
+
+  private RID ridOf(final String id) {
+    try (final com.arcadedb.query.sql.executor.ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE id = ?",
+        id)) {
+      return rs.next().getIdentity().orElseThrow();
+    }
+  }
+
+  private void createSchemaAndData() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 1");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      for (int i = 0; i < VECTORS; i++)
+        database.newDocument("Doc").set("id", "doc" + i).set("embedding", vector(i)).save();
+    });
+
+    database.command("sql", """
+        CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA {
+          "dimensions": %d,
+          "similarity": "COSINE",
+          "quantization": "PRODUCT",
+          "pqClusters": %d
+        }""".formatted(DIMENSIONS, PQ_CLUSTERS));
+  }
+
+  /**
+   * Deterministic, and spread over the whole space rather than clustered around one direction: with a constant
+   * offset added to every component the vectors are all nearly parallel, cosine similarity is ~1 for every pair, and
+   * every distance in the answer ties - which hides exactly the difference this test is here to measure.
+   */
+  private static float[] vector(final int seed) {
+    final Random rnd = new Random(seed * 1_000_003L);
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = rnd.nextFloat() * 2 - 1;
+    return v;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return (LSMVectorIndex) ((TypeIndex) database.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6559GroupedSearchShortfallSignalTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6559GroupedSearchShortfallSignalTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
+import com.arcadedb.utility.Pair;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6559 item 1 (and item 4): {@code groupedSearchesShortOfLimit} used to fire on every grouped search that came
+ * back with fewer than {@code limit} distinct groups, whatever the reason. A corpus that genuinely holds fewer
+ * distinct {@code groupBy} values than {@code limit} - not a corner case, just ordinary low-cardinality data - hit
+ * that on <em>every single query, forever</em>, and the counter's own contract ("raise efSearch") cannot be honoured:
+ * there is no wider beam that manufactures a group that does not exist.
+ * <p>
+ * The fix splits the counter in two: {@code groupedSearchesShortOfLimit} now fires only when the candidate budget cut
+ * the walk short while the graph still had more to give (the case efSearch actually helps), and
+ * {@code groupedSearchesGroupsUnavailable} fires when the reachable graph (or, on the pre-filter plan, the
+ * allow-list) ran out on its own - which is also the signal item 4 asked for: a grouped query that comes up short for
+ * a reason other than "the cap is doing its job" now leaves a trace on this counter, where before there was none.
+ */
+class Issue6559GroupedSearchShortfallSignalTest extends TestHelper {
+
+  private static final int DIMENSIONS  = 16;
+  private static final int VERTICES    = 300;
+  private static final int LIMIT       = 5;
+  private static final int GROUP_SIZE  = 3;
+  private static final int QUERY_COUNT = 5;
+
+  @BeforeEach
+  void freezeTheGraph() {
+    GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.setValue(1_000_000);
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO.setValue(0f);
+    GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS.setValue(0);
+  }
+
+  @AfterEach
+  void thawTheGraph() {
+    GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.reset();
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO.reset();
+    GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS.reset();
+  }
+
+  /**
+   * Every vertex shares the same {@code groupBy} key, so no query - however many times it is repeated - can ever open
+   * a second group. Before the fix this pinned {@code groupedSearchesShortOfLimit} up on every single one of them,
+   * a counter nobody could act on because raising efSearch changes nothing about how many distinct group keys exist.
+   */
+  @Test
+  void aLowCardinalityGroupByNeverCriesWolfOnTheActionableCounter() {
+    createSchema();
+    insertVertices();
+
+    final long shortBefore = vectorIndex().getStats().get("groupedSearchesShortOfLimit");
+    final long unavailableBefore = vectorIndex().getStats().get("groupedSearchesGroupsUnavailable");
+
+    for (int i = 0; i < QUERY_COUNT; i++) {
+      final List<Pair<RID, Float>> neighbors = vectorIndex().findNeighborsFromVectorGrouped(embedding(i), LIMIT,
+          GROUP_SIZE, -1, null, rid -> "one-and-only");
+      assertThat(neighbors).as("the one group that exists still has to come back, filled to groupSize")
+          .hasSize(GROUP_SIZE);
+    }
+
+    assertThat(vectorIndex().getStats().get("groupedSearchesShortOfLimit"))
+        .as("low groupBy cardinality is not a candidate-budget problem, so the efSearch-actionable counter must stay "
+            + "untouched across every repeat of the same query")
+        .isEqualTo(shortBefore);
+    assertThat(vectorIndex().getStats().get("groupedSearchesGroupsUnavailable"))
+        .as("but the shortfall still has to be visible somewhere, once per query")
+        .isEqualTo(unavailableBefore + QUERY_COUNT);
+  }
+
+  /**
+   * A narrow allow-list on the pre-filter plan (issue #6514) is the other path with no candidate-budget concept at
+   * all: every allow-listed candidate is scored up front, so a shortfall here can never be the "raise efSearch" case
+   * either.
+   */
+  @Test
+  void aNarrowAllowListOnThePreFilterPlanAlsoUsesTheNonActionableCounter() {
+    createSchema();
+    insertVertices();
+
+    final Set<RID> allowed = new HashSet<>();
+    for (int i = 0; i < 10; i++)
+      allowed.add(ridOf("doc" + i));
+
+    final long shortBefore = vectorIndex().getStats().get("groupedSearchesShortOfLimit");
+    final long unavailableBefore = vectorIndex().getStats().get("groupedSearchesGroupsUnavailable");
+
+    final List<Pair<RID, Float>> neighbors = vectorIndex().findNeighborsFromVectorGrouped(embedding(0), LIMIT,
+        GROUP_SIZE, -1, allowed, rid -> "one-and-only");
+
+    assertThat(neighbors).as("the allow-listed rows are still answered").isNotEmpty();
+    assertThat(vectorIndex().getStats().get("groupedSearchesShortOfLimit"))
+        .as("the pre-filter plan cannot hit a candidate-budget shortfall")
+        .isEqualTo(shortBefore);
+    assertThat(vectorIndex().getStats().get("groupedSearchesGroupsUnavailable"))
+        .as("an allow-list confined to one group cannot open %d groups", LIMIT)
+        .isEqualTo(unavailableBefore + 1);
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private RID ridOf(final String id) {
+    try (final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE id = ?", id)) {
+      return rs.next().getIdentity().orElseThrow();
+    }
+  }
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON Doc (id) UNIQUE");
+
+      final TypeLSMVectorIndexBuilder builder = (TypeLSMVectorIndexBuilder) database.getSchema()
+          .buildTypeIndex("Doc", new String[] { "embedding" }).withLSMVectorType();
+      builder.withDimensions(DIMENSIONS).withQuantization(VectorQuantizationType.INT8).withSimilarity("COSINE")
+          .create();
+    });
+  }
+
+  private void insertVertices() {
+    database.transaction(() -> {
+      for (int i = 0; i < VERTICES; i++)
+        database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + i, embedding(i));
+    });
+    // The graph is built on the first search, and it has to come out above ASYNC_REBUILD_MIN_GRAPH_SIZE or every
+    // later search would rebuild it synchronously.
+    vectorIndex().findNeighborsFromVector(embedding(0), 1);
+  }
+
+  private float[] embedding(final int vertex) {
+    final float[] v = new float[DIMENSIONS];
+    final double theta = vertex * 0.01;
+    for (int m = 1; m <= DIMENSIONS / 2; m++) {
+      v[(m - 1) * 2] = (float) (Math.cos(m * theta) / m);
+      v[(m - 1) * 2 + 1] = (float) (Math.sin(m * theta) / m);
+    }
+    return v;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return (LSMVectorIndex) ((TypeIndex) database.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+}


### PR DESCRIPTION
Closes #6559.

Four independent follow-ups from #6501, all in `LSMVectorIndex`'s grouped and PQ search paths. None was introduced by that PR.

## Item 1 - a shortfall counter that cries wolf

`groupedSearchesShortOfLimit` fired on **every** grouped search that returned fewer than `limit` distinct groups, whatever the reason. A corpus that genuinely holds fewer distinct `groupBy` values than `limit` - ordinary low-cardinality data, not a corner case - tripped it on every query forever, while telling the operator to raise `efSearch`, which cannot manufacture a group that does not exist. Since #6501 called this out as the *only* signal a grouped query has, a counter pinned high by ordinary data is one nobody can act on.

Split in two:

- `groupedSearchesShortOfLimit` now fires **only** when the candidate budget cut the walk short while the graph still had more to give - the case raising `efSearch` actually fixes.
- `groupedSearchesGroupsUnavailable` (new) covers the walk running out of graph on its own.

Exhaustion is detected as `walkRanDry || examined >= graphSize`, not from which `break` fired. `candidateBudget` is capped at `graphSize`, so on a corpus small enough for `graphSize` to be the binding constraint, hitting the budget and exhausting the graph are the *same event*; and the final pass can still return a full beam when `graphSize` is an exact multiple of the beam width, so a short final pass is not a reliable signal on its own. Both halves are needed: a short pass catches dead ends (unreachable islands) with budget left over, the count catches the small-corpus case.

`preFilterGrouped` has no candidate-budget concept at all - it scores every allow-listed candidate up front - so its shortfall can never be the `efSearch` case and always counts as unavailable.

## Item 2 - PQ ranking two scoring scales

`findNeighborsFromVectorApproximate` scores every graph candidate from the in-memory PQ codes, then merged in delta-buffer rows scored **exactly** and sorted the two against each other as one list. So a delta row and a graph row at the same true distance did not get the same number, and which one won was decided by the graph row's quantization error rather than by the data - systematically, since PQ error has structure. A caller thresholding on distance (`maxDistance`, or its own cut-off) was applying one bar to two different measurements.

Only the delta side can be moved: making the graph side exact means reading the real vectors, which is precisely the disk I/O this path exists to avoid. Delta rows are now quantized with the index's own codebooks and scored through the **same** `PQVectors.precomputedScoreFunctionFor` decoder the graph rows were scored by, over a scratch `ImmutablePQVectors` sized to exactly those rows.

Two deliberate choices worth review attention:

- **Through the decoder, not reconstruct-and-compare.** The two are the same quantity in exact arithmetic, but the decoder assembles it from a partial-sums table in a different order, and for `COSINE` against the global centroid. A hand-rolled `decode()`+`compare()` equivalent was measured landing ~5e-4 away on a 0.113 distance - back on two measurably different scales, i.e. the original defect. This was caught by the test, not by inspection.
- **The exact scan stays, as a pruner.** Encoding costs a comparison against all `clusterCount` centroids of every subspace, order 256x one exact comparison, so quantizing the whole buffer would cost more than the search it feeds - on the one path whose contract is microseconds, over a buffer that runs to hundreds of thousands of entries under ingestion. Only the at-most-`k` survivors are re-scored. Cost is bounded by `k` regardless of buffer size and is exactly **zero** when the buffer is empty, which is the steady state this path targets. The scratch store is sized to `rescored * compressedVectorSize()` bytes rather than the 1024-vectors-per-chunk a growable store rounds up to.

Residue, documented in the method: selecting the head exactly and then ranking it approximately can move a row between adjacent ranks near the `k` boundary. That window is bounded by the PQ error already present in every graph candidate on this path.

The no-graph branch deliberately stays exact: every row in that answer comes from the buffer, so it is already on one scale, and quantizing would lose accuracy to buy a consistency that already holds.

## Item 3 - a per-query INFO log on the microsecond path

`Level.INFO`, unconditional, once per query, on the path whose entire reason to exist is microsecond latency - the message says "µs" while emitting it. Now `FINE`, matching every comparable summary on the neighbouring search methods.

## Item 4 - a degraded graph silently under-answering grouped queries

`findNeighborsFromVector` treats a short answer as possible evidence of a broken graph and falls back to a brute-force scan (#3722); the grouped path deliberately does not, because for a grouped search coming up short is normally just the cap doing its job. That left the genuinely-degraded case with no trace at all except the item 1 counter, which was by then unreliable for the reason above.

Addressed as the issue itself suggested - "no fallback, but a signal that tells this apart from a full cap": it now lands on `groupedSearchesGroupsUnavailable`, and the log line no longer prescribes `efSearch` for it.

## Test plan

- **`Issue6559GroupedSearchShortfallSignalTest`** (new): repeated queries over single-valued `groupBy` data must never touch the actionable counter while still being visible on the new one, on both the graph-walk and pre-filter plans.
- **`Issue6559ApproximateDeltaScoringScaleTest`** (new): puts a **bit-identical twin** of a graph vector into the delta buffer - same point, same true distance, so both must come back with the same number - and asserts that, on the main PQ path and the #6514 pre-filter plan. Both tests were verified to **fail on pre-fix code** (0.145 and 0.106 off respectively) and each carries an explicit guard asserting PQ is genuinely lossy on the fixture, so they cannot pass vacuously. The first draft of the fixture used vectors with a constant offset added, which made every vector nearly parallel under `COSINE` and every distance tie - the guard is what caught that.
- `Issue5761GroupedSearchGroupChoiceTest` and `Issue6514GroupedVectorPrefilterTest`: existing shortfall assertions updated to the counter that now covers their case, plus an assertion that the *other* counter stays untouched.
- 610 tests green across `com.arcadedb.index.vector.*` and `com.arcadedb.function.sql.vector.*`; 1514 green across all `com.arcadedb.index.**`.
- `mvn -o -pl engine -am test-compile` clean.

## Docs

`groupedSearchesGroupsUnavailable` is a new stat key on `getStats()` and worth a note in arcadedb-docs alongside the existing `groupedSearchesShortOfLimit` description, whose "raise efSearch" guidance is now conditional. Not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved approximate vector-search ranking when combining graph results with newly indexed data.
  * Improved grouped-search handling when fewer distinct groups are available than requested.
  * Added clearer metrics distinguishing unavailable groups from candidate-budget limitations.
  * Improved result sizing and exhaustion tracking for grouped and filtered searches.
* **Bug Fixes**
  * Improved consistency of product-quantized scoring across vector-search paths.
  * Added safeguards for accurate grouped-search results when data or filters limit available groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->