### PR TITLE
fix(redis): use JSONArray(String) for bracketed composite keys in HMGET

### DIFF
--- a/redisw/src/main/java/com/arcadedb/redis/RedisIndexKeys.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisIndexKeys.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import com.arcadedb.serializer.json.JSONArray;
+
+/**
+ * Parses the textual key an index lookup arrives with over the Redis wire protocol (HGET / HMGET / HEXISTS / HDEL)
+ * and over the {@code redis} query language, in the ONE place both share.
+ * <p>
+ * It used to be copy/pasted per call site instead, and the copies drifted: the {@code HMGET} copy cast the key to
+ * {@code String[]} rather than parsing it, so every bracketed composite key answered with a
+ * {@code ClassCastException} (#6757) while its {@code HGET} sibling answered with the record.
+ * <p>
+ * Three key shapes are accepted:
+ * <ul>
+ *   <li>{@code [v1,v2]} - a JSON array, i.e. the composite key of a multi-property index;</li>
+ *   <li>{@code "v"} - a quoted single value, for a value that would otherwise look like one of the other shapes;</li>
+ *   <li>{@code v} - a bare single value.</li>
+ * </ul>
+ * Every component is handed to the index as it was written. Narrowing it to the property's declared type is the
+ * index's own job ({@code LSMTreeIndexAbstract.convertKeysToDeclaredTypes}), and doing it here instead would be
+ * strictly worse: this layer knows the key's characters but not the type they are a key FOR, so it can only guess
+ * - and a guess turns the {@code STRING} key {@code "007"} into the {@code Long} {@code 7} that no longer finds
+ * its record, and the 30-digit one into an uncaught {@code NumberFormatException}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class RedisIndexKeys {
+  private RedisIndexKeys() {
+  }
+
+  /**
+   * @param key the key exactly as the client wrote it
+   *
+   * @return the index key components, one entry per indexed property
+   *
+   * @throws RedisException if the key is a malformed or empty JSON array
+   */
+  public static Object[] parse(final String key) {
+    if (key.isEmpty())
+      return new Object[] { key };
+
+    if (key.charAt(0) == '[') {
+      final Object[] compositeKey;
+      try {
+        compositeKey = new JSONArray(key).toList().toArray();
+      } catch (final Exception e) {
+        throw new RedisException("Composite index key '" + key + "' is not a valid JSON array. Example: [\"John\",\"Doe\"]", e);
+      }
+      if (compositeKey.length == 0)
+        throw new RedisException("Composite index key '" + key + "' is empty. Example: [\"John\",\"Doe\"]");
+      return compositeKey;
+    }
+
+    // A LONE OR UNTERMINATED QUOTE IS PART OF THE VALUE, NOT A QUOTING OF IT: STRIPPING BOTH ENDS REGARDLESS WOULD
+    // EITHER THROW (KEY `"`) OR SILENTLY DROP THE LAST CHARACTER (KEY `"abc`)
+    if (key.length() > 1 && key.charAt(0) == '"' && key.charAt(key.length() - 1) == '"')
+      return new Object[] { key.substring(1, key.length() - 1) };
+
+    return new Object[] { key };
+  }
+}

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -32,7 +32,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalEdgeType;
 import com.arcadedb.schema.LocalVertexType;
 import com.arcadedb.schema.Type;
-import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.network.PreAuthConnectionGate;
@@ -501,15 +500,7 @@ public class RedisNetworkExecutor extends Thread {
         for (int i = 2; i < list.size(); i++) {
           final String key = (String) list.get(i);
 
-          final Object[] keys;
-          if (key.startsWith("[")) {
-            keys = new JSONArray(key).toList().toArray();
-          } else if (key.startsWith("\"")) {
-            keys = new String[]{key.substring(1, key.length() - 1)};
-          } else
-            keys = new String[]{key};
-
-          final IndexCursor cursor = index.get(keys);
+          final IndexCursor cursor = index.get(RedisIndexKeys.parse(key));
           if (cursor.hasNext()) {
             cursor.next().getRecord().delete();
             deleted[0]++;
@@ -1244,15 +1235,7 @@ public class RedisNetworkExecutor extends Thread {
 
       final Index index = database.getSchema().getIndexByName(keyType);
 
-      final Object[] keys;
-      if (key.startsWith("[")) {
-        keys = new JSONArray(key).toList().toArray();
-      } else if (key.startsWith("\"")) {
-        keys = new String[]{key.substring(1, key.length() - 1)};
-      } else
-        keys = new String[]{key};
-
-      final IndexCursor cursor = index.get(keys);
+      final IndexCursor cursor = index.get(RedisIndexKeys.parse(key));
       record = cursor.hasNext() ? cursor.next().asDocument() : null;
     }
     return record;
@@ -1295,16 +1278,7 @@ public class RedisNetworkExecutor extends Thread {
       final Index index = database.getSchema().getIndexByName(keyType);
 
       for (final Object key : keys) {
-        final String k = key.toString();
-        final Object[] compositeKey;
-        if (k.startsWith("[")) {
-          compositeKey = new JSONArray(k).toList().toArray();
-        } else if (k.startsWith("\"")) {
-          compositeKey = new String[]{k.substring(1, k.length() - 1)};
-        } else
-          compositeKey = new String[]{k};
-
-        final IndexCursor cursor = index.get(compositeKey);
+        final IndexCursor cursor = index.get(RedisIndexKeys.parse(key.toString()));
         records.add(cursor.hasNext() ? cursor.next().asDocument() : null);
       }
     }

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -1298,7 +1298,7 @@ public class RedisNetworkExecutor extends Thread {
         final String k = key.toString();
         final Object[] compositeKey;
         if (k.startsWith("[")) {
-          compositeKey = new JSONArray((String[]) key).toList().toArray();
+          compositeKey = new JSONArray(k).toList().toArray();
         } else if (k.startsWith("\"")) {
           compositeKey = new String[]{k.substring(1, k.length() - 1)};
         } else

--- a/redisw/src/main/java/com/arcadedb/redis/query/RedisQueryEngine.java
+++ b/redisw/src/main/java/com/arcadedb/redis/query/RedisQueryEngine.java
@@ -37,11 +37,11 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.redis.RedisException;
+import com.arcadedb.redis.RedisIndexKeys;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalEdgeType;
 import com.arcadedb.schema.LocalVertexType;
 import com.arcadedb.schema.Type;
-import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.NumberUtils;
 
@@ -603,7 +603,7 @@ public class RedisQueryEngine implements QueryEngine {
 
         for (int i = 2; i < parts.size(); i++) {
           final String key = parts.get(i);
-          final Object[] keys = parseIndexKey(key);
+          final Object[] keys = RedisIndexKeys.parse(key);
           final IndexCursor cursor = index.get(keys);
           if (cursor.hasNext()) {
             cursor.next().getRecord().delete();
@@ -618,22 +618,9 @@ public class RedisQueryEngine implements QueryEngine {
 
   private Record getRecordByIndex(final String indexName, final String key) {
     final Index index = database.getSchema().getIndexByName(indexName);
-    final Object[] keys = parseIndexKey(key);
+    final Object[] keys = RedisIndexKeys.parse(key);
     final IndexCursor cursor = index.get(keys);
     return cursor.hasNext() ? cursor.next().asDocument() : null;
   }
 
-  private Object[] parseIndexKey(final String key) {
-    if (key.startsWith("[")) {
-      return new JSONArray(key).toList().toArray();
-    } else if (key.startsWith("\"")) {
-      return new String[]{key.substring(1, key.length() - 1)};
-    } else {
-      // Try to parse as number first, then fallback to string
-      if (NumberUtils.isIntegerNumber(key)) {
-        return new Object[]{Long.parseLong(key)};
-      }
-      return new String[]{key};
-    }
-  }
 }

--- a/redisw/src/test/java/com/arcadedb/redis/RedisCompositeIndexKeyTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisCompositeIndexKeyTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Every index lookup the Redis wire protocol and the {@code redis} query language serve - HGET, HMGET, HEXISTS,
+ * HDEL - reads the key through the same {@link RedisIndexKeys#parse(String)}, so a key shape that works for one
+ * of them works for all of them.
+ * <p>
+ * It did not use to: the four call sites each carried their own copy of the parsing and the copies drifted.
+ * HMGET's cast the key to {@code String[]} instead of parsing it, so a bracketed composite key came back as a
+ * {@code ClassCastException} while HGET on the very same index and key came back with the record (#6757), and the
+ * query language's narrowed a numeric-looking key to a {@code Long} before the index could narrow it to the
+ * property's ACTUAL declared type, losing the record behind a {@code STRING} key like {@code 007}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/6757">Issue #6757</a>
+ */
+public class RedisCompositeIndexKeyTest extends BaseGraphServerTest {
+
+  private static final int DEF_PORT = GlobalConfiguration.REDIS_PORT.getValueAsInteger();
+
+  @Test
+  void hmgetReadsABracketedCompositeKeyJustLikeHget() {
+    try (final Jedis jedis = newClient()) {
+      createAccounts(10);
+
+      final String index = getDatabaseName() + ".CompositeAccount[firstName,lastName]";
+
+      // #6757: THIS IS THE COMBINATION THAT THREW ClassCastException
+      final List<String> single = jedis.hmget(index, "[\"first_3\",\"last_3\"]");
+      assertThat(single).hasSize(1);
+      assertAccount(single.get(0), 3);
+
+      // HMGET'S WHOLE POINT IS MORE THAN ONE KEY, AND A MISSING ONE MUST STILL HOLD ITS POSITION IN THE REPLY
+      final List<String> many = jedis.hmget(index, "[\"first_1\",\"last_1\"]", "[\"nobody\",\"here\"]", "[\"first_7\",\"last_7\"]");
+      assertThat(many).hasSize(3);
+      assertAccount(many.get(0), 1);
+      assertThat(many.get(1)).isNull();
+      assertAccount(many.get(2), 7);
+
+      // THE SINGLE-KEY SIBLING THAT ALWAYS WORKED, PINNED SO THE TWO CANNOT DRIFT APART AGAIN
+      assertAccount(jedis.hget(index, "[\"first_3\",\"last_3\"]"), 3);
+      assertThat(jedis.hexists(index, "[\"first_3\",\"last_3\"]")).isTrue();
+      assertThat(jedis.hexists(index, "[\"nobody\",\"here\"]")).isFalse();
+
+      assertThat(jedis.hdel(index, "[\"first_0\",\"last_0\"]", "[\"first_9\",\"last_9\"]")).isEqualTo(2);
+      assertThat(jedis.hexists(index, "[\"first_0\",\"last_0\"]")).isFalse();
+    }
+  }
+
+  @Test
+  void aNumericLookingStringKeyKeepsItsExactCharacters() {
+    try (final Jedis jedis = newClient()) {
+      final Database database = getServerDatabase(0, getDatabaseName());
+      database.command("sqlscript", """
+          CREATE DOCUMENT TYPE Badge;\
+          CREATE PROPERTY Badge.code STRING;\
+          CREATE INDEX ON Badge (code) UNIQUE;""");
+
+      // 007 AND THE 30-DIGIT ONE ARE BOTH VALID STRING KEYS, AND NEITHER SURVIVES BEING GUESSED INTO A Long
+      final String hugeCode = "123456789012345678901234567890";
+      for (final String code : new String[] { "007", "7", hugeCode })
+        jedis.hset(getDatabaseName(), "Badge", "{\"code\":\"" + code + "\"}");
+
+      final String index = getDatabaseName() + ".Badge[code]";
+      assertThat(new JSONObject(jedis.hget(index, "007")).getString("code")).isEqualTo("007");
+      assertThat(new JSONObject(jedis.hget(index, "7")).getString("code")).isEqualTo("7");
+      assertThat(new JSONObject(jedis.hget(index, hugeCode)).getString("code")).isEqualTo(hugeCode);
+
+      // ...INCLUDING THROUGH THE `redis` QUERY LANGUAGE, WHICH USED TO DO EXACTLY THAT GUESS
+      assertThat(firstCode(database, "HGET Badge[code] 007")).isEqualTo("007");
+      assertThat(firstCode(database, "HGET Badge[code] 7")).isEqualTo("7");
+      assertThat(firstCode(database, "HGET Badge[code] " + hugeCode)).isEqualTo(hugeCode);
+
+      // AND A LONG KEY IS STILL FOUND BY ITS PLAIN DECIMAL TEXT: NARROWING IS THE INDEX'S JOB, NOT THE PARSER'S
+      database.command("sqlscript", """
+          CREATE DOCUMENT TYPE Ticket;\
+          CREATE PROPERTY Ticket.id LONG;\
+          CREATE INDEX ON Ticket (id) UNIQUE;""");
+      jedis.hset(getDatabaseName(), "Ticket", "{\"id\":42}");
+      assertThat(new JSONObject(jedis.hget(getDatabaseName() + ".Ticket[id]", "42")).getInt("id")).isEqualTo(42);
+    }
+  }
+
+  @Test
+  void aMalformedCompositeKeyIsAnErrorReplyNotACrash() {
+    try (final Jedis jedis = newClient()) {
+      createAccounts(1);
+
+      final String index = getDatabaseName() + ".CompositeAccount[firstName,lastName]";
+
+      for (final String badKey : new String[] { "[\"first_0\"", "[]" })
+        assertThatThrownBy(() -> jedis.hmget(index, badKey)).isInstanceOf(JedisDataException.class)
+            .hasMessageContaining("Composite index key");
+
+      // A LONE QUOTE IS A ONE-CHARACTER VALUE, NOT AN UNTERMINATED QUOTING: IT MUST NOT BLOW UP THE CONNECTION
+      assertThat(jedis.hmget(getDatabaseName() + ".CompositeAccount[firstName]", "\"")).containsExactly((String) null);
+    }
+  }
+
+  private void createAccounts(final int total) {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    database.command("sqlscript", """
+        CREATE DOCUMENT TYPE CompositeAccount;\
+        CREATE PROPERTY CompositeAccount.firstName STRING;\
+        CREATE PROPERTY CompositeAccount.lastName STRING;\
+        CREATE INDEX ON CompositeAccount (firstName, lastName) UNIQUE;\
+        CREATE INDEX ON CompositeAccount (firstName) NOTUNIQUE;""");
+
+    try (final Jedis jedis = newClient()) {
+      for (int i = 0; i < total; ++i)
+        jedis.hset(getDatabaseName(), "CompositeAccount", "{\"firstName\":\"first_" + i + "\",\"lastName\":\"last_" + i + "\"}");
+    }
+  }
+
+  private static void assertAccount(final String json, final int i) {
+    assertThat(json).isNotNull();
+    final JSONObject doc = new JSONObject(json);
+    assertThat(doc.getString("firstName")).isEqualTo("first_" + i);
+    assertThat(doc.getString("lastName")).isEqualTo("last_" + i);
+  }
+
+  private static String firstCode(final Database database, final String redisCommand) {
+    try (final ResultSet rs = database.query("redis", redisCommand)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("code");
+    }
+  }
+
+  private Jedis newClient() {
+    final Jedis jedis = new Jedis("localhost", DEF_PORT);
+    jedis.auth("root", DEFAULT_PASSWORD_FOR_TESTS);
+    return jedis;
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Redis Protocol:com.arcadedb.redis.RedisProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+}

--- a/redisw/src/test/java/com/arcadedb/redis/RedisWTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisWTest.java
@@ -237,21 +237,6 @@ public class RedisWTest extends BaseGraphServerTest {
     System.out.println(
         "HMGET " + TOTAL_PERSISTENT + " items by chunks of 10 rids from the database. Elapsed " + (System.currentTimeMillis() - beginTime) + "ms");
 
-    // HMGET BY COMPOSITE INDEX KEY (bracketed composite key)
-    database.command("sqlscript",
-        "CREATE DOCUMENT TYPE CompositeAccount;" +//
-        "CREATE PROPERTY CompositeAccount.firstName STRING;" +//
-        "CREATE PROPERTY CompositeAccount.lastName STRING;" +//
-        "CREATE INDEX ON CompositeAccount (firstName, lastName) UNIQUE;");
-    for (int i = 0; i < 10; ++i)
-      jedis.hset(getDatabaseName(), "CompositeAccount", "{'firstName':'first_" + i + "','lastName':'last_" + i + "'}");
-
-    final List<String> compositeResult = jedis.hmget(getDatabaseName() + ".CompositeAccount[firstName,lastName]", "[\"first_3\",\"last_3\"]");
-    assertThat(compositeResult).hasSize(1);
-    assertThat(compositeResult.get(0)).isNotNull();
-    assertThat(new JSONObject(compositeResult.get(0)).getString("firstName")).isEqualTo("first_3");
-    assertThat(new JSONObject(compositeResult.get(0)).getString("lastName")).isEqualTo("last_3");
-
     // HDEL
     beginTime = System.currentTimeMillis();
     for (int i = 0; i < TOTAL_PERSISTENT; i += 2) {

--- a/redisw/src/test/java/com/arcadedb/redis/RedisWTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisWTest.java
@@ -237,6 +237,21 @@ public class RedisWTest extends BaseGraphServerTest {
     System.out.println(
         "HMGET " + TOTAL_PERSISTENT + " items by chunks of 10 rids from the database. Elapsed " + (System.currentTimeMillis() - beginTime) + "ms");
 
+    // HMGET BY COMPOSITE INDEX KEY (bracketed composite key)
+    database.command("sqlscript",
+        "CREATE DOCUMENT TYPE CompositeAccount;" +//
+        "CREATE PROPERTY CompositeAccount.firstName STRING;" +//
+        "CREATE PROPERTY CompositeAccount.lastName STRING;" +//
+        "CREATE INDEX ON CompositeAccount (firstName, lastName) UNIQUE;");
+    for (int i = 0; i < 10; ++i)
+      jedis.hset(getDatabaseName(), "CompositeAccount", "{'firstName':'first_" + i + "','lastName':'last_" + i + "'}");
+
+    final List<String> compositeResult = jedis.hmget(getDatabaseName() + ".CompositeAccount[firstName,lastName]", "[\"first_3\",\"last_3\"]");
+    assertThat(compositeResult).hasSize(1);
+    assertThat(compositeResult.get(0)).isNotNull();
+    assertThat(new JSONObject(compositeResult.get(0)).getString("firstName")).isEqualTo("first_3");
+    assertThat(new JSONObject(compositeResult.get(0)).getString("lastName")).isEqualTo("last_3");
+
     // HDEL
     beginTime = System.currentTimeMillis();
     for (int i = 0; i < TOTAL_PERSISTENT; i += 2) {


### PR DESCRIPTION
Fixes #6757

## Problem

`HMGET <db>.<compositeIndex> "[v1,v2]"` throws `ClassCastException` instead of
returning the record. The `getRecords()` path in `RedisNetworkExecutor`
builds the composite key with:

```java
compositeKey = new JSONArray((String[]) key).toList().toArray();
```

The incoming `key` is an `Object` holding a `String` (e.g. `"[v1,v2]"`), so
the cast to `String[]` fails at runtime. The single-key sibling `getRecord()`
(`new JSONArray(key)`) and `RedisQueryEngine.parseIndexKey()` both use the
`JSONArray(String)` constructor, which parses the bracketed key correctly.

## Fix

```java
compositeKey = new JSONArray(k).toList().toArray();
```

(`k` is `key.toString()`), matching `getRecord()` and `parseIndexKey()`.

## Test

Added a composite-index HMGET regression to `RedisWTest.persistentCommands()`:
creates a `CompositeAccount[firstName,lastName]` composite index, inserts 10
documents, and runs `HMGET` with the bracketed key `["first_3","last_3"]`
asserting the returned document. Fails on the old code with
ClassCastException, passes with the fix.

## Co-authored

Issue reporter @ruispereira identified the exact location and provided the
repro in #6757.

Signed-off-by: waterWang <waterWang@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of composite Redis index keys across record lookups, hash commands, and Redis queries.
  * Preserved numeric-looking values as strings when appropriate.
  * Added clearer errors for malformed or empty composite keys.
* **Tests**
  * Added coverage for composite-key operations, numeric and LONG index lookups, and invalid key formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->