### PR TITLE
fix(#6568): a wait for a task on a dedicated pool reclaims it instead of parking

### DIFF
--- a/.claude/skills/engine-concurrency/SKILL.md
+++ b/.claude/skills/engine-concurrency/SKILL.md
@@ -52,9 +52,10 @@ Used sparingly, only for publish-side serialization:
 
 ## Metrics (Micrometer)
 
-- `PoolMetrics` MeterBinder registers six gauges per pool with a `pool=<name>` tag: `size`, `active`, `queue_depth`, `queue_capacity_remaining`, `completed_tasks`, `caller_run_fallbacks`.
+- `PoolMetrics` MeterBinder registers seven gauges per pool with a `pool=<name>` tag: `size`, `active`, `queue_depth`, `queue_capacity_remaining`, `completed_tasks`, `caller_run_fallbacks`, `reclaimed`.
 - Studio surfaces these via the "Executor Pools" card on the Server tab (live numbers).
 - A sustained non-zero `caller_run_fallbacks` indicates pool saturation; the engine logs a throttled WARNING the first time and at most once per 60 s afterward.
+- `reclaimed` is NOT a fault signal and is not warned about: it counts queued tasks a caller about to wait for them ran itself (`runQueuedTaskOnCaller`, issue #6568). It says the pool was busy, where `caller_run_fallbacks` says it was full.
 
 ## The shared base: `com.arcadedb.utility.DedicatedThreadPool`
 
@@ -76,6 +77,29 @@ That is the checklist below being enforced rather than remembered.
 Each pool's REASONS stay in its own class javadoc - why blocking producers may not share a pool with non-blocking
 compute, why dispatched DDL cannot run on an async worker, why a sparse-vector fan-out must not nest.
 
+## Waiting for a task on a pool your thread may itself be running on (#6568)
+
+**Never park on it. Reclaim it.**
+
+The caller-runs saturation policy is routinely mistaken for the deadlock guarantee here, and it is not one: it fires
+only when the queue is **full**. A queue with a thousand free slots accepts the task, parks the submitter, and the
+deadlock is that both workers and submitters are now parked on tasks nobody is left to run. Every blocking fan-out has
+that shape by construction as soon as two of them nest, and the failure presents as a lane timeout with no failing
+assertion - which is how #6568 arrived, as a wedged `ParallelScanSafetyTest`.
+
+- `DedicatedThreadPool.runQueuedTaskOnCaller(task)` takes a task the queue accepted but no worker has started back out
+  and runs it on the calling thread. `ThreadPoolExecutor.remove` succeeding is the proof no worker has it, so it runs
+  exactly once. It counts into `PoolStats.reclaimedTasks()`.
+- `GraphAlgorithms.awaitFutures(futures, count[, pool])` is the ready-made reclaiming wait, and is what
+  `parallelForRange`, `GAVFusedChainOperator` and `PartitionedTriangleOp` use. Prefer it over a bare `Future.get()`
+  loop for anything submitted to a `DedicatedThreadPool`.
+- "The caller runs chunk 0 itself" (`parallelForRange`, `PartitionedTriangleOp`) is a latency optimisation, not the
+  liveness argument. It does not stop chunks 1..N-1 from queueing behind parked workers.
+- The other shape that is safe is refusing to nest at all, as `SparseVectorScoringPool.isPoolThread()` does. Use it
+  when the nested fan-out has no value; use the reclaiming wait when it does.
+- A reclaimed task runs with the CALLER's thread-locals (`DatabaseContext`, transaction, principal). That is the same
+  exposure caller-runs already has, so nothing on a caller-runs pool may depend on running on a worker thread.
+
 ## When adding new parallelism to engine code
 
 1. Pick the right home pool (`QueryEngineManager` for query-time, `SparseVectorScoringPool` if scoping to sparse vectors, etc.). If none fits, justify a new pool and add a `PoolMetrics` binding for it.
@@ -84,3 +108,4 @@ compute, why dispatched DDL cannot run on an async worker, why a sparse-vector f
 4. Throttled WARNING on saturation (60-second window, `WARN_THROTTLE_INTERVAL_MS`) so operators notice without getting spammed.
 5. Wire the pool into `PoolMetrics` so the Studio "Executor Pools" card shows it.
 6. If using the JDK common ForkJoinPool is unavoidable in the short term, tag the call site with a `NOTE (concurrency)` comment pointing at this skill so the migration stays tracked.
+7. If the submitting thread then WAITS for what it submitted, wait with `GraphAlgorithms.awaitFutures` (or reclaim by hand) rather than `Future.get()`. See the #6568 section above - the caller-runs policy is not the guarantee.

--- a/.claude/skills/engine-concurrency/SKILL.md
+++ b/.claude/skills/engine-concurrency/SKILL.md
@@ -89,7 +89,12 @@ assertion - which is how #6568 arrived, as a wedged `ParallelScanSafetyTest`.
 
 - `DedicatedThreadPool.runQueuedTaskOnCaller(task)` takes a task the queue accepted but no worker has started back out
   and runs it on the calling thread. `ThreadPoolExecutor.remove` succeeding is the proof no worker has it, so it runs
-  exactly once. It counts into `PoolStats.reclaimedTasks()`.
+  exactly once. It counts into `PoolStats.reclaimedTasks()` (and, like a caller-runs fallback, NOT into
+  `completedTasks` - no pool thread ran it).
+- It runs the task through `runRejectedTask`, the same hook a caller-runs rejection uses, so a reclaim and a fallback
+  are the same execution for every pool. That is what a subclass override has to be able to rely on: `AsyncCommandPool`
+  marks the borrowed thread as one of its own there, and the async barrier reads that mark to avoid waiting for the
+  command it is itself running. A new override on that hook must therefore be correct for BOTH paths.
 - `GraphAlgorithms.awaitFutures(futures, count[, pool])` is the ready-made reclaiming wait, and is what
   `parallelForRange`, `GAVFusedChainOperator` and `PartitionedTriangleOp` use. Prefer it over a bare `Future.get()`
   loop for anything submitted to a `DedicatedThreadPool`.

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -171,10 +171,10 @@ public final class GraphAlgorithms {
         // Defensive: a caller that partially populated the array must not NPE the whole await.
         continue;
       try {
-        // Deadlock avoidance, not an optimisation: see the #6568 note above. Skipped for a future already
-        // resolved, so the common uncontended case never pays for the queue scan.
-        if (pool != null && !futures[i].isDone() && futures[i] instanceof Runnable queued)
-          pool.runQueuedTaskOnCaller(queued);
+        // Deadlock avoidance, not an optimisation: see the #6568 note above. Reclaim only the chunk about to be
+        // waited on, PER INDEX, rather than sweeping the whole batch out of the queue up front - see
+        // reclaimQueuedChunk for why the greedier version is worse.
+        reclaimQueuedChunk(futures[i], pool);
         futures[i].get();
       } catch (final ExecutionException e) {
         if (firstError == null)
@@ -199,6 +199,35 @@ public final class GraphAlgorithms {
         throw er;
       throw new RuntimeException(firstError);
     }
+  }
+
+  /**
+   * Runs ONE chunk on the waiting thread if the pool has accepted it but not started it. Called per index from the
+   * wait above, immediately before that index is blocked on.
+   * <p>
+   * <b>Why per index and not a sweep of the whole batch up front.</b> The greedier version looks strictly better -
+   * the caller is about to block anyway, so why leave siblings queued - and it is not: the pool's threads are
+   * created lazily, so a fan-out that submits every chunk and awaits at once (both {@code GAVFusedChainOperator}
+   * paths do) would find its own chunks still queued and run them ITSELF, serialising a fan-out that was about to
+   * become parallel a microsecond later. Per index cannot do that for more than one chunk: reaching index i means
+   * every earlier chunk has finished, by which time the workers have long since drained the queue.
+   * <p>
+   * It costs nothing in liveness, which is the only thing that has to be guaranteed. If {@code futures[i]} is
+   * running rather than queued, some worker is making progress on it, and that worker reclaims its own nested work
+   * when it waits - which is exactly what the induction in the javadoc above rests on. The waiter can be idle
+   * while a sibling sits queued; it can never be deadlocked.
+   * <p>
+   * Costs nothing when there is nothing to reclaim either: an already-resolved future is skipped, and an empty
+   * queue is one {@code AtomicInteger} read inside {@code runQueuedTaskOnCaller}.
+   * <p>
+   * The {@code instanceof Runnable} gate is what {@code submit()} guarantees - {@code AbstractExecutorService}
+   * queues the very {@code RunnableFuture} it returns. A caller that hands in a future it wrapped (a derived
+   * {@code CompletableFuture}, say) silently loses reclaiming and gets the old parking behaviour back, which is
+   * why the fan-outs pass the array {@code submit()} gave them and nothing else.
+   */
+  private static void reclaimQueuedChunk(final Future<?> future, final DedicatedThreadPool pool) {
+    if (pool != null && !future.isDone() && future instanceof Runnable queued)
+      pool.runQueuedTaskOnCaller(queued);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -29,6 +29,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.Arrays;
 import java.util.PriorityQueue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -180,16 +181,17 @@ public final class GraphAlgorithms {
         if (firstError == null)
           firstError = e.getCause();
       } catch (final InterruptedException e) {
-        for (int j = i; j < count; j++)
-          if (futures[j] != null)
-            futures[j].cancel(true);
         Thread.currentThread().interrupt();
-        final CommandExecutionException interrupted = new CommandExecutionException(
-            "Parallel graph computation interrupted, partial results discarded");
-        if (firstError != null)
-          // A chunk had already failed before the interrupt: keep its cause for diagnostics.
-          interrupted.addSuppressed(firstError);
-        throw interrupted;
+        throw abort(futures, count, i, firstError, "interrupted");
+      } catch (final CancellationException e) {
+        // A chunk whose future was cancelled rather than run, which on this path means the pool was SHUT DOWN
+        // (#4961: a caller-runs rejection and, since #6568, a reclaim both cancel instead of running there, so
+        // that nobody is left waiting for a task no worker will ever take). Server shutdown with a query still
+        // in flight is exactly when it fires. Handled like the interrupt: without this the CancellationException
+        // - a RuntimeException neither clause below caught - unwound this frame while the remaining chunks kept
+        // running and writing into the caller's per-chunk arrays behind its back, which is the leak #4951 closed
+        // for the interrupt and left open here.
+        throw abort(futures, count, i, firstError, "cancelled, the executor was shut down");
       }
     }
     if (firstError != null) {
@@ -199,6 +201,30 @@ public final class GraphAlgorithms {
         throw er;
       throw new RuntimeException(firstError);
     }
+  }
+
+  /**
+   * Cancels every chunk this wait has not yet collected and builds the exception that replaces the partial result.
+   * <p>
+   * The guarantee both callers need (#4951): a fan-out that ends early must not leave background chunks running,
+   * because they keep writing into the per-chunk arrays the caller is about to abandon, and it must never let a
+   * truncated result be read as a complete one.
+   *
+   * @param from       the index the wait stopped at; everything from here on is still outstanding
+   * @param firstError a chunk failure seen before the abort, kept as a suppressed cause rather than lost
+   * @param why        what ended the wait, for the message
+   */
+  private static CommandExecutionException abort(final Future<?>[] futures, final int count, final int from,
+      final Throwable firstError, final String why) {
+    for (int j = from; j < count; j++)
+      if (futures[j] != null)
+        futures[j].cancel(true);
+
+    final CommandExecutionException aborted = new CommandExecutionException(
+        "Parallel graph computation " + why + ", partial results discarded");
+    if (firstError != null)
+      aborted.addSuppressed(firstError);
+    return aborted;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -168,6 +168,15 @@ public final class GraphAlgorithms {
   public static void awaitFutures(final Future<?>[] futures, final int count, final DedicatedThreadPool pool) {
     Throwable firstError = null;
     for (int i = 0; i < count; i++) {
+      // The interrupt is checked BEFORE the reclaim below, not left to get() alone. A reclaimed chunk runs inline,
+      // and FutureTask.run() does not consult the interrupt flag, so an already-interrupted waiter would run the
+      // chunk to completion, find its get() returning normally (the future IS done), and go on to run every
+      // remaining chunk the same way - returning normally, with the flag still set, from a wait that was supposed
+      // to abort. That is #4951's guarantee (a killed or timed-out query must never merge partial results and call
+      // them complete) undone by the reclaim, so the check is part of the fix rather than a tidy-up.
+      if (Thread.currentThread().isInterrupted())
+        throw abort(futures, count, i, firstError, "interrupted");
+
       if (futures[i] == null)
         // Defensive: a caller that partially populated the array must not NPE the whole await.
         continue;
@@ -194,6 +203,11 @@ public final class GraphAlgorithms {
         throw abort(futures, count, i, firstError, "cancelled, the executor was shut down");
       }
     }
+    // An interrupt that landed while the LAST chunk was being reclaimed has no further get() to surface it: the
+    // loop condition ends first. Without this the wait would return normally from work that was already abandoned.
+    if (Thread.currentThread().isInterrupted())
+      throw abort(futures, count, count, firstError, "interrupted");
+
     if (firstError != null) {
       if (firstError instanceof RuntimeException re)
         throw re;
@@ -206,7 +220,7 @@ public final class GraphAlgorithms {
   /**
    * Cancels every chunk this wait has not yet collected and builds the exception that replaces the partial result.
    * <p>
-   * The guarantee both callers need (#4951): a fan-out that ends early must not leave background chunks running,
+   * The guarantee every caller needs (#4951): a fan-out that ends early must not leave background chunks running,
    * because they keep writing into the per-chunk arrays the caller is about to abandon, and it must never let a
    * truncated result be read as a complete one.
    *

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.Vertex.DIRECTION;
 
 import com.arcadedb.query.QueryEngineManager;
+import com.arcadedb.utility.DedicatedThreadPool;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -136,14 +137,44 @@ public final class GraphAlgorithms {
    * a {@link CommandExecutionException} is thrown, with the interrupt flag preserved for the caller.
    * Public because the parallel Cypher operators (GAV fused chain, partitioned triangle count) reuse
    * it for the same guarantee.
+   * <p>
+   * #6568: it also RECLAIMS - a chunk still queued on the query pool is run on this thread rather than waited for,
+   * which is what makes the wait deadlock-free instead of relying on every caller running a chunk itself. See the
+   * {@link #awaitFutures(Future[], int, DedicatedThreadPool)} overload for why the caller-runs policy is not that
+   * guarantee.
    */
   public static void awaitFutures(final Future<?>[] futures, final int count) {
+    awaitFutures(futures, count, QueryEngineManager.getInstance());
+  }
+
+  /**
+   * {@link #awaitFutures(Future[], int)} for a fan-out submitted to a pool other than the query-parallelism one.
+   * <p>
+   * <b>#6568: the wait RECLAIMS before it parks.</b> Every future still sitting in {@code pool}'s queue is taken
+   * back out and run on this thread rather than waited for. That is what makes the fan-out deadlock-free rather
+   * than merely usually-fine: a caller that parks on a queued task while every worker is itself parked on a queued
+   * task can never be woken by anything, and the bounded queue's caller-runs policy does not save it - the policy
+   * only fires when the queue is FULL, and a queue with free slots quietly accepts the task and parks the
+   * submitter. Reclaiming means the waiter always has work it can make progress on, so by induction on nesting
+   * depth the whole fan-out completes. See {@link DedicatedThreadPool#runQueuedTaskOnCaller(Runnable)}.
+   * <p>
+   * A reclaimed task runs to completion inside {@code run()} and records its outcome in its own future, so the
+   * {@code get()} below still surfaces its exception exactly as if a worker had run it.
+   *
+   * @param pool the pool the futures were submitted to, or null to skip reclaiming (a foreign future is simply
+   *             never found in the queue, so passing the wrong pool costs a queue scan and nothing else)
+   */
+  public static void awaitFutures(final Future<?>[] futures, final int count, final DedicatedThreadPool pool) {
     Throwable firstError = null;
     for (int i = 0; i < count; i++) {
       if (futures[i] == null)
         // Defensive: a caller that partially populated the array must not NPE the whole await.
         continue;
       try {
+        // Deadlock avoidance, not an optimisation: see the #6568 note above. Skipped for a future already
+        // resolved, so the common uncontended case never pays for the queue scan.
+        if (pool != null && !futures[i].isDone() && futures[i] instanceof Runnable queued)
+          pool.runQueuedTaskOnCaller(queued);
         futures[i].get();
       } catch (final ExecutionException e) {
         if (firstError == null)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVFusedChainOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVFusedChainOperator.java
@@ -212,6 +212,9 @@ public class GAVFusedChainOperator extends AbstractPhysicalOperator {
       }
       // #4951: awaitFutures throws on interrupt (cancelling the outstanding chunks) instead of returning,
       // so a killed/timed-out query can never merge partial per-thread results as a complete answer.
+      // #6568: it also RECLAIMS, which is what lets this fan-out submit EVERY chunk - unlike parallelForRange
+      // and PartitionedTriangleOp, which keep chunk 0 on the caller for latency. A chunk still queued when the
+      // wait begins is run here rather than waited for, so the caller can never park behind busy workers.
       GraphAlgorithms.awaitFutures(futures, launched);
       threadCount = launched;
     }
@@ -292,6 +295,7 @@ public class GAVFusedChainOperator extends AbstractPhysicalOperator {
       }
       // #4951: awaitFutures throws on interrupt (cancelling the outstanding chunks) instead of returning,
       // so a killed/timed-out query can never merge partial per-thread maps as a complete answer.
+      // #6568: and it reclaims a still-queued chunk instead of parking on it - see the note on the DFS path.
       GraphAlgorithms.awaitFutures(futures, launched);
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
@@ -102,8 +102,10 @@ public final class PartitionedTriangleOp implements CountOp {
       // #4952: the calling thread runs chunk 0 itself (same discipline as GraphAlgorithms.parallelForRange)
       // instead of submitting ALL chunks and blocking. Submitting everything meant that, when this operator
       // was reached from a pool thread (or with the pool full of blocked producers), the caller waited on
-      // tasks queued behind threads that were themselves waiting: a pool-starvation deadlock only mitigated
-      // by the bounded queue's caller-runs rejection.
+      // tasks queued behind threads that were themselves waiting: a pool-starvation deadlock.
+      // #6568: the caller-runs rejection was never the mitigation it was taken for - it fires only once the
+      // queue is FULL. What makes the wait below safe is that awaitFutures RECLAIMS a still-queued chunk and
+      // runs it here; chunk 0 on the caller is now a latency win rather than the liveness argument.
       // #5063: chunk 0 runs inside try/finally so the submitted chunks are ALWAYS awaited.
       // Without it, a chunk-0 exception unwound this frame while chunks 1..N-1 kept running and writing
       // into partialCounts (and holding pool threads) behind the caller's back.

--- a/engine/src/main/java/com/arcadedb/utility/DedicatedThreadPool.java
+++ b/engine/src/main/java/com/arcadedb/utility/DedicatedThreadPool.java
@@ -159,7 +159,9 @@ public abstract class DedicatedThreadPool {
    *                               growth means the pool is undersized for the workload
    * @param reclaimedTasks         cumulative tasks a thread about to wait for them took back out of the queue and ran
    *                               itself, see {@link #runQueuedTaskOnCaller(Runnable)}. Not a fault: it is the pool
-   *                               being busy rather than full, and the waiter being the one thread with nothing to do
+   *                               being busy rather than full, and the waiter being the one thread with nothing to do.
+   *                               Like a caller-runs fallback, and for the same reason, a reclaimed task is counted
+   *                               here and NOT by {@code completedTasks} - no pool thread ran it
    */
   public record PoolStats(int poolSize, int activeThreads, int queueDepth, int queueCapacityRemaining,
                           long completedTasks, long callerRunFallbacks, long reclaimedTasks) {
@@ -273,19 +275,29 @@ public abstract class DedicatedThreadPool {
    * with the caller's thread-locals ({@code DatabaseContext}, transaction bindings, security principal) - which is
    * not a new exposure for any pool with a caller-runs policy, because a rejected task already runs there.
    * <p>
+   * <b>And it runs through {@link #runRejectedTask(Runnable)}, not through a bare {@code task.run()}</b>, so a
+   * reclaim and a caller-runs fallback are the same execution for every pool rather than only for the pools that
+   * do no bookkeeping. {@code AsyncCommandPool} overrides that hook to mark the borrowed thread as one of its own
+   * for the duration, and everything that asks "is this thread itself a dispatched command?" - the async barrier
+   * in {@code DatabaseAsyncExecutorImpl.waitCompletion} above all - has to get the same answer on a reclaimed
+   * task as on a rejected one, or the reclaim reintroduces the self-deadlock that override exists to prevent.
+   * The hook is also what makes a reclaim from a SHUT-DOWN pool end the caller's wait (#4961) instead of leaving
+   * it holding a task the queue no longer has and no worker will run.
+   * <p>
    * Cheap when there is nothing to reclaim: the queue-empty check is one {@code AtomicInteger} read, and only a
    * non-empty queue pays for {@code remove}'s scan.
    *
    * @param task the task to reclaim, i.e. the {@link RunnableFuture} {@code submit()} returned
    *
-   * @return true when the task was reclaimed and has now RUN TO COMPLETION on the calling thread
+   * @return true when the task was taken out of the queue and disposed of here - run to completion, or, on a
+   * shut-down pool whose policy says so, cancelled. Either way the caller's wait for it will not park.
    */
   public final boolean runQueuedTaskOnCaller(final Runnable task) {
     if (task == null || executor.getQueue().isEmpty() || !executor.remove(task))
       return false;
 
     reclaimedTaskCount.incrementAndGet();
-    task.run();
+    runRejectedTask(task);
     return true;
   }
 
@@ -312,9 +324,12 @@ public abstract class DedicatedThreadPool {
   }
 
   /**
-   * Runs a task the queue refused. Overridable for a pool that has to mark the borrowed thread for the duration -
-   * the submitter IS one of this pool's tasks while it runs one, and everything that asks has to get that answer
-   * there too.
+   * Runs a task the queue refused, or one {@link #runQueuedTaskOnCaller(Runnable)} took back out of it. Overridable
+   * for a pool that has to mark the borrowed thread for the duration - the submitter IS one of this pool's tasks
+   * while it runs one, and everything that asks has to get that answer there too.
+   * <p>
+   * Both paths come through here on purpose: a reclaim borrows the caller's thread exactly as a rejection does, so a
+   * subclass that has to know about one has to know about the other.
    */
   protected void runRejectedTask(final Runnable task) {
     if (saturationPolicy == SaturationPolicy.CALLER_RUNS_EVEN_WHEN_SHUT_DOWN || !executor.isShutdown())

--- a/engine/src/main/java/com/arcadedb/utility/DedicatedThreadPool.java
+++ b/engine/src/main/java/com/arcadedb/utility/DedicatedThreadPool.java
@@ -51,6 +51,12 @@ import java.util.logging.Level;
  * <p>
  * <b>"No JDK common ForkJoinPool" rule.</b> See {@code com.arcadedb.query.QueryEngineManager}'s class javadoc. Every
  * pool built here exists because of it.
+ * <p>
+ * <b>Waiting for a task on the pool you are running on.</b> Never park on it - reclaim it. A thread that blocks on a
+ * task it submitted to a pool whose workers can block the same way deadlocks as soon as the workers outnumber the
+ * free ones, and the caller-runs policy does NOT prevent it: the queue accepts long before it rejects.
+ * {@link #runQueuedTaskOnCaller(Runnable)} is the primitive, {@code GraphAlgorithms.awaitFutures} the ready-made
+ * wait that uses it, and issue #6568 the write-up.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -93,6 +99,13 @@ public abstract class DedicatedThreadPool {
   private final boolean    boundedQueue;
   private final AtomicLong callerRunCount       = new AtomicLong();
   /**
+   * Tasks {@link #runQueuedTaskOnCaller(Runnable)} took back out of the queue for a thread that was about to wait
+   * for them. Counted separately from {@link #callerRunCount} because the two say opposite things about the pool:
+   * a caller-runs fallback means the pool was FULL, a reclaim means the pool was BUSY and the waiter had a whole
+   * thread's worth of nothing to do.
+   */
+  private final AtomicLong reclaimedTaskCount   = new AtomicLong();
+  /**
    * Initialised to {@code 0L} and not {@code Long.MIN_VALUE}: the throttle below subtracts it from
    * {@code System.currentTimeMillis()}, and {@code MIN_VALUE} would overflow that subtraction and silently suppress
    * the first-ever warning - the one that matters most.
@@ -129,7 +142,7 @@ public abstract class DedicatedThreadPool {
 
   /**
    * Point-in-time snapshot of a pool's load, read by the metrics binder ({@code pool=<name>} gauges, Studio's
-   * "Executor Pools" card) and by tests. The six values are read under no lock and are not mutually consistent - the
+   * "Executor Pools" card) and by tests. The values are read under no lock and are not mutually consistent - the
    * pool may transition between two of them - but each individual reading is safe.
    *
    * @param poolSize               live thread count. Can be below the configured maximum when no work has needed the
@@ -144,9 +157,12 @@ public abstract class DedicatedThreadPool {
    *                               under caller-runs is counted by the next field and not by this one
    * @param callerRunFallbacks     cumulative tasks the rejection policy redirected to the submitting thread. Sustained
    *                               growth means the pool is undersized for the workload
+   * @param reclaimedTasks         cumulative tasks a thread about to wait for them took back out of the queue and ran
+   *                               itself, see {@link #runQueuedTaskOnCaller(Runnable)}. Not a fault: it is the pool
+   *                               being busy rather than full, and the waiter being the one thread with nothing to do
    */
   public record PoolStats(int poolSize, int activeThreads, int queueDepth, int queueCapacityRemaining,
-                          long completedTasks, long callerRunFallbacks) {
+                          long completedTasks, long callerRunFallbacks, long reclaimedTasks) {
   }
 
   /**
@@ -238,6 +254,41 @@ public abstract class DedicatedThreadPool {
     runRejectedTask(task);
   }
 
+  /**
+   * Takes a task this pool has ACCEPTED BUT NOT STARTED back out of its queue and runs it on the calling thread,
+   * for a caller that is about to block waiting for exactly that task. Returns {@code false}, having done nothing,
+   * when the task is not (or no longer) queued - it is already running on a worker, has finished, or never reached
+   * the queue at all because the rejection policy ran it inline.
+   * <p>
+   * <b>This is what makes a blocking fan-out on a dedicated pool deadlock-free (issue #6568).</b> The caller-runs
+   * saturation policy is often mistaken for that guarantee, and it is not: it only fires once the queue is FULL,
+   * and a queue with 1024 free slots accepts the task, parks the submitter, and leaves it there. If every worker is
+   * itself a thread parked on a task it submitted, nothing in the pool can ever run again - the exact shape
+   * {@code ParallelScanSafetyTest} hit with a latch, and the shape every nested fan-out has by construction. A
+   * waiter that reclaims first cannot be part of such a cycle: it always has work of its own it can make progress
+   * on, so by induction on nesting depth the whole fan-out completes.
+   * <p>
+   * <b>Safety.</b> {@link ThreadPoolExecutor#remove(Runnable)} succeeding is proof that no worker had taken the
+   * task, so it runs exactly once here and never concurrently with a worker. The task runs on the caller's thread
+   * with the caller's thread-locals ({@code DatabaseContext}, transaction bindings, security principal) - which is
+   * not a new exposure for any pool with a caller-runs policy, because a rejected task already runs there.
+   * <p>
+   * Cheap when there is nothing to reclaim: the queue-empty check is one {@code AtomicInteger} read, and only a
+   * non-empty queue pays for {@code remove}'s scan.
+   *
+   * @param task the task to reclaim, i.e. the {@link RunnableFuture} {@code submit()} returned
+   *
+   * @return true when the task was reclaimed and has now RUN TO COMPLETION on the calling thread
+   */
+  public final boolean runQueuedTaskOnCaller(final Runnable task) {
+    if (task == null || executor.getQueue().isEmpty() || !executor.remove(task))
+      return false;
+
+    reclaimedTaskCount.incrementAndGet();
+    task.run();
+    return true;
+  }
+
   /** " Raise 'a' or 'b' if this persists.", or nothing when the pool has no sizing settings to name. */
   private static String raiseSettingsAdvice(final GlobalConfiguration[] sizingSettingKeys) {
     if (sizingSettingKeys.length == 0)
@@ -289,7 +340,7 @@ public abstract class DedicatedThreadPool {
   public PoolStats getPoolStats() {
     return new PoolStats(executor.getPoolSize(), executor.getActiveCount(), executor.getQueue().size(),
         boundedQueue ? executor.getQueue().remainingCapacity() : -1, executor.getCompletedTaskCount(),
-        callerRunCount.get());
+        callerRunCount.get(), reclaimedTaskCount.get());
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
@@ -153,6 +153,13 @@ class Issue6568NestedFanOutDeadlockTest {
    * Pinning discipline, as {@code QueryEngineManagerPoolTest} documents it: the pool is JVM-wide, the release latch
    * is counted down in a {@code finally} with no assertion before the {@code try}, and the test waits for the
    * workers to drain before returning so it cannot hand the next test class a busy pool.
+   * <p>
+   * <b>What that discipline rests on</b>, said out loud because it is a fact about the BUILD and not about this
+   * file: Surefire runs this project's test classes sequentially ({@code forkCount} 1, no {@code parallel} mode,
+   * and no {@code junit.jupiter.execution.parallel.enabled} in {@code junit-platform.properties}), so nothing else
+   * is using the shared pool while every one of its workers is pinned here. Enabling parallel test execution would
+   * make this class - and every other one that pins this singleton - able to wedge an unrelated test, so that
+   * change needs a home for these tests first. Same caveat {@code ParallelScanSafetyTest} carries.
    */
   @Test
   @Timeout(value = HANG_DETECTOR_SECONDS, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.graph.olap;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.QueryEngineManager;
 import com.arcadedb.utility.DedicatedThreadPool;
 import com.arcadedb.utility.StallAwareStopwatch;
@@ -37,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for #6568: a thread that waits for a task it submitted to a dedicated pool must RECLAIM that task
@@ -202,6 +204,53 @@ class Issue6568NestedFanOutDeadlockTest {
     final Future<?> canary = executor.submit(() -> null);
     assertThat(awaited(canary, WORKER_PIN_MS)).as("the query pool must be running work on its own threads again")
         .isTrue();
+  }
+
+  /**
+   * A pool shut down with a fan-out still in flight - server shutdown while a query is running - must END the wait
+   * and take the outstanding chunks down with it, never let a CancellationException unwind the caller while the
+   * rest of the batch keeps writing into arrays it has abandoned.
+   * <p>
+   * The reclaim is what makes this reachable rather than theoretical: on a shut-down CALLER_RUNS pool
+   * {@code runRejectedTask} cancels the task instead of running it (#4961, so that nobody waits for a task no
+   * worker will take), and {@code Future.get()} then throws CancellationException - a RuntimeException that used
+   * to escape {@code awaitFutures} through neither of its catch clauses. Same leak #4951 closed for the interrupt.
+   */
+  @Test
+  @Timeout(value = HANG_DETECTOR_SECONDS, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  void aFanOutOnAShutDownPoolFailsAndCancelsTheChunksItLeavesBehind() throws Exception {
+    final FanOutPool pool = new FanOutPool(1);
+    final CountDownLatch pinWorker = new CountDownLatch(1);
+    final CountDownLatch workerPinned = new CountDownLatch(1);
+    try {
+      final ExecutorService executor = pool.getExecutorService();
+      executor.submit(() -> {
+        workerPinned.countDown();
+        pinWorker.await();
+        return null;
+      });
+      assertThat(awaited(workerPinned, WORKER_PIN_MS)).isTrue();
+
+      final AtomicInteger ran = new AtomicInteger();
+      final Future<?>[] chunks = { executor.submit(ran::incrementAndGet), executor.submit(ran::incrementAndGet) };
+
+      // shutdown() and not close(): shutdownNow() DRAINS the queue, which would leave nothing to reclaim and so
+      // test a different thing entirely. A graceful shutdown keeps the queued chunks exactly where they are.
+      executor.shutdown();
+
+      assertThatThrownBy(() -> GraphAlgorithms.awaitFutures(chunks, 2, pool))
+          .as("a shut-down pool must fail the fan-out, not leak a CancellationException past it")
+          .isInstanceOf(CommandExecutionException.class)
+          .hasMessageContaining("cancelled").hasMessageContaining("partial results discarded");
+
+      assertThat(chunks[1].isCancelled())
+          .as("the chunk the wait never reached must be cancelled, not left to run behind the caller's back")
+          .isTrue();
+      assertThat(ran.get()).as("a shut-down pool must not run a reclaimed chunk on the caller either").isZero();
+    } finally {
+      pinWorker.countDown();
+      pool.close();
+    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
@@ -21,16 +21,18 @@ package com.arcadedb.graph.olap;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.query.QueryEngineManager;
 import com.arcadedb.utility.DedicatedThreadPool;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,12 +57,22 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class Issue6568NestedFanOutDeadlockTest {
 
-  /** Both tests are all-or-nothing: they finish at once or not at all. Sized as a hang detector. */
-  private static final int HANG_DETECTOR_SECONDS = 60;
-  /** How long the fan-out is given to complete before the test calls it wedged and fails with a diagnosis. */
-  private static final int WEDGE_VERDICT_SECONDS = 20;
-  /** How long a task is given to reach a worker thread on a loaded CI runner. */
-  private static final int WORKER_PIN_SECONDS    = 30;
+  /**
+   * Both tests are all-or-nothing: they finish at once or not at all. Plain wall clock, because {@code @Timeout}
+   * cannot be stall-discounted - so it is sized as a hang detector and never as a bound on anything.
+   */
+  private static final int  HANG_DETECTOR_SECONDS = 300;
+  /**
+   * The tripwire between a fan-out that completes and one that is wedged for ever, spent in STALL-DISCOUNTED time
+   * (#6260): late in a full-suite run a stop-the-world pause of tens of seconds is routine, and charging one to
+   * this budget would report a healthy fan-out as a deadlock. Generous is free here - the wedge it separates from
+   * is unbounded, so widening it can only ever cost patience.
+   */
+  private static final long WEDGE_VERDICT_MS      = 20_000L;
+  /** Stall-discounted budget for a task to reach a worker thread on a loaded CI runner. */
+  private static final long WORKER_PIN_MS         = 30_000L;
+  /** How long each individual poll waits before the budget above is re-checked against the stall counter. */
+  private static final long POLL_MS               = 250L;
 
   /**
    * A private pool, not the JVM-wide query one: this test deliberately occupies every worker with a thread that is
@@ -87,9 +99,11 @@ class Issue6568NestedFanOutDeadlockTest {
     final FanOutPool pool = new FanOutPool(threads);
     try {
       final ExecutorService executor = pool.getExecutorService();
-      // Every outer task waits here until all of them are running, so the inner tasks are submitted only once
-      // there is provably no free worker left to run them.
-      final CyclicBarrier allOutersRunning = new CyclicBarrier(threads);
+      // A latch used as a barrier rather than a CyclicBarrier: every outer task waits here until all of them are
+      // running, so the inner tasks are submitted only once there is provably no free worker left to run them -
+      // and unlike CyclicBarrier.await, a latch wait can be RETRIED, which is what lets the budget below be
+      // stall-discounted instead of one stop-the-world pause breaking the barrier for every party.
+      final CountDownLatch allOutersRunning = new CountDownLatch(threads);
       final AtomicInteger innerTasksRun = new AtomicInteger();
       final AtomicReference<Throwable> outerFailure = new AtomicReference<>();
 
@@ -97,7 +111,9 @@ class Issue6568NestedFanOutDeadlockTest {
       for (int i = 0; i < threads; i++)
         outer[i] = executor.submit(() -> {
           try {
-            allOutersRunning.await(WORKER_PIN_SECONDS, TimeUnit.SECONDS);
+            allOutersRunning.countDown();
+            if (!awaited(allOutersRunning, WORKER_PIN_MS))
+              throw new IllegalStateException("the outer chunks never all reached a worker");
             final Future<?>[] inner = { executor.submit(innerTasksRun::incrementAndGet) };
             GraphAlgorithms.awaitFutures(inner, 1, pool);
           } catch (final Exception e) {
@@ -108,7 +124,7 @@ class Issue6568NestedFanOutDeadlockTest {
         });
 
       for (int i = 0; i < threads; i++)
-        assertThat(awaited(outer[i]))
+        assertThat(awaited(outer[i], WEDGE_VERDICT_MS))
             .as("outer chunk %d must not park on an inner task no worker is left to run (#6568)", i).isTrue();
 
       assertThat(outerFailure.get()).isNull();
@@ -153,7 +169,7 @@ class Issue6568NestedFanOutDeadlockTest {
           return null;
         });
 
-      assertThat(allWorkersPinned.await(WORKER_PIN_SECONDS, TimeUnit.SECONDS))
+      assertThat(awaited(allWorkersPinned, WORKER_PIN_MS))
           .as("every query-pool worker must be pinned for the scenario to be the one #6568 is about").isTrue();
 
       final long reclaimedBefore = queryPool.getExecutorStats().reclaimedTasks();
@@ -176,17 +192,41 @@ class Issue6568NestedFanOutDeadlockTest {
     // the workers have not necessarily noticed yet, and a shared pool left busy is exactly what makes a later
     // untimed wait look like an unrelated infrastructure timeout.
     final Future<?> canary = executor.submit(() -> null);
-    canary.get(WORKER_PIN_SECONDS, TimeUnit.SECONDS);
+    assertThat(awaited(canary, WORKER_PIN_MS)).as("the query pool must be usable again before the next test class")
+        .isTrue();
   }
 
-  /** True when the future completed within the wedge verdict, false when the fan-out is stuck. */
-  private static boolean awaited(final Future<?> future) throws Exception {
-    try {
-      future.get(WEDGE_VERDICT_SECONDS, TimeUnit.SECONDS);
-      return true;
-    } catch (final java.util.concurrent.TimeoutException e) {
-      future.cancel(true);
-      return false;
-    }
+  /**
+   * True when the future completed within a STALL-DISCOUNTED budget, false when it is wedged - in which case it is
+   * cancelled so nothing outlives the test.
+   * <p>
+   * Polled rather than waited once, because that is what lets the budget be stall-discounted: each poll is short,
+   * and only the time the JVM was actually running counts against it (#6260). A single {@code get(20s)} would be
+   * raw wall clock, and one stop-the-world pause would report a healthy fan-out as a deadlock.
+   */
+  private static boolean awaited(final Future<?> future, final long budgetMs)
+      throws InterruptedException, ExecutionException {
+    final StallAwareStopwatch watch = StallAwareStopwatch.start();
+    do {
+      try {
+        future.get(POLL_MS, TimeUnit.MILLISECONDS);
+        return true;
+      } catch (final TimeoutException stillRunning) {
+        // Not a verdict: only the loop condition, which discounts JVM-wide stalls, decides that.
+      }
+    } while (watch.effectiveMs() < budgetMs);
+
+    future.cancel(true);
+    return false;
+  }
+
+  /** {@link #awaited(Future, long)} for a latch: same stall-discounted budget, same reason. */
+  private static boolean awaited(final CountDownLatch latch, final long budgetMs) throws InterruptedException {
+    final StallAwareStopwatch watch = StallAwareStopwatch.start();
+    do {
+      if (latch.await(POLL_MS, TimeUnit.MILLISECONDS))
+        return true;
+    } while (watch.effectiveMs() < budgetMs);
+    return false;
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
@@ -254,6 +254,53 @@ class Issue6568NestedFanOutDeadlockTest {
   }
 
   /**
+   * An already-interrupted waiter must ABORT, not quietly do the pool's work for it.
+   * <p>
+   * This is the reclaim's own way of undoing #4951. A reclaimed chunk runs inline and {@code FutureTask.run()}
+   * never looks at the interrupt flag, so without the check an interrupted caller would run the queued chunk to
+   * completion, find {@code get()} returning normally because the future IS now done, and walk the rest of the
+   * batch the same way - returning normally, flag still set, from a wait whose whole job was to abort and discard.
+   * A query killed by a timeout or a cancel would have merged partial results and reported them as complete.
+   */
+  @Test
+  @Timeout(value = HANG_DETECTOR_SECONDS, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  void anInterruptedWaiterAbortsInsteadOfRunningTheQueuedChunkItself() throws Exception {
+    final FanOutPool pool = new FanOutPool(1);
+    final CountDownLatch pinWorker = new CountDownLatch(1);
+    final CountDownLatch workerPinned = new CountDownLatch(1);
+    try {
+      final ExecutorService executor = pool.getExecutorService();
+      executor.submit(() -> {
+        workerPinned.countDown();
+        pinWorker.await();
+        return null;
+      });
+      assertThat(awaited(workerPinned, WORKER_PIN_MS)).isTrue();
+
+      final AtomicInteger ran = new AtomicInteger();
+      final Future<?>[] chunks = { executor.submit(ran::incrementAndGet), executor.submit(ran::incrementAndGet) };
+
+      Thread.currentThread().interrupt();
+      assertThatThrownBy(() -> GraphAlgorithms.awaitFutures(chunks, 2, pool))
+          .as("an interrupted wait must abort, whether or not its chunks are reclaimable")
+          .isInstanceOf(CommandExecutionException.class)
+          .hasMessageContaining("interrupted").hasMessageContaining("partial results discarded");
+
+      assertThat(ran.get()).as("the interrupted thread must not have run a reclaimed chunk").isZero();
+      assertThat(chunks[0].isCancelled()).as("every outstanding chunk must be cancelled").isTrue();
+      assertThat(chunks[1].isCancelled()).isTrue();
+      assertThat(Thread.currentThread().isInterrupted())
+          .as("the interrupt must survive the abort, so the caller above can act on it too").isTrue();
+    } finally {
+      // Clear the flag before it leaks into the next test in this JVM, and only then release the pin: an
+      // interrupted thread cannot wait on anything.
+      Thread.interrupted();
+      pinWorker.countDown();
+      pool.close();
+    }
+  }
+
+  /**
    * True when the future completed within a STALL-DISCOUNTED budget, false when it is wedged - in which case it is
    * cancelled so nothing outlives the test.
    * <p>

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
@@ -161,9 +161,12 @@ class Issue6568NestedFanOutDeadlockTest {
 
     final CountDownLatch allWorkersPinned = new CountDownLatch(workers);
     final CountDownLatch releasePins = new CountDownLatch(1);
+    // Kept rather than fire-and-forget: they are what the cleanup below waits on. A canary alone proves only that
+    // ONE worker came back, so a pin still unwinding could be handed to the next test class in this shared JVM.
+    final Future<?>[] pins = new Future<?>[workers];
     try {
       for (int i = 0; i < workers; i++)
-        executor.submit(() -> {
+        pins[i] = executor.submit(() -> {
           allWorkersPinned.countDown();
           releasePins.await();
           return null;
@@ -185,14 +188,19 @@ class Issue6568NestedFanOutDeadlockTest {
           .isSameAs(Thread.currentThread());
       assertThat(queryPool.getExecutorStats().reclaimedTasks()).isGreaterThanOrEqualTo(reclaimedBefore + 1);
     } finally {
+      // Do not hand the next test class a pool whose workers are still unwinding: releasing the latch is not the
+      // same as the workers having noticed it, and a shared pool left busy is exactly what makes a later untimed
+      // wait look like an unrelated infrastructure timeout. Every pin is awaited, not just probed with a canary,
+      // and inside the finally so it happens on the failing path too.
       releasePins.countDown();
+      for (final Future<?> pin : pins)
+        if (pin != null && !awaited(pin, WORKER_PIN_MS))
+          throw new AssertionError("a pinned query-pool worker did not come back after the latch was released, so "
+              + "this test would poison the shared pool for the rest of the fork");
     }
 
-    // Do not hand the next test class a pool whose workers are still unwinding: the pins are released above, but
-    // the workers have not necessarily noticed yet, and a shared pool left busy is exactly what makes a later
-    // untimed wait look like an unrelated infrastructure timeout.
     final Future<?> canary = executor.submit(() -> null);
-    assertThat(awaited(canary, WORKER_PIN_MS)).as("the query pool must be usable again before the next test class")
+    assertThat(awaited(canary, WORKER_PIN_MS)).as("the query pool must be running work on its own threads again")
         .isTrue();
   }
 

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6568NestedFanOutDeadlockTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.QueryEngineManager;
+import com.arcadedb.utility.DedicatedThreadPool;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6568: a thread that waits for a task it submitted to a dedicated pool must RECLAIM that task
+ * when it is still queued, never park on it.
+ * <p>
+ * The issue arrived as a wedged {@code ParallelScanSafetyTest} - a caller-runs execution parked on a latch only a
+ * pool task could count down - and asked whether the same shape is reachable in production. It is, and it does not
+ * even need the caller-runs path: every blocking fan-out on a bounded pool has it by construction. The dangerous
+ * belief is that the caller-runs policy is the safety net. It is not: it fires only when the queue is FULL, and a
+ * queue with a thousand free slots accepts the task and parks the submitter, which is the deadlock.
+ * <p>
+ * Both tests here hang for ever on the pre-#6568 code and complete in milliseconds with the reclaiming wait, so the
+ * {@code @Timeout} is a hang detector rather than a latency bound - and it is
+ * {@link Timeout.ThreadMode#SEPARATE_THREAD}, because the default same-thread timeout can only report a breach after
+ * the method returns, which a wedged thread never does.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6568NestedFanOutDeadlockTest {
+
+  /** Both tests are all-or-nothing: they finish at once or not at all. Sized as a hang detector. */
+  private static final int HANG_DETECTOR_SECONDS = 60;
+  /** How long the fan-out is given to complete before the test calls it wedged and fails with a diagnosis. */
+  private static final int WEDGE_VERDICT_SECONDS = 20;
+  /** How long a task is given to reach a worker thread on a loaded CI runner. */
+  private static final int WORKER_PIN_SECONDS    = 30;
+
+  /**
+   * A private pool, not the JVM-wide query one: this test deliberately occupies every worker with a thread that is
+   * blocked waiting, which on a shared pool would poison every later test in the fork if anything went wrong.
+   */
+  private static final class FanOutPool extends DedicatedThreadPool {
+    private FanOutPool(final int threads) {
+      // A generously sized queue is the POINT, not an oversight: it guarantees the inner tasks are ACCEPTED rather
+      // than rejected, so the caller-runs policy never fires and the wait is left facing the real deadlock.
+      super("ArcadeDB-Issue6568-", threads, 256, SaturationPolicy.CALLER_RUNS, DedicatedThreadPool::plainWorker,
+          "Issue 6568 test pool", null, GlobalConfiguration.QUERY_PARALLELISM_POOL_THREADS);
+    }
+  }
+
+  /**
+   * The nested fan-out: every worker of the pool runs an outer task that submits an inner task and waits for it.
+   * Without reclaiming, the inner tasks sit in a queue no thread will ever reach - each worker is parked on one of
+   * them - and the pool is dead with no exception, no failing assertion and nothing in the log to point at.
+   */
+  @Test
+  @Timeout(value = HANG_DETECTOR_SECONDS, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  void aNestedFanOutCompletesInsteadOfStarvingItsOwnQueue() throws Exception {
+    final int threads = 4;
+    final FanOutPool pool = new FanOutPool(threads);
+    try {
+      final ExecutorService executor = pool.getExecutorService();
+      // Every outer task waits here until all of them are running, so the inner tasks are submitted only once
+      // there is provably no free worker left to run them.
+      final CyclicBarrier allOutersRunning = new CyclicBarrier(threads);
+      final AtomicInteger innerTasksRun = new AtomicInteger();
+      final AtomicReference<Throwable> outerFailure = new AtomicReference<>();
+
+      final Future<?>[] outer = new Future<?>[threads];
+      for (int i = 0; i < threads; i++)
+        outer[i] = executor.submit(() -> {
+          try {
+            allOutersRunning.await(WORKER_PIN_SECONDS, TimeUnit.SECONDS);
+            final Future<?>[] inner = { executor.submit(innerTasksRun::incrementAndGet) };
+            GraphAlgorithms.awaitFutures(inner, 1, pool);
+          } catch (final Exception e) {
+            outerFailure.compareAndSet(null, e);
+            throw e;
+          }
+          return null;
+        });
+
+      for (int i = 0; i < threads; i++)
+        assertThat(awaited(outer[i]))
+            .as("outer chunk %d must not park on an inner task no worker is left to run (#6568)", i).isTrue();
+
+      assertThat(outerFailure.get()).isNull();
+      assertThat(innerTasksRun.get()).as("every inner task must have run, on the thread that was waiting for it")
+          .isEqualTo(threads);
+      // Not asserted as exactly `threads`: the first outer to reclaim finishes and frees its worker, which is then
+      // free to take a later outer's inner task off the queue legitimately. What has to be true is that a reclaim
+      // happened at all, because at the moment the inner tasks were submitted no worker could have run any of them.
+      assertThat(pool.getPoolStats().reclaimedTasks())
+          .as("the inner tasks were queued behind fully occupied workers, so the wait had to take them back out")
+          .isPositive();
+      assertThat(pool.getPoolStats().callerRunFallbacks())
+          .as("the queue had free slots throughout: the caller-runs policy is NOT what saved this").isZero();
+    } finally {
+      pool.close();
+    }
+  }
+
+  /**
+   * The same guarantee wired to the pool the production fan-outs actually use, through the {@code awaitFutures}
+   * overload they actually call. Every query-pool worker is pinned, the fan-out's chunk is therefore queued behind
+   * them, and the caller must run it itself instead of waiting for a worker that is never coming.
+   * <p>
+   * Pinning discipline, as {@code QueryEngineManagerPoolTest} documents it: the pool is JVM-wide, the release latch
+   * is counted down in a {@code finally} with no assertion before the {@code try}, and the test waits for the
+   * workers to drain before returning so it cannot hand the next test class a busy pool.
+   */
+  @Test
+  @Timeout(value = HANG_DETECTOR_SECONDS, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  void theQueryPoolFanOutRunsItsOwnQueuedChunkRatherThanWaiting() throws Exception {
+    final QueryEngineManager queryPool = QueryEngineManager.getInstance();
+    final ExecutorService executor = queryPool.getExecutorService();
+    final int workers = ((ThreadPoolExecutor) executor).getMaximumPoolSize();
+
+    final CountDownLatch allWorkersPinned = new CountDownLatch(workers);
+    final CountDownLatch releasePins = new CountDownLatch(1);
+    try {
+      for (int i = 0; i < workers; i++)
+        executor.submit(() -> {
+          allWorkersPinned.countDown();
+          releasePins.await();
+          return null;
+        });
+
+      assertThat(allWorkersPinned.await(WORKER_PIN_SECONDS, TimeUnit.SECONDS))
+          .as("every query-pool worker must be pinned for the scenario to be the one #6568 is about").isTrue();
+
+      final long reclaimedBefore = queryPool.getExecutorStats().reclaimedTasks();
+      final AtomicReference<Thread> chunkRanOn = new AtomicReference<>();
+      final Future<?>[] chunk = { executor.submit(() -> chunkRanOn.set(Thread.currentThread())) };
+
+      assertThat(queryPool.getExecutorStats().queueCapacityRemaining())
+          .as("the queue must still have room, or this would be testing the caller-runs policy instead").isPositive();
+
+      GraphAlgorithms.awaitFutures(chunk, 1);
+
+      assertThat(chunkRanOn.get()).as("a chunk queued behind pinned workers must run on the thread waiting for it")
+          .isSameAs(Thread.currentThread());
+      assertThat(queryPool.getExecutorStats().reclaimedTasks()).isGreaterThanOrEqualTo(reclaimedBefore + 1);
+    } finally {
+      releasePins.countDown();
+    }
+
+    // Do not hand the next test class a pool whose workers are still unwinding: the pins are released above, but
+    // the workers have not necessarily noticed yet, and a shared pool left busy is exactly what makes a later
+    // untimed wait look like an unrelated infrastructure timeout.
+    final Future<?> canary = executor.submit(() -> null);
+    canary.get(WORKER_PIN_SECONDS, TimeUnit.SECONDS);
+  }
+
+  /** True when the future completed within the wedge verdict, false when the fan-out is stuck. */
+  private static boolean awaited(final Future<?> future) throws Exception {
+    try {
+      future.get(WEDGE_VERDICT_SECONDS, TimeUnit.SECONDS);
+      return true;
+    } catch (final java.util.concurrent.TimeoutException e) {
+      future.cancel(true);
+      return false;
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
@@ -150,7 +150,8 @@ class DedicatedThreadPoolTest {
         pinWorker.await();
         return null;
       });
-      assertThat(workerPinned.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(awaited(workerPinned)).as("the pool's single worker must be pinned before anything can be queued")
+          .isTrue();
 
       final AtomicReference<Thread> ranOn = new AtomicReference<>();
       final Future<?> queued = pool.getExecutorService().submit(() -> ranOn.set(Thread.currentThread()));
@@ -185,7 +186,7 @@ class DedicatedThreadPoolTest {
         releaseRunning.await();
         return null;
       });
-      assertThat(running.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(awaited(running)).as("the task must be running on the worker, not still queued").isTrue();
 
       assertThat(pool.runQueuedTaskOnCaller((Runnable) started))
           .as("a task a worker is already running must never be run a second time on the caller").isFalse();
@@ -201,6 +202,20 @@ class DedicatedThreadPoolTest {
       releaseRunning.countDown();
       pool.close();
     }
+  }
+
+  /**
+   * Waits for a readiness latch against a STALL-DISCOUNTED budget (#6260): a stop-the-world pause late in a
+   * full-suite run must not be charged to a wait that is only there to order two threads, or the test goes red
+   * for the JVM's mood rather than for the code. Polled, because that is what makes the discount possible.
+   */
+  private static boolean awaited(final CountDownLatch latch) throws InterruptedException {
+    final StallAwareStopwatch watch = StallAwareStopwatch.start();
+    do {
+      if (latch.await(250, TimeUnit.MILLISECONDS))
+        return true;
+    } while (watch.effectiveMs() < 30_000L);
+    return false;
   }
 
   /** The shared sizing: an explicit positive value wins, anything else is cores with a floor of two. */

--- a/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
@@ -43,6 +43,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class DedicatedThreadPoolTest {
 
+  /**
+   * Plain wall clock, because {@code @Timeout} cannot be stall-discounted - so it is sized as a hang detector and
+   * never as a bound on anything. The tests that wait for something get their actual verdict from
+   * {@link #awaited(CountDownLatch)}, whose budget IS stall-discounted (#6260); this only stops a genuine wedge
+   * from hanging the build. Same sizing as {@code Issue6568NestedFanOutDeadlockTest}, for the same reason.
+   */
+  private static final int HANG_DETECTOR_SECONDS = 300;
+
   private static final class TestPool extends DedicatedThreadPool {
     private TestPool(final int queueCapacity, final SaturationPolicy policy) {
       super("ArcadeDB-DedicatedThreadPoolTest-", 1, queueCapacity, policy, DedicatedThreadPool::plainWorker,
@@ -139,7 +147,7 @@ class DedicatedThreadPoolTest {
    * worker took it, so it runs exactly once.
    */
   @Test
-  @Timeout(60)
+  @Timeout(HANG_DETECTOR_SECONDS)
   void aQueuedTaskIsReclaimedAndRunByTheThreadWaitingForIt() throws Exception {
     final TestPool pool = new TestPool(16, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS);
     final CountDownLatch pinWorker = new CountDownLatch(1);
@@ -176,7 +184,7 @@ class DedicatedThreadPoolTest {
    * one that has already finished, and one that was never submitted to this pool at all.
    */
   @Test
-  @Timeout(60)
+  @Timeout(HANG_DETECTOR_SECONDS)
   void aTaskAWorkerAlreadyHasIsNeverReclaimed() throws Exception {
     final TestPool pool = new TestPool(16, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS);
     final CountDownLatch releaseRunning = new CountDownLatch(1);
@@ -212,7 +220,7 @@ class DedicatedThreadPoolTest {
    * worker would have given it", and this is the half of that claim liveness alone does not pin.
    */
   @Test
-  @Timeout(60)
+  @Timeout(HANG_DETECTOR_SECONDS)
   void aReclaimedTaskThatThrowsFailsItsFutureInsteadOfTheReclaimingThread() throws Exception {
     final TestPool pool = new TestPool(16, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS);
     final CountDownLatch pinWorker = new CountDownLatch(1);
@@ -246,7 +254,7 @@ class DedicatedThreadPoolTest {
    * command it is running - a reclaim that bypassed the hook would silently reintroduce that self-deadlock.
    */
   @Test
-  @Timeout(60)
+  @Timeout(HANG_DETECTOR_SECONDS)
   void aReclaimRunsThroughTheSameHookAsACallerRunsFallback() throws Exception {
     final AtomicReference<Thread> markedOn = new AtomicReference<>();
     final CountDownLatch pinWorker = new CountDownLatch(1);

--- a/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
@@ -22,7 +22,10 @@ import com.arcadedb.GlobalConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -126,6 +129,78 @@ class DedicatedThreadPoolTest {
 
     assertThat(ran.get()).as("the submitter has already counted this as in flight: dropping it strands that count")
         .isTrue();
+  }
+
+
+  /**
+   * The #6568 primitive: a task the queue has accepted but no worker has started is handed back to the thread that
+   * is about to wait for it, and runs there. What makes it safe is that {@code remove} succeeding is proof no
+   * worker took it, so it runs exactly once.
+   */
+  @Test
+  @Timeout(60)
+  void aQueuedTaskIsReclaimedAndRunByTheThreadWaitingForIt() throws Exception {
+    final TestPool pool = new TestPool(16, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS);
+    final CountDownLatch pinWorker = new CountDownLatch(1);
+    final CountDownLatch workerPinned = new CountDownLatch(1);
+    try {
+      // The pool has exactly one worker: pin it, and everything else submitted is queued but unreachable.
+      pool.getExecutorService().submit(() -> {
+        workerPinned.countDown();
+        pinWorker.await();
+        return null;
+      });
+      assertThat(workerPinned.await(30, TimeUnit.SECONDS)).isTrue();
+
+      final AtomicReference<Thread> ranOn = new AtomicReference<>();
+      final Future<?> queued = pool.getExecutorService().submit(() -> ranOn.set(Thread.currentThread()));
+
+      assertThat(pool.runQueuedTaskOnCaller((Runnable) queued)).isTrue();
+      assertThat(ranOn.get()).as("the reclaimed task runs on the reclaiming thread, not on a worker")
+          .isSameAs(Thread.currentThread());
+      assertThat(queued.isDone()).as("...and its future is resolved, so the wait that follows returns at once").isTrue();
+      assertThat(pool.getPoolStats().reclaimedTasks()).isEqualTo(1);
+      assertThat(pool.getPoolStats().callerRunFallbacks())
+          .as("a reclaim is the pool being busy, never the pool being full: it must not read as a sizing problem")
+          .isZero();
+    } finally {
+      pinWorker.countDown();
+      pool.close();
+    }
+  }
+
+  /**
+   * And it refuses everything it must refuse: a task already taken by a worker (reclaiming it would run it twice),
+   * one that has already finished, and one that was never submitted to this pool at all.
+   */
+  @Test
+  @Timeout(60)
+  void aTaskAWorkerAlreadyHasIsNeverReclaimed() throws Exception {
+    final TestPool pool = new TestPool(16, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS);
+    final CountDownLatch releaseRunning = new CountDownLatch(1);
+    final CountDownLatch running = new CountDownLatch(1);
+    try {
+      final Future<?> started = pool.getExecutorService().submit(() -> {
+        running.countDown();
+        releaseRunning.await();
+        return null;
+      });
+      assertThat(running.await(30, TimeUnit.SECONDS)).isTrue();
+
+      assertThat(pool.runQueuedTaskOnCaller((Runnable) started))
+          .as("a task a worker is already running must never be run a second time on the caller").isFalse();
+
+      final FutureTask<Void> foreign = new FutureTask<>(() -> null);
+      assertThat(pool.runQueuedTaskOnCaller(foreign)).as("a task this pool never queued is not this pool's to run")
+          .isFalse();
+      assertThat(foreign.isDone()).isFalse();
+
+      assertThat(pool.runQueuedTaskOnCaller(null)).as("nothing to reclaim, and no NPE either").isFalse();
+      assertThat(pool.getPoolStats().reclaimedTasks()).isZero();
+    } finally {
+      releaseRunning.countDown();
+      pool.close();
+    }
   }
 
   /** The shared sizing: an explicit positive value wins, anything else is cores with a floor of two. */

--- a/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
@@ -200,6 +201,82 @@ class DedicatedThreadPoolTest {
       assertThat(pool.getPoolStats().reclaimedTasks()).isZero();
     } finally {
       releaseRunning.countDown();
+      pool.close();
+    }
+  }
+
+  /**
+   * A reclaimed task that THROWS must be indistinguishable from a worker-run one that throws: the exception lands in
+   * the task's own future, so the caller's {@code get()} surfaces it as an {@link java.util.concurrent.ExecutionException}
+   * rather than blowing up in the middle of the reclaim. The whole fix rests on "a reclaim is the same execution a
+   * worker would have given it", and this is the half of that claim liveness alone does not pin.
+   */
+  @Test
+  @Timeout(60)
+  void aReclaimedTaskThatThrowsFailsItsFutureInsteadOfTheReclaimingThread() throws Exception {
+    final TestPool pool = new TestPool(16, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS);
+    final CountDownLatch pinWorker = new CountDownLatch(1);
+    final CountDownLatch workerPinned = new CountDownLatch(1);
+    try {
+      pool.getExecutorService().submit(() -> {
+        workerPinned.countDown();
+        pinWorker.await();
+        return null;
+      });
+      assertThat(awaited(workerPinned)).isTrue();
+
+      final Future<?> queued = pool.getExecutorService().submit(() -> {
+        throw new IllegalStateException("boom");
+      });
+
+      assertThat(pool.runQueuedTaskOnCaller((Runnable) queued))
+          .as("the reclaim itself must succeed - a failing task is still a task this thread ran").isTrue();
+      assertThatThrownBy(queued::get).isInstanceOf(ExecutionException.class)
+          .cause().isInstanceOf(IllegalStateException.class).hasMessage("boom");
+    } finally {
+      pinWorker.countDown();
+      pool.close();
+    }
+  }
+
+  /**
+   * A reclaim borrows the caller's thread exactly as a caller-runs rejection does, so it must go through the same
+   * {@link DedicatedThreadPool#runRejectedTask(Runnable)} hook. {@code AsyncCommandPool} overrides that hook to mark
+   * the borrowed thread as one of its own, and the async barrier reads that mark to avoid waiting for the very
+   * command it is running - a reclaim that bypassed the hook would silently reintroduce that self-deadlock.
+   */
+  @Test
+  @Timeout(60)
+  void aReclaimRunsThroughTheSameHookAsACallerRunsFallback() throws Exception {
+    final AtomicReference<Thread> markedOn = new AtomicReference<>();
+    final CountDownLatch pinWorker = new CountDownLatch(1);
+    final CountDownLatch workerPinned = new CountDownLatch(1);
+    final DedicatedThreadPool pool = new DedicatedThreadPool("ArcadeDB-DedicatedThreadPoolTest-hook-", 1, 16,
+        DedicatedThreadPool.SaturationPolicy.CALLER_RUNS, DedicatedThreadPool::plainWorker, "Test pool", null,
+        GlobalConfiguration.QUERY_PARALLELISM_POOL_THREADS) {
+      @Override
+      protected void runRejectedTask(final Runnable task) {
+        markedOn.set(Thread.currentThread());
+        super.runRejectedTask(task);
+      }
+    };
+    try {
+      pool.getExecutorService().submit(() -> {
+        workerPinned.countDown();
+        pinWorker.await();
+        return null;
+      });
+      assertThat(awaited(workerPinned)).isTrue();
+
+      final Future<?> queued = pool.getExecutorService().submit(() -> {
+      });
+      assertThat(pool.runQueuedTaskOnCaller((Runnable) queued)).isTrue();
+
+      assertThat(markedOn.get())
+          .as("the subclass hook must see the reclaim, on the thread that is borrowing itself out to the pool")
+          .isSameAs(Thread.currentThread());
+    } finally {
+      pinWorker.countDown();
       pool.close();
     }
   }

--- a/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
@@ -140,7 +140,6 @@ class DedicatedThreadPoolTest {
         .isTrue();
   }
 
-
   /**
    * The #6568 primitive: a task the queue has accepted but no worker has started is handed back to the thread that
    * is about to wait for it, and runs there. What makes it safe is that {@code remove} succeeding is proof no

--- a/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
@@ -23,13 +23,13 @@ import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.index.sparsevector.SparseVectorScoringPool;
 import com.arcadedb.query.ParallelScanProducerPool;
 import com.arcadedb.query.QueryEngineManager;
+import com.arcadedb.utility.DedicatedThreadPool.PoolStats;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 
-import java.util.function.IntSupplier;
-import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -55,55 +55,34 @@ public final class PoolMetrics implements MeterBinder {
    * {@link SparseVectorScoringPool} on the given registry.
    * <p>
    * Each gauge re-reads its source pool's {@code PoolStats} record on scrape - the record is a
-   * tiny allocation (six longs) and Micrometer scrape intervals are typically tens of seconds,
-   * so the cost is negligible. {@code callerRunFallbacks} is a strictly-monotonic counter so we
-   * register it as a gauge that exposes the cumulative count; downstream tools (Prometheus
-   * {@code rate()}, etc.) can derive a rate as needed.
+   * tiny allocation and Micrometer scrape intervals are typically tens of seconds, so the cost is
+   * negligible; one supplier per pool rather than one per gauge, so a new component on the record
+   * reaches every pool's row at once instead of being added to four argument lists. {@code
+   * callerRunFallbacks} and {@code reclaimedTasks} are strictly-monotonic counters so we register
+   * them as gauges that expose the cumulative count; downstream tools (Prometheus {@code rate()},
+   * etc.) can derive a rate as needed.
    */
   @Override
   public void bindTo(final MeterRegistry registry) {
     final QueryEngineManager qem = QueryEngineManager.getInstance();
-    bindPool(registry, "query", "QueryEngineManager parallel-query pool",
-        () -> qem.getExecutorStats().poolSize(),
-        () -> qem.getExecutorStats().activeThreads(),
-        () -> qem.getExecutorStats().queueDepth(),
-        () -> qem.getExecutorStats().queueCapacityRemaining(),
-        () -> qem.getExecutorStats().completedTasks(),
-        () -> qem.getExecutorStats().callerRunFallbacks());
+    bindPool(registry, "query", "QueryEngineManager parallel-query pool", qem::getExecutorStats);
 
     final SparseVectorScoringPool svsp = SparseVectorScoringPool.getInstance();
-    bindPool(registry, "sparse_vector", "SparseVectorScoringPool top-K fan-out pool",
-        () -> svsp.getPoolStats().poolSize(),
-        () -> svsp.getPoolStats().activeThreads(),
-        () -> svsp.getPoolStats().queueDepth(),
-        () -> svsp.getPoolStats().queueCapacityRemaining(),
-        () -> svsp.getPoolStats().completedTasks(),
-        () -> svsp.getPoolStats().callerRunFallbacks());
+    bindPool(registry, "sparse_vector", "SparseVectorScoringPool top-K fan-out pool", svsp::getPoolStats);
     bindSparseVectorSplit(registry, svsp);
 
     // Dedicated pool for the BLOCKING parallel-scan producers (issues #4948/#4950): unbounded task queue by
     // design (backpressure comes from each query's bounded result queue), so callerRunFallbacks is always 0
     // and queueCapacityRemaining reports -1 (not applicable); queue_depth is the signal to watch.
     final ParallelScanProducerPool pspp = ParallelScanProducerPool.getInstance();
-    bindPool(registry, "parallel_scan", "ParallelScanProducerPool bucket-scan producer pool",
-        () -> pspp.getPoolStats().poolSize(),
-        () -> pspp.getPoolStats().activeThreads(),
-        () -> pspp.getPoolStats().queueDepth(),
-        () -> pspp.getPoolStats().queueCapacityRemaining(),
-        () -> pspp.getPoolStats().completedTasks(),
-        () -> pspp.getPoolStats().callerRunFallbacks());
+    bindPool(registry, "parallel_scan", "ParallelScanProducerPool bucket-scan producer pool", pspp::getPoolStats);
 
     // The pool that runs commands dispatched with awaitResponse=false (issue #6303, item 3). Its caller-runs count is
     // the one an operator most wants to see here: a fallback means the pool was saturated and the command ran on the
     // HTTP worker that submitted it, so a client that explicitly asked NOT to wait for the answer waited for it.
     final AsyncCommandPool acp = AsyncCommandPool.getInstance();
     bindPool(registry, "async_command", "AsyncCommandPool asynchronously dispatched command/query pool",
-        () -> acp.getPoolStats().poolSize(),
-        () -> acp.getPoolStats().activeThreads(),
-        () -> acp.getPoolStats().queueDepth(),
-        () -> acp.getPoolStats().queueCapacityRemaining(),
-        () -> acp.getPoolStats().completedTasks(),
-        () -> acp.getPoolStats().callerRunFallbacks());
+        acp::getPoolStats);
 
     // Not a pool, but a graph data-integrity signal surfaced the same way. A monotonic FunctionCounter
     // (not a gauge) so dashboards can compute a rate() and alert on a sudden spike of corruption,
@@ -155,24 +134,28 @@ public final class PoolMetrics implements MeterBinder {
   }
 
   private static void bindPool(final MeterRegistry registry, final String poolTag, final String description,
-      final IntSupplier poolSize, final IntSupplier activeThreads,
-      final IntSupplier queueDepth, final IntSupplier queueCapacityRemaining,
-      final LongSupplier completedTasks, final LongSupplier callerRunFallbacks) {
+      final Supplier<PoolStats> stats) {
     final Tags tags = Tags.of(Tag.of("pool", poolTag));
-    Gauge.builder("arcadedb.executor.pool.size", poolSize::getAsInt)
+    Gauge.builder("arcadedb.executor.pool.size", () -> stats.get().poolSize())
         .description(description + ": currently allocated worker threads").tags(tags).register(registry);
-    Gauge.builder("arcadedb.executor.pool.active", activeThreads::getAsInt)
+    Gauge.builder("arcadedb.executor.pool.active", () -> stats.get().activeThreads())
         .description(description + ": worker threads currently running a task").tags(tags).register(registry);
-    Gauge.builder("arcadedb.executor.queue.depth", queueDepth::getAsInt)
+    Gauge.builder("arcadedb.executor.queue.depth", () -> stats.get().queueDepth())
         .description(description + ": tasks waiting in the queue").tags(tags).register(registry);
-    Gauge.builder("arcadedb.executor.queue.capacity_remaining", queueCapacityRemaining::getAsInt)
+    Gauge.builder("arcadedb.executor.queue.capacity_remaining", () -> stats.get().queueCapacityRemaining())
         .description(description + ": queue slots free before saturation triggers caller-runs fallback").tags(tags)
         .register(registry);
-    Gauge.builder("arcadedb.executor.tasks.completed", completedTasks::getAsLong)
+    Gauge.builder("arcadedb.executor.tasks.completed", () -> stats.get().completedTasks())
         .description(description + ": cumulative tasks finished by pool threads").tags(tags).register(registry);
-    Gauge.builder("arcadedb.executor.tasks.caller_run_fallbacks", callerRunFallbacks::getAsLong)
+    Gauge.builder("arcadedb.executor.tasks.caller_run_fallbacks", () -> stats.get().callerRunFallbacks())
         .description(
             description + ": cumulative tasks that ran on the submitter's thread because the queue was full. Sustained growth means the pool is undersized for the workload.")
+        .tags(tags).register(registry);
+    Gauge.builder("arcadedb.executor.tasks.reclaimed", () -> stats.get().reclaimedTasks())
+        .description(description + ": cumulative queued tasks taken back out of the queue and run by the thread that "
+            + "was about to wait for them (issue #6568). Unlike caller_run_fallbacks this is not a sizing signal - the "
+            + "pool was busy, not full - but sustained growth alongside a high pool.active says the fan-out callers are "
+            + "spending their time doing the pool's work, which is the shape that used to deadlock.")
         .tags(tags).register(registry);
   }
 }

--- a/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
@@ -56,11 +56,18 @@ public final class PoolMetrics implements MeterBinder {
    * <p>
    * Each gauge re-reads its source pool's {@code PoolStats} record on scrape - the record is a
    * tiny allocation and Micrometer scrape intervals are typically tens of seconds, so the cost is
-   * negligible; one supplier per pool rather than one per gauge, so a new component on the record
-   * reaches every pool's row at once instead of being added to four argument lists. {@code
-   * callerRunFallbacks} and {@code reclaimedTasks} are strictly-monotonic counters so we register
-   * them as gauges that expose the cumulative count; downstream tools (Prometheus {@code rate()},
-   * etc.) can derive a rate as needed.
+   * negligible.
+   * <p>
+   * The per-pool {@code Supplier<PoolStats>} buys MAINTENANCE, not scrape cost: every gauge still
+   * calls it once, exactly as the six separate suppliers it replaced did, so the record is still
+   * built once per gauge per scrape. What changes is that a new component on {@code PoolStats}
+   * reaches every pool's row by being read in one place, instead of having to be threaded through
+   * four call sites' argument lists - which is how the previous shape would have absorbed
+   * {@code reclaimedTasks}.
+   * <p>
+   * {@code callerRunFallbacks} and {@code reclaimedTasks} are strictly-monotonic counters so we
+   * register them as gauges that expose the cumulative count; downstream tools (Prometheus
+   * {@code rate()}, etc.) can derive a rate as needed.
    */
   @Override
   public void bindTo(final MeterRegistry registry) {

--- a/server/src/test/java/com/arcadedb/server/monitor/PoolMetricsTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/PoolMetricsTest.java
@@ -46,7 +46,10 @@ class PoolMetricsTest {
       "arcadedb.executor.queue.depth",
       "arcadedb.executor.queue.capacity_remaining",
       "arcadedb.executor.tasks.completed",
-      "arcadedb.executor.tasks.caller_run_fallbacks");
+      "arcadedb.executor.tasks.caller_run_fallbacks",
+      // #6568: queued tasks a waiting caller ran itself. On the same row as caller_run_fallbacks
+      // deliberately - the two are read together and say opposite things (busy vs full).
+      "arcadedb.executor.tasks.reclaimed");
 
   /**
    * Gauges only the sparse-vector pool publishes: they explain its per-query decision to split a
@@ -69,7 +72,7 @@ class PoolMetricsTest {
     final Set<String> registeredNames = registry.getMeters().stream()
         .map(m -> m.getId().getName())
         .collect(Collectors.toSet());
-    assertThat(registeredNames).as("all six gauges should be registered (per-pool tagging adds duplicates)")
+    assertThat(registeredNames).as("every shared gauge should be registered (per-pool tagging adds duplicates)")
         .containsAll(EXPECTED_GAUGE_NAMES);
 
     for (final String poolTag : new String[] { "query", "sparse_vector", "async_command" }) {
@@ -113,7 +116,7 @@ class PoolMetricsTest {
    * Studio's {@code studio-server.js} reads {@code metrics.executors.<pool>.<gauge>} from the
    * {@code GET /api/v1/server} JSON response - so the wire format produced by
    * {@link com.arcadedb.server.http.handler.GetServerHandler#buildExecutorsJSON} has to match
-   * what the JS expects: one object per pool tag, each holding the six gauges keyed by their
+   * what the JS expects: one object per pool tag, each holding the shared gauges keyed by their
    * post-prefix names ({@code "pool.size"}, {@code "pool.active"}, ...). This test pins that
    * contract without booting a full server - if the JSON shape ever changes, the dashboard
    * would silently render zeros and only this test would catch the regression.

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -305,7 +305,7 @@ function displayMetrics() {
   // PoolMetrics; expected pool names are "query" (QueryEngineManager), "sparse_vector"
   // (SparseVectorScoringPool) and "parallel_scan" (ParallelScanProducerPool). Each pool's gauges
   // are: pool.size, pool.active, queue.depth, queue.capacity_remaining, tasks.completed,
-  // tasks.caller_run_fallbacks. The sparse-vector pool adds pool.reserved, queries.in_flight and
+  // tasks.caller_run_fallbacks, tasks.reclaimed. The sparse-vector pool adds pool.reserved, queries.in_flight and
   // queries.split, which explain its per-query decision to parallelise or not (#4085).
   var ex = serverData.metrics.executors || {};
   var executorRowLabels = { "query": "Query Parallelism", "sparse_vector": "Sparse Vector Scoring",
@@ -329,6 +329,10 @@ function displayMetrics() {
     executorsHtml += "<td class='text-end'>" + Math.round(pool["queue.capacity_remaining"] || 0).toLocaleString() + "</td>";
     executorsHtml += "<td class='text-end'>" + Math.round(pool["tasks.completed"] || 0).toLocaleString() + "</td>";
     executorsHtml += "<td class='" + fallbackCellClass + "'>" + fallbacks.toLocaleString() + "</td>";
+    // Reclaimed (#6568): queued tasks a caller about to wait for them ran itself. Deliberately NOT
+    // highlighted like the fallback cell - it is the pool being busy rather than full, and it is the
+    // mechanism that keeps a blocking fan-out from deadlocking, so a non-zero value is healthy.
+    executorsHtml += "<td class='text-end'>" + Math.round(pool["tasks.reclaimed"] || 0).toLocaleString() + "</td>";
     // Split-decision columns (#4085). Only the sparse-vector pool decides per query whether to
     // parallelise, so a pool that does not report them shows "-" rather than a zero that would read
     // as "nothing is splitting" when the concept simply does not apply. "Queries Split" is the
@@ -339,7 +343,7 @@ function displayMetrics() {
     executorsHtml += "<td class='text-end'>" + gaugeOrDash(pool, "queries.split") + "</td>";
     executorsHtml += "</tr>";
   }
-  $("#srvMetricExecutorsTable").html(executorsHtml || "<tr><td colspan='9' class='text-muted text-center'>No executor pool metrics available.</td></tr>");
+  $("#srvMetricExecutorsTable").html(executorsHtml || "<tr><td colspan='10' class='text-muted text-center'>No executor pool metrics available.</td></tr>");
 
   // Sparse Vector Indexes table - rendered from metrics.sparseVectorIndexes. Shape:
   //   { dbName: { typeIndexName: { memtablePostings, segmentCount, totalPostings } } }

--- a/studio/src/main/resources/static/server.html
+++ b/studio/src/main/resources/static/server.html
@@ -261,7 +261,7 @@
         <div class="card mb-3">
           <div class="card-header">
             Executor Pools
-            <span class="text-muted small ms-2">live thread / queue / saturation gauges per engine pool; the last three columns apply to sparse-vector scoring, which decides per query whether to parallelise. Queries Split counts the decision, so read it with Caller-Run Fallbacks: a range submitted to a full queue still runs inline on the caller</span>
+            <span class="text-muted small ms-2">live thread / queue / saturation gauges per engine pool. Reclaimed counts queued tasks a waiting caller ran itself because no worker was free - the pool being busy, not full, and the mechanism that keeps a nested fan-out from deadlocking. The last three columns apply to sparse-vector scoring, which decides per query whether to parallelise. Queries Split counts the decision, so read it with Caller-Run Fallbacks: a range submitted to a full queue still runs inline on the caller</span>
           </div>
           <div class="card-body p-0">
             <div class="table-responsive">
@@ -274,6 +274,7 @@
                     <th class="text-end">Queue Free</th>
                     <th class="text-end">Tasks Completed</th>
                     <th class="text-end">Caller-Run Fallbacks</th>
+                    <th class="text-end">Reclaimed</th>
                     <th class="text-end">Reserved</th>
                     <th class="text-end">Queries In Flight</th>
                     <th class="text-end">Queries Split</th>


### PR DESCRIPTION
Closes #6568.

## What the issue asked

The issue arrived as a wedged `ParallelScanSafetyTest` - a caller-runs execution parked on a `CountDownLatch` only a pool task could count down - and the test-side symptom was already fixed in `b770784d6`, half an hour after it was filed. What was left is the question the issue actually raised:

> The caller-runs saturation policy is production behaviour, not test-only. Whether an engine-internal caller-runs execution can ever block on something only that pool can complete is worth an audit - if it can, the same shape is reachable outside tests.

It can.

## What the audit found

The belief that makes it invisible is that **the caller-runs saturation policy is the deadlock guarantee**. It is not. It fires only when the queue is **full**. A queue with a thousand free slots accepts the task, parks the submitter, and leaves it there. When every worker is itself a thread parked on a task it submitted, nothing in the pool can ever run again - and the failure presents as a lane timeout with no failing assertion, which is exactly how #6568 arrived.

Every blocking fan-out has that shape as soon as two of them nest. Today the three `QueryEngineManager`-pool fan-outs are safe only by call-site discipline that is undocumented as a rule and already divergent:

| Site | Discipline |
|---|---|
| `GraphAlgorithms.parallelForRange` | runs chunk 0 on the caller |
| `PartitionedTriangleOp.execute` | runs chunk 0 on the caller (#4952) |
| `GAVFusedChainOperator` (both paths) | submits **every** chunk and blocks |

And "the caller runs chunk 0" was never the liveness argument anyway: it does nothing for chunks 1..N-1 queued behind parked workers. `PartitionedTriangleOp`'s own comment said the residual deadlock was "only mitigated by the bounded queue's caller-runs rejection", which is the mistaken belief written down.

## The fix: reclaim, never park

Structural rather than remembered. `DedicatedThreadPool` gains:

```java
public final boolean runQueuedTaskOnCaller(final Runnable task)
```

It takes a task the queue **accepted but no worker started** back out and runs it on the thread that was about to wait for it. `ThreadPoolExecutor.remove` succeeding is the proof no worker has it, so it runs exactly once and never concurrently with a worker. It is cheap when there is nothing to reclaim: the queue-empty check is one `AtomicInteger` read, and only a non-empty queue pays for `remove`'s scan.

`GraphAlgorithms.awaitFutures` - the single wait all three fan-outs already share - reclaims before every `get()`. That makes the wait **deadlock-free by construction**: the waiter always has work of its own it can make progress on, so by induction on nesting depth the whole fan-out completes, at any pool size and any nesting depth. Chunk 0 on the caller becomes a latency optimisation rather than the liveness argument, and `GAVFusedChainOperator`'s divergence stops being a correctness gap.

A reclaimed task runs with the caller's thread-locals (`DatabaseContext`, transaction, principal) - not a new exposure for any caller-runs pool, since a rejected task already runs there.

## Why not the alternatives

- **The issue's suggestion** (bounded latch wait / reserve a worker first) is test-shaped. It fixes the one test and leaves the production question open.
- **A `isPoolThread()` nesting refusal**, as `SparseVectorScoringPool` uses, is the right answer when the nested fan-out has no value. Here it does have value, and refusing to nest would cost the parallelism rather than recover it.
- **An unbounded queue** removes the rejection but not the deadlock - the parked-worker cycle is what kills it, and an unbounded queue makes it strictly easier to reach.

## Observability

The reclaim is counted separately from the caller-runs fallback because the two say opposite things - **full** versus **busy** - and a reclaim is healthy. Surfaced as `arcadedb.executor.tasks.reclaimed` and a **Reclaimed** column on Studio's Executor Pools card (deliberately not highlighted like the fallback cell), so the shape that used to deadlock is visible rather than inferred from latency. `PoolMetrics` now binds one `PoolStats` supplier per pool instead of one per gauge, so the next component on the record reaches every row at once instead of four argument lists.

## Tests

Both regression tests in `Issue6568NestedFanOutDeadlockTest` **hang for ever** on the pre-fix code (verified by disabling the reclaim: one fails its 20s wedge verdict, the other times out at 60s):

1. `aNestedFanOutCompletesInsteadOfStarvingItsOwnQueue` - a private 4-thread pool with a deliberately roomy queue, every worker running an outer task that submits an inner one and waits for it. Asserts liveness, that a reclaim happened, and that `callerRunFallbacks` stayed **zero** - the caller-runs policy is provably not what saved it.
2. `theQueryPoolFanOutRunsItsOwnQueuedChunkRatherThanWaiting` - the real `QueryEngineManager` pool with every worker pinned, through the `awaitFutures` overload production calls. Asserts the chunk ran on the waiting thread, with the `QueryEngineManagerPoolTest` pinning discipline (release in `finally`, drain before returning).

Plus three unit tests on the primitive itself in `DedicatedThreadPoolTest`: it reclaims a queued task and runs it on the caller; it refuses a task a worker already has, a foreign task, and null.

`mvn -o -pl engine -am test` over `graph.olap`, `query`, `utility` and `database.async`: **8760 tests, 0 failures**. `PoolMetricsTest` green in `server`.

Also updated: the `engine-concurrency` skill gains a "Waiting for a task on a pool your thread may itself be running on" section and a new checklist item, so the rule is enforced by the next reviewer rather than rediscovered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deadlocks during nested parallel graph queries by reclaiming queued work while awaiting results.
  * Improved handling of cancelled tasks during executor shutdown.

* **New Features**
  * Added reclaimed-task statistics to executor pool metrics.
  * Added a Reclaimed column to the Studio executor metrics table.

* **Documentation**
  * Clarified task reclamation and caller-run fallback behavior.

* **Tests**
  * Added coverage for nested fan-out deadlocks, task reclamation, shutdown cancellation, and reclaimed-task failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->