### PR TITLE
fix(#6770): a resync-closed database answers 503, not a hard 500

### DIFF
--- a/docs/review-deferred-7a3eabf.md
+++ b/docs/review-deferred-7a3eabf.md
@@ -1,0 +1,31 @@
+# Review notes deferred from cycle 2 (base commit 7a3eabfd0d)
+
+`claude` reviewed commit `7a3eabfd0d9f23d600ac4be9c7236c84c83ba713`. One actionable finding was applied
+directly (see the commit on top of this note); the "main concern" below was deferred to a follow-up issue
+rather than fixed in this review cycle.
+
+## Deferred: 503 mapping for `DatabaseIsClosedException` is broader than the resync race it fixes
+
+`claude`'s review pointed out that `AbstractServerHttpHandler.sendMappedErrorResponse`'s new arm maps
+*every* `DatabaseIsClosedException` to 503, not only the HA snapshot-reinstall resync race this PR targets
+(#6770). `LocalDatabase.checkDatabaseIsOpen()` throws the same exception type for any operation on a
+closed database, including a concurrent `DROP DATABASE`/close admin action - which is a *permanent* close,
+not transient. Verified against the code: `PostServerCommandHandler.dropDatabase()`'s non-HA branch and
+`closeDatabase()` do not hold `databasesLock` across their close/remove sequence the way
+`SnapshotInstaller.swapAndReopen` deliberately does, so an in-flight request can race a permanent close the
+same way it races a resync. The client's automatic retry then re-resolves the database with
+`allowLoad=false`, which throws `DatabaseOperationException` once the registry entry is gone - unmapped, so
+it falls to the generic 500 this PR did not change for that path.
+
+**Why deferred, not fixed here:** distinguishing "transient resync" from "permanent close" needs a signal
+that does not exist yet. `ArcadeDBServer.isSnapshotInstallInProgress()` looked like a candidate but covers a
+different, whole-server snapshot-install condition (already consulted at request entry in this same file,
+line ~252) - reusing it for the per-database resync-reinstall case (#5977 pattern) needs verification it is
+semantically correct, which is more design work than a review-response cycle should absorb unattended. Filed
+as https://github.com/ArcadeData/arcadedb/issues/6778 with both candidate approaches from the review.
+
+## Applied, not deferred
+
+- Extracted `sendRetryableResponse(exchange, throwable)` to remove the near-duplicate log+503-response code
+  between the `NeedRetryException` and `DatabaseIsClosedException` arms (claude, "Minor" note, cycle 2).
+- Added a pointer comment at the `DatabaseIsClosedException` arm referencing issue #6778.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCommandReadConsistencyIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCommandReadConsistencyIT.java
@@ -70,7 +70,7 @@ class RaftCommandReadConsistencyIT extends BaseRaftHATest {
     try {
       RaftReplicatedDatabase.applyReadConsistencyContext(
           Database.READ_CONSISTENCY.READ_YOUR_WRITES, bookmark);
-      final long count = withResyncRetry(followerIndex, db -> {
+      final long count = withResyncRetry(followerIndex, (final Database db) -> {
         final var rs = db.command("sql", "SELECT count(*) as cnt FROM CmdCtx");
         assertThat(rs.hasNext()).isTrue();
         return ((Number) rs.next().getProperty("cnt")).longValue();
@@ -84,7 +84,7 @@ class RaftCommandReadConsistencyIT extends BaseRaftHATest {
     try {
       RaftReplicatedDatabase.applyReadConsistencyContext(
           Database.READ_CONSISTENCY.LINEARIZABLE, -1);
-      final long count = withResyncRetry(followerIndex, db -> {
+      final long count = withResyncRetry(followerIndex, (final Database db) -> {
         final var rs = db.command("sql", "SELECT count(*) as cnt FROM CmdCtx");
         assertThat(rs.hasNext()).isTrue();
         return ((Number) rs.next().getProperty("cnt")).longValue();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCommandReadConsistencyIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCommandReadConsistencyIT.java
@@ -61,15 +61,20 @@ class RaftCommandReadConsistencyIT extends BaseRaftHATest {
 
     final long bookmark = leaderRaft.getLastAppliedIndex();
 
-    final Database followerDb = getServerDatabase(followerIndex, getDatabaseName());
+    // Each read below is resolved through withResyncRetry rather than a Database handle captured once (see its
+    // javadoc): an HA snapshot-reinstall resync (issue #5977 pattern) can close and reinstall the follower's
+    // database in the gap between resolving a handle and this read reaching it, which surfaced as a flaky
+    // DatabaseIsClosedException rather than a defect in the read-consistency behaviour under test (issue #6770).
 
     // READ_YOUR_WRITES via command(): the barrier must wait until the follower applied the bookmark.
     try {
       RaftReplicatedDatabase.applyReadConsistencyContext(
           Database.READ_CONSISTENCY.READ_YOUR_WRITES, bookmark);
-      final var rs = followerDb.command("sql", "SELECT count(*) as cnt FROM CmdCtx");
-      assertThat(rs.hasNext()).isTrue();
-      final long count = rs.next().getProperty("cnt");
+      final long count = withResyncRetry(followerIndex, db -> {
+        final var rs = db.command("sql", "SELECT count(*) as cnt FROM CmdCtx");
+        assertThat(rs.hasNext()).isTrue();
+        return ((Number) rs.next().getProperty("cnt")).longValue();
+      });
       assertThat(count).as("READ_YOUR_WRITES command() read must see all 25 committed rows").isEqualTo(25);
     } finally {
       RaftReplicatedDatabase.removeReadConsistencyContext();
@@ -79,9 +84,11 @@ class RaftCommandReadConsistencyIT extends BaseRaftHATest {
     try {
       RaftReplicatedDatabase.applyReadConsistencyContext(
           Database.READ_CONSISTENCY.LINEARIZABLE, -1);
-      final var rs = followerDb.command("sql", "SELECT count(*) as cnt FROM CmdCtx");
-      assertThat(rs.hasNext()).isTrue();
-      final long count = rs.next().getProperty("cnt");
+      final long count = withResyncRetry(followerIndex, db -> {
+        final var rs = db.command("sql", "SELECT count(*) as cnt FROM CmdCtx");
+        assertThat(rs.hasNext()).isTrue();
+        return ((Number) rs.next().getProperty("cnt")).longValue();
+      });
       assertThat(count).as("LINEARIZABLE command() read must see all 25 committed rows").isEqualTo(25);
     } finally {
       RaftReplicatedDatabase.removeReadConsistencyContext();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCommandReadConsistencyIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCommandReadConsistencyIT.java
@@ -73,6 +73,9 @@ class RaftCommandReadConsistencyIT extends BaseRaftHATest {
       final long count = withResyncRetry(followerIndex, (final Database db) -> {
         final var rs = db.command("sql", "SELECT count(*) as cnt FROM CmdCtx");
         assertThat(rs.hasNext()).isTrue();
+        // Number, not long: the lambda's inferred return type doesn't narrow the property's declared Object
+        // type the way a directly-typed local assignment would, so an unguarded unbox risks a ClassCastException
+        // if the aggregate ever comes back as Integer instead of Long.
         return ((Number) rs.next().getProperty("cnt")).longValue();
       });
       assertThat(count).as("READ_YOUR_WRITES command() read must see all 25 committed rows").isEqualTo(25);
@@ -87,6 +90,9 @@ class RaftCommandReadConsistencyIT extends BaseRaftHATest {
       final long count = withResyncRetry(followerIndex, (final Database db) -> {
         final var rs = db.command("sql", "SELECT count(*) as cnt FROM CmdCtx");
         assertThat(rs.hasNext()).isTrue();
+        // Number, not long: the lambda's inferred return type doesn't narrow the property's declared Object
+        // type the way a directly-typed local assignment would, so an unguarded unbox risks a ClassCastException
+        // if the aggregate ever comes back as Integer instead of Long.
         return ((Number) rs.next().getProperty("cnt")).longValue();
       });
       assertThat(count).as("LINEARIZABLE command() read must see all 25 committed rows").isEqualTo(25);

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -671,6 +671,20 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       return;
     }
 
+    // 503: an HA snapshot-reinstall resync (issue #5977 pattern) closed and reinstalled the database out from
+    // under a handle a request had already resolved (or resolved while one was in flight). The condition is
+    // transient by construction - a handle resolved a moment later sees the reinstalled database - so it must be
+    // reported the same retryable way a Raft conflict already is, instead of the opaque 500 it fell through to
+    // before, which RemoteHttpComponent's NeedRetryException-driven auto-retry never saw (issue #6770).
+    final DatabaseIsClosedException databaseClosed = firstOf(e, cause, DatabaseIsClosedException.class);
+    if (databaseClosed != null) {
+      LogManager.instance()
+              .log(this, Level.FINE, "Error on command execution (%s): %s", getClass().getSimpleName(),
+                      databaseClosed.getMessage());
+      sendErrorResponse(exchange, 503, "Cannot execute command", databaseClosed, null);
+      return;
+    }
+
     final RecordNotFoundException notFound = firstOf(e, cause, RecordNotFoundException.class);
     if (notFound != null) {
       logUserError(notFound);

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -664,10 +664,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // auto-commit wrapper as well since #6201, which is where the engine raises most of them.
     final NeedRetryException retryable = firstOf(e, cause, NeedRetryException.class);
     if (retryable != null) {
-      LogManager.instance()
-              .log(this, Level.FINE, "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      retryable.getMessage());
-      sendErrorResponse(exchange, 503, "Cannot execute command", retryable, null);
+      sendRetryableResponse(exchange, retryable);
       return;
     }
 
@@ -676,12 +673,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // transient by construction - a handle resolved a moment later sees the reinstalled database - so it must be
     // reported the same retryable way a Raft conflict already is, instead of the opaque 500 it fell through to
     // before, which RemoteHttpComponent's NeedRetryException-driven auto-retry never saw (issue #6770).
+    //
+    // Scope: this maps EVERY DatabaseIsClosedException to 503, not only the resync race above. A concurrent
+    // DROP/CLOSE DATABASE admin action throws the same exception type on a still in-flight request, and that
+    // close is permanent rather than transient - a retry costs one wasted round trip before falling through to
+    // the same generic 500 this mapping did not change for that path. Distinguishing the two cases needs a
+    // resync-vs-permanent-close signal that does not exist yet - see issue #6778.
     final DatabaseIsClosedException databaseClosed = firstOf(e, cause, DatabaseIsClosedException.class);
     if (databaseClosed != null) {
-      LogManager.instance()
-              .log(this, Level.FINE, "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      databaseClosed.getMessage());
-      sendErrorResponse(exchange, 503, "Cannot execute command", databaseClosed, null);
+      sendRetryableResponse(exchange, databaseClosed);
       return;
     }
 
@@ -830,6 +830,18 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     if (type.isInstance(cause))
       return type.cast(cause);
     return null;
+  }
+
+  /**
+   * Sends a 503 for a failure the caller can retry as-is - a Raft conflict or a resync race, both transient by
+   * construction. Shared by the {@link NeedRetryException} and {@link DatabaseIsClosedException} arms of
+   * {@link #sendMappedErrorResponse}.
+   */
+  private void sendRetryableResponse(final HttpServerExchange exchange, final Throwable retryable) {
+    LogManager.instance()
+            .log(this, Level.FINE, "Error on command execution (%s): %s", getClass().getSimpleName(),
+                    retryable.getMessage());
+    sendErrorResponse(exchange, 503, "Cannot execute command", retryable, null);
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.DatabaseIsClosedException;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.QueryNotIdempotentException;
 import com.arcadedb.exception.RecordNotFoundException;
@@ -88,6 +89,10 @@ class Issue6201ErrorStatusParityTest {
           () -> new ConcurrentModificationException("Record modified by another transaction")),
       new MappedFailure("RecordNotFoundException", 404,
           () -> new RecordNotFoundException("Record not found", new RID(1, 1))),
+      // A database closed out from under an in-flight request by an HA snapshot-reinstall resync (issue #5977
+      // pattern) is a transient condition, not a permanent failure - it used to fall through to a hard 500,
+      // which a remote client's own retry-on-503 loop never saw (issue #6770).
+      new MappedFailure("DatabaseIsClosedException", 503, () -> new DatabaseIsClosedException("mydb")),
       // The mappings each earlier issue had to add to two or three chains by hand.
       new MappedFailure("DuplicatedKeyException", 409, () -> new DuplicatedKeyException("Idx", "[1]", new RID(1, 1))),
       new MappedFailure("TransactionCommittedRemotelyException", 409,
@@ -149,6 +154,23 @@ class Issue6201ErrorStatusParityTest {
     // The typed exception survives too: the remote Java driver and the HA leader-exception reconstruction both
     // rebuild the retryable type from this field, and a generic TransactionException is not retryable.
     assertThat(json.getString("exception")).isEqualTo(ConcurrentModificationException.class.getName());
+  }
+
+  /**
+   * The concrete defect reported in #6770: a follower's database closes out from under an in-flight read or write
+   * request while an HA snapshot-reinstall resync (issue #5977 pattern) is running. Before this fix that degraded
+   * to a hard 500 "Internal error" - opaque to a client, and invisible to {@code RemoteHttpComponent}'s
+   * NeedRetryException-driven auto-retry, which only fires on a 503. A resync closing and reinstalling the
+   * database is transient by construction (the fresh handle the retry resolves sees the reinstalled database), so
+   * it must be reported the same retryable way a Raft conflict already is.
+   */
+  @Test
+  void aDatabaseClosedByAConcurrentResyncIsReportedAsRetryable() {
+    final HandledResponse response = handle(new DatabaseIsClosedException("mydb"));
+
+    assertThat(response.statusCode).isEqualTo(503);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.getString("exception")).isEqualTo(DatabaseIsClosedException.class.getName());
   }
 
   /**


### PR DESCRIPTION
Closes #6770

## Summary

Issue #6770 reports `ha-integration-tests` red on main with 5 unrelated Raft ITs failing in a "different test each time" pattern, mirroring the previously-closed #5668. Of the 5 named tests, two (`RaftCommandReadConsistencyIT`, `RaftTimeSeriesWriteReadYourWritesIT`) failed with a `DatabaseIsClosedException`, either directly or wrapped in a `RemoteException`. This PR fixes that specific, diagnosable root cause; the other three named tests (`Issue6221VerifyFanOutGuardIT` type-count mismatch, `RaftHTTP2ServersCreateReplicatedDatabaseIT` HTTP 500, `RaftPriorityRejoinIT` group-commit timeout) were not reproduced locally and are **not** addressed here — see "Not addressed" below.

**Root cause.** `LocalDatabase.checkDatabaseIsOpen()` is the single throw site for `DatabaseIsClosedException`, raised whenever a request executes against a `Database` handle whose `open` flag has flipped false — which is exactly what an HA snapshot-reinstall resync does to a follower's database mid-flight (the #5977 pattern `BaseRaftHATest.withResyncRetry()` already exists to work around for *embedded* callers). Two gaps let this transient condition surface as a hard failure instead of a transparent retry:

1. **Server-side (production bug):** `AbstractServerHttpHandler.sendMappedErrorResponse` had no classification arm for `DatabaseIsClosedException`, so it fell through to a generic 500 "Internal error"/"Cannot execute command". `RemoteHttpComponent` (the remote Java driver / `RemoteDatabase`) only auto-retries on a 503-classified `NeedRetryException` — a 500 is a hard failure the caller sees immediately. This affects **any** remote client (not just tests) that races a follower resync window.
2. **Test-side:** `RaftCommandReadConsistencyIT` resolved a `Database` handle for the follower once, then reused it across two separate read attempts (`READ_YOUR_WRITES` then `LINEARIZABLE`) — precisely the anti-pattern `withResyncRetry`'s own javadoc warns against ("must not close over a handle obtained outside this method").

**Fix.**
1. `AbstractServerHttpHandler.sendMappedErrorResponse` now maps `DatabaseIsClosedException` (bare or wrapped in `TransactionException`/`CommandExecutionException`) to HTTP 503, using the same "Cannot execute command" message and FINE-level logging as the existing `NeedRetryException` arm. No client-side change is needed: `RemoteHttpComponent.manageException`'s existing "unrecognised exception type + 503" fallback already reconstructs this as a retryable `NeedRetryException` and the existing retry loop kicks in transparently.
2. `RaftCommandReadConsistencyIT` now resolves each follower read through `withResyncRetry(followerIndex, db -> ...)` instead of a handle captured once ahead of both reads.

**Not addressed (left for follow-up, consistent with how #5668 was worked across PRs #6095/#6112):**
- `Issue6221VerifyFanOutGuardIT`'s "type count mismatch (6 vs 5)" — `DatabaseComparator.compareTypes` failing after `assertClusterConsistency()` already waits for the follower's Raft-applied index to catch up. Not reproduced locally; no HTTP-level `DatabaseIsClosedException` is involved here since the comparison reads the embedded `Schema` directly, so this is a separate mechanism from the fix above.
- `RaftHTTP2ServersCreateReplicatedDatabaseIT`'s "HTTP 500" — plausible same root cause (the test drives everything through the raw `command()`/`executeCommand()` helpers rather than `RemoteDatabase`, which do not retry on 503), but that helper has no retry loop, so this PR's fix would not by itself turn a 500 into a pass for this test; would need its own change if confirmed.
- `RaftPriorityRejoinIT`'s "timeout during group commit operations" — looks unrelated (leader-priority rejoin timing), not investigated this session.

Both gaps above are already-established patterns in this codebase (see `BaseRaftHATest.withResyncRetry`'s own javadoc, and the #5977/#5668/#6112 history), so this PR applies the same, previously-proven fix shape rather than inventing a new one.


**Follow-up filed from review:** the new 503 mapping for `DatabaseIsClosedException` is scoped to the exception type, which is broader than the transient resync race above — a concurrent `DROP`/`CLOSE DATABASE` throws the same exception type on an in-flight request, and that close is permanent, not transient. Filed as #6778 with candidate approaches; pointer comment left at the new arm in `AbstractServerHttpHandler`.

## Test plan
- [x] New/updated unit test: `Issue6201ErrorStatusParityTest` — added a `DatabaseIsClosedException -> 503` entry to `MAPPED_FAILURES` (covers bare + wrapped in `TransactionException` + wrapped in `CommandExecutionException`, via the existing parametrized parity test), plus a dedicated `aDatabaseClosedByAConcurrentResyncIsReportedAsRetryable()` test. Ran with `mvn -pl server -am test -Dtest=Issue6201ErrorStatusParityTest`: 18/18 pass.
- [x] Full `com.arcadedb.server.http.handler.*Test` package (37 test classes) run to confirm no regression from the new classification arm's ordering: all green, 0 failures/errors.
- [x] `mvn -pl server,ha-raft -am compile` and `mvn -pl ha-raft -am test-compile`: both clean.
- [ ] Not run in this session: the live 3-node `RaftCommandReadConsistencyIT` / `RaftTimeSeriesWriteReadYourWritesIT` HA integration tests themselves (multi-node Ratis cluster startup/teardown is expensive, and port 2480 was already held locally by a concurrent process during this session) — the fix follows the exact `withResyncRetry` shape already proven correct elsewhere in this file, and the new unit test pins the server-side classification change directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error handling when a database is temporarily unavailable, returning a retryable 503 response.
  * Preserved specific database-closure error details in responses.
  * Improved read consistency during high-availability database resynchronization.
  * Standardized database-closure error handling during resynchronization.

* **Tests**
  * Added coverage for retryable database-closure responses and follower reads during resynchronization.
  * Verified consistent results across retried reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
