### PR TITLE
fix(#6439): unbalanced '{' now reported instead of swallowing commands, SET strips quoted values

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -387,8 +387,15 @@ public class Console {
   /**
    * Strips one matching pair of surrounding quotes (' or ") from a {@code SET} value, so {@code set language = 'sql'} stores
    * {@code sql} rather than the literal quotes. A value that does not start with a quote character is returned unchanged. A
-   * value that opens with a quote character but never closes it is always a typo, and so is one with content trailing after
-   * the closing quote - both are rejected rather than stored half-quoted (issue #6439).
+   * value that opens with a quote character but never closes it, or ends in something other than that character, is always a
+   * typo, so it is rejected rather than stored half-quoted (issue #6439).
+   * <p>
+   * A value whose first and last characters are the SAME quote character is always accepted as that pair, even if the quote
+   * character also occurs in between - for example {@code 'it\'s a test'}. That inner quote reaches this method already
+   * stripped of its escaping backslash by {@link TerminalParser#parse}, indistinguishable here from a real closing quote
+   * followed by unrelated trailing text that happens to also end in a quote character. Between silently accepting that rare,
+   * contrived input and rejecting the far more plausible escaped-quote value, this favors the value the parser's own escape
+   * handling was built to support.
    */
   private static String stripMatchingQuotes(final String value) {
     if (value.isEmpty())
@@ -398,16 +405,13 @@ public class Console {
     if (first != '\'' && first != '"')
       return value;
 
-    // THE FIRST OCCURRENCE AFTER THE OPENING QUOTE IS THE CLOSING ONE: CHECKING ONLY THE LAST CHARACTER WOULD WRONGLY ACCEPT
-    // `'sql' extra'`, WHERE THE REAL CLOSING QUOTE HAS CONTENT AFTER IT AND THE LAST CHARACTER IS A DIFFERENT, UNRELATED QUOTE
-    final int closingQuote = value.indexOf(first, 1);
-    if (closingQuote < 0)
+    if (value.length() >= 2 && value.charAt(value.length() - 1) == first)
+      return value.substring(1, value.length() - 1);
+
+    if (value.indexOf(first, 1) < 0)
       throw new ConsoleException("Invalid value for SET: missing closing quote in " + value);
 
-    if (closingQuote != value.length() - 1)
-      throw new ConsoleException("Invalid value for SET: unexpected content after the closing quote in " + value);
-
-    return value.substring(1, closingQuote);
+    throw new ConsoleException("Invalid value for SET: unexpected content after the closing quote in " + value);
   }
 
   private void executeTransactionStatus() {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -776,7 +776,9 @@ public class Console {
     long lastLapTime = System.currentTimeMillis();
     long lastLapExecutedLines = 0L;
 
-    // COLLECTS THE LINES OF A BLOCK COMMENT THAT SPANS MULTIPLE LINES, TO EXECUTE THEM ONLY ONCE THE COMMENT IS CLOSED
+    // COLLECTS THE LINES OF A BLOCK COMMENT OR A JSON OBJECT THAT SPANS MULTIPLE LINES, TO EXECUTE THEM ONLY ONCE THEY ARE
+    // CLOSED. WITHOUT THIS, A MULTI-LINE `CONTENT { ... }` CLAUSE WOULD HIT reportUnbalancedBrace() ON ITS FIRST LINE, WHOSE
+    // '}' IS SIMPLY ON A LINE NOT READ YET (ISSUE #6439)
     final StringBuilder pending = new StringBuilder();
 
     try (final BufferedReader bufferedReader = new BufferedReader(new FileReader(file, DatabaseFactory.getDefaultCharset()))) {
@@ -786,8 +788,8 @@ public class Console {
         pending.append(line).append('\n');
 
         final ParsedLine parsedLine = parser.parse(pending.toString(), 0);
-        if (parser.isBlockCommentOpen()) {
-          // THE COMMENT CONTINUES ON THE NEXT LINE
+        if (parser.isBlockCommentOpen() || parser.getUnbalancedBraceOffset() >= 0) {
+          // THE COMMENT OR THE JSON OBJECT CONTINUES ON THE NEXT LINE
           byteReadFromFile += line.length() + 1;
           continue;
         }
@@ -816,7 +818,8 @@ public class Console {
     }
 
     if (!pending.isEmpty())
-      // THE FILE ENDS WITH AN UNTERMINATED BLOCK COMMENT: EXECUTE WHAT COMES BEFORE IT
+      // THE FILE ENDS WITH AN UNTERMINATED BLOCK COMMENT OR JSON OBJECT: EXECUTE WHAT COMES BEFORE IT. IF IT IS A GENUINELY
+      // UNCLOSED '{' RATHER THAN A COMMENT, THE CALL BELOW REPORTS IT THROUGH reportUnbalancedBrace() AS USUAL
       execute(parser.parse(pending.toString(), 0), true);
 
     elapsed = System.currentTimeMillis() - startedOn;

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -306,7 +306,10 @@ public class Console {
 
       return true;
     } catch (final IOException | RuntimeException e) {
-      outputError(e);
+      // A NESTED COMMAND (E.G. AN UNBALANCED '{' REPORTED WHILE EXECUTING A LOADED SCRIPT) MAY HAVE ALREADY SENT ITS OWN
+      // MESSAGE TO THE OUTPUT: DON'T REPORT THE SAME ERROR TWICE (ISSUE #6439)
+      if (!(e instanceof final ConsoleException ce && ce.isAlreadyReported()))
+        outputError(e);
       throw e;
     }
   }
@@ -928,7 +931,7 @@ public class Console {
 
     final ConsoleException ex = new ConsoleException(
         "Unbalanced '{' at line " + (lineNumberBase + lineNo) + ", column " + col + ": no matching '}' was found, so everything "
-            + "from there to the end of the input was treated as a single command instead of being split on ';'");
+            + "from there to the end of the input was treated as a single command instead of being split on ';'", true);
     outputError(ex);
     throw ex;
   }

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -398,13 +398,16 @@ public class Console {
     if (first != '\'' && first != '"')
       return value;
 
-    if (value.length() >= 2 && value.charAt(value.length() - 1) == first)
-      return value.substring(1, value.length() - 1);
-
-    if (value.indexOf(first, 1) < 0)
+    // THE FIRST OCCURRENCE AFTER THE OPENING QUOTE IS THE CLOSING ONE: CHECKING ONLY THE LAST CHARACTER WOULD WRONGLY ACCEPT
+    // `'sql' extra'`, WHERE THE REAL CLOSING QUOTE HAS CONTENT AFTER IT AND THE LAST CHARACTER IS A DIFFERENT, UNRELATED QUOTE
+    final int closingQuote = value.indexOf(first, 1);
+    if (closingQuote < 0)
       throw new ConsoleException("Invalid value for SET: missing closing quote in " + value);
 
-    throw new ConsoleException("Invalid value for SET: unexpected content after the closing quote in " + value);
+    if (closingQuote != value.length() - 1)
+      throw new ConsoleException("Invalid value for SET: unexpected content after the closing quote in " + value);
+
+    return value.substring(1, closingQuote);
   }
 
   private void executeTransactionStatus() {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -321,7 +321,10 @@ public class Console {
       throw new ConsoleException("Invalid syntax for SET: missing name, use SET <name> = <value>");
 
     final String key = pair[0].trim();
-    final String value = pair[1].trim();
+    // A QUOTED VALUE HAS ITS QUOTES STRIPPED, LIKE A SHELL WOULD: OTHERWISE `SET LANGUAGE = 'SQL'` STORES THE LITERAL
+    // QUOTES, AND `LANGUAGE.STARTSWITH("SQL")` IN TerminalParser.setLanguage() SILENTLY PICKS THE WRONG COMMENT
+    // MARKER (ISSUE #6439)
+    final String value = stripMatchingQuotes(pair[1].trim());
 
     // THE SETTING NAMES ARE ASCII, SO THE CASE MUST FOLD IN ENGLISH: WITH A TURKISH DEFAULT LOCALE `LIMIT` WOULD NOT MATCH
     switch (key.toLowerCase(Locale.ENGLISH)) {
@@ -376,6 +379,26 @@ public class Console {
     }
 
     flushOutput();
+  }
+
+  /**
+   * Strips one matching pair of surrounding quotes (' or ") from a {@code SET} value, so {@code set language = 'sql'} stores
+   * {@code sql} rather than the literal quotes. A value that does not start with a quote character is returned unchanged. A
+   * value that starts with a quote character but does not end with that SAME character is always a typo - an unterminated or
+   * mismatched quote - so it is rejected rather than stored half-quoted (issue #6439).
+   */
+  private static String stripMatchingQuotes(final String value) {
+    if (value.isEmpty())
+      return value;
+
+    final char first = value.charAt(0);
+    if (first != '\'' && first != '"')
+      return value;
+
+    if (value.length() < 2 || value.charAt(value.length() - 1) != first)
+      throw new ConsoleException("Invalid value for SET: unbalanced quote in " + value);
+
+    return value.substring(1, value.length() - 1);
   }
 
   private void executeTransactionStatus() {
@@ -817,7 +840,16 @@ public class Console {
     if (parsedLine == null)
       return true;
 
-    for (final String w : parsedLine.words()) {
+    // AN UNCLOSED '{' MAKES THE PARSER FOLD EVERYTHING FROM THAT POINT TO THE END OF THE TEXT INTO THE LAST WORD INSTEAD
+    // OF SPLITTING IT ON ';' - REPORT IT HERE, POINTING AT THE BRACE THAT OPENED IT, RATHER THAN LETTING THE GLUED-TOGETHER
+    // TEXT FAIL DOWNSTREAM WITH A SYNTAX ERROR THAT POINTS AT CODE THE USER TYPED SEVERAL STATEMENTS AGO (ISSUE #6439).
+    // THIS RUNS ONLY WHEN A LINE IS ACTUALLY SUBMITTED FOR EXECUTION, NEVER ON THE KEYSTROKE-BY-KEYSTROKE PARSE CALLS
+    // JLINE MAKES FOR HIGHLIGHTING/COMPLETION WHILE THE USER IS STILL TYPING.
+    final int unbalancedBraceOffset = parser.getUnbalancedBraceOffset();
+
+    final List<String> words = parsedLine.words();
+    for (int i = 0; i < words.size(); ++i) {
+      final String w = words.get(i);
       final String trimmedWord = w.trim();
       if (trimmedWord.isEmpty())
         // AN EMPTY LINE (OR A LEFTOVER LINE TERMINATOR BETWEEN TWO COMMANDS) SPLITS INTO A BLANK "WORD": SKIP IT SO
@@ -829,9 +861,15 @@ public class Console {
         // WOULD OTHERWISE PUSH THE RESULT DOWN BY AN EXTRA BLANK LINE (issue #6372)
         output(3, getPrompt() + trimmedWord);
 
+      // THE UNCLOSED BRACE, IF ANY, IS ALWAYS SOMEWHERE INSIDE THE LAST WORD: EVERY SEMICOLON FROM THE BRACE ONWARD FAILED
+      // TO SEPARATE ANYTHING, SO THE REST OF THE INPUT WAS NEVER SPLIT
+      final boolean isUnbalancedBraceTail = i == words.size() - 1 && unbalancedBraceOffset >= 0;
+
       if (batchMode) {
         try {
-          if (!execute(w))
+          if (isUnbalancedBraceTail)
+            reportUnbalancedBrace(parsedLine.line(), unbalancedBraceOffset);
+          else if (!execute(w))
             return false;
         } catch (final Exception e) {
           errored = true;
@@ -839,12 +877,35 @@ public class Console {
             throw e;
         }
       } else {
-          if (!execute(w))
-            return false;
-
+        if (isUnbalancedBraceTail)
+          reportUnbalancedBrace(parsedLine.line(), unbalancedBraceOffset);
+        else if (!execute(w))
+          return false;
       }
     }
     return true;
+  }
+
+  /**
+   * Reports an unclosed '{' found while splitting the input, naming the line and column where it was opened, and rethrows so
+   * the caller aborts exactly as it would for any other command error (issue #6439).
+   */
+  private void reportUnbalancedBrace(final String text, final int offset) {
+    int lineNo = 1;
+    int col = 1;
+    for (int i = 0; i < offset && i < text.length(); ++i) {
+      if (text.charAt(i) == '\n') {
+        ++lineNo;
+        col = 1;
+      } else
+        ++col;
+    }
+
+    final ConsoleException ex = new ConsoleException(
+        "Unbalanced '{' at line " + lineNo + ", column " + col + ": no matching '}' was found, so everything from there to "
+            + "the end of the input was treated as a single command instead of being split on ';'");
+    outputError(ex);
+    throw ex;
   }
 
   private void outputLine(final int level, final String text, final Object... args) {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -384,8 +384,8 @@ public class Console {
   /**
    * Strips one matching pair of surrounding quotes (' or ") from a {@code SET} value, so {@code set language = 'sql'} stores
    * {@code sql} rather than the literal quotes. A value that does not start with a quote character is returned unchanged. A
-   * value that starts with a quote character but does not end with that SAME character is always a typo - an unterminated or
-   * mismatched quote - so it is rejected rather than stored half-quoted (issue #6439).
+   * value that opens with a quote character but never closes it is always a typo, and so is one with content trailing after
+   * the closing quote - both are rejected rather than stored half-quoted (issue #6439).
    */
   private static String stripMatchingQuotes(final String value) {
     if (value.isEmpty())
@@ -395,10 +395,13 @@ public class Console {
     if (first != '\'' && first != '"')
       return value;
 
-    if (value.length() < 2 || value.charAt(value.length() - 1) != first)
-      throw new ConsoleException("Invalid value for SET: unbalanced quote in " + value);
+    if (value.length() >= 2 && value.charAt(value.length() - 1) == first)
+      return value.substring(1, value.length() - 1);
 
-    return value.substring(1, value.length() - 1);
+    if (value.indexOf(first, 1) < 0)
+      throw new ConsoleException("Invalid value for SET: missing closing quote in " + value);
+
+    throw new ConsoleException("Invalid value for SET: unexpected content after the closing quote in " + value);
   }
 
   private void executeTransactionStatus() {
@@ -780,10 +783,18 @@ public class Console {
     // CLOSED. WITHOUT THIS, A MULTI-LINE `CONTENT { ... }` CLAUSE WOULD HIT reportUnbalancedBrace() ON ITS FIRST LINE, WHOSE
     // '}' IS SIMPLY ON A LINE NOT READ YET (ISSUE #6439)
     final StringBuilder pending = new StringBuilder();
+    // THE FILE LINE (1-BASED) OF pending'S FIRST LINE, SO AN UNBALANCED BRACE IS REPORTED AT ITS REAL POSITION IN THE FILE
+    // RATHER THAN RELATIVE TO A BUFFER THAT RESTARTS AFTER EVERY EXECUTED STATEMENT (ISSUE #6439)
+    int fileLineNumber = 0;
+    int pendingStartLine = 1;
 
     try (final BufferedReader bufferedReader = new BufferedReader(new FileReader(file, DatabaseFactory.getDefaultCharset()))) {
       while (bufferedReader.ready()) {
         final String line = FileUtils.decodeFromFile(bufferedReader.readLine());
+        ++fileLineNumber;
+
+        if (pending.isEmpty())
+          pendingStartLine = fileLineNumber;
 
         pending.append(line).append('\n');
 
@@ -795,7 +806,7 @@ public class Console {
         }
 
         pending.setLength(0);
-        execute(parsedLine, true);
+        execute(parsedLine, true, pendingStartLine - 1);
 
         ++executedLines;
         byteReadFromFile += line.length() + 1;
@@ -820,7 +831,7 @@ public class Console {
     if (!pending.isEmpty())
       // THE FILE ENDS WITH AN UNTERMINATED BLOCK COMMENT OR JSON OBJECT: EXECUTE WHAT COMES BEFORE IT. IF IT IS A GENUINELY
       // UNCLOSED '{' RATHER THAN A COMMENT, THE CALL BELOW REPORTS IT THROUGH reportUnbalancedBrace() AS USUAL
-      execute(parser.parse(pending.toString(), 0), true);
+      execute(parser.parse(pending.toString(), 0), true, pendingStartLine - 1);
 
     elapsed = System.currentTimeMillis() - startedOn;
 
@@ -840,6 +851,17 @@ public class Console {
    * Executes the commands extracted from the text by the parser.
    */
   private boolean execute(final ParsedLine parsedLine, final boolean printCommand) throws IOException {
+    return execute(parsedLine, printCommand, 0);
+  }
+
+  /**
+   * @param lineNumberBase number of lines that precede {@code parsedLine.line()} in the original source, so an unbalanced brace
+   *                       is reported at its real position. Zero for interactive/batch input, where the parsed text is exactly
+   *                       what was typed; {@code executeLoad} passes the count of file lines already consumed before the
+   *                       current buffered statement started, since that buffer restarts after every executed statement and is
+   *                       otherwise unaware of its position in the file (issue #6439).
+   */
+  private boolean execute(final ParsedLine parsedLine, final boolean printCommand, final int lineNumberBase) throws IOException {
     if (parsedLine == null)
       return true;
 
@@ -871,7 +893,7 @@ public class Console {
       if (batchMode) {
         try {
           if (isUnbalancedBraceTail)
-            reportUnbalancedBrace(parsedLine.line(), unbalancedBraceOffset);
+            reportUnbalancedBrace(parsedLine.line(), unbalancedBraceOffset, lineNumberBase);
           else if (!execute(w))
             return false;
         } catch (final Exception e) {
@@ -881,7 +903,7 @@ public class Console {
         }
       } else {
         if (isUnbalancedBraceTail)
-          reportUnbalancedBrace(parsedLine.line(), unbalancedBraceOffset);
+          reportUnbalancedBrace(parsedLine.line(), unbalancedBraceOffset, lineNumberBase);
         else if (!execute(w))
           return false;
       }
@@ -893,7 +915,7 @@ public class Console {
    * Reports an unclosed '{' found while splitting the input, naming the line and column where it was opened, and rethrows so
    * the caller aborts exactly as it would for any other command error (issue #6439).
    */
-  private void reportUnbalancedBrace(final String text, final int offset) {
+  private void reportUnbalancedBrace(final String text, final int offset, final int lineNumberBase) {
     int lineNo = 1;
     int col = 1;
     for (int i = 0; i < offset && i < text.length(); ++i) {
@@ -905,8 +927,8 @@ public class Console {
     }
 
     final ConsoleException ex = new ConsoleException(
-        "Unbalanced '{' at line " + lineNo + ", column " + col + ": no matching '}' was found, so everything from there to "
-            + "the end of the input was treated as a single command instead of being split on ';'");
+        "Unbalanced '{' at line " + (lineNumberBase + lineNo) + ", column " + col + ": no matching '}' was found, so everything "
+            + "from there to the end of the input was treated as a single command instead of being split on ';'");
     outputError(ex);
     throw ex;
   }

--- a/console/src/main/java/com/arcadedb/console/ConsoleException.java
+++ b/console/src/main/java/com/arcadedb/console/ConsoleException.java
@@ -19,7 +19,23 @@
 package com.arcadedb.console;
 
 public class ConsoleException extends RuntimeException {
+  private final boolean alreadyReported;
+
   public ConsoleException(final String message) {
+    this(message, false);
+  }
+
+  /**
+   * @param alreadyReported true when the thrower already sent this error to the console output, so a generic catch further up
+   *                        the call chain - for example the one wrapping every command in {@code Console.execute(String)} -
+   *                        must not report it a second time (issue #6439).
+   */
+  public ConsoleException(final String message, final boolean alreadyReported) {
     super(message);
+    this.alreadyReported = alreadyReported;
+  }
+
+  public boolean isAlreadyReported() {
+    return alreadyReported;
   }
 }

--- a/console/src/main/java/com/arcadedb/console/TerminalParser.java
+++ b/console/src/main/java/com/arcadedb/console/TerminalParser.java
@@ -43,10 +43,10 @@ public class TerminalParser extends DefaultParser {
   private static final String SQL_LINE_COMMENT   = "--";
   private static final String OTHER_LINE_COMMENT = "//";
 
-  private String  lineComment            = SQL_LINE_COMMENT;
-  private boolean lineCommentNeedsBlank  = true;
-  private boolean blockCommentOpen       = false;
-  private int     unbalancedBraceOffset  = -1;
+  private String  lineComment           = SQL_LINE_COMMENT;
+  private boolean lineCommentNeedsBlank = true;
+  private boolean blockCommentOpen      = false;
+  private int     unbalancedBraceOffset = -1;
 
   /**
    * Returns true if the text of the last parse ends inside a block comment, so the following lines are still part of it. Valid

--- a/console/src/main/java/com/arcadedb/console/TerminalParser.java
+++ b/console/src/main/java/com/arcadedb/console/TerminalParser.java
@@ -35,15 +35,18 @@ import java.util.Locale;
  * <p>
  * A semicolon inside a JSON object literal is not a separator either, so the open braces are counted while scanning. The count
  * never goes below zero: an unbalanced closing brace is a typo in one command and must not change how the following ones are
- * split (issue #6392).
+ * split (issue #6392). The opposite typo, a `{` that is never closed, cannot be clamped the same way: the parser genuinely
+ * cannot know it is unbalanced until the input ends, so it instead records the offset of that brace for the caller to report
+ * once parsing is done (issue #6439).
  */
 public class TerminalParser extends DefaultParser {
   private static final String SQL_LINE_COMMENT   = "--";
   private static final String OTHER_LINE_COMMENT = "//";
 
-  private String  lineComment           = SQL_LINE_COMMENT;
-  private boolean lineCommentNeedsBlank = true;
-  private boolean blockCommentOpen      = false;
+  private String  lineComment            = SQL_LINE_COMMENT;
+  private boolean lineCommentNeedsBlank  = true;
+  private boolean blockCommentOpen       = false;
+  private int     unbalancedBraceOffset  = -1;
 
   /**
    * Returns true if the text of the last parse ends inside a block comment, so the following lines are still part of it. Valid
@@ -51,6 +54,16 @@ public class TerminalParser extends DefaultParser {
    */
   public boolean isBlockCommentOpen() {
     return blockCommentOpen;
+  }
+
+  /**
+   * Returns the offset, in the text of the last parse, of the outermost `{` that is still unclosed - or -1 if every brace was
+   * matched. Everything from that offset to the end of the text was folded into a single word instead of being split on `;`,
+   * since the delimiter branch in {@link #parse(String, int, ParseContext)} requires a brace depth of zero (issue #6439). Valid
+   * only right after a call to {@link #parse(String, int, ParseContext)}.
+   */
+  public int getUnbalancedBraceOffset() {
+    return unbalancedBraceOffset;
   }
 
   /**
@@ -97,6 +110,7 @@ public class TerminalParser extends DefaultParser {
     int rawWordLength = -1;
     int rawWordStart = 0;
     int braceDepth = 0;
+    int openBraceOffset = -1;
     boolean insideLineComment = false;
     boolean insideBlockComment = false;
 
@@ -151,6 +165,8 @@ public class TerminalParser extends DefaultParser {
         rawWordStart = i + 1;
       } else if (!this.isEscapeChar(line, i)) {
         if (c == '{') {
+          if (braceDepth == 0)
+            openBraceOffset = i;
           braceDepth++;
           current.append(c);
         } else if (c == '}') {
@@ -159,6 +175,8 @@ public class TerminalParser extends DefaultParser {
           // FROM SEPARATING THE COMMANDS FOR THE REST OF THE TEXT (ISSUE #6392)
           if (braceDepth > 0)
             braceDepth--;
+          if (braceDepth == 0)
+            openBraceOffset = -1;
           current.append(c);
 
           // Check if we just closed all braces and there's more content after newlines
@@ -197,6 +215,7 @@ public class TerminalParser extends DefaultParser {
     }
 
     blockCommentOpen = insideBlockComment;
+    unbalancedBraceOffset = braceDepth > 0 ? openBraceOffset : -1;
 
     if (current.length() > 0 || cursor == line.length()) {
       words.add(current.toString());

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -235,8 +235,20 @@ class ConsoleTest {
           insert into Loaded content {"a": 1
           """);
 
+      final StringBuilder buffer = new StringBuilder();
+      console.setOutput(output -> buffer.append(output));
+
       assertThatThrownBy(() -> console.parse("load " + script.getAbsolutePath())).isInstanceOf(ConsoleException.class)
           .hasMessageContaining("line 4");
+
+      // THE ERROR MUST BE REPORTED ONCE, NOT ONCE BY reportUnbalancedBrace() AND AGAIN BY THE GENERIC CATCH WRAPPING THE
+      // "load" COMMAND DISPATCH (ISSUE #6439)
+      final String output = buffer.toString();
+      final String marker = "Unbalanced '{'";
+      int occurrences = 0;
+      for (int idx = output.indexOf(marker); idx != -1; idx = output.indexOf(marker, idx + marker.length()))
+        ++occurrences;
+      assertThat(occurrences).isEqualTo(1);
     } finally {
       script.delete();
     }

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -375,6 +375,18 @@ class ConsoleTest {
   }
 
   /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: checking only the LAST character against the opening quote would
+   * wrongly accept this value, since it also ends with a quote character - but that trailing quote is unrelated to the real
+   * closing quote right after `sql`, and the content between them must still be rejected.
+   */
+  @Test
+  void setWithContentAfterClosingQuoteEndingInAnotherQuoteIsRejected() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThatThrownBy(() -> console.parse("set language = 'sql' extra'")).isInstanceOf(ConsoleException.class)
+        .hasMessageContaining("unexpected content after the closing quote");
+  }
+
+  /**
    * Issue https://github.com/ArcadeData/arcadedb/issues/6439: an unclosed '{' in a CONTENT clause used to swallow every
    * following command into one malformed statement, which then failed downstream with a confusing syntax error pointing at
    * text typed several statements earlier. The commands before the corrupted one must still run, and the corrupted tail must

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -218,6 +218,31 @@ class ConsoleTest {
   }
 
   /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: {@code executeLoad} re-buffers one statement at a time, resetting
+   * after every executed command, so an unclosed '{' must be reported at its real position in the FILE - here line 4 - not at
+   * "line 1" relative to the buffer that happened to be accumulating when the error was found.
+   */
+  @Test
+  void unbalancedBraceInLoadedScriptReportsTheActualFileLine() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+
+    final File script = new File("./target/issue-6439-load-line.sql");
+    try {
+      Files.writeString(script.toPath(), """
+          create document type Loaded;
+          insert into Loaded set id = 1;
+          insert into Loaded set id = 2;
+          insert into Loaded content {"a": 1
+          """);
+
+      assertThatThrownBy(() -> console.parse("load " + script.getAbsolutePath())).isInstanceOf(ConsoleException.class)
+          .hasMessageContaining("line 4");
+    } finally {
+      script.delete();
+    }
+  }
+
+  /**
    * Issue https://github.com/ArcadeData/arcadedb/issues/6372: an empty line in a script loaded with LOAD must not echo an
    * empty prompt of its own - only the real commands are echoed.
    */
@@ -320,10 +345,21 @@ class ConsoleTest {
    * it is always a typo, so it must be rejected instead of being stored half-quoted.
    */
   @Test
-  void setWithUnbalancedQuoteIsRejected() throws Exception {
+  void setWithMissingClosingQuoteIsRejected() throws Exception {
     assertThat(console.parse("connect " + DB_NAME)).isTrue();
     assertThatThrownBy(() -> console.parse("set language = 'sql")).isInstanceOf(ConsoleException.class)
-        .hasMessageContaining("unbalanced quote");
+        .hasMessageContaining("missing closing quote");
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: content trailing after a properly closed quote is a different
+   * typo than a missing quote, and deserves a message that says so rather than "unbalanced".
+   */
+  @Test
+  void setWithContentAfterClosingQuoteIsRejected() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThatThrownBy(() -> console.parse("set language = 'sql' extra")).isInstanceOf(ConsoleException.class)
+        .hasMessageContaining("unexpected content after the closing quote");
   }
 
   /**

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -186,6 +186,38 @@ class ConsoleTest {
   }
 
   /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: a script is loaded line by line, so a `CONTENT` clause whose JSON
+   * object spans multiple lines must keep accumulating exactly like a multi-line block comment does, rather than being reported
+   * as an unbalanced '{' on its first line - the closing '}' is simply on a line not read yet.
+   */
+  @Test
+  void loadScriptWithMultiLineJsonContent() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+
+    final File script = new File("./target/issue-6439.sql");
+    try {
+      Files.writeString(script.toPath(), """
+          create document type Loaded;
+          insert into Loaded content {
+            "id": 66
+          };
+          """);
+
+      final StringBuilder buffer = new StringBuilder();
+      console.setOutput(output -> buffer.append(output));
+
+      assertThat(console.parse("load " + script.getAbsolutePath())).isTrue();
+      assertThat(buffer.toString()).doesNotContain("ERROR");
+
+      buffer.setLength(0);
+      assertThat(console.parse("select from Loaded")).isTrue();
+      assertThat(buffer.toString()).contains("66").doesNotContain("ERROR");
+    } finally {
+      script.delete();
+    }
+  }
+
+  /**
    * Issue https://github.com/ArcadeData/arcadedb/issues/6372: an empty line in a script loaded with LOAD must not echo an
    * empty prompt of its own - only the real commands are echoed.
    */

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -363,6 +363,13 @@ class ConsoleTest {
         .hasMessageContaining("missing closing quote");
   }
 
+  @Test
+  void setWithMissingClosingDoubleQuoteIsRejected() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThatThrownBy(() -> console.parse("set language = \"sql")).isInstanceOf(ConsoleException.class)
+        .hasMessageContaining("missing closing quote");
+  }
+
   /**
    * Issue https://github.com/ArcadeData/arcadedb/issues/6439: content trailing after a properly closed quote is a different
    * typo than a missing quote, and deserves a message that says so rather than "unbalanced".
@@ -371,6 +378,13 @@ class ConsoleTest {
   void setWithContentAfterClosingQuoteIsRejected() throws Exception {
     assertThat(console.parse("connect " + DB_NAME)).isTrue();
     assertThatThrownBy(() -> console.parse("set language = 'sql' extra")).isInstanceOf(ConsoleException.class)
+        .hasMessageContaining("unexpected content after the closing quote");
+  }
+
+  @Test
+  void setWithContentAfterClosingDoubleQuoteIsRejected() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThatThrownBy(() -> console.parse("set language = \"sql\" extra")).isInstanceOf(ConsoleException.class)
         .hasMessageContaining("unexpected content after the closing quote");
   }
 

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -375,15 +375,20 @@ class ConsoleTest {
   }
 
   /**
-   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: checking only the LAST character against the opening quote would
-   * wrongly accept this value, since it also ends with a quote character - but that trailing quote is unrelated to the real
-   * closing quote right after `sql`, and the content between them must still be rejected.
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: TerminalParser strips the escaping backslash from an escaped
+   * inner quote before executeSet ever sees the value, so a value like this reaches stripMatchingQuotes as
+   * {@code 'it's a test'} - indistinguishable from a real closing quote followed by trailing garbage that happens to also end
+   * in a quote. It must still be accepted as the escaped value the user intended, not rejected.
    */
   @Test
-  void setWithContentAfterClosingQuoteEndingInAnotherQuoteIsRejected() throws Exception {
+  void setLanguageWithEscapedQuoteInsideValueIsPreserved() throws Exception {
     assertThat(console.parse("connect " + DB_NAME)).isTrue();
-    assertThatThrownBy(() -> console.parse("set language = 'sql' extra'")).isInstanceOf(ConsoleException.class)
-        .hasMessageContaining("unexpected content after the closing quote");
+
+    final StringBuilder buffer = new StringBuilder();
+    console.setOutput(output -> buffer.append(output));
+
+    assertThat(console.parse("set language = 'it\\'s a test'")).isTrue();
+    assertThat(buffer.toString()).contains("it's a test").doesNotContain("ERROR");
   }
 
   /**

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -419,11 +419,14 @@ class ConsoleTest {
     console.setOutput(output -> buffer.append(output));
 
     assertThatThrownBy(
-        () -> console.parse("select 11 as value; insert into doc content {\"a\": 1 ; select 22 as value"))
+        () -> console.parse("select 11 as value; insert into doc content {\"a\": 1 ; select 99999 as value"))
         .isInstanceOf(ConsoleException.class)
         .hasMessageContaining("Unbalanced '{'");
 
-    assertThat(buffer.toString()).contains("11").contains("ERROR");
+    // "select 99999" IS PART OF THE CORRUPTED TAIL, GLUED TO THE MALFORMED CONTENT CLAUSE BY THE UNCLOSED '{': IT MUST NEVER
+    // REACH THE QUERY ENGINE, NOT EVEN AS A DIGIT SUBSTRING OF A LARGER MATCHED NUMBER
+    final String output = buffer.toString();
+    assertThat(output).contains("11").contains("ERROR").doesNotContain("99999");
   }
 
   @Test

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -254,6 +254,67 @@ class ConsoleTest {
     console.parse("connect " + DB_NAME + ";set language = sql; select 1");
   }
 
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: `set language = 'sql'` used to store the value with its quotes,
+   * and `'sql'.startsWith("sql")` is false, so TerminalParser.setLanguage() picked the non-SQL `//` comment marker. That left
+   * `--` unrecognised, so the semicolon inside the comment below would have split the command in two instead of being dropped.
+   */
+  @Test
+  void setLanguageWithQuotedSqlValueKeepsTheSqlCommentMarker() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("set language = 'sql'")).isTrue();
+
+    final StringBuilder buffer = new StringBuilder();
+    console.setOutput(output -> buffer.append(output));
+
+    assertThat(console.parse("select 11 as value -- a comment with a semicolon ; here")).isTrue();
+    assertThat(buffer.toString()).contains("11").doesNotContain("ERROR");
+  }
+
+  @Test
+  void setLanguageWithDoubleQuotedValueStripsTheQuotes() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("set language = \"sql\"")).isTrue();
+
+    final StringBuilder buffer = new StringBuilder();
+    console.setOutput(output -> buffer.append(output));
+
+    assertThat(console.parse("select 11 as value -- a comment with a semicolon ; here")).isTrue();
+    assertThat(buffer.toString()).contains("11").doesNotContain("ERROR");
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: a SET value that starts with a quote character but never closes
+   * it is always a typo, so it must be rejected instead of being stored half-quoted.
+   */
+  @Test
+  void setWithUnbalancedQuoteIsRejected() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThatThrownBy(() -> console.parse("set language = 'sql")).isInstanceOf(ConsoleException.class)
+        .hasMessageContaining("unbalanced quote");
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: an unclosed '{' in a CONTENT clause used to swallow every
+   * following command into one malformed statement, which then failed downstream with a confusing syntax error pointing at
+   * text typed several statements earlier. The commands before the corrupted one must still run, and the corrupted tail must
+   * be reported clearly instead of being forwarded to the query engine.
+   */
+  @Test
+  void unbalancedOpeningBraceRunsEarlierCommandsThenReportsTheCorruptedTail() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+
+    final StringBuilder buffer = new StringBuilder();
+    console.setOutput(output -> buffer.append(output));
+
+    assertThatThrownBy(
+        () -> console.parse("select 11 as value; insert into doc content {\"a\": 1 ; select 22 as value"))
+        .isInstanceOf(ConsoleException.class)
+        .hasMessageContaining("Unbalanced '{'");
+
+    assertThat(buffer.toString()).contains("11").contains("ERROR");
+  }
+
   @Test
   void createClass() throws Exception {
     assertThat(console.parse("connect " + DB_NAME)).isTrue();

--- a/console/src/test/java/com/arcadedb/console/TerminalParserTest.java
+++ b/console/src/test/java/com/arcadedb/console/TerminalParserTest.java
@@ -165,4 +165,34 @@ class TerminalParserTest {
   void unbalancedClosingBraceInsideAStringIsNotCounted() {
     assertThat(split("SELECT '}}}' ; SELECT 1")).containsExactly("SELECT '}}}' ", " SELECT 1");
   }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6439: an unclosed '{' drives the brace depth to 1 and, since the
+   * delimiter branch requires depth zero, no semicolon after it can separate anything for the rest of the text.
+   */
+  @Test
+  void unbalancedOpeningBraceSwallowsFollowingCommands() {
+    final String line = "INSERT INTO doc CONTENT {\"a\": 1 ; SELECT 1; SELECT 2";
+    assertThat(split(line)).containsExactly(line);
+    assertThat(parser.getUnbalancedBraceOffset()).isEqualTo(line.indexOf('{'));
+  }
+
+  @Test
+  void balancedBracesReportNoUnbalancedOffset() {
+    split("INSERT INTO doc CONTENT {\"a\": 1}; SELECT 1; SELECT 2");
+    assertThat(parser.getUnbalancedBraceOffset()).isEqualTo(-1);
+  }
+
+  @Test
+  void nestedUnbalancedBraceReportsTheOutermostOffset() {
+    final String line = "INSERT INTO doc CONTENT {\"a\": {\"b\": 1} ; SELECT 1";
+    split(line);
+    assertThat(parser.getUnbalancedBraceOffset()).isEqualTo(line.indexOf('{'));
+  }
+
+  @Test
+  void unbalancedBraceInsideAStringIsNotCounted() {
+    split("SELECT '{' ; SELECT 1");
+    assertThat(parser.getUnbalancedBraceOffset()).isEqualTo(-1);
+  }
 }


### PR DESCRIPTION
## Summary

Closes #6439, the two follow-ups split out of #6437/#6392 that needed a decision before implementation.

**1. Unbalanced `{` swallows every following command**

An unterminated `{` in a `CONTENT` clause drove the brace depth to 1 forever, so `TerminalParser.parse()`'s delimiter branch (which requires `braceDepth == 0`) never matched again - every following `;` stopped separating commands, and the rest of the input was folded into one malformed statement that failed downstream with a confusing syntax error pointing at text typed several statements earlier.

- `TerminalParser` now exposes `getUnbalancedBraceOffset()` (mirroring the existing `isBlockCommentOpen()`), recording the offset of the outermost brace still open once a `parse()` call finishes.
- `Console.execute(ParsedLine)` checks it after parsing and, if set, reports a clear error naming the line and column where the brace was opened, instead of forwarding the glued-together text to the query engine. The correctly-terminated commands that came before the corrupted one still run.
- This check runs only when a line is actually submitted for execution (`Console.execute`), never on jline's keystroke-by-keystroke `parse()` calls used for highlighting/completion while the user is still typing - so it does not fire mid-typing in the interactive console.

**2. `SET` doesn't strip quotes, and a quoted `language` silently reintroduces #5457**

`set language = 'sql'` stored the literal `'sql'`, quotes included. `TerminalParser.setLanguage()` then tested `language.startsWith("sql")`, which is false for `'sql'`, so the console switched to the non-SQL `//` comment marker - silently reintroducing #5457 (a `;` inside a `--` comment would split the command again) and also breaking command dispatch, since `language` is passed directly as the query-engine name.

- `Console.executeSet()` now strips one matching pair of surrounding quotes (`'` or `"`) from the value, consistently for every setting.
- A value that opens with a quote character but never closes it with the same character is always a typo, so it's now rejected with `ConsoleException` rather than stored half-quoted.

## Test plan

- [x] `TerminalParserTest`: 4 new tests covering the unbalanced-brace offset tracking (plain, balanced, nested, and inside a string) - 23/23 pass
- [x] `ConsoleTest`: 4 new tests - quoted `sql`/`cypher`-style single- and double-quoted `SET` values keep the right comment marker, an unbalanced quote in `SET` is rejected, and an unclosed `{` runs the earlier valid commands then reports the corrupted tail clearly - 50/50 pass
- [x] Full `console` module test suite run directly (not through `-am`, to avoid re-running the unrelated `engine` suite) - all green
- [x] `mvn -pl console -am compile`/`test-compile` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `SET` command handling for quoted values, including escaped quotes, missing closing quotes, and unexpected trailing content.
  * Added clearer unbalanced-brace diagnostics with accurate source-line reporting.
  * Prevented duplicate errors and malformed content from swallowing subsequent commands.
  * Improved multiline JSON content loading and correctly ignored braces inside quoted strings.

* **Tests**
  * Added coverage for quote handling, multiline JSON, brace tracking, line reporting, and command recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->