### PR TITLE
fix(#5671): UnionStatement clause accessors and positional variable-kind checks

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CypherStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CypherStatement.java
@@ -93,6 +93,31 @@ public interface CypherStatement {
   }
 
   /**
+   * Returns true if this statement contains a non-empty SET clause.
+   * Defaults to false for non-query (control/admin/DDL/session) statements.
+   * <p>
+   * Kept as a predicate rather than requiring callers to inspect {@link #getSetClause()} directly, because that
+   * accessor has no single answer for a {@code UnionStatement} - unlike {@link #hasCreate()}, {@link #hasMerge()}
+   * and {@link #hasDelete()}, which already avoid the same trap (issue #5671).
+   *
+   * @return true if contains SET
+   */
+  default boolean hasSet() {
+    return false;
+  }
+
+  /**
+   * Returns true if this statement contains REMOVE operations.
+   * Defaults to false for non-query (control/admin/DDL/session) statements.
+   * See {@link #hasSet()} for why this is a predicate rather than {@link #getRemoveClauses()} emptiness.
+   *
+   * @return true if contains REMOVE
+   */
+  default boolean hasRemove() {
+    return false;
+  }
+
+  /**
    * Returns the ORDER BY clause if present.
    * Defaults to null for non-query (control/admin/DDL/session) statements.
    *

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/SimpleCypherStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/SimpleCypherStatement.java
@@ -416,6 +416,16 @@ public class SimpleCypherStatement implements CypherStatement {
   }
 
   @Override
+  public boolean hasSet() {
+    return setClause != null && !setClause.isEmpty();
+  }
+
+  @Override
+  public boolean hasRemove() {
+    return hasRemove;
+  }
+
+  @Override
   public OrderByClause getOrderByClause() {
     return orderByClause;
   }
@@ -473,10 +483,6 @@ public class SimpleCypherStatement implements CypherStatement {
   @Override
   public List<RemoveClause> getRemoveClauses() {
     return removeClauses;
-  }
-
-  public boolean hasRemove() {
-    return hasRemove;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/UnionStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/UnionStatement.java
@@ -92,7 +92,6 @@ public class UnionStatement implements CypherStatement {
     return queries.get(0);
   }
 
-  // Delegate CypherStatement methods to the first query
   // UNION inherits read-only status from all subqueries
 
   @Override
@@ -103,16 +102,36 @@ public class UnionStatement implements CypherStatement {
     return true;
   }
 
+  /**
+   * A UNION has no {@code MATCH} of its own - each branch has its own, and they can differ (issue #5671):
+   * {@code MATCH (a:P) RETURN a.x AS c UNION MATCH q = (m:P)-->() RETURN q.name AS c} has two entirely different
+   * match shapes, and answering with branch 1's would silently drop branch 2's. Every caller that needs to know
+   * what a branch matches must go through {@link #getQueries()} and decide what a union means for its purpose -
+   * exactly what {@link com.arcadedb.query.opencypher.parser.CypherExpressionWalker} already does by walking each
+   * branch as a nested statement in its own right.
+   *
+   * @throws UnsupportedOperationException always
+   */
   @Override
   public List<MatchClause> getMatchClauses() {
-    return queries.getFirst().getMatchClauses();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single MATCH clause list: branches can differ. Use getQueries() and inspect each branch.");
   }
 
+  /**
+   * @throws UnsupportedOperationException always, for the reason documented on {@link #getMatchClauses()}
+   */
   @Override
   public WhereClause getWhereClause() {
-    return queries.getFirst().getWhereClause();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single WHERE clause: branches can differ. Use getQueries() and inspect each branch.");
   }
 
+  /**
+   * Unlike the other clause accessors, this one is safe to answer from the first branch: {@code validateUnion}
+   * enforces {@code DifferentColumnsInUnion}, so every branch is required to project the same return column
+   * names, which makes branch 1's column names the union's column names.
+   */
   @Override
   public ReturnClause getReturnClause() {
     return queries.getFirst().getReturnClause();
@@ -143,6 +162,22 @@ public class UnionStatement implements CypherStatement {
   }
 
   @Override
+  public boolean hasSet() {
+    for (final CypherStatement query : queries)
+      if (query.hasSet())
+        return true;
+    return false;
+  }
+
+  @Override
+  public boolean hasRemove() {
+    for (final CypherStatement query : queries)
+      if (query.hasRemove())
+        return true;
+    return false;
+  }
+
+  @Override
   public OrderByClause getOrderByClause() {
     // For UNION, ORDER BY applies to the final result
     // Currently we don't support ORDER BY after UNION in the grammar
@@ -159,38 +194,67 @@ public class UnionStatement implements CypherStatement {
     return null;
   }
 
+  /**
+   * @throws UnsupportedOperationException always, for the reason documented on {@link #getMatchClauses()}
+   */
   @Override
   public CreateClause getCreateClause() {
-    return queries.getFirst().getCreateClause();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single CREATE clause: branches can differ. Use getQueries() and inspect each branch.");
   }
 
+  /**
+   * @throws UnsupportedOperationException always, for the reason documented on {@link #getMatchClauses()}
+   */
   @Override
   public SetClause getSetClause() {
-    return queries.getFirst().getSetClause();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single SET clause: branches can differ. Use getQueries() and inspect each branch, "
+            + "or hasSet() for the aggregated presence check.");
   }
 
+  /**
+   * @throws UnsupportedOperationException always, for the reason documented on {@link #getMatchClauses()}
+   */
   @Override
   public DeleteClause getDeleteClause() {
-    return queries.getFirst().getDeleteClause();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single DELETE clause: branches can differ. Use getQueries() and inspect each branch.");
   }
 
+  /**
+   * @throws UnsupportedOperationException always, for the reason documented on {@link #getMatchClauses()}
+   */
   @Override
   public MergeClause getMergeClause() {
-    return queries.getFirst().getMergeClause();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single MERGE clause: branches can differ. Use getQueries() and inspect each branch.");
   }
 
+  /**
+   * @throws UnsupportedOperationException always, for the reason documented on {@link #getMatchClauses()}
+   */
   @Override
   public List<UnwindClause> getUnwindClauses() {
-    return queries.getFirst().getUnwindClauses();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single UNWIND clause list: branches can differ. Use getQueries() and inspect each branch.");
   }
 
+  /**
+   * @throws UnsupportedOperationException always, for the reason documented on {@link #getMatchClauses()}
+   */
   @Override
   public List<WithClause> getWithClauses() {
-    return queries.getFirst().getWithClauses();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single WITH clause list: branches can differ. Use getQueries() and inspect each branch.");
   }
 
+  /**
+   * @throws UnsupportedOperationException always, for the reason documented on {@link #getMatchClauses()}
+   */
   @Override
   public List<ClauseEntry> getClausesInOrder() {
-    return queries.getFirst().getClausesInOrder();
+    throw new UnsupportedOperationException(
+        "UnionStatement has no single ordered clause list: branches can differ. Use getQueries() and inspect each branch.");
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
@@ -73,6 +73,19 @@ public final class CypherVariableUsage {
    * @return true if the variable is referenced elsewhere in the query
    */
   public static boolean isEdgeVariableReferenced(final CypherStatement statement, final String variable) {
+    // A UNION has no clauses of its own (issue #5671): each branch is checked as one, and a reference in ANY
+    // branch keeps the edge binding alive - the same conservative policy documented on the CREATE/MERGE case
+    // below. Not currently reachable with a union statement (every call site plans a UNION branch-by-branch
+    // before reaching here), but this mirrors innerStatementReferencesVariable's guard below for the same
+    // defense-in-depth reason: nothing past this point can answer for a union, and answering wrongly (dropping
+    // an edge binding) is worse than the redundant check costs.
+    if (statement instanceof UnionStatement union) {
+      for (final CypherStatement branch : union.getQueries())
+        if (isEdgeVariableReferenced(branch, variable))
+          return true;
+      return false;
+    }
+
     // 0. RETURN * projects every variable in scope by name, so nothing is unreferenced under it.
     //    Reading only the explicit return items said otherwise and dropped the edge binding, which
     //    made the relationship column disappear from the result.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
@@ -35,6 +35,7 @@ import com.arcadedb.query.opencypher.ast.RemoveClause;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
 import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.ast.SubqueryClause;
+import com.arcadedb.query.opencypher.ast.UnionStatement;
 import com.arcadedb.query.opencypher.ast.UnwindClause;
 import com.arcadedb.query.opencypher.ast.VariableExpression;
 import com.arcadedb.query.opencypher.ast.WithClause;
@@ -316,8 +317,24 @@ public final class CypherVariableUsage {
     if (scope != null && scope.contains(variable))
       return true;
     // Otherwise inspect the inner statement's clauses (e.g. CALL { WITH r ... DELETE r }).
-    final CypherStatement inner = subqueryClause.getInnerStatement();
-    if (inner == null || inner.getClausesInOrder() == null)
+    return innerStatementReferencesVariable(subqueryClause.getInnerStatement(), variable);
+  }
+
+  /**
+   * A UNION has no clauses of its own (issue #5671): each branch is its own statement, so it is checked as
+   * one. A reference in <b>any</b> branch keeps the edge binding alive, matching the conservative,
+   * false-positive-only-costs-the-fast-path policy documented on the CREATE/MERGE case above.
+   */
+  private static boolean innerStatementReferencesVariable(final CypherStatement inner, final String variable) {
+    if (inner == null)
+      return false;
+    if (inner instanceof UnionStatement union) {
+      for (final CypherStatement branch : union.getQueries())
+        if (innerStatementReferencesVariable(branch, variable))
+          return true;
+      return false;
+    }
+    if (inner.getClausesInOrder() == null)
       return false;
     for (final ClauseEntry entry : inner.getClausesInOrder()) {
       switch (entry.getType()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -170,6 +170,14 @@ public final class CypherExpressionWalker {
      * {@code WITH}: its own projection items are evaluated against the scope it inherited, not the one it declares
      * (issue #5671) - so {@code walkWith} is handed both and decides which each part gets, rather than this method
      * trying to express two different answers through one return value.
+     * <p>
+     * Returning {@code null} is <b>not</b> "skip this one clause" the way it is for {@link #forNestedStatement} -
+     * there is no clause-scoped body to skip into, only a scope to keep advancing - so it stops the walk from this
+     * clause on: neither this clause's own expressions nor any clause after it, nor the statement's
+     * {@code RETURN}/{@code ORDER BY}/{@code SKIP}/{@code LIMIT}, are visited. No visitor in this codebase returns
+     * {@code null} here today; a future one that wants to opt out of just one clause should return {@code this}
+     * unchanged for that entry instead; a future one that wants to opt out of a scope's positional tracking wholesale
+     * should decide that at construction rather than mid-walk.
      */
     default Visitor forClauseEntry(final ClauseEntry entry) {
       return this;
@@ -198,41 +206,50 @@ public final class CypherExpressionWalker {
       return;
     }
 
-    final ReturnClause returnClause = statement.getReturnClause();
-    if (returnClause != null)
-      for (final ReturnClause.ReturnItem item : returnClause.getReturnItems())
-        walk(item.getExpression(), visitor);
-
-    // The top-level ORDER BY / SKIP / LIMIT belong to the statement rather than to any clause entry, and are walked
-    // here for the same reason walkWith() walks a WITH's: leaving them out is the clause-dependent asymmetry this
-    // traversal exists to remove.
-    walkOrderBy(statement.getOrderByClause(), visitor);
-    walk(statement.getSkip(), visitor);
-    walk(statement.getLimit(), visitor);
-
     // The ordered clause list is the whole clause tree, WITH included: StatementBuilder.addWith is the one place a
     // WITH is registered and it puts the same object on both getWithClauses() and this list, so walking the second
     // collection as well would walk every WITH twice rather than reach one this misses. That invariant is what makes
     // once-only structural here instead of guarded, and CypherSubqueryParseTimeValidationIssue5626Test pins it -
     // a builder path that ever registers a WITH on the statement alone has to add it here too, or the walk, and every
     // check running through it, will not see it.
-    // Each clause gets the chance to advance the visitor to a scope that includes what IT declares
-    // (Visitor#forClauseEntry), before its own expressions are visited and before the walk moves to the next
-    // clause - so a check that reads variable kinds sees them positionally instead of as one map for the whole
-    // statement (issue #5671, part 2). A visitor with no positional state (the default) just keeps returning
-    // itself, so this is a no-op for every check that does not opt in.
+    //
+    // Walked BEFORE RETURN/ORDER BY/SKIP/LIMIT - the reverse of their order in a statement's own source text -
+    // because RETURN is always the LAST clause a real statement or body has (issue #5671, part 2): its expressions,
+    // and the trailing ORDER BY/SKIP/LIMIT that see what it projects, are evaluated against the scope as of every
+    // clause having already run, which is exactly what walking the clause list to completion first produces. Each
+    // clause gets the chance to advance the visitor to a scope that includes what IT declares
+    // (Visitor#forClauseEntry), before its own expressions are visited and before the walk moves to the next clause,
+    // so a check that reads variable kinds sees them positionally instead of as one map for the whole statement. A
+    // visitor with no positional state (the default) just keeps returning itself, so this reordering changes nothing
+    // for a check that does not opt in.
+    Visitor current = visitor;
     final List<ClauseEntry> clauses = statement.getClausesInOrder();
     if (clauses != null) {
-      Visitor current = visitor;
-      for (int i = 0; i < clauses.size(); i++) {
+      for (int i = 0; i < clauses.size() && current != null; i++) {
         final ClauseEntry entry = clauses.get(i);
         final Visitor advanced = current.forClauseEntry(entry);
-        if (advanced == null)
+        if (advanced == null) {
+          current = null;
           break;
+        }
         walkClause(entry, current, advanced);
         current = advanced;
       }
     }
+    if (current == null)
+      return;
+
+    final ReturnClause returnClause = statement.getReturnClause();
+    if (returnClause != null)
+      for (final ReturnClause.ReturnItem item : returnClause.getReturnItems())
+        walk(item.getExpression(), current);
+
+    // The top-level ORDER BY / SKIP / LIMIT belong to the statement rather than to any clause entry, and are walked
+    // here for the same reason walkWith() walks a WITH's: leaving them out is the clause-dependent asymmetry this
+    // traversal exists to remove.
+    walkOrderBy(statement.getOrderByClause(), current);
+    walk(statement.getSkip(), current);
+    walk(statement.getLimit(), current);
   }
 
   /**
@@ -291,9 +308,13 @@ public final class CypherExpressionWalker {
         walk(callClause.getYieldWhere().getConditionExpression(), after);
     }
     case SUBQUERY -> {
+      // before, not after: what a body inherits is the outer scope as it stood entering this clause, not
+      // "after" - which already has this same subquery's own RETURN output names forgotten out of it, for the
+      // OUTER scope's benefit once the walk continues past this clause (see CypherSemanticValidator's SUBQUERY
+      // case in applyClauseToVarTypes). Seeding the body's own walk from "after" would seed it with itself.
       final SubqueryClause subqueryClause = entry.getTypedClause();
-      walk(subqueryClause.getBatchSize(), after);
-      walkNested(subqueryClause.getInnerStatement(), after);
+      walk(subqueryClause.getBatchSize(), before);
+      walkNested(subqueryClause.getInnerStatement(), before);
     }
     case LOAD_CSV -> walk(((LoadCSVClause) entry.getTypedClause()).getUrlExpression(), after);
     default -> {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -299,11 +299,23 @@ public final class CypherExpressionWalker {
     case FOREACH -> {
       final ForeachClause foreachClause = entry.getTypedClause();
       walk(foreachClause.getListExpression(), before);
-      // The inner clauses are FOREACH's own body, which lives and dies inside the loop (see buildVarTypes): they
-      // are walked flat, all against the scope FOREACH itself declared, rather than advancing between them.
-      if (foreachClause.getInnerClauses() != null)
-        for (final ClauseEntry inner : foreachClause.getInnerClauses())
-          walkClause(inner, after, after);
+      // The inner clauses are FOREACH's own body: what they bind lives and dies inside the loop (see
+      // applyClauseToVarTypes's FOREACH case, which declares only the loop variable itself, never an inner
+      // clause's own pattern) - nothing here escapes to the scope after this entry. But one inner clause can
+      // still see what an earlier inner clause in the SAME body just declared - an inner CREATE followed by an
+      // inner SET reading what it created - so this advances a visitor local to the body exactly the way the
+      // outer clause loop does, rather than checking every inner clause against the one scope FOREACH itself
+      // declared (issue #5671 review).
+      Visitor innerVisitor = after;
+      if (foreachClause.getInnerClauses() != null) {
+        for (final ClauseEntry inner : foreachClause.getInnerClauses()) {
+          final Visitor advancedInner = innerVisitor.forClauseEntry(inner);
+          if (advancedInner == null)
+            break;
+          walkClause(inner, innerVisitor, advancedInner);
+          innerVisitor = advancedInner;
+        }
+      }
     }
     case CALL -> {
       // The call's own arguments are evaluated before any YIELD rebinds a name, hence before; a YIELD's own

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -156,6 +156,24 @@ public final class CypherExpressionWalker {
     default Visitor forNestedStatement(final CypherStatement statement) {
       return this;
     }
+
+    /**
+     * Called once per clause of the ordered clause list, immediately before that clause's own expressions are
+     * visited, with the chance to advance to a scope that includes what THIS clause itself declares - a
+     * {@code MATCH}'s pattern variables, a {@code WITH}'s post-projection bindings, an {@code UNWIND}'s loop
+     * variable - so that a check reading variable kinds sees a clause's own declarations when it checks that same
+     * clause's expressions (an inline {@code MATCH} predicate reads the pattern it is written against), and sees
+     * them for every clause after it too (issue #5671, part 2). Returning {@code this} keeps the current visitor,
+     * right for a check that carries no positional state.
+     * <p>
+     * The one clause that needs the visitor from <i>before</i> this call as well as the one from after it is
+     * {@code WITH}: its own projection items are evaluated against the scope it inherited, not the one it declares
+     * (issue #5671) - so {@code walkWith} is handed both and decides which each part gets, rather than this method
+     * trying to express two different answers through one return value.
+     */
+    default Visitor forClauseEntry(final ClauseEntry entry) {
+      return this;
+    }
   }
 
   private CypherExpressionWalker() {
@@ -198,67 +216,86 @@ public final class CypherExpressionWalker {
     // once-only structural here instead of guarded, and CypherSubqueryParseTimeValidationIssue5626Test pins it -
     // a builder path that ever registers a WITH on the statement alone has to add it here too, or the walk, and every
     // check running through it, will not see it.
+    // Each clause gets the chance to advance the visitor to a scope that includes what IT declares
+    // (Visitor#forClauseEntry), before its own expressions are visited and before the walk moves to the next
+    // clause - so a check that reads variable kinds sees them positionally instead of as one map for the whole
+    // statement (issue #5671, part 2). A visitor with no positional state (the default) just keeps returning
+    // itself, so this is a no-op for every check that does not opt in.
     final List<ClauseEntry> clauses = statement.getClausesInOrder();
-    if (clauses != null)
-      for (int i = 0; i < clauses.size(); i++)
-        walkClause(clauses.get(i), visitor);
+    if (clauses != null) {
+      Visitor current = visitor;
+      for (int i = 0; i < clauses.size(); i++) {
+        final ClauseEntry entry = clauses.get(i);
+        final Visitor advanced = current.forClauseEntry(entry);
+        if (advanced == null)
+          break;
+        walkClause(entry, current, advanced);
+        current = advanced;
+      }
+    }
   }
 
   /**
-   * Visits every expression of one clause.
+   * Visits every expression of one clause. {@code before} is the visitor from before this clause declared
+   * anything of its own, {@code after} is the one {@link Visitor#forClauseEntry} returned for it - the same for
+   * every clause type except {@code WITH}, whose own projection items are evaluated against {@code before} while
+   * everything else about it (its {@code WHERE}, {@code ORDER BY}, {@code SKIP}, {@code LIMIT}) is evaluated
+   * against {@code after} - see {@code walkWith}.
    */
-  private static void walkClause(final ClauseEntry entry, final Visitor visitor) {
+  private static void walkClause(final ClauseEntry entry, final Visitor before, final Visitor after) {
     switch (entry.getType()) {
     case MATCH -> {
       final MatchClause matchClause = entry.getTypedClause();
       if (matchClause.hasWhereClause())
-        walk(matchClause.getWhereClause().getConditionExpression(), visitor);
+        walk(matchClause.getWhereClause().getConditionExpression(), after);
       if (matchClause.getPathPatterns() != null)
         for (final PathPattern pattern : matchClause.getPathPatterns())
-          walk(pattern, visitor);
+          walk(pattern, after);
     }
-    case WITH -> walkWith(entry.getTypedClause(), visitor);
-    case UNWIND -> walk(((UnwindClause) entry.getTypedClause()).getListExpression(), visitor);
+    case WITH -> walkWith(entry.getTypedClause(), before, after);
+    case UNWIND -> walk(((UnwindClause) entry.getTypedClause()).getListExpression(), after);
     case CREATE -> {
       final CreateClause createClause = entry.getTypedClause();
       if (createClause.getPathPatterns() != null)
         for (final PathPattern pattern : createClause.getPathPatterns())
-          walk(pattern, visitor);
+          walk(pattern, after);
     }
     case MERGE -> {
       final MergeClause mergeClause = entry.getTypedClause();
-      walk(mergeClause.getPathPattern(), visitor);
-      walkSet(mergeClause.getOnCreateSet(), visitor);
-      walkSet(mergeClause.getOnMatchSet(), visitor);
+      walk(mergeClause.getPathPattern(), after);
+      walkSet(mergeClause.getOnCreateSet(), after);
+      walkSet(mergeClause.getOnMatchSet(), after);
     }
-    case SET -> walkSet(entry.getTypedClause(), visitor);
+    case SET -> walkSet(entry.getTypedClause(), after);
     case DELETE -> {
       final DeleteClause deleteClause = entry.getTypedClause();
       if (deleteClause.getExpressions() != null)
         for (final Expression expression : deleteClause.getExpressions())
-          walk(expression, visitor);
+          walk(expression, after);
     }
     case FOREACH -> {
       final ForeachClause foreachClause = entry.getTypedClause();
-      walk(foreachClause.getListExpression(), visitor);
+      walk(foreachClause.getListExpression(), after);
+      // The inner clauses are FOREACH's own body, which lives and dies inside the loop (see buildVarTypes): they
+      // are walked flat, all against the scope FOREACH itself declared, rather than advancing between them.
       if (foreachClause.getInnerClauses() != null)
         for (final ClauseEntry inner : foreachClause.getInnerClauses())
-          walkClause(inner, visitor);
+          walkClause(inner, after, after);
     }
     case CALL -> {
       final CallClause callClause = entry.getTypedClause();
       if (callClause.getArguments() != null)
         for (final Expression argument : callClause.getArguments())
-          walk(argument, visitor);
+          walk(argument, after);
       if (callClause.getYieldWhere() != null)
-        walk(callClause.getYieldWhere().getConditionExpression(), visitor);
+        walk(callClause.getYieldWhere().getConditionExpression(), after);
     }
     case SUBQUERY -> {
       final SubqueryClause subqueryClause = entry.getTypedClause();
-      walk(subqueryClause.getBatchSize(), visitor);
-      walkNested(subqueryClause.getInnerStatement(), visitor);
+      walk(subqueryClause.getBatchSize(), after);
+      walkNested(subqueryClause.getInnerStatement(), after);
     }
-    case LOAD_CSV -> walk(((LoadCSVClause) entry.getTypedClause()).getUrlExpression(), visitor);
+    case LOAD_CSV -> walk(((LoadCSVClause) entry.getTypedClause()).getUrlExpression(), after);
     default -> {
       // RETURN is walked from the statement, and REMOVE / FINISH name variables, properties and labels rather than
       // carrying an expression of their own.
@@ -279,16 +316,23 @@ public final class CypherExpressionWalker {
       walk(statement, nested);
   }
 
-  private static void walkWith(final WithClause withClause, final Visitor visitor) {
+  /**
+   * A {@code WITH}'s own projection items are evaluated against {@code before} - the scope from before this
+   * {@code WITH}, matching real Cypher: {@code WITH r.name AS x} reads {@code r} as whatever it was up to this
+   * point, not as whatever the projection turns it into. Everything the projection's result governs -
+   * {@code WHERE}, {@code ORDER BY}, {@code SKIP}, {@code LIMIT} - is evaluated against {@code after}, which
+   * {@link Visitor#forClauseEntry} already built from the projection (issue #5671, part 2).
+   */
+  private static void walkWith(final WithClause withClause, final Visitor before, final Visitor after) {
     if (withClause == null)
       return;
     for (final ReturnClause.ReturnItem item : withClause.getItems())
-      walk(item.getExpression(), visitor);
+      walk(item.getExpression(), before);
     if (withClause.getWhereClause() != null)
-      walk(withClause.getWhereClause().getConditionExpression(), visitor);
-    walkOrderBy(withClause.getOrderByClause(), visitor);
-    walk(withClause.getSkip(), visitor);
-    walk(withClause.getLimit(), visitor);
+      walk(withClause.getWhereClause().getConditionExpression(), after);
+    walkOrderBy(withClause.getOrderByClause(), after);
+    walk(withClause.getSkip(), after);
+    walk(withClause.getLimit(), after);
   }
 
   private static void walkSet(final SetClause setClause, final Visitor visitor) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -254,10 +254,16 @@ public final class CypherExpressionWalker {
 
   /**
    * Visits every expression of one clause. {@code before} is the visitor from before this clause declared
-   * anything of its own, {@code after} is the one {@link Visitor#forClauseEntry} returned for it - the same for
-   * every clause type except {@code WITH}, whose own projection items are evaluated against {@code before} while
-   * everything else about it (its {@code WHERE}, {@code ORDER BY}, {@code SKIP}, {@code LIMIT}) is evaluated
-   * against {@code after} - see {@code walkWith}.
+   * anything of its own, {@code after} is the one {@link Visitor#forClauseEntry} returned for it.
+   * <p>
+   * Every expression that is evaluated <i>before</i> this clause's own binding takes effect - a {@code WITH}'s
+   * projection items, an {@code UNWIND}'s list expression, a {@code FOREACH}'s list expression, a procedure
+   * {@code CALL}'s own arguments - is walked against {@code before}: the name a clause is about to (re)bind may
+   * reuse an outer name, and the expression that produces the new binding's value is written and evaluated
+   * against what that name meant beforehand, not against the post-binding scope where {@code forget()} has
+   * already dropped it (issue #5671, part 2 review). Everything else - a clause's own {@code WHERE}, and
+   * {@code WITH}'s {@code ORDER BY}/{@code SKIP}/{@code LIMIT} - is walked against {@code after}, since those see
+   * what the clause itself produced.
    */
   private static void walkClause(final ClauseEntry entry, final Visitor before, final Visitor after) {
     switch (entry.getType()) {
@@ -270,7 +276,7 @@ public final class CypherExpressionWalker {
           walk(pattern, after);
     }
     case WITH -> walkWith(entry.getTypedClause(), before, after);
-    case UNWIND -> walk(((UnwindClause) entry.getTypedClause()).getListExpression(), after);
+    case UNWIND -> walk(((UnwindClause) entry.getTypedClause()).getListExpression(), before);
     case CREATE -> {
       final CreateClause createClause = entry.getTypedClause();
       if (createClause.getPathPatterns() != null)
@@ -292,7 +298,7 @@ public final class CypherExpressionWalker {
     }
     case FOREACH -> {
       final ForeachClause foreachClause = entry.getTypedClause();
-      walk(foreachClause.getListExpression(), after);
+      walk(foreachClause.getListExpression(), before);
       // The inner clauses are FOREACH's own body, which lives and dies inside the loop (see buildVarTypes): they
       // are walked flat, all against the scope FOREACH itself declared, rather than advancing between them.
       if (foreachClause.getInnerClauses() != null)
@@ -300,10 +306,12 @@ public final class CypherExpressionWalker {
           walkClause(inner, after, after);
     }
     case CALL -> {
+      // The call's own arguments are evaluated before any YIELD rebinds a name, hence before; a YIELD's own
+      // WHERE sees what it bound, hence after - the same split as WITH's items vs. its WHERE.
       final CallClause callClause = entry.getTypedClause();
       if (callClause.getArguments() != null)
         for (final Expression argument : callClause.getArguments())
-          walk(argument, after);
+          walk(argument, before);
       if (callClause.getYieldWhere() != null)
         walk(callClause.getYieldWhere().getConditionExpression(), after);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -199,62 +199,75 @@ public class CypherSemanticValidator {
       return scope;
     }
 
-    for (final ClauseEntry entry : clauses) {
-      switch (entry.getType()) {
-      case MATCH -> {
-        final MatchClause matchClause = entry.getTypedClause();
-        if (matchClause.hasPathPatterns())
-          for (final PathPattern path : matchClause.getPathPatterns())
-            declarePatternVarTypes(path, scope, declaredHere);
-      }
-      case CREATE -> {
-        final CreateClause createClause = entry.getTypedClause();
-        if (createClause != null && !createClause.isEmpty())
-          for (final PathPattern path : createClause.getPathPatterns())
-            declarePatternVarTypes(path, scope, declaredHere);
-      }
-      case MERGE -> {
-        final MergeClause mergeClause = entry.getTypedClause();
-        if (mergeClause != null)
-          declarePatternVarTypes(mergeClause.getPathPattern(), scope, declaredHere);
-      }
-      case WITH -> applyWithProjection(entry.getTypedClause(), scope, declaredHere);
-      case UNWIND -> forget(((UnwindClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
-      case LOAD_CSV -> forget(((LoadCSVClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
-      // Only the FOREACH variable itself: what the clause's inner CREATE/MERGE bind lives and dies inside the loop
-      // and is not in scope after it, so declaring those kinds here would be declaring them where they cannot be
-      // referenced. The expression walk still descends into the inner clauses and checks them against this scope.
-      case FOREACH -> forget(((ForeachClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
-      case CALL -> {
-        final CallClause callClause = entry.getTypedClause();
-        if (callClause.hasYield()) {
-          if (callClause.isYieldAll()) {
-            final List<String> yieldAllFields = resolveYieldAllFieldNames(callClause);
-            if (yieldAllFields != null)
-              for (final String field : yieldAllFields)
-                forget(field, scope, declaredHere);
-          } else
-            for (final CallClause.YieldItem item : callClause.getYieldItems())
-              forget(item.getOutputName(), scope, declaredHere);
-        }
-      }
-      case SUBQUERY -> {
-        // What a nested CALL subquery returns enters this scope under a kind this phase does not track back through
-        // it; that subquery's body is a scope of its own and gets its own map when the walk descends.
-        final SubqueryClause subqueryClause = entry.getTypedClause();
-        if (subqueryClause.getInnerStatement() != null) {
-          final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
-          if (innerReturn != null)
-            for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems())
-              forget(item.getOutputName(), scope, declaredHere);
-        }
-      }
-      default -> {
-        // No binding of its own.
-      }
+    for (final ClauseEntry entry : clauses)
+      applyClauseToVarTypes(entry, scope, declaredHere);
+    return scope;
+  }
+
+  /**
+   * Applies one clause's effect on the variable kinds in scope - a graph pattern declares them, a {@code WITH}
+   * resets the scope to what it projects, a binding that says nothing about the kind drops whatever the name held.
+   * <p>
+   * Factored out of {@link #buildVarTypes} so the same per-clause rule serves two callers: that method applying it
+   * to every clause up front to build one end-state map, and {@link FunctionArgumentChecks#forClauseEntry} applying
+   * it one clause at a time as {@link CypherExpressionWalker} walks the statement, so a check reads a clause's own
+   * declarations positionally instead of the whole statement's end state (issue #5671, part 2).
+   */
+  private static void applyClauseToVarTypes(final ClauseEntry entry, final Map<String, VarType> scope,
+      final Set<String> declaredHere) {
+    switch (entry.getType()) {
+    case MATCH -> {
+      final MatchClause matchClause = entry.getTypedClause();
+      if (matchClause.hasPathPatterns())
+        for (final PathPattern path : matchClause.getPathPatterns())
+          declarePatternVarTypes(path, scope, declaredHere);
+    }
+    case CREATE -> {
+      final CreateClause createClause = entry.getTypedClause();
+      if (createClause != null && !createClause.isEmpty())
+        for (final PathPattern path : createClause.getPathPatterns())
+          declarePatternVarTypes(path, scope, declaredHere);
+    }
+    case MERGE -> {
+      final MergeClause mergeClause = entry.getTypedClause();
+      if (mergeClause != null)
+        declarePatternVarTypes(mergeClause.getPathPattern(), scope, declaredHere);
+    }
+    case WITH -> applyWithProjection(entry.getTypedClause(), scope, declaredHere);
+    case UNWIND -> forget(((UnwindClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
+    case LOAD_CSV -> forget(((LoadCSVClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
+    // Only the FOREACH variable itself: what the clause's inner CREATE/MERGE bind lives and dies inside the loop
+    // and is not in scope after it, so declaring those kinds here would be declaring them where they cannot be
+    // referenced. The expression walk still descends into the inner clauses and checks them against this scope.
+    case FOREACH -> forget(((ForeachClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
+    case CALL -> {
+      final CallClause callClause = entry.getTypedClause();
+      if (callClause.hasYield()) {
+        if (callClause.isYieldAll()) {
+          final List<String> yieldAllFields = resolveYieldAllFieldNames(callClause);
+          if (yieldAllFields != null)
+            for (final String field : yieldAllFields)
+              forget(field, scope, declaredHere);
+        } else
+          for (final CallClause.YieldItem item : callClause.getYieldItems())
+            forget(item.getOutputName(), scope, declaredHere);
       }
     }
-    return scope;
+    case SUBQUERY -> {
+      // What a nested CALL subquery returns enters this scope under a kind this phase does not track back through
+      // it; that subquery's body is a scope of its own and gets its own map when the walk descends.
+      final SubqueryClause subqueryClause = entry.getTypedClause();
+      if (subqueryClause.getInnerStatement() != null) {
+        final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
+        if (innerReturn != null)
+          for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems())
+            forget(item.getOutputName(), scope, declaredHere);
+      }
+    }
+    default -> {
+      // No binding of its own.
+    }
+    }
   }
 
   /**
@@ -2065,6 +2078,14 @@ public class CypherSemanticValidator {
    * Issue #5626 closed the last gap: the body of a {@code CALL { ... }} clause and of the three subquery expressions
    * ({@code EXISTS}, {@code COUNT}, {@code COLLECT}) are walked too. Each body is a scope of its own, so the visitor
    * re-binds itself to the variable kinds visible inside it - see {@link FunctionArgumentChecks#forNestedStatement}.
+   * <p>
+   * Issue #5671 (part 2) closed the last asymmetry in the <i>other</i> dimension: which kind a variable has when a
+   * check reads it. The scope used to be one end-state map built once for the whole statement (or body), so
+   * {@code MATCH (m) WHERE type(m) = 'X' WITH 1 AS m RETURN m} read {@code m}'s kind as of the last clause rather
+   * than as of the {@code MATCH} the {@code type()} call is actually written against, and a check that should have
+   * fired on the clause as written silently didn't. {@link FunctionArgumentChecks#forClauseEntry} advances the
+   * scope clause by clause instead, so each clause's own expressions are checked against the scope as of that
+   * clause.
    */
   private void validateFunctionArgumentTypes(final CypherStatement statement) {
     CypherExpressionWalker.walk(statement, new FunctionArgumentChecks(varTypes));
@@ -2075,8 +2096,13 @@ public class CypherSemanticValidator {
    * <p>
    * Most of what they look at - the function name, how many arguments it was given, whether a literal argument is of
    * a type the function accepts - is the same wherever the call was written. What is not is the <i>kind</i> of a
-   * variable ({@code length(node)}, {@code p.name} on a path), and a subquery body has a variable scope of its own:
-   * hence one instance per scope rather than one per statement.
+   * variable ({@code length(node)}, {@code p.name} on a path), and both a subquery body and each clause within a
+   * statement or body have a variable scope of their own: hence one instance per scope, advanced by
+   * {@link #forClauseEntry} as the walk crosses a clause boundary and by {@link #forNestedStatement} as it crosses
+   * into a subquery body, rather than one shared instance checking every expression against a single end-state map
+   * (issue #5671, part 2). {@code type(m) = 'KNOWS'} in a {@code MATCH} is checked against the scope as of that
+   * {@code MATCH}, so a later {@code WITH 1 AS m} that drops {@code m}'s kind no longer erases the check on the
+   * clause written before it.
    */
   private final class FunctionArgumentChecks implements CypherExpressionWalker.Visitor {
     private final Map<String, VarType> scope;
@@ -2094,6 +2120,18 @@ public class CypherSemanticValidator {
     @Override
     public CypherExpressionWalker.Visitor forNestedStatement(final CypherStatement nested) {
       return new FunctionArgumentChecks(nestedVarTypes(scope, nested));
+    }
+
+    @Override
+    public CypherExpressionWalker.Visitor forClauseEntry(final ClauseEntry entry) {
+      // A throwaway declaredHere: applyClauseToVarTypes' only use for it is deciding whether a re-declaration is a
+      // VariableTypeConflict, and that conflict was already raised - for the statement by validateVariableTypes, for
+      // a subquery body by the buildVarTypes call inside nestedVarTypes that seeded this scope in the first place -
+      // before this phase ever runs (see CypherSemanticValidator#validate's phase order). This walk only needs the
+      // resulting kinds, not to re-decide a question already settled.
+      final Map<String, VarType> advanced = new HashMap<>(scope);
+      applyClauseToVarTypes(entry, advanced, new HashSet<>());
+      return new FunctionArgumentChecks(advanced);
     }
   }
 
@@ -2229,19 +2267,18 @@ public class CypherSemanticValidator {
    * harmless, because {@link #validateVariableScope} runs first and reports such a reference as the undefined variable
    * it is, before this phase gets to read a kind for it.
    * <p>
-   * What comes back is the body's <i>end</i> state, one map applied to every expression in it wherever that expression
-   * sits - deliberately, because it is the same approximation the top-level statement already runs on ({@code varTypes}
-   * is one map for the whole statement), and answering a body more precisely than the query around it would put back a
-   * clause-dependent asymmetry of exactly the kind #5602 and this issue exist to remove. It errs one way only: a name a
-   * later {@code WITH} re-binds to something kindless loses its kind for the clauses before it too, so a check is
-   * missed, never invented. It cannot err the other way, because the only rebinding Cypher allows on a bound name is a
-   * {@code WITH} projection, which can drop a kind but never turn a name into a path.
+   * What comes back is the body's <i>end</i> state, one map seeding every check that runs against it. For nine of the
+   * ten body phases (see {@link #validateBodyPhases}) and for {@link NestedStatementChecks} itself that is also the
+   * final answer, deliberately: it is the same approximation the top-level statement's own {@code varTypes} runs on,
+   * and answering a body more precisely than the query around it would put back a clause-dependent asymmetry of
+   * exactly the kind #5602 exists to remove. {@link FunctionArgumentChecks} is the one exception - it refines this
+   * seed further, clause by clause, as {@link CypherExpressionWalker} descends through the body (issue #5671, part
+   * 2), because unlike the other nine it already had to run positionally against the top-level statement too, and a
+   * body deserves the same precision as the query around it rather than less.
    */
   private static Map<String, VarType> nestedVarTypes(final Map<String, VarType> outer, final CypherStatement nested) {
     // A UNION declares nothing of its own - each branch is a scope of its own and is entered as a nested statement
     // in its own right, so it is the branch, not the union, that builds a scope over what is inherited here.
-    // (UnionStatement.getClausesInOrder() answers with its FIRST branch's clauses, which is why this returns before
-    // delegating rather than letting the shared build walk them as if they were the union's.)
     if (nested instanceof UnionStatement)
       return new HashMap<>(outer);
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -2085,10 +2085,14 @@ public class CypherSemanticValidator {
    * than as of the {@code MATCH} the {@code type()} call is actually written against, and a check that should have
    * fired on the clause as written silently didn't. {@link FunctionArgumentChecks#forClauseEntry} advances the
    * scope clause by clause instead, so each clause's own expressions are checked against the scope as of that
-   * clause.
+   * clause - which is why this seeds with an empty scope rather than {@code varTypes}: {@code varTypes} IS the
+   * end-state map this phase used to over-apply, and seeding the incremental walk from it would still start every
+   * top-level clause already contaminated with clauses written after it. A statement inherits nothing, so empty is
+   * the correct starting scope; {@link FunctionArgumentChecks#forClauseEntry} builds every declaration back up as
+   * the walk reaches it.
    */
   private void validateFunctionArgumentTypes(final CypherStatement statement) {
-    CypherExpressionWalker.walk(statement, new FunctionArgumentChecks(varTypes));
+    CypherExpressionWalker.walk(statement, new FunctionArgumentChecks(Map.of()));
   }
 
   /**
@@ -2117,18 +2121,30 @@ public class CypherSemanticValidator {
       checkPropertyAccessOnPath(expression, scope);
     }
 
+    /**
+     * Seeds the nested body's walk from {@code this.scope} - the outer scope exactly as it stands at the point the
+     * walk is crossing into the body, already advanced by every {@link #forClauseEntry} call for the clauses before
+     * this one - rather than from {@link #nestedVarTypes}, which is the body's own <i>end</i> state (issue #5671,
+     * part 2 regression found in review). Seeding from the end state would seed the body's first clause with kinds
+     * that clause has not been declared yet - including kinds the body itself only reaches by walking past this
+     * point - the exact contamination this phase exists to remove, just relocated to the nested-body boundary
+     * instead of removed. {@link #buildVarTypes}/{@link #nestedVarTypes} are still exactly right for the other nine
+     * body phases in {@link #validateBodyPhases}, which do want the body's precomputed end state; this is the one
+     * phase that has to build the body's kinds up positionally as it walks, the same as it does for a top-level
+     * statement.
+     */
     @Override
     public CypherExpressionWalker.Visitor forNestedStatement(final CypherStatement nested) {
-      return new FunctionArgumentChecks(nestedVarTypes(scope, nested));
+      return new FunctionArgumentChecks(new HashMap<>(scope));
     }
 
     @Override
     public CypherExpressionWalker.Visitor forClauseEntry(final ClauseEntry entry) {
       // A throwaway declaredHere: applyClauseToVarTypes' only use for it is deciding whether a re-declaration is a
-      // VariableTypeConflict, and that conflict was already raised - for the statement by validateVariableTypes, for
-      // a subquery body by the buildVarTypes call inside nestedVarTypes that seeded this scope in the first place -
-      // before this phase ever runs (see CypherSemanticValidator#validate's phase order). This walk only needs the
-      // resulting kinds, not to re-decide a question already settled.
+      // VariableTypeConflict, and that conflict is always raised independently of this walk - for the statement by
+      // validateVariableTypes, for a subquery body by validateNestedStatements (both run as their own phases of
+      // CypherSemanticValidator#validate, seeing every clause of their scope, not just the one this call was handed).
+      // This walk only needs the resulting kinds, not to re-decide a question those phases already settle.
       final Map<String, VarType> advanced = new HashMap<>(scope);
       applyClauseToVarTypes(entry, advanced, new HashSet<>());
       return new FunctionArgumentChecks(advanced);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -134,9 +134,9 @@ public class OpenCypherQueryEngine implements QueryEngine {
           }
           if (statement.hasDelete())
             ops.add(OperationType.DELETE);
-          if (statement.getSetClause() != null && !statement.getSetClause().isEmpty())
+          if (statement.hasSet())
             ops.add(OperationType.UPDATE);
-          if (!statement.getRemoveClauses().isEmpty())
+          if (statement.hasRemove())
             ops.add(OperationType.UPDATE);
           return ops.isEmpty() ? Set.of(OperationType.CREATE, OperationType.UPDATE, OperationType.DELETE) : Set.copyOf(ops);
         }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671PositionalVariableKindsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671PositionalVariableKindsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #5671, part 2: variable-kind checks (the function-argument-type phase - {@code type(m)} needs a
+ * relationship, {@code labels(m)} needs a node, and so on) used to be built as one end-state map for the
+ * whole statement, applied to every expression in it wherever that expression sits. A name a later
+ * {@code WITH} re-binds to something kindless (or to a different kind) lost its kind - or its wrongness -
+ * for every clause <i>before</i> that {@code WITH} too, so a check that should have fired against the
+ * clause as written silently didn't.
+ * <p>
+ * {@code MATCH (m:P) WHERE type(m) = 'KNOWS' WITH 1 AS m RETURN m}: {@code type(m)} is written against a
+ * {@code MATCH}-bound node, which is always a type error - {@code type()} needs a relationship - regardless
+ * of what a later clause does with the name {@code m}. The old end-state map disagreed: by the time it was
+ * built, {@code m} was whatever the last clause left it as ({@code WITH 1 AS m} makes it a SCALAR), so the
+ * check read the wrong kind and never fired.
+ * <p>
+ * Now {@link com.arcadedb.query.opencypher.parser.CypherExpressionWalker} advances the variable-kind scope
+ * clause by clause as it walks (issue #5671's {@code Visitor#forClauseEntry}), so a clause's own expressions
+ * are checked against the scope as of that clause, not the statement's end state - both at the top level and
+ * inside a {@code CALL { ... }} body, the shape the issue's own example uses.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5671PositionalVariableKindsTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testissue5671positional").create();
+    database.getSchema().createVertexType("P");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void typeOnANodeBeforeARebindingWithIsStillRejectedAtTopLevel() {
+    // m is a node from MATCH; type() requires a relationship. The later "WITH 1 AS m" must not retroactively
+    // excuse the type() call written against the node.
+    assertThatThrownBy(() -> database.query("opencypher", "MATCH (m:P) WHERE type(m) = 'KNOWS' WITH 1 AS m RETURN m"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument, got node");
+  }
+
+  @Test
+  void typeOnANodeBeforeARebindingWithIsStillRejectedInsideACallSubqueryBody() {
+    // The issue's own example, executed: CALL { ... } bodies are validated positionally too, not just the
+    // top-level statement.
+    assertThatThrownBy(() -> database.query("opencypher",
+        "CALL { MATCH (m:P) WHERE type(m) = 'KNOWS' WITH 1 AS m RETURN m } RETURN m"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument, got node");
+  }
+
+  @Test
+  void typeOnANodeIsRejectedEvenWithNoTrailingWithAtAll() {
+    // Sanity check the pre-existing behavior (no WITH involved) is unaffected by the positional rework.
+    assertThatThrownBy(() -> database.query("opencypher", "MATCH (m:P) WHERE type(m) = 'KNOWS' RETURN m"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument, got node");
+  }
+
+  @Test
+  void typeOnARelationshipCarriedThroughAWithIsStillAccepted() {
+    // Sanity check the other direction: a kind that a WITH legitimately carries forward unchanged must not
+    // start being rejected by the positional rework.
+    database.getSchema().createEdgeType("KNOWS");
+    try (ResultSet ignored = database.query("opencypher",
+        "MATCH ()-[m:KNOWS]->() WITH m AS m RETURN type(m)")) {
+      // Statement must parse and plan without a semantic error; an empty database yields zero rows, which is fine.
+      assertThatCode(ignored::hasNext).doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  void typeOnANodeAfterAWithThatKeepsItANodeIsStillRejected() {
+    // The check must still fire when the WITH does NOT change the kind - only a kind CHANGE/loss should shift
+    // when the check does or doesn't fire.
+    assertThatThrownBy(() -> database.query("opencypher", "MATCH (m:P) WITH m AS m WHERE type(m) = 'KNOWS' RETURN m"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument, got node");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671PositionalVariableKindsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671PositionalVariableKindsTest.java
@@ -171,4 +171,19 @@ class Issue5671PositionalVariableKindsTest {
         .isInstanceOf(CommandParsingException.class)
         .hasMessageContaining("type() requires a relationship argument, got node");
   }
+
+  /**
+   * Found in a second code-review round: {@code FOREACH}'s inner clauses were walked flat, all against the
+   * single scope {@code FOREACH} itself declared, so a later inner clause could not see what an earlier inner
+   * clause in the SAME body had just bound - unlike every other clause list, where {@link #forClauseEntry}
+   * advances the scope from one clause to the next. An inner {@code CREATE} followed by an inner {@code SET}
+   * reading what it just created is the concrete case: {@code n} is a node the moment the {@code CREATE} runs,
+   * and {@code type()} must still reject it inside the very next inner clause.
+   */
+  @Test
+  void foreachInnerClauseSeesWhatAnEarlierInnerClauseInTheSameBodyJustDeclared() {
+    assertThatThrownBy(() -> database.query("opencypher", "FOREACH (i IN [1] | CREATE (n:P) SET n.kind = type(n))"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument, got node");
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671PositionalVariableKindsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671PositionalVariableKindsTest.java
@@ -114,4 +114,39 @@ class Issue5671PositionalVariableKindsTest {
         .isInstanceOf(CommandParsingException.class)
         .hasMessageContaining("type() requires a relationship argument, got node");
   }
+
+  /**
+   * Found in code review of this issue's own fix: seeding a nested body's incremental walk from the body's
+   * {@code buildVarTypes} <i>end state</i> (rather than from the truly-inherited outer scope) relocates the
+   * exact contamination bug this issue is about to the body boundary instead of removing it. If the body's
+   * first clause is a pass-through {@code WITH} of a name the outer query bound to one kind, and the SAME
+   * name is later reassigned to a different kind further down in the body, the end-state-seeded walk would
+   * read the reassigned kind for the {@code WITH}'s own pass-through - even though the true kind entering the
+   * body, at that point, is still the one inherited from outside.
+   */
+  @Test
+  void aNameReassignedLaterInABodyDoesNotContaminateAnEarlierPassThroughWithOfTheSameName() {
+    database.getSchema().createEdgeType("KNOWS");
+    // r is a relationship from the outer MATCH. Inside the body, the importing "WITH r" passes it through
+    // unchanged and type(r) is checked right there - still genuinely a relationship at that point. Only later,
+    // and only after an intervening WITH that does NOT carry r forward (dropping it from scope), does a fresh
+    // MATCH reuse the name "r" for a node - a completely disconnected rebinding that must not reach backwards
+    // and change what "r" meant at the WITH written above it.
+    try (ResultSet ignored = database.query("opencypher",
+        "MATCH ()-[r:KNOWS]->() "
+            + "CALL { WITH r WHERE type(r) = 'KNOWS' WITH 1 AS x MATCH (r:P) RETURN r, x } "
+            + "RETURN r")) {
+      assertThatCode(ignored::hasNext).doesNotThrowAnyException();
+    }
+  }
+
+  /** The exact query from the code-review comment that first raised this concern, kept as a named anchor. */
+  @Test
+  void reviewCommentReproDoesNotFalselyReject() {
+    database.getSchema().createEdgeType("KNOWS");
+    try (ResultSet ignored = database.query("opencypher",
+        "MATCH ()-[r:KNOWS]->() CALL { WITH r WHERE type(r) = 'KNOWS' WITH 1 AS r RETURN r } RETURN r")) {
+      assertThatCode(ignored::hasNext).doesNotThrowAnyException();
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671PositionalVariableKindsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671PositionalVariableKindsTest.java
@@ -149,4 +149,26 @@ class Issue5671PositionalVariableKindsTest {
       assertThatCode(ignored::hasNext).doesNotThrowAnyException();
     }
   }
+
+  /**
+   * Found in code review: {@code UNWIND}'s own list expression (and, by the same reasoning, a procedure
+   * {@code CALL}'s own arguments) is evaluated <i>before</i> the clause's binding takes effect, the same as a
+   * {@code WITH}'s projection items - so it must be checked against the scope from before this clause, not the
+   * one {@code forClauseEntry} advanced to. {@code m} is a node here; {@code UNWIND [...] AS m} reuses the name,
+   * but {@code type(m)} inside the list is still the node from the {@code MATCH}, not yet rebound.
+   */
+  @Test
+  void unwindListExpressionIsCheckedAgainstTheScopeBeforeItsOwnVariableIsRebound() {
+    assertThatThrownBy(() -> database.query("opencypher", "MATCH (m:P) UNWIND [type(m)] AS m RETURN m"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument, got node");
+  }
+
+  /** Sanity check the other direction: an UNWIND that does not reuse an outer name is unaffected. */
+  @Test
+  void unwindListExpressionReferencingAnUnrelatedNodeIsUnaffected() {
+    assertThatThrownBy(() -> database.query("opencypher", "MATCH (m:P) UNWIND [type(m)] AS u RETURN u"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument, got node");
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671UnionStatementClauseAccessorsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671UnionStatementClauseAccessorsTest.java
@@ -167,6 +167,23 @@ class Issue5671UnionStatementClauseAccessorsTest {
     assertThat(CypherVariableUsage.isEdgeVariableReferenced(statement, "r")).isFalse();
   }
 
+  /**
+   * Defense-in-depth found in code review: no current call path reaches {@code isEdgeVariableReferenced} with a
+   * top-level {@link UnionStatement} (every caller plans a UNION branch-by-branch first), but the method has no
+   * internal guard of its own, unlike its {@code innerStatementReferencesVariable} sibling in the same file. Pins
+   * the hardening directly, independent of whether that call-graph guarantee holds.
+   */
+  @Test
+  void isEdgeVariableReferencedHandlesATopLevelUnionDirectly() {
+    final UnionStatement referencedInSecondBranch = (UnionStatement) PARSER.parse(
+        "MATCH (a)-[r:KNOWS]->(b) RETURN a AS n UNION MATCH (a)-[r:KNOWS]->(b) RETURN r.since AS n");
+    assertThat(CypherVariableUsage.isEdgeVariableReferenced(referencedInSecondBranch, "r")).isTrue();
+
+    final UnionStatement referencedInNeitherBranch = (UnionStatement) PARSER.parse(
+        "MATCH (a)-[r:KNOWS]->(b) RETURN a AS n UNION MATCH (a)-[r:KNOWS]->(b) RETURN a AS n");
+    assertThat(CypherVariableUsage.isEdgeVariableReferenced(referencedInNeitherBranch, "r")).isFalse();
+  }
+
   // ============================================================
   // Regression: OpenCypherQueryEngine.analyze(...).getOperationTypes() no longer throws for a
   // UNION whose write clause is only in one branch, and classifies it correctly

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671UnionStatementClauseAccessorsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5671UnionStatementClauseAccessorsTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.OperationType;
+import com.arcadedb.query.opencypher.ast.CypherStatement;
+import com.arcadedb.query.opencypher.ast.UnionStatement;
+import com.arcadedb.query.opencypher.executor.CypherVariableUsage;
+import com.arcadedb.query.opencypher.parser.Cypher25AntlrParser;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #5671: {@code UnionStatement} used to answer ten {@code CypherStatement} clause accessors by
+ * silently delegating to its <b>first</b> branch, with nothing to indicate that branches 2..n were
+ * dropped. Nine of them - every one except {@code getReturnClause()}, which is safe because
+ * {@code validateUnion} enforces that every branch projects the same column names - now fail loudly
+ * with {@link UnsupportedOperationException} instead of answering a question a UNION cannot answer.
+ * <p>
+ * Auditing every call site of those nine accessors surfaced two that were reached with an actual
+ * {@code UnionStatement} at runtime, unguarded:
+ * <ul>
+ *   <li>{@code CypherVariableUsage.subqueryReferencesVariable}, which silently checked only branch 1
+ *   of a {@code CALL { ... }} body, so a relationship variable read only in branch 2 was reported as
+ *   unreferenced - the exact "silently drop a still-referenced edge" failure mode this class exists
+ *   to prevent.</li>
+ *   <li>{@code OpenCypherQueryEngine.analyze(...).getOperationTypes()}, which read
+ *   {@code getSetClause()}/{@code getRemoveClauses()} directly instead of through an aggregated
+ *   predicate the way {@code hasCreate()}/{@code hasMerge()}/{@code hasDelete()} already do.</li>
+ * </ul>
+ * Both are fixed alongside the accessors themselves and covered below.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5671UnionStatementClauseAccessorsTest {
+  private static final Cypher25AntlrParser PARSER = new Cypher25AntlrParser();
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testissue5671").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ============================================================
+  // AST-level: the nine accessors throw, getReturnClause() does not
+  // ============================================================
+
+  @Test
+  void divergentClauseAccessorsThrowInsteadOfAnsweringForBranchOneOnly() {
+    // Branch 1 has a MATCH and no WITH/CREATE/SET/DELETE/MERGE/UNWIND; branch 2 has all of them, plus a
+    // different MATCH. Before the fix every accessor below silently answered with branch 1 - here, mostly
+    // empty/null - hiding that branch 2 has real clauses of its own.
+    final UnionStatement union = (UnionStatement) PARSER.parse(
+        """
+        MATCH (a:P) RETURN a.x AS c
+        UNION
+        MATCH (m:P) UNWIND [1,2] AS u WITH m, u CREATE (n:P {x: u}) SET n.y = 1 MERGE (o:P {x: 0}) \
+        DELETE n RETURN m.x AS c""");
+
+    assertThatThrownBy(union::getMatchClauses).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(union::getWhereClause).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(union::getCreateClause).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(union::getSetClause).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(union::getDeleteClause).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(union::getMergeClause).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(union::getUnwindClauses).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(union::getWithClauses).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(union::getClausesInOrder).isInstanceOf(UnsupportedOperationException.class);
+
+    // getReturnClause() is the one safe delegate: DifferentColumnsInUnion already guarantees branch 1's
+    // column names are the union's column names.
+    assertThat(union.getReturnClause()).isNotNull();
+    assertThat(union.getReturnClause().getReturnItems()).hasSize(1);
+    assertThat(union.getReturnClause().getReturnItems().getFirst().getAlias()).isEqualTo("c");
+  }
+
+  @Test
+  void hasCreateMergeDeleteSetRemoveAggregateAcrossBranchesRatherThanAnsweringForBranchOneOnly() {
+    final UnionStatement onlySecondBranchWrites = (UnionStatement) PARSER.parse(
+        """
+        MATCH (a:P) RETURN a.x AS c
+        UNION
+        MATCH (m:P) SET m.y = 1 REMOVE m.z CREATE (n:P {x: 1}) MERGE (o:P {x: 0}) DELETE m RETURN m.x AS c""");
+
+    assertThat(onlySecondBranchWrites.hasCreate()).isTrue();
+    assertThat(onlySecondBranchWrites.hasMerge()).isTrue();
+    assertThat(onlySecondBranchWrites.hasDelete()).isTrue();
+    assertThat(onlySecondBranchWrites.hasSet()).isTrue();
+    assertThat(onlySecondBranchWrites.hasRemove()).isTrue();
+
+    final UnionStatement neitherBranchWrites = (UnionStatement) PARSER.parse(
+        "MATCH (a:P) RETURN a.x AS c UNION MATCH (m:P) RETURN m.x AS c");
+
+    assertThat(neitherBranchWrites.hasCreate()).isFalse();
+    assertThat(neitherBranchWrites.hasMerge()).isFalse();
+    assertThat(neitherBranchWrites.hasDelete()).isFalse();
+    assertThat(neitherBranchWrites.hasSet()).isFalse();
+    assertThat(neitherBranchWrites.hasRemove()).isFalse();
+  }
+
+  // ============================================================
+  // Regression: CypherVariableUsage no longer drops a reference that only branch 2 of a
+  // CALL subquery body makes (found while auditing call sites for this fix)
+  // ============================================================
+
+  @Test
+  void edgeVariableReferencedOnlyInSecondUnionBranchOfACallSubqueryIsNotReportedAsUnreferenced() {
+    // CALL (*) imports every outer variable without requiring an importing WITH, so r is visible in both
+    // branches without either branch needing to mention "r" merely to import it - isolating the actual bug:
+    // branch 1 never reads r, branch 2 does, in its RETURN.
+    final CypherStatement statement = PARSER.parse(
+        """
+        MATCH (a)-[r:KNOWS]->(b)
+        CALL (*) { MATCH (x:P) RETURN x.x AS n UNION MATCH (y:P) RETURN r.since AS n }
+        RETURN b""");
+
+    assertThat(CypherVariableUsage.isEdgeVariableReferenced(statement, "r"))
+        .as("r is read in branch 2's RETURN (r.since); the check must not stop at branch 1")
+        .isTrue();
+  }
+
+  @Test
+  void edgeVariableReferencedInNeitherUnionBranchOfACallSubqueryIsStillUnreferenced() {
+    // Sanity check the other direction: the fix must not become unconditionally conservative.
+    final CypherStatement statement = PARSER.parse(
+        """
+        MATCH (a)-[r:KNOWS]->(b)
+        CALL (*) { MATCH (x:P) RETURN x AS n UNION MATCH (y:P) RETURN y AS n }
+        RETURN b""");
+
+    assertThat(CypherVariableUsage.isEdgeVariableReferenced(statement, "r")).isFalse();
+  }
+
+  // ============================================================
+  // Regression: OpenCypherQueryEngine.analyze(...).getOperationTypes() no longer throws for a
+  // UNION whose write clause is only in one branch, and classifies it correctly
+  // ============================================================
+
+  @Test
+  void operationTypesOfAUnionWithSetOnlyInOneBranchIncludesUpdateAndDoesNotThrow() {
+    final Set<OperationType> ops = database.getQueryEngine("opencypher")
+        .analyze("MATCH (a:P) RETURN a AS n UNION MATCH (m:P) SET m.y = 1 RETURN m AS n")
+        .getOperationTypes();
+
+    assertThat(ops).contains(OperationType.UPDATE);
+  }
+
+  @Test
+  void operationTypesOfAUnionWithRemoveOnlyInOneBranchIncludesUpdateAndDoesNotThrow() {
+    final Set<OperationType> ops = database.getQueryEngine("opencypher")
+        .analyze("MATCH (a:P) RETURN a AS n UNION MATCH (m:P) REMOVE m.y RETURN m AS n")
+        .getOperationTypes();
+
+    assertThat(ops).contains(OperationType.UPDATE);
+  }
+
+  // ============================================================
+  // Functional: a UNION with genuinely different MATCH shapes per branch, nested inside a CALL
+  // subquery, still parses, plans and executes correctly end to end
+  // ============================================================
+
+  @Test
+  void divergentUnionBranchesInsideACallSubqueryStillExecuteCorrectly() {
+    database.getSchema().createVertexType("P");
+    database.getSchema().createEdgeType("REL");
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (a:P {x: 1})");
+      database.command("opencypher", "CREATE (b:P {x: 2})");
+      database.command("opencypher", "CREATE (c:P {x: 3})");
+      database.command("opencypher", "MATCH (a:P {x: 1}), (b:P {x: 2}) CREATE (a)-[:REL]->(b)");
+    });
+
+    // Branch 1 matches every P directly; branch 2 matches a P reached by a REL hop. The two branches have
+    // different MATCH shapes (different pattern, different variable), which is exactly the case
+    // UnionStatement.getMatchClauses() used to silently collapse into "branch 1's shape".
+    final ResultSet result = database.query("opencypher",
+        """
+        CALL {
+          MATCH (a:P) RETURN a.x AS c
+          UNION
+          MATCH (:P)-[:REL]->(m:P) RETURN m.x AS c
+        }
+        RETURN c ORDER BY c""");
+
+    final Set<Integer> values = new HashSet<>();
+    while (result.hasNext()) {
+      final Result row = result.next();
+      values.add(((Number) row.getProperty("c")).intValue());
+    }
+
+    // UNION dedups: branch 1 contributes {1,2,3}, branch 2 contributes {2}, combined distinct is {1,2,3}.
+    assertThat(values).containsExactlyInAnyOrder(1, 2, 3);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5671 (both parts).

**Part 1 - `UnionStatement` answered clause accessors from branch 1 only.** Nine `CypherStatement` accessors (`getMatchClauses`, `getWhereClause`, `getCreateClause`, `getSetClause`, `getDeleteClause`, `getMergeClause`, `getUnwindClauses`, `getWithClauses`, `getClausesInOrder`) silently delegated to `queries.getFirst()`, with nothing to indicate branches 2..n were dropped. They now throw `UnsupportedOperationException` instead - a caller that needs branch-specific clauses must go through `getQueries()`. `getReturnClause()` is left delegating: `DifferentColumnsInUnion` already guarantees every branch shares the same return column names, so branch 1's answer is the union's answer.

Auditing every call site of the nine accessors (150+ across `com.arcadedb.query.opencypher`) found two genuinely unguarded ones that reached a real `UnionStatement` at runtime:
- `CypherVariableUsage.subqueryReferencesVariable` checked only branch 1 of a `CALL { ... }` body, so a relationship variable read only in branch 2 was reported as unreferenced - a silently dropped edge binding. Fixed to check every branch.
- `OpenCypherQueryEngine.analyze(...).getOperationTypes()` (the MCP permission-classification path) read `getSetClause()`/`getRemoveClauses()` directly and would have thrown for any UNION containing a write in any branch. Added `hasSet()`/`hasRemove()` predicates to `CypherStatement`, aggregated across branches on `UnionStatement` the same way `hasCreate()`/`hasMerge()`/`hasDelete()` already are (this also fixes a pre-existing miss: a `REMOVE` in a UNION branch was never classified as `UPDATE` at all).

**Part 2 - variable-kind checks used one end-state map for a whole statement/body.** `type(m)`/`labels(m)`/etc. argument-type checks were built from a single map computed once for the whole statement, so a later `WITH` that dropped or changed a name's kind retroactively erased a check against an earlier clause where the kind still applied:

```cypher
MATCH (m:P) WHERE type(m) = 'KNOWS' WITH 1 AS m RETURN m
```

`m` is a node from `MATCH`, and `type()` requires a relationship - this should always be rejected regardless of what a later clause does with the name `m`. It silently passed instead, because by the time the (single, whole-statement) kind map was built, `m` was a SCALAR (from `WITH 1 AS m`), not a NODE.

`CypherExpressionWalker` now advances the variable-kind scope clause by clause (`Visitor#forClauseEntry`) as it walks a statement or subquery body, so each clause's own expressions are checked against the scope as of that clause - matching real Cypher's `WITH` semantics (its projection items read the pre-projection scope; its `WHERE`/`ORDER BY`/`SKIP`/`LIMIT` read the post-projection one, confirmed against the Neo4j Cypher manual). This is a validation-strictness increase (rejects some previously-silently-accepted queries); the full OpenCypher suite was run to check for collateral rejections.

## Test plan
- [x] New regression tests: `Issue5671UnionStatementClauseAccessorsTest` (9 accessors throw, `hasSet`/`hasRemove` aggregate correctly, the two audited call-site fixes, and a functional divergent-UNION-inside-`CALL{}` execution test) and `Issue5671PositionalVariableKindsTest` (the exact `type(m)`/`WITH`/rebinding scenario, top-level and nested-body, plus sanity checks that unaffected shapes keep working)
- [x] Both new tests verified to fail without their respective fix (temporarily reverted each fix, confirmed red, restored)
- [x] Full `com.arcadedb.query.opencypher.**` suite: 9018 tests, 0 failures (1 unrelated pre-existing flake reproduced identically on unmodified `main`, confirmed passing in isolation)
- [x] `mcp` module (295 tests, exercises `getOperationTypes()` permission classification): all pass
- [x] `mvn -pl engine -am compile` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cypher `UNION` handling when branches contain different clauses or write operations.
  * Corrected variable scope and type validation across clauses, subqueries, `WITH`, and `FOREACH`.
  * Improved detection and classification of `SET` and `REMOVE` operations.
  * Ensured relationship-variable references are detected across all `UNION` branches.

* **Tests**
  * Added coverage for positional variable types, nested queries, divergent `UNION` branches, and branch-specific write operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->