### PR TITLE
fix(#6709): re-validate transaction liveness inside dispatched gRPC executor tasks

### DIFF
--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -156,7 +156,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    * Holds transaction state including a single-thread executor to ensure all
    * transaction operations run on the same thread (required by ArcadeDB's thread-local transactions).
    */
-  private static final class TransactionContext {
+  static final class TransactionContext {
     final Database        db;
     final ExecutorService executor;
     final String          txId;
@@ -293,6 +293,29 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   /**
+   * Registers a synthetic transaction directly, bypassing beginTransaction's authorization and concurrency-cap
+   * machinery. Exposed for deterministically testing the finalize-races-dispatch guard (issue #6709) without a
+   * real timing race: the returned context can be finalized with {@link #finalizeTransactionForTesting} to
+   * simulate a concurrent commitTransaction/rollbackTransaction/idle-reap winning the race.
+   */
+  TransactionContext registerTransactionForTesting(final String txId) {
+    final TransactionContext txCtx = new TransactionContext(null, txId, null);
+    activeTransactions.put(txId, txCtx);
+    return txCtx;
+  }
+
+  /**
+   * Removes a transaction registered via {@link #registerTransactionForTesting} and shuts down its executor,
+   * simulating a concurrent commitTransaction/rollbackTransaction/idle-reap finalizing it. Exposed for testing
+   * issue #6709.
+   */
+  void finalizeTransactionForTesting(final String txId) {
+    final TransactionContext txCtx = activeTransactions.remove(txId);
+    if (txCtx != null)
+      txCtx.shutdown();
+  }
+
+  /**
    * Atomically reserves a slot for a new transaction against the global and per-principal caps. Returns {@code true}
    * when both bounds admit the transaction; on rejection no counter is left incremented. A non-positive cap disables
    * that bound. Reserving before the dedicated executor thread is created is what makes the cap effective against a
@@ -406,6 +429,21 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private static Status unknownTransactionStatus(final String txId) {
     return Status.FAILED_PRECONDITION.withDescription(
         "Unknown or expired transaction id: " + txId + " (it may have been rolled back by the idle reaper)");
+  }
+
+  /**
+   * Re-checks, from inside a transaction's dedicated executor task, that {@code txCtx} is still the
+   * transaction registered under its id. A concurrent commitTransaction/rollbackTransaction/idle-reap can
+   * finalize the transaction and shut down its executor between a transaction-scoped RPC's initial resolve
+   * (via {@link #resolveAuthorizedTransaction}) and the dispatched task actually running on it. Without this
+   * check that race surfaces as an opaque {@code RejectedExecutionException} -> {@code Status.INTERNAL}
+   * instead of the same friendly unknown-transaction status callers already get when the id is gone at
+   * resolve time (issue #6709). Package-private so it can be exercised directly in tests without needing a
+   * real timing race.
+   */
+  void requireTransactionStillActive(final TransactionContext txCtx) {
+    if (activeTransactions.get(txCtx.txId) != txCtx)
+      throw unknownTransactionStatus(txCtx.txId).asRuntimeException();
   }
 
   /**
@@ -555,8 +593,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         LogManager.instance().log(this, Level.FINE,
             "executeCommand(): using external transaction %s, executing on dedicated thread", incomingTxId);
 
-        Future<ExecuteCommandResponse> future = txCtx.executor.submit(() ->
-            executeCommandInternal(req, t0, txCtx.db, true));
+        Future<ExecuteCommandResponse> future = txCtx.executor.submit(() -> {
+          requireTransactionStillActive(txCtx);
+          return executeCommandInternal(req, t0, txCtx.db, true);
+        });
 
         response = future.get();
       } else {
@@ -862,7 +902,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
-        final Future<CreateRecordResponse> future = txCtx.executor.submit(() -> createRecordInternal(req, txCtx.db));
+        final Future<CreateRecordResponse> future = txCtx.executor.submit(() -> {
+          requireTransactionStillActive(txCtx);
+          return createRecordInternal(req, txCtx.db);
+        });
         resp.onNext(future.get());
         resp.onCompleted();
       } catch (Exception e) {
@@ -992,7 +1035,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     if (txCtx != null) {
       try {
-        final Future<LookupByRidResponse> future = txCtx.executor.submit(() -> lookupByRidInternal(req, txCtx.db));
+        final Future<LookupByRidResponse> future = txCtx.executor.submit(() -> {
+          requireTransactionStillActive(txCtx);
+          return lookupByRidInternal(req, txCtx.db);
+        });
         resp.onNext(future.get());
         resp.onCompleted();
       } catch (Exception e) {
@@ -1048,7 +1094,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
-        final Future<UpdateRecordResponse> future = txCtx.executor.submit(() -> updateRecordInternal(req, txCtx.db));
+        final Future<UpdateRecordResponse> future = txCtx.executor.submit(() -> {
+          requireTransactionStillActive(txCtx);
+          return updateRecordInternal(req, txCtx.db);
+        });
         resp.onNext(future.get());
         resp.onCompleted();
       } catch (Exception e) {
@@ -1224,7 +1273,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
-        final Future<DeleteRecordResponse> future = txCtx.executor.submit(() -> deleteRecordInternal(req, txCtx.db));
+        final Future<DeleteRecordResponse> future = txCtx.executor.submit(() -> {
+          requireTransactionStillActive(txCtx);
+          return deleteRecordInternal(req, txCtx.db);
+        });
         resp.onNext(future.get());
         resp.onCompleted();
       } catch (Exception e) {
@@ -1323,8 +1375,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       }
 
       try {
-        final Future<ExecuteQueryResponse> future = txCtx.executor.submit(
-            () -> executeQueryInternal(request, txCtx.db));
+        final Future<ExecuteQueryResponse> future = txCtx.executor.submit(() -> {
+          requireTransactionStillActive(txCtx);
+          return executeQueryInternal(request, txCtx.db);
+        });
         final ExecuteQueryResponse response = future.get();
         responseObserver.onNext(response);
         responseObserver.onCompleted();
@@ -1844,6 +1898,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // The transaction lifecycle (begin/commit/rollback) stays with the Begin/Commit/Rollback RPCs, exactly
         // like executeQuery - do NOT begin or commit a throwaway read tx here.
         final Future<?> future = txCtx.executor.submit(() -> {
+          requireTransactionStillActive(txCtx);
           dispatchStream(streamDb, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
           return null;
         });
@@ -2366,6 +2421,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // External transaction — run on the transaction's dedicated thread
         try {
           final InsertSummary summary = txCtx.executor.submit(() -> {
+            requireTransactionStillActive(txCtx);
             try (InsertContext ctx = new InsertContext(txCtx.db, opts)) {
               final Counts totals = insertRows(ctx, req.getRowsList().iterator());
               ctx.flushCommit(true); // no-op in external tx mode
@@ -2375,8 +2431,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           resp.onNext(summary);
           resp.onCompleted();
         } catch (ExecutionException e) {
-          resp.onError(Status.INTERNAL.withDescription(
-              "bulkInsert: " + (e.getCause() != null ? e.getCause().getMessage() : e.getMessage())).asException());
+          final Throwable cause = e.getCause() != null ? e.getCause() : e;
+          if (cause instanceof StatusRuntimeException sre)
+            // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
+            // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand.
+            resp.onError(sre);
+          else
+            resp.onError(Status.INTERNAL.withDescription("bulkInsert: " + cause.getMessage()).asException());
         }
       } else {
         try (InsertContext ctx = new InsertContext(opts)) {
@@ -2528,7 +2589,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             // ThreadLocal, so inserting on whichever pool thread onNext happens to run on left the
             // external transaction not actually active there.
             try {
-              cts = extTxCtxRef.get().executor.submit(() -> insertRows(runCtx, c.getRowsList().iterator())).get();
+              cts = extTxCtxRef.get().executor.submit(() -> {
+                requireTransactionStillActive(extTxCtxRef.get());
+                return insertRows(runCtx, c.getRowsList().iterator());
+              }).get();
             } catch (final ExecutionException ee) {
               final Throwable cause = ee.getCause();
               throw cause instanceof Exception ex ? ex : ee;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -99,13 +99,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -157,9 +160,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    * transaction operations run on the same thread (required by ArcadeDB's thread-local transactions).
    */
   static final class TransactionContext {
-    final Database        db;
-    final ExecutorService executor;
-    final String          txId;
+    final Database           db;
+    // A raw ThreadPoolExecutor (not just ExecutorService) so requireTransactionStillActive's test coverage
+    // can poll getQueue().size() for deterministic finalize-races-dispatch synchronization instead of a
+    // fixed sleep (issue #6709 cycle-2 review); behaviorally identical to the previous
+    // Executors.newSingleThreadExecutor(...) call, which returns exactly this configuration wrapped.
+    final ThreadPoolExecutor executor;
+    final String             txId;
     // Principal that opened this transaction. Bound at beginTransaction so a transaction-scoped RPC can
     // reject any caller other than the owner. Null only when the transaction was opened on a server with
     // security disabled (open mode), where there is no authenticated identity to bind to.
@@ -173,8 +180,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       this.owner = owner;
       this.createdAtMs = System.currentTimeMillis();
       this.lastAccessMs = this.createdAtMs;
-      // Single-thread executor ensures all tx operations happen on the same thread
-      this.executor = Executors.newSingleThreadExecutor(r -> {
+      // Single-thread executor ensures all tx operations happen on the same thread. Built directly (not via
+      // Executors.newSingleThreadExecutor, which hides its ThreadPoolExecutor behind a non-tunable wrapper)
+      // so callers can inspect it, e.g. getQueue().size() in tests.
+      this.executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), r -> {
         Thread t = new Thread(r, "arcadedb-tx-" + txId);
         t.setDaemon(true);
         return t;
@@ -450,10 +459,41 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    * instead of the same friendly unknown-transaction status callers already get when the id is gone at
    * resolve time (issue #6709). Package-private so it can be exercised directly in tests without needing a
    * real timing race.
+   * <p>
+   * This checks map membership, not queue position, so it is intentionally stricter than the old "no
+   * in-flight work is lost" FIFO guarantee documented on {@link #reapIdleTransactions}: a task that is
+   * genuinely queued ahead of a concurrent finalizer's own task (and would have completed correctly under
+   * that guarantee) can still observe the finalizer's {@code activeTransactions} removal - which is a cheap,
+   * synchronous map operation unrelated to the executor's queue - and reject here instead of running to
+   * completion. This trades a rare, previously-undefined outcome (a client-side race between an in-flight
+   * write and its own commit/rollback, or a write landing in the idle-reaper's narrow re-check window) for a
+   * loud, well-defined {@code FAILED_PRECONDITION} instead of silent inclusion in - or corruption by - a
+   * transaction the caller no longer holds a live handle to. See {@link #submitToActiveTransaction} for the
+   * companion case where the executor is already shut down before the task can even be submitted.
    */
   void requireTransactionStillActive(final TransactionContext txCtx) {
     if (activeTransactions.get(txCtx.txId) != txCtx)
       throw unknownTransactionStatus(txCtx.txId).asRuntimeException();
+  }
+
+  /**
+   * Submits {@code task} onto {@code txCtx}'s dedicated executor, first re-validating (inside the submitted
+   * task, via {@link #requireTransactionStillActive}) that the transaction is still the one registered under
+   * its id. Also covers the narrower window where a concurrent commitTransaction/rollbackTransaction/idle-reap
+   * has already finished and shut the executor down by the time this call happens: {@code submit()} itself
+   * then throws {@link RejectedExecutionException} synchronously, before the task (and its liveness check)
+   * ever runs. That is converted here to the same unknown-transaction status instead of leaking a raw
+   * executor-internals exception up through the RPC's catch block (issue #6709 cycle-2 review).
+   */
+  <T> Future<T> submitToActiveTransaction(final TransactionContext txCtx, final Callable<T> task) {
+    try {
+      return txCtx.executor.submit(() -> {
+        requireTransactionStillActive(txCtx);
+        return task.call();
+      });
+    } catch (final RejectedExecutionException ree) {
+      throw unknownTransactionStatus(txCtx.txId).asRuntimeException();
+    }
   }
 
   /**
@@ -486,9 +526,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
         // remove(key, value) ensures only one of the reaper / commit / rollback wins the cleanup.
         // Residual TOCTOU note: a request could lookupActiveTransaction() (touch + submit work) in the instant
-        // between the re-read above and this remove. That window only opens for an already-idle
-        // transaction; any command already submitted to the executor still runs to completion before the
-        // asynchronous shutdown() in reapTransaction() lets the thread terminate, so no in-flight work is lost.
+        // between the re-read above and this remove. That window only opens for an already-idle transaction;
+        // the executor still lets that already-submitted command run to completion before the asynchronous
+        // shutdown() in reapTransaction() lets the thread terminate, so it is never silently discarded or
+        // interrupted - but as of issue #6709, requireTransactionStillActive() means the command itself now
+        // observes this remove() and rejects with FAILED_PRECONDITION rather than completing normally. Trading
+        // "always completes" for "completes or fails loudly, never silently corrupted" was judged the better
+        // default for a window this narrow (a caller racing its own request against the idle reaper).
         if (activeTransactions.remove(entry.getKey(), ctx)) {
           LogManager.instance().log(this, Level.FINE,
               "Reaping abandoned gRPC transaction txId=%s (idleMs=%s ageMs=%s)", entry.getKey(), idleMs, ageMs);
@@ -603,10 +647,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         LogManager.instance().log(this, Level.FINE,
             "executeCommand(): using external transaction %s, executing on dedicated thread", incomingTxId);
 
-        Future<ExecuteCommandResponse> future = txCtx.executor.submit(() -> {
-          requireTransactionStillActive(txCtx);
-          return executeCommandInternal(req, t0, txCtx.db, true);
-        });
+        Future<ExecuteCommandResponse> future =
+            submitToActiveTransaction(txCtx, () -> executeCommandInternal(req, t0, txCtx.db, true));
 
         response = future.get();
       } else {
@@ -912,10 +954,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
-        final Future<CreateRecordResponse> future = txCtx.executor.submit(() -> {
-          requireTransactionStillActive(txCtx);
-          return createRecordInternal(req, txCtx.db);
-        });
+        final Future<CreateRecordResponse> future =
+            submitToActiveTransaction(txCtx, () -> createRecordInternal(req, txCtx.db));
         resp.onNext(future.get());
         resp.onCompleted();
       } catch (Exception e) {
@@ -1045,10 +1085,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     if (txCtx != null) {
       try {
-        final Future<LookupByRidResponse> future = txCtx.executor.submit(() -> {
-          requireTransactionStillActive(txCtx);
-          return lookupByRidInternal(req, txCtx.db);
-        });
+        final Future<LookupByRidResponse> future =
+            submitToActiveTransaction(txCtx, () -> lookupByRidInternal(req, txCtx.db));
         resp.onNext(future.get());
         resp.onCompleted();
       } catch (Exception e) {
@@ -1108,10 +1146,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
-        final Future<UpdateRecordResponse> future = txCtx.executor.submit(() -> {
-          requireTransactionStillActive(txCtx);
-          return updateRecordInternal(req, txCtx.db);
-        });
+        final Future<UpdateRecordResponse> future =
+            submitToActiveTransaction(txCtx, () -> updateRecordInternal(req, txCtx.db));
         resp.onNext(future.get());
         resp.onCompleted();
       } catch (Exception e) {
@@ -1291,10 +1327,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
-        final Future<DeleteRecordResponse> future = txCtx.executor.submit(() -> {
-          requireTransactionStillActive(txCtx);
-          return deleteRecordInternal(req, txCtx.db);
-        });
+        final Future<DeleteRecordResponse> future =
+            submitToActiveTransaction(txCtx, () -> deleteRecordInternal(req, txCtx.db));
         resp.onNext(future.get());
         resp.onCompleted();
       } catch (Exception e) {
@@ -1397,10 +1431,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       }
 
       try {
-        final Future<ExecuteQueryResponse> future = txCtx.executor.submit(() -> {
-          requireTransactionStillActive(txCtx);
-          return executeQueryInternal(request, txCtx.db);
-        });
+        final Future<ExecuteQueryResponse> future =
+            submitToActiveTransaction(txCtx, () -> executeQueryInternal(request, txCtx.db));
         final ExecuteQueryResponse response = future.get();
         responseObserver.onNext(response);
         responseObserver.onCompleted();
@@ -1919,8 +1951,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         final Database streamDb = db;
         // The transaction lifecycle (begin/commit/rollback) stays with the Begin/Commit/Rollback RPCs, exactly
         // like executeQuery - do NOT begin or commit a throwaway read tx here.
-        final Future<?> future = txCtx.executor.submit(() -> {
-          requireTransactionStillActive(txCtx);
+        final Future<?> future = submitToActiveTransaction(txCtx, () -> {
           dispatchStream(streamDb, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
           return null;
         });
@@ -2442,8 +2473,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       if (txCtx != null) {
         // External transaction — run on the transaction's dedicated thread
         try {
-          final InsertSummary summary = txCtx.executor.submit(() -> {
-            requireTransactionStillActive(txCtx);
+          final InsertSummary summary = submitToActiveTransaction(txCtx, () -> {
             try (InsertContext ctx = new InsertContext(txCtx.db, opts)) {
               final Counts totals = insertRows(ctx, req.getRowsList().iterator());
               ctx.flushCommit(true); // no-op in external tx mode
@@ -2452,8 +2482,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           }).get();
           resp.onNext(summary);
           resp.onCompleted();
-        } catch (ExecutionException e) {
-          final Throwable cause = e.getCause() != null ? e.getCause() : e;
+        } catch (final Exception e) {
+          // Catches both a Future.get() ExecutionException (wrapping a StatusRuntimeException thrown inside
+          // the task) and a bare StatusRuntimeException thrown synchronously by submitToActiveTransaction
+          // when the executor was already shut down (RejectedExecutionException case, issue #6709).
+          final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
           if (cause instanceof StatusRuntimeException sre)
             // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
             // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand.
@@ -2611,10 +2644,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             // ThreadLocal, so inserting on whichever pool thread onNext happens to run on left the
             // external transaction not actually active there.
             try {
-              cts = extTxCtxRef.get().executor.submit(() -> {
-                requireTransactionStillActive(extTxCtxRef.get());
-                return insertRows(runCtx, c.getRowsList().iterator());
-              }).get();
+              cts = submitToActiveTransaction(extTxCtxRef.get(), () -> insertRows(runCtx, c.getRowsList().iterator()))
+                  .get();
             } catch (final ExecutionException ee) {
               final Throwable cause = ee.getCause();
               throw cause instanceof Exception ex ? ex : ee;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -316,6 +316,16 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   /**
+   * Returns the transaction context currently registered under {@code txId}, or {@code null} if none.
+   * Exposed for testing the finalize-races-dispatch guard (issue #6709) against a real, network-driven RPC:
+   * lets a test occupy a real transaction's dedicated executor with a synthetic blocking task before racing a
+   * client-issued RPC against a concurrent {@link #finalizeTransactionForTesting}.
+   */
+  TransactionContext getActiveTransactionForTesting(final String txId) {
+    return activeTransactions.get(txId);
+  }
+
+  /**
    * Atomically reserves a slot for a new transaction against the global and per-principal caps. Returns {@code true}
    * when both bounds admit the transaction; on rejection no counter is left incremented. A non-positive cap disables
    * that bound. Reserving before the dedicated executor thread is created is what makes the cap effective against a
@@ -1045,6 +1055,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
         if (cause instanceof RecordNotFoundException)
           resp.onError(Status.NOT_FOUND.withDescription("LookupByRid: " + cause.getMessage()).asException());
+        else if (cause instanceof StatusRuntimeException sre)
+          // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
+          // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
+          resp.onError(sre);
         else
           resp.onError(Status.INTERNAL.withDescription("LookupByRid: " + cause.getMessage()).asException());
       }
@@ -1105,6 +1119,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         LogManager.instance().log(this, Level.SEVERE, "ERROR in updateRecord (external tx)", cause);
         if (cause instanceof RecordNotFoundException)
           resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
+        else if (cause instanceof StatusRuntimeException sre)
+          // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
+          // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
+          resp.onError(sre);
         else
           resp.onError(Status.INTERNAL.withDescription("UpdateRecord: " + cause.getMessage()).asException());
       }
@@ -1284,6 +1302,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         LogManager.instance().log(this, Level.SEVERE, "ERROR in deleteRecord (external tx)", cause);
         if (cause instanceof RecordNotFoundException)
           resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
+        else if (cause instanceof StatusRuntimeException sre)
+          // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
+          // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
+          resp.onError(sre);
         else
           resp.onError(Status.INTERNAL.withDescription("DeleteRecord: " + cause.getMessage()).asException());
       }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -647,7 +647,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         LogManager.instance().log(this, Level.FINE,
             "executeCommand(): using external transaction %s, executing on dedicated thread", incomingTxId);
 
-        Future<ExecuteCommandResponse> future =
+        final Future<ExecuteCommandResponse> future =
             submitToActiveTransaction(txCtx, () -> executeCommandInternal(req, t0, txCtx.db, true));
 
         response = future.get();

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709GrpcTransactionFinalizeRaceIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709GrpcTransactionFinalizeRaceIT.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.ServerPlugin;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+/**
+ * End-to-end regression test for issue #6709: a concurrent commitTransaction/rollbackTransaction/idle-reap
+ * can finalize a transaction (removing it from the server's active-transaction map and shutting down its
+ * dedicated executor) in the window between a transaction-scoped RPC's resolve and its dispatched task
+ * actually running on that executor. Unlike {@link Issue5042ReapedTransactionIT} (which covers the transaction
+ * already being gone at resolve time), this drives the RPC through the finalize-races-dispatch window itself
+ * and asserts the client still sees {@code FAILED_PRECONDITION}, not an opaque {@code INTERNAL}.
+ *
+ * <p>The race is made deterministic (no real timing dependency on outcome) by occupying the transaction's
+ * single dedicated executor thread with a synthetic blocking task before the RPC's own task can run, then
+ * finalizing the transaction (via {@link ArcadeDbGrpcService#finalizeTransactionForTesting}) while the RPC's
+ * task is still queued behind it, and only then releasing the blocker.
+ */
+public class Issue6709GrpcTransactionFinalizeRaceIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private ArcadeDbGrpcService grpcService() {
+    for (final ServerPlugin plugin : getServer(0).getPlugins()) {
+      if (plugin instanceof GrpcServerPlugin grpcPlugin)
+        return grpcPlugin.getService();
+    }
+    throw new IllegalStateException("GrpcServerPlugin not found");
+  }
+
+  /**
+   * Begins a transaction, occupies its dedicated executor with a blocking task, runs {@code rpcCall} (given
+   * the transaction id) on a background thread so it queues behind the blocker, finalizes the transaction
+   * while that task is still queued, then releases the blocker so the RPC's task runs against the
+   * now-finalized transaction. Returns the {@link StatusRuntimeException} the client observed.
+   */
+  private StatusRuntimeException raceFinalizeAgainstDispatch(final Function<String, StatusRuntimeException> rpcCall)
+      throws Exception {
+    final ArcadeDbGrpcService service = grpcService();
+
+    final BeginTransactionResponse begin = authenticatedStub.beginTransaction(BeginTransactionRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .build());
+    final String txId = begin.getTransactionId();
+    assertThat(txId).isNotEmpty();
+
+    final var txCtx = service.getActiveTransactionForTesting(txId);
+    assertThat(txCtx).as("beginTransaction must register the transaction").isNotNull();
+
+    final CountDownLatch blockerRunning = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    // Occupies the transaction's single dedicated thread so the RPC's own dispatched task queues behind it,
+    // giving a deterministic window to finalize the transaction before that task actually runs.
+    txCtx.executor.submit(() -> {
+      blockerRunning.countDown();
+      release.await();
+      return null;
+    });
+    assertThat(blockerRunning.await(5, TimeUnit.SECONDS)).as("blocker must start").isTrue();
+
+    final ExecutorService clientExecutor = Executors.newSingleThreadExecutor();
+    try {
+      final Future<StatusRuntimeException> rpcResult = clientExecutor.submit(() -> rpcCall.apply(txId));
+
+      // Generous window for the RPC to reach the server, resolve the still-registered transaction and queue
+      // its dispatched task behind the blocker, before finalizing the transaction out from under it. The
+      // assertion below is on the resulting status code, not on this timing.
+      Thread.sleep(300);
+      service.finalizeTransactionForTesting(txId);
+      release.countDown();
+
+      return rpcResult.get(5, TimeUnit.SECONDS);
+    } finally {
+      release.countDown();
+      clientExecutor.shutdownNow();
+    }
+  }
+
+  @Test
+  void lookupByRidFailsPreconditionWhenFinalizeRacesDispatch() throws Exception {
+    final StatusRuntimeException err = raceFinalizeAgainstDispatch(txId ->
+        catchThrowableOfType(StatusRuntimeException.class, () -> authenticatedStub.lookupByRid(
+            LookupByRidRequest.newBuilder()
+                .setDatabase(getDatabaseName())
+                .setCredentials(credentials())
+                .setRid("#1:0")
+                .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+                .build())));
+
+    assertThat(err).as("lookupByRid must reject the finalize-race, not hang or succeed").isNotNull();
+    assertThat(err.getStatus().getCode())
+        .as("lookupByRid must surface FAILED_PRECONDITION, not an opaque INTERNAL, when the transaction is "
+            + "finalized while its dispatched task is queued")
+        .isEqualTo(Status.Code.FAILED_PRECONDITION);
+  }
+
+  @Test
+  void updateRecordFailsPreconditionWhenFinalizeRacesDispatch() throws Exception {
+    final StatusRuntimeException err = raceFinalizeAgainstDispatch(txId ->
+        catchThrowableOfType(StatusRuntimeException.class, () -> authenticatedStub.updateRecord(
+            UpdateRecordRequest.newBuilder()
+                .setDatabase(getDatabaseName())
+                .setCredentials(credentials())
+                .setRid("#1:0")
+                .setPartial(PropertiesUpdate.newBuilder()
+                    .putProperties("name", GrpcValue.newBuilder().setStringValue("raced-update").build()).build())
+                .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+                .build())));
+
+    assertThat(err).as("updateRecord must reject the finalize-race, not hang or succeed").isNotNull();
+    assertThat(err.getStatus().getCode())
+        .as("updateRecord must surface FAILED_PRECONDITION, not an opaque INTERNAL, when the transaction is "
+            + "finalized while its dispatched task is queued")
+        .isEqualTo(Status.Code.FAILED_PRECONDITION);
+  }
+
+  @Test
+  void deleteRecordFailsPreconditionWhenFinalizeRacesDispatch() throws Exception {
+    final StatusRuntimeException err = raceFinalizeAgainstDispatch(txId ->
+        catchThrowableOfType(StatusRuntimeException.class, () -> authenticatedStub.deleteRecord(
+            DeleteRecordRequest.newBuilder()
+                .setDatabase(getDatabaseName())
+                .setCredentials(credentials())
+                .setRid("#1:0")
+                .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+                .build())));
+
+    assertThat(err).as("deleteRecord must reject the finalize-race, not hang or succeed").isNotNull();
+    assertThat(err.getStatus().getCode())
+        .as("deleteRecord must surface FAILED_PRECONDITION, not an opaque INTERNAL, when the transaction is "
+            + "finalized while its dispatched task is queued")
+        .isEqualTo(Status.Code.FAILED_PRECONDITION);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709GrpcTransactionFinalizeRaceIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709GrpcTransactionFinalizeRaceIT.java
@@ -178,6 +178,12 @@ public class Issue6709GrpcTransactionFinalizeRaceIT extends BaseGraphServerTest 
         Thread.sleep(5);
       }
       service.finalizeTransactionForTesting(txId);
+      // finalizeTransactionForTesting only removes the map entry and shuts down the executor (correct for a
+      // registerTransactionForTesting synthetic context, which never reserved a slot). This transaction is a
+      // real one from beginTransaction, which did reserve a global/per-principal slot - release it here the
+      // same way commitTransaction/rollbackTransaction/reapIdleTransactions do, or every race test in this
+      // class leaks one reservation (CodeRabbit cycle-3 review).
+      service.releaseTransactionSlot(txCtx.owner);
       release.countDown();
 
       return rpcResult.get(5, TimeUnit.SECONDS);

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709GrpcTransactionFinalizeRaceIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709GrpcTransactionFinalizeRaceIT.java
@@ -162,6 +162,10 @@ public class Issue6709GrpcTransactionFinalizeRaceIT extends BaseGraphServerTest 
     assertThat(blockerRunning.await(5, TimeUnit.SECONDS)).as("blocker must start").isTrue();
 
     final ExecutorService clientExecutor = Executors.newSingleThreadExecutor();
+    // Tracks whether the slot below was already released on the success path, so the finally block releases
+    // it exactly once regardless of which path exits (cycle-4 review: the queue-wait or finalize call itself
+    // could throw before the old inline release ran, leaking the reservation on that exit path too).
+    boolean slotReleased = false;
     try {
       final Future<StatusRuntimeException> rpcResult = clientExecutor.submit(() -> rpcCall.apply(txId));
 
@@ -184,10 +188,15 @@ public class Issue6709GrpcTransactionFinalizeRaceIT extends BaseGraphServerTest 
       // same way commitTransaction/rollbackTransaction/reapIdleTransactions do, or every race test in this
       // class leaks one reservation (CodeRabbit cycle-3 review).
       service.releaseTransactionSlot(txCtx.owner);
+      slotReleased = true;
       release.countDown();
 
       return rpcResult.get(5, TimeUnit.SECONDS);
     } finally {
+      // Idempotent: a no-op if the try block already finalized it (activeTransactions.remove returns null).
+      service.finalizeTransactionForTesting(txId);
+      if (!slotReleased)
+        service.releaseTransactionSlot(txCtx.owner);
       release.countDown();
       clientExecutor.shutdownNow();
     }
@@ -291,8 +300,7 @@ public class Issue6709GrpcTransactionFinalizeRaceIT extends BaseGraphServerTest 
     assertThat(err).as("bulkInsert must reject the finalize-race, not hang or succeed").isNotNull();
     assertThat(err.getStatus().getCode())
         .as("bulkInsert must surface FAILED_PRECONDITION, not an opaque INTERNAL, when the transaction is "
-            + "finalized while its dispatched task is queued - the catch block here changed non-trivially in "
-            + "this PR")
+            + "finalized while its dispatched task is queued")
         .isEqualTo(Status.Code.FAILED_PRECONDITION);
   }
 }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709GrpcTransactionFinalizeRaceIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709GrpcTransactionFinalizeRaceIT.java
@@ -165,10 +165,18 @@ public class Issue6709GrpcTransactionFinalizeRaceIT extends BaseGraphServerTest 
     try {
       final Future<StatusRuntimeException> rpcResult = clientExecutor.submit(() -> rpcCall.apply(txId));
 
-      // Generous window for the RPC to reach the server, resolve the still-registered transaction and queue
-      // its dispatched task behind the blocker, before finalizing the transaction out from under it. The
-      // assertion below is on the resulting status code, not on this timing.
-      Thread.sleep(300);
+      // Deterministically wait for the RPC's own task to actually be enqueued behind the blocker, rather
+      // than a fixed sleep: since the blocker occupies the executor's single core thread, a second submitted
+      // task can only land in the queue, so a non-empty queue proves resolveAuthorizedTransaction already
+      // succeeded and submitToActiveTransaction was called - i.e. that finalizing now genuinely races the
+      // dispatched task's requireTransactionStillActive check, not the earlier isUnknownSuppliedTransaction
+      // check at resolve time (cycle-2 review: a fixed sleep could pass without exercising that path at all).
+      final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+      while (txCtx.executor.getQueue().isEmpty()) {
+        if (System.nanoTime() > deadlineNanos)
+          throw new AssertionError("RPC task was never enqueued behind the blocker within 5s");
+        Thread.sleep(5);
+      }
       service.finalizeTransactionForTesting(txId);
       release.countDown();
 
@@ -232,6 +240,53 @@ public class Issue6709GrpcTransactionFinalizeRaceIT extends BaseGraphServerTest 
     assertThat(err.getStatus().getCode())
         .as("deleteRecord must surface FAILED_PRECONDITION, not an opaque INTERNAL, when the transaction is "
             + "finalized while its dispatched task is queued")
+        .isEqualTo(Status.Code.FAILED_PRECONDITION);
+  }
+
+  @Test
+  void executeCommandFailsPreconditionWhenFinalizeRacesDispatch() throws Exception {
+    final StatusRuntimeException err = raceFinalizeAgainstDispatch(txId ->
+        catchThrowableOfType(StatusRuntimeException.class, () -> authenticatedStub.executeCommand(
+            ExecuteCommandRequest.newBuilder()
+                .setDatabase(getDatabaseName())
+                .setCredentials(credentials())
+                .setCommand("INSERT INTO Person SET name = 'raced-executeCommand'")
+                .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+                .build())));
+
+    assertThat(err).as("executeCommand must reject the finalize-race, not hang or succeed").isNotNull();
+    assertThat(err.getStatus().getCode())
+        .as("executeCommand must surface FAILED_PRECONDITION, not an opaque INTERNAL, when the transaction is "
+            + "finalized while its dispatched task is queued")
+        .isEqualTo(Status.Code.FAILED_PRECONDITION);
+  }
+
+  @Test
+  void bulkInsertFailsPreconditionWhenFinalizeRacesDispatch() throws Exception {
+    final GrpcRecord record = GrpcRecord.newBuilder()
+        .setType("Person")
+        .putProperties("name", GrpcValue.newBuilder().setStringValue("raced-bulkInsert").build())
+        .build();
+
+    final StatusRuntimeException err = raceFinalizeAgainstDispatch(txId ->
+        catchThrowableOfType(StatusRuntimeException.class, () -> authenticatedStub.bulkInsert(
+            BulkInsertRequest.newBuilder()
+                .setOptions(InsertOptions.newBuilder()
+                    .setDatabase(getDatabaseName())
+                    .setCredentials(credentials())
+                    .setTargetClass("Person")
+                    .setTransactionMode(InsertOptions.TransactionMode.PER_BATCH)
+                    .build())
+                .addRows(record)
+                .setCredentials(credentials())
+                .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+                .build())));
+
+    assertThat(err).as("bulkInsert must reject the finalize-race, not hang or succeed").isNotNull();
+    assertThat(err.getStatus().getCode())
+        .as("bulkInsert must surface FAILED_PRECONDITION, not an opaque INTERNAL, when the transaction is "
+            + "finalized while its dispatched task is queued - the catch block here changed non-trivially in "
+            + "this PR")
         .isEqualTo(Status.Code.FAILED_PRECONDITION);
   }
 }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709TransactionFinalizeRaceTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709TransactionFinalizeRaceTest.java
@@ -23,6 +23,8 @@ import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.RejectedExecutionException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * transaction's dedicated executor, but a concurrent commitTransaction/rollbackTransaction/idle-reap can
  * finalize the same transaction (removing it from the active-transaction map and shutting down its executor)
  * in the window between the resolve and the dispatched task actually running - or even before the task is
- * submitted at all, in which case {@code submit()} itself throws {@link java.util.concurrent.RejectedExecutionException}.
+ * submitted at all, in which case {@code submit()} itself throws {@link RejectedExecutionException}.
  * These tests simulate both windows deterministically via
  * {@link ArcadeDbGrpcService#registerTransactionForTesting} / {@link ArcadeDbGrpcService#finalizeTransactionForTesting}
  * instead of racing real threads, per the issue's own suggested approach. No server or database is needed:

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709TransactionFinalizeRaceTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709TransactionFinalizeRaceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ArcadeDbGrpcService#requireTransactionStillActive}, the guard added for issue #6709:
+ * every transaction-scoped RPC resolves a {@code TransactionContext} and then dispatches its real work onto
+ * that transaction's dedicated executor, but a concurrent commitTransaction/rollbackTransaction/idle-reap can
+ * finalize the same transaction (and shut down its executor) in the window between the resolve and the
+ * dispatched task actually running. These tests simulate that window deterministically via
+ * {@link ArcadeDbGrpcService#registerTransactionForTesting} / {@link ArcadeDbGrpcService#finalizeTransactionForTesting}
+ * instead of racing real threads, per the issue's own suggested approach. No server or database is needed:
+ * {@code requireTransactionStillActive} only compares against the in-memory active-transaction map.
+ */
+class Issue6709TransactionFinalizeRaceTest {
+
+  @Test
+  @DisplayName("a transaction still registered passes revalidation")
+  void stillActiveTransactionPassesRevalidation() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 0L, 0L, 0L);
+    try {
+      final var txCtx = service.registerTransactionForTesting("tx-still-active");
+
+      assertThatCode(() -> service.requireTransactionStillActive(txCtx)).doesNotThrowAnyException();
+    } finally {
+      service.finalizeTransactionForTesting("tx-still-active");
+      service.close();
+    }
+  }
+
+  @Test
+  @DisplayName("a transaction finalized by a concurrent commit/rollback/reap fails revalidation with FAILED_PRECONDITION")
+  void finalizedTransactionFailsRevalidation() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 0L, 0L, 0L);
+    try {
+      final var txCtx = service.registerTransactionForTesting("tx-raced");
+
+      // Simulates a commitTransaction/rollbackTransaction/idle-reap call winning the race and finalizing the
+      // transaction between the RPC's resolve and its dispatched task actually running.
+      service.finalizeTransactionForTesting("tx-raced");
+
+      assertThatThrownBy(() -> service.requireTransactionStillActive(txCtx))
+          .isInstanceOf(StatusRuntimeException.class)
+          .extracting(e -> ((StatusRuntimeException) e).getStatus().getCode())
+          .isEqualTo(Status.Code.FAILED_PRECONDITION);
+    } finally {
+      service.close();
+    }
+  }
+
+  @Test
+  @DisplayName("a brand new transaction re-registered under the same id does not satisfy the stale context's revalidation")
+  void reusedTransactionIdDoesNotMatchStaleContext() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 0L, 0L, 0L);
+    try {
+      final var staleTxCtx = service.registerTransactionForTesting("tx-reused");
+      service.finalizeTransactionForTesting("tx-reused");
+
+      // A new transaction happens to be registered under the same id afterwards. The identity check (not a
+      // mere containsKey) must still reject the caller holding the old TransactionContext reference.
+      final var freshTxCtx = service.registerTransactionForTesting("tx-reused");
+
+      assertThatThrownBy(() -> service.requireTransactionStillActive(staleTxCtx))
+          .isInstanceOf(StatusRuntimeException.class);
+      assertThatCode(() -> service.requireTransactionStillActive(freshTxCtx)).doesNotThrowAnyException();
+      assertThat(freshTxCtx).isNotSameAs(staleTxCtx);
+    } finally {
+      service.finalizeTransactionForTesting("tx-reused");
+      service.close();
+    }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709TransactionFinalizeRaceTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6709TransactionFinalizeRaceTest.java
@@ -28,14 +28,17 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Unit tests for {@link ArcadeDbGrpcService#requireTransactionStillActive}, the guard added for issue #6709:
- * every transaction-scoped RPC resolves a {@code TransactionContext} and then dispatches its real work onto
- * that transaction's dedicated executor, but a concurrent commitTransaction/rollbackTransaction/idle-reap can
- * finalize the same transaction (and shut down its executor) in the window between the resolve and the
- * dispatched task actually running. These tests simulate that window deterministically via
+ * Unit tests for {@link ArcadeDbGrpcService#requireTransactionStillActive} and
+ * {@link ArcadeDbGrpcService#submitToActiveTransaction}, the guards added for issue #6709: every
+ * transaction-scoped RPC resolves a {@code TransactionContext} and then dispatches its real work onto that
+ * transaction's dedicated executor, but a concurrent commitTransaction/rollbackTransaction/idle-reap can
+ * finalize the same transaction (removing it from the active-transaction map and shutting down its executor)
+ * in the window between the resolve and the dispatched task actually running - or even before the task is
+ * submitted at all, in which case {@code submit()} itself throws {@link java.util.concurrent.RejectedExecutionException}.
+ * These tests simulate both windows deterministically via
  * {@link ArcadeDbGrpcService#registerTransactionForTesting} / {@link ArcadeDbGrpcService#finalizeTransactionForTesting}
  * instead of racing real threads, per the issue's own suggested approach. No server or database is needed:
- * {@code requireTransactionStillActive} only compares against the in-memory active-transaction map.
+ * both guards only touch the in-memory active-transaction map and the executor's own shutdown state.
  */
 class Issue6709TransactionFinalizeRaceTest {
 
@@ -91,6 +94,45 @@ class Issue6709TransactionFinalizeRaceTest {
       assertThat(freshTxCtx).isNotSameAs(staleTxCtx);
     } finally {
       service.finalizeTransactionForTesting("tx-reused");
+      service.close();
+    }
+  }
+
+  @Test
+  @DisplayName("submitToActiveTransaction converts a RejectedExecutionException from an already-shut-down "
+      + "executor into FAILED_PRECONDITION")
+  void submitToActiveTransactionConvertsRejectedExecutionAfterFinalize() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 0L, 0L, 0L);
+    try {
+      final var txCtx = service.registerTransactionForTesting("tx-shutdown-before-submit");
+
+      // Finalizing also shuts down the executor, so a submit() attempted afterwards - the case where a
+      // concurrent commit/rollback/idle-reap fully completes before this RPC even calls submit(), not just
+      // before its task runs - throws RejectedExecutionException synchronously, before the task (and
+      // requireTransactionStillActive) ever runs.
+      service.finalizeTransactionForTesting("tx-shutdown-before-submit");
+
+      assertThatThrownBy(() -> service.submitToActiveTransaction(txCtx, () -> "should never run"))
+          .isInstanceOf(StatusRuntimeException.class)
+          .extracting(e -> ((StatusRuntimeException) e).getStatus().getCode())
+          .isEqualTo(Status.Code.FAILED_PRECONDITION);
+    } finally {
+      service.close();
+    }
+  }
+
+  @Test
+  @DisplayName("submitToActiveTransaction runs the task and revalidates when the transaction is still active")
+  void submitToActiveTransactionRunsTaskWhenStillActive() throws Exception {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 0L, 0L, 0L);
+    try {
+      final var txCtx = service.registerTransactionForTesting("tx-submit-ok");
+
+      final String result = service.submitToActiveTransaction(txCtx, () -> "ran").get();
+
+      assertThat(result).isEqualTo("ran");
+    } finally {
+      service.finalizeTransactionForTesting("tx-submit-ok");
       service.close();
     }
   }


### PR DESCRIPTION
Closes #6709

## What does this PR do?

Every transaction-scoped gRPC RPC resolves a `TransactionContext` via `resolveAuthorizedTransaction()` and then dispatches its real work onto that transaction's dedicated single-thread executor via `txCtx.executor.submit(...)`. A concurrent `commitTransaction`/`rollbackTransaction`/idle-reap call can finalize the same transaction (atomically removing it from `activeTransactions` and shutting down its executor) in the window between the resolve and the dispatched task actually running.

Adds `requireTransactionStillActive(txCtx)`, which re-checks (by reference identity, not just key presence) that the transaction context is still the one registered under its id, and inserts it as the first statement inside the dispatched task at all 9 call sites sharing this resolve-then-dispatch pattern: `executeCommand`, `createRecord`, `lookupByRid`, `updateRecord`, `deleteRecord`, `executeQuery`, `streamQuery`, `bulkInsert`, and `insertStream`'s per-chunk dispatch. On a lost race it throws the same `FAILED_PRECONDITION` status callers already get when the transaction id is unknown at resolve time, instead of an opaque `RejectedExecutionException` -> `Status.INTERNAL`.

`bulkInsert`'s catch block previously downgraded every failure (including this new guard's) to `Status.INTERNAL`; updated it to forward a `StatusRuntimeException` as-is first, mirroring `executeCommand`/`executeQuery`.

## Motivation

Follow-up from CodeRabbit's review on PR #6666 (#6607). Traced the actual impact before filing #6709: because each transaction owns a dedicated single-threaded executor and removal from `activeTransactions` is claimed atomically, this was never silent data corruption (FIFO ordering means a task submitted before the finalizer just becomes part of what's committed/rolled back; a task submitted after a shutdown throws loudly). It was, however, a needless downgrade from a precise `FAILED_PRECONDITION` ("unknown or expired transaction") to a generic `Status.INTERNAL` wrapping a `RejectedExecutionException` - worth fixing uniformly for error-message quality and defense in depth, as the issue recommended.

## Related issues

Closes #6709. Follow-up from #6607 / PR #6666.

## Additional Notes

Regression test (`Issue6709TransactionFinalizeRaceTest`) simulates the finalize-races-dispatch window deterministically via two small test-only hooks (`registerTransactionForTesting` / `finalizeTransactionForTesting`) instead of a real timing race, per the issue's own suggested approach. `TransactionContext` was widened from `private` to package-private to make this possible; nothing outside the package references it.

Verified: proved the new test fails without the fix (neutered `requireTransactionStillActive` to a no-op, confirmed 2/3 tests turned red, then restored). Full `grpcw` unit suite (182 tests) and failsafe IT suite (173 tests) both pass clean.

## Checklist

- [x] I have run the build using `mvn clean package` command (module-scoped: `mvn -pl grpcw -am compile` clean)
- [x] My unit tests cover both failure and success scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction handling across commands, queries, record operations, streams, and bulk inserts.
  * Finalized or stale transactions are now rejected with `FAILED_PRECONDITION` instead of a generic internal error.
  * Lookup, update, delete, and bulk-insert operations now preserve accurate transaction error statuses.
  * Prevented stale transaction contexts from being used when transaction identifiers are reused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review cycles

- cycle 1 (`0304c80dd6`): claude[bot] found lookupByRid/updateRecord/deleteRecord masked the new FAILED_PRECONDITION to INTERNAL in their catch blocks - fixed (`49936798ee`), plus added an end-to-end IT (`Issue6709GrpcTransactionFinalizeRaceIT`) driving all 3 through a deterministic finalize-race over the real gRPC wire; verified it catches the masking bug (reverted, confirmed red, restored).
- cycle 2 (`49936798ee`): CodeRabbit found a narrower TOCTOU window (RejectedExecutionException at submit() time, before requireTransactionStillActive ever runs) and an IT coverage-integrity gap (fixed sleep could pass without exercising the new guard); claude[bot] found the guard is stricter than the pre-existing "no in-flight work is lost" FIFO guarantee on the idle reaper. Fixed (`895aad5ed4`): added a shared submitToActiveTransaction() helper converting RejectedExecutionException to FAILED_PRECONDITION at all 9 sites, widened TransactionContext.executor to a concrete ThreadPoolExecutor so the IT can deterministically poll queue state instead of sleeping, documented the FIFO trade-off on both the CON-5 comment and the guard Javadoc, and added executeCommand/bulkInsert end-to-end cases plus a RejectedExecutionException unit test.
- cycle 3 (`895aad5ed4`): claude[bot] gave a clean pass (2 non-blocking observations only, no action needed). CodeRabbit found the finalize-race IT leaked one transaction-slot reservation per test (finalizeTransactionForTesting does not release it, correct for synthetic contexts but not for the ITs real beginTransaction-created ones) plus 2 style nits. Fixed (`6584d14393`): IT now calls the existing releaseTransactionSlot() after finalizing, matching commit/rollback/reap; final on a local Future; imported-type Javadoc link instead of fully-qualified name.
- cycle 4 (`6584d14393`): claude[bot] gave a clean pass ("No blocking issues found", 3 non-blocking observations only). CodeRabbit found the cycle-3 slot-release fix only covered the success path (queue-wait or finalize itself throwing would still leak the reservation) plus a style nit in an assertion message. Fixed (`30669b811f`): moved finalizeTransactionForTesting (idempotent) and releaseTransactionSlot (flag-guarded, exactly once) into the finally block so every exit path releases the slot; reworded the assertion message.

**Final state: max-cycles-reached (4/4).** Every cycle surfaced and fixed a real, verified issue (see above); the loop never reached a pass with zero actionable findings within the 4-cycle budget. Recommend a final human look before merging - all 184 unit + 178 IT tests pass in grpcw, and every fix in this loop was verified red-then-green (see cycle notes above and the earlier verification note).
