### PR TITLE
perf(#5467): sparse top-K pays for the postings it walks, not the blocks it lands in

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
@@ -243,6 +243,8 @@ public final class BmwScorer {
 
     final int[] heap = new int[n];     // essential term indices, min-heap by current RID
     final int[] aligned = new int[n];  // scratch: the term indices sitting on the current candidate
+    final int[] alignedSlots = new int[n];  // scratch: the heap slots those term indices occupy
+    final long[] frontier = new long[2];    // scratch: (bucketId, position) of the next essential key
     // Cursor positions, mirrored into flat arrays indexed by term. The heap reads a position far
     // more often than a cursor moves - about a dozen comparisons per posting consumed - and reading
     // it off the cursor costs two dependent loads through scattered objects. Mirroring turns each
@@ -292,39 +294,141 @@ public final class BmwScorer {
           && SparseSegmentBuilder.compareRid(candidateBucketId, candidatePosition, endBucketId, endPosition) >= 0)
         return;
 
-      // Detach the whole aligned run so the cursors can be moved without corrupting the heap order.
-      int alignedCount = 0;
-      while (heapSize > 0) {
-        final int top = heap[0];
-        if (keyPositions[top] != candidatePosition || keyBucketIds[top] != candidateBucketId)
-          break;
-        aligned[alignedCount++] = heap[0];
-        heapSize = popHeap(keyBucketIds, keyPositions, heap, heapSize);
-      }
-      final int nextEssentialBucketId = heapSize > 0 ? keyBucketIds[heap[0]] : -1;
-      final long nextEssentialPosition = heapSize > 0 ? keyPositions[heap[0]] : -1L;
+      // Locate the aligned run without touching the heap.
+      final int alignedCount = collectAlignedRun(keyBucketIds, keyPositions, heap, heapSize, candidateBucketId,
+          candidatePosition, aligned, alignedSlots);
 
-      if (!tryBlockMaxSkip(terms, keyBucketIds, keyPositions, aligned, alignedCount, prefix[split], candidateBucketId,
-          candidatePosition, threshold, nextEssentialBucketId, nextEssentialPosition))
+      if (!tryBlockMaxSkip(terms, keyBucketIds, keyPositions, aligned, alignedSlots, alignedCount, prefix[split],
+          candidateBucketId, candidatePosition, threshold, heap, heapSize, frontier))
         scoreCandidate(terms, keyBucketIds, keyPositions, aligned, alignedCount, split, prefix, candidateBucketId,
             candidatePosition, threshold, collector);
 
-      // Re-attach whatever is still live. An exhausted term contributes nothing from here on:
-      // dropping its ceiling tightens every prefix bound, which can only push the split further
-      // right on the next pass.
+      // The moved cursors are still in their slots holding keys that only ever grew, so the heap is
+      // repaired in place, deepest slot first: by then every slot below it is already a valid heap.
+      // An exhausted term has to leave the heap entirely, which a repair cannot express - the heap
+      // would have to shrink - so that (rare: at most once per term per query) case rebuilds instead.
+      // An exhausted term contributes nothing from here on, and dropping its ceiling tightens every
+      // prefix bound, which can only push the split further right on the next pass.
       boolean exhaustedAny = false;
+      boolean anyCursorExhausted = false;
       for (int j = 0; j < alignedCount; j++) {
         final int idx = aligned[j];
-        if (terms[idx].cursor.isExhausted())
+        // The mirror holds -1 for an exhausted cursor, so asking it costs one array load instead of
+        // three dependent dereferences through the term and its cursor.
+        if (keyBucketIds[idx] < 0) {
+          anyCursorExhausted = true;
           exhaustedAny |= terms[idx].clearSigma();
-        else
-          heapSize = pushHeap(keyBucketIds, keyPositions, heap, heapSize, idx);
+        }
       }
+      if (anyCursorExhausted)
+        heapDirty = true;
+      else
+        for (int j = alignedCount - 1; j >= 0; j--)
+          siftDownFromFloyd(keyBucketIds, keyPositions, heap, heapSize, alignedSlots[j]);
       if (exhaustedAny) {
         recomputePrefix(terms, prefix);
         splitDirty = true;
       }
     }
+  }
+
+  /**
+   * Collect the heap slots whose key equals {@code (candidateBucketId, candidatePosition)} - the
+   * traversal's aligned run - <b>without modifying the heap</b>.
+   * <p>
+   * Every slot holding the heap's minimum forms a connected subtree rooted at slot 0: if a slot holds
+   * the minimum then so does its parent, since a parent's key is at most its child's and at least the
+   * global minimum. A breadth-first walk that stops descending at the first non-matching child
+   * therefore visits exactly the run, and it visits it in ascending slot order because a binary heap
+   * array <i>is</i> its own level order - which is what lets the caller repair deepest-slot-first by
+   * walking the result backwards.
+   * <p>
+   * <b>Why not pop and push.</b> Detaching the run with one pop per term and re-attaching
+   * it with one push per term costs, per term, a descent to a leaf plus a climb from a
+   * leaf back to wherever the advanced cursor now belongs - and in a wide merge a just-advanced cursor
+   * usually still belongs near the top, so that climb is nearly the full height of the heap. Repairing
+   * in place skips it: the element starts where it already is, and one Floyd sift puts it back. On a
+   * SPLADE-shaped 100k corpus that is 695k key comparisons per query instead of 913k, a quarter of
+   * them gone (issue #5467).
+   * <p>
+   * An earlier attempt at the same idea repaired with a textbook top-down sift-down and measured
+   * <i>slower</i>, which is recorded on the issue. The reason is the sift, not the collection: a
+   * top-down sift spends two comparisons per level (pick the smaller child, then test it against the
+   * element), while Floyd's spends one per level going down and pays for the climb only when the
+   * element really does belong high up. See {@link #siftDownFromFloyd}.
+   *
+   * @param aligned      out: term indices of the run, in ascending heap-slot order
+   * @param alignedSlots out: the heap slots those terms occupy, parallel to {@code aligned}
+   *
+   * @return the number of terms in the run, always at least 1
+   */
+  private static int collectAlignedRun(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
+      final int heapSize, final int candidateBucketId, final long candidatePosition, final int[] aligned,
+      final int[] alignedSlots) {
+    aligned[0] = heap[0];
+    alignedSlots[0] = 0;
+    int count = 1;
+    for (int q = 0; q < count; q++) {
+      final int left = (alignedSlots[q] << 1) + 1;
+      if (left >= heapSize)
+        continue;  // a leaf slot, and a heap array is left-packed, so there is no right child either.
+      int term = heap[left];
+      if (keyPositions[term] == candidatePosition && keyBucketIds[term] == candidateBucketId) {
+        aligned[count] = term;
+        alignedSlots[count] = left;
+        count++;
+      }
+      final int right = left + 1;
+      if (right < heapSize) {
+        term = heap[right];
+        if (keyPositions[term] == candidatePosition && keyBucketIds[term] == candidateBucketId) {
+          aligned[count] = term;
+          alignedSlots[count] = right;
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  /**
+   * The smallest key in the heap that is not part of the aligned run, into
+   * {@code frontier[0]} (bucket id) and {@code frontier[1]} (position), or {@code -1} in both when the
+   * run is the whole heap.
+   * <p>
+   * The candidates for that minimum are exactly the children of run slots that are not themselves in
+   * the run: any slot outside the run reaches the root through one of them, and each of those is the
+   * minimum of its own subtree.
+   * <p>
+   * This is computed on demand rather than alongside {@link #collectAlignedRun} because only the
+   * block-max skip needs it, and only once it has already decided to skip. On a learned-sparse query
+   * the skip fires for a couple of percent of candidates - block maxima are no tighter than global
+   * maxima when weights are near-uniform - so folding it into the run walk paid a three-way
+   * comparison per heap child on every candidate to answer a question almost none of them asked
+   * (issue #5467).
+   */
+  private static void nextEssentialKey(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
+      final int heapSize, final int[] alignedSlots, final int alignedCount, final int candidateBucketId,
+      final long candidatePosition, final long[] frontier) {
+    int bestBucketId = -1;
+    long bestPosition = -1L;
+    for (int q = 0; q < alignedCount; q++) {
+      final int left = (alignedSlots[q] << 1) + 1;
+      for (int child = left, last = Math.min(left + 1, heapSize - 1); child <= last; child++) {
+        final int term = heap[child];
+        final int bucketId = keyBucketIds[term];
+        final long position = keyPositions[term];
+        // A child still sitting on the candidate IS a run slot; the run has not moved yet.
+        if (position == candidatePosition && bucketId == candidateBucketId)
+          continue;
+        if (bestBucketId < 0 || SparseSegmentBuilder.compareRid(bucketId, position, bestBucketId, bestPosition) < 0) {
+          bestBucketId = bucketId;
+          bestPosition = position;
+        }
+      }
+    }
+    frontier[0] = bestBucketId;
+    frontier[1] = bestPosition;
   }
 
   /**
@@ -363,12 +467,23 @@ public final class BmwScorer {
           alive = false;
           break;
         }
+        // The mirrored key answers the probe outright whenever the term's cursor already sits past
+        // this document, which on a dense non-essential list is most of the time: only a cursor that
+        // is still behind the candidate has to be moved. Reading it here instead of calling into the
+        // cursor turns the common case into two loads from arrays that stay in L1 (issue #5467).
+        if (keyBucketIds[i] < 0)
+          continue;  // exhausted; the mirror holds -1 for that.
+        int cmp = SparseSegmentBuilder.compareRid(keyBucketIds[i], keyPositions[i], candidateBucketId, candidatePosition);
+        if (cmp < 0) {
+          terms[i].cursor.seekTo(candidateBucketId, candidatePosition);
+          syncKey(terms, keyBucketIds, keyPositions, i);
+          if (keyBucketIds[i] < 0)
+            continue;
+          cmp = SparseSegmentBuilder.compareRid(keyBucketIds[i], keyPositions[i], candidateBucketId, candidatePosition);
+        }
+        if (cmp != 0)
+          continue;  // this term holds no posting for this document.
         final DimCursor c = terms[i].cursor;
-        if (c.isExhausted())
-          continue;
-        c.seekTo(candidateBucketId, candidatePosition);
-        if (c.isExhausted() || c.currentPosition() != candidatePosition || c.currentBucketId() != candidateBucketId)
-          continue;
         if (c.isTombstone()) {
           alive = false;
           break;
@@ -408,9 +523,9 @@ public final class BmwScorer {
    * @return {@code true} if a block range was skipped, {@code false} if the caller must score.
    */
   private static boolean tryBlockMaxSkip(final DimEntry[] terms, final int[] keyBucketIds, final long[] keyPositions,
-      final int[] aligned, final int alignedCount, final float nonEssentialCeiling, final int candidateBucketId,
-      final long candidatePosition, final float threshold, final int nextEssentialBucketId, final long nextEssentialPosition)
-      throws IOException {
+      final int[] aligned, final int[] alignedSlots, final int alignedCount, final float nonEssentialCeiling,
+      final int candidateBucketId, final long candidatePosition, final float threshold, final int[] heap, final int heapSize,
+      final long[] frontier) throws IOException {
     float bound = nonEssentialCeiling;
     if (bound > threshold)
       return false;  // no headroom at all (threshold still NEGATIVE_INFINITY, or an all-essential query).
@@ -421,7 +536,7 @@ public final class BmwScorer {
       bound += t.queryWeight * t.cursor.blockMaxAt(candidateBucketId, candidatePosition);
       if (bound > threshold)
         return false;
-      final RID be = t.cursor.blockEndAt(candidateBucketId, candidatePosition);
+      final RID be = t.cursor.lastProbedBlockEnd();
       if (be != null && (minBlockEnd == null || SparseSegmentBuilder.compareRid(be, minBlockEnd) < 0))
         minBlockEnd = be;
     }
@@ -433,6 +548,12 @@ public final class BmwScorer {
     // the first strictly greater than minBlockEnd.
     int targetBucketId = minBlockEnd.getBucketId();
     long targetPosition = minBlockEnd.getPosition() + 1;
+    // Only now, having committed to the skip, is the first essential cursor sitting strictly after the
+    // candidate worth locating: it bounds how far the skip may go, and nothing else needs it.
+    nextEssentialKey(keyBucketIds, keyPositions, heap, heapSize, alignedSlots, alignedCount, candidateBucketId,
+        candidatePosition, frontier);
+    final int nextEssentialBucketId = (int) frontier[0];
+    final long nextEssentialPosition = frontier[1];
     if (nextEssentialBucketId >= 0
         && SparseSegmentBuilder.compareRid(nextEssentialBucketId, nextEssentialPosition, targetBucketId, targetPosition) < 0) {
       targetBucketId = nextEssentialBucketId;
@@ -461,51 +582,35 @@ public final class BmwScorer {
   }
 
   /**
-   * Removes the minimum. Returns the new size.
+   * Repair heap slot {@code from} after its element's key grew, using Floyd's bottom-up variant:
+   * descend to a leaf of {@code from}'s subtree always following the smaller child, drop the element
+   * there, then climb back up - never above {@code from}, since the parent chain above it is
+   * untouched and holds keys no larger than the one that was there before.
    * <p>
-   * Uses the bottom-up (Floyd) variant: descend to a leaf always following the smaller child, then
-   * sift the promoted element back up from there. A textbook sift-down spends two comparisons per
-   * level - one to pick the smaller child, one to test it against the element being pushed down -
-   * whereas this spends one per level going down plus, in the common case, one or two coming back
-   * up. The element promoted here is the heap's last, which tends to be large and therefore belongs
-   * deep, so the return trip is usually trivial. On a learned-sparse query this comparison is run
-   * millions of times per query (issue #5467), and it is the traversal's single hottest operation.
+   * The variant matters. A textbook top-down sift-down spends <b>two</b> comparisons per level - one
+   * to pick the smaller child, one to test it against the element being pushed down - so it costs
+   * {@code 2 * depth} no matter where the element ends up. Floyd's spends one per level on the way
+   * down and pays for the climb only in proportion to how high the element really belongs. On a
+   * learned-sparse query the essential heap holds dozens of terms and this runs millions of times per
+   * query, which is why the traversal's single hottest operation is worth the asymmetry
+   * (issue #5467).
    */
-  private static int popHeap(final int[] keyBucketIds, final long[] keyPositions, final int[] heap, final int size) {
-    final int newSize = size - 1;
-    final int promoted = heap[newSize];
-    if (newSize > 1) {
-      int i = 0;
-      int left = 1;
-      while (left < newSize) {
-        final int right = left + 1;
-        final int child = (right < newSize && compareByRid(keyBucketIds, keyPositions, heap[right], heap[left]) < 0) ? right : left;
-        heap[i] = heap[child];
-        i = child;
-        left = (i << 1) + 1;
-      }
-      heap[i] = promoted;
-      while (i > 0) {
-        final int parent = (i - 1) >>> 1;
-        if (compareByRid(keyBucketIds, keyPositions, heap[i], heap[parent]) >= 0)
-          break;
-        final int tmp = heap[i];
-        heap[i] = heap[parent];
-        heap[parent] = tmp;
-        i = parent;
-      }
-    } else if (newSize == 1) {
-      heap[0] = promoted;
+  private static void siftDownFromFloyd(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
+      final int size, final int from) {
+    int left = (from << 1) + 1;
+    if (left >= size)
+      return;  // a leaf slot: no descendant can violate the ordering.
+    final int element = heap[from];
+    int i = from;
+    while (left < size) {
+      final int right = left + 1;
+      final int child = (right < size && compareByRid(keyBucketIds, keyPositions, heap[right], heap[left]) < 0) ? right : left;
+      heap[i] = heap[child];
+      i = child;
+      left = (i << 1) + 1;
     }
-    return newSize;
-  }
-
-  /** Inserts a term index. Returns the new size. */
-  private static int pushHeap(final int[] keyBucketIds, final long[] keyPositions, final int[] heap, final int size,
-      final int termIdx) {
-    int i = size;
-    heap[i] = termIdx;
-    while (i > 0) {
+    heap[i] = element;
+    while (i > from) {
       final int parent = (i - 1) >>> 1;
       if (compareByRid(keyBucketIds, keyPositions, heap[i], heap[parent]) >= 0)
         break;
@@ -514,7 +619,6 @@ public final class BmwScorer {
       heap[parent] = tmp;
       i = parent;
     }
-    return size + 1;
   }
 
   private static void siftDown(final int[] keyBucketIds, final long[] keyPositions, final int[] heap, final int size,

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
@@ -417,20 +417,26 @@ public final class BmwScorer {
     long bestPosition = -1L;
     for (int q = 0; q < alignedCount; q++) {
       final int left = (alignedSlots[q] << 1) + 1;
-      for (int child = left, last = Math.min(left + 1, heapSize - 1); child <= last; child++) {
-        final int term = heap[child];
-        final int bucketId = keyBucketIds[term];
-        final long position = keyPositions[term];
-        // Skip children that are themselves in the run. A run slot's child can be another run slot,
-        // and the run's key IS the candidate, so without this the walk would return the candidate as
-        // the next key after itself and the block-max skip would target where it already is. Testing
-        // the key rather than the slot is what keeps it O(1): no cursor has moved yet, so a child
-        // still sitting on the candidate is exactly a run member (BmwScorerHeapRepairTest pins it).
-        if (position == candidatePosition && bucketId == candidateBucketId)
-          continue;
-        if (bestBucketId < 0 || SparseSegmentBuilder.compareRid(bucketId, position, bestBucketId, bestPosition) < 0) {
-          bestBucketId = bucketId;
-          bestPosition = position;
+      if (left >= heapSize)
+        continue;  // a leaf slot, and a heap array is left-packed, so there is no right child either.
+      int term = heap[left];
+      // Skip children that are themselves in the run. A run slot's child can be another run slot, and
+      // the run's key IS the candidate, so without this the walk would return the candidate as the
+      // next key after itself and the block-max skip would target where it already is. Testing the
+      // key rather than the slot is what keeps it O(1): no cursor has moved yet, so a child still
+      // sitting on the candidate is exactly a run member (BmwScorerHeapRepairTest pins it).
+      if ((keyPositions[term] != candidatePosition || keyBucketIds[term] != candidateBucketId) && (bestBucketId < 0
+          || SparseSegmentBuilder.compareRid(keyBucketIds[term], keyPositions[term], bestBucketId, bestPosition) < 0)) {
+        bestBucketId = keyBucketIds[term];
+        bestPosition = keyPositions[term];
+      }
+      final int right = left + 1;
+      if (right < heapSize) {
+        term = heap[right];
+        if ((keyPositions[term] != candidatePosition || keyBucketIds[term] != candidateBucketId) && (bestBucketId < 0
+            || SparseSegmentBuilder.compareRid(keyBucketIds[term], keyPositions[term], bestBucketId, bestPosition) < 0)) {
+          bestBucketId = keyBucketIds[term];
+          bestPosition = keyPositions[term];
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
@@ -362,7 +362,9 @@ public final class BmwScorer {
    *
    * @return the number of terms in the run, always at least 1
    */
-  private static int collectAlignedRun(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
+  // Package-private rather than private so BmwScorerHeapRepairTest can pin these invariants against a
+  // hand-built heap, which fails with a small counterexample instead of only as a top-K mismatch.
+  static int collectAlignedRun(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
       final int heapSize, final int candidateBucketId, final long candidatePosition, final int[] aligned,
       final int[] alignedSlots) {
     aligned[0] = heap[0];
@@ -407,7 +409,7 @@ public final class BmwScorer {
    * comparison per heap child on every candidate to answer a question almost none of them asked
    * (issue #5467).
    */
-  private static void nextEssentialKey(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
+  static void nextEssentialKey(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
       final int heapSize, final int[] alignedSlots, final int alignedCount, final int candidateBucketId,
       final long candidatePosition, final long[] frontier) {
     int bestBucketId = -1;
@@ -418,7 +420,11 @@ public final class BmwScorer {
         final int term = heap[child];
         final int bucketId = keyBucketIds[term];
         final long position = keyPositions[term];
-        // A child still sitting on the candidate IS a run slot; the run has not moved yet.
+        // Skip children that are themselves in the run. A run slot's child can be another run slot,
+        // and the run's key IS the candidate, so without this the walk would return the candidate as
+        // the next key after itself and the block-max skip would target where it already is. Testing
+        // the key rather than the slot is what keeps it O(1): no cursor has moved yet, so a child
+        // still sitting on the candidate is exactly a run member (BmwScorerHeapRepairTest pins it).
         if (position == candidatePosition && bucketId == candidateBucketId)
           continue;
         if (bestBucketId < 0 || SparseSegmentBuilder.compareRid(bucketId, position, bestBucketId, bestPosition) < 0) {
@@ -536,7 +542,9 @@ public final class BmwScorer {
       bound += t.queryWeight * t.cursor.blockMaxAt(candidateBucketId, candidatePosition);
       if (bound > threshold)
         return false;
-      final RID be = t.cursor.lastProbedBlockEnd();
+      // Must stay immediately after this term's blockMaxAt for the same probe: that call is what
+      // refreshed the memo the block end is read from.
+      final RID be = t.cursor.lastProbedBlockEnd(candidateBucketId, candidatePosition);
       if (be != null && (minBlockEnd == null || SparseSegmentBuilder.compareRid(be, minBlockEnd) < 0))
         minBlockEnd = be;
     }
@@ -595,7 +603,7 @@ public final class BmwScorer {
    * query, which is why the traversal's single hottest operation is worth the asymmetry
    * (issue #5467).
    */
-  private static void siftDownFromFloyd(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
+  static void siftDownFromFloyd(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
       final int size, final int from) {
     int left = (from << 1) + 1;
     if (left >= size)

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
@@ -245,6 +245,7 @@ public final class BmwScorer {
     final int[] aligned = new int[n];  // scratch: the term indices sitting on the current candidate
     final int[] alignedSlots = new int[n];  // scratch: the heap slots those term indices occupy
     final long[] frontier = new long[2];    // scratch: (bucketId, position) of the next essential key
+    final RID[] blockEndOut = new RID[1];   // scratch: the block end paired with each block-max probe
     // Cursor positions, mirrored into flat arrays indexed by term. The heap reads a position far
     // more often than a cursor moves - about a dozen comparisons per posting consumed - and reading
     // it off the cursor costs two dependent loads through scattered objects. Mirroring turns each
@@ -299,7 +300,7 @@ public final class BmwScorer {
           candidatePosition, aligned, alignedSlots);
 
       if (!tryBlockMaxSkip(terms, keyBucketIds, keyPositions, aligned, alignedSlots, alignedCount, prefix[split],
-          candidateBucketId, candidatePosition, threshold, heap, heapSize, frontier))
+          candidateBucketId, candidatePosition, threshold, heap, heapSize, frontier, blockEndOut))
         scoreCandidate(terms, keyBucketIds, keyPositions, aligned, alignedCount, split, prefix, candidateBucketId,
             candidatePosition, threshold, collector);
 
@@ -531,7 +532,7 @@ public final class BmwScorer {
   private static boolean tryBlockMaxSkip(final DimEntry[] terms, final int[] keyBucketIds, final long[] keyPositions,
       final int[] aligned, final int[] alignedSlots, final int alignedCount, final float nonEssentialCeiling,
       final int candidateBucketId, final long candidatePosition, final float threshold, final int[] heap, final int heapSize,
-      final long[] frontier) throws IOException {
+      final long[] frontier, final RID[] blockEndOut) throws IOException {
     float bound = nonEssentialCeiling;
     if (bound > threshold)
       return false;  // no headroom at all (threshold still NEGATIVE_INFINITY, or an all-essential query).
@@ -539,12 +540,12 @@ public final class BmwScorer {
     RID minBlockEnd = null;
     for (int j = 0; j < alignedCount; j++) {
       final DimEntry t = terms[aligned[j]];
-      bound += t.queryWeight * t.cursor.blockMaxAt(candidateBucketId, candidatePosition);
+      // One call for both edges of this term's bound: the memo is consulted once, and the block end
+      // cannot belong to a different probe than the max it is paired with.
+      bound += t.queryWeight * t.cursor.blockBoundsAt(candidateBucketId, candidatePosition, blockEndOut);
       if (bound > threshold)
         return false;
-      // Must stay immediately after this term's blockMaxAt for the same probe: that call is what
-      // refreshed the memo the block end is read from.
-      final RID be = t.cursor.lastProbedBlockEnd(candidateBucketId, candidatePosition);
+      final RID be = blockEndOut[0];
       if (be != null && (minBlockEnd == null || SparseSegmentBuilder.compareRid(be, minBlockEnd) < 0))
         minBlockEnd = be;
     }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/DimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/DimCursor.java
@@ -195,29 +195,36 @@ public final class DimCursor implements AutoCloseable {
   }
 
   /**
-   * The block end that pairs with the block max returned by the immediately preceding
-   * {@link #blockMaxAt(int, long)} on this cursor - the same value {@link #blockEndAt(int, long)}
-   * would return for that same probe, without re-checking whether the memo covers it.
+   * Both edges of the Block-Max bound for one probe: the merged block max as the return value, and
+   * the merged block end in {@code endOut[0]}.
    * <p>
-   * The block-max skip always asks for both edges of the same probe, so going through the public
-   * entry point twice ran the memo's two range comparisons twice for one bound. The probe is per
-   * aligned term per candidate, which made those comparisons a double-digit share of query CPU on a
-   * learned-sparse workload (issue #5467).
+   * The block-max skip needs both for the same probe, and asking for them through
+   * {@link #blockMaxAt(int, long)} and {@link #blockEndAt(int, long)} ran the memo's two range
+   * comparisons twice for one bound - per aligned term per candidate, which made them a double-digit
+   * share of query CPU on a learned-sparse workload (issue #5467).
    * <p>
-   * The contract - "the memo already covers this probe" - is not something the compiler can enforce,
-   * and a caller that slipped another {@link #blockMaxAt} or {@link #seekTo} on the same cursor in
-   * between would silently read a bound for the wrong block. The probe is therefore passed in and
-   * checked by an {@code assert}: free when assertions are off, and Surefire runs the test suite with
-   * them on, so the invariant fails loudly the first time somebody breaks it rather than quietly
-   * returning an over-tight bound.
+   * Handing both back from one call is what keeps that cheap <b>without</b> creating a temporal
+   * contract to get wrong. An earlier version of this fix exposed the block end as a separate reader
+   * that assumed the caller had just refreshed the memo with the same probe; that is invisible to the
+   * compiler, and a caller inserting another {@link #blockMaxAt} or {@link #seekTo} between the two
+   * would have got a bound for the wrong block - which shows up not as a crash but as an
+   * over-aggressive skip quietly dropping a document from the top-K. Here the pairing is structural:
+   * there is no window in which the two can disagree.
+   *
+   * @param endOut single-slot scratch array, owned by the caller, that receives the block end (or
+   *               {@code null} when no live source bounds a finite one). Reporting a float and an
+   *               object from one call without allocating per candidate is what it is for.
+   *
+   * @return the merged block max, or {@code 0} when the cursor is exhausted
    */
-  RID lastProbedBlockEnd(final int bucketId, final long position) {
-    assert exhausted || (boundsValid
-        && SparseSegmentBuilder.compareRid(bucketId, position, boundsFromBucketId, boundsFromPosition) >= 0
-        && SparseSegmentBuilder.compareRid(bucketId, position, boundsEndBucketId, boundsEndPosition) <= 0) :
-        "lastProbedBlockEnd(" + bucketId + ":" + position + ") on dim " + dimId
-            + ": the block-bounds memo does not cover this probe, so blockMaxAt was not the immediately preceding call";
-    return exhausted ? null : boundsEndRid;
+  float blockBoundsAt(final int bucketId, final long position, final RID[] endOut) {
+    if (exhausted) {
+      endOut[0] = null;
+      return 0.0f;
+    }
+    ensureBlockBounds(bucketId, position);
+    endOut[0] = boundsEndRid;
+    return boundsBlockMax;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/DimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/DimCursor.java
@@ -203,8 +203,20 @@ public final class DimCursor implements AutoCloseable {
    * entry point twice ran the memo's two range comparisons twice for one bound. The probe is per
    * aligned term per candidate, which made those comparisons a double-digit share of query CPU on a
    * learned-sparse workload (issue #5467).
+   * <p>
+   * The contract - "the memo already covers this probe" - is not something the compiler can enforce,
+   * and a caller that slipped another {@link #blockMaxAt} or {@link #seekTo} on the same cursor in
+   * between would silently read a bound for the wrong block. The probe is therefore passed in and
+   * checked by an {@code assert}: free when assertions are off, and Surefire runs the test suite with
+   * them on, so the invariant fails loudly the first time somebody breaks it rather than quietly
+   * returning an over-tight bound.
    */
-  RID lastProbedBlockEnd() {
+  RID lastProbedBlockEnd(final int bucketId, final long position) {
+    assert exhausted || (boundsValid
+        && SparseSegmentBuilder.compareRid(bucketId, position, boundsFromBucketId, boundsFromPosition) >= 0
+        && SparseSegmentBuilder.compareRid(bucketId, position, boundsEndBucketId, boundsEndPosition) <= 0) :
+        "lastProbedBlockEnd(" + bucketId + ":" + position + ") on dim " + dimId
+            + ": the block-bounds memo does not cover this probe, so blockMaxAt was not the immediately preceding call";
     return exhausted ? null : boundsEndRid;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/DimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/DimCursor.java
@@ -345,7 +345,7 @@ public final class DimCursor implements AutoCloseable {
     // MaxScore traversal is a seek, and on a settled index each was walking the source array and
     // running the min-selection pass over a merge that has nothing to merge (issue #5467).
     if (single != null) {
-      if (sourceLive[0] && !single.seekTo(targetBucketId, targetPosition))
+      if (!single.seekTo(targetBucketId, targetPosition))
         sourceLive[0] = false;
       materializeSingle();
       return !exhausted;

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/DimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/DimCursor.java
@@ -195,6 +195,20 @@ public final class DimCursor implements AutoCloseable {
   }
 
   /**
+   * The block end that pairs with the block max returned by the immediately preceding
+   * {@link #blockMaxAt(int, long)} on this cursor - the same value {@link #blockEndAt(int, long)}
+   * would return for that same probe, without re-checking whether the memo covers it.
+   * <p>
+   * The block-max skip always asks for both edges of the same probe, so going through the public
+   * entry point twice ran the memo's two range comparisons twice for one bound. The probe is per
+   * aligned term per candidate, which made those comparisons a double-digit share of query CPU on a
+   * learned-sparse workload (issue #5467).
+   */
+  RID lastProbedBlockEnd() {
+    return exhausted ? null : boundsEndRid;
+  }
+
+  /**
    * Refresh {@code boundsBlockMax} / {@code boundsEndRid} unless the memo already covers
    * {@code (bucketId, position)}, i.e. unless the probe falls inside {@code [boundsFrom, boundsEnd]}.
    * <p>
@@ -314,6 +328,16 @@ public final class DimCursor implements AutoCloseable {
     if (currentBucketId >= 0
         && SparseSegmentBuilder.compareRid(currentBucketId, currentPosition, targetBucketId, targetPosition) >= 0)
       return true;
+
+    // Single source: same short-circuit as {@link #advance()}. Every non-essential probe of a
+    // MaxScore traversal is a seek, and on a settled index each was walking the source array and
+    // running the min-selection pass over a merge that has nothing to merge (issue #5467).
+    if (single != null) {
+      if (sourceLive[0] && !single.seekTo(targetBucketId, targetPosition))
+        sourceLive[0] = false;
+      materializeSingle();
+      return !exhausted;
+    }
 
     for (int i = 0; i < sources.length; i++) {
       if (!sourceLive[i])

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
@@ -540,6 +540,12 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
       // local offset instead of a ByteBuffer position (absolute reads only - see {@code pageBuf}),
       // and a method cannot return both the value and the bytes it consumed without either a second
       // pass or an allocation. This is the traversal's innermost loop.
+      // <p>
+      // {@code shift == 70} means a tenth byte was read, and a tenth byte contributes only bit 63, so
+      // its payload can be 0 or 1. Above that, the bits Java's shift silently discards would let a
+      // nine-continuation-bytes-then-{@code 0x02} encoding decode as a plausible small value that the
+      // ascending-order check below cannot see anything wrong with - so the width is checked once per
+      // VarLong, on a branch that is always false on anything a writer produced.
       int prevBucket = blockBuckets[0];
       long prevPosition = blockPositions[0];
       for (int i = 1; i < n; i++) {
@@ -553,6 +559,8 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
           bucketDelta |= ((long) (b & 0x7F)) << shift;
           shift += 7;
         } while ((b & 0x80) != 0);
+        if (shift == 70 && (b & 0x7F) > 1)
+          throw new IOException(corruptBlockMessage() + OVERWIDE_VARLONG);
         long secondField = 0L;
         shift = 0;
         do {
@@ -562,6 +570,8 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
           secondField |= ((long) (b & 0x7F)) << shift;
           shift += 7;
         } while ((b & 0x80) != 0);
+        if (shift == 70 && (b & 0x7F) > 1)
+          throw new IOException(corruptBlockMessage() + OVERWIDE_VARLONG);
         // Strictly ascending RIDs are a write-side invariant that the read side never checked:
         // SparseSegmentBuilder.appendInternal rejects a non-increasing RID and flushBlock fails loud
         // on a negative delta, precisely because "a negative delta would silently encode as a huge
@@ -610,6 +620,9 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     weightResolved = false;
   }
 
+  private static final String OVERWIDE_VARLONG =
+      " (a VarLong carries payload bits past the width of a long, which no encoder can produce)";
+
   private String notAscending(final int previousBucketId, final long previousPosition) {
     return " (postings are not in strictly ascending RID order after #" + previousBucketId + ":" + previousPosition + ")";
   }
@@ -632,6 +645,9 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
       return;
     weightResolved = true;
     resolvedWeightCount++;
+    // Branching on the stride rather than on the quantization enum keeps this to an int compare on the
+    // hot path; the stride IS the quantization here, mapped once in the constructor, so a new width
+    // has to be added in both places.
     final int at = weightsOffset + currentInBlock * weightStride;
     if (weightStride == 1) {
       final byte b = pageBuf.get(at);

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
@@ -80,6 +80,15 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
   // asks for the page, so touching its position would be a cross-cursor data race. Sealed segments
   // are never written again, so the bytes behind it cannot change under us, and a page evicted from
   // the cache stays valid here because eviction only drops the map entry.
+  // <p>
+  // <b>The footprint this costs, deliberately.</b> The reference keeps one page image reachable per
+  // open cursor until the cursor walks onto another page or is closed, so a wide learned-sparse query
+  // (up to ~120 terms) can hold ~120 distinct 64 KiB pages, and the parallel-range fan-out of issue
+  // #5518 multiplies that by the worker count. The pages are ones the query is actively reading and
+  // are already resident in the shared page cache; what the reference adds is only that an eviction
+  // racing the query cannot drop them from under it. It is bounded by open cursors rather than by
+  // blocks decoded, {@link #close()} releases it, and a REPEATABLE_READ transaction already pins
+  // every page it reads for its whole lifetime, which is strictly more.
   private ByteBuffer    pageBuf;
   private int           pageNum = -1;
   private int           pageLimit;
@@ -512,6 +521,13 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     final int limit = pageLimit;
     final int base = BasePage.PAGE_HEADER_SIZE + meta.blockOffset(currentBlock) + SegmentFormat.BLOCK_HEADER_SIZE;
     final int n = meta.blockPostingCount(currentBlock);
+    // The header's posting count is read off the segment file, so it is untrusted input (issue
+    // #6566): the decode arrays are sized to the segment's declared block size, and a count past that
+    // would run off their end. Reject it here so a corrupt header reads as a corrupt segment rather
+    // than as an ArrayIndexOutOfBoundsException from the middle of the decode loop.
+    if (n > blockBuckets.length)
+      throw new IOException(corruptBlockMessage() + " (posting count " + n + " exceeds the segment's block size "
+          + blockBuckets.length + ")");
     blockSize = n;
     blockBuckets[0] = meta.blockFirstBucketId(currentBlock);
     blockPositions[0] = meta.blockFirstPosition(currentBlock);

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
@@ -545,7 +545,9 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
       // its payload can be 0 or 1. Above that, the bits Java's shift silently discards would let a
       // nine-continuation-bytes-then-{@code 0x02} encoding decode as a plausible small value that the
       // ascending-order check below cannot see anything wrong with - so the width is checked once per
-      // VarLong, on a branch that is always false on anything a writer produced.
+      // VarLong, on a branch that is always false on anything a writer produced. This is the same
+      // condition {@link VarInt#readUnsignedVarLong} tests as {@code shift == 63}: that one checks
+      // before its {@code shift += 7}, this one after the loop has already applied it.
       int prevBucket = blockBuckets[0];
       long prevPosition = blockPositions[0];
       for (int i = 1; i < n; i++) {
@@ -603,7 +605,9 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
         blockPositions[i] = prevPosition;
       }
     } else {
-      if (p + (n - 1) * (4 + 8) > limit)
+      // The first posting's RID lives in the block header, so the payload holds n-1 of them at the
+      // format's fixed width.
+      if (p + (n - 1) * SegmentFormat.RID_SIZE_BYTES > limit)
         throw new IOException(corruptBlockMessage());
       for (int i = 1; i < n; i++) {
         blockBuckets[i] = buf.getInt(p);

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
@@ -18,19 +18,18 @@
  */
 package com.arcadedb.index.sparsevector;
 
-import com.arcadedb.database.Binary;
 import com.arcadedb.database.RID;
+import com.arcadedb.engine.BasePage;
 import com.arcadedb.index.sparsevector.SegmentFormat.RidCompression;
-import com.arcadedb.index.sparsevector.SegmentFormat.WeightQuantization;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
  * Forward cursor over the postings of a single dim within a page-backed sealed segment. Implements
- * a {@code block_header} / {@code posting} state machine and reads block payloads via
- * {@link PaginatedSegmentReader#readBlockPayloadInto} (page-cache-backed). The skip path uses the
- * per-segment skip list to avoid decompressing blocks that cannot beat the current threshold.
+ * a {@code block_header} / {@code posting} state machine and decodes block payloads straight out of
+ * the page-cache page they live on. The skip path uses the per-segment skip list to avoid
+ * decompressing blocks that cannot beat the current threshold.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -50,20 +49,50 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
   private int     currentBucketId = -1;
   private long    currentPosition = -1L;
   private RID     currentRidObj;
+  // Weight and tombstone of the posting the cursor sits on, decoded from the page on first read and
+  // held until the cursor moves. The traversal walks far more postings than it scores - a block-max
+  // skip reads none of them, and a non-essential probe that is abandoned early reads none either -
+  // so decoding the whole block's weights up front was work the query mostly threw away
+  // (issue #5467).
   private float   currentWeight;
   private boolean currentTombstone;
+  private boolean weightResolved;
 
-  // Decoded postings of the current block, held as parallel primitive arrays. An earlier version
+  // Decoded positions of the current block, held as parallel primitive arrays. An earlier version
   // materialised a RID per posting at decode time; on a learned-sparse query that is millions of
   // short-lived objects per query, and it dominated the traversal cost (issue #5388). Only the
   // posting the cursor is actually positioned on ever becomes a RID.
   private final int[]   blockBuckets;
   private final long[]  blockPositions;
-  private final float[] blockWeights;
-  private final boolean[] blockTombstones;
   private int           blockSize;
   private boolean       blockDecoded;
   private boolean       exhausted;
+
+  // The page that holds {@code currentBlock}, kept between blocks. The builder packs a dim's blocks
+  // back to back, so well over a hundred default-sized blocks share one 64 KiB page and a sequential walk used to
+  // re-resolve the same page once per block. Each resolution allocated a {@link com.arcadedb.engine.PageId}
+  // and an {@link com.arcadedb.engine.ImmutablePage}, hashed into the page-cache map, and bumped the
+  // cache's global hit counter - an atomic that every parallel-range worker of issue #5518 contends
+  // on. Holding the page collapses all of that to once per page (issue #5467).
+  // <p>
+  // Only ABSOLUTE reads are made through {@code pageBuf}: a REPEATABLE_READ transaction hands the
+  // same {@code ImmutablePage} - and therefore the same {@link ByteBuffer} - to every cursor that
+  // asks for the page, so touching its position would be a cross-cursor data race. Sealed segments
+  // are never written again, so the bytes behind it cannot change under us, and a page evicted from
+  // the cache stays valid here because eviction only drops the map entry.
+  private ByteBuffer    pageBuf;
+  private int           pageNum = -1;
+  private int           pageLimit;
+  private long          pageFetchCount;
+
+  // Where the current block's weight section starts in {@code pageBuf}, and the block's
+  // dequantization band. Weights are fixed-stride, so posting {@code i}'s weight is one indexed read
+  // at {@code weightsOffset + i * weightStride}; the offset itself is wherever the variable-length
+  // RID section ended.
+  private int           weightsOffset;
+  private float         blockWeightMin;
+  private float         blockWeightMax;
+  private final int     weightStride;
 
   // Lazy-decode state for Block-Max WAND skips (issue #5388). When {@code pendingDecode} is true
   // the cursor is parked at the FIRST posting of {@code currentBlock} ({@code currentInBlock == 0},
@@ -87,21 +116,19 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
   // Per-cursor (per-query) state, so it is contention-free even under concurrent queries.
   private long          decodedBlockCount;
 
-  // Per-cursor count of payload bytes copied out of the page cache by those decodes. Tracked
-  // separately from {@link #decodedBlockCount} because the two are not proportional: the reader used
-  // to hand back every byte from the block payload to the end of the page regardless of how long the
-  // block actually was, so a ~500-byte block cost a ~32 KB copy on a 64 KB page. Asserting on this
-  // counter is what keeps that from coming back (issue #5388).
+  // Per-cursor count of payload bytes those decodes read. Tracked separately from
+  // {@link #decodedBlockCount} because the two are not proportional: the reader used to hand back
+  // every byte from the block payload to the end of the page regardless of how long the block
+  // actually was, so a ~500-byte block cost a ~32 KB copy on a 64 KB page. Asserting on this counter
+  // is what keeps that from coming back (issue #5388). Since issue #5467 the decode works in place
+  // on the page and copies nothing at all, so this is the exact payload length of every block
+  // touched.
   private long          decodedPayloadBytes;
 
-  // Required scratch capacity (one full page of payload). The byte[] / ByteBuffer pair is
-  // borrowed from {@link com.arcadedb.database.DatabaseContext.DatabaseContextTL#getTemporaryBuffer1()}
-  // inside {@link #decodeBlockIfNeeded} - the same per-thread Binary that BinarySerializer and
-  // friends already share. Decoded values land in this cursor's
-  // {@code blockBuckets} / {@code blockPositions} / {@code blockWeights} / {@code blockTombstones} arrays before the call returns, so the
-  // buffer can be clobbered by any subsequent caller on the same thread without affecting us
-  // (issue #4086).
-  private final int scratchSize;
+  // Per-cursor count of postings whose weight was actually decoded. Compared against
+  // {@link #decodedBlockCount} times the block size, this is how much of the weight work the query
+  // used to do up front it now never does at all.
+  private long          resolvedWeightCount;
 
   PaginatedSegmentDimCursor(final PaginatedSegmentReader reader, final PaginatedDimMetadata meta) {
     this.reader = reader;
@@ -109,9 +136,11 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     this.params = reader.parameters();
     this.blockBuckets = new int[params.blockSize()];
     this.blockPositions = new long[params.blockSize()];
-    this.blockWeights = new float[params.blockSize()];
-    this.blockTombstones = new boolean[params.blockSize()];
-    this.scratchSize = reader.component().pageContentSize();
+    this.weightStride = switch (params.weightQuantization()) {
+      case INT8 -> 1;
+      case FP16 -> 2;
+      case FP32 -> 4;
+    };
   }
 
   public int dimId() {
@@ -151,17 +180,6 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     currentRidObj = null;
   }
 
-  /** Set the position from an existing {@link RID}, reusing it as the cached object. */
-  private void setPosition(final RID rid) {
-    if (rid == null) {
-      clearPosition();
-      return;
-    }
-    currentBucketId = rid.getBucketId();
-    currentPosition = rid.getPosition();
-    currentRidObj = rid;
-  }
-
   private void clearPosition() {
     currentBucketId = -1;
     currentPosition = -1L;
@@ -171,12 +189,14 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
   @Override
   public float currentWeight() {
     resolvePendingDecode();
+    resolveWeight();
     return currentWeight;
   }
 
   @Override
   public boolean isTombstone() {
     resolvePendingDecode();
+    resolveWeight();
     return currentTombstone;
   }
 
@@ -265,9 +285,22 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     return decodedBlockCount;
   }
 
-  /** Test/observability hook: total payload bytes copied out of the page cache by those decodes. */
+  /** Test/observability hook: total payload bytes read out of the page cache by those decodes. */
   public long decodedPayloadBytes() {
     return decodedPayloadBytes;
+  }
+
+  /**
+   * Test/observability hook: how many times this cursor asked the page cache for a page. One per
+   * distinct page it walked onto, not one per block decoded - see the {@code pageBuf} field.
+   */
+  public long pageFetchCount() {
+    return pageFetchCount;
+  }
+
+  /** Test/observability hook: postings whose weight this cursor actually decoded. */
+  public long resolvedWeightCount() {
+    return resolvedWeightCount;
   }
 
   @Override
@@ -414,6 +447,11 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     exhausted = true;
     clearPosition();
     pendingDecode = false;
+    // Release the page: a closed cursor must not keep a 64 KiB page image reachable after the query
+    // that opened it has finished with it.
+    pageBuf = null;
+    pageNum = -1;
+    blockDecoded = false;
   }
 
   // --- internals ------------------------------------------------------------
@@ -444,34 +482,68 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     }
   }
 
+  /**
+   * Decode the current block's RID section in place on the page it lives on, and record where its
+   * weight section starts.
+   * <p>
+   * Nothing is copied. Before issue #5467 the payload was copied into a per-thread scratch buffer
+   * first, which is why {@link SegmentFormat#maxBlockPayloadSize} and the "gap to the next block"
+   * estimate had to exist at all - the format does not store a block's byte length, so a copy needed
+   * an upper bound on how much to take. Decoding against the page needs no bound: the RID loop
+   * consumes exactly the bytes the block's posting count describes and ends on the first weight
+   * byte, which is the block's exact RID-section length rather than an estimate of it.
+   * <p>
+   * Reads are bounds-checked against the page's content limit so a corrupt posting count surfaces as
+   * an {@link IOException} naming the segment rather than as a buffer exception from the decode
+   * loop.
+   */
   private void decodeBlockIfNeeded() throws IOException {
     if (blockDecoded)
       return;
-    final int pageNum = meta.blockPageNum(currentBlock);
-    final int offsetInPage = meta.blockOffset(currentBlock);
-    final int blockPostingCount = meta.blockPostingCount(currentBlock);
-    // {@code getTemporaryBuffer1} returns a cleared per-thread {@link Binary}; {@code size(int)}
-    // grows the underlying byte[] to {@code scratchSize} on first sparse-vector decode and is a
-    // no-op on subsequent calls. The default Binary uses big-endian byte order, matching the
-    // segment format.
-    final Binary scratch = reader.component().getDatabase().getContext().getTemporaryBuffer1();
-    scratch.size(scratchSize);
-    final ByteBuffer buf = reader.readBlockPayloadInto(pageNum, offsetInPage, payloadLengthBound(currentBlock, blockPostingCount),
-        scratch.getContent(), scratch.getByteBuffer());
-    decodedBlockCount++;
-    decodedPayloadBytes += buf.limit();
-
-    final int n = blockPostingCount;
+    final int blockPage = meta.blockPageNum(currentBlock);
+    if (blockPage != pageNum || pageBuf == null) {
+      final BasePage page = reader.readPage(blockPage);
+      pageBuf = page.getContent();
+      pageLimit = BasePage.PAGE_HEADER_SIZE + page.getMaxContentSize();
+      pageNum = blockPage;
+      pageFetchCount++;
+    }
+    final ByteBuffer buf = pageBuf;
+    final int limit = pageLimit;
+    final int base = BasePage.PAGE_HEADER_SIZE + meta.blockOffset(currentBlock) + SegmentFormat.BLOCK_HEADER_SIZE;
+    final int n = meta.blockPostingCount(currentBlock);
     blockSize = n;
     blockBuckets[0] = meta.blockFirstBucketId(currentBlock);
     blockPositions[0] = meta.blockFirstPosition(currentBlock);
 
+    int p = base;
     if (params.ridCompression() == RidCompression.VARINT_DELTA) {
+      // The VarLong reader is inlined rather than called through {@link VarInt}: it has to advance a
+      // local offset instead of a ByteBuffer position (absolute reads only - see {@code pageBuf}),
+      // and a method cannot return both the value and the bytes it consumed without either a second
+      // pass or an allocation. This is the traversal's innermost loop.
       int prevBucket = blockBuckets[0];
       long prevPosition = blockPositions[0];
       for (int i = 1; i < n; i++) {
-        final long bucketDelta = VarInt.readUnsignedVarLong(buf);
-        final long secondField = VarInt.readUnsignedVarLong(buf);
+        long bucketDelta = 0L;
+        int shift = 0;
+        byte b;
+        do {
+          if (p >= limit || shift >= 64)
+            throw new IOException(corruptBlockMessage());
+          b = buf.get(p++);
+          bucketDelta |= ((long) (b & 0x7F)) << shift;
+          shift += 7;
+        } while ((b & 0x80) != 0);
+        long secondField = 0L;
+        shift = 0;
+        do {
+          if (p >= limit || shift >= 64)
+            throw new IOException(corruptBlockMessage());
+          b = buf.get(p++);
+          secondField |= ((long) (b & 0x7F)) << shift;
+          shift += 7;
+        } while ((b & 0x80) != 0);
         if (bucketDelta == 0L) {
           prevPosition += secondField;
         } else {
@@ -482,85 +554,81 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
         blockPositions[i] = prevPosition;
       }
     } else {
+      if (p + (n - 1) * (4 + 8) > limit)
+        throw new IOException(corruptBlockMessage());
       for (int i = 1; i < n; i++) {
-        blockBuckets[i] = buf.getInt();
-        blockPositions[i] = buf.getLong();
+        blockBuckets[i] = buf.getInt(p);
+        p += 4;
+        blockPositions[i] = buf.getLong(p);
+        p += 8;
       }
     }
 
-    final WeightQuantization wq = params.weightQuantization();
-    final float weightMin = meta.blockWeightMin(currentBlock);
-    final float weightMax = meta.blockWeightMax(currentBlock);
-    for (int i = 0; i < n; i++) {
-      switch (wq) {
-        case INT8 -> {
-          final byte b = buf.get();
-          if (b == SegmentFormat.INT8_TOMBSTONE_SENTINEL) {
-            blockTombstones[i] = true;
-            blockWeights[i] = Float.NaN;
-          } else {
-            blockTombstones[i] = false;
-            blockWeights[i] = WeightCodec.dequantizeInt8(b, weightMin, weightMax);
-          }
-        }
-        case FP16 -> {
-          final short s = buf.getShort();
-          if (s == SegmentFormat.FP16_TOMBSTONE_SENTINEL) {
-            blockTombstones[i] = true;
-            blockWeights[i] = Float.NaN;
-          } else {
-            blockTombstones[i] = false;
-            blockWeights[i] = WeightCodec.fromFp16(s);
-          }
-        }
-        case FP32 -> {
-          final int bits = buf.getInt();
-          if (WeightCodec.isFp32Tombstone(bits)) {
-            blockTombstones[i] = true;
-            blockWeights[i] = Float.NaN;
-          } else {
-            blockTombstones[i] = false;
-            blockWeights[i] = Float.intBitsToFloat(bits);
-          }
-        }
-      }
-    }
+    if (p + n * weightStride > limit)
+      throw new IOException(corruptBlockMessage());
+    weightsOffset = p;
+    blockWeightMin = meta.blockWeightMin(currentBlock);
+    blockWeightMax = meta.blockWeightMax(currentBlock);
 
+    decodedBlockCount++;
+    decodedPayloadBytes += (long) (p - base) + (long) n * weightStride;
     blockDecoded = true;
+    weightResolved = false;
+  }
+
+  private String corruptBlockMessage() {
+    return "sparse-vector block " + currentBlock + " of dim " + meta.dimId() + " in segment '"
+        + reader.component().getName() + "' runs past the end of page " + pageNum + "; segment is corrupt";
   }
 
   /**
-   * Upper bound on the payload bytes of {@code block}, used to keep the page-to-scratch copy down to
-   * the block instead of the rest of the page (issue #5388).
+   * Decode the weight and tombstone flag of the posting the cursor sits on, once per posting.
    * <p>
-   * Two independent bounds, whichever is tighter:
-   * <ul>
-   *   <li>the format's worst case for {@code postingCount} postings at this segment's quantization,
-   *       which always holds;</li>
-   *   <li>the gap to the next block of this dim when that block sits on the same page. The builder
-   *       writes a dim's blocks back to back (header immediately followed by payload, then the next
-   *       block), so on the common path this gap <i>is</i> the exact payload length. It is only
-   *       taken when positive, so a build path that ever lays blocks out non-contiguously falls back
-   *       to the worst case rather than truncating a payload.</li>
-   * </ul>
-   * The last block of a dim on a page has no next-block gap and rides on the worst case alone; the
-   * reader clamps whatever comes back to the bytes actually left on the page.
+   * The weight section is fixed-stride whatever the quantization, so this is a single indexed read
+   * plus the dequantization. Doing it here rather than in {@link #decodeBlockIfNeeded} is what makes
+   * the block-max skip and the early-abandoned non-essential probe free of weight work: neither ever
+   * asks for a weight, and before issue #5467 both paid for a full block of them.
    */
-  private int payloadLengthBound(final int block, final int postingCount) {
-    int bound = SegmentFormat.maxBlockPayloadSize(postingCount, params.weightQuantization());
-    if (block + 1 < meta.blockCount() && meta.blockPageNum(block + 1) == meta.blockPageNum(block)) {
-      final int gap = meta.blockOffset(block + 1) - meta.blockOffset(block) - SegmentFormat.BLOCK_HEADER_SIZE;
-      if (gap > 0 && gap < bound)
-        bound = gap;
+  private void resolveWeight() {
+    if (weightResolved)
+      return;
+    weightResolved = true;
+    resolvedWeightCount++;
+    final int at = weightsOffset + currentInBlock * weightStride;
+    if (weightStride == 1) {
+      final byte b = pageBuf.get(at);
+      if (b == SegmentFormat.INT8_TOMBSTONE_SENTINEL) {
+        currentTombstone = true;
+        currentWeight = Float.NaN;
+      } else {
+        currentTombstone = false;
+        currentWeight = WeightCodec.dequantizeInt8(b, blockWeightMin, blockWeightMax);
+      }
+    } else if (weightStride == 2) {
+      final short s = pageBuf.getShort(at);
+      if (s == SegmentFormat.FP16_TOMBSTONE_SENTINEL) {
+        currentTombstone = true;
+        currentWeight = Float.NaN;
+      } else {
+        currentTombstone = false;
+        currentWeight = WeightCodec.fromFp16(s);
+      }
+    } else {
+      final int bits = pageBuf.getInt(at);
+      if (WeightCodec.isFp32Tombstone(bits)) {
+        currentTombstone = true;
+        currentWeight = Float.NaN;
+      } else {
+        currentTombstone = false;
+        currentWeight = Float.intBitsToFloat(bits);
+      }
     }
-    return bound;
   }
 
   private void materializePosting(final int idxInBlock) {
     pendingDecode = false;
     currentInBlock = idxInBlock;
     setPosition(blockBuckets[idxInBlock], blockPositions[idxInBlock]);
-    currentWeight = blockWeights[idxInBlock];
-    currentTombstone = blockTombstones[idxInBlock];
+    weightResolved = false;
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
@@ -69,11 +69,11 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
   private boolean       exhausted;
 
   // The page that holds {@code currentBlock}, kept between blocks. The builder packs a dim's blocks
-  // back to back, so well over a hundred default-sized blocks share one 64 KiB page and a sequential walk used to
-  // re-resolve the same page once per block. Each resolution allocated a {@link com.arcadedb.engine.PageId}
-  // and an {@link com.arcadedb.engine.ImmutablePage}, hashed into the page-cache map, and bumped the
-  // cache's global hit counter - an atomic that every parallel-range worker of issue #5518 contends
-  // on. Holding the page collapses all of that to once per page (issue #5467).
+  // back to back, so well over a hundred default-sized blocks share one 64 KiB page and a sequential
+  // walk used to re-resolve the same page once per block. Each resolution allocated a {@code PageId}
+  // and an {@code ImmutablePage}, hashed into the page-cache map, and bumped the cache's global hit
+  // counter - an atomic that every parallel-range worker of issue #5518 contends on. Holding the page
+  // collapses all of that to once per page (issue #5467).
   // <p>
   // Only ABSOLUTE reads are made through {@code pageBuf}: a REPEATABLE_READ transaction hands the
   // same {@code ImmutablePage} - and therefore the same {@link ByteBuffer} - to every cursor that
@@ -522,12 +522,14 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     final int base = BasePage.PAGE_HEADER_SIZE + meta.blockOffset(currentBlock) + SegmentFormat.BLOCK_HEADER_SIZE;
     final int n = meta.blockPostingCount(currentBlock);
     // The header's posting count is read off the segment file, so it is untrusted input (issue
-    // #6566): the decode arrays are sized to the segment's declared block size, and a count past that
-    // would run off their end. Reject it here so a corrupt header reads as a corrupt segment rather
-    // than as an ArrayIndexOutOfBoundsException from the middle of the decode loop.
-    if (n > blockBuckets.length)
-      throw new IOException(corruptBlockMessage() + " (posting count " + n + " exceeds the segment's block size "
-          + blockBuckets.length + ")");
+    // #6566). Above the segment's declared block size it runs off the end of the decode arrays; at
+    // zero it makes the block report the header's first RID as a posting that is not there.
+    // {@link SparseSegmentBuilder#flushBlock} never writes an empty block, so both are corruption,
+    // and both should read as a corrupt segment rather than as an ArrayIndexOutOfBoundsException
+    // from the middle of the decode loop or as a phantom posting in the result set.
+    if (n <= 0 || n > blockBuckets.length)
+      throw new IOException(corruptBlockMessage() + " (posting count " + n + " is not in 1.." + blockBuckets.length
+          + ", the segment's declared block size)");
     blockSize = n;
     blockBuckets[0] = meta.blockFirstBucketId(currentBlock);
     blockPositions[0] = meta.blockFirstPosition(currentBlock);
@@ -560,10 +562,23 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
           secondField |= ((long) (b & 0x7F)) << shift;
           shift += 7;
         } while ((b & 0x80) != 0);
+        // Strictly ascending RIDs are a write-side invariant that the read side never checked:
+        // SparseSegmentBuilder.appendInternal rejects a non-increasing RID and flushBlock fails loud
+        // on a negative delta, precisely because "a negative delta would silently encode as a huge
+        // unsigned VarInt and decode to a different RID on read". Checking the same thing here is
+        // what turns that into a named error instead of a traversal quietly merging out of order,
+        // and it is what catches a wrapped delta - including the one a tenth VarLong byte produces
+        // when Java discards the payload bits it shifts past bit 63.
         if (bucketDelta == 0L) {
-          prevPosition += secondField;
+          final long nextPosition = prevPosition + secondField;
+          if (nextPosition <= prevPosition)
+            throw new IOException(corruptBlockMessage() + notAscending(prevBucket, prevPosition));
+          prevPosition = nextPosition;
         } else {
-          prevBucket += (int) bucketDelta;
+          final int nextBucket = prevBucket + (int) bucketDelta;
+          if (bucketDelta > Integer.MAX_VALUE || nextBucket <= prevBucket)
+            throw new IOException(corruptBlockMessage() + notAscending(prevBucket, prevPosition));
+          prevBucket = nextBucket;
           prevPosition = secondField;
         }
         blockBuckets[i] = prevBucket;
@@ -577,6 +592,9 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
         p += 4;
         blockPositions[i] = buf.getLong(p);
         p += 8;
+        if (SparseSegmentBuilder.compareRid(blockBuckets[i], blockPositions[i], blockBuckets[i - 1],
+            blockPositions[i - 1]) <= 0)
+          throw new IOException(corruptBlockMessage() + notAscending(blockBuckets[i - 1], blockPositions[i - 1]));
       }
     }
 
@@ -590,6 +608,10 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     decodedPayloadBytes += (long) (p - base) + (long) n * weightStride;
     blockDecoded = true;
     weightResolved = false;
+  }
+
+  private String notAscending(final int previousBucketId, final long previousPosition) {
+    return " (postings are not in strictly ascending RID order after #" + previousBucketId + ":" + previousPosition + ")";
   }
 
   private String corruptBlockMessage() {

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentDimCursor.java
@@ -572,21 +572,29 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
         } while ((b & 0x80) != 0);
         if (shift == 70 && (b & 0x7F) > 1)
           throw new IOException(corruptBlockMessage() + OVERWIDE_VARLONG);
+        // A VarLong is unsigned, so a decoded value at or above 2^63 arrives here as a NEGATIVE long.
+        // Neither RID component can legitimately be that large - a bucket id is an int and a position
+        // is a non-negative long - and the ordering checks below cannot see it: a negative bucket
+        // delta narrows to a small positive int (0x8000_0000_0000_0001 casts to 1, which looks like a
+        // perfectly ordinary step forward), and a negative absolute position rides in on a bucket
+        // that did increase. So the range is checked before anything narrows or accumulates.
+        if (bucketDelta < 0L || secondField < 0L)
+          throw new IOException(corruptBlockMessage() + OUT_OF_RANGE_RID);
         // Strictly ascending RIDs are a write-side invariant that the read side never checked:
         // SparseSegmentBuilder.appendInternal rejects a non-increasing RID and flushBlock fails loud
         // on a negative delta, precisely because "a negative delta would silently encode as a huge
         // unsigned VarInt and decode to a different RID on read". Checking the same thing here is
-        // what turns that into a named error instead of a traversal quietly merging out of order,
-        // and it is what catches a wrapped delta - including the one a tenth VarLong byte produces
-        // when Java discards the payload bits it shifts past bit 63.
+        // what turns that into a named error instead of a traversal quietly merging out of order.
         if (bucketDelta == 0L) {
           final long nextPosition = prevPosition + secondField;
           if (nextPosition <= prevPosition)
             throw new IOException(corruptBlockMessage() + notAscending(prevBucket, prevPosition));
           prevPosition = nextPosition;
         } else {
+          if (bucketDelta > Integer.MAX_VALUE)
+            throw new IOException(corruptBlockMessage() + OUT_OF_RANGE_RID);
           final int nextBucket = prevBucket + (int) bucketDelta;
-          if (bucketDelta > Integer.MAX_VALUE || nextBucket <= prevBucket)
+          if (nextBucket <= prevBucket)
             throw new IOException(corruptBlockMessage() + notAscending(prevBucket, prevPosition));
           prevBucket = nextBucket;
           prevPosition = secondField;
@@ -608,6 +616,17 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
       }
     }
 
+    // The header names the block's last RID, and the builder writes it from the same posting the
+    // payload ends on. Checking that they agree costs one comparison per block - not per posting -
+    // and cross-validates the payload against the header rather than only checking each against
+    // itself: a truncated, scrambled or mis-counted payload almost never lands on the right last RID,
+    // however well-ordered the sequence it decoded to happened to be.
+    if (SparseSegmentBuilder.compareRid(blockBuckets[n - 1], blockPositions[n - 1], meta.blockLastBucketId(currentBlock),
+        meta.blockLastPosition(currentBlock)) != 0)
+      throw new IOException(corruptBlockMessage() + " (the payload ends on #" + blockBuckets[n - 1] + ":"
+          + blockPositions[n - 1] + ", but the block header says #" + meta.blockLastBucketId(currentBlock) + ":"
+          + meta.blockLastPosition(currentBlock) + ")");
+
     if (p + n * weightStride > limit)
       throw new IOException(corruptBlockMessage());
     weightsOffset = p;
@@ -619,6 +638,9 @@ public final class PaginatedSegmentDimCursor implements SourceCursor {
     blockDecoded = true;
     weightResolved = false;
   }
+
+  private static final String OUT_OF_RANGE_RID =
+      " (a decoded RID component is outside the range a bucket id or a position can hold)";
 
   private static final String OVERWIDE_VARLONG =
       " (a VarLong carries payload bits past the width of a long, which no encoder can produce)";

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentReader.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentReader.java
@@ -462,9 +462,16 @@ public final class PaginatedSegmentReader implements AutoCloseable {
    * Page-cache fetch of one page of this segment, for a cursor that decodes block payloads in place
    * on it rather than copying them out (issue #5467).
    * <p>
-   * Callers must only make ABSOLUTE reads through the returned page's buffer: under
-   * {@code REPEATABLE_READ} the transaction caches the page image and hands the same object to every
-   * caller in the transaction, so the buffer's position is shared state.
+   * Two conditions come with holding the returned page rather than copying out of it, and both are
+   * properties of THIS class's subject - a sealed segment - not of {@code readPage} in general:
+   * <ul>
+   *   <li>callers must only make ABSOLUTE reads through the page's buffer, because under
+   *       {@code REPEATABLE_READ} the transaction caches the page image and hands the same object to
+   *       every caller in the transaction, so the buffer's position is shared state;</li>
+   *   <li>the bytes may be read after the call returns only because a sealed segment is never written
+   *       again. A reader over a component that is still being appended to could not keep the page,
+   *       and would have to copy.</li>
+   * </ul>
    */
   BasePage readPage(final int pageNum) {
     return component.readPage(pageNum);

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentReader.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSegmentReader.java
@@ -459,40 +459,15 @@ public final class PaginatedSegmentReader implements AutoCloseable {
   }
 
   /**
-   * Fetch the block payload that immediately follows a block header at
-   * {@code (pageNum, offsetInPage)} into a caller-owned scratch buffer. Returns the same
-   * {@code reusableView} (which must wrap {@code dest}) positioned at the first compressed RID
-   * byte and limited to the bytes-read window, so the caller can decode without allocating.
+   * Page-cache fetch of one page of this segment, for a cursor that decodes block payloads in place
+   * on it rather than copying them out (issue #5467).
    * <p>
-   * The block's byte length is not stored in the format, so the caller supplies
-   * {@code maxPayloadLength}: an upper bound derived from the block's posting count (see
-   * {@link SegmentFormat#maxBlockPayloadSize}) and, when the next block of the same dim sits on the
-   * same page, from the gap to it. This method reads the smaller of that bound and the bytes left on
-   * the page; the cursor stops decoding once it has the header's posting count either way. Before
-   * issue #5388 the bound did not exist and the reader copied everything from the payload to the end
-   * of the page - a ~32 KiB copy for a ~1 KiB block at the 64 KiB page default, which the reporter's
-   * CPU profile saw as ~10% of query time sitting in {@code jbyte_disjoint_arraycopy}.
-   *
-   * @param maxPayloadLength upper bound on the block's payload bytes; clamped to what is left on the
-   *                         page
-   * @param dest             scratch byte array sized at {@code &gt;= component.pageContentSize()};
-   *                         the reader fills it in place starting at offset 0
-   * @param reusableView     a {@link ByteBuffer} that wraps {@code dest}; the reader rewinds it,
-   *                         applies the limit, and returns it
+   * Callers must only make ABSOLUTE reads through the returned page's buffer: under
+   * {@code REPEATABLE_READ} the transaction caches the page image and hands the same object to every
+   * caller in the transaction, so the buffer's position is shared state.
    */
-  ByteBuffer readBlockPayloadInto(final int pageNum, final int offsetInPage, final int maxPayloadLength,
-      final byte[] dest, final ByteBuffer reusableView) throws IOException {
-    final BasePage page = component.readPage(pageNum);
-    final int payloadOffset = offsetInPage + SegmentFormat.BLOCK_HEADER_SIZE;
-    final int len = Math.min(maxPayloadLength, page.getMaxContentSize() - payloadOffset);
-    reusableView.clear();
-    if (len <= 0) {
-      reusableView.limit(0);
-      return reusableView;
-    }
-    page.readByteArray(payloadOffset, dest, 0, len);
-    reusableView.limit(len);
-    return reusableView;
+  BasePage readPage(final int pageNum) {
+    return component.readPage(pageNum);
   }
 
 }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/VarInt.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/VarInt.java
@@ -64,6 +64,13 @@ public final class VarInt {
       if (shift >= 64)
         throw new IllegalStateException("VarLong overflow at position " + in.position());
       final byte b = in.get();
+      // A tenth byte is reached at shift 63 and contributes only bit 63, so {@link #writeUnsignedVarLong}
+      // can only ever emit 0 or 1 there. A larger payload is bits this shift would silently discard,
+      // which decodes a byte sequence no encoder produced into a plausible-looking small value - so it
+      // is rejected rather than truncated.
+      if (shift == 63 && (b & 0x7F) > 1)
+        throw new IllegalStateException("VarLong carries payload bits past the width of a long at position "
+            + in.position());
       result |= ((long) (b & 0x7F)) << shift;
       if ((b & 0x80) == 0)
         return result;

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/BmwScorerHeapRepairTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/BmwScorerHeapRepairTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The essential-term heap discipline of {@link BmwScorer}, pinned directly against hand-built heaps
+ * rather than through a query.
+ * <p>
+ * Issue #5467 replaced "pop the whole aligned run, move the cursors, push the survivors back" with
+ * "find the run without touching the heap, move the cursors, repair each moved slot in place". That
+ * is a genuinely subtle exchange, and it rests on three claims that a top-K comparison against
+ * {@link BruteForceScorer} can only confirm indirectly - and only for whatever heap shapes the
+ * corpus generator happens to produce:
+ * <ol>
+ *   <li>the slots holding the heap minimum form a connected subtree rooted at slot 0, so a
+ *       breadth-first walk that stops at the first non-matching child finds <i>all</i> of them;</li>
+ *   <li>the smallest key outside that run is always held by a non-run child of a run slot;</li>
+ *   <li>repairing the moved slots deepest-first with a Floyd sift restores the heap property, given
+ *       every moved key only ever grew.</li>
+ * </ol>
+ * Each is checked here against an independent brute-force answer over a random heap, so a broken
+ * invariant fails with a small counterexample instead of as a top-K mismatch on a 25k-document
+ * corpus. The randomised cases carry the coverage; the fixed ones nail down the shapes a random
+ * generator produces too rarely to be relied on (a one-element heap, a heap that is entirely one
+ * run, a run that stops at one child but not the other).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BmwScorerHeapRepairTest {
+
+  @Test
+  void theRunIsExactlyTheSlotsHoldingTheMinimumAndTheFrontierIsTheNextKeyAfterIt() {
+    final Random rnd = new Random(5467L);
+    for (int iteration = 0; iteration < 3_000; iteration++) {
+      final int n = 1 + rnd.nextInt(64);
+      // A small key space on purpose: ties are the whole point, and a wide one would make the run a
+      // single slot almost every time.
+      final int[] keyBucketIds = new int[n];
+      final long[] keyPositions = new long[n];
+      for (int i = 0; i < n; i++) {
+        keyBucketIds[i] = rnd.nextInt(2);
+        keyPositions[i] = rnd.nextInt(6);
+      }
+      final int[] heap = heapOfAllTerms(keyBucketIds, keyPositions, n);
+
+      final int[] aligned = new int[n];
+      final int[] alignedSlots = new int[n];
+      final int alignedCount = BmwScorer.collectAlignedRun(keyBucketIds, keyPositions, heap, n, keyBucketIds[heap[0]],
+          keyPositions[heap[0]], aligned, alignedSlots);
+
+      assertRunMatchesBruteForce(keyBucketIds, keyPositions, heap, n, aligned, alignedSlots, alignedCount);
+
+      final long[] frontier = new long[2];
+      BmwScorer.nextEssentialKey(keyBucketIds, keyPositions, heap, n, alignedSlots, alignedCount, keyBucketIds[heap[0]],
+          keyPositions[heap[0]], frontier);
+      assertFrontierMatchesBruteForce(keyBucketIds, keyPositions, heap, n, alignedSlots, alignedCount, frontier);
+    }
+  }
+
+  @Test
+  void repairingTheMovedSlotsDeepestFirstRestoresTheHeap() {
+    final Random rnd = new Random(4085L);
+    for (int iteration = 0; iteration < 3_000; iteration++) {
+      final int n = 1 + rnd.nextInt(64);
+      final int[] keyBucketIds = new int[n];
+      final long[] keyPositions = new long[n];
+      for (int i = 0; i < n; i++) {
+        keyBucketIds[i] = rnd.nextInt(2);
+        keyPositions[i] = rnd.nextInt(6);
+      }
+      final int[] heap = heapOfAllTerms(keyBucketIds, keyPositions, n);
+      final int[] before = heap.clone();
+
+      final int[] aligned = new int[n];
+      final int[] alignedSlots = new int[n];
+      final int alignedCount = BmwScorer.collectAlignedRun(keyBucketIds, keyPositions, heap, n, keyBucketIds[heap[0]],
+          keyPositions[heap[0]], aligned, alignedSlots);
+
+      // Every cursor in the run advances, so its key only ever grows. That is the precondition the
+      // in-place repair relies on, and the traversal guarantees it: a cursor either moves forward or
+      // is dropped from the heap entirely.
+      for (int j = 0; j < alignedCount; j++) {
+        final int term = aligned[j];
+        keyPositions[term] += 1 + rnd.nextInt(8);
+        if (rnd.nextInt(4) == 0)
+          keyBucketIds[term] += 1;
+      }
+
+      for (int j = alignedCount - 1; j >= 0; j--)
+        BmwScorer.siftDownFromFloyd(keyBucketIds, keyPositions, heap, n, alignedSlots[j]);
+
+      assertIsMinHeap(keyBucketIds, keyPositions, heap, n);
+      assertThat(sorted(heap, n))
+          .as("the repair must permute the heap, never lose or duplicate a term")
+          .isEqualTo(sorted(before, n));
+    }
+  }
+
+  /**
+   * A repaired heap must keep answering "what is the smallest key" correctly for the rest of the
+   * traversal, not merely satisfy the parent-child ordering once. This drains one, repeatedly, and
+   * checks the minima come out non-decreasing.
+   */
+  @Test
+  void aRepairedHeapKeepsHandingBackTheMinimumInOrder() {
+    final Random rnd = new Random(5518L);
+    for (int iteration = 0; iteration < 400; iteration++) {
+      final int n = 1 + rnd.nextInt(48);
+      final int[] keyBucketIds = new int[n];
+      final long[] keyPositions = new long[n];
+      for (int i = 0; i < n; i++) {
+        keyBucketIds[i] = 0;
+        keyPositions[i] = rnd.nextInt(10);
+      }
+      final int[] heap = heapOfAllTerms(keyBucketIds, keyPositions, n);
+      final int[] aligned = new int[n];
+      final int[] alignedSlots = new int[n];
+
+      int lastBucketId = -1;
+      long lastPosition = -1L;
+      for (int step = 0; step < 200; step++) {
+        final int candidateBucketId = keyBucketIds[heap[0]];
+        final long candidatePosition = keyPositions[heap[0]];
+        assertThat(SparseSegmentBuilder.compareRid(candidateBucketId, candidatePosition, lastBucketId, lastPosition))
+            .as("candidates must come out in non-decreasing order")
+            .isGreaterThanOrEqualTo(0);
+        assertThat(candidatePosition).isEqualTo(bruteForceMinPosition(keyPositions, heap, n));
+        lastBucketId = candidateBucketId;
+        lastPosition = candidatePosition;
+
+        final int alignedCount = BmwScorer.collectAlignedRun(keyBucketIds, keyPositions, heap, n, candidateBucketId,
+            candidatePosition, aligned, alignedSlots);
+        for (int j = 0; j < alignedCount; j++)
+          keyPositions[aligned[j]] += 1 + rnd.nextInt(3);
+        for (int j = alignedCount - 1; j >= 0; j--)
+          BmwScorer.siftDownFromFloyd(keyBucketIds, keyPositions, heap, n, alignedSlots[j]);
+        assertIsMinHeap(keyBucketIds, keyPositions, heap, n);
+      }
+    }
+  }
+
+  /** Shapes a random generator produces too rarely to lean on. */
+  @Test
+  void theFixedShapesBehave() {
+    // One element: the run is the root and there is no frontier.
+    assertShape(new long[] { 7 }, 1, 1, -1L);
+    // Two elements, both on the minimum: the whole heap is one run.
+    assertShape(new long[] { 3, 3 }, 2, 2, -1L);
+    // Two elements, one on the minimum.
+    assertShape(new long[] { 3, 9 }, 2, 1, 9L);
+    // Three elements, the run stops at one child but not the other.
+    assertShape(new long[] { 4, 4, 8 }, 3, 2, 8L);
+    // A run that reaches the third level, so the walk has to descend past a matching child.
+    assertShape(new long[] { 1, 1, 1, 1, 5, 6, 7 }, 7, 4, 5L);
+  }
+
+  // ---------- helpers ----------
+
+  /**
+   * Build a valid min-heap over term indices {@code [0, n)}. Deliberately a plain reference sift-down
+   * written here rather than {@link BmwScorer}'s own heapify: the input to the code under test should
+   * not be produced by the code under test.
+   */
+  private static int[] heapOfAllTerms(final int[] keyBucketIds, final long[] keyPositions, final int n) {
+    final int[] heap = new int[n];
+    for (int i = 0; i < n; i++)
+      heap[i] = i;
+    for (int i = (n >> 1) - 1; i >= 0; i--)
+      referenceSiftDown(keyBucketIds, keyPositions, heap, n, i);
+    assertIsMinHeap(keyBucketIds, keyPositions, heap, n);
+    return heap;
+  }
+
+  private static void referenceSiftDown(final int[] keyBucketIds, final long[] keyPositions, final int[] heap, final int size,
+      final int from) {
+    int i = from;
+    while (true) {
+      final int left = (i << 1) + 1;
+      if (left >= size)
+        return;
+      int smallest = left;
+      final int right = left + 1;
+      if (right < size && compare(keyBucketIds, keyPositions, heap[right], heap[left]) < 0)
+        smallest = right;
+      if (compare(keyBucketIds, keyPositions, heap[i], heap[smallest]) <= 0)
+        return;
+      final int tmp = heap[i];
+      heap[i] = heap[smallest];
+      heap[smallest] = tmp;
+      i = smallest;
+    }
+  }
+
+  private static int compare(final int[] keyBucketIds, final long[] keyPositions, final int a, final int b) {
+    return SparseSegmentBuilder.compareRid(keyBucketIds[a], keyPositions[a], keyBucketIds[b], keyPositions[b]);
+  }
+
+  private static void assertIsMinHeap(final int[] keyBucketIds, final long[] keyPositions, final int[] heap, final int size) {
+    for (int i = 1; i < size; i++) {
+      final int parent = (i - 1) >>> 1;
+      assertThat(compare(keyBucketIds, keyPositions, heap[parent], heap[i]))
+          .as("slot %d must not hold a larger key than slot %d", parent, i)
+          .isLessThanOrEqualTo(0);
+    }
+  }
+
+  private static void assertRunMatchesBruteForce(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
+      final int size, final int[] aligned, final int[] alignedSlots, final int alignedCount) {
+    final int minBucketId = keyBucketIds[heap[0]];
+    final long minPosition = keyPositions[heap[0]];
+    final List<Integer> expected = new ArrayList<>();
+    for (int slot = 0; slot < size; slot++)
+      if (keyBucketIds[heap[slot]] == minBucketId && keyPositions[heap[slot]] == minPosition)
+        expected.add(slot);
+
+    final List<Integer> got = new ArrayList<>();
+    for (int j = 0; j < alignedCount; j++) {
+      got.add(alignedSlots[j]);
+      assertThat(aligned[j]).as("aligned[] must be the term held by alignedSlots[]").isEqualTo(heap[alignedSlots[j]]);
+    }
+    assertThat(got).as("the run must be every slot holding the minimum, and nothing else").isEqualTo(expected);
+    // Ascending slot order is what makes the caller's reverse walk a deepest-first repair.
+    for (int j = 1; j < alignedCount; j++)
+      assertThat(alignedSlots[j]).isGreaterThan(alignedSlots[j - 1]);
+  }
+
+  private static void assertFrontierMatchesBruteForce(final int[] keyBucketIds, final long[] keyPositions, final int[] heap,
+      final int size, final int[] alignedSlots, final int alignedCount, final long[] frontier) {
+    final boolean[] inRun = new boolean[size];
+    for (int j = 0; j < alignedCount; j++)
+      inRun[alignedSlots[j]] = true;
+
+    int expectedBucketId = -1;
+    long expectedPosition = -1L;
+    for (int slot = 0; slot < size; slot++) {
+      if (inRun[slot])
+        continue;
+      final int term = heap[slot];
+      if (expectedBucketId < 0
+          || SparseSegmentBuilder.compareRid(keyBucketIds[term], keyPositions[term], expectedBucketId, expectedPosition) < 0) {
+        expectedBucketId = keyBucketIds[term];
+        expectedPosition = keyPositions[term];
+      }
+    }
+    assertThat((int) frontier[0]).as("frontier bucket id").isEqualTo(expectedBucketId);
+    assertThat(frontier[1]).as("frontier position").isEqualTo(expectedPosition);
+  }
+
+  private static long bruteForceMinPosition(final long[] keyPositions, final int[] heap, final int size) {
+    long min = Long.MAX_VALUE;
+    for (int slot = 0; slot < size; slot++)
+      min = Math.min(min, keyPositions[heap[slot]]);
+    return min;
+  }
+
+  private static int[] sorted(final int[] heap, final int size) {
+    final int[] copy = Arrays.copyOf(heap, size);
+    Arrays.sort(copy);
+    return copy;
+  }
+
+  private void assertShape(final long[] positions, final int n, final int expectedRunSize, final long expectedFrontier) {
+    final int[] keyBucketIds = new int[n];
+    final long[] keyPositions = Arrays.copyOf(positions, n);
+    final int[] heap = heapOfAllTerms(keyBucketIds, keyPositions, n);
+
+    final int[] aligned = new int[n];
+    final int[] alignedSlots = new int[n];
+    final int alignedCount = BmwScorer.collectAlignedRun(keyBucketIds, keyPositions, heap, n, keyBucketIds[heap[0]],
+        keyPositions[heap[0]], aligned, alignedSlots);
+    assertThat(alignedCount).as("run size for %s", Arrays.toString(positions)).isEqualTo(expectedRunSize);
+    assertRunMatchesBruteForce(keyBucketIds, keyPositions, heap, n, aligned, alignedSlots, alignedCount);
+
+    final long[] frontier = new long[2];
+    BmwScorer.nextEssentialKey(keyBucketIds, keyPositions, heap, n, alignedSlots, alignedCount, keyBucketIds[heap[0]],
+        keyPositions[heap[0]], frontier);
+    assertThat(frontier[1]).as("frontier for %s", Arrays.toString(positions)).isEqualTo(expectedFrontier);
+
+    for (int j = 0; j < alignedCount; j++)
+      keyPositions[aligned[j]] += 100;
+    for (int j = alignedCount - 1; j >= 0; j--)
+      BmwScorer.siftDownFromFloyd(keyBucketIds, keyPositions, heap, n, alignedSlots[j]);
+    assertIsMinHeap(keyBucketIds, keyPositions, heap, n);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467RawRidCompressionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467RawRidCompressionTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.index.sparsevector.SegmentFormat.RidCompression;
+import com.arcadedb.index.sparsevector.SegmentFormat.WeightQuantization;
+import com.arcadedb.schema.LocalSchema;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link RidCompression#RAW}, which had no test anywhere in the repository.
+ * <p>
+ * It is not a dead branch: the compression mode is read straight off the segment header, and
+ * {@link SegmentParameters.Builder#ridCompression} is public, so a segment written with it decodes
+ * through {@link PaginatedSegmentDimCursor} like any other. It happens not to be what
+ * {@link LSMSparseVectorIndex} selects, which is presumably why it went uncovered - and why issue
+ * #5467 could rewrite its decode branch from relative to absolute page reads, and add two corruption
+ * guards to it, with nothing to catch a mistake.
+ * <p>
+ * This gives the RAW path the same treatment the varint path has: a round trip that pins what the
+ * cursor returns, a seek walk, and the corruption guards exercised by mutating real on-disk bytes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5467RawRidCompressionTest extends TestHelper {
+
+  private static final SegmentParameters RAW_PARAMS = SegmentParameters.builder()
+      .weightQuantization(WeightQuantization.FP32)
+      .ridCompression(RidCompression.RAW)
+      .blockSize(SegmentFormat.MIN_BLOCK_SIZE)
+      .build();
+
+  private static final int POSTINGS = 500;
+
+  /**
+   * Every posting the builder wrote comes back, in order, with its weight - across many blocks, so
+   * the block-to-block transitions are covered rather than just the first decode.
+   */
+  @Test
+  void aRawSegmentRoundTripsEveryPosting() throws Exception {
+    final List<RID> rids = new ArrayList<>();
+    final List<Float> weights = new ArrayList<>();
+    for (int i = 0; i < POSTINGS; i++) {
+      // Two buckets, so the decoder's bucket component is exercised and not just the position.
+      rids.add(new RID(i < POSTINGS / 2 ? 0 : 3, 1L + i));
+      weights.add(0.125f + (i % 11) * 0.0625f);
+    }
+
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-raw-roundtrip", rids, weights)));
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      assertThat(reader.parameters().ridCompression())
+          .as("the segment must really be RAW, or this test is covering the varint path again")
+          .isEqualTo(RidCompression.RAW);
+
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThat(c.metadata().blockCount()).as("the walk must span many blocks").isGreaterThan(20);
+        c.start();
+        for (int i = 0; i < POSTINGS; i++) {
+          assertThat(c.currentRid()).as("posting %d", i).isEqualTo(rids.get(i));
+          assertThat(c.currentWeight()).as("weight of posting %d", i).isEqualTo(weights.get(i));
+          assertThat(c.isTombstone()).isFalse();
+          if (i < POSTINGS - 1)
+            assertThat(c.advance()).as("advance off posting %d", i).isTrue();
+        }
+        assertThat(c.advance()).isFalse();
+        assertThat(c.isExhausted()).isTrue();
+      }
+    });
+  }
+
+  /**
+   * Seeking lands on the first posting at or after the target, including targets that fall in the
+   * gaps the fixture leaves and targets in the second bucket. A seek is the operation the
+   * non-essential probe of a MaxScore traversal runs, and on the RAW path it scans the decoded
+   * positions rather than replaying deltas.
+   */
+  @Test
+  void seekingIntoARawSegmentLandsOnTheFirstPostingAtOrAfterTheTarget() throws Exception {
+    final List<RID> rids = new ArrayList<>();
+    final List<Float> weights = new ArrayList<>();
+    for (int i = 0; i < POSTINGS; i++) {
+      rids.add(new RID(i < POSTINGS / 2 ? 0 : 3, 10L * (i + 1)));  // gaps of 10 between positions
+      weights.add(0.5f);
+    }
+
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-raw-seek", rids, weights)));
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      for (int i = 0; i < POSTINGS; i += 37) {
+        final RID target = rids.get(i);
+        try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+          c.start();
+          // A position between two postings must land on the later one, never before the target.
+          assertThat(c.seekTo(target.getBucketId(), target.getPosition() - 3)).isTrue();
+          assertThat(c.currentRid()).as("seek to just before posting %d", i).isEqualTo(target);
+          // Seeking to exactly where we already are must not move.
+          assertThat(c.seekTo(target.getBucketId(), target.getPosition())).isTrue();
+          assertThat(c.currentRid()).isEqualTo(target);
+        }
+      }
+
+      // Past the end: the cursor exhausts rather than reporting a stale position.
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        c.start();
+        assertThat(c.seekTo(99, 1L)).isFalse();
+        assertThat(c.isExhausted()).isTrue();
+        assertThat(c.currentRid()).isNull();
+      }
+    });
+  }
+
+  /**
+   * The RAW branch got the same strictly-ascending guard as the varint branch in issue #5467, and it
+   * is the branch where nothing else would catch a scrambled payload: absolute RIDs decode to
+   * whatever bytes are there, with no delta arithmetic to overflow first.
+   */
+  @Test
+  void aNonAscendingRawPayloadReadsAsACorruptSegment() throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    final int[] blockLocator = new int[2];
+    inTx(() -> component.set(buildAscendingSegment("seg-5467-raw-order")));
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    inTx(() -> {
+      // The block header holds posting 0; the payload starts at posting 1, as (int bucket, long
+      // position). Rewriting that position to 0 puts it at or before the block's first RID.
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      final int payloadStart = blockLocator[1] + SegmentFormat.BLOCK_HEADER_SIZE;
+      page.writeInt(payloadStart, 0);
+      page.writeLong(payloadStart + 4, 0L);
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).isInstanceOf(IOException.class)
+            .hasMessageContaining("segment is corrupt")
+            .hasMessageContaining("not in strictly ascending RID order");
+      }
+    });
+  }
+
+  /** The posting-count guard is shared, but it had never run against a RAW block. */
+  @Test
+  void aRawBlockClaimingTooManyPostingsReadsAsACorruptSegment() throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    final int[] blockLocator = new int[2];
+    inTx(() -> component.set(buildAscendingSegment("seg-5467-raw-count")));
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    inTx(() -> {
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      page.writeShort(blockLocator[1] + 2 * SegmentFormat.RID_SIZE_BYTES, (short) (RAW_PARAMS.blockSize() + 1));
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).isInstanceOf(IOException.class)
+            .hasMessageContaining("segment is corrupt")
+            .hasMessageContaining("is not in 1..");
+      }
+    });
+  }
+
+  // ---------- helpers ----------
+
+  @FunctionalInterface
+  private interface CheckedRunnable {
+    void run() throws Exception;
+  }
+
+  private void inTx(final CheckedRunnable r) {
+    database.transaction(() -> {
+      try {
+        r.run();
+      } catch (final RuntimeException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private SparseSegmentComponent buildAscendingSegment(final String name) throws IOException {
+    final List<RID> rids = new ArrayList<>();
+    final List<Float> weights = new ArrayList<>();
+    for (int i = 0; i < POSTINGS; i++) {
+      rids.add(new RID(0, 1L + i));
+      weights.add(0.5f);
+    }
+    return buildSegment(name, rids, weights);
+  }
+
+  private SparseSegmentComponent buildSegment(final String name, final List<RID> rids, final List<Float> weights)
+      throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final SparseSegmentComponent c = new SparseSegmentComponent(db, name, db.getDatabasePath() + "/" + name,
+        ComponentFile.MODE.READ_WRITE, SparseSegmentComponent.DEFAULT_PAGE_SIZE);
+    ((LocalSchema) db.getSchema().getEmbedded()).registerFile(c);
+
+    try (final SparseSegmentBuilder b = new SparseSegmentBuilder(c, RAW_PARAMS)) {
+      b.setSegmentId(5467L);
+      b.startDim(0);
+      for (int i = 0; i < rids.size(); i++)
+        b.appendPosting(rids.get(i), weights.get(i));
+      b.endDim();
+      b.finish();
+    }
+    return c;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467SmallCorpusTraversalCostTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467SmallCorpusTraversalCostTest.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.sparsevector.SegmentFormat.WeightQuantization;
+import com.arcadedb.schema.LocalSchema;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Third round of issue #5467: the small-corpus tier, and the posting-traversal cost that the
+ * reporter's last CPU profile left as the remainder.
+ * <p>
+ * The issue was filed because {@code LSM_SPARSE_VECTOR} top-K at the 100k tier had grown from
+ * 1.45 ms to 8.94 ms p50 while the 1M tier improved, on the hypothesis that a fixed per-query
+ * preparation cost was invisible at 1M and dominant at 100k. Two rounds of profiling disproved the
+ * hypothesis - setup is under 0.1% of the query - and attacked what the profile actually showed:
+ * the essential-term min-heap, the per-candidate block-max recomputation, and the multi-segment
+ * merge on a settled index. The last profile (released 26.8.1.dev23) put what was left in posting
+ * traversal: {@code advance} plus {@code decodeBlockIfNeeded} at 26.8% of query CPU, with scoring
+ * down at 1.5%.
+ * <p>
+ * This class covers the third bullet of the original scope, which the first two rounds never
+ * delivered: <b>a benchmark that reports a small-corpus tier</b>, so a per-query cost regression
+ * cannot hide behind a healthy 1M number again. The corpus is shaped like the reporter's harness -
+ * 100k documents, 59 query terms, roughly a million postings across them, near-uniform weights - so
+ * the traversal it drives has the same shape as the one being measured upstream.
+ * <p>
+ * The assertions in the non-benchmark tests are on <b>work counters</b>, never on wall-clock: how
+ * many times a cursor asked the page cache for a page, and how many posting weights it decoded.
+ * Those are the two quantities this round changed, and unlike elapsed time they are deterministic
+ * and CI-safe.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5467SmallCorpusTraversalCostTest extends TestHelper {
+
+  /** Production default: the arm the reporter measures. */
+  private static final SegmentParameters INT8_PARAMS = SegmentParameters.builder()
+      .weightQuantization(WeightQuantization.INT8)
+      .build();
+
+  /** FP32 so weights round-trip exactly and scores match brute force without quantization noise. */
+  private static final SegmentParameters EXACT_PARAMS = SegmentParameters.builder()
+      .weightQuantization(WeightQuantization.FP32)
+      .build();
+
+  /** Query terms. Real SPLADE queries carry 30-120; the reporter's harness averages 59. */
+  private static final int   DIMS    = 59;
+  /**
+   * Document-frequency model, calibrated against the counters the reporter measures on real SPLADE at
+   * this tier: roughly a million postings across the query's terms, of which MaxScore keeps most out
+   * of the traversal, ~89k candidates, and ~2.8 essential postings consumed per candidate.
+   * <p>
+   * Learned-sparse expansion terms form a <b>plateau</b> - a handful of them appear in most documents
+   * carrying small weights - while the query's original vocabulary terms are comparatively rare. A
+   * Zipf curve cannot express that: it has no plateau, so tuning it to make the head fat enough makes
+   * the tail fat too and every term stays essential, which is a different traversal regime from the
+   * one being measured. Two bands with a gentle gradient inside each reproduce the counters.
+   */
+  private static final int   FAT_DIMS = 11;
+  private static final float FAT_DF   = 0.79f;
+  private static final float THIN_DF  = 0.051f;
+  private static final int   K        = 10;
+  /** Documents that genuinely answer the query, so the top-K watermark rises and MaxScore prunes. */
+  private static final int   RELEVANT_DOCS    = 60;
+  private static final int   RELEVANT_MATCHES = 30;
+
+  /**
+   * A cursor walking a dim sequentially must ask the page cache for each page <b>once</b>, not once
+   * per block.
+   * <p>
+   * The builder packs a dim's blocks back to back, so well over a hundred default-sized blocks share
+   * one 64 KiB page. Before this round every block decode called {@code readPage} again, and each call
+   * allocated a {@code PageId} and an {@code ImmutablePage}, hashed into the page-cache map and
+   * bumped the cache's global hit counter - an atomic that every parallel-range worker of #5518
+   * contends on. The assertion is exact rather than a ratio: the cursor's page fetches must equal
+   * the number of distinct pages its blocks actually live on.
+   */
+  @Test
+  void aSequentialWalkFetchesEachPageExactlyOnce() throws Exception {
+    final Map<RID, Map<Integer, Float>> docs = buildCorpus(100_000, 2);
+
+    final List<PaginatedSegmentReader> readers = new ArrayList<>();
+    inTx(() -> readers.add(buildSegment("seg-5467-pagefetch", 1L, docs, INT8_PARAMS)));
+
+    inTx(() -> {
+      try (final PaginatedSegmentDimCursor c = readers.getFirst().openCursor(0)) {
+        final PaginatedDimMetadata meta = c.metadata();
+        final Set<Integer> pages = new HashSet<>();
+        for (int b = 0; b < meta.blockCount(); b++)
+          pages.add(meta.blockPageNum(b));
+
+        // A dense dim must actually span several pages and many blocks, or the assertion below is
+        // vacuous - it would be satisfied by a one-block, one-page dim.
+        assertThat(meta.blockCount()).as("blocks in the walked dim").isGreaterThan(50);
+        assertThat(pages.size()).as("distinct pages the dim spans").isGreaterThan(1);
+
+        long postings = 0;
+        c.start();
+        while (!c.isExhausted()) {
+          postings++;
+          if (!c.advance())
+            break;
+        }
+        assertThat(postings).isEqualTo(meta.postingCount());
+        assertThat(c.decodedBlockCount()).isEqualTo(meta.blockCount());
+        assertThat(c.pageFetchCount())
+            .as("fetched %d pages to decode %d blocks living on %d pages", c.pageFetchCount(), c.decodedBlockCount(),
+                pages.size())
+            .isEqualTo(pages.size());
+      }
+    });
+  }
+
+  /**
+   * A cursor that navigates but never scores must decode <b>no</b> weights, and one that scores every
+   * posting must decode exactly one weight per posting - never more.
+   * <p>
+   * The weight section used to be decoded in full whenever a block was touched: 128 dequantizations
+   * and 128 float plus 128 boolean stores for a block that a block-max skip walks straight past, or
+   * that a non-essential probe enters to read a single posting. Weights are fixed-stride, so posting
+   * {@code i}'s weight is one indexed read and there is no reason to pay for the other 127.
+   */
+  @Test
+  void weightsAreDecodedOnlyForThePostingsThatAreRead() throws Exception {
+    final Map<RID, Map<Integer, Float>> docs = buildCorpus(100_000, 2);
+
+    final List<PaginatedSegmentReader> readers = new ArrayList<>();
+    inTx(() -> readers.add(buildSegment("seg-5467-lazyweights", 1L, docs, INT8_PARAMS)));
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = readers.getFirst();
+      try (final PaginatedSegmentDimCursor navigateOnly = reader.openCursor(0)) {
+        navigateOnly.start();
+        while (navigateOnly.advance())
+          ;
+        assertThat(navigateOnly.decodedBlockCount()).isGreaterThan(50L);
+        assertThat(navigateOnly.resolvedWeightCount())
+            .as("a pure navigation decoded %d weights across %d blocks", navigateOnly.resolvedWeightCount(),
+                navigateOnly.decodedBlockCount())
+            .isZero();
+      }
+
+      try (final PaginatedSegmentDimCursor scoreEverything = reader.openCursor(0)) {
+        long postings = 0;
+        scoreEverything.start();
+        while (!scoreEverything.isExhausted()) {
+          postings++;
+          // Both getters resolve the same posting; the second must not decode it again.
+          assertThat(scoreEverything.isTombstone()).isFalse();
+          assertThat(scoreEverything.currentWeight()).isNotNaN();
+          if (!scoreEverything.advance())
+            break;
+        }
+        assertThat(scoreEverything.resolvedWeightCount())
+            .as("decoded %d weights for %d postings read", scoreEverything.resolvedWeightCount(), postings)
+            .isEqualTo(postings);
+      }
+    });
+  }
+
+  /**
+   * The same two properties, observed through a real Block-Max MaxScore traversal instead of a hand
+   * walk: the query must decode far fewer weights than the blocks it touched contain, must fetch far
+   * fewer pages than it decoded blocks, and must still return exactly the brute-force top-K.
+   */
+  @Test
+  void aMaxScoreQueryPaysForNeitherUnreadWeightsNorRepeatedPageLookups() throws Exception {
+    final Map<RID, Map<Integer, Float>> docs = buildCorpus(25_000, DIMS);
+
+    final List<PaginatedSegmentReader> readers = new ArrayList<>();
+    inTx(() -> readers.add(buildSegment("seg-5467-traversal", 1L, docs, EXACT_PARAMS)));
+
+    final int[] queryDims = new int[DIMS];
+    final float[] queryWeights = new float[DIMS];
+    for (int d = 0; d < DIMS; d++) {
+      queryDims[d] = d;
+      queryWeights[d] = 1.0f;
+    }
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = readers.getFirst();
+      final PaginatedSegmentDimCursor[] sources = new PaginatedSegmentDimCursor[DIMS];
+      final DimCursor[] cursors = new DimCursor[DIMS];
+      try {
+        for (int i = 0; i < DIMS; i++) {
+          sources[i] = reader.openCursor(queryDims[i]);
+          cursors[i] = new DimCursor(queryDims[i], List.of(sources[i]));
+        }
+
+        final List<RidScore> got = BmwScorer.topK(queryDims, queryWeights, cursors, K);
+
+        long decodedBlocks = 0;
+        long pageFetches = 0;
+        long weights = 0;
+        for (final PaginatedSegmentDimCursor c : sources) {
+          decodedBlocks += c.decodedBlockCount();
+          pageFetches += c.pageFetchCount();
+          weights += c.resolvedWeightCount();
+        }
+
+        // Correctness first: the traversal must be untouched by any of this.
+        final List<RidScore> expected = BruteForceScorer.topK(queryDims, queryWeights,
+            readers.toArray(new PaginatedSegmentReader[0]), K);
+        assertThat(got).hasSize(expected.size());
+        for (int i = 0; i < got.size(); i++) {
+          assertThat(got.get(i).rid()).isEqualTo(expected.get(i).rid());
+          assertThat(got.get(i).score()).isCloseTo(expected.get(i).score(), Offset.offset(1e-4f));
+        }
+
+        assertThat(decodedBlocks).as("the query must decode a meaningful number of blocks").isGreaterThan(200L);
+
+        final long postingsInDecodedBlocks = decodedBlocks * EXACT_PARAMS.blockSize();
+        assertThat(weights)
+            .as("decoded %d weights out of %d postings in the %d blocks touched", weights, postingsInDecodedBlocks,
+                decodedBlocks)
+            .isLessThan(postingsInDecodedBlocks * 7 / 10);
+
+        assertThat(pageFetches)
+            .as("fetched %d pages to decode %d blocks", pageFetches, decodedBlocks)
+            .isLessThan(decodedBlocks / 4);
+      } finally {
+        for (final DimCursor c : cursors)
+          if (c != null)
+            c.close();
+      }
+    });
+  }
+
+  /**
+   * The small-corpus tier the original scope asked for and never got: wall-clock and work counters
+   * for one learned-sparse query against a 100k-document corpus, in both the production INT8 arm and
+   * the exact FP32 arm. Run with {@code -DexcludedGroups=} (the {@code benchmark} tag is excluded
+   * from normal builds).
+   * <p>
+   * The corpus is 59 query terms over 100k documents with roughly a million postings between them
+   * and weights drawn from a narrow band, which is the shape the reporter measures: per-block maxima
+   * carry no information beyond the global maximum, so the term-level MaxScore split has to do all
+   * the pruning and most of the corpus becomes a scored candidate. Latency at this tier is dominated
+   * by per-posting and per-candidate work rather than by anything proportional to corpus size, which
+   * is exactly what makes it the tier where a fixed-cost regression shows up first.
+   * <p>
+   * Measured on an M-series laptop before and after this round, arms interleaved across five rounds
+   * so machine drift cancels (400 reps each, first fifth discarded):
+   * <pre>
+   * INT8  p50 7.76 -> 7.32 ms (-5.7%)   FP32  p50 7.52 -> 7.15 ms (-4.9%)
+   * </pre>
+   * The wall-clock is indicative - it was taken on a laptop with other work on it - but the work
+   * counters underneath it are deterministic and are what the non-benchmark tests here assert on:
+   * <pre>
+   * page-cache fetches   2,559 -> 103    (-96%)
+   * weights decoded    325,406 -> 140,077 (-57%)
+   * heap comparisons   913,455 -> 695,016 (-24%)
+   * payload bytes copied out of the page cache: all of them -> none
+   * </pre>
+   */
+  @Tag("benchmark")
+  @Test
+  void smallCorpusTierQueryCost() throws Exception {
+    final int docs = 100_000;
+    final Map<RID, Map<Integer, Float>> corpus = buildCorpus(docs, DIMS);
+
+    final List<PaginatedSegmentReader> readers = new ArrayList<>();
+    inTx(() -> {
+      readers.add(buildSegment("seg-5467-bench-int8", 1L, corpus, INT8_PARAMS));
+      readers.add(buildSegment("seg-5467-bench-fp32", 2L, corpus, EXACT_PARAMS));
+    });
+
+    final int[] queryDims = new int[DIMS];
+    final float[] queryWeights = new float[DIMS];
+    for (int d = 0; d < DIMS; d++) {
+      queryDims[d] = d;
+      queryWeights[d] = 1.0f;
+    }
+
+    for (int r = 0; r < readers.size(); r++) {
+      final String label = r == 0 ? "INT8 (production default)" : "FP32 (exact)";
+      final PaginatedSegmentReader reader = readers.get(r);
+      inTx(() -> benchmarkQuery(reader, label, docs, queryDims, queryWeights));
+    }
+  }
+
+  private void benchmarkQuery(final PaginatedSegmentReader reader, final String label, final int docs, final int[] queryDims,
+      final float[] queryWeights) {
+    try {
+      long totalBlocks = 0;
+      long totalPostings = 0;
+      for (int i = 0; i < DIMS; i++) {
+        final PaginatedDimMetadata meta = reader.openCursor(queryDims[i]).metadata();
+        totalBlocks += meta.blockCount();
+        totalPostings += meta.postingCount();
+      }
+
+      // {@code -Dbench.reps=N} raises the rep count for a profiling run, where a 60-second sampling
+      // window has to fall inside the measured loop.
+      final int reps = Integer.getInteger("bench.reps", 400);
+      final double[] samples = new double[reps];
+      long decoded = 0;
+      long payloadBytes = 0;
+      long pageFetches = 0;
+      long weights = 0;
+
+      for (int rep = 0; rep < reps; rep++) {
+        final PaginatedSegmentDimCursor[] sources = new PaginatedSegmentDimCursor[DIMS];
+        final DimCursor[] cursors = new DimCursor[DIMS];
+        for (int i = 0; i < DIMS; i++) {
+          sources[i] = reader.openCursor(queryDims[i]);
+          cursors[i] = new DimCursor(queryDims[i], List.of(sources[i]));
+        }
+        final long start = System.nanoTime();
+        BmwScorer.topK(queryDims, queryWeights, cursors, K);
+        samples[rep] = (System.nanoTime() - start) / 1_000_000.0;
+        decoded = 0;
+        payloadBytes = 0;
+        pageFetches = 0;
+        weights = 0;
+        for (final PaginatedSegmentDimCursor c : sources) {
+          decoded += c.decodedBlockCount();
+          payloadBytes += c.decodedPayloadBytes();
+          pageFetches += c.pageFetchCount();
+          weights += c.resolvedWeightCount();
+        }
+        for (final DimCursor c : cursors)
+          c.close();
+      }
+
+      // Discard the first 20% as warm-up before taking the statistics.
+      final double[] tail = Arrays.copyOfRange(samples, reps / 5, reps);
+      Arrays.sort(tail);
+      System.out.printf("%n%s: docs=%,d terms=%d postings=%,d k=%d reps=%d (measured %d)%n", label, docs, DIMS,
+          totalPostings, K, reps, tail.length);
+      System.out.printf("  p50 %.2f ms  min %.2f ms  p90 %.2f ms%n", tail[tail.length / 2], tail[0],
+          tail[(int) (tail.length * 0.9)]);
+      System.out.printf("  %,d of %,d blocks decoded | %,d payload bytes | %,d page fetches | %,d weights decoded%n",
+          decoded, totalBlocks, payloadBytes, pageFetches, weights);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // ---------- corpus ----------
+
+  /**
+   * Corpus shaped like a learned-sparse (SPLADE) collection restricted to the query's own terms: a
+   * plateau of expansion terms carries most of the posting mass, the rest are rare, and every weight
+   * sits in a narrow band so per-block maxima are no tighter than the global maximum. Dims outside the query are omitted on purpose - they cost build time and contribute
+   * nothing to the traversal being measured.
+   */
+  private Map<RID, Map<Integer, Float>> buildCorpus(final int docs, final int dims) {
+    final Random rnd = new Random(5467L);
+    final float[] density = new float[dims];
+    for (int d = 0; d < dims; d++)
+      density[d] = d < FAT_DIMS ? FAT_DF * (1.0f - 0.03f * d) : THIN_DF * (1.0f - 0.008f * (d - FAT_DIMS));
+
+    final TreeMap<RID, Map<Integer, Float>> out = new TreeMap<>();
+    for (int i = 0; i < docs; i++) {
+      final TreeMap<Integer, Float> doc = new TreeMap<>();
+      for (int d = 0; d < dims; d++)
+        if (rnd.nextFloat() < density[d])
+          doc.put(d, 0.90f + rnd.nextFloat() * 0.10f);
+      if (!doc.isEmpty())
+        out.put(new RID(0, 1L + i), doc);
+    }
+
+    // A real query has real answers: a small set of documents matching many of its terms, which is
+    // what lifts the top-K watermark far enough for MaxScore to prove terms non-essential. Without
+    // them the watermark never clears a single term's ceiling and the traversal stays exhaustive -
+    // a property of the synthetic corpus rather than of the workload.
+    for (int r = 0; r < RELEVANT_DOCS; r++) {
+      final Map<Integer, Float> doc = out.computeIfAbsent(new RID(0, 1L + rnd.nextInt(docs)), rid -> new TreeMap<>());
+      for (int m = 0; m < RELEVANT_MATCHES && m < dims; m++)
+        doc.putIfAbsent(rnd.nextInt(dims), 0.90f + rnd.nextFloat() * 0.10f);
+    }
+    return out;
+  }
+
+  // ---------- helpers ----------
+
+  @FunctionalInterface
+  private interface CheckedRunnable {
+    void run() throws Exception;
+  }
+
+  private void inTx(final CheckedRunnable r) {
+    database.transaction(() -> {
+      try {
+        r.run();
+      } catch (final RuntimeException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private SparseSegmentComponent newComponent(final String name) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    try {
+      final SparseSegmentComponent c = new SparseSegmentComponent(db, name, db.getDatabasePath() + "/" + name,
+          ComponentFile.MODE.READ_WRITE, SparseSegmentComponent.DEFAULT_PAGE_SIZE);
+      ((LocalSchema) db.getSchema().getEmbedded()).registerFile(c);
+      return c;
+    } catch (final IOException e) {
+      throw new RuntimeException("failed to create sparse segment component '" + name + "'", e);
+    }
+  }
+
+  private PaginatedSegmentReader buildSegment(final String name, final long segmentId, final Map<RID, Map<Integer, Float>> docs,
+      final SegmentParameters params) throws IOException {
+    final TreeMap<Integer, TreeMap<RID, Float>> byDim = new TreeMap<>();
+    for (final var doc : docs.entrySet())
+      for (final var dw : doc.getValue().entrySet())
+        byDim.computeIfAbsent(dw.getKey(), k -> new TreeMap<>()).put(doc.getKey(), dw.getValue());
+
+    final SparseSegmentComponent c = newComponent(name);
+    try (final SparseSegmentBuilder b = new SparseSegmentBuilder(c, params)) {
+      b.setSegmentId(segmentId);
+      for (final var dim : byDim.entrySet()) {
+        b.startDim(dim.getKey());
+        for (final var p : dim.getValue().entrySet())
+          b.appendPosting(p.getKey(), p.getValue());
+        b.endDim();
+      }
+      b.finish();
+    }
+    return new PaginatedSegmentReader(c);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467SmallCorpusTraversalCostTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467SmallCorpusTraversalCostTest.java
@@ -327,8 +327,9 @@ class Issue5467SmallCorpusTraversalCostTest extends TestHelper {
       }
 
       // {@code -Dbench.reps=N} raises the rep count for a profiling run, where a 60-second sampling
-      // window has to fall inside the measured loop.
-      final int reps = Integer.getInteger("bench.reps", 400);
+      // window has to fall inside the measured loop. Clamped at 1 so the knob cannot turn the
+      // statistics below into an out-of-bounds read on an empty sample array.
+      final int reps = Math.max(1, Integer.getInteger("bench.reps", 400));
       final double[] samples = new double[reps];
       long decoded = 0;
       long payloadBytes = 0;

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
@@ -37,22 +37,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * The two guards issue #5467 introduced alongside the in-place block decode, pinned as tests rather
- * than as prose.
+ * What the in-place block decode of issue #5467 has to prove for itself, pinned as tests rather than
+ * as prose.
  * <p>
- * <b>Corrupt block headers.</b> Decoding used to copy a bounded slice of the page into a scratch
+ * <b>Untrusted block payloads.</b> Decoding used to copy a bounded slice of the page into a scratch
  * buffer, so a header describing more postings than the block really holds ran out of that slice and
- * surfaced as a {@code BufferUnderflowException} from the decode loop. Reading the page in
- * place has no slice to run out of, so the decode carries its own bounds checks and reports a corrupt
- * segment by name. The header is untrusted input in the same sense as issue #6566's segment surface:
- * it is whatever is on disk.
+ * surfaced as a {@code BufferUnderflowException} from the decode loop - protection that came for free
+ * with the copy. Reading the page in place has no slice to run out of, so the decode carries its own
+ * checks and reports a corrupt segment by name. A block header is untrusted input in the same sense
+ * as issue #6566's segment surface: it is whatever is on disk. The cases below are the ones each
+ * successive check was added for, and each fails if its check is removed:
+ * <ul>
+ *   <li>a posting count past the segment's block size, or of zero;</li>
+ *   <li>a VarLong carrying payload bits past the width of a {@code long};</li>
+ *   <li>a decoded RID component too large for a bucket id or a position;</li>
+ *   <li>a posting sequence that is not strictly ascending;</li>
+ *   <li>a payload that is well-formed and well-ordered throughout and still ends somewhere other
+ *       than where the block header says it does.</li>
+ * </ul>
  * <p>
- * <b>The block-bounds memo contract.</b> {@link DimCursor#lastProbedBlockEnd} reads the memo without
- * re-validating that it covers the probe, which is only safe because the block-max skip calls it
- * immediately after {@link DimCursor#blockMaxAt} for the same probe. That is enforced by a Java
- * {@code assert}, so the guard exists only while assertions are enabled - which this test also pins,
- * because a Surefire configuration that turned them off would remove the check silently rather than
- * visibly.
+ * <b>The fused block bounds.</b> The block-max skip needs both edges of one probe, and
+ * {@link DimCursor#blockBoundsAt} returns them together so the memo is consulted once instead of
+ * twice. This pins that the fused reader agrees with the two single-edge readers it replaced, across
+ * a walk long enough to cross block boundaries repeatedly - which is where a memo answering for the
+ * wrong probe would start to disagree.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.index.sparsevector.SegmentFormat.WeightQuantization;
+import com.arcadedb.schema.LocalSchema;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The two guards issue #5467 introduced alongside the in-place block decode, pinned as tests rather
+ * than as prose.
+ * <p>
+ * <b>Corrupt block headers.</b> Decoding used to copy a bounded slice of the page into a scratch
+ * buffer, so a header describing more postings than the block really holds ran out of that slice and
+ * surfaced as a {@link java.nio.BufferUnderflowException} from the decode loop. Reading the page in
+ * place has no slice to run out of, so the decode carries its own bounds checks and reports a corrupt
+ * segment by name. The header is untrusted input in the same sense as issue #6566's segment surface:
+ * it is whatever is on disk.
+ * <p>
+ * <b>The block-bounds memo contract.</b> {@link DimCursor#lastProbedBlockEnd} reads the memo without
+ * re-validating that it covers the probe, which is only safe because the block-max skip calls it
+ * immediately after {@link DimCursor#blockMaxAt} for the same probe. That is enforced by a Java
+ * {@code assert}, so the guard exists only while assertions are enabled - which this test also pins,
+ * because a Surefire configuration that turned them off would remove the check silently rather than
+ * visibly.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5467UntrustedBlockAndMemoContractTest extends TestHelper {
+
+  private static final SegmentParameters PARAMS = SegmentParameters.builder()
+      .weightQuantization(WeightQuantization.FP32)
+      .blockSize(SegmentFormat.MIN_BLOCK_SIZE)
+      .build();
+
+  /**
+   * A posting count larger than the segment's own block size cannot be decoded into arrays sized for
+   * that block size. Without the guard it is an {@code ArrayIndexOutOfBoundsException} from the
+   * middle of the decode loop; with it, a named {@link IOException}.
+   */
+  @Test
+  void aPostingCountPastTheBlockSizeReadsAsACorruptSegment() throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-corrupt-count", 640)));
+
+    final int[] blockLocator = new int[2];
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThat(c.metadata().blockCount()).as("the dim must span several blocks").isGreaterThan(2);
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    // posting_count sits after the block header's two RIDs.
+    inTx(() -> {
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      page.writeShort(blockLocator[1] + 2 * SegmentFormat.RID_SIZE_BYTES, (short) (PARAMS.blockSize() + 1));
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).isInstanceOf(IOException.class)
+            .hasMessageContaining("segment is corrupt")
+            .hasMessageContaining("exceeds the segment's block size");
+      }
+    });
+  }
+
+  /**
+   * A payload overwritten with continuation bytes never terminates a VarLong. The decode has to stop
+   * on its own rather than shifting past the width of a {@code long} - Java masks shift amounts by 63,
+   * so an unguarded loop would silently wrap and decode garbage instead of failing.
+   */
+  @Test
+  void aPayloadOfContinuationBytesReadsAsACorruptSegmentRatherThanWrappingTheShift() throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-corrupt-varint", 640)));
+
+    final int[] blockLocator = new int[2];
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    inTx(() -> {
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      final int payloadStart = blockLocator[1] + SegmentFormat.BLOCK_HEADER_SIZE;
+      // Enough bytes to blow past the 64-bit shift budget, all with the continuation bit set.
+      for (int i = 0; i < 4 * VarInt.MAX_VARLONG_BYTES; i++)
+        page.writeByte(payloadStart + i, (byte) 0xFF);
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).isInstanceOf(IOException.class).hasMessageContaining("segment is corrupt");
+      }
+    });
+  }
+
+  /**
+   * {@link DimCursor#lastProbedBlockEnd} may only be called for the probe the preceding
+   * {@link DimCursor#blockMaxAt} refreshed the memo with. Calling it for any other probe must fail,
+   * and it must fail <i>here</i>, in the test suite, rather than in production where assertions are
+   * off and the caller would silently get a bound for the wrong block.
+   */
+  @Test
+  void theBlockBoundsMemoContractIsEnforcedWhileTheSuiteRunsWithAssertions() throws Exception {
+    boolean assertionsEnabled = false;
+    assert assertionsEnabled = true;
+    assertThat(assertionsEnabled)
+        .as("lastProbedBlockEnd's contract is enforced by a Java assert, so the suite must run with -ea "
+            + "(Surefire enables assertions by default); without it this guard is not present at all")
+        .isTrue();
+
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-memo-contract", 640)));
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final DimCursor c = new DimCursor(0, List.of(reader.openCursor(0)))) {
+        c.start();
+        final int probeBucketId = c.currentBucketId();
+        final long probePosition = c.currentPosition();
+
+        // The sanctioned pairing: refresh the memo, then read the block end it goes with.
+        assertThat(c.blockMaxAt(probeBucketId, probePosition)).isGreaterThan(0.0f);
+        assertThat(c.lastProbedBlockEnd(probeBucketId, probePosition)).isNotNull();
+
+        // Any other probe is a misuse, and the assert has to say so.
+        assertThatThrownBy(() -> c.lastProbedBlockEnd(probeBucketId, probePosition - 1_000_000L))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("the block-bounds memo does not cover this probe");
+      }
+    });
+  }
+
+  // ---------- helpers ----------
+
+  @FunctionalInterface
+  private interface CheckedRunnable {
+    void run() throws Exception;
+  }
+
+  private void inTx(final CheckedRunnable r) {
+    database.transaction(() -> {
+      try {
+        r.run();
+      } catch (final RuntimeException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  /** One dim of {@code postings} sequential RIDs, which at the minimum block size spans many blocks. */
+  private SparseSegmentComponent buildSegment(final String name, final int postings) throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final SparseSegmentComponent c = new SparseSegmentComponent(db, name, db.getDatabasePath() + "/" + name,
+        ComponentFile.MODE.READ_WRITE, SparseSegmentComponent.DEFAULT_PAGE_SIZE);
+    ((LocalSchema) db.getSchema().getEmbedded()).registerFile(c);
+
+    final TreeMap<RID, Float> byRid = new TreeMap<>();
+    for (int i = 0; i < postings; i++)
+      byRid.put(new RID(0, 1L + i), 0.25f + (i % 7) * 0.1f);
+
+    try (final SparseSegmentBuilder b = new SparseSegmentBuilder(c, PARAMS)) {
+      b.setSegmentId(5467L);
+      b.startDim(0);
+      for (final var e : byRid.entrySet())
+        b.appendPosting(e.getKey(), e.getValue());
+      b.endDim();
+      b.finish();
+    }
+    return c;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
@@ -271,6 +271,81 @@ class Issue5467UntrustedBlockAndMemoContractTest extends TestHelper {
   }
 
   /**
+   * A VarLong is unsigned, so a value at or above 2^63 arrives as a negative long - and neither
+   * ordering check can see what is wrong with it.
+   * <p>
+   * A bucket delta of {@code 2^63 + 1} narrows to {@code 1}, which reads as an ordinary step to the
+   * next bucket. A position of {@code 2^63} rides in on a bucket that genuinely did increase, so the
+   * RID compares as greater however negative the position is. Both are rejected on range before
+   * anything narrows or accumulates.
+   */
+  @Test
+  void aDecodedRidComponentTooLargeForItsTypeReadsAsACorruptSegment() throws Exception {
+    // (bucketDelta = 2^63 + 1): bit 0 in the first byte, bit 63 in the tenth.
+    final byte[] hugeBucketDelta = new byte[VarInt.MAX_VARLONG_BYTES];
+    hugeBucketDelta[0] = (byte) 0x81;
+    for (int i = 1; i < VarInt.MAX_VARLONG_BYTES - 1; i++)
+      hugeBucketDelta[i] = (byte) 0x80;
+    hugeBucketDelta[VarInt.MAX_VARLONG_BYTES - 1] = (byte) 0x01;
+    assertCorruptPayload("seg-5467-huge-bucket", hugeBucketDelta);
+
+    // (bucketDelta = 1, position = 2^63): a real bucket step carrying a negative absolute position.
+    final byte[] negativePosition = new byte[1 + VarInt.MAX_VARLONG_BYTES];
+    negativePosition[0] = (byte) 0x01;
+    for (int i = 1; i < negativePosition.length - 1; i++)
+      negativePosition[i] = (byte) 0x80;
+    negativePosition[negativePosition.length - 1] = (byte) 0x01;
+    assertCorruptPayload("seg-5467-negative-position", negativePosition);
+  }
+
+  /**
+   * The payload has to land where the block header says it ends. This is the check that does not
+   * depend on spotting anything wrong with the bytes themselves: a payload can decode to a perfectly
+   * well-ordered sequence of in-range RIDs and still be the wrong sequence, and the header's last RID
+   * is an independent witness of what the builder actually wrote.
+   * <p>
+   * Bumping the first posting's delta by one shifts every RID after it, so the block ends one past
+   * where the header says - ordered, in range, and wrong.
+   */
+  @Test
+  void aPayloadThatDoesNotEndWhereTheHeaderSaysReadsAsACorruptSegment() throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-header-mismatch", 640)));
+
+    final int[] blockLocator = new int[2];
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    inTx(() -> {
+      // The fixture's RIDs are consecutive, so the first delta pair is (bucket 0, position 1).
+      // Raising the position delta to 2 keeps everything ordered and in range, and moves the end.
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      final int payloadStart = blockLocator[1] + SegmentFormat.BLOCK_HEADER_SIZE;
+      assertThat(page.readByte(payloadStart)).as("first bucket delta").isEqualTo((byte) 0x00);
+      assertThat(page.readByte(payloadStart + 1)).as("first position delta").isEqualTo((byte) 0x01);
+      page.writeByte(payloadStart + 1, (byte) 0x02);
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).isInstanceOf(IOException.class)
+            .hasMessageContaining("segment is corrupt")
+            .hasMessageContaining("but the block header says");
+      }
+    });
+  }
+
+  /**
    * {@link DimCursor#blockBoundsAt} must hand back exactly what the two single-edge readers would for
    * the same probe. Fusing them is what lets the block-max skip consult the memo once instead of
    * twice, so it is worth pinning that the fusion is faithful and not merely fast - and that the pair
@@ -314,6 +389,42 @@ class Issue5467UntrustedBlockAndMemoContractTest extends TestHelper {
   }
 
   // ---------- helpers ----------
+
+  /** Overwrite the start of a block payload with {@code bytes} and assert the decode reports corruption. */
+  private void assertCorruptPayload(final String name, final byte[] bytes) throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment(name, 640)));
+
+    final int[] blockLocator = new int[2];
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    inTx(() -> {
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      final int payloadStart = blockLocator[1] + SegmentFormat.BLOCK_HEADER_SIZE;
+      for (int i = 0; i < bytes.length; i++)
+        page.writeByte(payloadStart + i, bytes[i]);
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).as("payload %s must not decode", name)
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("segment is corrupt")
+            .hasMessageContaining("outside the range a bucket id or a position can hold");
+      }
+    });
+  }
 
   @FunctionalInterface
   private interface CheckedRunnable {

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
@@ -227,38 +227,44 @@ class Issue5467UntrustedBlockAndMemoContractTest extends TestHelper {
   }
 
   /**
-   * {@link DimCursor#lastProbedBlockEnd} may only be called for the probe the preceding
-   * {@link DimCursor#blockMaxAt} refreshed the memo with. Calling it for any other probe must fail,
-   * and it must fail <i>here</i>, in the test suite, rather than in production where assertions are
-   * off and the caller would silently get a bound for the wrong block.
+   * {@link DimCursor#blockBoundsAt} must hand back exactly what the two single-edge readers would for
+   * the same probe. Fusing them is what lets the block-max skip consult the memo once instead of
+   * twice, so it is worth pinning that the fusion is faithful and not merely fast - and that the pair
+   * it returns belongs to one probe, which is the property an earlier version of this fix left to a
+   * temporal contract nothing could enforce outside the test suite.
    */
   @Test
-  void theBlockBoundsMemoContractIsEnforcedWhileTheSuiteRunsWithAssertions() throws Exception {
-    boolean assertionsEnabled = false;
-    assert assertionsEnabled = true;
-    assertThat(assertionsEnabled)
-        .as("lastProbedBlockEnd's contract is enforced by a Java assert, so the suite must run with -ea "
-            + "(Surefire enables assertions by default); without it this guard is not present at all")
-        .isTrue();
-
+  void theFusedBlockBoundsMatchBothSingleEdgeReadersForTheSameProbe() throws Exception {
     final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
-    inTx(() -> component.set(buildSegment("seg-5467-memo-contract", 640)));
+    inTx(() -> component.set(buildSegment("seg-5467-fused-bounds", 640)));
 
     inTx(() -> {
       final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
-      try (final DimCursor c = new DimCursor(0, List.of(reader.openCursor(0)))) {
-        c.start();
-        final int probeBucketId = c.currentBucketId();
-        final long probePosition = c.currentPosition();
+      try (final DimCursor probe = new DimCursor(0, List.of(reader.openCursor(0)));
+          final DimCursor viaMax = new DimCursor(0, List.of(reader.openCursor(0)));
+          final DimCursor viaEnd = new DimCursor(0, List.of(reader.openCursor(0)))) {
+        probe.start();
+        viaMax.start();
+        viaEnd.start();
 
-        // The sanctioned pairing: refresh the memo, then read the block end it goes with.
-        assertThat(c.blockMaxAt(probeBucketId, probePosition)).isGreaterThan(0.0f);
-        assertThat(c.lastProbedBlockEnd(probeBucketId, probePosition)).isNotNull();
+        final RID[] endOut = new RID[1];
+        int checked = 0;
+        // Walk far enough to cross several block boundaries, which is where a memo that answered for
+        // the wrong probe would start disagreeing.
+        while (!probe.isExhausted() && checked < 400) {
+          final int bucketId = probe.currentBucketId();
+          final long position = probe.currentPosition();
 
-        // Any other probe is a misuse, and the assert has to say so.
-        assertThatThrownBy(() -> c.lastProbedBlockEnd(probeBucketId, probePosition - 1_000_000L))
-            .isInstanceOf(AssertionError.class)
-            .hasMessageContaining("the block-bounds memo does not cover this probe");
+          final float fusedMax = probe.blockBoundsAt(bucketId, position, endOut);
+          assertThat(fusedMax).isEqualTo(viaMax.blockMaxAt(bucketId, position));
+          assertThat(endOut[0]).isEqualTo(viaEnd.blockEndAt(bucketId, position));
+          assertThat(endOut[0]).as("a sealed segment always bounds a finite block end").isNotNull();
+          checked++;
+
+          if (!probe.advance())
+            break;
+        }
+        assertThat(checked).as("the walk must actually cross block boundaries").isGreaterThan(3 * PARAMS.blockSize());
       }
     });
   }

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
@@ -227,6 +227,50 @@ class Issue5467UntrustedBlockAndMemoContractTest extends TestHelper {
   }
 
   /**
+   * The maximum-width VarLong case, which the ascending-RID check cannot see: nine continuation bytes
+   * followed by a terminal {@code 0x02}. A tenth byte contributes only bit 63, so Java's shift
+   * discards the {@code 2}, and the delta decodes as a perfectly ordered zero. No encoder can produce
+   * that byte sequence - {@link VarInt#writeUnsignedVarLong} emits a tenth byte only for bit 63, with
+   * payload 0 or 1 - so the width is checked rather than the resulting value.
+   */
+  @Test
+  void aVarLongWiderThanALongReadsAsACorruptSegment() throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-corrupt-varwidth", 640)));
+
+    final int[] blockLocator = new int[2];
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    inTx(() -> {
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      final int payloadStart = blockLocator[1] + SegmentFormat.BLOCK_HEADER_SIZE;
+      for (int i = 0; i < VarInt.MAX_VARLONG_BYTES - 1; i++)
+        page.writeByte(payloadStart + i, (byte) 0x80);
+      // Payload 2 at shift 63: the bits Java throws away, leaving a delta of 0.
+      page.writeByte(payloadStart + VarInt.MAX_VARLONG_BYTES - 1, (byte) 0x02);
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).isInstanceOf(IOException.class)
+            .hasMessageContaining("segment is corrupt")
+            .hasMessageContaining("payload bits past the width of a long");
+      }
+    });
+  }
+
+  /**
    * {@link DimCursor#blockBoundsAt} must hand back exactly what the two single-edge readers would for
    * the same probe. Fusing them is what lets the block-max skip consult the memo once instead of
    * twice, so it is worth pinning that the fusion is faithful and not merely fast - and that the pair

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue5467UntrustedBlockAndMemoContractTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>
  * <b>Corrupt block headers.</b> Decoding used to copy a bounded slice of the page into a scratch
  * buffer, so a header describing more postings than the block really holds ran out of that slice and
- * surfaced as a {@link java.nio.BufferUnderflowException} from the decode loop. Reading the page in
+ * surfaced as a {@code BufferUnderflowException} from the decode loop. Reading the page in
  * place has no slice to run out of, so the decode carries its own bounds checks and reports a corrupt
  * segment by name. The header is untrusted input in the same sense as issue #6566's segment surface:
  * it is whatever is on disk.
@@ -98,7 +98,91 @@ class Issue5467UntrustedBlockAndMemoContractTest extends TestHelper {
             ;
         }).isInstanceOf(IOException.class)
             .hasMessageContaining("segment is corrupt")
-            .hasMessageContaining("exceeds the segment's block size");
+            .hasMessageContaining("is not in 1..");
+      }
+    });
+  }
+
+  /**
+   * A header claiming zero postings is corruption too - {@link SparseSegmentBuilder} never writes an
+   * empty block - and it is the more dangerous of the two, because nothing runs off the end of
+   * anything: the block would simply report the header's first RID as a posting that is not there.
+   */
+  @Test
+  void aZeroPostingCountReadsAsACorruptSegmentRatherThanAPhantomPosting() throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-corrupt-zero", 640)));
+
+    final int[] blockLocator = new int[2];
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    inTx(() -> {
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      page.writeShort(blockLocator[1] + 2 * SegmentFormat.RID_SIZE_BYTES, (short) 0);
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).isInstanceOf(IOException.class)
+            .hasMessageContaining("segment is corrupt")
+            .hasMessageContaining("posting count 0");
+      }
+    });
+  }
+
+  /**
+   * RIDs within a block are strictly ascending by construction: {@code appendInternal} rejects a
+   * non-increasing RID and {@code flushBlock} fails loud on a negative delta, on the stated grounds
+   * that "a negative delta would silently encode as a huge unsigned VarInt and decode to a different
+   * RID on read". The read side has to say the same thing, or a corrupt payload decodes to a
+   * descending or wrapped RID sequence and the merge quietly runs out of order.
+   * <p>
+   * A zero delta pair is the smallest expression of that: it encodes "the same RID again", which no
+   * writer can produce.
+   */
+  @Test
+  void aNonAscendingPostingSequenceReadsAsACorruptSegment() throws Exception {
+    final AtomicReference<SparseSegmentComponent> component = new AtomicReference<>();
+    inTx(() -> component.set(buildSegment("seg-5467-corrupt-order", 640)));
+
+    final int[] blockLocator = new int[2];
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        blockLocator[0] = c.metadata().blockPageNum(1);
+        blockLocator[1] = c.metadata().blockOffset(1);
+      }
+    });
+
+    inTx(() -> {
+      final MutablePage page = component.get().modifyPage(blockLocator[0]);
+      final int payloadStart = blockLocator[1] + SegmentFormat.BLOCK_HEADER_SIZE;
+      // (bucketDelta 0, positionDelta 0): a repeat of the previous RID.
+      page.writeByte(payloadStart, (byte) 0x00);
+      page.writeByte(payloadStart + 1, (byte) 0x00);
+    });
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = new PaginatedSegmentReader(component.get());
+      try (final PaginatedSegmentDimCursor c = reader.openCursor(0)) {
+        assertThatThrownBy(() -> {
+          c.start();
+          while (c.advance())
+            ;
+        }).isInstanceOf(IOException.class)
+            .hasMessageContaining("segment is corrupt")
+            .hasMessageContaining("not in strictly ascending RID order");
       }
     });
   }


### PR DESCRIPTION
Closes #5467 (third round).

The reporter's 30 July CPU profile of released 26.8.1.dev23 put what was left of the learned-sparse
query in **posting traversal at 42% of query CPU**, with scoring already down at 1.5% and the heap
work of round 1 halved. This round goes after that, and delivers the third bullet of the original
scope that neither earlier round did: a benchmark that reports a **small-corpus tier**.

## Getting the tier's shape right mattered more than any single fix

The first version of the harness reused the Zipf document-frequency curve from `MaxScorePruningTest`.
It produced a 100k corpus with the right posting count and completely the wrong traversal: about 10.5
essential postings consumed per candidate against the reporter's 2.76, because a Zipf tail keeps too
many terms fat enough to stay essential. Its profile put 27% of query CPU in a frame that is 0.2% on
the real shape.

Learned-sparse expansion terms form a **plateau**, not a Zipf tail: a handful appear in most documents
carrying small weights, while the query's original vocabulary terms are rare. A Zipf has no plateau,
so tuning it to make the head fat enough makes the tail fat too. Two document-frequency bands
reproduce the reporter's counters, and that is what `Issue5467SmallCorpusTraversalCostTest` builds.

## What changed

Five things the traversal paid for and did not need to. None alters what a query visits or returns,
and there is no format change.

1. **Every block decode re-resolved its page through the page cache.** The builder packs well over a
   hundred default-sized blocks onto one 64 KiB page, so a sequential walk asked for the same page a
   hundred times. Each ask allocated a `PageId` and an `ImmutablePage`, hashed into the cache map and
   bumped the cache's global hit counter, an atomic every parallel-range worker of #5518 contends on.
   The cursor now holds the page across the blocks that live on it.

2. **The block payload was copied into a scratch buffer before decoding.** That copy is the entire
   reason `SegmentFormat.maxBlockPayloadSize` and the "gap to the next block" estimate exist: the
   format does not store a block's byte length, so a copy needed an upper bound. Decoding in place on
   the page needs no bound - the RID loop consumes exactly the bytes the posting count describes - so
   the copy is gone, and `decodedPayloadBytes` now reports the exact length instead of an estimate.

3. **Touching a block decoded all 128 of its weights.** A block-max skip reads none of them, and a
   non-essential probe abandoned early reads none either. Weights are fixed-stride, so a posting's
   weight is one indexed read, taken on demand.

4. **The essential-term heap detached the aligned run with a pop per term and re-attached it with a
   push per term.** The push climbs from a leaf back to wherever the just-advanced cursor now belongs,
   which in a wide merge is near the top, so it is nearly the full height of the heap. The run is a
   connected subtree at the root, so it is located without touching the heap and repaired in place,
   deepest slot first, with one Floyd sift per moved slot.

   This is the idea round 1 tried and discarded as slower. It was slower because that attempt repaired
   with a textbook top-down sift-down, which spends two comparisons per level whatever happens; Floyd's
   spends one per level going down and pays for the climb only in proportion to how high the element
   really belongs, which is the shape a just-advanced cursor has.

5. **The next-essential position was computed for every candidate**, though only a block-max skip needs
   it and the skip fires for a couple of percent of candidates on this data. It is now computed once
   the skip has been decided. The skip also asked the merged cursor for both edges of the same probe
   through two entry points, running the block-bounds memo's range comparisons twice for one bound.

Plus two smaller ones: a non-essential probe consults the scorer's mirrored key before calling into
the cursor at all, and `DimCursor.seekTo` gets the single-source short circuit `advance()` already had.

## Measured

100k tier, 59 terms, top-10, arms interleaved over five rounds so machine drift cancels:

| | before | after | delta |
|---|---|---|---|
| INT8 p50 | 7.76 ms | **7.32 ms** | **-5.7%** |
| FP32 p50 | 7.52 ms | **7.15 ms** | **-4.9%** |

That wall clock is indicative - a laptop with other work on it, and the effect is only a few times the
run-to-run spread. The work counters underneath it are exact, and they are what the tests assert on:

| per query | before | after |
|---|---:|---:|
| page-cache fetches | 2,559 | **103** |
| weights decoded | 325,406 | **140,077** |
| heap key comparisons | 913,455 | **695,016** |
| payload bytes copied out of the page cache | all of them | **none** |

Results are identical in every arm.

## Tests

`Issue5467SmallCorpusTraversalCostTest` carries the harness. Its three non-benchmark tests assert on
**work counters, never on wall clock**:

- a sequential walk fetches each page exactly once, not once per block (asserted against the exact
  number of distinct pages the dim's blocks live on, so the check cannot go vacuous);
- a cursor that navigates without scoring decodes **zero** weights, and one that scores every posting
  decodes exactly one per posting;
- a real Block-Max MaxScore query decodes far fewer weights than the blocks it touched contain, fetches
  far fewer pages than it decoded blocks, and still returns exactly the brute-force top-K.

Verification run:

- 136 sparse-vector tests green (`index.sparsevector` plus the SQL sparse-vector functions).
- Full engine module: **13,541 tests, 1 failure**, and that one is
  `CypherGAVBoundTargetCardinalityTest.theViewFallsBackToTheEdgeListWhenADeletionMasksThePair`, the
  documented pre-existing full-suite flake that reproduces on unmodified `main` and passes in
  isolation. Nothing here touches OpenCypher.
- `FullTextSparseVectorIndexExportImportIT` green.

## Left on the table, deliberately

The block-max probe is still around 11% of query CPU and almost never pays off on SPLADE, because
near-uniform weights make a block maximum no tighter than the term's global maximum. The obvious move
is to gate or sample the attempt, and that is not in this PR: it is the idea discussed and rejected on
the issue thread, it trades the machinery away on precisely the corpora it exists for (the tail-spike
shapes round 1 targeted), and unlike everything above it is a policy change rather than a cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved sparse-vector search efficiency through faster term traversal, block skipping, and heap management.
  - Reduced temporary memory use with page reuse and lazy weight decoding.
  - Optimized searches across quantized vector data.

- **Reliability**
  - Strengthened result ordering and search consistency.
  - Improved detection and reporting of corrupted index data, including invalid posting blocks, identifiers, and numeric encodings.

- **Testing**
  - Expanded coverage for search accuracy, traversal costs, quantization, performance, and malformed segment data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->