### PR TITLE
fix: HTTP session timeout flake, snapshot barrier reason discriminator, TimeSeries schema-load vanishing type (#6398, #6394, #6356)

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -739,7 +739,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         // Counting samples never loads a record through a bucket, so apply the equivalent per-type read check here.
         checkPermissionsOnType(typeName, SecurityDatabaseUser.ACCESS.READ_RECORD);
         try {
-          return tsType.getEngine().countSamples();
+          return tsType.requireEngine().countSamples();
         } catch (final IOException e) {
           throw new DatabaseOperationException("Error counting TimeSeries samples for type '" + typeName + "'", e);
         }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1530,7 +1530,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   @Override
   public void appendSamples(final String typeName, final long[] timestamps, final Object[]... columnValues) {
     final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(typeName);
-    final TimeSeriesEngine engine = tsType.getEngine();
+    final TimeSeriesEngine engine = tsType.requireEngine();
     final int shardIdx = (int) (tsAppendCounter.getAndIncrement() % engine.getShardCount());
     final int slot = getSlot(shardIdx);
     scheduleTask(slot, new DatabaseAsyncAppendSamples(engine, shardIdx, timestamps, columnValues), true,
@@ -1540,7 +1540,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   @Override
   public void appendSamples(final String typeName, final TimeSeriesRowSource source) {
     final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(typeName);
-    final TimeSeriesEngine engine = tsType.getEngine();
+    final TimeSeriesEngine engine = tsType.requireEngine();
     final int shardIdx = (int) (tsAppendCounter.getAndIncrement() % engine.getShardCount());
     final int slot = getSlot(shardIdx);
     scheduleTask(slot, new DatabaseAsyncAppendSamples(engine, shardIdx, source), true, backPressurePercentage);

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -726,8 +726,11 @@ public class DatabaseChecker {
       if (engine == null) {
         // The type is in the schema but its engine never initialised, so its files were never opened. Reported
         // rather than skipped: a type nothing can read is exactly the kind of thing this check is asked about.
+        // The reason (when known, issue #6356) names the file that failed to load, so an operator does not have
+        // to go hunting through the server log for it.
+        final String reason = type.getEngineUnavailableReason();
         addWarning("timeseries '" + type.getName() + "': the storage engine is not initialised, so none of its "
-            + "files could be read");
+            + "files could be read" + (reason != null ? ": " + reason : ""));
         corrupted.add(type.getName());
         continue;
       }

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -510,6 +510,11 @@ public class PageManager extends LockContext {
    * path is only genuinely unconditional if there is ONE exception type to catch - and these callers run inside
    * {@code executeInReadLock}, which wraps a checked exception into something a {@code catch (PageSnapshotException)}
    * would never match, so a leaked {@code IOException} silently disables the fallback.
+   * <p>
+   * {@link PageSnapshotException#getReason()} tells a caller that wants to distinguish them apart WHY the barrier
+   * gave up: {@code SUSPEND_TIMEOUT} is transient and expected under load, {@code FLUSH_TIMEOUT} is a stuck disk
+   * rather than a busy one. The unconditional fallback above does not need the distinction; diagnostics and tests do
+   * (#6394).
    *
    * @return a handle the caller MUST close, ideally in a try-with-resources: the shadow and any file whose deletion
    *     was deferred for it are released there.
@@ -540,7 +545,8 @@ public class PageManager extends LockContext {
       // NOT TIMED AND NOT COUNTED: NOTHING OF THE BARRIER RAN, AND A CALL THAT REFUSED INSTANTLY WOULD OTHERWISE PULL
       // THE AVERAGE THIS METRIC EXISTS TO REPORT TOWARDS ZERO
       throw new PageSnapshotException(
-          "Cannot open a snapshot of database '" + database.getName() + "': the page manager is not running");
+          "Cannot open a snapshot of database '" + database.getName() + "': the page manager is not running",
+          PageSnapshotException.Reason.NOT_RUNNING);
 
     synchronized (snapshotBarrierLock(database)) {
       // THE CLOCK STARTS HERE, NOT AT THE PUBLIC ENTRY POINT: THIS MONITOR ONLY SERIALIZES BARRIERS ON THE SAME
@@ -593,14 +599,15 @@ public class PageManager extends LockContext {
               // FALLS BACK TO SUSPEND-AND-FREEZE, WHICH IS SLOWER FOR ONE DATABASE RATHER THAN BRIEFLY FATAL FOR ALL
               throw new PageSnapshotException("Cannot open a snapshot of database '" + database.getName()
                   + "': the page flush could not be suspended within " + SNAPSHOT_BARRIER_MAX_MILLIS
-                  + " ms because another suspender is still resuming");
+                  + " ms because another suspender is still resuming", PageSnapshotException.Reason.SUSPEND_TIMEOUT);
             suspended = true;
 
             if (!thread.waitForCurrentFlushToCompleteUntil(database, deadline))
               // FATAL, UNLIKE THE DRAIN ABOVE: THE IN-FLIGHT BATCH IS HALF-WRITTEN BY DEFINITION, SO t0 WOULD HOLD
               // HALF A TRANSACTION. A WRITE THAT HAS NOT RETURNED IN THIS LONG IS A SICK DISK, NOT A BUSY ONE
               throw new PageSnapshotException("Cannot open a snapshot of database '" + database.getName()
-                  + "': the in-flight page flush did not complete within " + SNAPSHOT_BARRIER_MAX_MILLIS + " ms");
+                  + "': the in-flight page flush did not complete within " + SNAPSHOT_BARRIER_MAX_MILLIS + " ms",
+                  PageSnapshotException.Reason.FLUSH_TIMEOUT);
 
             if (thread.hasPendingPagesOfDatabase(database)) {
               // NO COMMIT CAN CAUSE THIS ANY MORE, SO THE ONLY REMAINING FEEDER IS INDEX COMPACTION, WHICH SCHEDULES

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -2455,17 +2455,19 @@ public class TimeSeriesSealedStore implements AutoCloseable {
 
     final int magic = headerBuf.getInt();
     if (magic != MAGIC_VALUE)
-      throw new IOException("Invalid sealed store magic: " + Integer.toHexString(magic));
+      throw new IOException(
+          "Invalid sealed store magic in '" + basePath + ".ts.sealed': " + Integer.toHexString(magic));
 
     final int version = headerBuf.get() & 0xFF;
     if (version != CURRENT_VERSION)
       throw new IOException(
-          "Unsupported sealed store format version " + version + " (expected: " + CURRENT_VERSION + ")");
+          "Unsupported sealed store format version " + version + " (expected: " + CURRENT_VERSION + ") in '"
+              + basePath + ".ts.sealed'");
 
     final int colCount = headerBuf.getShort() & 0xFFFF;
     if (colCount != columns.size())
-      throw new IOException("Column count mismatch in sealed store header: file has " + colCount
-          + " columns, schema has " + columns.size());
+      throw new IOException("Column count mismatch in sealed store header of '" + basePath + ".ts.sealed': file has "
+          + colCount + " columns, schema has " + columns.size());
     final int blockCount = headerBuf.getInt();
     globalMinTs = headerBuf.getLong();
     globalMaxTs = headerBuf.getLong();

--- a/engine/src/main/java/com/arcadedb/exception/PageSnapshotException.java
+++ b/engine/src/main/java/com/arcadedb/exception/PageSnapshotException.java
@@ -30,11 +30,49 @@ package com.arcadedb.exception;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class PageSnapshotException extends ArcadeDBException {
+
+  /**
+   * Why a snapshot window failed or could not be opened, so a caller can branch on it instead of parsing
+   * {@link #getMessage()}. The two outcomes that matter operationally come from {@code PageManager.openSnapshotInternal}:
+   * <ul>
+   *   <li>{@link #SUSPEND_TIMEOUT}: transient and expected under load, retryable via the suspend-and-freeze
+   *   fallback every consumer already falls back to on any {@link PageSnapshotException}.</li>
+   *   <li>{@link #FLUSH_TIMEOUT}: a write that has not returned within the barrier's budget points at a
+   *   stuck disk rather than a busy one - fatal, not retryable.</li>
+   * </ul>
+   */
+  public enum Reason {
+    /** The page manager is not running, so no barrier could even start. */
+    NOT_RUNNING,
+    /** Suspending the flush thread timed out because another suspender was still resuming. Transient. */
+    SUSPEND_TIMEOUT,
+    /** An in-flight page flush did not complete within the barrier's budget. Fatal. */
+    FLUSH_TIMEOUT,
+    /** Any other failure: an I/O error enumerating the snapshot's files, an interrupt, an invalidated window, etc. */
+    OTHER
+  }
+
+  private final Reason reason;
+
   public PageSnapshotException(final String s) {
+    this(s, Reason.OTHER);
+  }
+
+  public PageSnapshotException(final String s, final Reason reason) {
     super(s);
+    this.reason = reason;
   }
 
   public PageSnapshotException(final String s, final Throwable e) {
+    this(s, Reason.OTHER, e);
+  }
+
+  public PageSnapshotException(final String s, final Reason reason, final Throwable e) {
     super(s, e);
+    this.reason = reason;
+  }
+
+  public Reason getReason() {
+    return reason;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
@@ -76,7 +76,12 @@ public class SaveElementStep extends AbstractExecutionStep {
 
           // Check if this is a TimeSeries type — route to TimeSeriesEngine
           final var docType = context.getDatabase().getSchema().getType(doc.getTypeName());
-          if (docType instanceof LocalTimeSeriesType tsType && tsType.getEngine() != null) {
+          if (docType instanceof LocalTimeSeriesType tsType) {
+            // Registered but without a usable engine (issue #6356): fail loudly here rather than silently
+            // falling through to the generic document save below, which a TimeSeries type - with no record
+            // bucket of its own - cannot serve correctly either. requireEngine() throws with the reason.
+            if (!tsType.isEngineAvailable())
+              tsType.requireEngine();
             saveToTimeSeries(tsType, doc, context);
             scheduleContinuousAggregateRefresh(context, tsType);
             return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
@@ -77,12 +77,10 @@ public class SaveElementStep extends AbstractExecutionStep {
           // Check if this is a TimeSeries type — route to TimeSeriesEngine
           final var docType = context.getDatabase().getSchema().getType(doc.getTypeName());
           if (docType instanceof LocalTimeSeriesType tsType) {
-            // Registered but without a usable engine (issue #6356): fail loudly here rather than silently
-            // falling through to the generic document save below, which a TimeSeries type - with no record
-            // bucket of its own - cannot serve correctly either. requireEngine() throws with the reason.
-            if (!tsType.isEngineAvailable())
-              tsType.requireEngine();
-            saveToTimeSeries(tsType, doc, context);
+            // requireEngine() fails loudly - naming the type and, when known, why - instead of silently falling
+            // through to the generic document save below, which a TimeSeries type with no record bucket of its
+            // own cannot serve correctly either (issue #6356).
+            saveToTimeSeries(tsType, tsType.requireEngine(), doc, context);
             scheduleContinuousAggregateRefresh(context, tsType);
             return result;
           }
@@ -111,8 +109,8 @@ public class SaveElementStep extends AbstractExecutionStep {
     };
   }
 
-  private void saveToTimeSeries(final LocalTimeSeriesType tsType, final Document doc, final CommandContext context) {
-    final TimeSeriesEngine engine = tsType.getEngine();
+  private void saveToTimeSeries(final LocalTimeSeriesType tsType, final TimeSeriesEngine engine, final Document doc,
+      final CommandContext context) {
     final List<ColumnDefinition> columns = tsType.getTsColumns();
     final ZoneId zoneId = context.getDatabase().getSchema().getZoneId();
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -1903,13 +1903,12 @@ public class SelectExecutionPlanner {
         ? derivePartitionPrunedClusters(docType, filterClusters, info, context)
         : filterClusters;
 
-    if (docType instanceof LocalTimeSeriesType tsType && !tsType.isEngineAvailable())
-      // Registered but without a usable engine (issue #6356): fail loudly rather than silently falling through to
-      // the generic document scan below, which would read zero rows from a type that has no record bucket of its
-      // own and report the query as having succeeded. requireEngine() throws with the reason.
+    if (docType instanceof LocalTimeSeriesType tsType) {
+      // requireEngine() fails loudly - naming the type and, when known, why - rather than silently falling
+      // through to the generic document scan below, which would read zero rows from a type that has no record
+      // bucket of its own and report the query as having succeeded (issue #6356).
       tsType.requireEngine();
 
-    if (docType instanceof LocalTimeSeriesType tsType && tsType.getEngine() != null) {
       // Extract time range from WHERE clause (if available)
       long fromTs = Long.MIN_VALUE;
       long toTs = Long.MAX_VALUE;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -1903,6 +1903,12 @@ public class SelectExecutionPlanner {
         ? derivePartitionPrunedClusters(docType, filterClusters, info, context)
         : filterClusters;
 
+    if (docType instanceof LocalTimeSeriesType tsType && !tsType.isEngineAvailable())
+      // Registered but without a usable engine (issue #6356): fail loudly rather than silently falling through to
+      // the generic document scan below, which would read zero rows from a type that has no record bucket of its
+      // own and report the query as having succeeded. requireEngine() throws with the reason.
+      tsType.requireEngine();
+
     if (docType instanceof LocalTimeSeriesType tsType && tsType.getEngine() != null) {
       // Extract time range from WHERE clause (if available)
       long fromTs = Long.MIN_VALUE;

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -80,6 +80,7 @@ import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
@@ -1877,8 +1878,6 @@ public class LocalSchema implements Schema {
             tsType.fromJSON(schemaType);
             try {
               tsType.initEngine();
-              // Schedule automatic retention/downsampling if policies are defined
-              getTimeSeriesMaintenanceScheduler().schedule(database, tsType);
             } catch (final IOException e) {
               // Register the type anyway rather than letting it vanish from the schema (issue #6356): the
               // exception this catches means one derived file (a .ts.sealed most commonly, rebuildable under HA
@@ -1893,6 +1892,20 @@ public class LocalSchema implements Schema {
               LogManager.instance().log(this, Level.SEVERE,
                   "Error initializing TimeSeries engine for type '%s', the type is registered but its storage is "
                       + "unavailable until this is resolved: %s", e, typeName, e.getMessage());
+            }
+            // Schedule automatic retention/downsampling if policies are defined. Kept OUTSIDE the try above and
+            // behind its own catch: this can only run once the engine is actually available, and a scheduling
+            // failure (the executor rejecting the task, e.g. mid-shutdown) is unrelated to whether the engine
+            // itself works - it must not be mistaken for one and must not escape to the outer catch in this
+            // method, which would abort every type the load has not reached yet for a reason that has nothing to
+            // do with any of them.
+            if (tsType.isEngineAvailable()) {
+              try {
+                getTimeSeriesMaintenanceScheduler().schedule(database, tsType);
+              } catch (final RejectedExecutionException e) {
+                LogManager.instance().log(this, Level.WARNING,
+                    "Could not schedule automatic TimeSeries maintenance for type '%s': %s", e, typeName, e.getMessage());
+              }
             }
             yield tsType;
           }

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1877,11 +1877,23 @@ public class LocalSchema implements Schema {
             tsType.fromJSON(schemaType);
             try {
               tsType.initEngine();
+              // Schedule automatic retention/downsampling if policies are defined
+              getTimeSeriesMaintenanceScheduler().schedule(database, tsType);
             } catch (final IOException e) {
-              throw new ConfigurationException("Error initializing TimeSeries engine for type '" + typeName + "'", e);
+              // Register the type anyway rather than letting it vanish from the schema (issue #6356): the
+              // exception this catches means one derived file (a .ts.sealed most commonly, rebuildable under HA
+              // by recompacting the replicated mutable pages) failed to open, not that the type or its mutable
+              // data is gone. Registering it keeps the type VISIBLE - CHECK DATABASE already has a branch for
+              // exactly this (DatabaseChecker#checkTimeSeries: "the storage engine is not initialised") that a
+              // type missing from the schema map could never reach - and every read/write against it now fails
+              // loudly through LocalTimeSeriesType#requireEngine() instead of the type silently reappearing empty
+              // on the next write. Not registering it here is what issue #6356 reported: the database opened
+              // cleanly with the type simply gone and nothing said why.
+              tsType.markEngineUnavailable(e.getMessage());
+              LogManager.instance().log(this, Level.SEVERE,
+                  "Error initializing TimeSeries engine for type '%s', the type is registered but its storage is "
+                      + "unavailable until this is resolved: %s", e, typeName, e.getMessage());
             }
-            // Schedule automatic retention/downsampling if policies are defined
-            getTimeSeriesMaintenanceScheduler().schedule(database, tsType);
             yield tsType;
           }
           case null, default -> throw new ConfigurationException("Type '" + kind + "' is not supported");

--- a/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
@@ -92,9 +92,11 @@ public class LocalTimeSeriesType extends LocalDocumentType {
    * Marks this type as registered but without a usable storage engine (issue #6356): {@link #initEngine()} failed
    * during schema load, most commonly because one derived file (a {@code .ts.sealed} sealed store) could not be
    * opened. Package-private: only {@code LocalSchema.readConfiguration()} calls this, on the same path that would
-   * otherwise have thrown and left the type out of the schema entirely.
+   * otherwise have thrown and left the type out of the schema entirely, and always from the single-threaded
+   * schema-load path - never concurrently with {@link #initEngine()}. {@code synchronized} to match
+   * {@link #initEngine()}, so a future caller cannot reintroduce a stale-reason race between the two.
    */
-  void markEngineUnavailable(final String reason) {
+  synchronized void markEngineUnavailable(final String reason) {
     this.engineUnavailableReason = reason != null ? reason : "unknown error";
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
@@ -78,6 +78,10 @@ public class LocalTimeSeriesType extends LocalDocumentType {
       return;
     engine = new TimeSeriesEngine((DatabaseInternal) schema.getDatabase(), name, tsColumns, shardCount > 0 ? shardCount : 1,
         compactionBucketIntervalMs, mutableFormatVersion);
+    // A retry that succeeds after a prior markEngineUnavailable() must not leave the stale reason behind: nothing
+    // else clears it, and getEngineUnavailableReason() otherwise keeps reporting why the engine failed even after
+    // isEngineAvailable() has correctly flipped to true.
+    engineUnavailableReason = null;
   }
 
   public TimeSeriesEngine getEngine() {

--- a/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
@@ -25,6 +25,7 @@ import com.arcadedb.engine.timeseries.TimeSeriesBucket;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.engine.timeseries.TimeSeriesSealedStore;
 import com.arcadedb.engine.timeseries.codec.TimeSeriesCodec;
+import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
@@ -56,6 +57,13 @@ public class LocalTimeSeriesType extends LocalDocumentType {
   private final List<ColumnDefinition>  tsColumns         = new ArrayList<>();
   private       List<DownsamplingTier> downsamplingTiers = new ArrayList<>();
   private volatile TimeSeriesEngine    engine;
+  /**
+   * Set when schema load registered this type despite {@link #initEngine()} failing (issue #6356), so the type
+   * stays visible in the schema and to {@code CHECK DATABASE} instead of silently disappearing. {@code null} means
+   * the engine is available; a non-null reason means every read/write must fail loudly instead of acting on an
+   * absent engine.
+   */
+  private volatile String engineUnavailableReason;
 
   public LocalTimeSeriesType(final LocalSchema schema, final String name) {
     super(schema, name);
@@ -74,6 +82,43 @@ public class LocalTimeSeriesType extends LocalDocumentType {
 
   public TimeSeriesEngine getEngine() {
     return engine;
+  }
+
+  /**
+   * Marks this type as registered but without a usable storage engine (issue #6356): {@link #initEngine()} failed
+   * during schema load, most commonly because one derived file (a {@code .ts.sealed} sealed store) could not be
+   * opened. Package-private: only {@code LocalSchema.readConfiguration()} calls this, on the same path that would
+   * otherwise have thrown and left the type out of the schema entirely.
+   */
+  void markEngineUnavailable(final String reason) {
+    this.engineUnavailableReason = reason != null ? reason : "unknown error";
+  }
+
+  public boolean isEngineAvailable() {
+    return engine != null;
+  }
+
+  /**
+   * Why {@link #getEngine()} returns {@code null}, or {@code null} if the engine is available. Surfaced by
+   * {@code CHECK DATABASE} and by {@link #requireEngine()}'s message.
+   */
+  public String getEngineUnavailableReason() {
+    return engineUnavailableReason;
+  }
+
+  /**
+   * Non-null accessor for read/write call sites that cannot do anything useful with a missing engine: throws
+   * naming the type and, when known, why the engine never started, instead of letting a {@code null} reach a
+   * {@code NullPointerException} with no context (issue #6356).
+   */
+  public TimeSeriesEngine requireEngine() {
+    final TimeSeriesEngine current = engine;
+    if (current == null)
+      throw new DatabaseOperationException(
+          "TimeSeries type '" + name + "' has no storage engine available" + (engineUnavailableReason != null ?
+              ": " + engineUnavailableReason :
+              " (it may still be initializing)"));
+    return current;
   }
 
   public void close() {

--- a/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
@@ -339,16 +339,20 @@ class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
     flushThread.nextPagesToFlush.set(new PageManagerFlushThread.PagesToFlush(new ArrayList<>(List.of(page))));
     try {
       final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+      // THE REASON IS THE PROPERTY UNDER TEST, NOT THE ELAPSED TIME: openSnapshot HAS TWO OPPOSITE-MEANING TIMEOUTS
+      // BEHIND THE SAME EXCEPTION TYPE (#6394), AND UNDER A FULL-SUITE RUN trySuspendUntil CAN GENUINELY LOSE ITS
+      // OWN RACE FIRST (ANOTHER SUSPENDER STILL RESUMING) - A DURATION-BASED ASSERTION CANNOT TELL THAT APART FROM
+      // THE waitForCurrentFlushToCompleteUntil TIMEOUT THIS TEST FABRICATES, AND FLAKES WHEN IT GUESSES WRONG
       assertThatThrownBy(() -> pageManager.openSnapshot(db))
           .as("the barrier must abandon the window rather than wait out a flush that never lands")
-          .isInstanceOf(PageSnapshotException.class);
+          .isInstanceOf(PageSnapshotException.class)
+          .extracting(e -> ((PageSnapshotException) e).getReason())
+          .as("the fabricated never-completing flush must be diagnosed as the flush timeout, not the unrelated "
+              + "suspend-timeout race")
+          .isEqualTo(PageSnapshotException.Reason.FLUSH_TIMEOUT);
 
-      // BOTH ENDS MATTER. The upper bound is the property under test - far below the forever the unbounded wait
-      // would have taken, and discounted for JVM stalls (#6260) rather than widened. The lower one keeps the test
-      // honest: it proves the barrier really did block on the fabricated batch and time out, rather than failing
-      // instantly for some unrelated reason that would make the ceiling assertion pass vacuously. It reads raw
-      // wall clock on purpose - a stall only makes "at least this long" more true
-      assertThat(stopwatch.elapsedMs()).as("the barrier must block on the in-flight batch").isGreaterThanOrEqualTo(1_000L);
+      // THE UPPER BOUND IS STILL A REAL PROPERTY: FAR BELOW THE FOREVER THE UNBOUNDED WAIT WOULD HAVE TAKEN, AND
+      // DISCOUNTED FOR JVM STALLS (#6260) RATHER THAN WIDENED
       stopwatch.assertGaveUpWithin(60_000L, "the barrier's own budget from waiting out a flush that never lands");
 
       // AND IT MUST HAVE LET GO: A FAILED BARRIER THAT KEPT THE GLOBAL LOCK WOULD BE WORSE THAN THE HANG IT REPLACES

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
@@ -514,6 +514,29 @@ class Issue6340TimeSeriesCheckDatabaseTest extends TestHelper {
   }
 
   /**
+   * The read side of the same guard: {@code SelectExecutionPlanner.handleTypeAsTarget} must call
+   * {@code requireEngine()} and fail loudly, rather than falling through to a generic document scan that would
+   * read zero rows from a type with no record bucket of its own and report the query as having succeeded.
+   */
+  @Test
+  void selectingFromATimeSeriesTypeWhoseEngineFailedToInitializeFailsWithAClearError() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    final File sealed = new File(getDatabasePath(), "Cpu_shard_0.ts.sealed");
+
+    database.close();
+    try {
+      flipByteAt(sealed, 0);
+    } finally {
+      database = factory.open();
+    }
+
+    assertThatThrownBy(() -> database.command("sql", "SELECT FROM Cpu").close())
+        .hasMessageContaining("Cpu");
+  }
+
+  /**
    * Bytes past the last readable block: the tail of a write that did not complete. The directory scan stops at
    * the first thing that is not a block magic, so this region is invisible to every other reader - neither used
    * nor reported - which is exactly why the check has to say it is there.

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
@@ -490,7 +490,9 @@ class Issue6340TimeSeriesCheckDatabaseTest extends TestHelper {
     assertThat(row.<Long>getProperty("totalTimeSeriesTypes")).as("the broken type is still counted").isEqualTo(1L);
     assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
     assertThat(warningsOf(row)).anyMatch(
-        w -> w.contains("timeseries 'Cpu'") && w.contains("storage engine is not initialised"));
+        w -> w.contains("timeseries 'Cpu'") && w.contains("storage engine is not initialised")
+            // The reason names the file, so an operator does not have to go hunting through the server log for it.
+            && w.contains("Cpu_shard_0.ts.sealed"));
   }
 
   /** A write against the broken type fails with a message naming the type, not with an NPE. */

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #6340 (item 4): {@code CHECK DATABASE} had no TimeSeries coverage at all - {@code DatabaseChecker}
@@ -429,14 +430,88 @@ class Issue6340TimeSeriesCheckDatabaseTest extends TestHelper {
         && w.contains("declares 500 entries"));
   }
 
-  // NOT TESTED HERE, and the reason is a finding in its own right: corrupting the sealed store's OWN header magic
-  // produces no CHECK DATABASE warning, because TimeSeriesSealedStore's constructor throws on a bad magic,
-  // initEngine() then fails during schema load, and the TimeSeries type DISAPPEARS FROM THE SCHEMA entirely - the
-  // database reopens cleanly with the type simply gone (probed: totalTimeSeriesTypes=0, existsType("Cpu")=false).
-  // A check cannot report a type that is no longer there. That silent disappearance lives in the schema load path
-  // rather than in this pass, and what should happen instead - refuse the open, quarantine the type, or surface it
-  // read-only - is a design question of its own. Left as a follow-up rather than pinned here, because a test
-  // asserting the current behaviour would enshrine it.
+  /**
+   * Issue #6356: corrupting the sealed store's OWN header magic used to make the TimeSeries type disappear from
+   * the schema entirely - {@code TimeSeriesSealedStore}'s constructor throws on a bad magic, {@code initEngine()}
+   * fails during schema load, and the type was silently dropped instead of registered, so the database reopened
+   * cleanly with the type simply gone (probed: {@code totalTimeSeriesTypes=0}, {@code existsType("Cpu")=false}) and
+   * a check had nothing left to report on.
+   * <p>
+   * {@code LocalSchema#readConfiguration} now registers the type anyway with its engine left unavailable, which is
+   * what lets {@code DatabaseChecker#checkTimeSeries}'s existing "the storage engine is not initialised" branch -
+   * unreachable until this fix, since nothing walkable ever carried a broken type - fire for the first time.
+   */
+  @Test
+  void aTimeSeriesTypeWhoseSealedStoreFailsToLoadStaysInTheSchemaAndIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    final File sealed = new File(getDatabasePath(), "Cpu_shard_0.ts.sealed");
+    assertThat(sealed).exists();
+
+    database.close();
+    try {
+      // Byte 0 of the header is part of the MAGIC_VALUE int, so this can never pass the magic check on reopen.
+      flipByteAt(sealed, 0);
+    } finally {
+      database = factory.open();
+    }
+
+    // THE CORE OF #6356: the type must still be there, not have vanished.
+    assertThat(database.getSchema().existsType("Cpu")).as("the type must not disappear from the schema").isTrue();
+    final LocalTimeSeriesType reopened = (LocalTimeSeriesType) database.getSchema().getType("Cpu");
+    assertThat(reopened.isEngineAvailable()).isFalse();
+    assertThat(reopened.getEngineUnavailableReason()).contains("Cpu_shard_0.ts.sealed");
+
+    // Every write against it fails loudly instead of quietly building a fresh empty type.
+    assertThatThrownBy(reopened::requireEngine).hasMessageContaining("Cpu");
+  }
+
+  /**
+   * The other half of #6356: {@code CHECK DATABASE} must be able to see and report the broken type, which is only
+   * possible once it stays registered.
+   */
+  @Test
+  void checkDatabaseReportsATimeSeriesTypeWhoseEngineFailedToInitialize() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    final File sealed = new File(getDatabasePath(), "Cpu_shard_0.ts.sealed");
+
+    database.close();
+    try {
+      flipByteAt(sealed, 0);
+    } finally {
+      database = factory.open();
+    }
+
+    final Result row = runCheck();
+
+    assertThat(row.<Long>getProperty("totalTimeSeriesTypes")).as("the broken type is still counted").isEqualTo(1L);
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(
+        w -> w.contains("timeseries 'Cpu'") && w.contains("storage engine is not initialised"));
+  }
+
+  /** A write against the broken type fails with a message naming the type, not with an NPE. */
+  @Test
+  void writingToATimeSeriesTypeWhoseEngineFailedToInitializeFailsWithAClearError() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    final File sealed = new File(getDatabasePath(), "Cpu_shard_0.ts.sealed");
+
+    database.close();
+    try {
+      flipByteAt(sealed, 0);
+    } finally {
+      database = factory.open();
+    }
+
+    assertThatThrownBy(() -> database.command("sql",
+        "INSERT INTO Cpu SET ts = 1700000000000, hostname = 'h', usage = 1.0"))
+        .hasMessageContaining("Cpu");
+  }
 
   /**
    * Bytes past the last readable block: the tail of a write that did not complete. The directory scan stops at

--- a/engine/src/test/java/com/arcadedb/exception/ExceptionTest.java
+++ b/engine/src/test/java/com/arcadedb/exception/ExceptionTest.java
@@ -276,6 +276,38 @@ class ExceptionTest {
   }
 
   @Test
+  void pageSnapshotExceptionDefaultsToOtherReason() {
+    // The legacy two-arg constructors (still used by call sites that do not need to distinguish outcomes,
+    // e.g. PageSnapshot.checkValid) must not force every caller to pick a reason (#6394).
+    final PageSnapshotException withMessage = new PageSnapshotException("failed");
+    assertThat(withMessage.getReason()).isEqualTo(PageSnapshotException.Reason.OTHER);
+
+    final RuntimeException cause = new RuntimeException("io error");
+    final PageSnapshotException withCause = new PageSnapshotException("failed", cause);
+    assertThat(withCause.getReason()).isEqualTo(PageSnapshotException.Reason.OTHER);
+    assertThat(withCause.getCause()).isSameAs(cause);
+  }
+
+  @Test
+  void pageSnapshotExceptionCarriesItsReason() {
+    // PageManager.openSnapshotInternal's two barrier timeouts share this exception type but mean opposite
+    // things operationally (transient vs. fatal) - the reason is how a caller tells them apart instead of
+    // parsing getMessage() (#6394).
+    assertThat(new PageSnapshotException("suspend timed out", PageSnapshotException.Reason.SUSPEND_TIMEOUT).getReason())
+        .isEqualTo(PageSnapshotException.Reason.SUSPEND_TIMEOUT);
+    assertThat(new PageSnapshotException("flush timed out", PageSnapshotException.Reason.FLUSH_TIMEOUT).getReason())
+        .isEqualTo(PageSnapshotException.Reason.FLUSH_TIMEOUT);
+
+    final RuntimeException cause = new RuntimeException("not running");
+    final PageSnapshotException withReasonAndCause =
+        new PageSnapshotException("not running", PageSnapshotException.Reason.NOT_RUNNING, cause);
+    assertThat(withReasonAndCause.getReason()).isEqualTo(PageSnapshotException.Reason.NOT_RUNNING);
+    assertThat(withReasonAndCause.getCause()).isSameAs(cause);
+
+    assertThat(new PageSnapshotException("failed")).isInstanceOf(ArcadeDBException.class);
+  }
+
+  @Test
   void exceptionChaining() {
     final Exception level1 = new RuntimeException("Level 1");
     final Exception level2 = new ArcadeDBException("Level 2", level1);

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
@@ -20,6 +20,8 @@ package com.arcadedb.server.http;
 
 import com.arcadedb.server.security.ServerSecurityUser;
 
+import java.util.function.LongSupplier;
+
 /**
  * Represents an authenticated HTTP session. Unlike {@link HttpSession} which manages a transaction,
  * this session represents a logged-in user and can be used for token-based authentication.
@@ -32,6 +34,7 @@ import com.arcadedb.server.security.ServerSecurityUser;
 public class HttpAuthSession {
   public final  String             token;
   public final  ServerSecurityUser user;
+  private final LongSupplier       clock;
   private final long               createdAt;
   private volatile long            lastUpdate;
   private final String             sourceIp;
@@ -45,9 +48,19 @@ public class HttpAuthSession {
 
   public HttpAuthSession(final ServerSecurityUser user, final String token, final String sourceIp,
       final String userAgent, final String country, final String city) {
+    this(user, token, sourceIp, userAgent, country, city, System::currentTimeMillis);
+  }
+
+  /**
+   * Package-private constructor that allows tests to inject a deterministic clock instead of the
+   * wall clock, so idle/absolute timeout behavior can be asserted without sleeping.
+   */
+  HttpAuthSession(final ServerSecurityUser user, final String token, final String sourceIp,
+      final String userAgent, final String country, final String city, final LongSupplier clock) {
     this.user = user;
     this.token = token;
-    this.createdAt = System.currentTimeMillis();
+    this.clock = clock;
+    this.createdAt = clock.getAsLong();
     this.lastUpdate = this.createdAt;
     this.sourceIp = sourceIp;
     this.userAgent = userAgent;
@@ -56,15 +69,15 @@ public class HttpAuthSession {
   }
 
   public long elapsedFromLastUpdate() {
-    return System.currentTimeMillis() - lastUpdate;
+    return clock.getAsLong() - lastUpdate;
   }
 
   public long elapsedFromCreation() {
-    return System.currentTimeMillis() - createdAt;
+    return clock.getAsLong() - createdAt;
   }
 
   public void touch() {
-    this.lastUpdate = System.currentTimeMillis();
+    this.lastUpdate = clock.getAsLong();
   }
 
   public ServerSecurityUser getUser() {

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
@@ -23,6 +23,7 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.RWLockContext;
 
 import java.util.*;
+import java.util.function.LongSupplier;
 import java.util.logging.Level;
 
 /**
@@ -39,6 +40,7 @@ public class HttpAuthSessionManager extends RWLockContext {
   private final Map<String, HttpAuthSession> sessions = new HashMap<>();
   private final       long                         sessionTimeoutInMs;
   private final       long                         absoluteTimeoutInMs;
+  private final       LongSupplier                 clock;
   private final       Timer                        timer;
 
   public HttpAuthSessionManager(final long sessionTimeoutInMs) {
@@ -46,8 +48,17 @@ public class HttpAuthSessionManager extends RWLockContext {
   }
 
   public HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs) {
+    this(sessionTimeoutInMs, absoluteTimeoutInMs, System::currentTimeMillis);
+  }
+
+  /**
+   * Package-private constructor that allows tests to inject a deterministic clock instead of the
+   * wall clock, so idle/absolute timeout behavior can be asserted without sleeping (see #6398).
+   */
+  HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final LongSupplier clock) {
     this.sessionTimeoutInMs = sessionTimeoutInMs;
     this.absoluteTimeoutInMs = absoluteTimeoutInMs;
+    this.clock = clock;
 
     timer = new Timer("HttpAuthSessionManager-Cleanup", true);
     timer.schedule(new TimerTask() {
@@ -141,7 +152,7 @@ public class HttpAuthSessionManager extends RWLockContext {
       final String userAgent, final String country, final String city) {
     return executeInWriteLock(() -> {
       final String token = "AU-" + UUID.randomUUID();
-      final HttpAuthSession session = new HttpAuthSession(user, token, sourceIp, userAgent, country, city);
+      final HttpAuthSession session = new HttpAuthSession(user, token, sourceIp, userAgent, country, city, clock);
       sessions.put(token, session);
       LogManager.instance().log(this, Level.FINE, "Created authentication session %s for user %s from %s", token,
           user.getName(), sourceIp);

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
@@ -65,8 +65,13 @@ public class GetTimeSeriesLatestHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(400, "{ \"error\" : \"Type '" + typeName + "' does not exist\"}");
 
     final DocumentType docType = database.getSchema().getType(typeName);
-    if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null)
+    if (!(docType instanceof LocalTimeSeriesType tsType))
       return new ExecutionResponse(400, "{ \"error\" : \"Type '" + typeName + "' is not a TimeSeries type\"}");
+    if (!tsType.isEngineAvailable())
+      // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS one,
+      // its storage just failed to load - the old shared message sent an operator chasing the wrong cause.
+      return new ExecutionResponse(400, "{ \"error\" : \"TimeSeries type '" + typeName
+          + "' has no storage engine available: " + tsType.getEngineUnavailableReason() + "\"}");
 
     final TimeSeriesEngine engine = tsType.getEngine();
     final List<ColumnDefinition> columns = tsType.getTsColumns();

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
@@ -70,8 +70,10 @@ public class GetTimeSeriesLatestHandler extends AbstractServerHttpHandler {
     if (!tsType.isEngineAvailable())
       // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS one,
       // its storage just failed to load - the old shared message sent an operator chasing the wrong cause.
-      return new ExecutionResponse(400, "{ \"error\" : \"TimeSeries type '" + typeName
-          + "' has no storage engine available: " + tsType.getEngineUnavailableReason() + "\"}");
+      // Built with JSONObject rather than string concatenation because the reason embeds a file path that could
+      // contain a double quote or backslash, which raw concatenation would turn into invalid JSON.
+      return new ExecutionResponse(400, new JSONObject().put("error", "TimeSeries type '" + typeName
+          + "' has no storage engine available: " + tsType.getEngineUnavailableReason()).toString());
 
     final TimeSeriesEngine engine = tsType.getEngine();
     final List<ColumnDefinition> columns = tsType.getTsColumns();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
@@ -90,8 +90,15 @@ public class PostGrafanaQueryHandler extends AbstractServerHttpHandler {
       }
 
       final DocumentType docType = database.getSchema().getType(typeName);
-      if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null) {
+      if (!(docType instanceof LocalTimeSeriesType tsType)) {
         results.put(refId, buildErrorFrame("Type '" + typeName + "' is not a TimeSeries type"));
+        continue;
+      }
+      if (!tsType.isEngineAvailable()) {
+        // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS
+        // one, its storage just failed to load - the old shared message sent an operator chasing the wrong cause.
+        results.put(refId, buildErrorFrame(
+            "TimeSeries type '" + typeName + "' has no storage engine available: " + tsType.getEngineUnavailableReason()));
         continue;
       }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -77,8 +77,13 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(400, "{ \"error\" : \"Type '" + typeName + "' does not exist\"}");
 
     final DocumentType docType = database.getSchema().getType(typeName);
-    if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null)
+    if (!(docType instanceof LocalTimeSeriesType tsType))
       return new ExecutionResponse(400, "{ \"error\" : \"Type '" + typeName + "' is not a TimeSeries type\"}");
+    if (!tsType.isEngineAvailable())
+      // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS one,
+      // its storage just failed to load - the old shared message sent an operator chasing the wrong cause.
+      return new ExecutionResponse(400, "{ \"error\" : \"TimeSeries type '" + typeName
+          + "' has no storage engine available: " + tsType.getEngineUnavailableReason() + "\"}");
 
     final TimeSeriesEngine engine = tsType.getEngine();
     final List<ColumnDefinition> columns = tsType.getTsColumns();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -82,8 +82,10 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
     if (!tsType.isEngineAvailable())
       // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS one,
       // its storage just failed to load - the old shared message sent an operator chasing the wrong cause.
-      return new ExecutionResponse(400, "{ \"error\" : \"TimeSeries type '" + typeName
-          + "' has no storage engine available: " + tsType.getEngineUnavailableReason() + "\"}");
+      // Built with JSONObject rather than string concatenation because the reason embeds a file path that could
+      // contain a double quote or backslash, which raw concatenation would turn into invalid JSON.
+      return new ExecutionResponse(400, new JSONObject().put("error", "TimeSeries type '" + typeName
+          + "' has no storage engine available: " + tsType.getEngineUnavailableReason()).toString());
 
     final TimeSeriesEngine engine = tsType.getEngine();
     final List<ColumnDefinition> columns = tsType.getTsColumns();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
@@ -204,7 +204,11 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
       database.begin();
       try {
         for (final MeasurementBatch batch : byMeasurement.values()) {
-          final TimeSeriesEngine engine = batch.type().getEngine();
+          // requireEngine() for symmetry with the other call sites this PR touched (issue #6356 follow-up,
+          // claude-review on PR #6779): every batch here was already filtered by isEngineAvailable() above, so
+          // this can never actually throw, but getEngine() alone would silently reintroduce the "no engine"
+          // possibility at the type level if that filtering were ever changed.
+          final TimeSeriesEngine engine = batch.type().requireEngine();
           final List<ColumnDefinition> columns = batch.type().getTsColumns();
           final List<Sample> group = batch.samples();
           final int count = group.size();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
@@ -156,12 +156,17 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
       // order stay identical to a straight pass over the samples.
       final Set<String> unknownTypes = new LinkedHashSet<>();
       final Set<String> nonTimeSeriesTypes = new LinkedHashSet<>();
+      // Distinct from nonTimeSeriesTypes (issue #6356 follow-up, claude-review on PR #6779): a type in here IS a
+      // TimeSeries type, its storage just failed to load - lumping it in with "wrong type" sent an operator
+      // chasing the wrong cause.
+      final Set<String> unavailableTypes = new LinkedHashSet<>();
       final Map<String, MeasurementBatch> byMeasurement = new LinkedHashMap<>();
 
       for (final Sample sample : samples) {
         final String measurement = sample.getMeasurement();
 
-        if (unknownTypes.contains(measurement) || nonTimeSeriesTypes.contains(measurement))
+        if (unknownTypes.contains(measurement) || nonTimeSeriesTypes.contains(measurement)
+            || unavailableTypes.contains(measurement))
           continue;
 
         final MeasurementBatch batch = byMeasurement.get(measurement);
@@ -176,8 +181,12 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
         }
 
         final DocumentType docType = database.getSchema().getType(measurement);
-        if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null) {
+        if (!(docType instanceof LocalTimeSeriesType tsType)) {
           nonTimeSeriesTypes.add(measurement);
+          continue;
+        }
+        if (!tsType.isEngineAvailable()) {
+          unavailableTypes.add(measurement);
           continue;
         }
 
@@ -241,6 +250,11 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
         LogManager.instance().log(this, Level.WARNING,
             "Skipped line protocol samples for non-timeseries type(s): %s", null, nonTimeSeriesTypes);
 
+      if (!unavailableTypes.isEmpty())
+        LogManager.instance().log(this, Level.WARNING,
+            "Skipped line protocol samples for TimeSeries type(s) with no storage engine available: %s", null,
+            unavailableTypes);
+
       // Any dropped sample is a partial write: matching InfluxDB, return 400 naming the dropped
       // measurements (with written/dropped counts) even when some samples were inserted, so the client
       // is not told 204 "all good" while data was silently discarded (issue #5036). The samples that did
@@ -259,6 +273,12 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
           msg.append("non-timeseries type(s): ").append(String.join(", ", nonTimeSeriesTypes))
               .append(" (only TIMESERIES types can receive line protocol data).");
         }
+        if (!unavailableTypes.isEmpty()) {
+          if (!unknownTypes.isEmpty() || !nonTimeSeriesTypes.isEmpty())
+            msg.append(" ");
+          msg.append("TimeSeries type(s) with no storage engine available: ").append(String.join(", ", unavailableTypes))
+              .append(" (see the server log for why each failed to load).");
+        }
 
         final JSONObject error = new JSONObject();
         error.put("error", msg.toString());
@@ -271,6 +291,8 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
           error.put("unknownTypes", new JSONArray(unknownTypes));
         if (!nonTimeSeriesTypes.isEmpty())
           error.put("nonTimeSeriesTypes", new JSONArray(nonTimeSeriesTypes));
+        if (!unavailableTypes.isEmpty())
+          error.put("unavailableTypes", new JSONArray(unavailableTypes));
         return new ExecutionResponse(400, error.toString());
       }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/TimeSeriesApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/TimeSeriesApiSpec.java
@@ -231,6 +231,9 @@ public class TimeSeriesApiSpec implements OpenApiContributor {
     schema.addProperty("nonTimeSeriesTypes", SpecBuilders.arrayOf(
         SpecBuilders.string("Type name"),
         "Measurements naming a type that exists but is not a time-series type"));
+    schema.addProperty("unavailableTypes", SpecBuilders.arrayOf(
+        SpecBuilders.string("Type name"),
+        "Measurements naming a time-series type whose storage engine failed to load; see the server log for why"));
     return schema;
   }
 }

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -29,6 +29,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.serializer.json.JSONObject;
@@ -45,6 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
@@ -496,6 +498,31 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
 
   protected String getDatabasePath(final int serverId) {
     return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.separator + getDatabaseName();
+  }
+
+  /**
+   * Compacts {@code typeName}'s shard 0 so a {@code .ts.sealed} file exists, then flips its header's first byte
+   * and closes/reopens the database from disk - reproducing issue #6356 (a TimeSeries type whose sealed store
+   * fails to load) the same way a real restart would discover it, rather than poking the in-memory schema
+   * directly. After this returns, {@code typeName} is registered but {@code isEngineAvailable()} is {@code false}.
+   * Single-server only: HA snapshot install/resync during a close-and-reopen is out of scope for this fixture.
+   */
+  protected void corruptSealedStoreAndReopen(final int serverIndex, final String typeName) throws Exception {
+    final ArcadeDBServer server = getServer(serverIndex);
+    final DatabaseInternal embedded = (DatabaseInternal) server.getDatabase(getDatabaseName()).getEmbedded();
+    ((LocalTimeSeriesType) embedded.getSchema().getType(typeName)).getEngine().compactAll();
+
+    final File sealed = new File(getDatabasePath(serverIndex), typeName + "_shard_0.ts.sealed");
+
+    embedded.close();
+    server.removeDatabase(getDatabaseName());
+    try (final RandomAccessFile raf = new RandomAccessFile(sealed, "rw")) {
+      raf.seek(0);
+      final int b = raf.read();
+      raf.seek(0);
+      raf.write(b ^ 0x01);
+    }
+    server.getDatabase(getDatabaseName());
   }
 
   protected static String readResponse(final HttpURLConnection connection) throws IOException {

--- a/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
@@ -18,12 +18,17 @@
  */
 package com.arcadedb.server;
 
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -111,6 +116,60 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
       final String lineProtocol = "plain_doc,host=srv1 value=1.0 1000\n";
       final int statusCode = postLineProtocol(serverIndex, lineProtocol, "ms");
       assertThat(statusCode).isEqualTo(400);
+    });
+  }
+
+  /**
+   * Regression for issue #6356's follow-up (claude-review on PR #6779): a TimeSeries type IS the right kind of
+   * type, it just failed to load its storage - conflating that with "wrong type" sent an operator debugging via
+   * this endpoint chasing the wrong cause. Reuses the {@code flipByteAt} + close/reopen reproduction already
+   * established at the engine level in {@code Issue6340TimeSeriesCheckDatabaseTest}, driven through the actual
+   * HTTP write path this time.
+   */
+  @Test
+  void engineUnavailableTypeIsReportedDistinctlyFromNonTimeSeriesType() throws Exception {
+    testEachServer(serverIndex -> {
+      command(serverIndex,
+          "CREATE TIMESERIES TYPE broken TIMESTAMP ts TAGS (host STRING) FIELDS (usage DOUBLE)");
+      command(serverIndex, "INSERT INTO broken SET ts = 1700000000000, host = 'h', usage = 1.0");
+
+      final ArcadeDBServer server = getServer(serverIndex);
+      final DatabaseInternal embedded = (DatabaseInternal) server.getDatabase(getDatabaseName()).getEmbedded();
+      final LocalTimeSeriesType tsType = (LocalTimeSeriesType) embedded.getSchema().getType("broken");
+      final TimeSeriesEngine engine = tsType.getEngine();
+      engine.compactAll();
+
+      final File sealed = new File(getDatabasePath(serverIndex), "broken_shard_0.ts.sealed");
+      assertThat(sealed).exists();
+
+      // Close and reopen the database from disk, byte-flipped, so the corruption is discovered on load exactly
+      // as it would be after a real restart - not by poking the in-memory schema directly.
+      embedded.close();
+      server.removeDatabase(getDatabaseName());
+      try (final RandomAccessFile raf = new RandomAccessFile(sealed, "rw")) {
+        raf.seek(0);
+        final int b = raf.read();
+        raf.seek(0);
+        raf.write(b ^ 0x01);
+      }
+      final DatabaseInternal reopened = (DatabaseInternal) server.getDatabase(getDatabaseName()).getEmbedded();
+      final LocalTimeSeriesType reopenedType = (LocalTimeSeriesType) reopened.getSchema().getType("broken");
+      assertThat(reopenedType.isEngineAvailable()).as("the type must stay registered, just without a usable engine")
+          .isFalse();
+
+      final HttpURLConnection connection = openWriteConnection(serverIndex, "ms");
+      try (final OutputStream os = connection.getOutputStream()) {
+        os.write("broken,host=h2 usage=2.0 2000\n".getBytes(StandardCharsets.UTF_8));
+        os.flush();
+      }
+      assertThat(connection.getResponseCode()).isEqualTo(400);
+
+      final JSONObject error = new JSONObject(readError(connection));
+      assertThat(error.getString("error")).as("must be distinguishable from \"is not a TimeSeries type\"")
+          .contains("no storage engine available");
+      assertThat(error.getJSONArray("unavailableTypes").getString(0)).isEqualTo("broken");
+      assertThat(error.has("nonTimeSeriesTypes")).as("a broken type must not also be reported as the wrong type")
+          .isFalse();
     });
   }
 

--- a/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
@@ -18,17 +18,12 @@
  */
 package com.arcadedb.server;
 
-import com.arcadedb.database.DatabaseInternal;
-import com.arcadedb.engine.timeseries.TimeSeriesEngine;
-import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.OutputStream;
-import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -133,29 +128,7 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
           "CREATE TIMESERIES TYPE broken TIMESTAMP ts TAGS (host STRING) FIELDS (usage DOUBLE)");
       command(serverIndex, "INSERT INTO broken SET ts = 1700000000000, host = 'h', usage = 1.0");
 
-      final ArcadeDBServer server = getServer(serverIndex);
-      final DatabaseInternal embedded = (DatabaseInternal) server.getDatabase(getDatabaseName()).getEmbedded();
-      final LocalTimeSeriesType tsType = (LocalTimeSeriesType) embedded.getSchema().getType("broken");
-      final TimeSeriesEngine engine = tsType.getEngine();
-      engine.compactAll();
-
-      final File sealed = new File(getDatabasePath(serverIndex), "broken_shard_0.ts.sealed");
-      assertThat(sealed).exists();
-
-      // Close and reopen the database from disk, byte-flipped, so the corruption is discovered on load exactly
-      // as it would be after a real restart - not by poking the in-memory schema directly.
-      embedded.close();
-      server.removeDatabase(getDatabaseName());
-      try (final RandomAccessFile raf = new RandomAccessFile(sealed, "rw")) {
-        raf.seek(0);
-        final int b = raf.read();
-        raf.seek(0);
-        raf.write(b ^ 0x01);
-      }
-      final DatabaseInternal reopened = (DatabaseInternal) server.getDatabase(getDatabaseName()).getEmbedded();
-      final LocalTimeSeriesType reopenedType = (LocalTimeSeriesType) reopened.getSchema().getType("broken");
-      assertThat(reopenedType.isEngineAvailable()).as("the type must stay registered, just without a usable engine")
-          .isFalse();
+      corruptSealedStoreAndReopen(serverIndex, "broken");
 
       final HttpURLConnection connection = openWriteConnection(serverIndex, "ms");
       try (final OutputStream os = connection.getOutputStream()) {

--- a/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
@@ -205,6 +205,28 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
     });
   }
 
+  /**
+   * Regression for issue #6356's follow-up (claude-review on PR #6779): a TimeSeries type whose engine failed to
+   * load must be told apart from "not a TimeSeries type" here too, on the query endpoint.
+   */
+  @Test
+  void queryEngineUnavailableTypeIsReportedDistinctlyFromNonTimeSeriesType() throws Exception {
+    testEachServer(serverIndex -> {
+      command(serverIndex,
+          "CREATE TIMESERIES TYPE broken TIMESTAMP ts TAGS (host STRING) FIELDS (usage DOUBLE)");
+      command(serverIndex, "INSERT INTO broken SET ts = 1700000000000, host = 'h', usage = 1.0");
+
+      corruptSealedStoreAndReopen(serverIndex, "broken");
+
+      final JSONObject request = new JSONObject();
+      request.put("type", "broken");
+
+      final JSONObject error = postTsQueryError(serverIndex, request);
+      assertThat(error.getString("error")).as("must be distinguishable from \"is not a TimeSeries type\"")
+          .contains("no storage engine available");
+    });
+  }
+
   @Test
   void latestValue() throws Exception {
     testEachServer(serverIndex -> {
@@ -253,6 +275,25 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
     testEachServer(serverIndex -> {
       final int statusCode = getTsLatestRaw(serverIndex, null, null);
       assertThat(statusCode).isEqualTo(400);
+    });
+  }
+
+  /**
+   * Regression for issue #6356's follow-up (claude-review on PR #6779): a TimeSeries type whose engine failed to
+   * load must be told apart from "not a TimeSeries type" here too, on the latest-value endpoint.
+   */
+  @Test
+  void latestEngineUnavailableTypeIsReportedDistinctlyFromNonTimeSeriesType() throws Exception {
+    testEachServer(serverIndex -> {
+      command(serverIndex,
+          "CREATE TIMESERIES TYPE broken TIMESTAMP ts TAGS (host STRING) FIELDS (usage DOUBLE)");
+      command(serverIndex, "INSERT INTO broken SET ts = 1700000000000, host = 'h', usage = 1.0");
+
+      corruptSealedStoreAndReopen(serverIndex, "broken");
+
+      final JSONObject error = getTsLatestError(serverIndex, "broken");
+      assertThat(error.getString("error")).as("must be distinguishable from \"is not a TimeSeries type\"")
+          .contains("no storage engine available");
     });
   }
 
@@ -334,6 +375,27 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
     return connection.getResponseCode();
   }
 
+  private JSONObject postTsQueryError(final int serverIndex, final JSONObject request) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/ts/graph/query")
+        .toURL()
+        .openConnection();
+
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+
+    try (final OutputStream os = connection.getOutputStream()) {
+      os.write(request.toString().getBytes(StandardCharsets.UTF_8));
+      os.flush();
+    }
+
+    assertThat(connection.getResponseCode()).isEqualTo(400);
+    return new JSONObject(readError(connection));
+  }
+
   private JSONObject getTsLatest(final int serverIndex, final String type, final String tag) throws Exception {
     final StringBuilder url = new StringBuilder("http://127.0.0.1:248" + serverIndex + "/api/v1/ts/graph/latest?type=" + type);
     if (tag != null)
@@ -370,5 +432,19 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
         "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
 
     return connection.getResponseCode();
+  }
+
+  private JSONObject getTsLatestError(final int serverIndex, final String type) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/ts/graph/latest?type=" + type)
+        .toURL()
+        .openConnection();
+
+    connection.setRequestMethod("GET");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+
+    assertThat(connection.getResponseCode()).isEqualTo(400);
+    return new JSONObject(readError(connection));
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
@@ -36,7 +36,10 @@ import static org.mockito.Mockito.when;
 class HttpAuthSessionManagerTest {
 
   private HttpAuthSessionManager manager;
-  private long                   fakeNow;
+  // Also read by the manager's background cleanup Timer thread via the () -> fakeNow supplier passed to
+  // createManagerWithFakeClock(): volatile so that read is guaranteed to see this thread's writes, even though
+  // every test only asserts after advancing the clock and calling checkSessionsValidity() itself.
+  private volatile long          fakeNow;
 
   @AfterEach
   void tearDown() {

--- a/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
@@ -45,8 +45,8 @@ class HttpAuthSessionManagerTest {
     }
   }
 
-  private ServerSecurityUser createMockUser(String username) {
-    ServerSecurityUser user = mock(ServerSecurityUser.class);
+  private ServerSecurityUser createMockUser(final String username) {
+    final ServerSecurityUser user = mock(ServerSecurityUser.class);
     when(user.getName()).thenReturn(username);
     when(user.getAuthorizedDatabases()).thenReturn(Set.of());
     return user;
@@ -64,9 +64,9 @@ class HttpAuthSessionManagerTest {
   @Test
   void createAndGetSession() {
     manager = new HttpAuthSessionManager(30_000L); // 30 second idle timeout
-    ServerSecurityUser user = createMockUser("testuser");
+    final ServerSecurityUser user = createMockUser("testuser");
 
-    HttpAuthSession session = manager.createSession(user);
+    final HttpAuthSession session = manager.createSession(user);
 
     assertThat(session).isNotNull();
     assertThat(session.getToken()).startsWith("AU-");
@@ -74,7 +74,7 @@ class HttpAuthSessionManagerTest {
     assertThat(manager.getActiveSessionCount()).isEqualTo(1);
 
     // Should be able to get the session back
-    HttpAuthSession retrieved = manager.getSessionByToken(session.getToken());
+    final HttpAuthSession retrieved = manager.getSessionByToken(session.getToken());
     assertThat(retrieved).isNotNull();
     assertThat(retrieved.getToken()).isEqualTo(session.getToken());
   }
@@ -82,13 +82,13 @@ class HttpAuthSessionManagerTest {
   @Test
   void sessionIdleTimeout() throws Exception {
     manager = createManagerWithFakeClock(100L, 0); // 100ms idle timeout
-    ServerSecurityUser user = createMockUser("testuser");
+    final ServerSecurityUser user = createMockUser("testuser");
 
-    HttpAuthSession session = manager.createSession(user);
+    final HttpAuthSession session = manager.createSession(user);
 
     // Don't call getSessionByToken here as it would reset the idle timer via touch()
     assertThat(session).isNotNull();
-    String token = session.getToken();
+    final String token = session.getToken();
 
     // Advance the fake clock well past the idle timeout; no wall-clock wait needed
     fakeNow += 300;
@@ -101,9 +101,9 @@ class HttpAuthSessionManagerTest {
   @Test
   void sessionIdleTimeoutResetByAccess() throws Exception {
     manager = createManagerWithFakeClock(200L, 0); // 200ms idle timeout
-    ServerSecurityUser user = createMockUser("testuser");
+    final ServerSecurityUser user = createMockUser("testuser");
 
-    HttpAuthSession session = manager.createSession(user);
+    final HttpAuthSession session = manager.createSession(user);
 
     // Access session before it times out (resets idle timer)
     fakeNow += 100;
@@ -114,31 +114,31 @@ class HttpAuthSessionManagerTest {
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
 
     // Session should still be valid because we kept accessing it
-    int expired = manager.checkSessionsValidity();
+    final int expired = manager.checkSessionsValidity();
     assertThat(expired).isEqualTo(0);
   }
 
   @Test
   void absoluteTimeoutZeroMeansUnlimited() throws Exception {
     manager = createManagerWithFakeClock(10_000L, 0); // 10s idle timeout, 0 = unlimited absolute
-    ServerSecurityUser user = createMockUser("testuser");
+    final ServerSecurityUser user = createMockUser("testuser");
 
-    HttpAuthSession session = manager.createSession(user);
+    final HttpAuthSession session = manager.createSession(user);
 
     fakeNow += 100;
 
     // Session should still be valid (no absolute timeout)
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
-    int expired = manager.checkSessionsValidity();
+    final int expired = manager.checkSessionsValidity();
     assertThat(expired).isEqualTo(0);
   }
 
   @Test
   void absoluteTimeoutExpiresSession() throws Exception {
     manager = createManagerWithFakeClock(10_000L, 100L); // 10s idle timeout, 100ms absolute timeout
-    ServerSecurityUser user = createMockUser("testuser");
+    final ServerSecurityUser user = createMockUser("testuser");
 
-    HttpAuthSession session = manager.createSession(user);
+    final HttpAuthSession session = manager.createSession(user);
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
 
     // Advance the fake clock past the absolute timeout
@@ -148,16 +148,16 @@ class HttpAuthSessionManagerTest {
     assertThat(manager.getSessionByToken(session.getToken())).isNull();
 
     // Cleanup should also remove it
-    int expired = manager.checkSessionsValidity();
+    final int expired = manager.checkSessionsValidity();
     assertThat(expired).isEqualTo(1);
   }
 
   @Test
   void absoluteTimeoutNotResetByAccess() throws Exception {
     manager = createManagerWithFakeClock(10_000L, 200L); // 10s idle timeout, 200ms absolute timeout
-    ServerSecurityUser user = createMockUser("testuser");
+    final ServerSecurityUser user = createMockUser("testuser");
 
-    HttpAuthSession session = manager.createSession(user);
+    final HttpAuthSession session = manager.createSession(user);
 
     // Access session multiple times (this should reset idle timeout but NOT absolute)
     fakeNow += 80;
@@ -176,9 +176,9 @@ class HttpAuthSessionManagerTest {
   @Test
   void removeSession() {
     manager = new HttpAuthSessionManager(30_000L);
-    ServerSecurityUser user = createMockUser("testuser");
+    final ServerSecurityUser user = createMockUser("testuser");
 
-    HttpAuthSession session = manager.createSession(user);
+    final HttpAuthSession session = manager.createSession(user);
     assertThat(manager.getActiveSessionCount()).isEqualTo(1);
 
     boolean removed = manager.removeSession(session.getToken());
@@ -195,16 +195,16 @@ class HttpAuthSessionManagerTest {
   void getSessionByInvalidToken() {
     manager = new HttpAuthSessionManager(30_000L);
 
-    HttpAuthSession session = manager.getSessionByToken("AU-invalid-token");
+    final HttpAuthSession session = manager.getSessionByToken("AU-invalid-token");
     assertThat(session).isNull();
   }
 
   @Test
   void elapsedFromCreation() throws Exception {
     manager = createManagerWithFakeClock(30_000L, 0);
-    ServerSecurityUser user = createMockUser("testuser");
+    final ServerSecurityUser user = createMockUser("testuser");
 
-    HttpAuthSession session = manager.createSession(user);
+    final HttpAuthSession session = manager.createSession(user);
     assertThat(session.elapsedFromCreation()).isEqualTo(0);
 
     fakeNow += 100;
@@ -215,11 +215,11 @@ class HttpAuthSessionManagerTest {
   @Test
   void multipleSessions() {
     manager = new HttpAuthSessionManager(30_000L);
-    ServerSecurityUser user1 = createMockUser("user1");
-    ServerSecurityUser user2 = createMockUser("user2");
+    final ServerSecurityUser user1 = createMockUser("user1");
+    final ServerSecurityUser user2 = createMockUser("user2");
 
-    HttpAuthSession session1 = manager.createSession(user1);
-    HttpAuthSession session2 = manager.createSession(user2);
+    final HttpAuthSession session1 = manager.createSession(user1);
+    final HttpAuthSession session2 = manager.createSession(user2);
 
     assertThat(manager.getActiveSessionCount()).isEqualTo(2);
     assertThat(session1.getToken()).isNotEqualTo(session2.getToken());

--- a/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 class HttpAuthSessionManagerTest {
 
   private HttpAuthSessionManager manager;
+  private long                   fakeNow;
 
   @AfterEach
   void tearDown() {
@@ -49,6 +50,15 @@ class HttpAuthSessionManagerTest {
     when(user.getName()).thenReturn(username);
     when(user.getAuthorizedDatabases()).thenReturn(Set.of());
     return user;
+  }
+
+  /**
+   * Builds a manager backed by a deterministic fake clock (advanced via {@link #fakeNow}) instead of
+   * the wall clock, so idle/absolute timeout assertions cannot flake under a stop-the-world pause (#6398).
+   */
+  private HttpAuthSessionManager createManagerWithFakeClock(final long sessionTimeoutInMs, final long absoluteTimeoutInMs) {
+    fakeNow = 0L;
+    return new HttpAuthSessionManager(sessionTimeoutInMs, absoluteTimeoutInMs, () -> fakeNow);
   }
 
   @Test
@@ -71,7 +81,7 @@ class HttpAuthSessionManagerTest {
 
   @Test
   void sessionIdleTimeout() throws Exception {
-    manager = new HttpAuthSessionManager(100L); // 100ms idle timeout
+    manager = createManagerWithFakeClock(100L, 0); // 100ms idle timeout
     ServerSecurityUser user = createMockUser("testuser");
 
     HttpAuthSession session = manager.createSession(user);
@@ -80,11 +90,9 @@ class HttpAuthSessionManagerTest {
     assertThat(session).isNotNull();
     String token = session.getToken();
 
-    // Wait for idle timeout + timer to run (timer runs every 100ms)
-    Thread.sleep(300);
+    // Advance the fake clock well past the idle timeout; no wall-clock wait needed
+    fakeNow += 300;
 
-    // Session should be cleaned up by the background timer or manually
-    // Either the timer already ran, or we trigger it now
     manager.checkSessionsValidity();
     assertThat(manager.getActiveSessionCount()).isEqualTo(0);
     assertThat(manager.getSessionByToken(token)).isNull();
@@ -92,17 +100,17 @@ class HttpAuthSessionManagerTest {
 
   @Test
   void sessionIdleTimeoutResetByAccess() throws Exception {
-    manager = new HttpAuthSessionManager(200L); // 200ms idle timeout
+    manager = createManagerWithFakeClock(200L, 0); // 200ms idle timeout
     ServerSecurityUser user = createMockUser("testuser");
 
     HttpAuthSession session = manager.createSession(user);
 
     // Access session before it times out (resets idle timer)
-    Thread.sleep(100);
+    fakeNow += 100;
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
 
     // Access again
-    Thread.sleep(100);
+    fakeNow += 100;
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
 
     // Session should still be valid because we kept accessing it
@@ -112,13 +120,12 @@ class HttpAuthSessionManagerTest {
 
   @Test
   void absoluteTimeoutZeroMeansUnlimited() throws Exception {
-    manager = new HttpAuthSessionManager(10_000L, 0); // 10s idle timeout, 0 = unlimited absolute
+    manager = createManagerWithFakeClock(10_000L, 0); // 10s idle timeout, 0 = unlimited absolute
     ServerSecurityUser user = createMockUser("testuser");
 
     HttpAuthSession session = manager.createSession(user);
 
-    // Wait a bit
-    Thread.sleep(100);
+    fakeNow += 100;
 
     // Session should still be valid (no absolute timeout)
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
@@ -128,14 +135,14 @@ class HttpAuthSessionManagerTest {
 
   @Test
   void absoluteTimeoutExpiresSession() throws Exception {
-    manager = new HttpAuthSessionManager(10_000L, 100L); // 10s idle timeout, 100ms absolute timeout
+    manager = createManagerWithFakeClock(10_000L, 100L); // 10s idle timeout, 100ms absolute timeout
     ServerSecurityUser user = createMockUser("testuser");
 
     HttpAuthSession session = manager.createSession(user);
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
 
-    // Wait for absolute timeout to expire
-    Thread.sleep(150);
+    // Advance the fake clock past the absolute timeout
+    fakeNow += 150;
 
     // Session should be rejected even though idle timeout hasn't expired
     assertThat(manager.getSessionByToken(session.getToken())).isNull();
@@ -147,20 +154,20 @@ class HttpAuthSessionManagerTest {
 
   @Test
   void absoluteTimeoutNotResetByAccess() throws Exception {
-    manager = new HttpAuthSessionManager(10_000L, 200L); // 10s idle timeout, 200ms absolute timeout
+    manager = createManagerWithFakeClock(10_000L, 200L); // 10s idle timeout, 200ms absolute timeout
     ServerSecurityUser user = createMockUser("testuser");
 
     HttpAuthSession session = manager.createSession(user);
 
     // Access session multiple times (this should reset idle timeout but NOT absolute)
-    Thread.sleep(80);
+    fakeNow += 80;
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
 
-    Thread.sleep(80);
+    fakeNow += 80;
     assertThat(manager.getSessionByToken(session.getToken())).isNotNull();
 
-    // Wait for absolute timeout to expire
-    Thread.sleep(100);
+    // Advance the fake clock past the absolute timeout
+    fakeNow += 100;
 
     // Session should now be rejected because absolute timeout expired
     assertThat(manager.getSessionByToken(session.getToken())).isNull();
@@ -194,18 +201,15 @@ class HttpAuthSessionManagerTest {
 
   @Test
   void elapsedFromCreation() throws Exception {
-    manager = new HttpAuthSessionManager(30_000L);
+    manager = createManagerWithFakeClock(30_000L, 0);
     ServerSecurityUser user = createMockUser("testuser");
 
     HttpAuthSession session = manager.createSession(user);
-    long initialElapsed = session.elapsedFromCreation();
-    assertThat(initialElapsed).isGreaterThanOrEqualTo(0);
-    assertThat(initialElapsed).isLessThan(100);
+    assertThat(session.elapsedFromCreation()).isEqualTo(0);
 
-    Thread.sleep(100);
+    fakeNow += 100;
 
-    long laterElapsed = session.elapsedFromCreation();
-    assertThat(laterElapsed).isGreaterThanOrEqualTo(100);
+    assertThat(session.elapsedFromCreation()).isEqualTo(100);
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/TimeSeriesApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/TimeSeriesApiSpecTest.java
@@ -84,7 +84,7 @@ class TimeSeriesApiSpecTest {
   void writeErrorBodyCarriesTheIngestionCounts() {
     final Schema<?> schema = openAPI.getComponents().getSchemas().get("TimeSeriesWriteError");
     assertThat(schema.getProperties().keySet()).containsExactlyInAnyOrder(
-        "error", "requestId", "written", "dropped", "unknownTypes", "nonTimeSeriesTypes");
+        "error", "requestId", "written", "dropped", "unknownTypes", "nonTimeSeriesTypes", "unavailableTypes");
     assertThat(openAPI.getPaths().get("/api/v1/ts/{database}/write").getPost()
         .getResponses().get("400").getContent().get("application/json").getSchema().get$ref())
         .isEqualTo("#/components/schemas/TimeSeriesWriteError");


### PR DESCRIPTION
## Summary

Three unrelated but simple issues that surfaced as follow-ups from other analyses. Each has its own root cause and its own regression test.

### #6398 — `HttpAuthSessionManagerTest.absoluteTimeoutNotResetByAccess` flake
`HttpAuthSession`/`HttpAuthSessionManager` now accept an injectable clock (`LongSupplier`), defaulting to `System::currentTimeMillis` in production. The whole test class was swept to drive a fake clock instead of `Thread.sleep`, per the issue's own suggestion ("the only version that cannot flake"). Tests are also much faster now (no more real sleeps).

### #6394 — snapshot barrier timeout test infers cause from elapsed time
`PageManager.openSnapshotInternal` has two `PageSnapshotException` throw sites with opposite operational meaning: `SUSPEND_TIMEOUT` (transient, expected under load) and `FLUSH_TIMEOUT` (fatal, a stuck disk). `PageSnapshotException` now carries a `Reason` enum (`NOT_RUNNING`, `SUSPEND_TIMEOUT`, `FLUSH_TIMEOUT`, `OTHER`) so callers/tests can branch on *why* instead of parsing `getMessage()` or inferring it from timing. `Issue6125SnapshotBarrierAndCapTest` now asserts on `getReason()` and drops the 1000ms floor that caused the flake under a full-suite run.

### #6356 — TimeSeries type disappears from schema when its sealed store fails to load
Root cause: `LocalSchema.readConfiguration()` wrapped an `initEngine()` `IOException` (e.g. a corrupt `.ts.sealed` magic) in a `ConfigurationException` that aborted the type's registration, and the method's own outer `catch (Exception e)` logged and swallowed it — so the database reopened cleanly with the type simply gone, no warning, and the next write silently created a fresh empty type.

`DatabaseChecker#checkTimeSeries` already had an unreachable branch for exactly this case (`"the storage engine is not initialised"`, added in #6340/#6347) — the strongest signal for which of the three designs discussed in the issue was intended. Implemented: **register the type with its engine unavailable** rather than refusing the whole database open (the sealed store is HA-derived/rebuildable by recompaction) or discarding the type silently.

- `LocalTimeSeriesType` now tracks `engineUnavailableReason` and exposes `isEngineAvailable()` / `getEngineUnavailableReason()` / `requireEngine()`.
- Read/write call sites that previously would have NPE'd on a null engine (`LocalDatabase.countType`, `DatabaseAsyncExecutorImpl.appendSamples` x2, `SaveElementStep`, `SelectExecutionPlanner`) now fail loudly and by name via `requireEngine()`.
- `TimeSeriesSealedStore.loadDirectory()`'s three header-validation `IOException`s now name the `.ts.sealed` file.
- `DatabaseChecker`'s existing null-engine branch is exercised for the first time.

Verified against a real reproduction (flip byte 0 of a `.ts.sealed` file, close, reopen) with three new tests: the type stays registered and reports its reason, `CHECK DATABASE` reports it, and a write against it fails with a clear message instead of an NPE.

## Test plan
- [x] `HttpAuthSessionManagerTest` + `HttpAuthSessionManagerConcurrencyTest` (server): 11/11 pass, no sleeps
- [x] `Issue6125SnapshotBarrierAndCapTest` + `ExceptionTest` (engine): 44/44 pass
- [x] Full `com.arcadedb.engine.timeseries.**` package: 533/533 pass
- [x] `DatabaseChecker`/`LocalSchema`-adjacent regression tests: 29/29 pass
- [x] `mvn -o -pl engine,network,server,ha-raft,integration -am compile` and `test-compile`: clean

## Files changed
- engine/src/main/java/com/arcadedb/database/LocalDatabase.java
- engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
- engine/src/main/java/com/arcadedb/engine/PageManager.java
- engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
- engine/src/main/java/com/arcadedb/exception/PageSnapshotException.java
- engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
- engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
- engine/src/main/java/com/arcadedb/schema/LocalSchema.java
- engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
- engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
- engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
- engine/src/test/java/com/arcadedb/exception/ExceptionTest.java
- server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
- server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
- server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java

Closes #6398, closes #6394, closes #6356.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved time-series behavior when storage engines are unavailable, preserving schema visibility and providing clearer read/write errors.
  - Added file-path details for corrupted time-series storage files and improved database diagnostics.
  - Snapshot failures now identify stopped databases, suspend timeouts, and flush timeouts.
  - Prevented unsupported fallback processing for time-series queries and writes.
  - Improved error formatting for reliable JSON responses.

- **API Improvements**
  - Time-series write responses now identify unavailable measurements.

- **Reliability**
  - Improved authentication session timeout consistency.

- **Tests**
  - Expanded coverage for time-series failures, snapshot reasons, exception details, and session expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->