### PR TITLE
fix(#6754,#6755,#6756): gRPC SHORT/BYTE encoding, insertStream tx reap, lifecycle/termination defects

### DIFF
--- a/docs/6754-6755-6756-pr-and-review-history.md
+++ b/docs/6754-6755-6756-pr-and-review-history.md
@@ -1,0 +1,26 @@
+# PR and review history for #6754, #6755, #6756
+
+PR: https://github.com/ArcadeData/arcadedb/pull/6768 (closes all three issues; single worktree/branch/PR
+per request, since all three are small, gRPC-only, and were filed as a batch).
+
+## Review cycles
+
+- **Cycle 1** - head `5143670adc` - initial PR. `claude` review: no functional bugs; one nit (log calls
+  pulled inside the `!txResponded` guard in `executeQuery`'s external-tx catch, silencing logging on the
+  race). Applied.
+- **Cycle 2** - head `ea720aa8fe` - fix for cycle 1's nit. `claude` + `coderabbitai` both reviewed.
+  Actionable: `isIdleReaperShutdown()` checked `isShutdown()` instead of awaiting real termination
+  (coderabbitai); `Issue6756DoubleTerminateGuardTest` didn't verify `onCompleted()` was actually invoked
+  (coderabbitai). Both applied. Also added a boundary test for `max_rows == actual row count` (claude
+  suggestion, non-blocking but cheap). One item explicitly skipped with rationale recorded in
+  `docs/review-deferred-ea720aa8.md`: `GrpcServerPlugin`'s `stopped` CAS never resets after a failed
+  `startService()` - both bots called this a non-blocking, practice-non-issue since plugin instances are
+  constructed fresh per server start with no retry path in this codebase.
+- **Cycle 3** - head `124e852795` - fix for cycle 2's actionable items. `claude`: "No correctness, security,
+  or performance concerns found. Looks good to merge pending CI." `coderabbitai`'s only inline comment was
+  the stale cycle-2 finding, which it marked "✅ Addressed in commit 124e852" itself. Clean working tree, no
+  new actionable items - **clean-approval**, loop ends here (max-cycles reached anyway at 3/3).
+
+## Final state
+
+`clean-approval`. Merge is left to the developer.

--- a/docs/6754-grpc-short-byte-int32-encoding.md
+++ b/docs/6754-grpc-short-byte-int32-encoding.md
@@ -1,0 +1,27 @@
+# #6754: gRPC returns SHORT/BYTE column values as string_value instead of int32
+
+## Summary
+
+All three gRPC value encoders (`ArcadeDbGrpcService.toGrpcValue`, `GrpcTypeConverter.toGrpcValue`,
+`ProtoUtils.toGrpcValue` in `grpc-client`) had `instanceof` branches for `Boolean`/`Integer`/`Long`/
+`Float`/`Double`/... but none for `Short`/`Byte`. A `SHORT`/`BYTE` column value therefore fell through to
+the `String.valueOf(o)` fallback and was sent as `string_value` instead of `int32_value`, diverging from
+the HTTP/SQL paths and from a type-sensitive client's expectations.
+
+## Fix
+
+Added `Short`/`Byte` branches immediately after the `Integer` branch in all three encoders, each mapping to
+`int32_value` (Java allows the implicit unboxing + widening conversion `Short`/`Byte` -> `int` at the
+`setInt32Value(int)` call site).
+
+## Tests
+
+- `GrpcTypeConverterTest.toGrpcValueShort` / `toGrpcValueByte` (grpcw, unit)
+- `ProtoUtilsTest.toGrpcValueShort` / `toGrpcValueByte` (grpc-client, unit)
+- `ArcadeDbGrpcServiceExtendedTest.executeQueryReturnsShortAndByteColumnsAsInt32NotString` (grpcw,
+  end-to-end over a real gRPC connection): creates a SHORT/BYTE-typed vertex property, inserts values,
+  queries them back, and asserts the wire `GrpcValue.KindCase` is `INT32_VALUE`, not `STRING_VALUE` -
+  the existing `Issue5046GrpcByteShortWriteIT` could not have caught this regression because it asserts via
+  `getInteger()`, which parses the (wrongly) returned string back into a number.
+
+All new/modified tests verified to fail without the fix (reverted the encoder changes and reran).

--- a/docs/6755-insertstream-external-tx-touch.md
+++ b/docs/6755-insertstream-external-tx-touch.md
@@ -1,0 +1,29 @@
+# #6755: gRPC insertStream on an external transaction reaped mid-stream
+
+## Summary
+
+`insertStream`'s external-transaction branch resolved and touched the transaction (refreshing
+`lastAccessMs`) only on the first inbound chunk, via `resolveAuthorizedTransaction` ->
+`lookupActiveTransaction` -> `touch()`. Every subsequent chunk dispatched straight onto the transaction's
+executor without touching it. A stream whose total active duration exceeded `txMaxIdleMs` (default 5
+minutes) - even with every individual gap between chunks well under that threshold - was reclaimed by the
+idle-transaction reaper while the client was still sending, discarding all rows streamed so far (the
+external transaction is never committed until the caller's own `commitTransaction` call, so a mid-stream
+reap loses everything, not just the tail).
+
+## Fix
+
+`ArcadeDbGrpcService.insertStream`'s subsequent-chunk branch (`onNext`, the `else` arm once `ctx != null`)
+now touches the external transaction (`extTxCtxRef.get().touch()`) on every chunk, matching every other
+transaction-scoped RPC (each of which calls `resolveAuthorizedTransaction`/`touch()` per call).
+
+## Tests
+
+- `Issue6755InsertStreamExternalTxTouchIT` (grpcw, `@Tag("slow")`): configures a short
+  `arcadedb.grpc.tx.maxIdleMs` (600ms) / `arcadedb.grpc.tx.reaperPeriodMs` (100ms) via system properties,
+  begins an external transaction, and streams 4 chunks 250ms apart (each gap under the idle threshold, but
+  the stream's total ~750ms duration exceeds it). Asserts all 4 rows are inserted with no errors, the
+  transaction is still alive to commit, and the commit persists all 4 rows.
+
+Verified to fail without the fix: reverted the `touch()` call and reran - the stream failed mid-way with
+`FAILED_PRECONDITION: Unknown or expired transaction id ... rolled back by the idle reaper`.

--- a/docs/6756-grpc-lifecycle-and-termination-defects.md
+++ b/docs/6756-grpc-lifecycle-and-termination-defects.md
@@ -1,0 +1,50 @@
+# #6756: gRPC server lifecycle, double-terminate, and executeCommand row-cap defects
+
+Three unrelated defects in `ArcadeDbGrpcService`/`GrpcServerPlugin`, grouped in the issue because they share
+the same service/plugin.
+
+## 1. `GrpcServerPlugin.startService()` failure leaks the server and reaper thread
+
+`configureServer()` constructs `ArcadeDbGrpcService` (which starts its idle-transaction reaper thread)
+*before* `serverBuilder.build().start()` actually binds the port. `ArcadeDBServer.start()` deliberately
+never calls `stopService()` on a plugin whose `startService()` threw, so a bind failure (port in use) - or,
+in `mode=both`, the xDS server failing after the standard server fully started - left the already-created
+service/reaper (and possibly a bound port) running with no teardown path.
+
+**Fix:** `startService()`'s catch block now calls the (idempotent, CAS-guarded) `stopService()` before
+rethrowing.
+
+**Test:** `Issue6756StartServiceFailureCleanupTest` - occupies a real port with a raw `ServerSocket`, points
+the plugin at that port, asserts `startService()` throws, and asserts the leaked service's idle reaper was
+actually shut down (`ArcadeDbGrpcService.isIdleReaperShutdown()`, a new test-support accessor - unlike the
+existing `isIdleReaperActive()`, which reflects only the constructor-time decision and never flips back).
+Verified to fail without the fix.
+
+## 2. Unary handlers can double-terminate on a concurrent client cancel
+
+Only `executeCommand` guarded its catch block with a `responded` flag (issue #6192) against calling
+`onError` after `onNext`+`onCompleted` had already been delivered. A client cancel landing exactly as the
+response is delivered can make `onCompleted()` throw; every other unary handler's catch then called
+`onError` on an already-closed call, letting an `IllegalStateException` ("call already closed") escape the
+handler instead of the call simply completing.
+
+**Fix:** applied the same `responded` guard to `executeQuery`, `createRecord`, `lookupByRid`,
+`updateRecord`, `deleteRecord`, `bulkInsert`, `beginTransaction`, `commitTransaction`, `rollbackTransaction`.
+
+**Test:** `Issue6756DoubleTerminateGuardTest` (9 cases, one per handler) - calls each handler directly
+against a real `ArcadeDbGrpcService` (no gRPC transport) with a mocked `StreamObserver` whose
+`onCompleted()` throws, and asserts `onError` is never invoked afterward. All 9 verified to fail without the
+fix.
+
+## 3. `executeCommand` with `return_rows=true` silently drops rows past `max_rows`
+
+Rows beyond `max_rows` (default 1000) were still counted into `affected` but never added to the response,
+and nothing signalled the truncation - diverging from `executeQuery`, which fails loudly with
+`RESOURCE_EXHAUSTED` when its own row cap is exceeded.
+
+**Fix:** mirrored `executeQuery`: a result exceeding `max_rows` now throws `RESOURCE_EXHAUSTED` instead of
+returning a silently truncated result.
+
+**Test:** `Issue6756ExecuteCommandMaxRowsTest` - asserts a 10-row result with `max_rows=5` fails with
+`RESOURCE_EXHAUSTED` (and never calls `onNext`), and a 10-row result with `max_rows=20` succeeds normally
+with all 10 records. Verified the first case fails without the fix.

--- a/docs/review-deferred-ea720aa8.md
+++ b/docs/review-deferred-ea720aa8.md
@@ -1,0 +1,25 @@
+# Review notes deferred from cycle 2 (base commit ea720aa8)
+
+Both bots (`claude`, `coderabbitai`) reviewed commit `ea720aa8fe00f9530d80b06ad68218111be1ba43`. Two
+actionable findings were applied (see the commit on top of this note); the following were assessed and
+intentionally skipped, not deferred to the developer - both are non-blocking per the reviewing bot itself.
+
+## Skipped: `GrpcServerPlugin.stopService()`'s `stopped` CAS never resets (claude, cycle 2)
+
+Both `claude` and `coderabbitai`'s cycle-1/2 reviews independently raised the same observation: once a
+failed `startService()` trips the `stopped` CAS via the new cleanup call, a hypothetical retried
+`startService()` on the *same* plugin instance that later succeeds would leave a live `grpcServer`/
+`xdsServer`/`grpcService` that a subsequent real `stopService()` call would silently no-op on.
+
+**Why skipped:** both reviewers themselves call this "probably a non-issue in practice" / "worth a sanity
+check, not a blocker." `GrpcServerPlugin` instances are constructed fresh per server start (via reflection
+from the `SERVER_PLUGINS` config string, per `ArcadeDBServer`'s plugin loading) - there is no code path in
+this codebase that retries `startService()` on an already-failed, already-constructed plugin instance.
+Adding a `stopped` reset would be speculative generality for a scenario the codebase does not exercise.
+Worth revisiting only if a "retry gRPC startup without restarting the whole server" feature is ever added.
+
+## Applied, not skipped
+
+- `isIdleReaperShutdown()` now awaits real termination instead of just `isShutdown()` (coderabbitai, cycle 2).
+- `Issue6756DoubleTerminateGuardTest`'s 9 cases now also `verify(resp).onCompleted()` (coderabbitai, cycle 2).
+- `Issue6756ExecuteCommandMaxRowsTest.resultExactlyAtMaxRowsSucceedsWithoutThrowing` added (claude, cycle 2).

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
@@ -260,6 +260,10 @@ public class ProtoUtils {
       return dbgEnc("toGrpcValue", value, b.setBoolValue(v).build());
     if (value instanceof Integer v)
       return dbgEnc("toGrpcValue", value, b.setInt32Value(v).build());
+    if (value instanceof Short v)
+      return dbgEnc("toGrpcValue", value, b.setInt32Value(v).build());
+    if (value instanceof Byte v)
+      return dbgEnc("toGrpcValue", value, b.setInt32Value(v).build());
     if (value instanceof Long v)
       return dbgEnc("toGrpcValue", value, b.setInt64Value(v).build());
     if (value instanceof Float v)

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsTest.java
@@ -77,6 +77,22 @@ class ProtoUtilsTest {
   }
 
   @Test
+  void toGrpcValueShort() {
+    // Issue #6754: SHORT values fell through to the string_value fallback instead of int32_value.
+    final GrpcValue value = ProtoUtils.toGrpcValue((short) 1000);
+    assertThat(value.getKindCase()).isEqualTo(GrpcValue.KindCase.INT32_VALUE);
+    assertThat(value.getInt32Value()).isEqualTo(1000);
+  }
+
+  @Test
+  void toGrpcValueByte() {
+    // Issue #6754: BYTE values fell through to the string_value fallback instead of int32_value.
+    final GrpcValue value = ProtoUtils.toGrpcValue((byte) 5);
+    assertThat(value.getKindCase()).isEqualTo(GrpcValue.KindCase.INT32_VALUE);
+    assertThat(value.getInt32Value()).isEqualTo(5);
+  }
+
+  @Test
   void toGrpcValueLong() {
     final GrpcValue value = ProtoUtils.toGrpcValue(9876543210L);
     assertThat(value.getInt64Value()).isEqualTo(9876543210L);

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -293,13 +293,25 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   /**
-   * Returns whether the idle-transaction reaper thread has actually been shut down (as opposed to merely
-   * configured). Unlike {@link #isIdleReaperActive()} - which only reflects the constructor-time decision
-   * and stays {@code true} forever once a reaper was created - this reflects live state, so it is the
-   * right check for "did {@link #close()} actually stop the background thread" (issue #6756).
+   * Returns whether the idle-transaction reaper thread has actually terminated (as opposed to merely
+   * configured, or merely told to shut down). Unlike {@link #isIdleReaperActive()} - which only reflects
+   * the constructor-time decision and stays {@code true} forever once a reaper was created - this reflects
+   * live state, so it is the right check for "did {@link #close()} actually stop the background thread"
+   * (issue #6756). {@code shutdownNow()} returns as soon as shutdown is requested, so
+   * {@code isShutdown()} alone would be true well before the thread has actually stopped running; wait
+   * (briefly, bounded) for real termination instead.
    */
   boolean isIdleReaperShutdown() {
-    return txReaper == null || txReaper.isShutdown();
+    if (txReaper == null)
+      return true;
+    if (!txReaper.isShutdown())
+      return false;
+    try {
+      return txReaper.awaitTermination(2, TimeUnit.SECONDS);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
   }
 
   /**

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -293,6 +293,16 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   /**
+   * Returns whether the idle-transaction reaper thread has actually been shut down (as opposed to merely
+   * configured). Unlike {@link #isIdleReaperActive()} - which only reflects the constructor-time decision
+   * and stays {@code true} forever once a reaper was created - this reflects live state, so it is the
+   * right check for "did {@link #close()} actually stop the background thread" (issue #6756).
+   */
+  boolean isIdleReaperShutdown() {
+    return txReaper == null || txReaper.isShutdown();
+  }
+
+  /**
    * Returns the number of open transactions currently attributed to the given principal. Exposed for testing the
    * per-principal concurrency cap.
    */
@@ -780,17 +790,23 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                 }
               }
 
-              if (emitted < maxRows) {
-                final long serRowStart = System.nanoTime();
-                // Convert Result to GrpcRecord, preserving aliases and all properties
-                GrpcRecord grpcRecord = convertResultToGrpcRecord(result, db,
-                    new ProjectionConfig(true, ProjectionEncoding.PROJECTION_AS_JSON, 0));
-                out.addRecords(grpcRecord);
-                serializationAccum += System.nanoTime() - serRowStart;
+              final long serRowStart = System.nanoTime();
+              // Convert Result to GrpcRecord, preserving aliases and all properties
+              GrpcRecord grpcRecord = convertResultToGrpcRecord(result, db,
+                  new ProjectionConfig(true, ProjectionEncoding.PROJECTION_AS_JSON, 0));
+              out.addRecords(grpcRecord);
+              serializationAccum += System.nanoTime() - serRowStart;
 
-                emitted++;
-              }
+              emitted++;
 
+              // Issue #6756 (3): mirror executeQuery's hard ceiling (RESOURCE_EXHAUSTED) instead of
+              // silently dropping rows past maxRows with no indication to the caller that the result was
+              // incomplete.
+              if (emitted >= maxRows && rs.hasNext())
+                throw Status.RESOURCE_EXHAUSTED
+                    .withDescription("ExecuteCommand result exceeds the maximum of " + maxRows
+                        + " rows; set a larger max_rows, add a LIMIT, or use return_rows=false")
+                    .asRuntimeException();
             }
           } else {
 
@@ -951,19 +967,27 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
+    // Issue #6756 (2): guards each catch below against calling onError once onNext has already handed a
+    // response to the observer - a concurrent client-side cancel landing between onNext and onCompleted can
+    // make onCompleted() throw, and without this guard the catch would call onError on an already-closed
+    // call (the same double-terminate exposure fixed for executeCommand in #6192).
+    boolean responded = false;
+
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
         final Future<CreateRecordResponse> future =
             submitToActiveTransaction(txCtx, () -> createRecordInternal(req, txCtx.db));
         resp.onNext(future.get());
+        responded = true;
         resp.onCompleted();
       } catch (Exception e) {
         final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
         LogManager.instance().log(this, Level.SEVERE, "ERROR in createRecord (external tx)", cause);
         // Preserve the engine exception type (e.g. DuplicatedKeyException -> ALREADY_EXISTS with index/keys)
         // so the client can reconstruct it instead of receiving an opaque INTERNAL.
-        resp.onError(GrpcErrorMapper.toStatusRuntimeException(cause, "CreateRecord", ha()));
+        if (!responded)
+          resp.onError(GrpcErrorMapper.toStatusRuntimeException(cause, "CreateRecord", ha()));
       }
       return;
     }
@@ -972,10 +996,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     try {
       final Database db = getDatabase(req.getDatabase(), req.getCredentials());
       resp.onNext(createRecordInternal(req, db));
+      responded = true;
       resp.onCompleted();
     } catch (Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "ERROR in createRecord", e);
-      resp.onError(GrpcErrorMapper.toStatusRuntimeException(e, "CreateRecord", ha()));
+      if (!responded)
+        resp.onError(GrpcErrorMapper.toStatusRuntimeException(e, "CreateRecord", ha()));
     }
   }
 
@@ -1083,22 +1109,29 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
+    // Issue #6756 (2): guards each catch below against calling onError once onNext has already handed a
+    // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+    boolean responded = false;
+
     if (txCtx != null) {
       try {
         final Future<LookupByRidResponse> future =
             submitToActiveTransaction(txCtx, () -> lookupByRidInternal(req, txCtx.db));
         resp.onNext(future.get());
+        responded = true;
         resp.onCompleted();
       } catch (Exception e) {
         final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
-        if (cause instanceof RecordNotFoundException)
-          resp.onError(Status.NOT_FOUND.withDescription("LookupByRid: " + cause.getMessage()).asException());
-        else if (cause instanceof StatusRuntimeException sre)
-          // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
-          // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
-          resp.onError(sre);
-        else
-          resp.onError(Status.INTERNAL.withDescription("LookupByRid: " + cause.getMessage()).asException());
+        if (!responded) {
+          if (cause instanceof RecordNotFoundException)
+            resp.onError(Status.NOT_FOUND.withDescription("LookupByRid: " + cause.getMessage()).asException());
+          else if (cause instanceof StatusRuntimeException sre)
+            // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
+            // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
+            resp.onError(sre);
+          else
+            resp.onError(Status.INTERNAL.withDescription("LookupByRid: " + cause.getMessage()).asException());
+        }
       }
       return;
     }
@@ -1106,11 +1139,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     try {
       final Database db = getDatabase(req.getDatabase(), req.getCredentials());
       resp.onNext(lookupByRidInternal(req, db));
+      responded = true;
       resp.onCompleted();
     } catch (RecordNotFoundException e) {
-      resp.onError(Status.NOT_FOUND.withDescription("LookupByRid: " + e.getMessage()).asException());
+      if (!responded)
+        resp.onError(Status.NOT_FOUND.withDescription("LookupByRid: " + e.getMessage()).asException());
     } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("LookupByRid: " + e.getMessage()).asException());
+      if (!responded)
+        resp.onError(Status.INTERNAL.withDescription("LookupByRid: " + e.getMessage()).asException());
     }
   }
 
@@ -1143,24 +1179,31 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
+    // Issue #6756 (2): guards each catch below against calling onError once onNext has already handed a
+    // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+    boolean responded = false;
+
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
         final Future<UpdateRecordResponse> future =
             submitToActiveTransaction(txCtx, () -> updateRecordInternal(req, txCtx.db));
         resp.onNext(future.get());
+        responded = true;
         resp.onCompleted();
       } catch (Exception e) {
         final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
         LogManager.instance().log(this, Level.SEVERE, "ERROR in updateRecord (external tx)", cause);
-        if (cause instanceof RecordNotFoundException)
-          resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
-        else if (cause instanceof StatusRuntimeException sre)
-          // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
-          // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
-          resp.onError(sre);
-        else
-          resp.onError(Status.INTERNAL.withDescription("UpdateRecord: " + cause.getMessage()).asException());
+        if (!responded) {
+          if (cause instanceof RecordNotFoundException)
+            resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
+          else if (cause instanceof StatusRuntimeException sre)
+            // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
+            // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
+            resp.onError(sre);
+          else
+            resp.onError(Status.INTERNAL.withDescription("UpdateRecord: " + cause.getMessage()).asException());
+        }
       }
       return;
     }
@@ -1169,12 +1212,15 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     try {
       final Database db = getDatabase(req.getDatabase(), req.getCredentials());
       resp.onNext(updateRecordInternal(req, db));
+      responded = true;
       resp.onCompleted();
     } catch (RecordNotFoundException e) {
-      resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
+      if (!responded)
+        resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
     } catch (Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "ERROR in updateRecord", e);
-      resp.onError(Status.INTERNAL.withDescription("UpdateRecord: " + e.getMessage()).asException());
+      if (!responded)
+        resp.onError(Status.INTERNAL.withDescription("UpdateRecord: " + e.getMessage()).asException());
     }
   }
 
@@ -1324,24 +1370,31 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
+    // Issue #6756 (2): guards each catch below against calling onError once onNext has already handed a
+    // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+    boolean responded = false;
+
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
         final Future<DeleteRecordResponse> future =
             submitToActiveTransaction(txCtx, () -> deleteRecordInternal(req, txCtx.db));
         resp.onNext(future.get());
+        responded = true;
         resp.onCompleted();
       } catch (Exception e) {
         final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
         LogManager.instance().log(this, Level.SEVERE, "ERROR in deleteRecord (external tx)", cause);
-        if (cause instanceof RecordNotFoundException)
-          resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
-        else if (cause instanceof StatusRuntimeException sre)
-          // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
-          // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
-          resp.onError(sre);
-        else
-          resp.onError(Status.INTERNAL.withDescription("DeleteRecord: " + cause.getMessage()).asException());
+        if (!responded) {
+          if (cause instanceof RecordNotFoundException)
+            resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
+          else if (cause instanceof StatusRuntimeException sre)
+            // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
+            // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand/bulkInsert.
+            resp.onError(sre);
+          else
+            resp.onError(Status.INTERNAL.withDescription("DeleteRecord: " + cause.getMessage()).asException());
+        }
       }
       return;
     }
@@ -1350,14 +1403,17 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     try {
       final Database db = getDatabase(req.getDatabase(), req.getCredentials());
       resp.onNext(deleteRecordInternal(req, db));
+      responded = true;
       resp.onCompleted();
     } catch (RecordNotFoundException e) {
-      resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
+      if (!responded)
+        resp.onError(Status.NOT_FOUND.withDescription("Record not found: " + req.getRid()).asException());
     } catch (Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "ERROR in deleteRecord", e);
-      resp.onError(
-          Status.INTERNAL.withDescription("DeleteRecord: " + (e.getMessage() == null ? e.toString() : e.getMessage()))
-              .asException());
+      if (!responded)
+        resp.onError(
+            Status.INTERNAL.withDescription("DeleteRecord: " + (e.getMessage() == null ? e.toString() : e.getMessage()))
+                .asException());
     }
   }
 
@@ -1430,44 +1486,56 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         return;
       }
 
+      // Issue #6756 (2): guards the catch below against calling onError once onNext has already handed a
+      // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+      boolean txResponded = false;
       try {
         final Future<ExecuteQueryResponse> future =
             submitToActiveTransaction(txCtx, () -> executeQueryInternal(request, txCtx.db));
         final ExecuteQueryResponse response = future.get();
         responseObserver.onNext(response);
+        txResponded = true;
         responseObserver.onCompleted();
       } catch (Exception e) {
         final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
-        if (cause instanceof StatusRuntimeException sre) {
-          // Preserve an explicit gRPC status (e.g. RESOURCE_EXHAUSTED from the result cap, or the
-          // authz/authn status from getDatabase) instead of masking it as INTERNAL.
-          LogManager.instance().log(this, Level.FINE, "Query rejected: %s", sre, sre.getMessage());
-          responseObserver.onError(sre);
-        } else {
-          LogManager.instance().log(this, Level.SEVERE, "Error executing query: %s", cause, cause.getMessage());
-          responseObserver.onError(Status.INTERNAL
-              .withDescription("Query execution failed: " + cause.getMessage()).asException());
+        if (!txResponded) {
+          if (cause instanceof StatusRuntimeException sre) {
+            // Preserve an explicit gRPC status (e.g. RESOURCE_EXHAUSTED from the result cap, or the
+            // authz/authn status from getDatabase) instead of masking it as INTERNAL.
+            LogManager.instance().log(this, Level.FINE, "Query rejected: %s", sre, sre.getMessage());
+            responseObserver.onError(sre);
+          } else {
+            LogManager.instance().log(this, Level.SEVERE, "Error executing query: %s", cause, cause.getMessage());
+            responseObserver.onError(Status.INTERNAL
+                .withDescription("Query execution failed: " + cause.getMessage()).asException());
+          }
         }
       }
       return;
     }
 
     // No external transaction: run on the gRPC worker thread.
+    // Issue #6756 (2): guards each catch below against calling onError once onNext has already handed a
+    // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+    boolean responded = false;
     Database database = null;
     try {
       database = getDatabase(request.getDatabase(), request.getCredentials());
       final ExecuteQueryResponse response = executeQueryInternal(request, database);
       responseObserver.onNext(response);
+      responded = true;
       responseObserver.onCompleted();
     } catch (final StatusRuntimeException e) {
       // Preserve the status code chosen by getDatabase (e.g. INVALID_ARGUMENT for a rejected
       // database name, PERMISSION_DENIED/UNAUTHENTICATED for authz/authn failures) instead of
       // masking it as INTERNAL.
       LogManager.instance().log(this, Level.FINE, "Query rejected: %s", e, e.getMessage());
-      responseObserver.onError(e);
+      if (!responded)
+        responseObserver.onError(e);
     } catch (Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error executing query: %s", e, e.getMessage());
-      responseObserver.onError(Status.INTERNAL.withDescription("Query execution failed: " + e.getMessage()).asException());
+      if (!responded)
+        responseObserver.onError(Status.INTERNAL.withDescription("Query execution failed: " + e.getMessage()).asException());
     }
   }
 
@@ -1633,6 +1701,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     // Track whether we hold a reserved concurrency slot so the failure path releases it exactly once.
     boolean reserved = false;
     String owner = null;
+    // Issue #6756 (2): guards the catch below against calling onError once onNext has already handed a
+    // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+    boolean responded = false;
 
     try {
       final Database database = getDatabase(reqDb, request.getCredentials());
@@ -1730,6 +1801,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           .setTimestamp(System.currentTimeMillis()).build();
 
       responseObserver.onNext(response);
+      responded = true;
       responseObserver.onCompleted();
     } catch (Throwable t) {
       // Shutdown the executor if it was created but not registered (prevents thread leak)
@@ -1748,7 +1820,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       LogManager.instance().log(this, Level.SEVERE, "Error beginning transaction: %s", cause, cause.getMessage());
       // Pass through an already-mapped status (e.g. UNAUTHENTICATED/PERMISSION_DENIED from getDatabase)
       // instead of masking it as INTERNAL, and preserve the exception type for everything else.
-      responseObserver.onError(GrpcErrorMapper.toStatusRuntimeException(cause, "Failed to begin transaction", ha()));
+      if (!responded)
+        responseObserver.onError(GrpcErrorMapper.toStatusRuntimeException(cause, "Failed to begin transaction", ha()));
     }
   }
 
@@ -1798,6 +1871,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
+    // Issue #6756 (2): guards the catch below against calling onError once onNext has already handed a
+    // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+    boolean responded = false;
+
     try {
       LogManager.instance().log(this, Level.FINE, """
           commitTransaction(): committing txId=%s on db=%s (on dedicated \
@@ -1811,6 +1888,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       LogManager.instance().log(this, Level.FINE, "commitTransaction(): commit OK txId=%s", txId);
       rsp.onNext(CommitTransactionResponse.newBuilder().setSuccess(true).setCommitted(true).build());
+      responded = true;
       rsp.onCompleted();
     } catch (Throwable t) {
       Throwable cause = t instanceof ExecutionException && t.getCause() != null ? t.getCause() : t;
@@ -1820,7 +1898,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       // ConcurrentModificationException/NeedRetryException stays ABORTED while a permanent commit-time
       // DuplicatedKeyException becomes ALREADY_EXISTS (not retried forever), carrying the exception class
       // name so the client rebuilds the exact type.
-      rsp.onError(GrpcErrorMapper.toStatusRuntimeException(cause, "Commit failed", ha()));
+      // Issue #6756 (2): guard against a concurrent client cancel making onCompleted() throw above and
+      // this catch calling onError on an already-closed call - see the identical guard on executeCommand
+      // (#6192) / createRecord.
+      if (!responded)
+        rsp.onError(GrpcErrorMapper.toStatusRuntimeException(cause, "Commit failed", ha()));
     } finally {
       // The transaction was claimed above (removed from activeTransactions), so release its concurrency slot and
       // shut the executor down exactly once here.
@@ -1873,6 +1955,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
+    // Issue #6756 (2): guards the catch below against calling onError once onNext has already handed a
+    // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+    boolean responded = false;
+
     try {
       LogManager.instance().log(this, Level.FINE, """
           rollbackTransaction(): rolling back txId=%s on db=%s (on dedicated\
@@ -1886,12 +1972,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       LogManager.instance().log(this, Level.FINE, "rollbackTransaction(): rollback OK txId=%s", txId);
       rsp.onNext(RollbackTransactionResponse.newBuilder().setSuccess(true).setRolledBack(true).build());
+      responded = true;
       rsp.onCompleted();
     } catch (Throwable t) {
       Throwable cause = t instanceof ExecutionException && t.getCause() != null ? t.getCause() : t;
       LogManager.instance().log(this, Level.FINE, "rollbackTransaction(): rollback FAILED txId=%s err=%s", txId,
           cause.toString(), cause);
-      rsp.onError(Status.ABORTED.withDescription("Rollback failed: " + cause.getMessage()).asException());
+      if (!responded)
+        rsp.onError(Status.ABORTED.withDescription("Rollback failed: " + cause.getMessage()).asException());
     } finally {
       // The transaction was claimed above (removed from activeTransactions), so release its concurrency slot and
       // shut the executor down exactly once here.
@@ -2448,6 +2536,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   public void bulkInsert(BulkInsertRequest req, StreamObserver<InsertSummary> resp) {
     final long started = System.currentTimeMillis();
 
+    // Issue #6756 (2): guards every catch below against calling onError once onNext has already handed a
+    // response to the observer - see the identical guard on executeCommand (#6192) / createRecord.
+    boolean responded = false;
+
     ProtocolContext.set("grpc");
     try {
       final boolean hasTx = req.hasTransaction();
@@ -2481,29 +2573,34 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             }
           }).get();
           resp.onNext(summary);
+          responded = true;
           resp.onCompleted();
         } catch (final Exception e) {
           // Catches both a Future.get() ExecutionException (wrapping a StatusRuntimeException thrown inside
           // the task) and a bare StatusRuntimeException thrown synchronously by submitToActiveTransaction
           // when the executor was already shut down (RejectedExecutionException case, issue #6709).
           final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
-          if (cause instanceof StatusRuntimeException sre)
-            // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
-            // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand.
-            resp.onError(sre);
-          else
-            resp.onError(Status.INTERNAL.withDescription("bulkInsert: " + cause.getMessage()).asException());
+          if (!responded) {
+            if (cause instanceof StatusRuntimeException sre)
+              // Preserve an explicit gRPC status (e.g. FAILED_PRECONDITION from requireTransactionStillActive)
+              // instead of masking it as INTERNAL, mirroring executeQuery/executeCommand.
+              resp.onError(sre);
+            else
+              resp.onError(Status.INTERNAL.withDescription("bulkInsert: " + cause.getMessage()).asException());
+          }
         }
       } else {
         try (InsertContext ctx = new InsertContext(opts)) {
           Counts totals = insertRows(ctx, req.getRowsList().iterator());
           ctx.flushCommit(true);
           resp.onNext(ctx.summary(totals, started));
+          responded = true;
           resp.onCompleted();
         }
       }
     } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("bulkInsert: " + e.getMessage()).asException());
+      if (!responded)
+        resp.onError(Status.INTERNAL.withDescription("bulkInsert: " + e.getMessage()).asException());
     } finally {
       ProtocolContext.clear();
     }
@@ -2621,6 +2718,15 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             // Issue #4644: a later chunk may be dispatched on a different pool thread than the one
             // that began the transaction; re-bind the transaction to this thread before inserting.
             ctx.bindToCurrentThread();
+
+            // Issue #6755: resolveAuthorizedTransaction() (via lookupActiveTransaction()) touches the
+            // external transaction only on the first chunk. A stream whose active duration between
+            // chunks exceeds txMaxIdleMs was reaped mid-stream even though the client was still
+            // sending. Touch it on every subsequent chunk too, matching every other transaction-scoped
+            // RPC (each of which calls resolveAuthorizedTransaction/touch() per call).
+            final TransactionContext extTxCtx = extTxCtxRef.get();
+            if (extTxCtx != null)
+              extTxCtx.touch();
 
             // -------- Subsequent chunks: optionally validate option consistency --------
             if (c.hasOptions()) {
@@ -3809,6 +3915,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (o instanceof Boolean v)
       return dbgEnc("toGrpcValue", o, b.setBoolValue(v).build(), null);
     if (o instanceof Integer v)
+      return dbgEnc("toGrpcValue", o, b.setInt32Value(v).build(), null);
+    if (o instanceof Short v)
+      return dbgEnc("toGrpcValue", o, b.setInt32Value(v).build(), null);
+    if (o instanceof Byte v)
       return dbgEnc("toGrpcValue", o, b.setInt32Value(v).build(), null);
     if (o instanceof Long v)
       return dbgEnc("toGrpcValue", o, b.setInt64Value(v).build(), null);

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1498,17 +1498,17 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         responseObserver.onCompleted();
       } catch (Exception e) {
         final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
-        if (!txResponded) {
-          if (cause instanceof StatusRuntimeException sre) {
-            // Preserve an explicit gRPC status (e.g. RESOURCE_EXHAUSTED from the result cap, or the
-            // authz/authn status from getDatabase) instead of masking it as INTERNAL.
-            LogManager.instance().log(this, Level.FINE, "Query rejected: %s", sre, sre.getMessage());
+        if (cause instanceof StatusRuntimeException sre) {
+          // Preserve an explicit gRPC status (e.g. RESOURCE_EXHAUSTED from the result cap, or the
+          // authz/authn status from getDatabase) instead of masking it as INTERNAL.
+          LogManager.instance().log(this, Level.FINE, "Query rejected: %s", sre, sre.getMessage());
+          if (!txResponded)
             responseObserver.onError(sre);
-          } else {
-            LogManager.instance().log(this, Level.SEVERE, "Error executing query: %s", cause, cause.getMessage());
+        } else {
+          LogManager.instance().log(this, Level.SEVERE, "Error executing query: %s", cause, cause.getMessage());
+          if (!txResponded)
             responseObserver.onError(Status.INTERNAL
                 .withDescription("Query execution failed: " + cause.getMessage()).asException());
-          }
         }
       }
       return;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -136,6 +136,13 @@ public class GrpcServerPlugin implements ServerPlugin {
 
     } catch (IOException e) {
       LogManager.instance().log(this, Level.SEVERE, "Failed to start gRPC server", e);
+      // Issue #6756 (1): ArcadeDBServer.start() deliberately does not call stopService() on a plugin
+      // whose startService() threw, so a partially-started server (the service/reaper created by
+      // configureServer() before the failing build().start(), or - in "both" mode - a fully running
+      // standard server left behind when the xDS server fails afterward) would otherwise leak with no
+      // teardown path. stopService() is idempotent (guarded by the "stopped" CAS), so this is safe even
+      // when nothing was actually started yet.
+      stopService();
       throw new RuntimeException("Failed to start gRPC server", e);
     }
   }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
@@ -145,6 +145,10 @@ class GrpcTypeConverter {
       return b.setBoolValue(v).build();
     if (o instanceof Integer v)
       return b.setInt32Value(v).build();
+    if (o instanceof Short v)
+      return b.setInt32Value(v).build();
+    if (o instanceof Byte v)
+      return b.setInt32Value(v).build();
     if (o instanceof Long v)
       return b.setInt64Value(v).build();
     if (o instanceof Float v)

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/ArcadeDbGrpcServiceExtendedTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/ArcadeDbGrpcServiceExtendedTest.java
@@ -311,6 +311,51 @@ public class ArcadeDbGrpcServiceExtendedTest extends BaseGraphServerTest {
   }
 
   @Test
+  void executeQueryReturnsShortAndByteColumnsAsInt32NotString() {
+    // Issue #6754: SHORT/BYTE values had no numeric branch in toGrpcValue() and fell through to
+    // the string fallback, so a type-sensitive client received a String where HTTP/SQL return a
+    // number. Assert on the wire kind directly - getInteger()-style decoding would parse the
+    // string back to a number and mask the regression.
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setCommand("CREATE VERTEX TYPE Issue6754Vertex IF NOT EXISTS")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setCommand("CREATE PROPERTY Issue6754Vertex.s IF NOT EXISTS SHORT")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setCommand("CREATE PROPERTY Issue6754Vertex.b IF NOT EXISTS BYTE")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setCommand("INSERT INTO Issue6754Vertex SET s = 1000, b = 5")
+        .build());
+
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setQuery("SELECT FROM Issue6754Vertex")
+        .build());
+
+    final GrpcRecord record = response.getResults(0).getRecords(0);
+    final GrpcValue shortValue = record.getPropertiesMap().get("s");
+    final GrpcValue byteValue = record.getPropertiesMap().get("b");
+
+    assertThat(shortValue.getKindCase()).as("SHORT column must encode as int32_value, not string_value")
+        .isEqualTo(GrpcValue.KindCase.INT32_VALUE);
+    assertThat(shortValue.getInt32Value()).isEqualTo(1000);
+    assertThat(byteValue.getKindCase()).as("BYTE column must encode as int32_value, not string_value")
+        .isEqualTo(GrpcValue.KindCase.INT32_VALUE);
+    assertThat(byteValue.getInt32Value()).isEqualTo(5);
+  }
+
+  @Test
   void createRecordWithNonExistentTypeReturnsError() {
     final GrpcRecord record = GrpcRecord.newBuilder()
         .setType("NonExistentType")

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTypeConverterTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTypeConverterTest.java
@@ -241,6 +241,22 @@ class GrpcTypeConverterTest {
   }
 
   @Test
+  void toGrpcValueShort() {
+    // Issue #6754: SHORT values fell through to the string_value fallback instead of int32_value.
+    GrpcValue result = GrpcTypeConverter.toGrpcValue((short) 1000);
+    assertThat(result.getKindCase()).isEqualTo(GrpcValue.KindCase.INT32_VALUE);
+    assertThat(result.getInt32Value()).isEqualTo(1000);
+  }
+
+  @Test
+  void toGrpcValueByte() {
+    // Issue #6754: BYTE values fell through to the string_value fallback instead of int32_value.
+    GrpcValue result = GrpcTypeConverter.toGrpcValue((byte) 5);
+    assertThat(result.getKindCase()).isEqualTo(GrpcValue.KindCase.INT32_VALUE);
+    assertThat(result.getInt32Value()).isEqualTo(5);
+  }
+
+  @Test
   void toGrpcValueLong() {
     GrpcValue result = GrpcTypeConverter.toGrpcValue(123456789012L);
     assertThat(result.getInt64Value()).isEqualTo(123456789012L);

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6755InsertStreamExternalTxTouchIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6755InsertStreamExternalTxTouchIT.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6755: an {@code insertStream} driven inside a caller-created (external)
+ * transaction was reaped mid-stream because {@code lastAccessMs} was refreshed only on the first chunk.
+ * A stream whose chunks stayed within the idle window individually, but whose total active duration
+ * exceeded it, was reclaimed by the idle-transaction reaper while the client was still sending - discarding
+ * every row streamed so far, committed or not, because the external transaction is never actually committed
+ * until the caller's own {@code commitTransaction} call runs.
+ * <p>
+ * Uses tiny {@code arcadedb.grpc.tx.maxIdleMs} / {@code arcadedb.grpc.tx.reaperPeriodMs} values so the
+ * reaper's window is exercised in milliseconds instead of the default 5 minutes.
+ */
+@Tag("slow")
+public class Issue6755InsertStreamExternalTxTouchIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  // Idle window shorter than the total time the 4-chunk stream below takes to send (4 x 250ms = 750ms),
+  // but longer than the 250ms gap between any two consecutive chunks - so the fix (touching on every
+  // chunk) keeps the transaction alive, while the pre-fix behaviour (touch on the first chunk only) lets
+  // total idle time accumulate past maxIdleMs and reaps it mid-stream.
+  private static final String TX_MAX_IDLE_MS      = "600";
+  private static final String TX_REAPER_PERIOD_MS = "100";
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub         asyncAuthenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    System.setProperty("arcadedb.grpc.tx.maxIdleMs", TX_MAX_IDLE_MS);
+    System.setProperty("arcadedb.grpc.tx.reaperPeriodMs", TX_REAPER_PERIOD_MS);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+    asyncAuthenticatedStub = ArcadeDbServiceGrpc.newStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    System.clearProperty("arcadedb.grpc.tx.maxIdleMs");
+    System.clearProperty("arcadedb.grpc.tx.reaperPeriodMs");
+    super.endTest();
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private void cmd(final String sql) {
+    final ExecuteCommandResponse resp = authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setCommand(sql).build());
+    assertThat(resp.getSuccess()).as("setup command failed: %s -> %s", sql, resp.getMessage()).isTrue();
+  }
+
+  @Test
+  void insertStreamOnExternalTransactionSurvivesGapsShorterThanIdleTimeout() throws Exception {
+    final String typeName = "Issue6755Vertex";
+    cmd("CREATE VERTEX TYPE " + typeName + " IF NOT EXISTS");
+    cmd("CREATE PROPERTY " + typeName + ".k IF NOT EXISTS STRING");
+
+    final BeginTransactionResponse begin = authenticatedStub.beginTransaction(BeginTransactionRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .build());
+    final String txId = begin.getTransactionId();
+    assertThat(txId).isNotEmpty();
+
+    final TransactionContext txCtx = TransactionContext.newBuilder()
+        .setTransactionId(txId).setDatabase(getDatabaseName()).build();
+
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
+      @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
+      @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
+      @Override public void onCompleted() { done.countDown(); }
+    });
+
+    final int rowCount = 4;
+    final InsertOptions options = InsertOptions.newBuilder().setTargetClass(typeName).build();
+    // Each gap (250ms) is well under TX_MAX_IDLE_MS (600ms), but the stream's total active duration
+    // (750ms across 4 chunks) exceeds it - exactly the scenario #6755 describes.
+    for (int i = 0; i < rowCount; i++) {
+      final InsertChunk.Builder chunk = InsertChunk.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setTransaction(txCtx)
+          .setSessionId("issue-6755")
+          .setChunkSeq(i)
+          .setLast(i == rowCount - 1)
+          .addRows(GrpcRecord.newBuilder()
+              .setType(typeName)
+              .putProperties("k", GrpcValue.newBuilder().setStringValue("row-" + i).build())
+              .build());
+      if (i == 0)
+        chunk.setOptions(options);
+      req.onNext(chunk.build());
+      if (i < rowCount - 1)
+        Thread.sleep(250);
+    }
+    req.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).as("insertStream must not error out").isNull();
+    assertThat(summaryRef.get()).isNotNull();
+    assertThat(summaryRef.get().getErrorsList())
+        .as("no chunk should have failed against a reaped/unknown transaction: %s", summaryRef.get().getErrorsList())
+        .isEmpty();
+    assertThat(summaryRef.get().getInserted()).as("all rows must have been inserted").isEqualTo(rowCount);
+
+    final CommitTransactionResponse commit = authenticatedStub.commitTransaction(CommitTransactionRequest.newBuilder()
+        .setCredentials(credentials())
+        .setTransaction(txCtx)
+        .build());
+    assertThat(commit.getSuccess()).as("the transaction must still be alive to commit").isTrue();
+
+    final ExecuteQueryResponse q = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setQuery("SELECT count(*) AS cnt FROM " + typeName)
+        .build());
+    final long persisted = q.getResultsList().get(0).getRecords(0).getPropertiesMap().get("cnt").getInt64Value();
+    assertThat(persisted).as("every streamed row must have been durably committed").isEqualTo(rowCount);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756DoubleTerminateGuardTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756DoubleTerminateGuardTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Regression test for issue #6756 (2): every unary gRPC handler must guard its catch block against
+ * calling {@code onError} once {@code onNext} has already handed a response to the observer. A
+ * concurrent client-side cancel landing between {@code onNext} and {@code onCompleted} can make
+ * {@code onCompleted()} throw; without the {@code responded} guard (already present on
+ * {@code executeCommand} since issue #6192) the catch block would call {@code onError} on an
+ * already-closed call, letting an {@code IllegalStateException} ("call already closed") escape the
+ * handler instead of the call simply completing successfully from the caller's point of view.
+ * <p>
+ * Calls each handler directly against a real {@link ArcadeDbGrpcService} bound to the test server's
+ * database (no gRPC transport involved) with a mocked {@link StreamObserver} whose {@code onCompleted()}
+ * throws, and asserts {@code onError} is never invoked afterward.
+ */
+public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
+
+  private static final String TYPE_NAME = "Issue6756Vertex";
+
+  private ArcadeDbGrpcService service;
+
+  @BeforeEach
+  void setupService() {
+    final String databasePath = getServer(0).getRootPath() + File.separator + "databases";
+    // Idle/age/period all zero: no reaper thread is started, keeping this a pure unit-style test.
+    service = new ArcadeDbGrpcService(databasePath, getServer(0), 0L, 0L, 0L);
+
+    final ExecuteCommandResponse resp = executeCommand("CREATE VERTEX TYPE " + TYPE_NAME + " IF NOT EXISTS");
+    assertSuccess(resp);
+  }
+
+  @AfterEach
+  void teardownService() {
+    if (service != null)
+      service.close();
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private void assertSuccess(final ExecuteCommandResponse resp) {
+    if (!resp.getSuccess())
+      throw new AssertionError("setup command failed: " + resp.getMessage());
+  }
+
+  /** Runs a command through the real (non-mocked) path, used only for test setup/fixtures. */
+  private ExecuteCommandResponse executeCommand(final String sql) {
+    final ExecuteCommandRequest req = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setCommand(sql).build();
+    @SuppressWarnings("unchecked")
+    final StreamObserver<ExecuteCommandResponse> resp = mock(StreamObserver.class);
+    service.executeCommand(req, resp);
+    final org.mockito.ArgumentCaptor<ExecuteCommandResponse> captor =
+        org.mockito.ArgumentCaptor.forClass(ExecuteCommandResponse.class);
+    verify(resp).onNext(captor.capture());
+    return captor.getValue();
+  }
+
+  private String insertOneRecordAndGetRid() {
+    final ExecuteCommandResponse resp = executeCommand(
+        "INSERT INTO " + TYPE_NAME + " SET k = 'v-" + System.nanoTime() + "'");
+    assertSuccess(resp);
+    final ExecuteQueryResponse q = executeCommandAsQuery("SELECT FROM " + TYPE_NAME + " LIMIT 1");
+    return q.getResults(0).getRecords(0).getRid();
+  }
+
+  private ExecuteQueryResponse executeCommandAsQuery(final String sql) {
+    final ExecuteQueryRequest req = ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setQuery(sql).build();
+    @SuppressWarnings("unchecked")
+    final StreamObserver<ExecuteQueryResponse> resp = mock(StreamObserver.class);
+    service.executeQuery(req, resp);
+    final org.mockito.ArgumentCaptor<ExecuteQueryResponse> captor =
+        org.mockito.ArgumentCaptor.forClass(ExecuteQueryResponse.class);
+    verify(resp).onNext(captor.capture());
+    return captor.getValue();
+  }
+
+  @Test
+  void createRecordDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    @SuppressWarnings("unchecked")
+    final StreamObserver<CreateRecordResponse> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final CreateRecordRequest req = CreateRecordRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setType(TYPE_NAME).build();
+
+    service.createRecord(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+
+  @Test
+  void lookupByRidDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final String rid = insertOneRecordAndGetRid();
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<LookupByRidResponse> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final LookupByRidRequest req = LookupByRidRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setRid(rid).build();
+
+    service.lookupByRid(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+
+  @Test
+  void updateRecordDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final String rid = insertOneRecordAndGetRid();
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<UpdateRecordResponse> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final UpdateRecordRequest req = UpdateRecordRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setRid(rid)
+        .setPartial(PropertiesUpdate.newBuilder()
+            .putProperties("k", GrpcValue.newBuilder().setStringValue("updated").build()).build())
+        .build();
+
+    service.updateRecord(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+
+  @Test
+  void deleteRecordDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final String rid = insertOneRecordAndGetRid();
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<DeleteRecordResponse> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final DeleteRecordRequest req = DeleteRecordRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setRid(rid).build();
+
+    service.deleteRecord(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+
+  @Test
+  void executeQueryDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    @SuppressWarnings("unchecked")
+    final StreamObserver<ExecuteQueryResponse> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final ExecuteQueryRequest req = ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setQuery("SELECT FROM " + TYPE_NAME).build();
+
+    service.executeQuery(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+
+  @Test
+  void bulkInsertDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    @SuppressWarnings("unchecked")
+    final StreamObserver<InsertSummary> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final BulkInsertRequest req = BulkInsertRequest.newBuilder()
+        .setOptions(InsertOptions.newBuilder().setDatabase(getDatabaseName()).setCredentials(credentials())
+            .setTargetClass(TYPE_NAME).build())
+        .addRows(GrpcRecord.newBuilder()
+            .putProperties("k", GrpcValue.newBuilder().setStringValue("bulk").build()).build())
+        .build();
+
+    service.bulkInsert(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+
+  @Test
+  void beginTransactionDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    @SuppressWarnings("unchecked")
+    final StreamObserver<BeginTransactionResponse> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final BeginTransactionRequest req = BeginTransactionRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).build();
+
+    service.beginTransaction(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+
+  private String beginRealTransaction() {
+    @SuppressWarnings("unchecked")
+    final StreamObserver<BeginTransactionResponse> resp = mock(StreamObserver.class);
+    final BeginTransactionRequest req = BeginTransactionRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).build();
+    service.beginTransaction(req, resp);
+    final org.mockito.ArgumentCaptor<BeginTransactionResponse> captor =
+        org.mockito.ArgumentCaptor.forClass(BeginTransactionResponse.class);
+    verify(resp).onNext(captor.capture());
+    return captor.getValue().getTransactionId();
+  }
+
+  @Test
+  void commitTransactionDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final String txId = beginRealTransaction();
+    final TransactionContext txCtx = TransactionContext.newBuilder()
+        .setTransactionId(txId).setDatabase(getDatabaseName()).build();
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<CommitTransactionResponse> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final CommitTransactionRequest req = CommitTransactionRequest.newBuilder()
+        .setCredentials(credentials()).setTransaction(txCtx).build();
+
+    service.commitTransaction(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+
+  @Test
+  void rollbackTransactionDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final String txId = beginRealTransaction();
+    final TransactionContext txCtx = TransactionContext.newBuilder()
+        .setTransactionId(txId).setDatabase(getDatabaseName()).build();
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<RollbackTransactionResponse> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+
+    final RollbackTransactionRequest req = RollbackTransactionRequest.newBuilder()
+        .setCredentials(credentials()).setTransaction(txCtx).build();
+
+    service.rollbackTransaction(req, resp);
+
+    verify(resp).onNext(any());
+    verify(resp, never()).onError(any());
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756DoubleTerminateGuardTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756DoubleTerminateGuardTest.java
@@ -121,6 +121,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.createRecord(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 
@@ -138,6 +141,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.lookupByRid(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 
@@ -158,6 +164,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.updateRecord(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 
@@ -175,6 +184,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.deleteRecord(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 
@@ -190,6 +202,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.executeQuery(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 
@@ -209,6 +224,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.bulkInsert(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 
@@ -224,6 +242,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.beginTransaction(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 
@@ -255,6 +276,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.commitTransaction(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 
@@ -274,6 +298,9 @@ public class Issue6756DoubleTerminateGuardTest extends BaseGraphServerTest {
     service.rollbackTransaction(req, resp);
 
     verify(resp).onNext(any());
+    // Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw
+    // alone does not distinguish "invoked and threw" from "never invoked" (CodeRabbit review, cycle 2).
+    verify(resp).onCompleted();
     verify(resp, never()).onError(any());
   }
 }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756ExecuteCommandMaxRowsTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756ExecuteCommandMaxRowsTest.java
@@ -118,4 +118,28 @@ public class Issue6756ExecuteCommandMaxRowsTest extends BaseGraphServerTest {
     verify(resp).onNext(captor.capture());
     assertThat(captor.getValue().getRecordsCount()).isEqualTo(10);
   }
+
+  @Test
+  void resultExactlyAtMaxRowsSucceedsWithoutThrowing() {
+    // Boundary case for the "emitted >= maxRows && rs.hasNext()" throw condition (code review, cycle 2):
+    // when the row count exactly equals max_rows there are no rows left once the cap is reached, so this
+    // must succeed normally rather than throw.
+    final ExecuteCommandRequest req = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("SELECT FROM " + TYPE_NAME)
+        .setReturnRows(true)
+        .setMaxRows(10) // exactly 10 rows exist
+        .build();
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<ExecuteCommandResponse> resp = mock(StreamObserver.class);
+
+    service.executeCommand(req, resp);
+
+    verify(resp, never()).onError(any());
+    final org.mockito.ArgumentCaptor<ExecuteCommandResponse> captor =
+        org.mockito.ArgumentCaptor.forClass(ExecuteCommandResponse.class);
+    verify(resp).onNext(captor.capture());
+    assertThat(captor.getValue().getRecordsCount()).isEqualTo(10);
+  }
 }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756ExecuteCommandMaxRowsTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756ExecuteCommandMaxRowsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Regression test for issue #6756 (3): {@code executeCommand} with {@code return_rows=true} used to
+ * silently drop rows past {@code max_rows} - the extra rows were still counted into {@code affected} but
+ * never added to the response, and nothing told the caller the result was incomplete. This diverges from
+ * {@code executeQuery}, which fails loudly with {@code RESOURCE_EXHAUSTED} when its own row cap is
+ * exceeded. The fix mirrors that: a result exceeding {@code max_rows} now fails with
+ * {@code RESOURCE_EXHAUSTED} instead of returning a truncated, unmarked result.
+ */
+public class Issue6756ExecuteCommandMaxRowsTest extends BaseGraphServerTest {
+
+  private static final String TYPE_NAME = "Issue6756MaxRowsVertex";
+
+  private ArcadeDbGrpcService service;
+
+  @BeforeEach
+  void setupService() {
+    final String databasePath = getServer(0).getRootPath() + File.separator + "databases";
+    service = new ArcadeDbGrpcService(databasePath, getServer(0), 0L, 0L, 0L);
+
+    exec("CREATE VERTEX TYPE " + TYPE_NAME + " IF NOT EXISTS");
+    for (int i = 0; i < 10; i++)
+      exec("INSERT INTO " + TYPE_NAME + " SET k = " + i);
+  }
+
+  @AfterEach
+  void teardownService() {
+    if (service != null)
+      service.close();
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private void exec(final String sql) {
+    final ExecuteCommandRequest req = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setCommand(sql).build();
+    @SuppressWarnings("unchecked")
+    final StreamObserver<ExecuteCommandResponse> resp = mock(StreamObserver.class);
+    service.executeCommand(req, resp);
+  }
+
+  @Test
+  void resultExceedingMaxRowsFailsLoudlyInsteadOfSilentlyTruncating() {
+    final ExecuteCommandRequest req = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("SELECT FROM " + TYPE_NAME)
+        .setReturnRows(true)
+        .setMaxRows(5) // 10 rows exist, only 5 allowed
+        .build();
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<ExecuteCommandResponse> resp = mock(StreamObserver.class);
+
+    service.executeCommand(req, resp);
+
+    verify(resp, never()).onNext(any());
+    final org.mockito.ArgumentCaptor<Throwable> captor = org.mockito.ArgumentCaptor.forClass(Throwable.class);
+    verify(resp).onError(captor.capture());
+    assertThat(captor.getValue()).isInstanceOf(StatusRuntimeException.class);
+    assertThat(((StatusRuntimeException) captor.getValue()).getStatus().getCode())
+        .isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
+  }
+
+  @Test
+  void resultWithinMaxRowsSucceedsNormally() {
+    final ExecuteCommandRequest req = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("SELECT FROM " + TYPE_NAME)
+        .setReturnRows(true)
+        .setMaxRows(20) // 10 rows exist, well within the cap
+        .build();
+
+    @SuppressWarnings("unchecked")
+    final StreamObserver<ExecuteCommandResponse> resp = mock(StreamObserver.class);
+
+    service.executeCommand(req, resp);
+
+    verify(resp, never()).onError(any());
+    final org.mockito.ArgumentCaptor<ExecuteCommandResponse> captor =
+        org.mockito.ArgumentCaptor.forClass(ExecuteCommandResponse.class);
+    verify(resp).onNext(captor.capture());
+    assertThat(captor.getValue().getRecordsCount()).isEqualTo(10);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756StartServiceFailureCleanupTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6756StartServiceFailureCleanupTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for issue #6756 (1): {@code GrpcServerPlugin.startService()} constructs the
+ * {@link ArcadeDbGrpcService} (which starts its idle-transaction reaper thread) inside
+ * {@code configureServer()}, before the Netty server actually binds the port. If binding fails (e.g. the
+ * port is already in use), {@code ArcadeDBServer.start()} deliberately never calls {@code stopService()}
+ * on a plugin whose {@code startService()} threw - so the already-created service and its reaper thread
+ * leaked with no teardown path.
+ * <p>
+ * The fix wraps {@code startService()}'s body so any failure calls the (idempotent) {@code stopService()}
+ * before rethrowing.
+ */
+class Issue6756StartServiceFailureCleanupTest {
+
+  @TempDir
+  Path tempDir;
+
+  private ServerSocket portHog;
+  private GrpcServerPlugin plugin;
+
+  @AfterEach
+  void cleanup() throws IOException {
+    if (plugin != null)
+      plugin.stopService();
+    if (portHog != null)
+      portHog.close();
+  }
+
+  @Test
+  void startServiceFailureStopsTheLeakedServiceAndReaper() throws IOException {
+    // Occupy a real port so the plugin's own bind attempt fails with a genuine "address already in use".
+    portHog = new ServerSocket(0);
+    final int occupiedPort = portHog.getLocalPort();
+
+    plugin = new GrpcServerPlugin();
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    final ContextConfiguration config = new ContextConfiguration();
+    // GrpcServerPlugin reads this back via ContextConfiguration.getValueAsString, which casts the stored
+    // value directly to String - it must be stored as a String, not the boxed Integer overload would give.
+    config.setValue(GlobalConfiguration.GRPC_PORT.getKey(), String.valueOf(occupiedPort));
+    when(mockServer.getRootPath()).thenReturn(tempDir.toString());
+    when(mockServer.getConfiguration()).thenReturn(config);
+    plugin.configure(mockServer, config);
+
+    assertThatThrownBy(plugin::startService).isInstanceOf(RuntimeException.class);
+
+    // configureServer() built the service (and its reaper) before the failing bind - confirm the leak
+    // scenario is real, not a no-op test.
+    final ArcadeDbGrpcService service = plugin.getService();
+    assertThat(service).as("the service must have been constructed before the bind failure").isNotNull();
+
+    // The fix: startService()'s catch block must have called stopService(), which shuts the reaper down.
+    assertThat(service.isIdleReaperShutdown())
+        .as("the idle-transaction reaper thread must not leak past a failed startService()").isTrue();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes three independent gRPC defects, bundled into one branch/PR since they're small, all in `grpcw`/`grpc-client`, and were filed together as a batch:

- **#6754** - `toGrpcValue` in all three encoders (`ArcadeDbGrpcService`, `GrpcTypeConverter`, client-side `ProtoUtils`) lacked a `Short`/`Byte` branch and fell through to the `string_value` fallback. Added the missing branches mapping to `int32_value`, matching HTTP/SQL.
- **#6755** - `insertStream` on an externally-managed transaction only touched (refreshed `lastAccessMs` on) the transaction on its first chunk. A stream whose total active duration exceeded `txMaxIdleMs`, even with every individual gap under the threshold, was reaped mid-stream, discarding all uncommitted rows. Now every chunk touches the transaction, matching every other transaction-scoped RPC.
- **#6756** - three related lifecycle/termination defects in `ArcadeDbGrpcService`/`GrpcServerPlugin`:
  1. A failed `startService()` left the already-constructed service and its idle-transaction reaper thread running with no teardown path. `startService()` now calls the (idempotent) `stopService()` on failure before rethrowing.
  2. Only `executeCommand` guarded against a double-terminate (`onError` called after `onNext`+`onCompleted` already succeeded) on a concurrent client cancel. Applied the same `responded` guard to `executeQuery`, `createRecord`, `lookupByRid`, `updateRecord`, `deleteRecord`, `bulkInsert`, `beginTransaction`, `commitTransaction`, `rollbackTransaction`.
  3. `executeCommand` with `return_rows=true` silently dropped rows past `max_rows` (counted into `affected` but never returned, no truncation signal). Now fails with `RESOURCE_EXHAUSTED`, mirroring `executeQuery`'s existing hard-ceiling behavior.

## Motivation

Three issues filed against the gRPC wire protocol module, all assigned to me and labeled `grpc`.

## Related issues

Closes #6754
Closes #6755
Closes #6756

## Additional Notes

Per-issue tracking docs with fix rationale and test details: `docs/6754-grpc-short-byte-int32-encoding.md`, `docs/6755-insertstream-external-tx-touch.md`, `docs/6756-grpc-lifecycle-and-termination-defects.md`.

Every fix has a regression test that was verified to **fail** without the fix (reverted the production change, reran, confirmed red, restored):

- `GrpcTypeConverterTest`/`ProtoUtilsTest`: `toGrpcValueShort`/`toGrpcValueByte` unit tests
- `ArcadeDbGrpcServiceExtendedTest.executeQueryReturnsShortAndByteColumnsAsInt32NotString`: end-to-end wire-kind assertion
- `Issue6755InsertStreamExternalTxTouchIT` (`@Tag("slow")`): short idle/reaper timeouts, 4-chunk stream with gaps under the idle threshold but total duration over it
- `Issue6756StartServiceFailureCleanupTest`: real port-bind failure via a raw `ServerSocket`, asserts the reaper is actually shut down
- `Issue6756DoubleTerminateGuardTest`: 9 cases (one per handler), mocked `StreamObserver` whose `onCompleted()` throws
- `Issue6756ExecuteCommandMaxRowsTest`: over-cap fails with `RESOURCE_EXHAUSTED`, within-cap succeeds normally

Full `grpcw` (199 tests) and `grpc-client` (147 tests) default test lanes green, plus the `slow`-tagged `insertStream` tests (16 tests) run explicitly.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * gRPC now correctly encodes `Short` and `Byte` values as 32-bit integers.
  * Long-running streamed inserts remain active during externally managed transactions.
  * Exceeding command row limits now returns `RESOURCE_EXHAUSTED`.
  * Improved cleanup when gRPC startup fails.
  * Prevented duplicate responses after client cancellation or completed transactions.

* **Documentation**
  * Added documentation covering the gRPC fixes and related lifecycle behavior.

* **Tests**
  * Added unit, integration, and regression coverage for all corrected behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->