### PR TITLE
fix (#6765): 3 unrelated main CI failures (all test-only)

### DIFF
--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2939,10 +2939,19 @@ class GraphAnalyticalViewTest extends TestHelper {
     // effect of checking it, but must never even look at whether LIKES is ready - it doesn't cover FOLLOWS.
     GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS");
 
-    assertThat(follows.getStatus())
+    // The dispatch itself (status flips to BUILDING synchronously, before the background work even starts)
+    // happens on findProvider()'s own call stack, but this assertion runs on a SEPARATE, later call: the
+    // background restore (a virtual thread, reading a few bytes off disk) can legitimately race ahead and
+    // already have flipped status back to READY by the time this line runs, especially under a loaded/
+    // throttled CI runner where the main thread can be descheduled right after findProvider() returns.
+    // Accept either observation - still-in-flight (BUILDING) or already-resolved (READY with the snapshot
+    // actually loaded from the persisted CSR, not the pre-dispatch provisional READY from line 2933-2936) -
+    // as proof the dispatch happened. Only the #6641 regression itself (isReady() never dispatching a real
+    // candidate's restore at all, leaving it forever in the provisional READY with nothing loaded) fails this.
+    assertThat(follows.getStatus() == GraphAnalyticalView.Status.BUILDING || follows.isRestoredFromPersistedCsr())
         .as("the FOLLOWS view was a real candidate for this lookup, so its deferred restore must have been "
-            + "dispatched (status flips to BUILDING synchronously, before the background work even starts)")
-        .isEqualTo(GraphAnalyticalView.Status.BUILDING);
+            + "dispatched: either still building, or already resolved from the persisted CSR")
+        .isTrue();
     assertThat(likes.getStatus())
         .as("issue #6641: the LIKES view does not cover FOLLOWS and must never have been asked about "
             + "readiness at all - its deferred restore must stay untouched")

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2934,6 +2934,12 @@ class GraphAnalyticalViewTest extends TestHelper {
         .as("both views' persisted CSRs must still be provisionally READY, unresolved, right after reopen")
         .isEqualTo(GraphAnalyticalView.Status.READY);
     assertThat(likes.getStatus()).isEqualTo(GraphAnalyticalView.Status.READY);
+    assertThat(follows.isBuilt())
+        .as("precondition for the relaxed post-lookup assertion below: FOLLOWS must have nothing loaded yet "
+            + "(status READY here is the provisional, pre-dispatch one), so that assertion's READY branch "
+            + "can only be satisfied by a restore this lookup itself dispatched, not one already resolved "
+            + "before it ran")
+        .isFalse();
 
     // A query for FOLLOWS only: findProvider() must resolve the FOLLOWS view's deferred restore as a side
     // effect of checking it, but must never even look at whether LIKES is ready - it doesn't cover FOLLOWS.

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexConcurrentRebuildVisibilityTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexConcurrentRebuildVisibilityTest.java
@@ -56,8 +56,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * returned however good its score - the miss is stable across retries and survives any {@code efSearch}. On a miss
  * the test therefore reports whether the vector is reachable from the entry node at all, which is what separates
  * this from ordinary ANN recall.
+ * <p>
+ * Tagged {@code vector}, not {@code slow}: this test deliberately drives 4 indexes' worth of concurrent async
+ * rebuilds against the single JVM-wide {@code REBUILD_SEMAPHORE} permit, and a rebuild whose JVector compute
+ * loop does not respond promptly to {@code releaseBackgroundResources()}'s cancellation can still be holding
+ * that permit when the test method returns and {@code TestHelper}'s teardown drops the database. Running in
+ * the {@code slow} lane, that leftover thread would convoy against whichever unrelated test happens to run
+ * next and needs its own rebuild permit - exactly the failure mode the {@code vector} lane exists to contain
+ * (see CLAUDE.md's {@code @Tag("vector")} note).
  */
-@Tag("slow")
+@Tag("vector")
 class LSMVectorIndexConcurrentRebuildVisibilityTest extends TestHelper {
 
   private static final int EMBEDDING_DIM = 32;

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6458PortalSuspensionIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6458PortalSuspensionIT.java
@@ -264,22 +264,23 @@ public class Issue6458PortalSuspensionIT extends PostgresWireProtocolTestBase {
   }
 
   /**
-   * Regression test for a review finding on PR #6658 (2026-08-24 cycle): {@code bindCommand()}'s
+   * Regression test for a review finding on PR #6658 (2026-08-24 cycle): {@code bindCommand()} used to have a
    * "backwards-compatible fallback" - reached when a Bind's own {@code sourcePreparedStatement} name is not a
-   * real, Parsed prepared statement, so the lookup falls back to treating {@code portalName} itself as the
-   * template ({@code portals.get(portalName)}) - can pick up an already-executed, real portal as that template.
-   * {@link PostgresPortal#bindFrom} copies {@code executed}/{@code cachedResultSet} from whatever template it
-   * is given (safe for the {@code preparedStatements}-map template, which parseCommand writes once and never
-   * mutates afterwards, so its {@code executed} is never true for a real query) but this fallback template is a
-   * normal, mutable portal that may already have run a real query - without a reset, the clone would inherit a
-   * stale {@code executed=true} and stale {@code cachedResultSet} while {@code fullResultSet} stays at its
-   * fresh {@code null} default, so {@code executeCommand()} would skip both its "not yet executed" branch and
-   * its {@code fullResultSet}-pagination branch and serve the OLD run's stale result instead of re-executing
-   * this Bind. Confirmed failing without the reset (second run replays the stale first-run row count instead
-   * of picking up rows inserted in between).
+   * real, Parsed prepared statement - that fell back to treating {@code portalName} itself as the template
+   * ({@code portals.get(portalName)}), which could pick up an already-executed, real portal as that template
+   * and serve its stale result instead of re-executing.
+   * <p>
+   * That fallback no longer exists at all as of #6698/#6707 (d38315e267): an unresolvable
+   * {@code sourcePreparedStatement} now binds a throwaway, do-nothing portal (draining Bind's wire bytes
+   * without executing anything) and, per {@code bindCommand()}'s own comment, "without resurrecting any
+   * previously bound portal" - the old portal under {@code portalName}, if any, is explicitly removed rather
+   * than reused as a fallback template. This is a strictly stronger fix than the reset this test originally
+   * pinned: there is no stale state to serve because nothing is ever resurrected. Confirmed failing (with
+   * {@code 'T'} instead of {@code 'n'}) against the pre-#6707 code, where the fallback still exists and this
+   * Bind would resurrect and re-run the old portal instead of finding it gone.
    */
   @Test
-  void bindFallbackOnAnUnknownSourceStatementReRunsInsteadOfServingTheStaleExecutedPortal() throws Exception {
+  void bindOnAnUnknownSourceStatementClearsAnyExistingPortalInsteadOfServingItsStaleResult() throws Exception {
     try (final Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
       final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
@@ -308,45 +309,39 @@ public class Issue6458PortalSuspensionIT extends PostgresWireProtocolTestBase {
       assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
       assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
 
-      // Data changes between the two Binds, so a stale vs. fresh cachedResultSet is observable.
+      // Data changes between the two Binds, so a resurrected-and-stale vs. correctly-cleared portal is observable.
       runSimpleQueryToCompletion(out, in, "INSERT INTO FallbackBind6458 SET id = 5");
       runSimpleQueryToCompletion(out, in, "INSERT INTO FallbackBind6458 SET id = 6");
       runSimpleQueryToCompletion(out, in, "INSERT INTO FallbackBind6458 SET id = 7");
 
       // Second Bind on the SAME portal name, naming a source prepared statement that was never Parsed -
-      // bindCommand()'s preparedStatements.get(...) lookup misses, so it falls back to portals.get(portalName),
-      // which is the already-executed PF1 portal from above.
+      // bindCommand()'s preparedStatements.get(...) lookup misses, so it binds a throwaway portal and removes
+      // the already-executed PF1 portal from above instead of resurrecting it.
       sendBind(out, "PF1", "never-parsed-statement-name");
       assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
       sendExecute(out, "PF1", 0);
       sendSync(out);
       assertThat(readOneMessage(in).type)
-          .as("RowDescription again - this must be a fresh execution, not the stale first run replayed")
-          .isEqualTo('T');
-      assertThat(readNextBatchOfIds(in, 8))
-          .as("re-executes against the now-8-row table instead of replaying the first run's stale 5-row result")
-          .containsExactly(0, 1, 2, 3, 4, 5, 6, 7);
-      assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
+          .as("PF1 was removed by the Bind above, not resurrected with its stale first-run result")
+          .isEqualTo('n');
       assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
     }
   }
 
   /**
-   * Regression test for a review finding on PR #6658 (2026-08-24, cycle 5): the reset added in {@link
-   * #bindFallbackOnAnUnknownSourceStatementReRunsInsteadOfServingTheStaleExecutedPortal}'s fix was gated on
-   * {@code portal.sqlStatement != null}, which correctly excludes BEGIN/COMMIT/ROLLBACK and a RESOLVED
-   * (parameter-less) catalog answer - both precomputed once during Parse - but also, unintentionally, a
-   * DEFERRED catalog query ({@code portal.catalogQuery = true}, set by {@code parseCommand()} when the query
-   * names an emulated catalog relation - {@code pg_class} here - but its filter is a bound parameter whose
-   * value only arrives with Bind). That case's {@code sqlStatement} is null too, but unlike BEGIN/COMMIT/
-   * ROLLBACK it genuinely re-runs the query per Execute in {@code executeCommand()}'s {@code
-   * if (portal.catalogQuery)} branch, so it can go stale through {@code bindCommand()}'s fallback exactly like
-   * the plain-SQL case, just missed by the original gate. Confirmed failing without {@code || portal
-   * .catalogQuery} in the gate (second run replays the stale one-row answer instead of the two rows a type
-   * created in between should have added).
+   * Regression test for a review finding on PR #6658 (2026-08-24, cycle 5): the same fallback as {@link
+   * #bindOnAnUnknownSourceStatementClearsAnyExistingPortalInsteadOfServingItsStaleResult}, but for a DEFERRED
+   * catalog query ({@code portal.catalogQuery = true}, set by {@code parseCommand()} when the query names an
+   * emulated catalog relation - {@code pg_class} here - but its filter is a bound parameter whose value only
+   * arrives with Bind) rather than plain SQL.
+   * <p>
+   * Like the plain-SQL case, the fallback this originally guarded no longer exists as of #6698/#6707
+   * (d38315e267): an unresolvable {@code sourcePreparedStatement} removes the old portal outright instead of
+   * resurrecting it as a template, so there is nothing left that could serve a stale catalog answer. Confirmed
+   * failing (with {@code 'T'} instead of {@code 'n'}) against the pre-#6707 code.
    */
   @Test
-  void bindFallbackOnAnUnknownSourceStatementReRunsADeferredCatalogQueryTooNotJustPlainSql() throws Exception {
+  void bindOnAnUnknownSourceStatementClearsAnExistingDeferredCatalogPortalToo() throws Exception {
     try (final Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
       final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
@@ -379,23 +374,20 @@ public class Issue6458PortalSuspensionIT extends PostgresWireProtocolTestBase {
       assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
       assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
 
-      // A second matching type appears between the two Binds, so a stale vs. fresh catalog answer is observable.
+      // A second matching type appears between the two Binds, so a resurrected-and-stale vs. correctly-cleared
+      // catalog portal is observable.
       runSimpleQueryToCompletion(out, in, "CREATE DOCUMENT TYPE CatalogFB6458Second IF NOT EXISTS");
 
       // Second Bind on the SAME portal name, naming a source prepared statement that was never Parsed -
-      // bindCommand()'s preparedStatements.get(...) lookup misses, so it falls back to portals.get(portalName),
-      // which is the already-executed PCQ1 catalog-query portal from above.
+      // bindCommand()'s preparedStatements.get(...) lookup misses, so it binds a throwaway portal and removes
+      // the already-executed PCQ1 catalog-query portal from above instead of resurrecting it.
       sendBindWithOneTextParam(out, "PCQ1", "never-parsed-statement-name", "CatalogFB6458%");
       assertThat(readOneMessage(in).type).as("BindComplete").isEqualTo('2');
       sendExecute(out, "PCQ1", 0);
       sendSync(out);
       assertThat(readOneMessage(in).type)
-          .as("RowDescription again - this must be a fresh execution, not the stale first run replayed")
-          .isEqualTo('T');
-      assertThat(readNextBatchOfStrings(in, 2))
-          .as("re-runs the catalog query and picks up the type created in between, instead of replaying the stale one-row answer")
-          .containsExactlyInAnyOrder("CatalogFB6458First", "CatalogFB6458Second");
-      assertThat(readOneMessage(in).type).as("CommandComplete - fully drained").isEqualTo('C');
+          .as("PCQ1 was removed by the Bind above, not resurrected with its stale one-row catalog answer")
+          .isEqualTo('n');
       assertThat(readOneMessage(in).type).as("ReadyForQuery closes this Sync").isEqualTo('Z');
     }
   }


### PR DESCRIPTION
## What does this PR do?

Fixes 3 distinct, unrelated failing jobs from a single failed `main` CI run (https://github.com/ArcadeData/arcadedb/actions/runs/32931660057, main @ e432e416fd): `unit-tests`, `slow-unit-tests`, `integration-tests`. All three are test-only fixes - no production code was wrong in any of them.

- **`GraphAnalyticalViewTest.issue6641_findProviderDoesNotTriggerUnrelatedViewsDeferredRestore`** (unit-tests): flaky assertion, not a regression. `isReady()`'s dispatch sets `status=BUILDING` synchronously, but the test re-reads `getStatus()` in a *separate* call afterward - on a loaded runner the tiny background restore can legitimately finish first and flip status back to `READY` before the assertion runs. Fixed by accepting either `BUILDING` (still in flight) or `READY && isRestoredFromPersistedCsr()` (already resolved) - both `status` and `snapshot` are `volatile`, with `snapshot` written before `status=READY`, so this stays race-free while still catching the real #6641 regression (dispatch never happening at all). Also added an explicit `isBuilt()==false` precondition before the lookup (CodeRabbit review), so the relaxed assertion's READY branch can only be satisfied by a restore the lookup itself dispatched.

- **`Issue6655StaleGraphPrefixReuseTest`** (slow-unit-tests): mistagged neighbor test, not a regression. `LSMVectorIndexConcurrentRebuildVisibilityTest` runs immediately before it in the `slow` lane and deliberately drives concurrent rebuilds across 4 vector indexes against the single JVM-wide `REBUILD_SEMAPHORE` permit (its own docstring says so). A lingering rebuild thread from it can still hold that sole permit into the next test class's window, starving `Issue6655...`'s own async rebuild past its 60s Awaitility budget. Retagged `LSMVectorIndexConcurrentRebuildVisibilityTest` from `@Tag("slow")` to `@Tag("vector")`, matching CLAUDE.md's documented purpose for that tag, so it runs in the isolated `vector-unit-tests` lane instead.

- **`Issue6458PortalSuspensionIT`** (integration-tests, 2/9 failing): stale regression tests, not a regression. PR #6707 (`d38315e267`, fix for **closed** issue #6698 - already on `main`) removed the "fallback to an existing portal as Bind template" mechanism these two tests were guarding, replacing it with a strictly safer design: an unresolvable source statement now binds a throwaway portal and removes any existing portal under that name outright, so a follow-up Execute correctly returns `NoData` instead of resurrecting anything - the same contract already asserted by `Issue6698PreparedStatementCloseIT.rebindPortalFromClosedStatementClearsExistingPortalAndReturnsNoData` for the same code path via a different route. Renamed and updated the two tests to assert the current, correct behavior.

## Motivation

A CI failure on `main` blocks everyone; these three were triaged one at a time in an isolated worktree, each root-caused individually rather than papered over.

## Related issues

Closes #6765 (tracking issue for this CI triage). Also references #6641, #6655, #6458 and #6698 for context on why each test's original assumptions no longer hold - this PR does not close any of those: #6698 is already closed (fixed by #6707); the others are pre-existing issues this PR doesn't otherwise change behavior for.

## Additional Notes

- `#6698`/"Out of Scope" pre-merge check warnings on this PR are false positives: this PR does not target #6698 (already closed, fixed by #6707 already on `main`), it's referenced only as context for the `Issue6458PortalSuspensionIT` changes.

## Checklist

- [x] I have run the build using `mvn clean package` command - full reactor build passes through every Java module including `engine` and `postgresw` (the two this PR touches); it fails only at the unrelated `studio` frontend module's `npm install --offline=true` step (`ENOTCACHED`, a local npm-cache limitation, not a code issue - CI's `studio-*` jobs have real network access and are unaffected by this PR, which touches no `studio/**` files)
- [x] My unit tests cover both failure and success scenarios - see per-fix test plan below

## Test plan
- [x] `GraphAnalyticalViewTest`: 156/156 passing
- [x] `LSMVectorIndexConcurrentRebuildVisibilityTest`: confirmed lane switch both ways (`-Dgroups=slow -DexcludedGroups=vector` no longer selects it; `-Dgroups=vector` does, passes standalone)
- [x] `Issue6655StaleGraphPrefixReuseTest`: passing standalone
- [x] Full `postgresw` integration suite: 24 classes, 201/201 tests passing (matches CI's own count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unknown prepared-statement parameters: affected portals are safely cleared and return no data instead of re-executing stale statements.
  * Improved reliability when restoring analytical graph views during concurrent operations.

* **Tests**
  * Expanded regression coverage for portal suspension, deferred catalog queries, analytical view restoration, and concurrent vector-index rebuild visibility.
  * Refined test categorization to improve execution in the vector-focused test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
