### PR TITLE
fix(graph): exclude overlay-added edges deleted in the same window

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -48,8 +48,12 @@ class DeltaOverlay {
   // Deleted overflow nodes (indexed by overflowIdx = globalId - baseNodeCount)
   private final BitSet                      deletedOverflowNodes;
 
-  // Added edges per type: edgeType -> list of (srcGlobalId, tgtGlobalId) pairs
-  private final Map<String, List<long[]>>   addedEdgesPerType;
+  // Added edges per type: edgeType -> the added edge's own identity -> (srcGlobalId, tgtGlobalId) pair.
+  // Keyed by RID rather than held in a plain list so that an edge added and later deleted within the SAME
+  // not-yet-compacted overlay window can be withdrawn from here by identity, instead of being masked with a
+  // pair-keyed deletion it has no right to spend (issue #6775 - see merge()). Insertion-ordered, because
+  // the neighbour index below is built from it and parallel edges must keep their addition order.
+  private final Map<String, Map<RID, long[]>> addedEdgesPerType;
 
   // Secondary indexes for O(1) neighbor lookup: edgeType -> nodeId -> neighbor list
   private final Map<String, Map<Integer, int[]>> outNeighborIndex;
@@ -58,6 +62,8 @@ class DeltaOverlay {
   // Deleted edges per type: edgeType -> packed (src << 32 | tgt) -> number of distinct edges deleted for
   // that pair. A count rather than a presence flag: two parallel edges between the same pair, only one of
   // them deleted, must leave the other one discoverable (see #copyBaseExcludingDeleted and issue #6769).
+  // Holds ONLY deletions of edges the overlay never added itself, so the count is exactly the exclusion
+  // budget to spend against the BASE CSR's run for the pair - never against the overlay's own additions.
   private final Map<String, Map<Long, Integer>> deletedEdgesPerType;
 
   // The deleted edges' own identities, per type. Exists purely to tell a genuinely new deletion apart from
@@ -105,7 +111,7 @@ class DeltaOverlay {
       final Map<RID, Integer> overflowNodeIds, final RID[] overflowIdToRID,
       final Map<String, Object>[] overflowProperties,
       final BitSet deletedBaseNodes, final BitSet deletedOverflowNodes,
-      final Map<String, List<long[]>> addedEdgesPerType,
+      final Map<String, Map<RID, long[]>> addedEdgesPerType,
       final Map<String, Map<Long, Integer>> deletedEdgesPerType,
       final Map<String, Set<RID>> deletedEdgeRIDsPerType,
       final Map<String, IntIntHashMap> deletedOutEdgeCounts,
@@ -160,9 +166,9 @@ class DeltaOverlay {
     final List<Map<String, Object>> overflowPropsList = new ArrayList<>(Arrays.asList(overflowProperties));
     final BitSet newDeleted = (BitSet) deletedBaseNodes.clone();
     final BitSet newDeletedOverflow = (BitSet) deletedOverflowNodes.clone();
-    final Map<String, List<long[]>> newAddedEdges = new HashMap<>();
+    final Map<String, Map<RID, long[]>> newAddedEdges = new HashMap<>();
     for (final var entry : addedEdgesPerType.entrySet())
-      newAddedEdges.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+      newAddedEdges.put(entry.getKey(), new LinkedHashMap<>(entry.getValue()));
     final Map<String, Map<Long, Integer>> newDeletedEdges = new HashMap<>();
     for (final var entry : deletedEdgesPerType.entrySet())
       newDeletedEdges.put(entry.getKey(), new HashMap<>(entry.getValue()));
@@ -236,9 +242,11 @@ class DeltaOverlay {
             continue; // already represented by the fresh base CSR
         }
       }
-      newAddedEdges.computeIfAbsent(ed.edgeType, k -> new ArrayList<>())
-          .add(new long[] { srcId, tgtId });
-      newDeltaEdgeCount++;
+      // Keyed by the edge's own identity, so a replayed add of an edge the overlay already holds is
+      // absorbed instead of appending a second, phantom, occurrence of the same edge.
+      if (newAddedEdges.computeIfAbsent(ed.edgeType, k -> new LinkedHashMap<>())
+          .put(ed.rid, new long[] { srcId, tgtId }) == null)
+        newDeltaEdgeCount++;
     }
 
     // Process deleted edges
@@ -247,6 +255,23 @@ class DeltaOverlay {
       final int tgtId = resolveNodeId(ed.target, baseMapping, newOverflowIds);
       if (srcId < 0 || tgtId < 0)
         continue;
+      // The edge was added by THIS overlay window and is now gone: the add and the delete are one no-op, so
+      // withdraw the add instead of recording a deletion (issue #6775). The distinction matters because the
+      // deleted counts below are a budget spent against the BASE CSR's run for the pair: recording one here
+      // would mask a base edge nobody deleted, while leaving the phantom add in place - which is exactly how
+      // the append-only added index used to surface an added-then-deleted edge as a live neighbour. Done by
+      // identity, before the dedup guard below, so a RID recycled onto a new edge (the #6777 hole-reuse gap)
+      // still cancels its own add rather than having the whole deletion dropped.
+      final Map<RID, long[]> addedForType = newAddedEdges.get(ed.edgeType);
+      if (addedForType != null && addedForType.remove(ed.rid) != null) {
+        newDeltaEdgeCount--; // undo the +1 the withdrawn add contributed
+        if (addedForType.isEmpty())
+          newAddedEdges.remove(ed.edgeType); // keep hasChanges() honest: no adds left for this type
+        // Remembered anyway, so a replay of this same deletion cannot fall through to the branch below and
+        // spend a budget against the base CSR now that the add it belongs to is gone.
+        newDeletedEdgeRIDs.computeIfAbsent(ed.edgeType, k -> new HashSet<>()).add(ed.rid);
+        continue;
+      }
       // Only count when the deletion is new: newDeletedEdgeRIDs is keyed by the edge's own identity, so a
       // duplicate deletion (replayed across merges or emitted twice within one TxDelta) is absorbed by
       // add() returning false. Counting it again would drift newDeltaEdgeCount negative and corrupt the
@@ -440,12 +465,12 @@ class DeltaOverlay {
    * that would occur with a growable-array approach for high-degree nodes.
    */
   private static Map<String, Map<Integer, int[]>> buildNeighborIndex(
-      final Map<String, List<long[]>> addedEdges, final boolean outgoing) {
+      final Map<String, Map<RID, long[]>> addedEdges, final boolean outgoing) {
     if (addedEdges.isEmpty())
       return Collections.emptyMap();
     final Map<String, Map<Integer, int[]>> result = new HashMap<>();
     for (final var entry : addedEdges.entrySet()) {
-      final List<long[]> edges = entry.getValue();
+      final Collection<long[]> edges = entry.getValue().values();
 
       // Pass 1: count neighbors per node
       final IntIntHashMap counts = new IntIntHashMap();

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -36,7 +36,6 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.VertexType;
-import com.arcadedb.utility.IntIntHashMap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -101,8 +100,10 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   private static final int MAX_CONCURRENT_BUILDS = Math.max(2, Runtime.getRuntime().availableProcessors());
 
   /**
-   * Returned by {@link #countEdgesBetween} when the overlay makes the multiplicity unknowable, which
-   * the {@link com.arcadedb.graph.GraphTraversalProvider} contract spells as any negative value.
+   * The "multiplicity unknowable" answer, which the {@link com.arcadedb.graph.GraphTraversalProvider}
+   * contract spells as any negative value. Still returned by {@link #getMeanEdgesPerConnectedPair}; since
+   * issue #6775 an active delta overlay is no longer a reason for {@link #countEdgesBetween} to give it,
+   * because a pair the overlay has deletions for is now counted exactly (see {@link #countBetweenForType}).
    */
   private static final long MULTIPLICITY_UNKNOWN = -1L;
 
@@ -922,16 +923,17 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
         if (csr != null)
           total += countDirectional(snap, csr, nodeId, direction, edgeType);
         else {
-          // No base CSR but overlay may have edges for this type. The overlay's added-edge index is
-          // append-only, so an edge added and then deleted within the same window is still counted
-          // there; subtract the per-node deleted counts back out (same cancellation as
-          // countDirectional's overlay branch). See issue #6775.
+          // No base CSR but overlay may have edges for this type. Nothing to subtract here: the overlay's
+          // deleted counts are an exclusion budget spent against a base CSR run, and there is no base run
+          // for this type. An edge added and then deleted within the same window is withdrawn from the
+          // added index by DeltaOverlay.merge() rather than masked (issue #6775), so what is left is
+          // already the live set.
           final DeltaOverlay ov = snap.overlay;
           if (ov != null) {
             if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH)
-              total += ov.getAddedOutNeighbors(nodeId, edgeType).length - ov.countDeletedOutEdges(nodeId, edgeType);
+              total += ov.getAddedOutNeighbors(nodeId, edgeType).length;
             if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH)
-              total += ov.getAddedInNeighbors(nodeId, edgeType).length - ov.countDeletedInEdges(nodeId, edgeType);
+              total += ov.getAddedInNeighbors(nodeId, edgeType).length;
           }
         }
       }
@@ -1036,8 +1038,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
-   * Counts the edges joining nodeA to nodeB, optionally filtered by edge type, or a negative value
-   * when the delta overlay makes the count unknowable (see {@link #countBetweenForType}).
+   * Counts the edges joining nodeA to nodeB, optionally filtered by edge type. A negative value means
+   * the count is unknowable; since issue #6775 a delta overlay is no longer a reason for that - a pair
+   * the overlay has deletions for is counted exactly, in agreement with {@link #getVertices} and
+   * {@link #isConnectedTo} rather than against them (see {@link #countBetweenForType}) - but the
+   * "negative means unknown" branch below stays, because it is the contract
+   * {@link com.arcadedb.graph.GraphTraversalProvider} publishes and a future edge type may need it.
    * <p>
    * This is the multiplicity {@link #isConnectedTo} collapses to a boolean, and a pattern
    * relationship matches once per edge, so a Cypher hop between two pinned vertices needs it rather
@@ -2219,75 +2225,47 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       }
     }
 
-    // Check overlay added edges. Same known gap as getNeighborsFromCSR (issue #6775): not filtered
-    // against deletedEdgesPerType, so an edge added and deleted within the same overlay window
-    // before compaction is still reported connected here.
+    // Check overlay added edges. No filtering against deletedEdgesPerType is needed - or correct - here:
+    // that map is the exclusion budget for the BASE CSR run above and holds only deletions of edges the
+    // overlay never added itself, because an edge added and then deleted within the same window is
+    // withdrawn from the added index at merge time instead (issue #6775). Anything still listed here is
+    // live.
     if (ov != null) {
       if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-        // The deleted budget is spent against base CSR occurrences first (see isConnectedForType's
-        // base branch and copyBaseExcludingDeleted); the pair stays connected through its added
-        // edges only if more added occurrences of nodeB survive than the leftover budget.
-        final int deleted = ov.countDeletedEdges(edgeType, nodeA, nodeB);
-        final int baseOccurrences = nodeAInBase && csr != null
-            ? equalRangeCount(csr.getForwardNeighbors(), csr.getForwardOffsets()[nodeA], csr.getForwardOffsets()[nodeA + 1], nodeB)
-            : 0;
-        if (deleted > baseOccurrences) {
-          int addedSurvivors = 0;
-          for (final int neighbor : ov.getAddedOutNeighbors(nodeA, edgeType))
-            if (neighbor == nodeB)
-              addedSurvivors++;
-          if (addedSurvivors > deleted - baseOccurrences)
+        for (final int neighbor : ov.getAddedOutNeighbors(nodeA, edgeType))
+          if (neighbor == nodeB)
             return true;
-        } else {
-          // No leftover budget: any added edge of the pair survives.
-          for (final int neighbor : ov.getAddedOutNeighbors(nodeA, edgeType))
-            if (neighbor == nodeB)
-              return true;
-        }
       }
       if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-        final int deleted = ov.countDeletedEdges(edgeType, nodeB, nodeA);
-        final int baseOccurrences = nodeAInBase && csr != null
-            ? equalRangeCount(csr.getBackwardNeighbors(), csr.getBackwardOffsets()[nodeA], csr.getBackwardOffsets()[nodeA + 1], nodeB)
-            : 0;
-        if (deleted > baseOccurrences) {
-          int addedSurvivors = 0;
-          for (final int neighbor : ov.getAddedInNeighbors(nodeA, edgeType))
-            if (neighbor == nodeB)
-              addedSurvivors++;
-          if (addedSurvivors > deleted - baseOccurrences)
+        for (final int neighbor : ov.getAddedInNeighbors(nodeA, edgeType))
+          if (neighbor == nodeB)
             return true;
-        } else {
-          for (final int neighbor : ov.getAddedInNeighbors(nodeA, edgeType))
-            if (neighbor == nodeB)
-              return true;
-        }
       }
     }
     return false;
   }
 
   /**
-   * Counts the edges of one type joining nodeA to nodeB, or {@link #MULTIPLICITY_UNKNOWN} when the
-   * overlay cannot say how many of them survive.
+   * Counts the edges of one type joining nodeA to nodeB.
    * <p>
    * A self-loop is held by both adjacency lists of its vertex, so a BOTH walk would see it twice; the
    * backward side is skipped when the two nodes are the same, which is what the OLTP expansion
    * achieves by de-duplicating on edge identity.
    * <p>
-   * <b>Why a deleted pair is still answered "unknown" rather than the exact survivor count.</b>
-   * {@link DeltaOverlay} now tracks an exact per-pair deleted count (issue #6769), which is exactly
-   * what {@link #isConnectedTo} and {@link #getNeighborIds} compare against the base CSR's occurrence
-   * count for the pair to keep the surviving parallel edges discoverable. This method could mirror that
-   * arithmetic and return an exact number for the base-CSR side, but the overlay's ADDED neighbours are
-   * not filtered against deletedEdgesPerType at all yet (issue #6775), so a masked pair's added-edge
-   * contribution here has no safe way to exclude a since-deleted add. A pattern hop turns the count
-   * directly into rows, and getting that arithmetic wrong silently produces the wrong row count rather
-   * than an exception - so it keeps the conservative "unknown" answer here until #6775 closes that gap,
-   * and leaves
-   * {@code com.arcadedb.query.opencypher.executor.operators.GAVExpandInto}'s existing OLTP fallback
-   * to do the exact counting, which it already had to have for the "vertex not in the GAV mapping"
-   * case anyway.
+   * <b>Why a pair with overlay deletions is now counted exactly rather than answered "unknown".</b> The
+   * count is the same arithmetic {@link #isConnectedTo} and {@link #getNeighborIds} already run, only
+   * kept as a number instead of collapsed to a boolean: the base CSR's occurrence count for the pair
+   * minus the overlay's exact per-pair deleted count (issue #6769), plus the overlay's added occurrences.
+   * It became safe once {@link DeltaOverlay#merge} stopped recording a pair deletion for an edge the same
+   * overlay window had added (issue #6775) - the deleted count is now exclusively a budget against the
+   * BASE run, so there is no double-spend between the two terms and no since-deleted add left to exclude
+   * from the second. Answering "unknown" here while {@link #getVertices} happily lists the pair as a live
+   * neighbour was the very inconsistency #6775 is about, so the two agree instead.
+   * <p>
+   * The subtraction is clamped at zero rather than trusted to stay non-negative: a budget wider than the
+   * base run is exactly what the two documented overlay gaps (#4588's pair-level re-application dedup and
+   * #6777's RID reuse) can produce, and a negative contribution would corrupt the sum for the OTHER edge
+   * types {@link #countEdgesBetween} adds it to.
    */
   private long countBetweenForType(final Snapshot snap, final int nodeA, final int nodeB,
       final Vertex.DIRECTION direction, final String edgeType) {
@@ -2299,20 +2277,19 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     final boolean walkBackward = (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH)
         && !(direction == Vertex.DIRECTION.BOTH && selfLoop);
 
-    if (ov != null
-        && ((walkForward && ov.isEdgeDeleted(edgeType, nodeA, nodeB))
-        || (walkBackward && ov.isEdgeDeleted(edgeType, nodeB, nodeA))))
-      return MULTIPLICITY_UNKNOWN;
-
     long count = 0;
 
     if (csr != null && nodeAInBase) {
-      if (walkForward)
-        count += equalRangeCount(csr.getForwardNeighbors(), csr.getForwardOffsets()[nodeA],
+      if (walkForward) {
+        final int occurrences = equalRangeCount(csr.getForwardNeighbors(), csr.getForwardOffsets()[nodeA],
             csr.getForwardOffsets()[nodeA + 1], nodeB);
-      if (walkBackward)
-        count += equalRangeCount(csr.getBackwardNeighbors(), csr.getBackwardOffsets()[nodeA],
+        count += Math.max(0, occurrences - (ov != null ? ov.countDeletedEdges(edgeType, nodeA, nodeB) : 0));
+      }
+      if (walkBackward) {
+        final int occurrences = equalRangeCount(csr.getBackwardNeighbors(), csr.getBackwardOffsets()[nodeA],
             csr.getBackwardOffsets()[nodeA + 1], nodeB);
+        count += Math.max(0, occurrences - (ov != null ? ov.countDeletedEdges(edgeType, nodeB, nodeA) : 0));
+      }
     }
 
     if (ov != null) {
@@ -2451,22 +2428,17 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       }
     }
 
-    // KNOWN GAP (issue #6775): unlike baseOut/baseIn above, the overlay-added neighbours below are
-    // not filtered against deletedEdgesPerType. An edge added and then deleted within the same
-    // not-yet-compacted overlay window still surfaces here. countEdgesBetween is unaffected - it
-    // answers "unknown" for any pair with a recorded deletion before it looks at added neighbours -
-    // but getNeighborIds/getVertices/isConnectedTo's overlay-added branch is not.
+    // Unlike baseOut/baseIn above, the overlay-added neighbours below need no exclusion pass: the deleted
+    // counts are the budget for the base CSR run and hold only deletions of edges the overlay never added,
+    // an edge added and then deleted within the same not-yet-compacted window having been withdrawn from
+    // the added index at merge time instead (issue #6775).
     int[] ovOut = EMPTY_INT;
     int[] ovIn = EMPTY_INT;
     if (ov != null) {
-      // Spend the overlay's per-pair deleted budget against the added neighbours, mirroring how
-      // copyBaseExcludingDeleted spends it against the base CSR run. This closes the #6775 gap: an
-      // edge added and then deleted within the same not-yet-compacted overlay window no longer
-      // surfaces as a phantom live neighbour.
       if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH)
-        ovOut = excludeDeletedAddedNeighbors(ov.getAddedOutNeighbors(nodeId, edgeType), ov, edgeType, nodeId, true, csr, nodeInBase);
+        ovOut = ov.getAddedOutNeighbors(nodeId, edgeType);
       if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH)
-        ovIn = excludeDeletedAddedNeighbors(ov.getAddedInNeighbors(nodeId, edgeType), ov, edgeType, nodeId, false, csr, nodeInBase);
+        ovIn = ov.getAddedInNeighbors(nodeId, edgeType);
     }
 
     final int totalLen = baseOut.length + baseIn.length + ovOut.length + ovIn.length;
@@ -2537,74 +2509,6 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     for (int i = 0; i < len; i++)
       if (!deletedMask[i])
         result[pos++] = neighbors[start + i];
-    return result;
-  }
-
-  /**
-   * Excludes overlay-added neighbours that the overlay records as deleted, spending the same per-pair
-   * deleted budget {@link #copyBaseExcludingDeleted} spends against the base CSR run. The budget is
-   * applied in two stages: the base CSR's occurrence count for the pair absorbs as much of the budget
-   * as it can (matching {@code copyBaseExcludingDeleted}, which already dropped those slots), and any
-   * budget left over is spent here against the added neighbours. An edge added and then deleted within
-   * the same not-yet-compacted overlay window therefore no longer surfaces as a phantom live neighbour,
-   * while parallel added edges survive deletion of only some of their siblings (issue #6775).
-   * <p>
-   * The added array is unsorted (it is built in addition order from {@code addedEdgesPerType}), so a
-   * per-value remaining-budget map is used instead of the slice-run technique of the base helper. The
-   * mask is allocated lazily, so the common no-deletion case stays allocation-free.
-   */
-  private static int[] excludeDeletedAddedNeighbors(final int[] added, final DeltaOverlay ov,
-      final String edgeType, final int nodeId, final boolean outgoing,
-      final CSRAdjacencyIndex csr, final boolean nodeInBase) {
-    final int len = added.length;
-    if (len == 0 || (outgoing ? ov.countDeletedOutEdges(nodeId, edgeType) : ov.countDeletedInEdges(nodeId, edgeType)) == 0)
-      return added;
-
-    boolean[] deletedMask = null;
-    int kept = 0;
-    // Remaining deleted budget per neighbour value. Lazily allocated; -1 (default) means "not yet
-    // computed", 0 means the budget is exhausted and further occurrences of the value survive.
-    IntIntHashMap remainingBudget = null;
-    for (int i = 0; i < len; i++) {
-      final int n = added[i];
-      int budget = remainingBudget != null ? remainingBudget.get(n, -1) : -1;
-      if (budget == -1) {
-        // First occurrence of this value: leftover budget after the base CSR run absorbs what it can
-        // (mirroring copyBaseExcludingDeleted's spending on the same pair).
-        budget = outgoing ? ov.countDeletedEdges(edgeType, nodeId, n) : ov.countDeletedEdges(edgeType, n, nodeId);
-        int baseOccurrences = 0;
-        if (nodeInBase && csr != null) {
-          if (outgoing)
-            baseOccurrences = equalRangeCount(csr.getForwardNeighbors(), csr.outOffset(nodeId), csr.outOffsetEnd(nodeId), n);
-          else
-            baseOccurrences = equalRangeCount(csr.getBackwardNeighbors(), csr.inOffset(nodeId), csr.inOffsetEnd(nodeId), n);
-        }
-        budget = Math.max(0, budget - baseOccurrences);
-        if (remainingBudget == null)
-          remainingBudget = new IntIntHashMap();
-        remainingBudget.put(n, budget);
-      }
-      if (budget > 0) {
-        remainingBudget.put(n, budget - 1);
-        if (deletedMask == null) {
-          deletedMask = new boolean[len];
-          kept = i; // every neighbour seen so far was kept
-        }
-        deletedMask[i] = true;
-      } else if (deletedMask != null) {
-        kept++;
-      }
-    }
-    if (deletedMask == null)
-      return added;
-    if (kept == 0)
-      return EMPTY_INT;
-
-    final int[] result = new int[kept];
-    int pos = 0;
-    for (int i = 0; i < len; i++)
-      if (!deletedMask[i])
-        result[pos++] = added[i];
     return result;
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -36,6 +36,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.VertexType;
+import com.arcadedb.utility.IntIntHashMap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -921,13 +922,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
         if (csr != null)
           total += countDirectional(snap, csr, nodeId, direction, edgeType);
         else {
-          // No base CSR but overlay may have edges for this type
+          // No base CSR but overlay may have edges for this type. The overlay's added-edge index is
+          // append-only, so an edge added and then deleted within the same window is still counted
+          // there; subtract the per-node deleted counts back out (same cancellation as
+          // countDirectional's overlay branch). See issue #6775.
           final DeltaOverlay ov = snap.overlay;
           if (ov != null) {
             if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH)
-              total += ov.getAddedOutNeighbors(nodeId, edgeType).length;
+              total += ov.getAddedOutNeighbors(nodeId, edgeType).length - ov.countDeletedOutEdges(nodeId, edgeType);
             if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH)
-              total += ov.getAddedInNeighbors(nodeId, edgeType).length;
+              total += ov.getAddedInNeighbors(nodeId, edgeType).length - ov.countDeletedInEdges(nodeId, edgeType);
           }
         }
       }
@@ -2220,14 +2224,44 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // before compaction is still reported connected here.
     if (ov != null) {
       if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-        for (final int neighbor : ov.getAddedOutNeighbors(nodeA, edgeType))
-          if (neighbor == nodeB)
+        // The deleted budget is spent against base CSR occurrences first (see isConnectedForType's
+        // base branch and copyBaseExcludingDeleted); the pair stays connected through its added
+        // edges only if more added occurrences of nodeB survive than the leftover budget.
+        final int deleted = ov.countDeletedEdges(edgeType, nodeA, nodeB);
+        final int baseOccurrences = nodeAInBase && csr != null
+            ? equalRangeCount(csr.getForwardNeighbors(), csr.getForwardOffsets()[nodeA], csr.getForwardOffsets()[nodeA + 1], nodeB)
+            : 0;
+        if (deleted > baseOccurrences) {
+          int addedSurvivors = 0;
+          for (final int neighbor : ov.getAddedOutNeighbors(nodeA, edgeType))
+            if (neighbor == nodeB)
+              addedSurvivors++;
+          if (addedSurvivors > deleted - baseOccurrences)
             return true;
+        } else {
+          // No leftover budget: any added edge of the pair survives.
+          for (final int neighbor : ov.getAddedOutNeighbors(nodeA, edgeType))
+            if (neighbor == nodeB)
+              return true;
+        }
       }
       if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-        for (final int neighbor : ov.getAddedInNeighbors(nodeA, edgeType))
-          if (neighbor == nodeB)
+        final int deleted = ov.countDeletedEdges(edgeType, nodeB, nodeA);
+        final int baseOccurrences = nodeAInBase && csr != null
+            ? equalRangeCount(csr.getBackwardNeighbors(), csr.getBackwardOffsets()[nodeA], csr.getBackwardOffsets()[nodeA + 1], nodeB)
+            : 0;
+        if (deleted > baseOccurrences) {
+          int addedSurvivors = 0;
+          for (final int neighbor : ov.getAddedInNeighbors(nodeA, edgeType))
+            if (neighbor == nodeB)
+              addedSurvivors++;
+          if (addedSurvivors > deleted - baseOccurrences)
             return true;
+        } else {
+          for (final int neighbor : ov.getAddedInNeighbors(nodeA, edgeType))
+            if (neighbor == nodeB)
+              return true;
+        }
       }
     }
     return false;
@@ -2425,10 +2459,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     int[] ovOut = EMPTY_INT;
     int[] ovIn = EMPTY_INT;
     if (ov != null) {
+      // Spend the overlay's per-pair deleted budget against the added neighbours, mirroring how
+      // copyBaseExcludingDeleted spends it against the base CSR run. This closes the #6775 gap: an
+      // edge added and then deleted within the same not-yet-compacted overlay window no longer
+      // surfaces as a phantom live neighbour.
       if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH)
-        ovOut = ov.getAddedOutNeighbors(nodeId, edgeType);
+        ovOut = excludeDeletedAddedNeighbors(ov.getAddedOutNeighbors(nodeId, edgeType), ov, edgeType, nodeId, true, csr, nodeInBase);
       if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH)
-        ovIn = ov.getAddedInNeighbors(nodeId, edgeType);
+        ovIn = excludeDeletedAddedNeighbors(ov.getAddedInNeighbors(nodeId, edgeType), ov, edgeType, nodeId, false, csr, nodeInBase);
     }
 
     final int totalLen = baseOut.length + baseIn.length + ovOut.length + ovIn.length;
@@ -2499,6 +2537,74 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     for (int i = 0; i < len; i++)
       if (!deletedMask[i])
         result[pos++] = neighbors[start + i];
+    return result;
+  }
+
+  /**
+   * Excludes overlay-added neighbours that the overlay records as deleted, spending the same per-pair
+   * deleted budget {@link #copyBaseExcludingDeleted} spends against the base CSR run. The budget is
+   * applied in two stages: the base CSR's occurrence count for the pair absorbs as much of the budget
+   * as it can (matching {@code copyBaseExcludingDeleted}, which already dropped those slots), and any
+   * budget left over is spent here against the added neighbours. An edge added and then deleted within
+   * the same not-yet-compacted overlay window therefore no longer surfaces as a phantom live neighbour,
+   * while parallel added edges survive deletion of only some of their siblings (issue #6775).
+   * <p>
+   * The added array is unsorted (it is built in addition order from {@code addedEdgesPerType}), so a
+   * per-value remaining-budget map is used instead of the slice-run technique of the base helper. The
+   * mask is allocated lazily, so the common no-deletion case stays allocation-free.
+   */
+  private static int[] excludeDeletedAddedNeighbors(final int[] added, final DeltaOverlay ov,
+      final String edgeType, final int nodeId, final boolean outgoing,
+      final CSRAdjacencyIndex csr, final boolean nodeInBase) {
+    final int len = added.length;
+    if (len == 0 || (outgoing ? ov.countDeletedOutEdges(nodeId, edgeType) : ov.countDeletedInEdges(nodeId, edgeType)) == 0)
+      return added;
+
+    boolean[] deletedMask = null;
+    int kept = 0;
+    // Remaining deleted budget per neighbour value. Lazily allocated; -1 (default) means "not yet
+    // computed", 0 means the budget is exhausted and further occurrences of the value survive.
+    IntIntHashMap remainingBudget = null;
+    for (int i = 0; i < len; i++) {
+      final int n = added[i];
+      int budget = remainingBudget != null ? remainingBudget.get(n, -1) : -1;
+      if (budget == -1) {
+        // First occurrence of this value: leftover budget after the base CSR run absorbs what it can
+        // (mirroring copyBaseExcludingDeleted's spending on the same pair).
+        budget = outgoing ? ov.countDeletedEdges(edgeType, nodeId, n) : ov.countDeletedEdges(edgeType, n, nodeId);
+        int baseOccurrences = 0;
+        if (nodeInBase && csr != null) {
+          if (outgoing)
+            baseOccurrences = equalRangeCount(csr.getForwardNeighbors(), csr.outOffset(nodeId), csr.outOffsetEnd(nodeId), n);
+          else
+            baseOccurrences = equalRangeCount(csr.getBackwardNeighbors(), csr.inOffset(nodeId), csr.inOffsetEnd(nodeId), n);
+        }
+        budget = Math.max(0, budget - baseOccurrences);
+        if (remainingBudget == null)
+          remainingBudget = new IntIntHashMap();
+        remainingBudget.put(n, budget);
+      }
+      if (budget > 0) {
+        remainingBudget.put(n, budget - 1);
+        if (deletedMask == null) {
+          deletedMask = new boolean[len];
+          kept = i; // every neighbour seen so far was kept
+        }
+        deletedMask[i] = true;
+      } else if (deletedMask != null) {
+        kept++;
+      }
+    }
+    if (deletedMask == null)
+      return added;
+    if (kept == 0)
+      return EMPTY_INT;
+
+    final int[] result = new int[kept];
+    int pos = 0;
+    for (int i = 0; i < len; i++)
+      if (!deletedMask[i])
+        result[pos++] = added[i];
     return result;
   }
 

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDedupTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDedupTest.java
@@ -158,8 +158,13 @@ class DeltaOverlayCompactionDedupTest {
   }
 
   /**
-   * Delete then re-add of the same edge within a single buffered delta must keep the add for the same
-   * reason: the deletion would otherwise erase the base edge.
+   * Delete of an edge then add of a replacement edge on the same pair, within a single buffered delta:
+   * the add must be kept for the same reason, the deletion would otherwise erase the base edge.
+   * <p>
+   * The two edges carry DIFFERENT identities, because that is the only shape the engine can produce - a
+   * record cannot be re-created under the RID of one deleted in the same transaction. Same-RID in both
+   * lists means something else entirely, and means it unambiguously: an edge created and deleted inside
+   * one transaction, which {@code merge()} cancels rather than masks (issue #6775).
    */
   @Test
   void deleteThenReAddWithinSingleDeltaReinstatesEdge() {
@@ -168,7 +173,7 @@ class DeltaOverlayCompactionDedupTest {
 
     final TxDelta delta = new TxDelta();
     delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
-    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(11)));
 
     final DeltaOverlay merged = empty.merge(delta, mapping, csrWithEdge(2, 0, 1));
     assertThat(merged.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
@@ -191,7 +196,7 @@ class DeltaOverlayCompactionDedupTest {
 
     final TxDelta delta = new TxDelta();
     delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
-    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(11)));
 
     final DeltaOverlay merged = empty.merge(delta, mapping, csr);
 

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayTest.java
@@ -165,6 +165,134 @@ class DeltaOverlayTest {
   }
 
   /**
+   * Issue #6775: an edge created and deleted inside ONE transaction must be withdrawn from the added-edge
+   * index, not masked with a pair-keyed deletion. Both facts reach {@code merge()} in the same
+   * {@link TxDelta} (adds are processed first), and the pair alone cannot say which of the pair's edges
+   * the deletion belongs to - recording one would spend an exclusion budget against the base CSR's run for
+   * the pair, masking an edge nobody deleted, while leaving the phantom add on record as a live neighbour.
+   */
+  @Test
+  void edgeAddedAndDeletedWithinOneDeltaIsWithdrawnRatherThanMasked() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final DeltaOverlay empty = new DeltaOverlay(mapping.size());
+    final RID edgeRid = rid(10);
+
+    final TxDelta delta = new TxDelta();
+    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
+
+    final DeltaOverlay merged = empty.merge(delta, mapping);
+
+    assertThat(merged.getAddedOutNeighbors(0, EDGE_TYPE)).isEmpty();
+    assertThat(merged.getAddedInNeighbors(1, EDGE_TYPE)).isEmpty();
+    // No budget on record: there is no base edge for it to be spent against.
+    assertThat(merged.countDeletedEdges(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(merged.countDeletedOutEdges(0, EDGE_TYPE)).isZero();
+    assertThat(merged.countDeletedInEdges(1, EDGE_TYPE)).isZero();
+    assertThat(merged.getDeltaEdgeCount()).isZero();
+    assertThat(merged.hasChanges()).isFalse();
+  }
+
+  /**
+   * Issue #6775, the across-transactions shape: the add lands in one overlay window and the deletion in a
+   * later one, before any compaction. The withdrawal must reach back into the added index the earlier
+   * merge built.
+   */
+  @Test
+  void edgeAddedAndDeletedAcrossDeltasIsWithdrawnRatherThanMasked() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final RID edgeRid = rid(10);
+
+    final TxDelta addDelta = new TxDelta();
+    addDelta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
+    final DeltaOverlay afterAdd = new DeltaOverlay(mapping.size()).merge(addDelta, mapping);
+    assertThat(afterAdd.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
+
+    final TxDelta delDelta = new TxDelta();
+    delDelta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
+    final DeltaOverlay afterDelete = afterAdd.merge(delDelta, mapping);
+
+    assertThat(afterDelete.getAddedOutNeighbors(0, EDGE_TYPE)).isEmpty();
+    assertThat(afterDelete.getAddedInNeighbors(1, EDGE_TYPE)).isEmpty();
+    assertThat(afterDelete.countDeletedEdges(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(afterDelete.getDeltaEdgeCount()).isZero();
+
+    // The earlier overlay is immutable and must not have been reached into.
+    assertThat(afterAdd.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
+  }
+
+  /**
+   * Issue #6775 meets #6769: deleting ONE of two parallel edges the overlay itself added must withdraw
+   * exactly that edge and leave its sibling live, rather than withdrawing both or masking the pair.
+   */
+  @Test
+  void deletingOneOfTwoParallelAddedEdgesWithdrawsOnlyThatOne() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+
+    final TxDelta addDelta = new TxDelta();
+    addDelta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    addDelta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(11)));
+    final DeltaOverlay afterAdd = new DeltaOverlay(mapping.size()).merge(addDelta, mapping);
+    assertThat(afterAdd.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1, 1);
+    assertThat(afterAdd.getDeltaEdgeCount()).isEqualTo(2);
+
+    final TxDelta delDelta = new TxDelta();
+    delDelta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    final DeltaOverlay afterDelete = afterAdd.merge(delDelta, mapping);
+
+    assertThat(afterDelete.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
+    assertThat(afterDelete.getAddedInNeighbors(1, EDGE_TYPE)).containsExactly(0);
+    assertThat(afterDelete.countDeletedEdges(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(afterDelete.getDeltaEdgeCount()).isEqualTo(1);
+  }
+
+  /**
+   * The other half of the #6775 rule: a deletion of an edge the overlay never added is a BASE edge, and it
+   * must still leave the per-pair budget {@code GraphAnalyticalView#copyBaseExcludingDeleted} spends
+   * against the base CSR run. Withdrawing adds must not have made every deletion vanish.
+   */
+  @Test
+  void deletionOfAnEdgeTheOverlayNeverAddedStillRecordsTheBaseBudget() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+
+    // One edge the overlay added, and one it did not (it lives in the base CSR).
+    final TxDelta addDelta = new TxDelta();
+    addDelta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(11)));
+    final DeltaOverlay afterAdd = new DeltaOverlay(mapping.size()).merge(addDelta, mapping);
+
+    final TxDelta delDelta = new TxDelta();
+    delDelta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10)));
+    final DeltaOverlay afterDelete = afterAdd.merge(delDelta, mapping);
+
+    assertThat(afterDelete.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(afterDelete.countDeletedOutEdges(0, EDGE_TYPE)).isEqualTo(1);
+    // ...and the unrelated added edge is untouched
+    assertThat(afterDelete.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
+    assertThat(afterDelete.getDeltaEdgeCount()).isZero();
+  }
+
+  /**
+   * Keying the added edges by identity also absorbs a replayed add of an edge the overlay already holds,
+   * which the previous append-only list turned into a second, phantom, occurrence of one edge.
+   */
+  @Test
+  void replayedAddOfTheSameEdgeIsAbsorbed() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final RID edgeRid = rid(10);
+
+    final TxDelta addDelta = new TxDelta();
+    addDelta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
+    final DeltaOverlay afterAdd = new DeltaOverlay(mapping.size()).merge(addDelta, mapping);
+
+    final TxDelta replay = new TxDelta();
+    replay.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
+    final DeltaOverlay afterReplay = afterAdd.merge(replay, mapping);
+
+    assertThat(afterReplay.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
+    assertThat(afterReplay.getDeltaEdgeCount()).isEqualTo(1);
+  }
+
+  /**
    * Issue #4720: {@code getOverflowCount()} must report the number of live overflow vertices,
    * subtracting the ones that have been deleted, consistently with {@code getTotalNodeCount()}.
    * Before the fix the counter kept counting deleted overflow slots, inflating the reported count.

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -3941,10 +3941,11 @@ class GraphAnalyticalViewTest extends TestHelper {
 
   /**
    * Regression for #6775: an edge added and then deleted within the same not-yet-compacted overlay
-   * window (SYNCHRONOUS mode) must not surface as a live neighbour. The overlay's added-edge index is
-   * append-only — an edge is never removed from {@code addedEdgesPerType} — so
-   * {@link #getNeighborIds}/{@link #getVertices} and {@link #isConnectedTo} must exclude added
-   * neighbours whose pair the overlay also records as deleted. The base-CSR case is covered by
+   * window (SYNCHRONOUS mode) must not surface as a live neighbour. The overlay's added-edge index used
+   * to be append-only - an edge was never removed from {@code addedEdgesPerType} - so the phantom kept
+   * being reported by {@code getNeighborIds}/{@code getVertices}/{@code isConnectedTo}, while
+   * {@code countEdgesBetween} answered the same pair as deleted. The add is now withdrawn at merge time
+   * instead, so every read path agrees. The base-CSR case is covered by
    * {@link #getVerticesExcludesEdgesDeletedInOverlay}; this covers the overlay-added path.
    */
   @Test
@@ -3990,6 +3991,126 @@ class GraphAnalyticalViewTest extends TestHelper {
     // Counts must agree with the neighbour lists.
     assertThat(gav.countEdges(aliceId, Vertex.DIRECTION.OUT, "FOLLOWS")).isEqualTo(0);
     assertThat(gav.countEdges(bobId, Vertex.DIRECTION.IN, "FOLLOWS")).isEqualTo(0);
+    // ...including the multiplicity, which no longer has to answer "unknown" (a negative value) for a
+    // pair the overlay has touched: withdrawing the add leaves no deletion on record at all.
+    assertThat(gav.countEdgesBetween(aliceId, bobId, Vertex.DIRECTION.OUT, "FOLLOWS")).isZero();
+    assertThat(gav.countEdgesBetween(bobId, aliceId, Vertex.DIRECTION.IN, "FOLLOWS")).isZero();
+
+    gav.drop();
+  }
+
+  /**
+   * The shape issue #6775 was reported with: the edge is created AND deleted inside ONE transaction, so
+   * both facts reach the overlay in a single {@code TxDelta}. It is the same bug, but it exercises the
+   * within-one-delta ordering (adds are merged before deletes) rather than the across-windows one above.
+   */
+  @Test
+  void edgeCreatedAndDeletedInTheSameTransactionIsNotALiveNeighbour() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+
+    database.begin();
+    final MutableVertex alice = database.newVertex("Person").set("name", "Alice").save();
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("add-del-same-tx")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+
+    final int aliceId = gav.getNodeId(alice.getIdentity());
+
+    // Carol is created in the same transaction too, so she is an OVERFLOW node: the edge's target is not
+    // in the base mapping and there is no base CSR run for the pair to fall back on.
+    database.begin();
+    final MutableVertex carol = database.newVertex("Person").set("name", "Carol").save();
+    alice.newEdge("FOLLOWS", carol).delete();
+    database.commit();
+
+    final int carolId = gav.getNodeId(carol.getIdentity());
+    assertThat(carolId).isNotNegative();
+
+    assertThat(gav.getNeighborIds(aliceId, Vertex.DIRECTION.OUT, "FOLLOWS")).isEmpty();
+    assertThat(gav.getVertices(carolId, Vertex.DIRECTION.IN, "FOLLOWS")).isEmpty();
+    assertThat(gav.isConnectedTo(aliceId, carolId, Vertex.DIRECTION.OUT, "FOLLOWS")).isFalse();
+    assertThat(gav.isConnectedTo(aliceId, carolId, Vertex.DIRECTION.BOTH, "FOLLOWS")).isFalse();
+    assertThat(gav.countEdges(aliceId, Vertex.DIRECTION.OUT, "FOLLOWS")).isZero();
+    assertThat(gav.countEdges(carolId, Vertex.DIRECTION.BOTH, "FOLLOWS")).isZero();
+    assertThat(gav.countEdgesBetween(aliceId, carolId, Vertex.DIRECTION.OUT, "FOLLOWS")).isZero();
+
+    gav.drop();
+  }
+
+  /**
+   * #6775 meets #6769 on the overlay-added side: two PARALLEL edges added in the same overlay window,
+   * only one of them deleted. The survivor must stay a live neighbour and the multiplicity must be 1 -
+   * withdrawing the deleted add must not take its sibling with it, and must not mask the pair.
+   * <p>
+   * Also pins the interaction with a base edge on the same pair: the base occurrence is untouched by a
+   * deletion that belongs to an overlay-added edge, which is precisely the budget the old pair-keyed
+   * masking would have spent in the wrong place.
+   */
+  @Test
+  void deletingOneOfSeveralOverlayAddedParallelEdgesLeavesTheOthersLive() {
+    database.getSchema().createVertexType("Party");
+    database.getSchema().createEdgeType("PAID");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Party").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Party").set("name", "B").save();
+    a.newEdge("PAID", b, "seq", 0); // one edge in the BASE CSR
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("parallel-added-partial-delete")
+        .withVertexTypes("Party")
+        .withEdgeTypes("PAID")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+
+    final int idA = gav.getNodeId(a.getIdentity());
+    final int idB = gav.getNodeId(b.getIdentity());
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(1);
+
+    // Two more parallel edges, added within the overlay window.
+    database.begin();
+    a.newEdge("PAID", b, "seq", 1);
+    a.newEdge("PAID", b, "seq", 2);
+    database.commit();
+
+    assertThat(gav.getNeighborIds(idA, Vertex.DIRECTION.OUT, "PAID")).containsExactly(idB, idB, idB);
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(3);
+
+    // Delete exactly one of the two overlay-added edges, still within the same window.
+    database.begin();
+    for (final var edge : a.getIdentity().asVertex().getEdges(Vertex.DIRECTION.OUT, "PAID"))
+      if (Integer.valueOf(1).equals(edge.get("seq"))) {
+        edge.delete();
+        break;
+      }
+    database.commit();
+
+    // The base edge and the surviving added edge are both still live, and every read path agrees.
+    assertThat(gav.getNeighborIds(idA, Vertex.DIRECTION.OUT, "PAID")).containsExactly(idB, idB);
+    assertThat(gav.getVertices(idB, Vertex.DIRECTION.IN, "PAID")).containsExactly(idA, idA);
+    assertThat(gav.isConnectedTo(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isTrue();
+    assertThat(gav.countEdges(idA, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(2);
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(2);
+
+    // Deleting the BASE edge as well leaves only the surviving added edge.
+    database.begin();
+    for (final var edge : a.getIdentity().asVertex().getEdges(Vertex.DIRECTION.OUT, "PAID"))
+      if (Integer.valueOf(0).equals(edge.get("seq"))) {
+        edge.delete();
+        break;
+      }
+    database.commit();
+
+    assertThat(gav.getNeighborIds(idA, Vertex.DIRECTION.OUT, "PAID")).containsExactly(idB);
+    assertThat(gav.countEdges(idA, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(1);
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(1);
 
     gav.drop();
   }
@@ -5617,13 +5738,17 @@ class GraphAnalyticalViewTest extends TestHelper {
    * The overlay tracks a per-pair COUNT of deleted edges, not merely a deleted/not-deleted flag, so deleting
    * one of several parallel edges leaves the others discoverable: {@code isConnectedTo} and
    * {@code getNeighborIds} still report the surviving edges, only the deleted one is excluded (issue #6769 -
-   * before that fix, any deletion touching a pair masked every parallel edge between it). A count cannot
-   * absorb that the way a boolean or a neighbour list can, because the caller turns it into rows and an
-   * exact base-CSR-plus-overlay count would have to special-case every deletion combination; it says
-   * "unknown" instead and leaves the caller to walk the edge list (issue #5663).
+   * before that fix, any deletion touching a pair masked every parallel edge between it).
+   * <p>
+   * {@code countEdgesBetween} used to answer "unknown" (a negative value) for such a pair, because the
+   * overlay's ADDED neighbours were not deletion-aware and it had no safe way to exclude a since-deleted
+   * add from the second term. Since issue #6775 an add withdrawn in the same overlay window leaves no
+   * deletion on record at all, so the deleted count is purely a budget against the base run and the exact
+   * survivor count is just the arithmetic {@code isConnectedTo} already runs. It answers exactly now, in
+   * agreement with the neighbour list on the same view rather than against it.
    */
   @Test
-  void countEdgesBetweenAnswersUnknownWhenTheOverlayMasksAPair() {
+  void countEdgesBetweenCountsTheSurvivorsWhenTheOverlayDeletesOneOfSeveralParallelEdges() {
     database.getSchema().createVertexType("Party");
     database.getSchema().createEdgeType("PAID");
 
@@ -5658,9 +5783,9 @@ class GraphAnalyticalViewTest extends TestHelper {
       }
     database.commit();
 
-    // countEdgesBetween cannot state the exact survivor count, so it says so...
-    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isNegative();
-    // ...but the pair is still connected via its two surviving parallel edges, and both are still
+    // The two survivors are counted exactly, and the count agrees with the neighbour list below
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(2);
+    // the pair is still connected via its two surviving parallel edges, and both are still
     // discoverable - only the deleted one is excluded, not the whole pair
     assertThat(gav.isConnectedTo(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isTrue();
     // A's PAID out-neighbours: 2 surviving A->B edges plus the untouched A->C edge

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -3939,6 +3939,61 @@ class GraphAnalyticalViewTest extends TestHelper {
     gav.drop();
   }
 
+  /**
+   * Regression for #6775: an edge added and then deleted within the same not-yet-compacted overlay
+   * window (SYNCHRONOUS mode) must not surface as a live neighbour. The overlay's added-edge index is
+   * append-only — an edge is never removed from {@code addedEdgesPerType} — so
+   * {@link #getNeighborIds}/{@link #getVertices} and {@link #isConnectedTo} must exclude added
+   * neighbours whose pair the overlay also records as deleted. The base-CSR case is covered by
+   * {@link #getVerticesExcludesEdgesDeletedInOverlay}; this covers the overlay-added path.
+   */
+  @Test
+  void addedThenDeletedEdgeWithinOverlayWindowIsNotALiveNeighbour() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+
+    database.begin();
+    final MutableVertex alice = database.newVertex("Person").set("name", "Alice").save();
+    final MutableVertex bob = database.newVertex("Person").set("name", "Bob").save();
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("add-then-del-edge")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+
+    final int aliceId = gav.getNodeId(alice.getIdentity());
+    final int bobId = gav.getNodeId(bob.getIdentity());
+
+    // Add the edge within the overlay window (no compaction in between).
+    database.begin();
+    alice.newEdge("FOLLOWS", bob);
+    database.commit();
+
+    // The freshly added edge is live in the overlay.
+    assertThat(gav.getVertices(aliceId, Vertex.DIRECTION.OUT, "FOLLOWS")).containsExactly(bobId);
+    assertThat(gav.isConnectedTo(aliceId, bobId, Vertex.DIRECTION.OUT, "FOLLOWS")).isTrue();
+
+    // Delete it in a later transaction, still within the same uncompacted overlay window.
+    database.begin();
+    alice.getIdentity().asVertex().getEdges(Vertex.DIRECTION.OUT, "FOLLOWS").forEach(e -> e.delete());
+    database.commit();
+
+    // The phantom edge must no longer be reported as a live neighbour.
+    assertThat(gav.getNeighborIds(aliceId, Vertex.DIRECTION.OUT, "FOLLOWS")).isEmpty();
+    assertThat(gav.getVertices(aliceId, Vertex.DIRECTION.OUT, "FOLLOWS")).isEmpty();
+    assertThat(gav.getVertices(bobId, Vertex.DIRECTION.IN, "FOLLOWS")).isEmpty();
+    assertThat(gav.isConnectedTo(aliceId, bobId, Vertex.DIRECTION.OUT, "FOLLOWS")).isFalse();
+    assertThat(gav.isConnectedTo(bobId, aliceId, Vertex.DIRECTION.IN, "FOLLOWS")).isFalse();
+    // Counts must agree with the neighbour lists.
+    assertThat(gav.countEdges(aliceId, Vertex.DIRECTION.OUT, "FOLLOWS")).isEqualTo(0);
+    assertThat(gav.countEdges(bobId, Vertex.DIRECTION.IN, "FOLLOWS")).isEqualTo(0);
+
+    gav.drop();
+  }
+
   @Test
   void incrementalDeleteVertex() {
     database.getSchema().createVertexType("Person");


### PR DESCRIPTION
## What does this PR do?

Fixes #6775. `DeltaOverlay`'s added-edge index is append-only — an edge created and later deleted within the same not-yet-compacted `SYNCHRONOUS` overlay window stays in `addedEdgesPerType` and keeps surfacing as a live neighbour from `getNeighborIds`/`getVertices`/`isConnectedTo` (and `countEdges` for edge types with no base CSR), while `countEdgesBetween` already answers the pair as deleted.

This PR spends the overlay's per-pair deleted budget against the added neighbours, mirroring how `copyBaseExcludingDeleted` spends it against the base CSR run (added in #6773 for #6769): base CSR occurrences absorb the budget first, and the leftover is spent against added occurrences — so an edge added then deleted in the same window disappears, while parallel added edges survive deletion of only some of their siblings, consistent with the exact-count semantics of #6769.

## Motivation

A phantom live neighbour produces invalid BydbQL/query results: mismatch between `getVertices`/`getNeighborIds`/`isConnectedTo` and `countEdgesBetween` on the same view.

## Related issues

- #6775 (fixed)
- #6769 / #6773 (sibling bug: base-CSR side; this closes the overlay-added gap those PRs left annotated)
- #4512 (base-CSR deleted-edge filtering in the slow path)

## Additional Notes

- `getDegrees`/`countDirectional` are untouched: they already compute `added.length - countDeletedOut/InEdges`, which cancels correctly for added-then-deleted edges.
- Added regression test `addedThenDeletedEdgeWithinOverlayWindowIsNotALiveNeighbour`: fails on `main` (`Expecting empty but was: [1]`) and passes with this fix.
- Verified: full `com.arcadedb.graph.olap.*Test` suite — 213 tests, 0 failures.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected graph analytics results when edges are added and deleted before overlay compaction.
  * Edge counts, connectivity checks, neighbor results, and pairwise counts now consistently exclude deleted edges.
  * Preserved accurate handling of parallel edges, replacement edges, and unsorted additions.
  * Prevented replayed operations from creating duplicate edges or masking existing base edges.

* **Tests**
  * Added regression coverage for transactional edge additions and deletions, merges, compaction, and partially deleted parallel edges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->