### PR TITLE
fix(#6778): a database made unavailable by a permanent close answers 404, not 500

### DIFF
--- a/docs/6778-database-not-available-404-mapping.md
+++ b/docs/6778-database-not-available-404-mapping.md
@@ -52,3 +52,37 @@ happens - it now just ends in an accurate 404 instead of a generic 500.
 - `Issue6201ErrorStatusParityTest` (new row + new test) - confirmed red before the handler arm was
   added (fell through to the generic 500 "Internal error" arm), green after.
 - Full `server` module `http.handler` package test run for regressions.
+- Full `engine` + `network` + `integration` + `server` reactor unit-test run, excluding
+  `benchmark`/`slow`/`vector` lanes (831 tests) - no regressions.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6782
+
+## Review cycles
+
+- **Cycle 1** (head `cc94c43a92`): `claude` bot review landed clean-ish with one nit; `coderabbitai`
+  flagged one actionable item. Both addressed in a follow-up commit (head `d90a7380f6`):
+  - `coderabbitai` (actionable): the parity test constructed `DatabaseNotAvailableException` directly
+    rather than exercising `ArcadeDBServer.getDatabase(..., false, false)` itself. Added
+    `Issue6778DatabaseNotAvailableExceptionTest`, which starts a real `ArcadeDBServer` and asserts the
+    lookup throws the new type end-to-end.
+  - `claude` (nit): `PostPrometheusWriteHandler`'s ordering comment still described the pre-fix
+    `DatabaseOperationException`/500 fallthrough this PR closes. Updated to name the current
+    `DatabaseNotAvailableException`/404 behavior.
+  - No disputed or deferred items this cycle.
+- **Cycle 2** (head `d90a7380f6`): no `claude` bot review landed after two consecutive 15-minute polls
+  (30 minutes total). Confirmed this is CI-runner congestion, not a bot or PR-specific problem: no
+  "Claude Code Review" workflow run was ever created for this head SHA, and a concurrent PR's own run
+  (`headSha d88c4dbc0f`) was independently observed stuck in `queued` for 45+ minutes across both poll
+  windows. Per the skill's "a cycle-1 timeout is not proof the bot is off" guidance, the first timeout
+  was treated as inconclusive and re-polled once; the second timeout with the same congestion evidence
+  ended the loop.
+
+## Final state
+
+`timeout` - the review loop stopped after cycle 2's bot response never arrived (CI congestion, see
+above). The PR is open at head `d90a7380f6843464792a736d8fa2d825f6fe0c8a` with cycle 1's review fully
+addressed and zero known disputed/deferred items. No `review-deferred-*.md` notes file was produced.
+Recommend the developer either wait for CI to drain and re-poll, or merge directly given cycle 1's
+clean review history.

--- a/docs/6778-database-not-available-404-mapping.md
+++ b/docs/6778-database-not-available-404-mapping.md
@@ -1,0 +1,54 @@
+# Issue #6778: 503 mapping for `DatabaseIsClosedException` is broader than the resync race it fixes
+
+## Root cause
+
+Follow-up from the #6770 / PR #6776 review loop.
+
+`AbstractServerHttpHandler.sendMappedErrorResponse` maps every `DatabaseIsClosedException` to a
+retryable 503 (added in #6776 for the HA snapshot-reinstall resync race). That mapping is correct for
+the resync case, but `LocalDatabase.checkDatabaseIsOpen()` throws the same exception type for **any**
+operation on a closed database - including one closed permanently by a concurrent `DROP DATABASE` /
+`CLOSE DATABASE`.
+
+Net effect for a dropped/closed database racing an in-flight request:
+
+1. The in-flight request hits `DatabaseIsClosedException` -> 503 ("retry me").
+2. The client's automatic retry (`RemoteHttpComponent`) re-resolves the database with `allowLoad=false`
+   (`DatabaseAbstractHandler.execute`, line ~74).
+3. Once the registry entry is gone, `ArcadeDBServer.getDatabase()` throws
+   `DatabaseOperationException("Database '...' is not available")` (line ~1011).
+4. `sendMappedErrorResponse` has no arm for that message, so it falls through to the generic 500
+   "Internal error" - opaque to the client, and not the accurate 404 the situation calls for.
+
+## Approach taken
+
+Of the two candidates the issue records, this implements #2 (narrower blast radius, no new
+whole-server/resync-tracking state needed): a dedicated `DatabaseNotAvailableException` (a
+`DatabaseOperationException` subtype) is thrown from the single call site instead of the generic
+type, and `sendMappedErrorResponse` gets an explicit arm mapping it to 404 "Database not found".
+
+Approach #1 (scoping the 503 itself to the resync condition) is intentionally **not** attempted here:
+it needs a resync-vs-permanent-close signal that does not exist yet, and the issue's own text flags
+`ArcadeDBServer.isSnapshotInstallInProgress()` as the wrong tool for it (whole-server condition, not
+per-database). The wasted 503-then-retry round trip for the permanent-close race therefore still
+happens - it now just ends in an accurate 404 instead of a generic 500.
+
+## Changes
+
+- `engine/src/main/java/com/arcadedb/exception/DatabaseNotAvailableException.java` (new): narrow
+  `DatabaseOperationException` subtype for "no open database handle when the caller forbade loading one".
+- `server/src/main/java/com/arcadedb/server/ArcadeDBServer.java`: `getDatabase(..., allowLoad=false)`
+  throws the new type instead of the generic `DatabaseOperationException`.
+- `server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java`: new arm in
+  `sendMappedErrorResponse` mapping `DatabaseNotAvailableException` to 404 "Database not found"; the
+  existing #6778 pointer comment on the `DatabaseIsClosedException` arm is updated to reflect that the
+  generic-500 tail is now closed.
+- `server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java`: new
+  `MAPPED_FAILURES` row (bare / `TransactionException`-wrapped / `CommandExecutionException`-wrapped
+  parity) plus a dedicated regression test naming the #6778 scenario.
+
+## Test plan
+
+- `Issue6201ErrorStatusParityTest` (new row + new test) - confirmed red before the handler arm was
+  added (fell through to the generic 500 "Internal error" arm), green after.
+- Full `server` module `http.handler` package test run for regressions.

--- a/engine/src/main/java/com/arcadedb/exception/DatabaseNotAvailableException.java
+++ b/engine/src/main/java/com/arcadedb/exception/DatabaseNotAvailableException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.exception;
+
+/**
+ * No open database handle exists for the requested name and the caller forbade loading one
+ * (`allowLoad=false`) - either the database was never opened, or it was closed/dropped after the
+ * caller last resolved it. Distinct from the generic {@link DatabaseOperationException} it extends so
+ * callers that need to answer this specific condition (e.g. an HTTP 404) do not have to match on every
+ * other unrelated failure that type also carries. See issue #6778.
+ */
+public class DatabaseNotAvailableException extends DatabaseOperationException {
+  public DatabaseNotAvailableException(final String s) {
+    super(s);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -28,7 +28,7 @@ import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.ConfigurationException;
-import com.arcadedb.exception.DatabaseOperationException;
+import com.arcadedb.exception.DatabaseNotAvailableException;
 import com.arcadedb.log.DefaultLogger;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.network.binary.ChannelBinary;
@@ -1008,7 +1008,7 @@ public class ArcadeDBServer {
 
       if (db == null || !db.isOpen()) {
         if (!allowLoad)
-          throw new DatabaseOperationException("Database '" + databaseName + "' is not available");
+          throw new DatabaseNotAvailableException("Database '" + databaseName + "' is not available");
 
         checkDatabaseNameIsValid(databaseName);
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -677,11 +677,22 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // Scope: this maps EVERY DatabaseIsClosedException to 503, not only the resync race above. A concurrent
     // DROP/CLOSE DATABASE admin action throws the same exception type on a still in-flight request, and that
     // close is permanent rather than transient - a retry costs one wasted round trip before falling through to
-    // the same generic 500 this mapping did not change for that path. Distinguishing the two cases needs a
-    // resync-vs-permanent-close signal that does not exist yet - see issue #6778.
+    // the arm below (issue #6778, #6770 follow-up). Scoping THIS 503 itself to the resync case needs a
+    // resync-vs-permanent-close signal that does not exist yet, so that half of #6778 is not attempted here.
     final DatabaseIsClosedException databaseClosed = firstOf(e, cause, DatabaseIsClosedException.class);
     if (databaseClosed != null) {
       sendRetryableResponse(exchange, databaseClosed);
+      return;
+    }
+
+    // 404: the wasted retry the comment above describes re-resolves the database with allowLoad=false
+    // (DatabaseAbstractHandler.execute), which raises this narrower type - not the generic
+    // DatabaseOperationException - once the registry entry is gone. Answered as an accurate "not there"
+    // instead of falling through to the generic 500 below (issue #6778).
+    final DatabaseNotAvailableException notAvailable = firstOf(e, cause, DatabaseNotAvailableException.class);
+    if (notAvailable != null) {
+      logUserError(notAvailable);
+      sendErrorResponse(exchange, 404, "Database not found", notAvailable, null);
       return;
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
@@ -72,14 +72,14 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
 
     // These checks - and the writeRequest.getTimeSeries().isEmpty() short-circuit below - stay ahead of
     // resolving `database` on purpose: httpServer.getServer().getDatabase(..., allowLoad=false) throws
-    // DatabaseOperationException (a plain RuntimeException, not one of the specific arms
-    // AbstractServerHttpHandler.handleRequest's catch chain recognizes) when the database is absent or
-    // closed, which falls through to a 500 instead of a 400/204. An earlier revision of this fix moved
-    // `database` resolution ahead of the isEmpty() check so that response could also carry the bookmark;
-    // review caught that this turns ANY request against a nonexistent database - even a well-formed one
-    // that resolves to zero series - into a 500. None of these checks need the database, and a
-    // zero-series write has nothing to bookmark, so this keeps the pre-#5866 ordering: `database` is
-    // resolved only once there is an actual write to make.
+    // DatabaseNotAvailableException when the database is absent or closed, which AbstractServerHttpHandler's
+    // classification maps to 404 (issue #6778) rather than the 400/204 these checks answer with. An earlier
+    // revision of this fix moved `database` resolution ahead of the isEmpty() check so that response could
+    // also carry the bookmark; review caught that this turns ANY request against a nonexistent database -
+    // even a well-formed one that resolves to zero series - into a 404 instead of the more specific 400/204
+    // these checks give. None of these checks need the database, and a zero-series write has nothing to
+    // bookmark, so this keeps the pre-#5866 ordering: `database` is resolved only once there is an actual
+    // write to make.
     if (rawBytes == null || rawBytes.length == 0)
       return new ExecutionResponse(400, "{ \"error\" : \"Request body is empty\"}");
 

--- a/server/src/test/java/com/arcadedb/server/Issue6778DatabaseNotAvailableExceptionTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue6778DatabaseNotAvailableExceptionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.DatabaseNotAvailableException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6778: {@link ArcadeDBServer#getDatabase(String, boolean, boolean)} with
+ * {@code allowLoad=false} and no open handle for the name must throw the narrow
+ * {@link DatabaseNotAvailableException} - not the generic {@code DatabaseOperationException} it used to
+ * throw - so {@code AbstractServerHttpHandler} can answer an accurate 404 instead of falling through to a
+ * generic 500 (pinned separately in {@code Issue6201ErrorStatusParityTest}).
+ */
+class Issue6778DatabaseNotAvailableExceptionTest extends StaticBaseServerTest {
+  private ArcadeDBServer server;
+
+  @BeforeEach
+  public void beginTest() {
+    super.beginTest();
+  }
+
+  @AfterEach
+  public void endTest() {
+    if (server != null && server.isStarted())
+      server.stop();
+    super.endTest();
+  }
+
+  @Test
+  void allowLoadFalseWithNoOpenHandleThrowsDatabaseNotAvailableException() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, DEFAULT_PASSWORD_FOR_TESTS);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_IO_THREADS, 2);
+    config.setValue(GlobalConfiguration.TYPE_DEFAULT_BUCKETS, 2);
+
+    server = new ArcadeDBServer(config);
+    server.start();
+
+    assertThatThrownBy(() -> server.getDatabase("issue6778-never-opened", false, false))
+        .isInstanceOf(DatabaseNotAvailableException.class)
+        .hasMessageContaining("issue6778-never-opened");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DatabaseIsClosedException;
+import com.arcadedb.exception.DatabaseNotAvailableException;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.QueryNotIdempotentException;
 import com.arcadedb.exception.RecordNotFoundException;
@@ -93,6 +94,11 @@ class Issue6201ErrorStatusParityTest {
       // pattern) is a transient condition, not a permanent failure - it used to fall through to a hard 500,
       // which a remote client's own retry-on-503 loop never saw (issue #6770).
       new MappedFailure("DatabaseIsClosedException", 503, () -> new DatabaseIsClosedException("mydb")),
+      // A permanent DROP/CLOSE DATABASE race (not the transient resync above) that lost the retry-then-reresolve
+      // round trip: allowLoad=false found no open handle for the name. An accurate 404, not the generic 500 the
+      // un-typed DatabaseOperationException used to fall through to (issue #6778, #6770 follow-up).
+      new MappedFailure("DatabaseNotAvailableException", 404,
+          () -> new DatabaseNotAvailableException("Database 'mydb' is not available")),
       // The mappings each earlier issue had to add to two or three chains by hand.
       new MappedFailure("DuplicatedKeyException", 409, () -> new DuplicatedKeyException("Idx", "[1]", new RID(1, 1))),
       new MappedFailure("TransactionCommittedRemotelyException", 409,
@@ -171,6 +177,25 @@ class Issue6201ErrorStatusParityTest {
     assertThat(response.statusCode).isEqualTo(503);
     final JSONObject json = new JSONObject(response.body);
     assertThat(json.getString("exception")).isEqualTo(DatabaseIsClosedException.class.getName());
+  }
+
+  /**
+   * The concrete defect reported in #6778 (a #6770 follow-up): a database dropped/closed permanently by a
+   * concurrent admin action races an in-flight request the same way the transient resync above does, but
+   * {@code ArcadeDBServer.getDatabase(..., allowLoad=false)} - what the client's automatic 503 retry re-resolves
+   * through once it re-hits the database - throws a narrower {@link DatabaseNotAvailableException} rather than
+   * the generic {@link com.arcadedb.exception.DatabaseOperationException}. Before this fix that fell through to
+   * the generic 500 "Internal error", leaving the client with no accurate signal that the database is simply
+   * gone; it now answers the same 404 a client already expects for "the thing you asked for isn't there".
+   */
+  @Test
+  void aPermanentlyUnavailableDatabaseIsReported404NotAGeneric500() {
+    final HandledResponse response = handle(new DatabaseNotAvailableException("Database 'mydb' is not available"));
+
+    assertThat(response.statusCode).isEqualTo(404);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.getString("error")).isEqualTo("Database not found");
+    assertThat(json.getString("exception")).isEqualTo(DatabaseNotAvailableException.class.getName());
   }
 
   /**


### PR DESCRIPTION
Closes #6778

`AbstractServerHttpHandler.sendMappedErrorResponse` maps every `DatabaseIsClosedException` to a retryable 503 (added in #6776 for the HA snapshot-reinstall resync race, #6770). That mapping is correct for the resync case, but `LocalDatabase.checkDatabaseIsOpen()` raises the same exception type for any operation on a closed database - including one closed permanently by a concurrent `DROP DATABASE` / `CLOSE DATABASE`.

For a database dropped/closed permanently while a request is in flight, the client's automatic 503 retry re-resolves the database with `allowLoad=false` (`DatabaseAbstractHandler.execute`). Once the registry entry is gone, `ArcadeDBServer.getDatabase()` threw the generic `DatabaseOperationException("Database '...' is not available")`, which has no arm in `sendMappedErrorResponse` and fell through to a generic 500 "Internal error" - opaque to the client instead of an accurate "not there" signal.

This implements the narrower of the two approaches the issue records: a dedicated `DatabaseNotAvailableException` (a `DatabaseOperationException` subtype) is thrown from that single call site, and `sendMappedErrorResponse` gets an explicit arm mapping it to HTTP 404 "Database not found". Scoping the 503 itself to the resync case (the other candidate approach) is intentionally not attempted here - it needs a resync-vs-permanent-close signal that does not exist yet, and the issue's own text flags `ArcadeDBServer.isSnapshotInstallInProgress()` as the wrong tool for it. The wasted 503-then-retry round trip for the permanent-close race still happens; it now ends in an accurate 404 instead of a generic 500.

## Changes
- `engine/.../exception/DatabaseNotAvailableException.java` (new): narrow `DatabaseOperationException` subtype for "no open database handle when the caller forbade loading one".
- `server/.../ArcadeDBServer.java`: `getDatabase(..., allowLoad=false)` throws the new type instead of the generic one.
- `server/.../AbstractServerHttpHandler.java`: new classification arm mapping `DatabaseNotAvailableException` to 404; updated the existing #6778 pointer comment on the `DatabaseIsClosedException` arm.
- `server/src/test/.../Issue6201ErrorStatusParityTest.java`: new `MAPPED_FAILURES` row (parity across bare / `TransactionException`-wrapped / `CommandExecutionException`-wrapped) plus a dedicated regression test for the #6778 scenario.

## Test plan
- [x] `Issue6201ErrorStatusParityTest` - confirmed red (500 instead of 404) before the handler arm was added, green after.
- [x] Full `server` module `http.handler` package (189 tests) - no regressions.
- [x] Full `engine` + `network` + `integration` + `server` reactor unit-test run, excluding `benchmark`/`slow`/`vector` lanes (831 tests) - no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests for unavailable databases now return a clear HTTP 404 response instead of a generic server error.
  * Temporarily closed databases continue to return retryable HTTP 503 responses.
  * Improved error details distinguish permanent database unavailability from temporary closure.

* **Documentation**
  * Added documentation describing database availability behavior and test coverage.

* **Tests**
  * Added regression coverage for unavailable database responses and error-status consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->