### PR TITLE
fix(#6769): GAV overlay masks all parallel edges when only one is deleted

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
@@ -80,7 +80,7 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
       if (record instanceof Vertex vertex)
         delta.addedVertices.add(new TxDelta.VertexDelta(vertex.getIdentity(), extractProperties(vertex)));
       else if (record instanceof Edge edge)
-        delta.addedEdges.add(new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(), edge.getIn()));
+        delta.addedEdges.add(new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(), edge.getIn(), edge.getIdentity()));
       scheduleSyncCallback(delta);
     } else {
       scheduleAsyncCallback();
@@ -123,7 +123,7 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
       if (record instanceof Vertex vertex)
         delta.deletedVertices.add(vertex.getIdentity());
       else if (record instanceof Edge edge)
-        delta.deletedEdges.add(new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(), edge.getIn()));
+        delta.deletedEdges.add(new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(), edge.getIn(), edge.getIdentity()));
       scheduleSyncCallback(delta);
     } else {
       scheduleAsyncCallback();

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -253,6 +253,10 @@ class DeltaOverlay {
       // compaction trigger (Math.abs(deltaEdgeCount) > threshold, issue #4587) - and, since the per-pair
       // count below feeds copyBaseExcludingDeleted's exclusion budget, it would also mask a second, still
       // live, parallel edge that was never actually deleted (issue #6769).
+      // KNOWN GAP (issue #6777): this assumes an edge's RID is never reused while it sits in this set,
+      // but LocalBucket deliberately reuses a slot freed by a delete for a later insert ("hole reuse",
+      // #5279). A different, unrelated edge landing on the same freed slot and later being deleted too
+      // would collide here and have ITS deletion silently dropped.
       if (newDeletedEdgeRIDs.computeIfAbsent(ed.edgeType, k -> new HashSet<>()).add(ed.rid)) {
         newDeletedEdges.computeIfAbsent(ed.edgeType, k -> new HashMap<>())
             .merge(packEdge(srcId, tgtId), 1, Integer::sum);

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -256,7 +256,11 @@ class DeltaOverlay {
       // KNOWN GAP (issue #6777): this assumes an edge's RID is never reused while it sits in this set,
       // but LocalBucket deliberately reuses a slot freed by a delete for a later insert ("hole reuse",
       // #5279). A different, unrelated edge landing on the same freed slot and later being deleted too
-      // would collide here and have ITS deletion silently dropped.
+      // would collide here and have ITS deletion silently dropped. The window this can happen in is
+      // bounded by the same compaction trigger #4587 protects: a full rebuild clears this set entirely
+      // (see the no-delta constructor), so the exposure is at most GraphAnalyticalView.compactionThreshold
+      // (default GraphAnalyticalView.DEFAULT_COMPACTION_THRESHOLD = 10,000) net edge deltas of churn on
+      // one covered edge type - not unbounded, but wide enough to be reachable on a busy graph.
       if (newDeletedEdgeRIDs.computeIfAbsent(ed.edgeType, k -> new HashSet<>()).add(ed.rid)) {
         newDeletedEdges.computeIfAbsent(ed.edgeType, k -> new HashMap<>())
             .merge(packEdge(srcId, tgtId), 1, Integer::sum);

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -55,8 +55,16 @@ class DeltaOverlay {
   private final Map<String, Map<Integer, int[]>> outNeighborIndex;
   private final Map<String, Map<Integer, int[]>> inNeighborIndex;
 
-  // Deleted edges per type: edgeType -> set of packed (src << 32 | tgt)
-  private final Map<String, Set<Long>>      deletedEdgesPerType;
+  // Deleted edges per type: edgeType -> packed (src << 32 | tgt) -> number of distinct edges deleted for
+  // that pair. A count rather than a presence flag: two parallel edges between the same pair, only one of
+  // them deleted, must leave the other one discoverable (see #copyBaseExcludingDeleted and issue #6769).
+  private final Map<String, Map<Long, Integer>> deletedEdgesPerType;
+
+  // The deleted edges' own identities, per type. Exists purely to tell a genuinely new deletion apart from
+  // the same edge being reported deleted twice (replayed across merges, or emitted twice within one
+  // TxDelta) when deriving deletedEdgesPerType above - the pair alone cannot make that distinction once a
+  // pair carries more than one parallel edge.
+  private final Map<String, Set<RID>>       deletedEdgeRIDsPerType;
 
   // Per-node deleted edge counts for O(1) lookup: edgeType -> nodeId -> count
   private final Map<String, IntIntHashMap> deletedOutEdgeCounts;
@@ -79,6 +87,7 @@ class DeltaOverlay {
     this.deletedOverflowNodes = new BitSet();
     this.addedEdgesPerType = Collections.emptyMap();
     this.deletedEdgesPerType = Collections.emptyMap();
+    this.deletedEdgeRIDsPerType = Collections.emptyMap();
     this.deletedOutEdgeCounts = Collections.emptyMap();
     this.deletedInEdgeCounts = Collections.emptyMap();
     this.propertyOverrides = Collections.emptyMap();
@@ -97,7 +106,8 @@ class DeltaOverlay {
       final Map<String, Object>[] overflowProperties,
       final BitSet deletedBaseNodes, final BitSet deletedOverflowNodes,
       final Map<String, List<long[]>> addedEdgesPerType,
-      final Map<String, Set<Long>> deletedEdgesPerType,
+      final Map<String, Map<Long, Integer>> deletedEdgesPerType,
+      final Map<String, Set<RID>> deletedEdgeRIDsPerType,
       final Map<String, IntIntHashMap> deletedOutEdgeCounts,
       final Map<String, IntIntHashMap> deletedInEdgeCounts,
       final Map<Integer, Map<String, Object>> propertyOverrides,
@@ -112,6 +122,7 @@ class DeltaOverlay {
     this.deletedOverflowNodes = deletedOverflowNodes;
     this.addedEdgesPerType = addedEdgesPerType;
     this.deletedEdgesPerType = deletedEdgesPerType;
+    this.deletedEdgeRIDsPerType = deletedEdgeRIDsPerType;
     this.deletedOutEdgeCounts = deletedOutEdgeCounts;
     this.deletedInEdgeCounts = deletedInEdgeCounts;
     this.propertyOverrides = propertyOverrides;
@@ -152,9 +163,12 @@ class DeltaOverlay {
     final Map<String, List<long[]>> newAddedEdges = new HashMap<>();
     for (final var entry : addedEdgesPerType.entrySet())
       newAddedEdges.put(entry.getKey(), new ArrayList<>(entry.getValue()));
-    final Map<String, Set<Long>> newDeletedEdges = new HashMap<>();
+    final Map<String, Map<Long, Integer>> newDeletedEdges = new HashMap<>();
     for (final var entry : deletedEdgesPerType.entrySet())
-      newDeletedEdges.put(entry.getKey(), new HashSet<>(entry.getValue()));
+      newDeletedEdges.put(entry.getKey(), new HashMap<>(entry.getValue()));
+    final Map<String, Set<RID>> newDeletedEdgeRIDs = new HashMap<>();
+    for (final var entry : deletedEdgeRIDsPerType.entrySet())
+      newDeletedEdgeRIDs.put(entry.getKey(), new HashSet<>(entry.getValue()));
     final Map<Integer, Map<String, Object>> newPropOverrides = new HashMap<>(propertyOverrides.size());
     for (final var propEntry : propertyOverrides.entrySet())
       newPropOverrides.put(propEntry.getKey(), new HashMap<>(propEntry.getValue()));
@@ -215,8 +229,8 @@ class DeltaOverlay {
         final CSRAdjacencyIndex csr = baseCsrPerType.get(ed.edgeType);
         if (csr != null && csr.hasForwardEdge(srcId, tgtId)) {
           final long packed = packEdge(srcId, tgtId);
-          final Set<Long> prevDel = newDeletedEdges.get(ed.edgeType);
-          final boolean masked = (prevDel != null && prevDel.contains(packed))
+          final Map<Long, Integer> prevDel = newDeletedEdges.get(ed.edgeType);
+          final boolean masked = (prevDel != null && prevDel.containsKey(packed))
               || (sameDeltaDeleted != null && sameDeltaDeleted.contains(packed));
           if (!masked)
             continue; // already represented by the fresh base CSR
@@ -233,17 +247,17 @@ class DeltaOverlay {
       final int tgtId = resolveNodeId(ed.target, baseMapping, newOverflowIds);
       if (srcId < 0 || tgtId < 0)
         continue;
-      // Only decrement when the deletion is new: newDeletedEdges is a Set, so a duplicate
-      // deletion (replayed across merges or emitted twice within one TxDelta) is absorbed by
-      // add() returning false. Decrementing unconditionally would drift the counter negative
-      // and corrupt the compaction trigger (Math.abs(deltaEdgeCount) > threshold). See issue #4587.
-      // Only decrement when the deletion is new: newDeletedEdges is a Set, so a duplicate
-      // deletion (replayed across merges or emitted twice within one TxDelta) is absorbed by
-      // add() returning false. Decrementing unconditionally would drift the counter negative
-      // and corrupt the compaction trigger (Math.abs(deltaEdgeCount) > threshold). See issue #4587.
-      if (newDeletedEdges.computeIfAbsent(ed.edgeType, k -> new HashSet<>())
-          .add(packEdge(srcId, tgtId)))
+      // Only count when the deletion is new: newDeletedEdgeRIDs is keyed by the edge's own identity, so a
+      // duplicate deletion (replayed across merges or emitted twice within one TxDelta) is absorbed by
+      // add() returning false. Counting it again would drift newDeltaEdgeCount negative and corrupt the
+      // compaction trigger (Math.abs(deltaEdgeCount) > threshold, issue #4587) - and, since the per-pair
+      // count below feeds copyBaseExcludingDeleted's exclusion budget, it would also mask a second, still
+      // live, parallel edge that was never actually deleted (issue #6769).
+      if (newDeletedEdgeRIDs.computeIfAbsent(ed.edgeType, k -> new HashSet<>()).add(ed.rid)) {
+        newDeletedEdges.computeIfAbsent(ed.edgeType, k -> new HashMap<>())
+            .merge(packEdge(srcId, tgtId), 1, Integer::sum);
         newDeltaEdgeCount--;
+      }
     }
 
     // Process property updates
@@ -265,7 +279,7 @@ class DeltaOverlay {
         Collections.unmodifiableMap(newOverflowIds),
         overflowRIDsList.toArray(new RID[0]),
         overflowPropsList.toArray(new Map[0]),
-        newDeleted, newDeletedOverflow, newAddedEdges, newDeletedEdges,
+        newDeleted, newDeletedOverflow, newAddedEdges, newDeletedEdges, newDeletedEdgeRIDs,
         newDelOutCounts, newDelInCounts, newPropOverrides,
         newOutIndex, newInIndex,
         newOverflowCount, newDeltaEdgeCount);
@@ -312,8 +326,18 @@ class DeltaOverlay {
   }
 
   boolean isEdgeDeleted(final String edgeType, final int srcId, final int tgtId) {
-    final Set<Long> deleted = deletedEdgesPerType.get(edgeType);
-    return deleted != null && deleted.contains(packEdge(srcId, tgtId));
+    return countDeletedEdges(edgeType, srcId, tgtId) > 0;
+  }
+
+  /**
+   * Returns how many distinct edges of {@code edgeType} between {@code srcId} and {@code tgtId} the
+   * overlay has recorded as deleted - the exclusion budget {@link GraphAnalyticalView#copyBaseExcludingDeleted}
+   * spends against the base CSR's parallel-edge run for that pair, so that deleting one of several
+   * parallel edges leaves the others discoverable instead of masking the whole pair (issue #6769).
+   */
+  int countDeletedEdges(final String edgeType, final int srcId, final int tgtId) {
+    final Map<Long, Integer> deleted = deletedEdgesPerType.get(edgeType);
+    return deleted == null ? 0 : deleted.getOrDefault(packEdge(srcId, tgtId), 0);
   }
 
   /**
@@ -448,15 +472,16 @@ class DeltaOverlay {
    * @param outgoing true for outgoing counts (keyed by source), false for incoming (keyed by target)
    */
   private static Map<String, IntIntHashMap> buildDeletedEdgeCounts(
-      final Map<String, Set<Long>> deletedEdges, final boolean outgoing) {
+      final Map<String, Map<Long, Integer>> deletedEdges, final boolean outgoing) {
     if (deletedEdges.isEmpty())
       return Collections.emptyMap();
     final Map<String, IntIntHashMap> result = new HashMap<>();
     for (final var entry : deletedEdges.entrySet()) {
       final IntIntHashMap counts = new IntIntHashMap();
-      for (final long packed : entry.getValue()) {
+      for (final var pairEntry : entry.getValue().entrySet()) {
+        final long packed = pairEntry.getKey();
         final int nodeId = outgoing ? (int) (packed >>> 32) : (int) packed;
-        counts.increment(nodeId);
+        counts.add(nodeId, pairEntry.getValue());
       }
       result.put(entry.getKey(), counts);
     }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -2244,10 +2244,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * <b>Why a deleted pair is still answered "unknown" rather than the exact survivor count.</b>
    * {@link DeltaOverlay} now tracks an exact per-pair deleted count (issue #6769), which is exactly
    * what {@link #isConnectedTo} and {@link #getNeighborIds} compare against the base CSR's occurrence
-   * count for the pair to keep the surviving parallel edges discoverable. This method could do the
-   * same arithmetic and return an exact number, but a pattern hop turns the count directly into rows,
-   * and getting that arithmetic wrong silently produces the wrong row count rather than an exception -
-   * so it keeps the conservative "unknown" answer here and leaves
+   * count for the pair to keep the surviving parallel edges discoverable. This method could mirror that
+   * arithmetic and return an exact number for the base-CSR side, but the overlay's ADDED neighbours are
+   * not filtered against deletedEdgesPerType at all yet (issue #6775), so a masked pair's added-edge
+   * contribution here has no safe way to exclude a since-deleted add. A pattern hop turns the count
+   * directly into rows, and getting that arithmetic wrong silently produces the wrong row count rather
+   * than an exception - so it keeps the conservative "unknown" answer here until #6775 closes that gap,
+   * and leaves
    * {@code com.arcadedb.query.opencypher.executor.operators.GAVExpandInto}'s existing OLTP fallback
    * to do the exact counting, which it already had to have for the "vertex not in the GAV mapping"
    * case anyway.

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -2193,25 +2193,25 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     final DeltaOverlay ov = snap.overlay;
     final boolean nodeAInBase = nodeA < snap.nodeMapping.size();
 
-    // Check base CSR
+    // Check base CSR. A pair with parallel edges stays connected as long as at least one of them
+    // survives, so the base occurrence count is compared against the overlay's exact deleted count
+    // for the pair rather than treating any deletion as removing the whole pair (issue #6769).
     if (csr != null && nodeAInBase) {
       if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-        if (ov != null && ov.isEdgeDeleted(edgeType, nodeA, nodeB)) { /* deleted */ }
-        else {
-          final int[] neighbors = csr.getForwardNeighbors();
-          final int[] offsets = csr.getForwardOffsets();
-          if (Arrays.binarySearch(neighbors, offsets[nodeA], offsets[nodeA + 1], nodeB) >= 0)
-            return true;
-        }
+        final int[] neighbors = csr.getForwardNeighbors();
+        final int[] offsets = csr.getForwardOffsets();
+        final int occurrences = equalRangeCount(neighbors, offsets[nodeA], offsets[nodeA + 1], nodeB);
+        final int deleted = ov != null ? ov.countDeletedEdges(edgeType, nodeA, nodeB) : 0;
+        if (occurrences > deleted)
+          return true;
       }
       if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-        if (ov != null && ov.isEdgeDeleted(edgeType, nodeB, nodeA)) { /* deleted */ }
-        else {
-          final int[] neighbors = csr.getBackwardNeighbors();
-          final int[] offsets = csr.getBackwardOffsets();
-          if (Arrays.binarySearch(neighbors, offsets[nodeA], offsets[nodeA + 1], nodeB) >= 0)
-            return true;
-        }
+        final int[] neighbors = csr.getBackwardNeighbors();
+        final int[] offsets = csr.getBackwardOffsets();
+        final int occurrences = equalRangeCount(neighbors, offsets[nodeA], offsets[nodeA + 1], nodeB);
+        final int deleted = ov != null ? ov.countDeletedEdges(edgeType, nodeB, nodeA) : 0;
+        if (occurrences > deleted)
+          return true;
       }
     }
 
@@ -2239,16 +2239,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * backward side is skipped when the two nodes are the same, which is what the OLTP expansion
    * achieves by de-duplicating on edge identity.
    * <p>
-   * <b>Why a deleted pair is answered "unknown" rather than zero.</b> {@link DeltaOverlay} keys its
-   * pending deletions on the {@code (source, target)} pair, not on the edge, because the CSR holds
-   * adjacency ids and has no edge identity to key on. Deleting one of three parallel edges therefore
-   * marks the whole pair, and every read that consults the mask drops all three - which is what
-   * {@link #isConnectedTo} and {@link #getNeighborIds} do, and it is why they report a pair as gone
-   * while two of its edges remain. A boolean can absorb that; a count cannot, because the caller
-   * turns it directly into rows. So a masked pair is reported unknown and the caller walks the edge
-   * list, which is exact. Resolving it here instead would take per-edge identity in the CSR, and a
-   * per-pair counter cannot substitute: the overlay absorbs a deletion replayed across merges by
-   * set semantics (issue #4587), which a counter would double-count.
+   * <b>Why a deleted pair is still answered "unknown" rather than the exact survivor count.</b>
+   * {@link DeltaOverlay} now tracks an exact per-pair deleted count (issue #6769), which is exactly
+   * what {@link #isConnectedTo} and {@link #getNeighborIds} compare against the base CSR's occurrence
+   * count for the pair to keep the surviving parallel edges discoverable. This method could do the
+   * same arithmetic and return an exact number, but a pattern hop turns the count directly into rows,
+   * and getting that arithmetic wrong silently produces the wrong row count rather than an exception -
+   * so it keeps the conservative "unknown" answer here and leaves
+   * {@code com.arcadedb.query.opencypher.executor.operators.GAVExpandInto}'s existing OLTP fallback
+   * to do the exact counting, which it already had to have for the "vertex not in the GAV mapping"
+   * case anyway.
    */
   private long countBetweenForType(final Snapshot snap, final int nodeA, final int nodeB,
       final Vertex.DIRECTION direction, final String edgeType) {
@@ -2441,20 +2441,34 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * for an incoming slice it represents {@code n -> nodeId}. When no relevant deletions exist the original slice is
    * returned verbatim to keep the no-deletion case allocation-cheap.
    * <p>
+   * The slice is sorted, so parallel edges to the same neighbour form a contiguous run; {@link DeltaOverlay
+   * #countDeletedEdges} gives the number of THOSE parallel edges the overlay recorded as deleted, and only that
+   * many slots of the run are excluded - not the whole run - so deleting one of several parallel edges between a
+   * pair leaves the others discoverable instead of masking the whole pair (issue #6769).
+   * <p>
    * The caller only reaches this helper on the slow path, which is taken precisely when an overlay is present, so
    * {@code ov} is always non-null here (the {@code ov == null} fast paths in {@link #getNeighborsFromCSR} return earlier).
    */
   private static int[] copyBaseExcludingDeleted(final int[] neighbors, final int start, final int end,
       final DeltaOverlay ov, final String edgeType, final int nodeId, final boolean outgoing) {
-    // Single pass over the slice. ov.isEdgeDeleted() autoboxes a packed long for a Set lookup, so we call it
-    // exactly once per neighbour and cache the result in a boolean[]. The cache is allocated lazily, only when
-    // the first deleted edge is found, so the common no-deletion case stays allocation-free.
+    // Single pass over the slice. One countDeletedEdges() lookup per distinct neighbour value (cached for the
+    // run), not per slot. The mask is allocated lazily, only once the first deleted edge is found, so the
+    // common no-deletion case stays allocation-free.
     final int len = end - start;
     boolean[] deletedMask = null;
     int kept = 0;
+    int runValue = 0;
+    int runIndex = 0;
+    int runDeletedBudget = 0;
     for (int i = 0; i < len; i++) {
       final int n = neighbors[start + i];
-      final boolean deleted = outgoing ? ov.isEdgeDeleted(edgeType, nodeId, n) : ov.isEdgeDeleted(edgeType, n, nodeId);
+      if (i == 0 || n != runValue) {
+        runValue = n;
+        runIndex = 0;
+        runDeletedBudget = outgoing ? ov.countDeletedEdges(edgeType, nodeId, n) : ov.countDeletedEdges(edgeType, n, nodeId);
+      }
+      final boolean deleted = runIndex < runDeletedBudget;
+      runIndex++;
       if (deleted) {
         if (deletedMask == null) {
           deletedMask = new boolean[len];

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -2215,7 +2215,9 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       }
     }
 
-    // Check overlay added edges
+    // Check overlay added edges. Same known gap as getNeighborsFromCSR (issue #6775): not filtered
+    // against deletedEdgesPerType, so an edge added and deleted within the same overlay window
+    // before compaction is still reported connected here.
     if (ov != null) {
       if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
         for (final int neighbor : ov.getAddedOutNeighbors(nodeA, edgeType))
@@ -2412,6 +2414,11 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       }
     }
 
+    // KNOWN GAP (issue #6775): unlike baseOut/baseIn above, the overlay-added neighbours below are
+    // not filtered against deletedEdgesPerType. An edge added and then deleted within the same
+    // not-yet-compacted overlay window still surfaces here. countEdgesBetween is unaffected - it
+    // answers "unknown" for any pair with a recorded deletion before it looks at added neighbours -
+    // but getNeighborIds/getVertices/isConnectedTo's overlay-added branch is not.
     int[] ovOut = EMPTY_INT;
     int[] ovIn = EMPTY_INT;
     if (ov != null) {

--- a/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
@@ -71,11 +71,17 @@ class TxDelta {
     final String edgeType;
     final RID    source;
     final RID    target;
+    // The deleted/added edge's own identity. For deletedEdges this is what lets DeltaOverlay.merge()
+    // tell "the same edge reported twice" (replayed across merges, or emitted twice within one TxDelta -
+    // must not double-count) apart from "two distinct parallel edges between the same pair" (must each
+    // count, see issue #6769).
+    final RID    rid;
 
-    EdgeDelta(final String edgeType, final RID source, final RID target) {
+    EdgeDelta(final String edgeType, final RID source, final RID target, final RID rid) {
       this.edgeType = edgeType;
       this.source = source;
       this.target = target;
+      this.rid = rid;
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDedupTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDedupTest.java
@@ -83,7 +83,7 @@ class DeltaOverlayCompactionDedupTest {
     final DeltaOverlay empty = new DeltaOverlay(mapping.size());
 
     final TxDelta replay = new TxDelta();
-    replay.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    replay.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
 
     // Without CSR awareness (legacy path) the edge would be appended to the overlay → duplicate.
     final DeltaOverlay legacy = empty.merge(replay, mapping);
@@ -107,7 +107,7 @@ class DeltaOverlayCompactionDedupTest {
     final DeltaOverlay empty = new DeltaOverlay(mapping.size());
 
     final TxDelta delta = new TxDelta();
-    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
 
     final DeltaOverlay merged = empty.merge(delta, mapping, emptyCsr(2));
     assertThat(merged.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
@@ -125,12 +125,12 @@ class DeltaOverlayCompactionDedupTest {
     final DeltaOverlay empty = new DeltaOverlay(mapping.size());
 
     final TxDelta del = new TxDelta();
-    del.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    del.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
     final DeltaOverlay afterDelete = empty.merge(del, mapping, csr);
     assertThat(afterDelete.isEdgeDeleted(EDGE_TYPE, 0, 1)).isTrue();
 
     final TxDelta readd = new TxDelta();
-    readd.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    readd.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
     final DeltaOverlay afterReadd = afterDelete.merge(readd, mapping, csr);
 
     // The explicit add is kept so the base deletion is offset → edge present once on read.
@@ -147,8 +147,8 @@ class DeltaOverlayCompactionDedupTest {
     final DeltaOverlay empty = new DeltaOverlay(mapping.size());
 
     final TxDelta delta = new TxDelta();
-    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
-    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
 
     final DeltaOverlay merged = empty.merge(delta, mapping, csrWithEdge(2, 0, 1));
     assertThat(merged.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDedupTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDedupTest.java
@@ -67,6 +67,26 @@ class DeltaOverlayCompactionDedupTest {
     return Map.of(EDGE_TYPE, csr);
   }
 
+  /**
+   * Builds a base CSR over {@code nodeCount} nodes containing {@code count} parallel forward edges
+   * {@code src -> tgt}.
+   */
+  private Map<String, CSRAdjacencyIndex> csrWithParallelEdges(final int nodeCount, final int src, final int tgt,
+      final int count) {
+    final int[] fwdOffsets = new int[nodeCount + 1];
+    final int[] bwdOffsets = new int[nodeCount + 1];
+    for (int i = 0; i <= nodeCount; i++) {
+      fwdOffsets[i] = i > src ? count : 0;
+      bwdOffsets[i] = i > tgt ? count : 0;
+    }
+    final int[] fwdNeighbors = new int[count];
+    final int[] bwdNeighbors = new int[count];
+    java.util.Arrays.fill(fwdNeighbors, tgt);
+    java.util.Arrays.fill(bwdNeighbors, src);
+    final CSRAdjacencyIndex csr = new CSRAdjacencyIndex(fwdOffsets, fwdNeighbors, bwdOffsets, bwdNeighbors, nodeCount, count);
+    return Map.of(EDGE_TYPE, csr);
+  }
+
   private Map<String, CSRAdjacencyIndex> emptyCsr(final int nodeCount) {
     final CSRAdjacencyIndex csr = new CSRAdjacencyIndex(new int[nodeCount + 1], new int[0], new int[nodeCount + 1], new int[0],
         nodeCount, 0);
@@ -153,5 +173,34 @@ class DeltaOverlayCompactionDedupTest {
     final DeltaOverlay merged = empty.merge(delta, mapping, csrWithEdge(2, 0, 1));
     assertThat(merged.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
     assertThat(merged.isEdgeDeleted(EDGE_TYPE, 0, 1)).isTrue();
+  }
+
+  /**
+   * Issue #6769 review follow-up: delete-then-re-add-within-one-buffered-delta (the scenario above)
+   * combined with a pair that has SEVERAL parallel edges in the freshly built base CSR. The masking
+   * ("this pair was deleted, so the re-add is not a duplicate, reinstate it") must not be confused
+   * with the exact-count deletion tracking #6769 added ("only ONE of the parallel edges was actually
+   * deleted") - reinstating the add must not make the pair look like all of them were deleted, and
+   * the deletion count must stay exact rather than collapsing to a presence flag again.
+   */
+  @Test
+  void deleteThenReAddOneOfSeveralParallelEdgesDuringCompactionReplayStaysExact() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final Map<String, CSRAdjacencyIndex> csr = csrWithParallelEdges(2, 0, 1, 3);
+    final DeltaOverlay empty = new DeltaOverlay(mapping.size());
+
+    final TxDelta delta = new TxDelta();
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+
+    final DeltaOverlay merged = empty.merge(delta, mapping, csr);
+
+    // The re-add is reinstated (masked by this same delta's own deletion of the pair) ...
+    assertThat(merged.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
+    // ... but exactly ONE deletion is on record for the pair, not three - the masking check only
+    // needed to know "was this pair touched at all", it must not inflate the exact count #6769 added.
+    assertThat(merged.isEdgeDeleted(EDGE_TYPE, 0, 1)).isTrue();
+    assertThat(merged.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(merged.getDeltaEdgeCount()).isZero();
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayTest.java
@@ -57,20 +57,22 @@ class DeltaOverlayTest {
   void duplicateEdgeDeletionAcrossMergesDecrementsOnce() {
     final NodeIdMapping mapping = baseMappingWith(2);
     final DeltaOverlay empty = new DeltaOverlay(mapping.size());
+    final RID edgeRid = rid(10);
 
     final TxDelta firstDelete = new TxDelta();
-    firstDelete.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    firstDelete.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
     final DeltaOverlay afterFirst = empty.merge(firstDelete, mapping);
     assertThat(afterFirst.getDeltaEdgeCount()).isEqualTo(-1);
 
-    // Replay the exact same deletion in a subsequent transaction delta.
+    // Replay the exact same deletion (same edge identity) in a subsequent transaction delta.
     final TxDelta secondDelete = new TxDelta();
-    secondDelete.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    secondDelete.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
     final DeltaOverlay afterSecond = afterFirst.merge(secondDelete, mapping);
 
     // Before the fix this drifted to -2.
     assertThat(afterSecond.getDeltaEdgeCount()).isEqualTo(-1);
     assertThat(afterSecond.isEdgeDeleted(EDGE_TYPE, 0, 1)).isTrue();
+    assertThat(afterSecond.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
   }
 
   /**
@@ -80,13 +82,15 @@ class DeltaOverlayTest {
   void duplicateEdgeDeletionWithinSingleDeltaDecrementsOnce() {
     final NodeIdMapping mapping = baseMappingWith(2);
     final DeltaOverlay empty = new DeltaOverlay(mapping.size());
+    final RID edgeRid = rid(10);
 
     final TxDelta delta = new TxDelta();
-    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
-    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
 
     final DeltaOverlay merged = empty.merge(delta, mapping);
     assertThat(merged.getDeltaEdgeCount()).isEqualTo(-1);
+    assertThat(merged.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
   }
 
   /**
@@ -99,11 +103,39 @@ class DeltaOverlayTest {
     final DeltaOverlay empty = new DeltaOverlay(mapping.size());
 
     final TxDelta delta = new TxDelta();
-    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
-    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(2)));
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(2), rid(11)));
 
     final DeltaOverlay merged = empty.merge(delta, mapping);
     assertThat(merged.getDeltaEdgeCount()).isEqualTo(-2);
+  }
+
+  /**
+   * Issue #6769: two DISTINCT parallel edges between the SAME pair, each deleted, must each be
+   * counted - the pair alone cannot distinguish "one of two parallel edges deleted" from "the
+   * same edge reported twice". A boolean per-pair flag (the pre-fix representation) collapses
+   * both to the same answer, which then made {@code GraphAnalyticalView#copyBaseExcludingDeleted}
+   * exclude every parallel edge between the pair instead of just the ones actually deleted.
+   */
+  @Test
+  void distinctParallelEdgesBetweenSamePairAreCountedSeparately() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final DeltaOverlay empty = new DeltaOverlay(mapping.size());
+
+    final TxDelta delta = new TxDelta();
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(11)));
+
+    final DeltaOverlay merged = empty.merge(delta, mapping);
+    assertThat(merged.getDeltaEdgeCount()).isEqualTo(-2);
+    assertThat(merged.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(2);
+
+    // Replaying just one of the two deletions must not inflate the count further.
+    final TxDelta replayOne = new TxDelta();
+    replayOne.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    final DeltaOverlay afterReplay = merged.merge(replayOne, mapping);
+    assertThat(afterReplay.getDeltaEdgeCount()).isEqualTo(-2);
+    assertThat(afterReplay.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(2);
   }
 
   /**
@@ -113,20 +145,21 @@ class DeltaOverlayTest {
   void addThenDeleteNetsToZero() {
     final NodeIdMapping mapping = baseMappingWith(2);
     final DeltaOverlay empty = new DeltaOverlay(mapping.size());
+    final RID edgeRid = rid(10);
 
     final TxDelta addDelta = new TxDelta();
-    addDelta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    addDelta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
     final DeltaOverlay afterAdd = empty.merge(addDelta, mapping);
     assertThat(afterAdd.getDeltaEdgeCount()).isEqualTo(1);
 
     final TxDelta delDelta = new TxDelta();
-    delDelta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    delDelta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
     final DeltaOverlay afterDelete = afterAdd.merge(delDelta, mapping);
     assertThat(afterDelete.getDeltaEdgeCount()).isEqualTo(0);
 
     // Replaying the deletion must not push it negative.
     final TxDelta replay = new TxDelta();
-    replay.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1)));
+    replay.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
     final DeltaOverlay afterReplay = afterDelete.merge(replay, mapping);
     assertThat(afterReplay.getDeltaEdgeCount()).isEqualTo(0);
   }

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -5559,10 +5559,13 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
-   * The overlay keys a pending deletion on the (source, target) pair, so deleting one of several parallel
-   * edges masks all of them: {@code isConnectedTo} and {@code getNeighborIds} then report the pair as gone
-   * while the others remain. A count cannot absorb that the way a boolean can, because the caller turns it
-   * into rows, so the count says "unknown" and leaves the caller to walk the edge list (issue #5663).
+   * The overlay tracks a per-pair COUNT of deleted edges, not merely a deleted/not-deleted flag, so deleting
+   * one of several parallel edges leaves the others discoverable: {@code isConnectedTo} and
+   * {@code getNeighborIds} still report the surviving edges, only the deleted one is excluded (issue #6769 -
+   * before that fix, any deletion touching a pair masked every parallel edge between it). A count cannot
+   * absorb that the way a boolean or a neighbour list can, because the caller turns it into rows and an
+   * exact base-CSR-plus-overlay count would have to special-case every deletion combination; it says
+   * "unknown" instead and leaves the caller to walk the edge list (issue #5663).
    */
   @Test
   void countEdgesBetweenAnswersUnknownWhenTheOverlayMasksAPair() {
@@ -5600,11 +5603,13 @@ class GraphAnalyticalViewTest extends TestHelper {
       }
     database.commit();
 
-    // The pair is masked, so the view cannot say how many survive and says so...
+    // countEdgesBetween cannot state the exact survivor count, so it says so...
     assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isNegative();
-    // ...which is the honest form of what the boolean and the neighbour list already report
-    assertThat(gav.isConnectedTo(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isFalse();
-    assertThat(gav.getNeighborIds(idA, Vertex.DIRECTION.OUT, "PAID")).doesNotContain(idB);
+    // ...but the pair is still connected via its two surviving parallel edges, and both are still
+    // discoverable - only the deleted one is excluded, not the whole pair
+    assertThat(gav.isConnectedTo(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isTrue();
+    // A's PAID out-neighbours: 2 surviving A->B edges plus the untouched A->C edge
+    assertThat(gav.getNeighborIds(idA, Vertex.DIRECTION.OUT, "PAID")).containsExactlyInAnyOrder(idB, idB, idC);
 
     // a pair the deletion did not touch still answers exactly
     assertThat(gav.countEdgesBetween(idA, idC, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(1);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
@@ -67,7 +67,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Roberto Franchini (r.franchini@arcadedata.com)
  */
-@Tag("slow")
+// Spends most of its time waiting on the async rebuild LSMVectorIndex.REBUILD_SEMAPHORE serializes
+// JVM-wide (see CLAUDE.md's @Tag("vector") note) - the vector lane is where that convoy costs nobody
+// else anything; the slow lane still has other REBUILD_SEMAPHORE waiters this one would convoy against.
+@Tag("vector")
 class Issue6655StaleGraphPrefixReuseTest {
   private static final String DB_ROOT         = "target/test-databases/Issue6655StaleGraphPrefixReuseTest";
   private static final int    DIMENSIONS      = 128;


### PR DESCRIPTION
## What does this PR do?

Fixes `GraphAnalyticalView`'s delta overlay so deleting one of several parallel edges between the same pair of vertices no longer masks the survivors from `getNeighborIds`/`getVertices` (the `GAVExpandAll` Cypher operator) and `isConnectedTo`. Also retags `Issue6655StaleGraphPrefixReuseTest` from `@Tag("slow")` to `@Tag("vector")`.

## Motivation

Triaging a red `main` CI run (https://github.com/ArcadeData/arcadedb/actions/runs/32960831041) surfaced a flaky failure in `CypherGAVBoundTargetCardinalityTest.theViewFallsBackToTheEdgeListWhenADeletionMasksThePair` (`unit-tests` job) and a timeout in `Issue6655StaleGraphPrefixReuseTest` (`slow-unit-tests` job).

Root cause of the first: `DeltaOverlay` tracked a pending edge deletion keyed on `(edgeType, source, target)` only - a presence flag, not a count. When a pair is joined by two parallel edges and only one is deleted (SYNCHRONOUS update mode), every reader other than `GAVExpandInto`'s `countEdgesBetween` (which deliberately answers "unknown" for a masked pair and falls back to the OLTP edge list) treated the *whole pair* as gone. The Cypher test is flaky rather than deterministically red because the optimizer only sometimes selects the affected operator for a given hop; reproduced reliably (~10-20% of runs) by running the test alongside other `algo.*` tests in the same JVM, confirmed 20/20 green after the fix.

Fix: `TxDelta.EdgeDelta` now carries the edge's own RID, letting `DeltaOverlay` distinguish "the same edge reported deleted twice" (replayed across merges, or emitted twice within one `TxDelta` - must not double-count, issue #4587) from "two distinct parallel edges deleted" (must each count). `deletedEdgesPerType` became an exact per-pair deletion **count** (`Map<String, Map<Long,Integer>>`) instead of a `Set`. `GraphAnalyticalView.copyBaseExcludingDeleted` and `isConnectedForType` now compare the base CSR's occurrence count for a pair against that exact deleted count, excluding only the edges actually gone. `countEdgesBetween`/`countBetweenForType` are deliberately unchanged (still answers "unknown", the existing OLTP fallback is already correct) to keep the change minimal.

The second fix is a mistagging: `Issue6655StaleGraphPrefixReuseTest` spends most of its time waiting (up to 60s) on an async vector-graph rebuild serialized by the JVM-wide `LSMVectorIndex.REBUILD_SEMAPHORE` - exactly the scenario CLAUDE.md's `@Tag("vector")` convention exists for - but was tagged only `@Tag("slow")`, so it convoyed against other slow-lane tests waiting on the same semaphore instead of running in the isolated vector lane.

A second, riding-along correctness fix (found by review): `DeltaOverlay.buildDeletedEdgeCounts` switched from `counts.increment(nodeId)` (once per distinct pair) to `counts.add(nodeId, pairEntry.getValue())` (once per actual deleted edge). This also fixes a latent undercount in `countDeletedOutEdges`/`countDeletedInEdges`, which feed the per-node degree calculations in `GraphAnalyticalView.getDegrees`, whenever 2+ of several parallel edges between the same pair were deleted.

## Related issues

Fixes #6769.

Also investigated the `ha-integration-tests` failures from the same CI run (5 unrelated Raft ITs, heterogeneous symptoms) but did not attempt a fix - filed as #6770 instead, referencing the closed #5668 which covers the same "different test each time" pattern.

Two more follow-ups filed during review, both verified reachable but deliberately kept out of this PR's scope:
- #6775 - the overlay's ADDED-edge neighbor indexes (`getAddedOutNeighbors`/`getAddedInNeighbors`) are not filtered against `deletedEdgesPerType`, so an edge created and deleted within the same overlay window before compaction still shows as a live neighbor via `getNeighborIds`/`isConnectedTo`. Pre-existing, not introduced by this fix.
- #6777 - `DeltaOverlay`'s new RID-keyed deletion dedup (`deletedEdgeRIDsPerType`) assumes an edge's RID is never reused while it sits in that set, but `LocalBucket` deliberately reuses a slot freed by a delete for a later insert ("hole reuse", #5279). Bounded by the same compaction trigger #4587 gates on (so not unbounded), but reachable within one compaction window (default 10,000 net edge deltas) on a busy edge type.

## Additional Notes

- Existing `GraphAnalyticalViewTest.countEdgesBetweenAnswersUnknownWhenTheOverlayMasksAPair` had encoded the pre-fix behavior as intentional ("deleting one of several parallel edges masks all of them... which is what `isConnectedTo` and `getNeighborIds` do"); updated its assertions and docstring to the corrected, precise behavior.
- New regression tests: `DeltaOverlayTest.distinctParallelEdgesBetweenSamePairAreCountedSeparately` and `DeltaOverlayCompactionDedupTest.deleteThenReAddOneOfSeveralParallelEdgesDuringCompactionReplayStaysExact` (the latter added in review to pin that the compaction-replay masking logic composes correctly with the new exact-count tracking even with several parallel edges - confirmed correct on the first try, no code change needed).
- Four sibling vector tests have the same latent `@Tag("slow")` mistagging risk (`Issue6067DeferredCloseRebuildTest`, `Issue6657CloseTimeRebuildPendingStatTest`, `LSMVectorIndexCloseCancelsInFlightBuildTest`, `Issue6713EnsureGraphAvailableUnlockedValidationTest`) - left untouched to keep this PR scoped; worth a follow-up.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph analytics when deleting parallel edges.
  * Preserved remaining connections when only some duplicate edges are removed.
  * Prevented repeated deletion events from incorrectly reducing edge counts.
  * Improved neighbor filtering and connectivity results after edge updates.
  * Ensured edge additions and deletions are tracked accurately across transactions.
* **Tests**
  * Added regression coverage for duplicate, parallel-edge, and delete/re-add scenarios.
  * Updated vector index test classification and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
