### PR TITLE
fix(#6569): decouple lint from test lanes, add a ci-status aggregator

### DIFF
--- a/.github/scripts/check-ci-status-completeness.py
+++ b/.github/scripts/check-ci-status-completeness.py
@@ -72,6 +72,15 @@ def needs_closure(jobs, name, seen=None):
 
 
 def is_aggregator(job_id):
+    """A job id counts as an aggregator by naming convention alone, not by inspecting what it does.
+
+    That is deliberate - there is nothing else in a job's YAML that reliably marks "this is the
+    required check for the workflow" - but it does mean any job whose id happens to end in
+    `-status` (e.g. a hypothetical `slack-notify-status` that only posts a message) is treated as
+    one and held to the same "needs everything" bar. Low risk while this repository is the only
+    caller and controls its own job ids; if that ever becomes a real collision, tighten this to an
+    explicit allowlist rather than a suffix match.
+    """
     return job_id == "ci-status" or job_id.endswith("-status")
 
 

--- a/.github/scripts/check-ci-status-completeness.py
+++ b/.github/scripts/check-ci-status-completeness.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+#
+# Fails when a workflow's status-aggregator job does not transitively depend on every other job in
+# the file.
+#
+# Context (issue #6569): when `setup` failed in mvn-test.yml, GitHub reported the fifteen jobs
+# behind it as `skipping` rather than `failure`. A `skipped` check reads as "nothing to worry about"
+# to a reviewer scanning the check list, and branch protection can be satisfied by a check that
+# never ran at all - a single missing trailing newline silently took the whole test suite offline
+# for every open PR until someone happened to investigate a red `setup` instead of assuming flake.
+#
+# The fix in mvn-test.yml is a final `ci-status` job with `if: always()` that reads
+# `needs.*.result` and fails the run whenever a job it depends on is anything but `success`,
+# turning "some required job never even ran" into one explicit, named failure instead of a
+# checklist row that looks the same as "passed".
+#
+# That only holds while the aggregator's `needs` actually reaches every job whose failure or skip
+# should be caught. It is very easy to add a new lane below `build-and-package` and forget to wire
+# it into the aggregator too - the omission is invisible until the exact incident this exists to
+# prevent happens again, for that one lane. This script makes the invariant enforced instead of
+# remembered:
+#
+#     a job named 'ci-status', or whose id ends in '-status', must transitively `need` every
+#     other job defined in the same workflow file.
+#
+# A workflow with no such job is not checked - not every workflow needs an aggregator, and this
+# only activates once one opts in by name.
+#
+# Usage:
+#   check-ci-status-completeness.py                 # check .github/workflows
+#   check-ci-status-completeness.py FILE|DIR ...    # check the given workflows
+#
+# @author Luca Garulli (l.garulli@arcadedata.com)
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - the workflow installs it explicitly
+    sys.exit("check-ci-status-completeness: PyYAML is required (pip install pyyaml)")
+
+
+def workflow_files(argv):
+    targets = [Path(a) for a in argv] or [Path(".github/workflows")]
+    files = []
+    for target in targets:
+        if target.is_dir():
+            files.extend(sorted(p for p in target.iterdir() if p.suffix in (".yml", ".yaml")))
+        else:
+            files.append(target)
+    return files
+
+
+def needs_of(job):
+    if not isinstance(job, dict):
+        return []
+    needs = job.get("needs")
+    if isinstance(needs, str):
+        return [needs]
+    return [n for n in needs if isinstance(n, str)] if isinstance(needs, list) else []
+
+
+def needs_closure(jobs, name, seen=None):
+    """Every job `name` transitively depends on, direct or indirect."""
+    seen = set() if seen is None else seen
+    for parent in needs_of(jobs.get(name) or {}):
+        if parent not in seen:
+            seen.add(parent)
+            needs_closure(jobs, parent, seen)
+    return seen
+
+
+def is_aggregator(job_id):
+    return job_id == "ci-status" or job_id.endswith("-status")
+
+
+def check(path):
+    """Violations in one workflow file, as printable strings."""
+    try:
+        document = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as error:
+        return [f"{path}: not parseable as YAML: {error}"]
+
+    if not isinstance(document, dict):
+        return []
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+    jobs = {job_id: job for job_id, job in jobs.items() if isinstance(job, dict)}
+
+    violations = []
+    for job_id in jobs:
+        if not is_aggregator(job_id):
+            continue
+
+        others = set(jobs) - {job_id}
+        if not others:
+            continue
+
+        missing = sorted(others - needs_closure(jobs, job_id))
+        if missing:
+            violations.append(
+                f"{path}: aggregator job '{job_id}' does not (transitively) need {missing}. "
+                f"A job left out here can fail or be skipped without '{job_id}' ever noticing, "
+                f"which is the exact failure mode issue #6569 exists to prevent - add {missing} to "
+                f"'{job_id}.needs' (directly, or via a job already in its closure)."
+            )
+    return violations
+
+
+def main():
+    violations = []
+    for path in workflow_files(sys.argv[1:]):
+        violations.extend(check(path))
+
+    if violations:
+        print("Status-aggregator jobs that do not cover every job in their workflow:\n")
+        for violation in violations:
+            print(f"  {violation}")
+        return 1
+
+    print("check-ci-status-completeness: every aggregator job covers its whole workflow")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -28,6 +28,7 @@ ALLOWLIST="$SCRIPTS/check-license-allowlist.py"
 DBDOCSSYNC="$SCRIPTS/check-database-docs-sync.py"
 CONTROLCHARS="$SCRIPTS/check-source-control-chars.py"
 NEEDSOUTPUTS="$SCRIPTS/check-workflow-needs-outputs.py"
+STATUSCOMPLETE="$SCRIPTS/check-ci-status-completeness.py"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -1251,6 +1252,95 @@ jobs:
 YAML
 expect "ignores a reference into a reusable-workflow job" 0 "" \
     "$NEEDSOUTPUTS" "$work/needs-reusable"
+
+echo "check-ci-status-completeness.py"
+
+# #6569's shape, minimal: an aggregator job that forgot to wait for one of its siblings, so that
+# sibling can fail or be skipped without the aggregator ever noticing.
+mkdir -p "$work/status-incomplete"
+cat >"$work/status-incomplete/ci.yml" <<'YAML'
+name: incomplete
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo building
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+  new-lane:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+  ci-status:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [ build, unit-tests ]
+    steps:
+      - run: echo status
+YAML
+expect "rejects an aggregator whose needs omit a sibling job" 1 "['new-lane']" \
+    "$STATUSCOMPLETE" "$work/status-incomplete"
+
+# The same workflow with `new-lane` added to the aggregator's `needs`: the only change that should
+# matter, same pairing technique as the needs-outputs fixtures above.
+mkdir -p "$work/status-complete"
+awk '/^    needs: \[ build, unit-tests \]$/{print "    needs: [ build, unit-tests, new-lane ]"; next} {print}' \
+    "$work/status-incomplete/ci.yml" >"$work/status-complete/ci.yml"
+expect "accepts the same workflow once the aggregator needs every job" 0 "" \
+    "$STATUSCOMPLETE" "$work/status-complete"
+
+# A job reached only transitively still counts: `ci-status` needing `unit-tests`, which itself needs
+# `build`, covers `build` without naming it directly - same closure semantics as the sibling
+# artifact-deps script, deliberately unlike check-workflow-needs-outputs.py's needs CONTEXT (which is
+# direct-only for an unrelated reason: see that script's own transitive-outputs fixture).
+mkdir -p "$work/status-transitive"
+cat >"$work/status-transitive/ci.yml" <<'YAML'
+name: transitive
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo building
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+  ci-status:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: unit-tests
+    steps:
+      - run: echo status
+YAML
+expect "accepts a job reached only transitively through the aggregator's needs" 0 "" \
+    "$STATUSCOMPLETE" "$work/status-transitive"
+
+# A workflow with no job named 'ci-status' or ending in '-status' opts out entirely: not every
+# workflow needs (or should be forced to have) an aggregator.
+mkdir -p "$work/status-no-aggregator"
+cat >"$work/status-no-aggregator/ci.yml" <<'YAML'
+name: no-aggregator
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo building
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+YAML
+expect "ignores a workflow with no status-aggregator job" 0 "" \
+    "$STATUSCOMPLETE" "$work/status-no-aggregator"
 
 echo
 if [[ $failures -gt 0 ]]; then

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -1342,6 +1342,45 @@ YAML
 expect "ignores a workflow with no status-aggregator job" 0 "" \
     "$STATUSCOMPLETE" "$work/status-no-aggregator"
 
+# `is_aggregator()` matches by naming convention, not just the literal 'ci-status' id: anything
+# ending in '-status' is held to the same bar.
+mkdir -p "$work/status-suffix-match"
+cat >"$work/status-suffix-match/ci.yml" <<'YAML'
+name: suffix-match
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo building
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+  gate-status:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: build
+    steps:
+      - run: echo status
+YAML
+expect "rejects an aggregator matched only by its '-status' suffix" 1 "gate-status" \
+    "$STATUSCOMPLETE" "$work/status-suffix-match"
+
+# A workflow this script cannot even parse is reported, not silently skipped - the same posture as
+# the sibling needs-outputs script's own YAML-error fixture.
+mkdir -p "$work/status-unparseable"
+cat >"$work/status-unparseable/ci.yml" <<'YAML'
+name: broken
+on: [push
+jobs:
+  ci-status:
+    runs-on: ubuntu-latest
+YAML
+expect "reports a workflow it cannot parse as YAML" 1 "not parseable as YAML" \
+    "$STATUSCOMPLETE" "$work/status-unparseable"
+
 echo
 if [[ $failures -gt 0 ]]; then
     echo "$failures of $checks checks failed"

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -19,7 +19,15 @@ permissions:
   contents: read
 
 jobs:
-  setup:
+  # Repo/workflow hygiene only: formatting, the meta-checks below, and the CI scripts' own self-test.
+  # None of it needs the code to build or the tests to run, and until #6569 it gated both anyway
+  # through `build-and-package`'s `needs: setup` - so a single unrelated formatting nit (a missing
+  # trailing newline that trips the end-of-file-fixer pre-commit hook, c816a66c7) took the entire
+  # test suite offline for every open PR, and did so as fifteen `skipping` checks rather than one
+  # named failure. This job is deliberately NOT a dependency of `build-and-package` or any test lane
+  # any more, so a lint failure here shows up as its own red check without ever silencing the tests.
+  # The `ci-status` job at the end of this file is what still catches it project-wide.
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,14 +42,17 @@ jobs:
           cache: "pip"
       # Every step below needs PyYAML, so it gets its own step rather than hiding inside the first
       # one that happens to run - reordering those would otherwise break the rest confusingly.
-      # Pinned for the same reason the actions here are pinned to a SHA: this job gates every other
-      # one, so what it installs should not change under it between runs.
+      # Pinned for the same reason the actions here are pinned to a SHA: this job used to gate every
+      # other one, and even now that it does not, what it installs should not change under it
+      # between runs.
       - name: Install workflow linting dependencies
         run: python3 -m pip install --quiet pyyaml==6.0.3
       - name: Check workflow artifact dependencies
         run: ./.github/scripts/check-workflow-artifact-deps.py
       - name: Check workflow needs outputs
         run: ./.github/scripts/check-workflow-needs-outputs.py
+      - name: Check CI status aggregator completeness
+        run: ./.github/scripts/check-ci-status-completeness.py
       - name: Check test reporter guards
         run: ./.github/scripts/check-test-reporter-guards.py
       - name: Check source files for raw control bytes
@@ -52,7 +63,6 @@ jobs:
 
   build-and-package:
     runs-on: ubuntu-latest
-    needs: setup
     # Seven downstream jobs pass `needs.build-and-package.outputs.image-tag` as
     # ARCADEDB_DOCKER_IMAGE, but this block did not exist, so all seven were handed an EMPTY string.
     # It went unnoticed because every consumer is defensive in a way that hides it: e2e-go guards
@@ -208,7 +218,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # A test that derives its path from SERVER_ROOT_PATH cannot be caught by the static grep in
-      # the setup job - only the directory it leaves behind proves it wrote outside target/.
+      # the lint job - only the directory it leaves behind proves it wrote outside target/.
       - name: Check no test leaked a databases/ directory
         run: ./.github/scripts/check-test-database-paths.sh --runtime
 
@@ -1262,7 +1272,7 @@ jobs:
   # the merge loses whenever that job is the slow one. ha-integration-tests was missing here and
   # takes ~55 minutes - the longest job in the workflow - so its reports were usually absent and
   # the whole ha-raft module was published as uncovered (#5701). check-workflow-artifact-deps.py
-  # in the setup job now enforces the rule for every workflow.
+  # in the lint job now enforces the rule for every workflow.
   coverage-report:
     runs-on: ubuntu-latest
     needs: [ unit-tests, integration-tests, slow-unit-tests, vector-unit-tests, opencypher-tck-tests, ha-integration-tests ]
@@ -1369,3 +1379,60 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ArcadeData/arcadedb
           verbose: true
+
+  # Single required check for the whole workflow (#6569). Every job below `build-and-package` skips
+  # when a job it needs fails, and GitHub reports that as `skipping` - a result that reads as
+  # benign to a reviewer scanning the check list, and that branch protection can be satisfied by
+  # without a single test having run. This job turns "some required job did not succeed, for any
+  # reason" into one explicit, named failure instead of a checklist row indistinguishable from a
+  # pass, so this is the one check to mark as required in branch protection.
+  #
+  # `needs` must list every job whose result matters, or a lane left out of it can fail or be
+  # skipped invisibly - the exact shape of this issue, for that one lane.
+  # check-ci-status-completeness.py (run in the `lint` job) enforces that this list stays complete.
+  #
+  # client-smoke-test is included so a build that never reached it (e.g. build-and-package failed)
+  # is still caught, but its own `continue-on-error: true` means a genuine smoke-test failure
+  # resolves to `success` here too - that job is deliberately non-blocking while the cross-repo
+  # arrangement is new (see its own comment), and this must not silently make it blocking again.
+  ci-status:
+    name: CI Status
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - lint
+      - build-and-package
+      - unit-tests
+      - slow-unit-tests
+      - vector-unit-tests
+      - opencypher-tck-tests
+      - integration-tests
+      - ha-integration-tests
+      - builder-tests
+      - java-e2e-tests
+      - js-e2e-tests
+      - client-smoke-test
+      - studio-e2e-tests
+      - python-e2e-tests
+      - csharp-e2e-tests
+      - go-e2e-tests
+      - coverage-report
+    steps:
+      - name: Check every required job succeeded
+        run: |
+          failed="$(echo '${{ toJSON(needs) }}' | jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"')"
+          if [ -n "$failed" ]; then
+            echo "::error::One or more required jobs did not succeed:"
+            {
+              echo "## CI Status: FAILED"
+              echo
+              echo "The following required jobs did not succeed. A \`skipped\` result usually means"
+              echo "an earlier required job failed and this lane never ran at all - see issue #6569."
+              echo
+              echo '```'
+              echo "$failed"
+              echo '```'
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "All required jobs succeeded."

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -1418,9 +1418,15 @@ jobs:
       - go-e2e-tests
       - coverage-report
     steps:
+      # NEEDS_JSON goes through env, not spliced straight into the script body: every value in
+      # `needs` today is a fixed job id or one of GitHub's result enum strings, but a future job
+      # output could put free-form text there, and env is what keeps that from ever becoming a
+      # script injection instead of just a jq parse.
       - name: Check every required job succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          failed="$(echo '${{ toJSON(needs) }}' | jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"')"
+          failed="$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"')"
           if [ -n "$failed" ]; then
             echo "::error::One or more required jobs did not succeed:"
             {

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -27,6 +27,10 @@ jobs:
   # named failure. This job is deliberately NOT a dependency of `build-and-package` or any test lane
   # any more, so a lint failure here shows up as its own red check without ever silencing the tests.
   # The `ci-status` job at the end of this file is what still catches it project-wide.
+  #
+  # The tradeoff: `build-and-package`'s multi-minute Docker build now always runs, even on a PR whose
+  # `lint` is going to fail anyway. Deliberate - a few wasted CI minutes on a lint-only failure beats
+  # a silent full-suite skip - but real, and worth remembering if this job's CI cost is ever questioned.
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Fixes #6569.

`setup` (repo/workflow lint + pre-commit hygiene checks) gated `build-and-package`, and every one of the fifteen downstream test lanes hangs off `build-and-package`. So a lint-only failure - concretely, a missing trailing newline that trips the `end-of-file-fixer` pre-commit hook (c816a66c7, #6468) - silently took the entire test suite offline for every open PR. GitHub reports the affected lanes as `skipping`, which reads as benign to a reviewer scanning the check list, and can satisfy branch protection without a single test having run.

The issue's own "suggested" list offers several partial options. This applies the strongest combination rather than picking one:

- **Decouple lint from the build/test gate.** `setup` is renamed to `lint` and dropped from `build-and-package`'s `needs`. A lint failure (formatting, workflow hygiene, pre-commit) now shows up as its own red check and runs in parallel with the build, instead of silently suppressing every real test.
- **Make "something upstream prevented tests from running" an explicit, named failure.** A new `ci-status` job waits on every other job in the workflow and fails with the offending job names whenever any of them is not `success` - so a `skipped` lane (for any reason, not just a lint failure) can never again pass as "nothing to worry about". This is the one check to mark as required in branch protection going forward.
- **Prevent the aggregator itself from silently rotting.** `check-ci-status-completeness.py` (new) fails the `lint` job if `ci-status`'s `needs` ever stops covering every job in the workflow - so adding a new lane and forgetting to wire it into the safety net is caught immediately instead of becoming the next #6569, for that one lane.

I deliberately did not adopt the issue's fourth suggestion (running pre-commit non-blocking / diff-only): softening enforcement isn't needed once lint no longer gates the tests, and it would weaken hygiene enforcement for no remaining benefit.

## Changes

- `.github/workflows/mvn-test.yml`: `setup` → `lint`, `build-and-package` no longer `needs` it, new `ci-status` aggregator job at the end.
- `.github/scripts/check-ci-status-completeness.py` (new): enforces that a `ci-status`-style aggregator job's `needs` transitively covers every job in its workflow.
- `.github/scripts/tests/test-ci-scripts.sh`: regression fixtures for the new script (rejects an incomplete aggregator, accepts a complete one, accepts transitive coverage, ignores workflows with no aggregator).

## Test plan

- [x] `check-workflow-artifact-deps.py`, `check-workflow-needs-outputs.py`, `check-test-reporter-guards.py`, and the new `check-ci-status-completeness.py` all pass against the modified `mvn-test.yml` and against every other workflow in the repo (no false positives).
- [x] `test-ci-scripts.sh` (all 84 checks, including 6 new ones for the new script) passes locally.
- [x] Verified the modified/added files satisfy the pre-commit hooks that actually apply outside `bindings/python/` (trailing whitespace, end-of-file newline, YAML parseability) - i.e., this PR doesn't reproduce the byte that caused #6569 in the first place.
- [x] Simulated the `ci-status` job's `jq` filter against synthetic `needs` payloads (all-success → passes silently; a skipped job → fails with the job name and a step-summary explanation).
- [x] `lint` and `build-and-package` ran as separate, parallel checks on this PR's own CI run, confirming the decoupling works end to end (not just in the meta-checks).

## Manual follow-up needed (not in this diff)

`setup` is renamed to `lint`, and the required check to protect going forward is the new `CI Status` (`ci-status`) job. If branch protection on `main` currently names `setup` (or any individual downstream lane) as a required status check, whoever has admin access should repoint it at `CI Status` after this merges - otherwise a rule pointing at the old name can never be satisfied again, or removing it without replacing it re-opens exactly the gap this PR closes. Called out here per code review since it's invisible in the diff and easy to forget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated validation to ensure workflow status checks cover all required jobs.
  - Added an always-running CI status report for failed or skipped required checks.
  - Published the latest Docker image for downstream end-to-end testing.

- **Bug Fixes**
  - Improved workflow execution so packaging and test jobs are not unnecessarily blocked by preparatory checks.

- **Tests**
  - Added coverage for incomplete, complete, transitive, and invalid workflow configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
