### PR TITLE
fix(#6758,#6759,#6760,#6761,#6762): robustness batch across Python bindings, polyglot, HA, network and server

### DIFF
--- a/bindings/python/src/arcadedb_embedded/results.py
+++ b/bindings/python/src/arcadedb_embedded/results.py
@@ -330,7 +330,9 @@ class ResultSet:
                 break
             total += count
             if first_names is not None and not joined:
-                joined = ";".join(first_names)  # keep column set stable
+                # JSON, not ";".join: a projection alias may legally contain a semicolon, a quote or a
+                # backslash, and the legacy separator split such a name into two bogus columns.
+                joined = json.dumps(first_names)  # keep column set stable
 
         if total == 0:
             return {}
@@ -470,7 +472,8 @@ class ResultSet:
                 break
             total += count
             if first_names is not None and not joined:
-                joined = ";".join(first_names)
+                # See to_columns: the column spec is JSON so odd-but-legal aliases survive the round trip.
+                joined = json.dumps(first_names)
 
         if total == 0 or not first_names:
             return pa.table({})

--- a/bindings/python/src/java/com/arcadedb/python/ColumnBatcher.java
+++ b/bindings/python/src/java/com/arcadedb/python/ColumnBatcher.java
@@ -13,6 +13,8 @@ package com.arcadedb.python;
 
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -47,8 +49,8 @@ public final class ColumnBatcher {
   }
 
   public static byte[] nextColumnBatch(final ResultSet rs, final int max, final String joinedColumns) {
-    // empty joinedColumns: derive the column set from the first row
-    String[] columns = joinedColumns.isEmpty() ? null : joinedColumns.split(";");
+    // empty column spec: derive the column set from the first row
+    String[] columns = parseColumnSpec(joinedColumns);
     final List<Result> results = new ArrayList<>(Math.min(max, 1 << 16));
     while (results.size() < max && rs.hasNext())
       results.add(rs.next());
@@ -68,7 +70,11 @@ public final class ColumnBatcher {
     }
     final int count = rows.size();
 
-    final StringBuilder header = new StringBuilder("{\"count\":" + count + ",\"cols\":[");
+    // The header goes through JSONObject/JSONArray rather than string concatenation: a column name is an
+    // arbitrary query projection alias, so a name carrying a quote, a backslash or a control character used to
+    // emit invalid JSON and break the decode of the WHOLE batch on the Python side. RowBatcher already does it
+    // this way; the cost is n objects per batch, not per row.
+    final JSONArray headerColumns = new JSONArray();
     final ByteArrayOutputStream body = new ByteArrayOutputStream(count * n * 8);
 
     for (int c = 0; c < n; c++) {
@@ -227,17 +233,21 @@ public final class ColumnBatcher {
         colBuf = bb.array();
       }
 
-      if (c > 0)
-        header.append(',');
-      header.append("{\"name\":\"").append(columns[c]).append("\",\"type\":\"").append(type)
-          .append("\",\"nulls\":").append(nulls.length).append(",\"bytes\":").append(colBuf.length);
+      final JSONObject columnHeader = new JSONObject();
+      columnHeader.put("name", columns[c]);
+      columnHeader.put("type", type);
+      columnHeader.put("nulls", nulls.length);
+      columnHeader.put("bytes", colBuf.length);
       if (vdim > 0 && (type.equals("f4v") || type.equals("f8v")))
-        header.append(",\"dim\":").append(vdim);
-      header.append('}');
+        columnHeader.put("dim", vdim);
+      headerColumns.put(columnHeader);
       body.write(nulls, 0, nulls.length);
       body.write(colBuf, 0, colBuf.length);
     }
-    header.append("]}");
+
+    final JSONObject header = new JSONObject();
+    header.put("count", count);
+    header.put("cols", headerColumns);
 
     final byte[] headerBytes = header.toString().getBytes(StandardCharsets.UTF_8);
     final byte[] bodyBytes = body.toByteArray();
@@ -247,5 +257,27 @@ public final class ColumnBatcher {
     out.put(headerBytes);
     out.put(bodyBytes);
     return out.array();
+  }
+
+  /**
+   * Decodes the caller-supplied column spec, which pins the column set across the batches of one result set.
+   * <p>
+   * The canonical form is a JSON array, because the names are arbitrary projection aliases: the legacy
+   * {@code ';'}-joined form silently split a name that contained a semicolon into two bogus columns. The legacy
+   * form is still accepted so an older Python side paired with a newer bridge jar keeps working.
+   *
+   * @return the pinned column names, or {@code null} when the spec is empty and the set must be derived from the
+   *         first row
+   */
+  private static String[] parseColumnSpec(final String spec) {
+    if (spec == null || spec.isEmpty())
+      return null;
+    if (spec.charAt(0) != '[')
+      return spec.split(";");
+    final JSONArray names = new JSONArray(spec);
+    final String[] columns = new String[names.length()];
+    for (int i = 0; i < columns.length; i++)
+      columns[i] = names.getString(i);
+    return columns;
   }
 }

--- a/bindings/python/tests/test_core.py
+++ b/bindings/python/tests/test_core.py
@@ -1113,6 +1113,32 @@ def test_to_columns_typed_bulk_materialization(temp_db_path):
         assert db.query("sql", "SELECT FROM T WHERE n > 99").to_columns() == {}
 
 
+def test_to_columns_survives_json_metacharacters_in_aliases(temp_db_path):
+    """A projection alias is arbitrary text, so the columnar header must be real JSON (issue #6758).
+
+    The Java side used to concatenate the alias straight into the header string, so a quote produced
+    invalid JSON and killed the decode of the whole batch; a semicolon additionally broke the
+    ``;``-joined column spec that pins the column set across batches.
+    """
+    pytest.importorskip("numpy")
+    weird = 'we"ird'
+    semi = "a;b"
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE T")
+        with db.transaction():
+            for i in range(3):
+                db.command("sql", "INSERT INTO T SET n = ?, s = ?", i, f"v{i}")
+
+        cols = db.query(
+            "sql",
+            "SELECT s AS `{}`, n AS `{}` FROM T ORDER BY n".format(weird, semi),
+        ).to_columns()
+        assert cols is not None
+        assert sorted(cols.keys()) == sorted([weird, semi])
+        assert list(cols[weird]) == ["v0", "v1", "v2"]
+        assert list(cols[semi]) == [0, 1, 2]
+
+
 def test_to_dataframe_fast_path(temp_db_path):
     """to_dataframe uses the columnar path and yields typed dtypes."""
     pytest.importorskip("pandas")

--- a/bindings/python/tests/test_core.py
+++ b/bindings/python/tests/test_core.py
@@ -1129,10 +1129,13 @@ def test_to_columns_survives_json_metacharacters_in_aliases(temp_db_path):
             for i in range(3):
                 db.command("sql", "INSERT INTO T SET n = ?, s = ?", i, f"v{i}")
 
+        # batch_size=2 so the three rows span MORE THAN ONE non-empty batch: the column spec is only sent back
+        # to Java from the second batch onwards, so a single-batch result would never exercise the round trip
+        # that the ';'-joined form used to break.
         cols = db.query(
             "sql",
             "SELECT s AS `{}`, n AS `{}` FROM T ORDER BY n".format(weird, semi),
-        ).to_columns()
+        ).to_columns(batch_size=2)
         assert cols is not None
         assert sorted(cols.keys()) == sorted([weird, semi])
         assert list(cols[weird]) == ["v0", "v1", "v2"]

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1214,6 +1214,28 @@ public enum GlobalConfiguration {
 
   NETWORK_SOCKET_TIMEOUT("arcadedb.network.socketTimeout", SCOPE.SERVER, "TCP/IP Socket timeout (in ms)", Integer.class, 30000),
 
+  NETWORK_SOCKET_KEEP_ALIVE("arcadedb.network.socketKeepAlive", SCOPE.SERVER, """
+      Enable TCP keepalive (SO_KEEPALIVE) on every wire-protocol socket. The Postgres and Redis executors drop the
+      socket read timeout to infinite once a connection is authenticated, because an authenticated client legitimately
+      holds an idle connection open, and those protocols carry no application-level heartbeat. With keepalive off, a
+      peer that dies without a FIN/RST (host crash, silent partition) leaves the server thread blocked in read()
+      forever, leaking a thread and a file descriptor per event. Keepalive lets the OS discover the dead peer and fail
+      the read.""", Boolean.class, true),
+
+  NETWORK_SOCKET_KEEP_ALIVE_IDLE("arcadedb.network.socketKeepAliveIdle", SCOPE.SERVER, """
+      Seconds an authenticated connection may sit idle before the OS sends the first TCP keepalive probe. Only applied
+      when the JDK and the platform expose TCP_KEEPIDLE (Linux and macOS do); elsewhere the system-wide default
+      applies, which is typically 2 hours. 0 leaves the system default in place.""", Integer.class, 120),
+
+  NETWORK_SOCKET_KEEP_ALIVE_INTERVAL("arcadedb.network.socketKeepAliveInterval", SCOPE.SERVER, """
+      Seconds between TCP keepalive probes once the first one has gone unanswered (TCP_KEEPINTERVAL). 0 leaves the
+      system default in place.""", Integer.class, 15),
+
+  NETWORK_SOCKET_KEEP_ALIVE_COUNT("arcadedb.network.socketKeepAliveCount", SCOPE.SERVER, """
+      Number of unanswered TCP keepalive probes after which the connection is declared dead (TCP_KEEPCOUNT). With the
+      defaults a dead peer is detected about 3 minutes after the connection goes idle. 0 leaves the system default in
+      place.""", Integer.class, 4),
+
   NETWORK_MAX_PREAUTH_CONNECTIONS("arcadedb.network.maxPreAuthConnections", SCOPE.SERVER, """
       Maximum number of connections a binary wire-protocol listener (Postgres, Redis, BOLT) may hold in the phase
       before authentication. Each accepted socket costs one thread and one file descriptor before the client has
@@ -1443,6 +1465,13 @@ public enum GlobalConfiguration {
   // SERVER WS
   SERVER_WS_EVENT_BUS_QUEUE_SIZE("arcadedb.server.eventBusQueueSize", SCOPE.SERVER,
       "Size of the queue used as a buffer for unserviced database change events.", Integer.class, 1000),
+
+  SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES("arcadedb.server.eventBusMaxPendingBytes", SCOPE.SERVER, """
+      Maximum number of bytes of change-stream frames that may be outstanding towards a single WebSocket subscriber
+      before it is evicted. Frames are sent asynchronously, so a subscriber that never reads accumulates them in the
+      server's send buffer: the producer-side queue is bounded but a slow consumer is charged to the server's heap,
+      not to its own. Past this cap the subscription is dropped and the channel closed, which is what the client
+      would experience anyway. 0 disables the cap (the pre-26.9.1 behaviour).""", Long.class, 16 * 1024 * 1024L),
 
   // SERVER SECURITY
   SERVER_SECURITY_ALGORITHM("arcadedb.server.securityAlgorithm", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1219,6 +1219,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
             .log(this, Level.WARNING, "Could not load vectors from pages for index %s: %s", indexName, e.getMessage());
         this.graphState = GraphState.LOADING;
       } finally {
+        // The load may have thrown AFTER inserting entries, and the failure above is swallowed by design (one
+        // attempt, carry on with whatever was read). Leaving the allocator at 0 on top of those entries is exactly
+        // what allocateVectorId() exists to prevent: the next put() would hand out 0, 1, 2... and addOrUpdate
+        // would supersede live vectors instead of adding new ones (issue #6762). A no-op on the success path,
+        // where loadVectorsFromPages() already computed the same value.
+        syncNextIdWithResidentLocations();
         // Written last, and volatile: a thread that reads it true has a happens-before edge on every entry the
         // loop above put into the map, which is what lets vectorIndex()'s fast path hand the instance out with no
         // lock at all. Set even when the load threw, so the one-attempt contract above holds.
@@ -3753,7 +3759,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
               getTotalPages(), residentLocations.size());
 
       int entriesRead = 0;
-      int maxVectorId = -1;
 
       // Load from compacted sub-index first (if it exists)
       if (compactedSubIndex != null) {
@@ -3772,8 +3777,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // Compute nextId from the maximum vector ID found across both files. Tombstoned ids are not resident
       // (issue #5516) but they were still handed out, so the location index's own high-water mark - which every
       // addOrUpdate advances, tombstones included - is what guarantees an id is never reused.
-      maxVectorId = residentLocations.getAllVectorIds().max().orElse(-1);
-      nextId.set(Math.max(maxVectorId + 1, residentLocations.getNextId()));
+      syncNextIdWithResidentLocations();
 
       LogManager.instance().log(this, Level.FINE,
           "loadVectorsFromPages DONE: Loaded " + residentLocations.size() + " vector locations (" + entriesRead
@@ -3791,9 +3795,27 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // Graph initialization is handled separately by the constructor and ensureGraphAvailable()
 
     } catch (final Exception e) {
+      // A parse that threw partway may already have inserted entries, and materializeLocations() swallows this
+      // failure while still marking the (one-attempt) materialisation done. Leaving nextId at 0 on top of those
+      // entries is exactly what allocateVectorId() exists to prevent: the next put() would hand out 0, 1, 2... and
+      // addOrUpdate would supersede live vectors. Advance the allocator over whatever was actually read before
+      // propagating the failure (issue #6762).
+      syncNextIdWithResidentLocations();
       LogManager.instance().log(this, Level.SEVERE, "Error loading vectors from pages", e);
       throw new IndexException("Error loading vectors from pages", e);
     }
+  }
+
+  /**
+   * Points {@link #nextId} past every id the location index has ever handed out.
+   * <p>
+   * Tombstoned ids are not resident (issue #5516) but they were still allocated, so the location index's own
+   * high-water mark - which every {@code addOrUpdate} advances, tombstones included - is the other half of the
+   * bound.
+   */
+  private void syncNextIdWithResidentLocations() {
+    final int maxVectorId = residentLocations.getAllVectorIds().max().orElse(-1);
+    nextId.set(Math.max(maxVectorId + 1, residentLocations.getNextId()));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/polyglot/GraalPolyglotEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/GraalPolyglotEngine.java
@@ -32,9 +32,13 @@ import org.graalvm.polyglot.io.IOAccess;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 
 /**
@@ -83,8 +87,13 @@ public class GraalPolyglotEngine implements AutoCloseable {
     this.allowedPackages = allowedPackages == null ? Collections.emptyList() : allowedPackages;
     this.restrictedPackages = restrictedPackages;
 
-    // DISABLED LIMIT BECAUSE THE CONTEXT IS INVOKED MULTIPLE TIMES
-    //final ResourceLimits limits = ResourceLimits.newBuilder().statementLimit(10000, null).build();
+    // No ResourceLimits here, and none is available: GraalVM CE's only limit is statementLimit(), which is
+    // CUMULATIVE over the life of a context and permanently cancels it once reached, so on a context that serves
+    // every command of a database it would eventually kill the engine on a legitimate workload. A per-execution
+    // context would let it back in, but the engine deliberately shares one so registerFunctions()' declarations
+    // survive across commands. The CPU bound is therefore enforced by PolyglotQueryEngine's timeout (which now
+    // cancels through Context.interrupt(), not only Thread.interrupt()); there is no allocation bound, because
+    // GraalVM CE exposes none (issue #6759).
 
     //final HostAccess hostAccess = HostAccess.newBuilder(HostAccess.ALL).targetTypeMapping(Double.class, Float.class, null, x -> x.floatValue()).build();
 
@@ -223,6 +232,87 @@ public class GraalPolyglotEngine implements AutoCloseable {
   public void setAttribute(final String name, final Object value) {
     context.getBindings(language).putMember(name, value);
     context.getPolyglotBindings().putMember(name, value);
+  }
+
+  /**
+   * Binds {@code parameters} for one evaluation and returns what they displaced, so
+   * {@link #restoreAttributes(Map)} can put the bindings back afterwards.
+   * <p>
+   * Parameters used to be bound and never removed. The context is shared by every caller on the database
+   * ({@code PolyglotQueryEngine} is a reusable engine), so a value passed by one command stayed visible to every
+   * later one - {@code command("js", "return x", Map.of("x", 5))} followed by {@code command("js", "return x")}
+   * returned 5 instead of failing, across callers (issue #6759).
+   * <p>
+   * A snapshot rather than a plain removal because a parameter may shadow a binding the engine itself owns
+   * (a parameter literally named {@code database}, or a function declared through {@link #eval(String)}):
+   * removing those would break every subsequent script instead of merely un-leaking one value.
+   *
+   * @return the displaced value per parameter name, {@code null} for a name that was not bound before
+   */
+  public Map<String, Value> setAttributes(final Map<String, Object> parameters) {
+    final Value languageBindings = context.getBindings(language);
+    final Map<String, Value> displaced = new HashMap<>(parameters.size());
+    for (final Map.Entry<String, Object> entry : parameters.entrySet()) {
+      final String name = entry.getKey();
+      displaced.put(name, languageBindings.hasMember(name) ? languageBindings.getMember(name) : null);
+      setAttribute(name, entry.getValue());
+    }
+    return displaced;
+  }
+
+  /**
+   * Undoes {@link #setAttributes(Map)}: a name that carried a value before the evaluation gets it back, one that
+   * did not is removed outright.
+   */
+  public void restoreAttributes(final Map<String, Value> displaced) {
+    for (final Map.Entry<String, Value> entry : displaced.entrySet()) {
+      final Value previous = entry.getValue();
+      if (previous != null)
+        setAttribute(entry.getKey(), previous);
+      else
+        removeAttribute(entry.getKey());
+    }
+  }
+
+  /** Unbinds {@code name} from both the language and the polyglot bindings. */
+  public void removeAttribute(final String name) {
+    removeMember(context.getBindings(language), name);
+    removeMember(context.getPolyglotBindings(), name);
+  }
+
+  private static void removeMember(final Value bindings, final String name) {
+    if (!bindings.hasMember(name))
+      return;
+    try {
+      bindings.removeMember(name);
+    } catch (final UnsupportedOperationException e) {
+      // A language whose top-level bindings refuse removal (or a member declared non-configurable by the script
+      // itself): overwriting with null still stops the value from leaking into the next command.
+      bindings.putMember(name, null);
+    }
+  }
+
+  /**
+   * Asks GraalVM to cancel whatever is executing in this context, waiting up to {@code timeout} for the guest
+   * frames to unwind.
+   * <p>
+   * {@code Future.cancel(true)} only interrupts the host thread, which a guest loop ignores unless the language
+   * happens to poll for it; {@code Context.interrupt} is the supported cancellation and unwinds the guest stack at
+   * the next safepoint. It matters because every command on the database serialises on this one context, so a
+   * script that outlives its timeout without releasing it blocks the whole engine (issue #6759).
+   *
+   * @return {@code true} when the context came to rest within {@code timeout}
+   */
+  public boolean interrupt(final Duration timeout) {
+    try {
+      context.interrupt(timeout);
+      return true;
+    } catch (final TimeoutException e) {
+      return false;
+    } catch (final IllegalStateException e) {
+      // Called from a thread that is itself inside the context: nothing to interrupt from here.
+      return true;
+    }
   }
 
   public static boolean isCriticalError(final PolyglotException e) {

--- a/engine/src/main/java/com/arcadedb/query/polyglot/PolyglotQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/PolyglotQueryEngine.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 public class PolyglotQueryEngine implements QueryEngine {
@@ -146,11 +147,15 @@ public class PolyglotQueryEngine implements QueryEngine {
   @Override
   public ResultSet command(final String query, final ContextConfiguration configuration, final Map<String, Object> parameters) {
     checkScriptingPermissions();
+    // Which context THIS invocation is evaluating in, or null while it is still queued behind another one. Read by
+    // the timeout path so it never cancels a context its own task never entered (PR #6783 review).
+    final AtomicReference<GraalPolyglotEngine> running = new AtomicReference<>();
     try {
       return executeUserCode(() -> {
 
         synchronized (engineLock) {
           final GraalPolyglotEngine engine = polyglotEngine;
+          running.set(engine);
           // Parameters are scoped to THIS evaluation: the context is shared by every caller on the database, so a
           // parameter left bound would be readable by the next command, from any caller (issue #6759).
           final Map<String, Value> displaced =
@@ -183,10 +188,11 @@ public class PolyglotQueryEngine implements QueryEngine {
           } finally {
             if (displaced != null)
               engine.restoreAttributes(displaced);
+            running.compareAndSet(engine, null);
           }
         }
 
-      }, timeout);
+      }, running, timeout);
 
     } catch (final CommandExecutionException e) {
       throw e;
@@ -231,13 +237,20 @@ public class PolyglotQueryEngine implements QueryEngine {
   public AnalyzedQuery analyze(final String query) {
     // analyze() evaluates the script to determine its characteristics, so it is gated identically to command().
     checkScriptingPermissions();
+    final AtomicReference<GraalPolyglotEngine> running = new AtomicReference<>();
     try {
       executeUserCode(() -> {
         synchronized (engineLock) {
-          polyglotEngine.eval(query);
+          final GraalPolyglotEngine engine = polyglotEngine;
+          running.set(engine);
+          try {
+            engine.eval(query);
+          } finally {
+            running.compareAndSet(engine, null);
+          }
         }
         return null;
-      }, timeout);
+      }, running, timeout);
     } catch (final CommandExecutionException e) {
       throw e;
     } catch (final ExecutionException e) {
@@ -269,7 +282,8 @@ public class PolyglotQueryEngine implements QueryEngine {
     polyglotEngine.close();
   }
 
-  private ResultSet executeUserCode(final Callable task, final long executionTimeoutMs) throws Exception {
+  private ResultSet executeUserCode(final Callable task, final AtomicReference<GraalPolyglotEngine> running,
+      final long executionTimeoutMs) throws Exception {
     // IF NOT INITIALIZED, EXECUTE AS SOON AS THE SERVICE STARTS
     final Future future = userCodeExecutor.submit(task);
     if (future == null)
@@ -287,7 +301,7 @@ public class PolyglotQueryEngine implements QueryEngine {
       // task had in fact just completed - in which case there is nothing left in the context to cancel, and
       // interrupting would only risk hitting whichever command acquired the lock next.
       if (future.cancel(true))
-        cancelRunningScript();
+        cancelRunningScript(running.get());
       throw e;
     }
   }
@@ -300,8 +314,11 @@ public class PolyglotQueryEngine implements QueryEngine {
    * {@link #engineLock} - the monitor every command on this database serialises on - until it unwinds. A script that
    * outlives its timeout would otherwise block the engine for every caller (issue #6759).
    */
-  private void cancelRunningScript() {
-    final GraalPolyglotEngine engine = polyglotEngine;
+  private void cancelRunningScript(final GraalPolyglotEngine engine) {
+    // null means this invocation was still QUEUED behind another one when it timed out: its own script never
+    // entered the context, so there is nothing of ours to cancel - and interrupting anyway would abort whichever
+    // OTHER caller's script is currently holding the lock (PR #6783 review). Reading the recorded instance rather
+    // than the field also means a context unregisterFunctions() replaced in the meantime is left alone.
     if (engine == null)
       return;
     try {

--- a/engine/src/main/java/com/arcadedb/query/polyglot/PolyglotQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/PolyglotQueryEngine.java
@@ -29,16 +29,26 @@ import com.arcadedb.query.QueryEngine;
 import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.security.SecurityDatabaseUser;
 import org.graalvm.polyglot.Value;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
 
 public class PolyglotQueryEngine implements QueryEngine {
-  private       GraalPolyglotEngine          polyglotEngine;
+  /**
+   * The shared script context. Volatile and guarded by {@link #engineLock} rather than being its own monitor:
+   * {@link #unregisterFunctions()} replaces it, and {@code synchronized} on a field that can be reassigned lets two
+   * commands run concurrently on two different monitors over what is meant to be a serialised context (issue #6759).
+   */
+  private volatile GraalPolyglotEngine       polyglotEngine;
+  /** Serialises every access to {@link #polyglotEngine}; stable for the life of this engine. */
+  private final Object                       engineLock      = new Object();
   private final String                       language;
   private final long                         timeout;
   private final DatabaseInternal             database;
@@ -48,6 +58,9 @@ public class PolyglotQueryEngine implements QueryEngine {
 
   /** #5418: names the user-code workers and marks them DAEMON (see the constructor). */
   private static final AtomicLong USER_CODE_THREAD_SEQ = new AtomicLong();
+
+  /** How long {@link #cancelRunningScript()} waits for a timed-out script to unwind before reporting it wedged. */
+  private static final long INTERRUPT_GRACE_MS = 5_000;
 
   private static final AnalyzedQuery ANALYZED_QUERY = new AnalyzedQuery() {
     @Override
@@ -136,36 +149,41 @@ public class PolyglotQueryEngine implements QueryEngine {
     try {
       return executeUserCode(() -> {
 
-        synchronized (polyglotEngine) {
-          if (parameters != null && !parameters.isEmpty()) {
-            for (final Map.Entry<String, Object> entry : parameters.entrySet())
-              polyglotEngine.setAttribute(entry.getKey(), entry.getValue());
-          }
+        synchronized (engineLock) {
+          final GraalPolyglotEngine engine = polyglotEngine;
+          // Parameters are scoped to THIS evaluation: the context is shared by every caller on the database, so a
+          // parameter left bound would be readable by the next command, from any caller (issue #6759).
+          final Map<String, Value> displaced =
+              parameters == null || parameters.isEmpty() ? null : engine.setAttributes(parameters);
+          try {
+            final Value result = engine.eval(query);
 
-          final Value result = polyglotEngine.eval(query);
+            if (result.isHostObject()) {
+              final Object host = result.asHostObject();
+              if (host instanceof ResultSet)
+                return host;
 
-          if (result.isHostObject()) {
-            final Object host = result.asHostObject();
-            if (host instanceof ResultSet)
-              return host;
+              final InternalResultSet resultSet = new InternalResultSet();
+              if (host instanceof Iterable iterable) {
+                for (final Object o : iterable)
+                  resultSet.add(extractResult(o));
+              } else
+                resultSet.add(extractResult(host));
+
+              return resultSet;
+
+            }
 
             final InternalResultSet resultSet = new InternalResultSet();
-            if (host instanceof Iterable iterable) {
-              for (final Object o : iterable)
-                resultSet.add(extractResult(o));
-            } else
-              resultSet.add(extractResult(host));
 
+            final Object value = JavascriptFunctionDefinition.jsValueToJava(result);
+
+            resultSet.add(new ResultInternal(database).setProperty("value", value));
             return resultSet;
-
+          } finally {
+            if (displaced != null)
+              engine.restoreAttributes(displaced);
           }
-
-          final InternalResultSet resultSet = new InternalResultSet();
-
-          final Object value = JavascriptFunctionDefinition.jsValueToJava(result);
-
-          resultSet.add(new ResultInternal(database).setProperty("value", value));
-          return resultSet;
         }
 
       }, timeout);
@@ -183,7 +201,7 @@ public class PolyglotQueryEngine implements QueryEngine {
   @Override
   public QueryEngine registerFunctions(final String function) {
     checkScriptingPermissions();
-    synchronized (polyglotEngine) {
+    synchronized (engineLock) {
       try {
         polyglotEngine.eval(function);
       } catch (final CommandExecutionException e) {
@@ -197,8 +215,15 @@ public class PolyglotQueryEngine implements QueryEngine {
 
   @Override
   public QueryEngine unregisterFunctions() {
-    this.polyglotEngine = GraalPolyglotEngine.newBuilder(database, PolyglotEngineManager.getInstance().getSharedEngine())
-        .setLanguage(language).setAllowedPackages(allowedPackages).build();
+    synchronized (engineLock) {
+      final GraalPolyglotEngine previous = this.polyglotEngine;
+      this.polyglotEngine = GraalPolyglotEngine.newBuilder(database, PolyglotEngineManager.getInstance().getSharedEngine())
+          .setLanguage(language).setAllowedPackages(allowedPackages).build();
+      // The replaced context owns native GraalVM state; dropping the reference without closing it leaks it for the
+      // life of the JVM.
+      if (previous != null)
+        previous.close();
+    }
     return this;
   }
 
@@ -208,7 +233,7 @@ public class PolyglotQueryEngine implements QueryEngine {
     checkScriptingPermissions();
     try {
       executeUserCode(() -> {
-        synchronized (polyglotEngine) {
+        synchronized (engineLock) {
           polyglotEngine.eval(query);
         }
         return null;
@@ -258,8 +283,35 @@ public class PolyglotQueryEngine implements QueryEngine {
       return (ResultSet) result;
 
     } catch (final TimeoutException e) {
-      future.cancel(true); //this method will stop the running underlying task
+      // cancel(true) interrupts the HOST thread, which a guest loop is free to ignore. It returns false when the
+      // task had in fact just completed - in which case there is nothing left in the context to cancel, and
+      // interrupting would only risk hitting whichever command acquired the lock next.
+      if (future.cancel(true))
+        cancelRunningScript();
       throw e;
+    }
+  }
+
+  /**
+   * Cancels whatever the timed-out script left running inside the shared context.
+   * <p>
+   * {@code Future.cancel(true)} only sets the host thread's interrupt flag. A guest program is stopped by GraalVM's
+   * own cancellation ({@code Context.interrupt}), and it has to be stopped, because the task holds
+   * {@link #engineLock} - the monitor every command on this database serialises on - until it unwinds. A script that
+   * outlives its timeout would otherwise block the engine for every caller (issue #6759).
+   */
+  private void cancelRunningScript() {
+    final GraalPolyglotEngine engine = polyglotEngine;
+    if (engine == null)
+      return;
+    try {
+      if (!engine.interrupt(Duration.ofMillis(INTERRUPT_GRACE_MS)))
+        LogManager.instance().log(this, Level.WARNING,
+            "Timed-out %s script did not unwind within %dms: it is blocked in a host call that cannot be "
+                + "interrupted and still holds the shared script context of database '%s'",
+            language, INTERRUPT_GRACE_MS, database.getName());
+    } catch (final Exception ex) {
+      LogManager.instance().log(this, Level.WARNING, "Error while cancelling a timed-out %s script", ex, language);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6762VectorIdAllocatorAfterFailedLoadTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6762VectorIdAllocatorAfterFailedLoadTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6762: a failed first-use materialisation must not leave the vector-id allocator at 0.
+ * <p>
+ * {@code materializeLocations()} catches a load failure, logs a WARNING and still marks the materialisation done -
+ * deliberately, because the alternative is re-parsing a corrupt index once per query instead of once per open. But
+ * {@code nextId} was only advanced at the END of a successful load, so a failure that threw after some entries had
+ * already been inserted left the map populated and the allocator at 0. {@code allocateVectorId()} exists precisely
+ * to stop ids restarting at 0 on top of live entries, and it would then hand out 0, 1, 2... - so the next insert
+ * superseded a live vector instead of adding one, losing one vector per insert.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6762VectorIdAllocatorAfterFailedLoadTest {
+  private static final String DB_PATH    = "target/databases/Issue6762VectorIdAllocatorAfterFailedLoadTest";
+  private static final int    DIMENSIONS = 8;
+  private static final int    VECTORS    = 20;
+
+  @AfterEach
+  void cleanUp() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void anInsertAfterAFailedMaterialisationDoesNotSupersedeALiveVector() throws Exception {
+    createDatabaseWithVectorIndex();
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndexOf(db);
+
+        // Populate the location map for real, then put the index back into the state a PARTIAL load leaves behind:
+        // entries already in the map, the one-attempt flag not yet latched, and the allocator still at its initial
+        // 0. Breaking the mutable component makes the materialisation that follows fail the way the real one does.
+        assertThat(index.countEntries()).isEqualTo(VECTORS);
+        final Object mutable = readField(index, "mutable");
+        setField(index, "locationsMaterialized", false);
+        ((AtomicInteger) readField(index, "nextId")).set(0);
+        setField(index, "mutable", null);
+        try {
+          index.getVectorIndex(); // materialises: throws internally, and the failure is swallowed by design
+        } finally {
+          setField(index, "mutable", mutable);
+        }
+
+        assertThat(index.areLocationsMaterializedForTest())
+            .as("the one-attempt contract still holds: a failed load is not retried")
+            .isTrue();
+        assertThat(((AtomicInteger) readField(index, "nextId")).get())
+            .as("but the allocator must sit past every id the map already holds, not back at 0")
+            .isGreaterThanOrEqualTo(VECTORS);
+
+        // The observable consequence: with the allocator at 0 this insert would overwrite the entry holding id 0.
+        db.transaction(() -> db.newDocument("Doc").set("id", VECTORS).set("embedding", randomVector(7)).save());
+
+        assertThat(index.countEntries())
+            .as("an insert must ADD a vector, not supersede a live one")
+            .isEqualTo(VECTORS + 1);
+      } finally {
+        db.close();
+      }
+    }
+  }
+
+  private LSMVectorIndex vectorIndexOf(final Database db) {
+    final TypeIndex typeIndex = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+    return (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+  }
+
+  private static float[] randomVector(final long seed) {
+    final Random rnd = new Random(seed);
+    final float[] v = new float[DIMENSIONS];
+    for (int j = 0; j < DIMENSIONS; j++)
+      v[j] = (float) rnd.nextGaussian();
+    return v;
+  }
+
+  private void createDatabaseWithVectorIndex() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.create();
+      try {
+        db.transaction(() -> {
+          final DocumentType type = db.getSchema().createDocumentType("Doc");
+          type.createProperty("id", Type.INTEGER);
+          type.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+          for (int i = 0; i < VECTORS; i++)
+            db.newDocument("Doc").set("id", i).set("embedding", randomVector(i)).save();
+        });
+        db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+            + ", \"similarity\": \"EUCLIDEAN\" }");
+      } finally {
+        db.close();
+      }
+    }
+  }
+
+  private static Object readField(final Object target, final String name) throws Exception {
+    final Field f = LSMVectorIndex.class.getDeclaredField(name);
+    f.setAccessible(true);
+    return f.get(target);
+  }
+
+  private static void setField(final Object target, final String name, final Object value) throws Exception {
+    final Field f = LSMVectorIndex.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(target, value);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/polyglot/PolyglotQueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/polyglot/PolyglotQueryTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -136,6 +137,65 @@ class PolyglotQueryTest extends TestHelper {
     } finally {
       GlobalConfiguration.POLYGLOT_COMMAND_TIMEOUT.reset();
     }
+  }
+
+  /**
+   * Issue #6759: the script context is shared by every caller on the database, and parameters used to be bound to it
+   * and never removed, so a value one command passed stayed readable by the next one - from any caller.
+   */
+  @Test
+  void parametersDoNotLeakIntoTheNextCommand() {
+    final ResultSet withParameter = database.command("js", "x", Map.of("x", 5));
+    assertThat(withParameter.next().<Object>getProperty("value")).isEqualTo(5);
+
+    // Same engine, same context, no parameter: 'x' must be gone rather than still resolving to 5.
+    try {
+      database.command("js", "x");
+      fail("The parameter of the previous command is still bound");
+    } catch (final CommandExecutionException e) {
+      assertThat(e.getCause()).isInstanceOf(PolyglotException.class);
+      assertThat(e.getCause().getMessage()).contains("x is not defined");
+    }
+  }
+
+  /**
+   * Issue #6759: a parameter is allowed to shadow a binding the engine owns for the duration of one command, but the
+   * original must come back afterwards - removing it outright would break every later script.
+   */
+  @Test
+  void aParameterShadowingAnEngineBindingIsRestored() {
+    final ResultSet shadowed = database.command("js", "database", Map.of("database", "not-a-database"));
+    assertThat(shadowed.next().<Object>getProperty("value")).isEqualTo("not-a-database");
+
+    database.transaction(() -> database.getSchema().createVertexType("Restored"));
+
+    // The real 'database' binding is back: this would throw if the parameter had simply been unbound.
+    final ResultSet result = database.command("js", "database.query('sql', 'select from Restored')");
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  /**
+   * Issue #6759: a timed-out script must leave the shared context usable. Before the fix the only cancellation was
+   * {@code Future.cancel(true)}, i.e. a host-thread interrupt a guest loop is free to ignore.
+   */
+  @Test
+  void theEngineStaysUsableAfterATimeout() {
+    GlobalConfiguration.POLYGLOT_COMMAND_TIMEOUT.setValue(2000);
+    try {
+      try {
+        database.command("js", "while(true);");
+        fail("It should go in timeout");
+      } catch (final Exception e) {
+        assertThat(e).isInstanceOf(CommandExecutionException.class);
+        assertThat(e.getCause()).isInstanceOf(TimeoutException.class);
+      }
+    } finally {
+      GlobalConfiguration.POLYGLOT_COMMAND_TIMEOUT.reset();
+    }
+
+    final ResultSet result = database.command("js", "3 + 5");
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(8);
   }
 
   @Test

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -77,8 +77,11 @@ public class RemoteGrpcServer implements AutoCloseable {
   // path off any DNS lookup.
   private final boolean                 refuseCredentialsOverChannel;
 
-  private ManagedChannel channel;
-  private EventLoopGroup eventLoopGroup;
+  // Volatile: mutated only under this object's monitor by start()/close(), but channel() and the stub factories
+  // read it WITHOUT the monitor, so without volatile a reader racing the first start() or a close() has no
+  // happens-before edge and may observe a stale (or half-published) value (issue #6762).
+  private volatile ManagedChannel channel;
+  private volatile EventLoopGroup eventLoopGroup;
 
   private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingV2Stub adminServiceBlockingV2Stub;
 
@@ -148,14 +151,21 @@ public class RemoteGrpcServer implements AutoCloseable {
 
   /**
    * Returns a Channel (wrapped with interceptors if provided).
+   * <p>
+   * Reads the field ONCE per decision: re-reading it after the null check let a concurrent {@link #close()} turn the
+   * return value into {@code null} between the two reads, surfacing as an NPE inside gRPC rather than as a usable
+   * error (issue #6762).
    */
   public Channel channel() {
-
-    if (channel == null) {
+    ManagedChannel current = channel;
+    if (current == null) {
       start();
+      current = channel;
+      if (current == null)
+        throw new IllegalStateException("The gRPC channel to '" + host + "' is not available: the connection is closed");
     }
 
-    return interceptors.isEmpty() ? channel : ClientInterceptors.intercept(channel, interceptors);
+    return interceptors.isEmpty() ? current : ClientInterceptors.intercept(current, interceptors);
   }
 
   public ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub newBlockingStub(int timeout) {

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -82,6 +82,14 @@ public class RemoteGrpcServer implements AutoCloseable {
   // happens-before edge and may observe a stale (or half-published) value (issue #6762).
   private volatile ManagedChannel channel;
   private volatile EventLoopGroup eventLoopGroup;
+  /**
+   * Set the moment {@link #close()} begins and cleared by the next explicit {@link #start()}. Without it,
+   * {@code channel()} could still hand out the channel that {@code close()} had already begun shutting down, and
+   * worse: once {@code close()} nulled the field, {@code channel()} would silently BUILD A NEW CHANNEL for a
+   * server the caller has explicitly closed. An explicit restart is still allowed - that is what clears it - a
+   * lazy resurrection from a stale reference is not (PR #6783 review).
+   */
+  private volatile boolean       closing;
 
   private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingV2Stub adminServiceBlockingV2Stub;
 
@@ -115,6 +123,7 @@ public class RemoteGrpcServer implements AutoCloseable {
   }
 
   public synchronized void start() {
+    closing = false;
 
     if (channel != null)
       return;
@@ -157,6 +166,8 @@ public class RemoteGrpcServer implements AutoCloseable {
    * error (issue #6762).
    */
   public Channel channel() {
+    if (closing)
+      throw new IllegalStateException("The gRPC channel to '" + host + "' is closed");
     ManagedChannel current = channel;
     if (current == null) {
       start();
@@ -200,6 +211,9 @@ public class RemoteGrpcServer implements AutoCloseable {
   public synchronized void close() {
     if (channel == null)
       return;
+    // Set BEFORE the shutdown begins, so channel() refuses from this point rather than handing out a channel that
+    // is already terminating (PR #6783 review).
+    closing = true;
     try {
       channel.shutdown();
       if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6762ChannelLifecycleTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6762ChannelLifecycleTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import io.grpc.ClientInterceptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6762 item 6 and its PR #6783 review follow-up: the channel field is read without the monitor that mutates
+ * it, so it has to be {@code volatile}, read once per decision, and it must not be resurrected after close.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6762ChannelLifecycleTest {
+
+  /**
+   * The field is mutated only under this object's monitor by start()/close() but read WITHOUT it by channel() and
+   * the stub factories, so a reader racing either has no happens-before edge on the write.
+   */
+  @Test
+  void theChannelAndItsEventLoopGroupAreVolatile() throws Exception {
+    assertThat(java.lang.reflect.Modifier.isVolatile(
+        RemoteGrpcServer.class.getDeclaredField("channel").getModifiers()))
+        .as("channel is read outside the monitor that writes it")
+        .isTrue();
+    assertThat(java.lang.reflect.Modifier.isVolatile(
+        RemoteGrpcServer.class.getDeclaredField("eventLoopGroup").getModifiers()))
+        .as("eventLoopGroup is torn down on the same path")
+        .isTrue();
+  }
+
+  /**
+   * close() used to leave channel() free to observe the null it had just written and silently BUILD A NEW CHANNEL
+   * for a server the caller had explicitly closed - a reconnect nobody asked for, to a server being shut down.
+   */
+  @Test
+  void channelRefusesToResurrectAClosedServer() {
+    final RemoteGrpcServer server = new RemoteGrpcServer("localhost", 50051, "root", "pwd", true, List.of(), 30_000, true);
+    server.start();
+    assertThatNoException().isThrownBy(server::channel);
+
+    server.close();
+
+    assertThatThrownBy(server::channel)
+        .as("a closed server hands out no channel, and certainly does not open a fresh one")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+  }
+
+  /** An EXPLICIT restart is still allowed: it is the lazy resurrection from a stale reference that is not. */
+  @Test
+  void anExplicitRestartAfterCloseStillWorks() {
+    final RemoteGrpcServer server = new RemoteGrpcServer("localhost", 50051, "root", "pwd", true, List.of(), 30_000, true);
+    server.start();
+    server.close();
+
+    server.start();
+    try {
+      assertThatNoException().isThrownBy(server::channel);
+    } finally {
+      server.close();
+    }
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1386,13 +1386,6 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // re-checks against the restored state instead of the floor (issue #6111).
       clearStaleSnapshotFloor();
 
-      // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this
-      // leader-driven snapshot install advances the applied index without going through
-      // applyTransaction(), the only other notifyApplied() call site (issue #5846).
-      final RaftHAServer raftHA = this.raftHAServer;
-      if (raftHA != null)
-        raftHA.notifyApplied();
-
       LogManager.instance().log(this, Level.INFO,
           "HA resync finished (mode=snapshot, result=%s): snapshotIndex=%d",
           notInstalled.isEmpty() ? "ok" : "partial", snapshotIndex);
@@ -1403,6 +1396,23 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // ... except the ones it did not reinstall. Re-arm those AFTER clearDivergedState()/clearStaleSnapshotFloor()
       // above, which are written for the all-databases-refreshed case (issue #6760).
       markDatabasesNotAtSnapshotIndex(notInstalled, snapshotIndex);
+
+      // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this
+      // leader-driven snapshot install advances the applied index without going through
+      // applyTransaction(), the only other notifyApplied() call site (issue #5846).
+      //
+      // LAST, after every floor and diverged mark of this install is in its final state. notifyApplied() holds
+      // applyNotifier only long enough to notifyAll(), so a waiter can reacquire it and re-check
+      // getTrustedAppliedIndex(db) immediately. Notifying any earlier than this leaves a window in which the
+      // global floor is already cleared and the per-database one is not yet published - clearDivergedState()
+      // above has just wiped it, or the first give-up never had one - so the woken waiter sees the raw Ratis
+      // index, which already equals snapshotIndex, and a LINEARIZABLE or read-your-writes read of a database
+      // this install did NOT refresh passes its wait and is served from the stale copy. That is precisely the
+      // outcome issue #6760 exists to prevent, so the notify has to come after the re-arm, not before it.
+      final RaftHAServer raftHA = this.raftHAServer;
+      if (raftHA != null)
+        raftHA.notifyApplied();
+
       return installedTermIndex;
 
     } catch (final SnapshotRefusedException e) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -314,6 +314,21 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // last cleared. Throttles the HealthMonitor-driven backstop, which ticks far more often than a full
   // multi-database resync costs.
   private final AtomicLong    lastStaleSnapshotRetryMs   = new AtomicLong();
+  // Per-database read floor (issue #6760), the per-database counterpart of staleSnapshotAppliedFloor above.
+  //
+  // A leader-driven install may "give up" on a database that failed to refresh ACQUIRE_GIVE_UP_AFTER times in a
+  // row: past that point the reconciler stops failing the whole install for it, so Ratis is not made to re-download
+  // every healthy database on this node in a tight loop. That is the right call for the RETRY, but the install then
+  // went on to record snapshotIndex as applied for EVERY database, clear the global floor and the diverged marks,
+  // and return the installed TermIndex to Ratis - which purges the log. The node re-entered the ready set
+  // advertising itself fully caught up while one database was still on its old copy, so a LINEARIZABLE (or
+  // read-your-writes) read of THAT database passed the apply wait instantly and was served from stale state.
+  //
+  // Unlike the global floor, which is derived from a global signal and therefore has to clamp everything, this one
+  // is published from a per-database verdict: exactly the databases the install did not bring to snapshotIndex are
+  // clamped, and the healthy co-located ones keep serving unclamped reads. Entries are removed when the database is
+  // genuinely refreshed (a later install, a targeted resync, or a full resync).
+  private final ConcurrentHashMap<String, Long> staleDatabaseAppliedFloors = new ConcurrentHashMap<>();
   // Set to true after applyTransaction hits a genuinely unrecoverable, node-wide condition: a JVM
   // Error (OOM, StackOverflow - the JVM itself is unstable), an unknown committed entry type (#4798,
   // rolling-upgrade safety), or an unexpected error on an entry with no single target database
@@ -1329,7 +1344,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
       final String leaderHttpsAddr = source.httpsAddress();
       final String clusterToken = raftHAServer.getClusterToken();
 
-      reconciler.reconcileDatabasesFromLeader(leaderHttpAddr, leaderHttpsAddr, clusterToken);
+      // Databases the reconciler gave up on: it stopped failing the install for them, so they are NOT at the
+      // snapshot index and must not be recorded as if they were (issue #6760).
+      final Set<String> notInstalled = reconciler.reconcileDatabasesFromLeader(leaderHttpAddr, leaderHttpsAddr,
+          clusterToken);
 
       // Compute the installed snapshot TermIndex. firstTermIndexInLog is the first log entry
       // AFTER the snapshot, so the snapshot covers all entries up to getIndex()-1.
@@ -1362,7 +1380,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // replay-skip honest after a full resync (issue #4824).
       lastAppliedIndex.set(snapshotIndex);
       updateLastAppliedTermIndex(snapshotTerm, snapshotIndex);
-      writePersistedAppliedIndexForAllDatabases(snapshotIndex);
+      writePersistedAppliedIndexForAllDatabases(snapshotIndex, notInstalled);
       // The install brought every database up to the snapshot point, so any read floor an earlier
       // stale marker published is now satisfied. Cleared BEFORE the notify below so a woken waiter
       // re-checks against the restored state instead of the floor (issue #6111).
@@ -1376,11 +1394,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
         raftHA.notifyApplied();
 
       LogManager.instance().log(this, Level.INFO,
-          "HA resync finished (mode=snapshot, result=ok): snapshotIndex=%d", snapshotIndex);
+          "HA resync finished (mode=snapshot, result=%s): snapshotIndex=%d",
+          notInstalled.isEmpty() ? "ok" : "partial", snapshotIndex);
       clearDivergedState();
       // A leader-driven install reinstalls every database present on this node, so a copy the bootstrap
       // overwrite guard had kept is gone and its divergence mark with it (issue #6124).
       clearAllBootstrapUnreconciled();
+      // ... except the ones it did not reinstall. Re-arm those AFTER clearDivergedState()/clearStaleSnapshotFloor()
+      // above, which are written for the all-databases-refreshed case (issue #6760).
+      markDatabasesNotAtSnapshotIndex(notInstalled, snapshotIndex);
       return installedTermIndex;
 
     } catch (final SnapshotRefusedException e) {
@@ -2688,12 +2710,23 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * the shared temp file.
    */
   void writePersistedAppliedIndexForAllDatabases(final long index) {
+    writePersistedAppliedIndexForAllDatabases(index, Set.of());
+  }
+
+  /**
+   * Same, minus {@code excluded}: the databases a snapshot install gave up on are not at {@code index}, so recording
+   * them there would make {@link #reinitialize()} skip exactly the replay that would have caught them up on the next
+   * restart, and would silently launder a stale copy into "applied" (issue #6760). The GLOBAL position still
+   * advances: it is the Raft-log position Ratis is being told about, and Ratis has been told.
+   */
+  void writePersistedAppliedIndexForAllDatabases(final long index, final Set<String> excluded) {
     synchronized (appliedIndexFileLock) {
       ensureAppliedIndexLoaded();
       globalAppliedIndex = index;
       if (server != null)
         for (final String dbName : server.getDatabaseNames())
-          appliedIndexByDb.put(dbName, index);
+          if (!excluded.contains(dbName))
+            appliedIndexByDb.put(dbName, index);
       persistAppliedIndexFile();
     }
   }
@@ -3208,7 +3241,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
     if (raftHA == null || server == null || raftHA.isLeader())
       return;
     final long floor = staleSnapshotAppliedFloor.get();
-    if (floor < 0)
+    // A per-database floor is an unfilled gap too: it is published exactly when an install gave up on a database,
+    // which is the case that otherwise never re-arms anything (issue #6760). Same throttle, same single-flight.
+    if (floor < 0 && staleDatabaseAppliedFloors.isEmpty())
       return; // no unfilled gap
     if (snapshotDownloadInProgress.get())
       return; // one is genuinely running; it will clear the floor or re-arm the request
@@ -3232,8 +3267,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
       return; // another tick won the throttle slot
 
     LogManager.instance().log(this, Level.WARNING,
-        "Snapshot marker is still ahead of the applied state (read floor=%d) with no download in flight: "
-            + "retrying the resync from the leader (issue #6111)", floor);
+        "Local state is still behind what the snapshot marker claims (read floor=%d, databases short of the "
+            + "snapshot index=%s) with no download in flight: retrying the resync from the leader "
+            + "(issues #6111, #6760)", floor, staleDatabaseAppliedFloors.keySet());
     try {
       lifecycleExecutor.submit(this::triggerSnapshotDownload);
     } catch (final RejectedExecutionException ree) {
@@ -3250,6 +3286,45 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   public long getStaleSnapshotAppliedFloor() {
     return staleSnapshotAppliedFloor.get();
+  }
+
+  /**
+   * Highest Raft-log index whose data is genuinely present in {@code dbName}, or {@code -1} when this database is
+   * not known to be behind (the normal case). Consumed by
+   * {@link RaftHAServer#getTrustedAppliedIndex(String)} so a read of a database a snapshot install gave up on is
+   * clamped, while its healthy co-located databases are not (issue #6760).
+   */
+  public long getDatabaseAppliedFloor(final String dbName) {
+    if (dbName == null)
+      return -1;
+    final Long floor = staleDatabaseAppliedFloors.get(dbName);
+    return floor != null ? floor : -1;
+  }
+
+  /**
+   * Records that a snapshot install completed WITHOUT bringing {@code databases} to {@code snapshotIndex}
+   * (issue #6760).
+   * <p>
+   * Each one keeps its diverged mark - so the node does not advertise readiness while it holds a copy it knows is
+   * behind - and publishes a read floor at its own honest applied position, so a LINEARIZABLE or read-your-writes
+   * read targeting it fails or degrades instead of being served from the stale copy. Recovery is the existing
+   * machinery: the mark keeps {@link #isResyncInProgress()} true, and {@link #retryUnfilledSnapshotGap()} re-drives
+   * the resync on the HealthMonitor tick until the database is refreshed for real.
+   */
+  private void markDatabasesNotAtSnapshotIndex(final Set<String> databases, final long snapshotIndex) {
+    for (final String dbName : databases) {
+      // The persisted position was deliberately NOT advanced for this database above, so it still carries whatever
+      // this node genuinely applied. -1 (never recorded) clamps to 0, which is the honest answer for a database
+      // nothing is known about.
+      final long floor = Math.max(0L, readPersistedAppliedIndex(dbName));
+      staleDatabaseAppliedFloors.put(dbName, floor);
+      markStateDiverged(dbName);
+      LogManager.instance().log(this, Level.SEVERE,
+          "Snapshot install did not bring database '%s' to snapshotIndex=%d: keeping it marked diverged and "
+              + "clamping its LINEARIZABLE / read-your-writes reads at appliedIndex=%d until a resync succeeds. "
+              + "The other databases on this node are unaffected. Check the leader's copy of '%s'.",
+          dbName, snapshotIndex, floor, dbName);
+    }
   }
 
   /**
@@ -3331,6 +3406,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
   void clearDivergedDatabase(final String dbName) {
     divergedDatabases.remove(dbName);
     lastDivergedResyncLogByDb.remove(dbName);
+    // The resync restored this database, so its read floor is satisfied (issue #6760).
+    staleDatabaseAppliedFloors.remove(dbName);
     if (divergedDatabases.isEmpty())
       divergedSwallowedErrors.set(0);
   }
@@ -3372,6 +3449,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
     divergedDatabases.clear();
     lastDivergedResyncLogByDb.clear();
     divergedSwallowedErrors.set(0);
+    // A resync reinstalls every database, so every per-database read floor is satisfied too (issue #6760). The
+    // snapshot-install path re-publishes the floors of the databases it could NOT reinstall right after calling
+    // this, so clearing wholesale here stays correct.
+    staleDatabaseAppliedFloors.clear();
   }
 
   // @VisibleForTesting
@@ -3421,7 +3502,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * and must not advertise itself as ready.
    */
   public boolean isResyncInProgress() {
-    return isSnapshotDownloadPending() || !divergedDatabases.isEmpty() || staleSnapshotAppliedFloor.get() >= 0;
+    return isSnapshotDownloadPending() || !divergedDatabases.isEmpty() || staleSnapshotAppliedFloor.get() >= 0
+        || !staleDatabaseAppliedFloors.isEmpty();
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DatabaseReconciler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DatabaseReconciler.java
@@ -83,6 +83,19 @@ public class DatabaseReconciler {
   }
 
   /**
+   * What a reconcile pass concluded (issue #6760).
+   *
+   * @param retryWorthwhile whether at least one failed database is still inside its retry budget, so the overall
+   *                        install should be failed and Ratis made to re-drive it
+   * @param givenUp         the databases that failed and have EXHAUSTED that budget. The install proceeds without
+   *                        them - which is the point of the budget - so the caller has to remember that these
+   *                        databases are NOT at the snapshot index, or the node would ACK the index and advertise
+   *                        itself caught up over stale data
+   */
+  public record ReconcileVerdict(boolean retryWorthwhile, Set<String> givenUp) {
+  }
+
+  /**
    * Per-database auto-acquisition status (issue #4727), surfaced in the cluster status endpoint and the
    * Studio HA panel. Updated by {@link #reconcileDatabasesFromLeader} as a joining node reconciles its
    * local database set against the leader's.
@@ -186,10 +199,14 @@ public class DatabaseReconciler {
    * {@link AcquireState#LEADER_MISSING} alert plus the leadership-transfer flow cover the #4522 redistribution
    * edge, so this boundary is not reachable in normal operation.
    *
-   * @throws IOException if a database install fails (so the caller leaves the Ratis snapshot install incomplete
-   *                     and Ratis re-triggers it; installs are idempotent).
+   * @return the databases this pass gave up on, i.e. that failed and have exhausted their retry budget so the
+   *         install is allowed to proceed without them. The caller MUST treat those as not-at-the-snapshot-index
+   *         (issue #6760). Empty on every clean pass and on every path that fails the install outright.
+   *
+   * @throws IOException if a database install fails while still inside its retry budget (so the caller leaves the
+   *                     Ratis snapshot install incomplete and Ratis re-triggers it; installs are idempotent).
    */
-  void reconcileDatabasesFromLeader(final String leaderHttpAddr, final String leaderHttpsAddr,
+  Set<String> reconcileDatabasesFromLeader(final String leaderHttpAddr, final String leaderHttpsAddr,
       final String clusterToken) throws IOException {
 
     final boolean autoAcquire = server.getConfiguration().getValueAsBoolean(
@@ -197,7 +214,7 @@ public class DatabaseReconciler {
 
     if (!autoAcquire) {
       refreshExistingDatabases(leaderHttpAddr, leaderHttpsAddr, clusterToken);
-      return;
+      return Set.of();
     }
 
     // Enumerate the leader's databases via the existing bootstrap-state RPC. On failure, degrade to the legacy
@@ -215,13 +232,13 @@ public class DatabaseReconciler {
           "Interrupted while listing the leader's databases for auto-acquire; refreshing only the databases "
               + "already present locally.");
       refreshExistingDatabasesOrFailWhenEmpty(leaderHttpAddr, leaderHttpsAddr, clusterToken);
-      return;
+      return Set.of();
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING,
           "Could not list the leader's databases for auto-acquire (%s); refreshing only the databases already "
               + "present locally. Missing databases will be retried on the next reconcile.", e.getMessage());
       refreshExistingDatabasesOrFailWhenEmpty(leaderHttpAddr, leaderHttpsAddr, clusterToken);
-      return;
+      return Set.of();
     }
 
     // Build the leader's database set. Skip entries the leader reported it could not open (lastTxId < 0): such a
@@ -267,9 +284,11 @@ public class DatabaseReconciler {
     // Apply the status-map / failure-counter bookkeeping and decide whether to fail the overall install so Ratis
     // re-triggers it. Extracted to a package-private method so these transitions are unit-testable without a live
     // cluster (the InstallSnapshot path is not deterministically reachable in-process - see SnapshotAcquireNewDatabaseIT).
-    if (applyReconcileOutcome(plan, outcome))
+    final ReconcileVerdict verdict = applyReconcileOutcome(plan, outcome);
+    if (verdict.retryWorthwhile())
       throw new IOException(String.format("Reconcile from leader had database failure(s); will retry (acquire=%s, refresh=%s)",
           outcome.acquireFailures(), outcome.refreshFailures()));
+    return verdict.givenUp();
   }
 
   /**
@@ -278,11 +297,13 @@ public class DatabaseReconciler {
    * leader/network I/O so the FAILED/ACQUIRED/LEADER_MISSING transitions and the give-up decision are directly
    * unit-testable.
    *
-   * @return {@code true} if at least one failed database is still within its retry budget
-   *         ({@link #ACQUIRE_GIVE_UP_AFTER}); {@code false} when there were no failures, or every failure has
-   *         exhausted its budget (so a persistently bad database no longer forces the whole install to re-run).
+   * @return a {@link ReconcileVerdict} carrying whether at least one failed database is still within its retry
+   *         budget ({@link #ACQUIRE_GIVE_UP_AFTER}) - {@code false} when there were no failures, or every failure
+   *         has exhausted its budget, so a persistently bad database no longer forces the whole install to re-run -
+   *         together with the databases that exhausted it, which the caller must not treat as installed
+   *         (issue #6760).
    */
-  boolean applyReconcileOutcome(final ReconcilePlan plan, final ReconcileOutcome outcome) {
+  ReconcileVerdict applyReconcileOutcome(final ReconcilePlan plan, final ReconcileOutcome outcome) {
     // acquireStatuses records only genuine acquisitions, so operators can tell a true pull from a routine refresh.
     // A success also resets the consecutive-failure counter for that database.
     for (final String dbName : outcome.acquired()) {
@@ -316,19 +337,20 @@ public class DatabaseReconciler {
     // FAILED and is still attempted on the next *natural* InstallSnapshot - which already re-downloads every
     // database anyway - so it can still recover if the leader's copy is later fixed; it just no longer hot-loops.
     boolean retryWorthwhile = false;
+    final Set<String> givenUp = new HashSet<>();
     for (final String dbName : outcome.acquireFailures().keySet())
-      retryWorthwhile |= bumpFailureAndShouldRetry(dbName);
+      retryWorthwhile |= bumpFailureOrGiveUp(dbName, givenUp);
     for (final String dbName : outcome.refreshFailures().keySet())
-      retryWorthwhile |= bumpFailureAndShouldRetry(dbName);
-    return retryWorthwhile;
+      retryWorthwhile |= bumpFailureOrGiveUp(dbName, givenUp);
+    return new ReconcileVerdict(retryWorthwhile, givenUp);
   }
 
   /**
    * Increments the consecutive-failure counter for a database and returns whether it is still within the retry
-   * budget ({@link #ACQUIRE_GIVE_UP_AFTER}). Once exceeded, logs once and returns false so the caller stops
-   * forcing Ratis to re-trigger the whole install for this one database.
+   * budget ({@link #ACQUIRE_GIVE_UP_AFTER}). Once exceeded, logs once, records the database in {@code givenUp} and
+   * returns false so the caller stops forcing Ratis to re-trigger the whole install for this one database.
    */
-  private boolean bumpFailureAndShouldRetry(final String dbName) {
+  private boolean bumpFailureOrGiveUp(final String dbName, final Set<String> givenUp) {
     final int count = acquireFailureCounts.merge(dbName, 1, Integer::sum);
     if (count < ACQUIRE_GIVE_UP_AFTER)
       return true;
@@ -337,6 +359,9 @@ public class DatabaseReconciler {
           "Database '%s' failed to acquire/refresh %d times in a row; leaving it FAILED and no longer re-triggering "
               + "the snapshot install for it (it will be retried on the next install). Check the leader's copy.",
           dbName, count);
+    // Reported to the caller so the install does not record this database as being at the snapshot index: giving up
+    // on the RETRY must not be the same thing as declaring the database installed (issue #6760).
+    givenUp.add(dbName);
     return false;
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2683,7 +2683,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * LINEARIZABLE path - see {@link #waitForAppliedIndex(long, boolean)}.
    */
   public void waitForAppliedIndex(final long targetIndex) {
-    waitForAppliedIndex(targetIndex, false);
+    waitForAppliedIndex(null, targetIndex, false);
+  }
+
+  /** Database-scoped lenient overload: see {@link #waitForAppliedIndex(String, long, boolean)}. */
+  public void waitForAppliedIndex(final String databaseName, final long targetIndex) {
+    waitForAppliedIndex(databaseName, targetIndex, false);
   }
 
   /**
@@ -2703,13 +2708,23 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    *                              reached before the local applied index catches up.
    */
   public void waitForAppliedIndex(final long targetIndex, final boolean throwOnTimeout) {
+    waitForAppliedIndex(null, targetIndex, throwOnTimeout);
+  }
+
+  /**
+   * As {@link #waitForAppliedIndex(long, boolean)}, but scoped to the database the read targets so a per-database
+   * read floor applies (issue #6760).
+   *
+   * @param databaseName the database the read targets, or {@code null} for a node-wide wait
+   */
+  public void waitForAppliedIndex(final String databaseName, final long targetIndex, final boolean throwOnTimeout) {
     if (targetIndex <= 0)
       return;
     try {
       final long deadline = System.currentTimeMillis() + quorumTimeout;
       synchronized (applyNotifier) {
-        while (getTrustedAppliedIndex() < targetIndex) {
-          if (!throwOnTimeout && getStaleSnapshotAppliedFloor() >= 0) {
+        while (getTrustedAppliedIndex(databaseName) < targetIndex) {
+          if (!throwOnTimeout && (getStaleSnapshotAppliedFloor() >= 0 || getDatabaseAppliedFloor(databaseName) >= 0)) {
             // No explicit "targetIndex > floor" test is needed, and adding one would be dead code:
             // reaching this line means the loop condition held, i.e. getTrustedAppliedIndex() (pinned at
             // the floor for the whole life of an outstanding gap, since Ratis' own counter starts at the
@@ -2721,13 +2736,16 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
             // holds while the floor is outstanding. Anything that changes what that branch publishes
             // must revisit this reasoning.
             //
+            // The same holds for a per-database floor (issue #6760): it is published exactly when the install
+            // could not bring THIS database to the snapshot index, so only a later resync can close it.
+            //
             // READ_YOUR_WRITES / bookmark: the target therefore sits inside a gap that only the pending
             // snapshot resync can fill, so waiting out the quorum timeout cannot change the outcome.
             // Degrade now with the same contract the timeout branch below applies (issue #6111).
             LogManager.instance().log(this, Level.WARNING,
-                "READ_YOUR_WRITES target %d is inside a pending snapshot resync gap (trusted applied=%d): "
-                    + "consistency degraded to EVENTUAL without waiting",
-                targetIndex, getTrustedAppliedIndex());
+                "READ_YOUR_WRITES target %d is inside a pending snapshot resync gap on database '%s' "
+                    + "(trusted applied=%d): consistency degraded to EVENTUAL without waiting",
+                targetIndex, databaseName, getTrustedAppliedIndex(databaseName));
             return;
           }
           final long remaining = deadline - System.currentTimeMillis();
@@ -2735,15 +2753,16 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
             if (throwOnTimeout) {
               LogManager.instance().log(this, Level.WARNING,
                   "LINEARIZABLE read failed: local apply timeout applied=%d < readIndex=%d after %dms "
-                      + "(staleSnapshotFloor=%d, failing read)",
-                  getTrustedAppliedIndex(), targetIndex, quorumTimeout, getStaleSnapshotAppliedFloor());
+                      + "(staleSnapshotFloor=%d, database '%s' floor=%d, failing read)",
+                  getTrustedAppliedIndex(databaseName), targetIndex, quorumTimeout, getStaleSnapshotAppliedFloor(),
+                  databaseName, getDatabaseAppliedFloor(databaseName));
               throw new ReplicationException(
-                  "LINEARIZABLE read timed out waiting for local apply: applied=" + getTrustedAppliedIndex()
+                  "LINEARIZABLE read timed out waiting for local apply: applied=" + getTrustedAppliedIndex(databaseName)
                       + " < readIndex=" + targetIndex);
             }
             LogManager.instance().log(this, Level.WARNING,
                 "READ_YOUR_WRITES consistency timeout: applied=%d < target=%d (consistency degraded to EVENTUAL)",
-                getTrustedAppliedIndex(), targetIndex);
+                getTrustedAppliedIndex(databaseName), targetIndex);
             return;
           }
           applyNotifier.wait(Math.min(remaining, APPLY_WAIT_RECHECK_INTERVAL_MS));
@@ -2832,9 +2851,25 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * lag detection) deliberately keep using the raw Ratis value.
    */
   public long getTrustedAppliedIndex() {
-    final long applied = getLastAppliedIndex();
+    return getTrustedAppliedIndex(null);
+  }
+
+  /**
+   * As {@link #getTrustedAppliedIndex()}, additionally clamped to the read floor of {@code databaseName} when a
+   * snapshot install gave up on that database (issue #6760).
+   * <p>
+   * The two floors are independent and both conservative, so the answer is the minimum of whichever are
+   * outstanding. Passing {@code null} asks the node-wide question and consults the global floor only.
+   */
+  public long getTrustedAppliedIndex(final String databaseName) {
+    long trusted = getLastAppliedIndex();
     final long floor = getStaleSnapshotAppliedFloor();
-    return floor < 0 ? applied : Math.min(applied, floor);
+    if (floor >= 0)
+      trusted = Math.min(trusted, floor);
+    final long databaseFloor = getDatabaseAppliedFloor(databaseName);
+    if (databaseFloor >= 0)
+      trusted = Math.min(trusted, databaseFloor);
+    return trusted;
   }
 
   /**
@@ -2844,6 +2879,17 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private long getStaleSnapshotAppliedFloor() {
     final ArcadeStateMachine sm = stateMachine;
     return sm == null ? -1 : sm.getStaleSnapshotAppliedFloor();
+  }
+
+  /**
+   * The read floor of a single database, or {@code -1} when it has none, the state machine is not wired yet, or no
+   * database was named. See {@link ArcadeStateMachine#getDatabaseAppliedFloor(String)} (issue #6760).
+   */
+  private long getDatabaseAppliedFloor(final String databaseName) {
+    if (databaseName == null)
+      return -1;
+    final ArcadeStateMachine sm = stateMachine;
+    return sm == null ? -1 : sm.getDatabaseAppliedFloor(databaseName);
   }
 
   public long getCommitIndex() {
@@ -2949,11 +2995,16 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * the local state machine cannot catch up to the read index before the quorum timeout.
    */
   public void ensureLinearizableRead() {
+    ensureLinearizableRead(null);
+  }
+
+  /** As {@link #ensureLinearizableRead()}, scoped to the database the read targets (issue #6760). */
+  public void ensureLinearizableRead(final String databaseName) {
     final long readIndex = fetchReadIndex(true);
     if (!isLeader())
       throw new ReplicationException("Lost leadership after ReadIndex confirmation");
     // LINEARIZABLE: a timeout MUST throw (HTTP 503) - never silently degrade to a stale read.
-    waitForAppliedIndex(readIndex, true);
+    waitForAppliedIndex(databaseName, readIndex, true);
   }
 
   /**
@@ -2965,9 +3016,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * state machine cannot catch up to it before the quorum timeout (never serves stale state).
    */
   public void ensureLinearizableFollowerRead() {
+    ensureLinearizableFollowerRead(null);
+  }
+
+  /** As {@link #ensureLinearizableFollowerRead()}, scoped to the database the read targets (issue #6760). */
+  public void ensureLinearizableFollowerRead(final String databaseName) {
     final long readIndex = fetchReadIndex(false);
     // LINEARIZABLE: a timeout MUST throw (HTTP 503) - never silently degrade to a stale read.
-    waitForAppliedIndex(readIndex, true);
+    waitForAppliedIndex(databaseName, readIndex, true);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -593,7 +593,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // turn into a NeedRetryException telling the caller to retry a write that is durably committed.
       final RaftHAServer raft = raftHAServer;
       if (raft != null && committedLogIndex > 0) {
-        raft.waitForAppliedIndex(committedLogIndex);
+        raft.waitForAppliedIndex(getName(), committedLogIndex);
 
         // The wait degrades to best-effort on timeout, and releasing the locks below with the pages still
         // behind is exactly the pre-#5503 condition. waitForAppliedIndex does log, but as a READ_YOUR_WRITES
@@ -1511,14 +1511,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     if (consistency == null || consistency == Database.READ_CONSISTENCY.EVENTUAL)
       return;
 
+    // Scoped to THIS database: a snapshot install that gave up on one database publishes a read floor for it
+    // alone, and the healthy co-located databases must keep serving unclamped reads (issue #6760).
     if (consistency == Database.READ_CONSISTENCY.READ_YOUR_WRITES) {
       if (!isLeader() && ctx.readAfterIndex() >= 0)
-        raftHAServer.waitForAppliedIndex(ctx.readAfterIndex());
+        raftHAServer.waitForAppliedIndex(getName(), ctx.readAfterIndex());
     } else if (consistency == Database.READ_CONSISTENCY.LINEARIZABLE) {
       if (isLeader())
-        raftHAServer.ensureLinearizableRead();
+        raftHAServer.ensureLinearizableRead(getName());
       else
-        raftHAServer.ensureLinearizableFollowerRead();
+        raftHAServer.ensureLinearizableFollowerRead(getName());
     }
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/DatabaseReconcilerTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/DatabaseReconcilerTest.java
@@ -149,12 +149,13 @@ class DatabaseReconcilerTest {
     final var reconciler = new DatabaseReconciler();
     final var plan = new DatabaseReconciler.ReconcilePlan(List.of("newok", "newbad"), List.of(), List.of("orphan"));
 
-    final boolean retry = reconciler.applyReconcileOutcome(plan, outcome(List.of("newok"), List.of("newbad"), List.of(), List.of()));
+    final var verdict = reconciler.applyReconcileOutcome(plan, outcome(List.of("newok"), List.of("newbad"), List.of(), List.of()));
 
     assertThat(reconciler.getAcquireStatus("newok").state()).isEqualTo(DatabaseReconciler.AcquireState.ACQUIRED);
     assertThat(reconciler.getAcquireStatus("newbad").state()).isEqualTo(DatabaseReconciler.AcquireState.FAILED);
     assertThat(reconciler.getAcquireStatus("orphan").state()).isEqualTo(DatabaseReconciler.AcquireState.LEADER_MISSING);
-    assertThat(retry).as("a fresh failure is still within the retry budget").isTrue();
+    assertThat(verdict.retryWorthwhile()).as("a fresh failure is still within the retry budget").isTrue();
+    assertThat(verdict.givenUp()).as("nothing has been given up yet").isEmpty();
   }
 
   @Test
@@ -196,15 +197,41 @@ class DatabaseReconcilerTest {
     final var failing = outcome(List.of(), List.of("bad"), List.of(), List.of());
 
     // Within the budget the failure keeps forcing a retry; once the threshold is hit it stops.
-    assertThat(reconciler.applyReconcileOutcome(plan, failing)).isTrue();  // 1
-    assertThat(reconciler.applyReconcileOutcome(plan, failing)).isTrue();  // 2
-    assertThat(reconciler.applyReconcileOutcome(plan, failing)).isFalse(); // 3 -> give up
+    assertThat(reconciler.applyReconcileOutcome(plan, failing).retryWorthwhile()).isTrue();  // 1
+    assertThat(reconciler.applyReconcileOutcome(plan, failing).retryWorthwhile()).isTrue();  // 2
+    final var giveUp = reconciler.applyReconcileOutcome(plan, failing);                      // 3 -> give up
+    assertThat(giveUp.retryWorthwhile()).isFalse();
     assertThat(reconciler.getAcquireStatus("bad").state()).isEqualTo(DatabaseReconciler.AcquireState.FAILED);
+
+    // Issue #6760: giving up on the RETRY must not be reported as "installed". The database has to come back in
+    // the verdict so the install does not record it at the snapshot index.
+    assertThat(giveUp.givenUp()).containsExactly("bad");
 
     // A later success resets the counter (and would let it retry again if it failed afresh).
     reconciler.applyReconcileOutcome(new DatabaseReconciler.ReconcilePlan(List.of("bad"), List.of(), List.of()),
         outcome(List.of("bad"), List.of(), List.of(), List.of()));
     assertThat(reconciler.getAcquireStatus("bad").state()).isEqualTo(DatabaseReconciler.AcquireState.ACQUIRED);
-    assertThat(reconciler.applyReconcileOutcome(plan, failing)).as("counter reset after success").isTrue();
+    final var afterReset = reconciler.applyReconcileOutcome(plan, failing);
+    assertThat(afterReset.retryWorthwhile()).as("counter reset after success").isTrue();
+    assertThat(afterReset.givenUp()).as("back inside the budget, so nothing is given up").isEmpty();
+  }
+
+  /**
+   * Issue #6760: only the databases that exhausted their budget are reported, and one healthy database failing
+   * afresh alongside them still forces the retry.
+   */
+  @Test
+  void onlyTheExhaustedDatabasesAreReportedAsGivenUp() {
+    final var reconciler = new DatabaseReconciler();
+    final var plan = new DatabaseReconciler.ReconcilePlan(List.of(), List.of("stubborn", "flaky"), List.of());
+
+    reconciler.applyReconcileOutcome(plan, outcome(List.of(), List.of(), List.of(), List.of("stubborn")));
+    reconciler.applyReconcileOutcome(plan, outcome(List.of(), List.of(), List.of(), List.of("stubborn")));
+
+    final var verdict = reconciler.applyReconcileOutcome(plan,
+        outcome(List.of(), List.of(), List.of(), List.of("stubborn", "flaky")));
+
+    assertThat(verdict.givenUp()).containsExactly("stubborn");
+    assertThat(verdict.retryWorthwhile()).as("'flaky' is on its first failure, so the install must still retry").isTrue();
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202SnapshotInstallGuardTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202SnapshotInstallGuardTest.java
@@ -40,6 +40,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -270,14 +271,17 @@ class Issue6202SnapshotInstallGuardTest {
 
   /** Records the endpoints the install hands it, and does nothing else: no network, no databases. */
   private static class CapturingReconciler extends DatabaseReconciler {
-    private volatile String httpAddr;
-    private volatile String httpsAddr;
+    private volatile String      httpAddr;
+    private volatile String      httpsAddr;
+    /** What the reconcile reports as not brought to the snapshot index (issue #6760); nothing, by default. */
+    private volatile Set<String> givenUp = Set.of();
 
     @Override
-    void reconcileDatabasesFromLeader(final String leaderHttpAddr, final String leaderHttpsAddr,
+    Set<String> reconcileDatabasesFromLeader(final String leaderHttpAddr, final String leaderHttpsAddr,
         final String clusterToken) {
       this.httpAddr = leaderHttpAddr;
       this.httpsAddr = leaderHttpsAddr;
+      return givenUp;
     }
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6760PartialSnapshotInstallTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6760PartialSnapshotInstallTest.java
@@ -197,6 +197,46 @@ class Issue6760PartialSnapshotInstallTest {
     }
   }
 
+  /**
+   * The per-database floor must be published BEFORE any waiter is woken (PR #6783 review).
+   * <p>
+   * {@code notifyApplied()} holds {@code applyNotifier} only long enough to {@code notifyAll()}, so a waiter can
+   * reacquire it and re-check {@code getTrustedAppliedIndex(db)} at once. Notifying before the re-arm leaves a
+   * window where the global floor is already cleared and the per-database one is not yet published, so the waiter
+   * sees the raw Ratis index - which already equals snapshotIndex - and the stale read #6760 exists to prevent
+   * happens anyway, just in a narrower window.
+   * <p>
+   * Driven by observing the state at the instant of the notify rather than by racing threads, so it is
+   * deterministic: a regression flips the captured floor to -1 every time.
+   */
+  @Test
+  void theDatabaseFloorIsPublishedBeforeAnyWaiterIsWoken(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir, Set.of(STALE_DB, HEALTHY_DB));
+    replaceReconciler(sm, new StubReconciler(Set.of(STALE_DB)));
+
+    final AtomicLong floorSeenByAWokenWaiter = new AtomicLong(Long.MIN_VALUE);
+    final RaftHAServer raft = followerRaft();
+    // Stands in for the woken waiter: notifyApplied() is the moment it can re-check, so whatever the floor reads
+    // here is exactly what that waiter would have based its decision on.
+    org.mockito.Mockito.doAnswer(inv -> {
+      floorSeenByAWokenWaiter.set(sm.getDatabaseAppliedFloor(STALE_DB));
+      return null;
+    }).when(raft).notifyApplied();
+    sm.setRaftHAServer(raft);
+
+    try {
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, STALE_DB);
+
+      sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(), TermIndex.valueOf(9L, FIRST_LOG_INDEX)).get();
+
+      assertThat(floorSeenByAWokenWaiter.get())
+          .as("a waiter woken by this install must already see the floor that keeps it off the stale copy")
+          .isEqualTo(PERSISTED_APPLIED);
+    } finally {
+      sm.close();
+    }
+  }
+
   // -----------------------------------------------------------------------------------------------
   // The read gate
   // -----------------------------------------------------------------------------------------------

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6760PartialSnapshotInstallTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6760PartialSnapshotInstallTest.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.DivisionInfo;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for issue #6760: a leader-driven snapshot install that GIVES UP on a database must not record
+ * that database as installed.
+ * <p>
+ * The reconciler stops failing the whole install for a database that has failed {@code ACQUIRE_GIVE_UP_AFTER}
+ * times in a row, so Ratis is not made to re-download every healthy database on the node in a tight loop. That is
+ * the right call for the retry - but the install then went on to write {@code snapshotIndex} as applied for EVERY
+ * database, clear the read floor and the diverged marks, and return the installed {@code TermIndex} to Ratis,
+ * which purges the log. The node re-entered the ready set advertising itself fully caught up while one database
+ * was still on its old copy, and a LINEARIZABLE (or read-your-writes) read of that database passed the apply wait
+ * instantly and was served from stale state.
+ * <p>
+ * What must hold instead: the given-up database keeps its diverged mark and gets a read floor of its own, its
+ * persisted applied position is left where it really is, and the healthy co-located databases are untouched -
+ * they still serve unclamped reads, which is the whole reason the give-up threshold exists.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6760PartialSnapshotInstallTest {
+  private static final String LEADER_PEER_ID    = "peer-b_2434";
+  private static final String LOCAL_HTTP        = "localhost:2480";
+  private static final long   FIRST_LOG_INDEX   = 5_000L;
+  private static final long   SNAPSHOT_INDEX    = FIRST_LOG_INDEX - 1;
+  private static final long   PERSISTED_APPLIED = 100L;
+  private static final String STALE_DB          = "db-stale";
+  private static final String HEALTHY_DB        = "db-ok";
+
+  // -----------------------------------------------------------------------------------------------
+  // The install itself
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * The core regression. The install completes - it must, or the give-up threshold buys nothing - but the
+   * database it gave up on is left visibly behind instead of being laundered into "applied".
+   */
+  @Test
+  void aGivenUpDatabaseIsNotRecordedAsInstalled(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir, Set.of(STALE_DB, HEALTHY_DB));
+    replaceReconciler(sm, new StubReconciler(Set.of(STALE_DB)));
+    sm.setRaftHAServer(followerRaft());
+    try {
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, STALE_DB);
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, HEALTHY_DB);
+
+      final TermIndex installed = sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(),
+          TermIndex.valueOf(9L, FIRST_LOG_INDEX)).get();
+
+      assertThat(installed.getIndex())
+          .as("Ratis is still told what it needs, so it stops re-driving the install")
+          .isEqualTo(SNAPSHOT_INDEX);
+
+      assertThat(sm.readPersistedAppliedIndex(HEALTHY_DB))
+          .as("the database that WAS refreshed really is at the snapshot index")
+          .isEqualTo(SNAPSHOT_INDEX);
+      assertThat(sm.readPersistedAppliedIndex(STALE_DB))
+          .as("the one that was not stays at the position it genuinely reached")
+          .isEqualTo(PERSISTED_APPLIED);
+
+      assertThat(sm.getDatabaseAppliedFloor(STALE_DB))
+          .as("and publishes a read floor there, so reads of it cannot be served from the stale copy")
+          .isEqualTo(PERSISTED_APPLIED);
+      assertThat(sm.getDatabaseAppliedFloor(HEALTHY_DB))
+          .as("the healthy database is clamped by nothing")
+          .isEqualTo(-1L);
+
+      assertThat(sm.isDatabaseDiverged(STALE_DB))
+          .as("it is still diverged: the install did not restore it")
+          .isTrue();
+      assertThat(sm.isDatabaseDiverged(HEALTHY_DB)).isFalse();
+      assertThat(sm.isResyncInProgress())
+          .as("so the node must not advertise itself ready")
+          .isTrue();
+    } finally {
+      sm.close();
+    }
+  }
+
+  /**
+   * Control: an install that gave up on nothing behaves exactly as before - every database at the snapshot index,
+   * no floors, nothing diverged, node ready.
+   */
+  @Test
+  void aCleanInstallIsUnchanged(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir, Set.of(STALE_DB, HEALTHY_DB));
+    replaceReconciler(sm, new StubReconciler(Set.of()));
+    sm.setRaftHAServer(followerRaft());
+    try {
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, STALE_DB);
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, HEALTHY_DB);
+
+      sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(), TermIndex.valueOf(9L, FIRST_LOG_INDEX)).get();
+
+      assertThat(sm.readPersistedAppliedIndex(STALE_DB)).isEqualTo(SNAPSHOT_INDEX);
+      assertThat(sm.readPersistedAppliedIndex(HEALTHY_DB)).isEqualTo(SNAPSHOT_INDEX);
+      assertThat(sm.getDatabaseAppliedFloor(STALE_DB)).isEqualTo(-1L);
+      assertThat(sm.isResyncInProgress()).isFalse();
+    } finally {
+      sm.close();
+    }
+  }
+
+  /** A later install that does refresh the database resolves everything the partial one left behind. */
+  @Test
+  void aLaterSuccessfulInstallClearsTheFloor(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir, Set.of(STALE_DB, HEALTHY_DB));
+    final StubReconciler reconciler = new StubReconciler(Set.of(STALE_DB));
+    replaceReconciler(sm, reconciler);
+    sm.setRaftHAServer(followerRaft());
+    try {
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, STALE_DB);
+      sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(), TermIndex.valueOf(9L, FIRST_LOG_INDEX)).get();
+      assertThat(sm.getDatabaseAppliedFloor(STALE_DB)).isEqualTo(PERSISTED_APPLIED);
+
+      // The leader's copy was fixed: this pass gives up on nothing.
+      reconciler.givenUp = Set.of();
+      sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(), TermIndex.valueOf(9L, FIRST_LOG_INDEX + 1)).get();
+
+      assertThat(sm.getDatabaseAppliedFloor(STALE_DB)).isEqualTo(-1L);
+      assertThat(sm.isDatabaseDiverged(STALE_DB)).isFalse();
+      assertThat(sm.isResyncInProgress()).isFalse();
+    } finally {
+      sm.close();
+    }
+  }
+
+  /**
+   * The floor is a per-database read floor, so the HealthMonitor backstop has to treat it as an unfilled gap:
+   * nothing else re-arms a resync for a database the install stopped retrying.
+   */
+  @Test
+  void aPerDatabaseFloorKeepsTheResyncBackstopArmed(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir, Set.of(STALE_DB));
+    replaceReconciler(sm, new StubReconciler(Set.of(STALE_DB)));
+    sm.setRaftHAServer(followerRaft());
+    try {
+      sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(), TermIndex.valueOf(9L, FIRST_LOG_INDEX)).get();
+      assertThat(sm.getStaleSnapshotAppliedFloor()).as("the GLOBAL floor is resolved, only the database is not")
+          .isEqualTo(-1L);
+
+      sm.retryUnfilledSnapshotGap();
+
+      assertThat(readLastRetryMs(sm))
+          .as("the backstop must submit a resync for the database still short of the snapshot index")
+          .isNotZero();
+    } finally {
+      sm.close();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // The read gate
+  // -----------------------------------------------------------------------------------------------
+
+  /** The observable half: a LINEARIZABLE read of the stale database fails, while the healthy one is served. */
+  @Test
+  void theReadGateClampsOnlyTheStaleDatabase() throws Exception {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    publishDatabaseFloor(sm, STALE_DB, PERSISTED_APPLIED);
+    final RaftHAServer raft = newDetachedRaftHAServer(new AtomicLong(SNAPSHOT_INDEX), SNAPSHOT_INDEX, sm, 500L);
+
+    assertThat(raft.getLastAppliedIndex())
+        .as("Ratis still advertises the snapshot index for the whole node")
+        .isEqualTo(SNAPSHOT_INDEX);
+    assertThat(raft.getTrustedAppliedIndex(STALE_DB))
+        .as("but only the floor is backed by local data for this database")
+        .isEqualTo(PERSISTED_APPLIED);
+    assertThat(raft.getTrustedAppliedIndex(HEALTHY_DB))
+        .as("and the co-located healthy database is not clamped at all")
+        .isEqualTo(SNAPSHOT_INDEX);
+
+    assertThatThrownBy(() -> raft.waitForAppliedIndex(STALE_DB, PERSISTED_APPLIED + 1, true))
+        .isInstanceOf(ReplicationException.class)
+        .hasMessageContaining("LINEARIZABLE read timed out");
+
+    assertThatNoException()
+        .as("the whole point of the per-database floor: one bad database does not stop the others")
+        .isThrownBy(() -> raft.waitForAppliedIndex(HEALTHY_DB, SNAPSHOT_INDEX, true));
+  }
+
+  /** A target at or below the database's own floor is genuinely on disk and must still be served. */
+  @Test
+  void aReadBelowTheDatabaseFloorStillSucceeds() throws Exception {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    publishDatabaseFloor(sm, STALE_DB, PERSISTED_APPLIED);
+    final RaftHAServer raft = newDetachedRaftHAServer(new AtomicLong(SNAPSHOT_INDEX), SNAPSHOT_INDEX, sm, 500L);
+
+    assertThatNoException().isThrownBy(() -> raft.waitForAppliedIndex(STALE_DB, PERSISTED_APPLIED, true));
+  }
+
+  /**
+   * The lenient (READ_YOUR_WRITES / bookmark) waiter keeps its degrade-do-not-fail contract, and must not burn
+   * the whole quorum timeout on a gap only a resync can close - the same treatment the global floor gets.
+   */
+  @Test
+  void readYourWritesDegradesImmediatelyOnAPerDatabaseFloor() throws Exception {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    publishDatabaseFloor(sm, STALE_DB, PERSISTED_APPLIED);
+    final RaftHAServer raft = newDetachedRaftHAServer(new AtomicLong(SNAPSHOT_INDEX), SNAPSHOT_INDEX, sm, 10_000L);
+
+    assertThat(raft.getTrustedAppliedIndex(STALE_DB))
+        .as("the clamp must be in force, otherwise the waiter never enters the loop and proves nothing")
+        .isEqualTo(PERSISTED_APPLIED);
+
+    final long start = System.currentTimeMillis();
+    assertThatNoException().isThrownBy(() -> raft.waitForAppliedIndex(STALE_DB, SNAPSHOT_INDEX, false));
+    assertThat(System.currentTimeMillis() - start)
+        .as("waiting cannot help while the floor stands, so the lenient waiter degrades at once")
+        .isLessThan(2_000L);
+  }
+
+  /** With no floor anywhere the trusted index is the raw Ratis one, named database or not. */
+  @Test
+  void withoutAnyFloorTheTrustedIndexIsTheRatisIndex() throws Exception {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final RaftHAServer raft = newDetachedRaftHAServer(new AtomicLong(SNAPSHOT_INDEX), SNAPSHOT_INDEX, sm, 500L);
+
+    assertThat(raft.getTrustedAppliedIndex()).isEqualTo(SNAPSHOT_INDEX);
+    assertThat(raft.getTrustedAppliedIndex(STALE_DB)).isEqualTo(SNAPSHOT_INDEX);
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------------------------------
+
+  /** A reconciler that touches nothing and reports exactly the databases the test wants given up on. */
+  private static class StubReconciler extends DatabaseReconciler {
+    private volatile Set<String> givenUp;
+
+    private StubReconciler(final Set<String> givenUp) {
+      this.givenUp = givenUp;
+    }
+
+    @Override
+    Set<String> reconcileDatabasesFromLeader(final String leaderHttpAddr, final String leaderHttpsAddr,
+        final String clusterToken) {
+      return givenUp;
+    }
+  }
+
+  private static RaftHAServer followerRaft() {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.isLeader()).thenReturn(false);
+    when(raft.getLeaderId()).thenReturn(RaftPeerId.valueOf(LEADER_PEER_ID));
+    when(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf(LEADER_PEER_ID))).thenReturn("peer-b:2480");
+    when(raft.getLocalHttpAddress()).thenReturn(LOCAL_HTTP);
+    return raft;
+  }
+
+  private static RaftProtos.RoleInfoProto leaderRoleInfo() {
+    return RaftProtos.RoleInfoProto.newBuilder()
+        .setFollowerInfo(RaftProtos.FollowerInfoProto.newBuilder()
+            .setLeaderInfo(RaftProtos.ServerRpcProto.newBuilder()
+                .setId(RaftProtos.RaftPeerProto.newBuilder()
+                    .setId(ByteString.copyFromUtf8(LEADER_PEER_ID)))))
+        .build();
+  }
+
+  /**
+   * A state machine with real Ratis storage (the install registers a snapshot marker through it) and a server
+   * that reports {@code databaseNames} as present, which is what the applied-index bookkeeping iterates.
+   */
+  private static ArcadeStateMachine newStateMachine(final Path tempDir, final Set<String> databaseNames)
+      throws IOException {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, tempDir.resolve("databases").toString());
+    config.setValue(GlobalConfiguration.HA_AUTO_ACQUIRE_DATABASES, false);
+    config.setValue(GlobalConfiguration.HA_SNAPSHOT_INSTALL_RETRIES, 0);
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(config);
+    when(server.getDatabaseNames()).thenReturn(databaseNames);
+
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(server);
+    sm.initialize(stubRaftServer(), RaftGroupId.valueOf(UUID.randomUUID()),
+        newFormattedStorage(tempDir.resolve("raft")));
+    return sm;
+  }
+
+  private static RaftStorage newFormattedStorage(final Path dir) throws IOException {
+    return RaftStorage.newBuilder()
+        .setDirectory(dir.toFile())
+        .setOption(RaftStorage.StartupOption.FORMAT)
+        .build();
+  }
+
+  private static RaftServer stubRaftServer() {
+    return (RaftServer) Proxy.newProxyInstance(
+        Issue6760PartialSnapshotInstallTest.class.getClassLoader(),
+        new Class<?>[] { RaftServer.class },
+        (proxy, method, args) -> {
+          if ("getId".equals(method.getName()))
+            return RaftPeerId.valueOf("test-peer");
+          if ("close".equals(method.getName()) || "start".equals(method.getName()))
+            return null;
+          throw new UnsupportedOperationException("Stub: " + method.getName());
+        });
+  }
+
+  private static RaftHAServer newDetachedRaftHAServer(final AtomicLong appliedIndex, final long commitIndex,
+      final ArcadeStateMachine sm, final long quorumTimeoutMs) throws Exception {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "localhost:2434:2480");
+    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, quorumTimeoutMs);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getServerName()).thenReturn("localhost");
+
+    final RaftHAServer raft = new RaftHAServer(mockServer, config);
+
+    final DivisionInfo mockInfo = mock(DivisionInfo.class);
+    when(mockInfo.getLastAppliedIndex()).thenAnswer(inv -> appliedIndex.get());
+
+    final RaftLog mockRaftLog = mock(RaftLog.class);
+    when(mockRaftLog.getLastCommittedIndex()).thenReturn(commitIndex);
+
+    final RaftServer.Division mockDivision = mock(RaftServer.Division.class);
+    when(mockDivision.getInfo()).thenReturn(mockInfo);
+    when(mockDivision.getRaftLog()).thenReturn(mockRaftLog);
+
+    final RaftServer mockRaftServer = mock(RaftServer.class);
+    when(mockRaftServer.getDivision(any())).thenReturn(mockDivision);
+
+    setField(RaftHAServer.class, raft, "raftServer", mockRaftServer);
+    setField(RaftHAServer.class, raft, "stateMachine", sm);
+    return raft;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void publishDatabaseFloor(final ArcadeStateMachine sm, final String dbName, final long floor)
+      throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("staleDatabaseAppliedFloors");
+    f.setAccessible(true);
+    ((java.util.Map<String, Long>) f.get(sm)).put(dbName, floor);
+  }
+
+  private static long readLastRetryMs(final ArcadeStateMachine sm) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("lastStaleSnapshotRetryMs");
+    f.setAccessible(true);
+    return ((AtomicLong) f.get(sm)).get();
+  }
+
+  private static void replaceReconciler(final ArcadeStateMachine sm, final DatabaseReconciler reconciler)
+      throws Exception {
+    setField(ArcadeStateMachine.class, sm, "reconciler", reconciler);
+  }
+
+  private static void setField(final Class<?> owner, final Object target, final String name, final Object value)
+      throws Exception {
+    final Field f = owner.getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(target, value);
+  }
+}

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/ExecuteCommandTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/ExecuteCommandTool.java
@@ -40,6 +40,8 @@ import java.util.Set;
 public class ExecuteCommandTool {
 
   private static final int DEFAULT_LIMIT = 1000;
+  /** Same reason as {@link QueryTool}: the result rows are accumulated in memory before the reply (issue #6762). */
+  private static final int MAX_LIMIT     = 100_000;
 
   public static JSONObject getDefinition() {
     return new JSONObject()
@@ -63,7 +65,11 @@ public class ExecuteCommandTool {
                     .put("description", "The command to execute"))
                 .put("limit", new JSONObject()
                     .put("type", "integer")
-                    .put("description", "Maximum number of results to return (default: 1000)")))
+                    .put("description",
+                        "Maximum number of results to return (default: " + DEFAULT_LIMIT + ", maximum: " + MAX_LIMIT
+                            + ")")
+                    .put("minimum", 1)
+                    .put("maximum", MAX_LIMIT)))
             .put("required", new JSONArray().put("database").put("command")));
   }
 
@@ -73,6 +79,8 @@ public class ExecuteCommandTool {
     final String language = args.getString("language", "cypher");
     final String command = args.getString("command");
     final int limit = args.getInt("limit", DEFAULT_LIMIT);
+    if (limit < 1 || limit > MAX_LIMIT)
+      throw new IllegalArgumentException("'limit' must be between 1 and " + MAX_LIMIT);
 
     final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
         server, user, databaseName, config, MCPToolUtils.RequiredAccess.ACCESS);

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/ProfilerStartTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/ProfilerStartTool.java
@@ -27,6 +27,9 @@ import com.arcadedb.server.security.ServerSecurityUser;
 
 public class ProfilerStartTool {
 
+  private static final int DEFAULT_TIMEOUT_SECONDS = 60;
+  private static final int MAX_TIMEOUT_SECONDS     = 3600;
+
   public static JSONObject getDefinition() {
     return new JSONObject()
         .put("name", "profiler_start")
@@ -41,9 +44,11 @@ public class ProfilerStartTool {
             .put("properties", new JSONObject()
                 .put("timeoutSeconds", new JSONObject()
                     .put("type", "integer")
-                    .put("description", "Recording timeout in seconds. The profiler auto-stops after this duration. Default: 60.")
+                    .put("description",
+                        "Recording timeout in seconds. The profiler auto-stops after this duration. Default: "
+                            + DEFAULT_TIMEOUT_SECONDS + ".")
                     .put("minimum", 1)
-                    .put("maximum", 3600)))
+                    .put("maximum", MAX_TIMEOUT_SECONDS)))
             .put("required", new JSONArray()));
   }
 
@@ -58,7 +63,11 @@ public class ProfilerStartTool {
     MCPToolUtils.checkServerAdmin(user, "profiler_start");
 
     final ServerQueryProfiler profiler = server.getQueryProfiler();
-    final int timeout = args.getInt("timeoutSeconds", 60);
+    final int timeout = args.getInt("timeoutSeconds", DEFAULT_TIMEOUT_SECONDS);
+    // The declared schema range is advisory - the MCP client is the one that would enforce it - so re-check it
+    // here, as every sibling tool does with its own window (issue #6762).
+    if (timeout < 1 || timeout > MAX_TIMEOUT_SECONDS)
+      throw new IllegalArgumentException("'timeoutSeconds' must be between 1 and " + MAX_TIMEOUT_SECONDS);
 
     if (profiler.isRecording()) {
       final JSONObject result = new JSONObject();

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/QueryTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/QueryTool.java
@@ -37,6 +37,11 @@ import java.util.Collections;
 public class QueryTool {
 
   private static final int DEFAULT_LIMIT = 1000;
+  /**
+   * Upper bound on the requested window (issue #6762): every row is accumulated into an in-memory JSONArray before
+   * anything is returned, so an unbounded 'limit' turns one call into a whole-database materialization.
+   */
+  private static final int MAX_LIMIT     = 100_000;
 
   public static JSONObject getDefinition() {
     return new JSONObject()
@@ -60,7 +65,11 @@ public class QueryTool {
                     .put("description", "The query to execute"))
                 .put("limit", new JSONObject()
                     .put("type", "integer")
-                    .put("description", "Maximum number of results to return (default: 1000)")))
+                    .put("description",
+                        "Maximum number of results to return (default: " + DEFAULT_LIMIT + ", maximum: " + MAX_LIMIT
+                            + ")")
+                    .put("minimum", 1)
+                    .put("maximum", MAX_LIMIT)))
             .put("required", new JSONArray().put("database").put("query")));
   }
 
@@ -70,6 +79,8 @@ public class QueryTool {
     final String language = args.getString("language", "cypher");
     final String query = args.getString("query");
     final int limit = args.getInt("limit", DEFAULT_LIMIT);
+    if (limit < 1 || limit > MAX_LIMIT)
+      throw new IllegalArgumentException("'limit' must be between 1 and " + MAX_LIMIT);
 
     final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
         server, user, databaseName, config, MCPToolUtils.RequiredAccess.READ);

--- a/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6762ToolInputBoundsTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6762ToolInputBoundsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mcp.tools;
+
+import com.arcadedb.mcp.MCPConfiguration;
+import com.arcadedb.mcp.MCPPlugin;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6762: the declared JSON-Schema range is advisory - the MCP client is the one that would enforce it - so
+ * every tool has to re-check its own numeric inputs server-side, the way {@code SampleRecordsTool},
+ * {@code FullTextSearchTool} and {@code VectorSearchTool} already do. {@code profiler_start} declared a range and
+ * checked nothing, and {@code query} / {@code execute_command} accumulate every row into an in-memory JSONArray
+ * with no upper bound on 'limit' at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6762ToolInputBoundsTest extends BaseGraphServerTest {
+  private MCPConfiguration   config;
+  private ServerSecurityUser user;
+
+  @BeforeEach
+  void setupMCP() {
+    config = MCPPlugin.of(getServer(0)).getConfiguration();
+    config.setEnabled(true);
+    config.setAllowReads(true);
+    config.setAllowAdmin(true);
+    config.setAllowedUsers(List.of("root"));
+    final JSONObject clearOverrides = new JSONObject();
+    clearOverrides.put("databases", (Object) null);
+    config.updateFrom(clearOverrides);
+    user = getServer(0).getSecurity().authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
+  }
+
+  @Test
+  void profilerStartRejectsATimeoutOutsideItsDeclaredRange() {
+    assertThatThrownBy(() -> ProfilerStartTool.execute(getServer(0), user,
+        new JSONObject().put("timeoutSeconds", 0), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'timeoutSeconds' must be between 1 and 3600");
+
+    assertThatThrownBy(() -> ProfilerStartTool.execute(getServer(0), user,
+        new JSONObject().put("timeoutSeconds", -1), config))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() -> ProfilerStartTool.execute(getServer(0), user,
+        new JSONObject().put("timeoutSeconds", 86_400), config))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void queryRejectsALimitOutsideItsWindow() {
+    assertThatThrownBy(() -> QueryTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("query", "SELECT 1 AS value")
+        .put("limit", Integer.MAX_VALUE), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'limit' must be between 1 and");
+
+    assertThatThrownBy(() -> QueryTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("query", "SELECT 1 AS value")
+        .put("limit", 0), config))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void executeCommandRejectsALimitOutsideItsWindow() {
+    assertThatThrownBy(() -> ExecuteCommandTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("command", "SELECT 1 AS value")
+        .put("limit", Integer.MAX_VALUE), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'limit' must be between 1 and");
+  }
+
+  /** Control: a limit inside the window is untouched, so the bound costs a legitimate caller nothing. */
+  @Test
+  void aLimitInsideTheWindowStillWorks() {
+    final JSONObject result = QueryTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("query", "SELECT 1 AS value")
+        .put("limit", 10), config);
+
+    assertThat(result.getInt("count")).isEqualTo(1);
+  }
+
+  /** And the declared schema advertises the same window the server enforces, so a client can pre-validate. */
+  @Test
+  void theDeclaredSchemaMatchesTheEnforcedWindow() {
+    final JSONObject limit = QueryTool.getDefinition().getJSONObject("inputSchema")
+        .getJSONObject("properties").getJSONObject("limit");
+    assertThat(limit.getInt("minimum")).isEqualTo(1);
+    assertThat(limit.getInt("maximum")).isEqualTo(100_000);
+  }
+}

--- a/network/src/main/java/com/arcadedb/network/binary/Channel.java
+++ b/network/src/main/java/com/arcadedb/network/binary/Channel.java
@@ -18,7 +18,9 @@
  */
 package com.arcadedb.network.binary;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
+import jdk.net.ExtendedSocketOptions;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,12 +40,75 @@ public abstract class Channel {
   private final        AtomicLong   metricTransmittedBytes       = new AtomicLong();
   private final        AtomicLong   metricReceivedBytes          = new AtomicLong();
   private final        AtomicLong   metricFlushes                = new AtomicLong();
+  private static final boolean      EXTENDED_KEEP_ALIVE_AVAILABLE = extendedKeepAliveAvailable();
 
   public Channel(final Socket iSocket) throws IOException {
     socket = iSocket;
     socket.setTcpNoDelay(true);
+    enableKeepAlive(socket);
     // THIS TIMEOUT IS CORRECT BUT CREATE SOME PROBLEM ON REMOTE, NEED CHECK BEFORE BE ENABLED
     // timeout = iConfig.getValueAsLong(OGlobalConfiguration.NETWORK_REQUEST_TIMEOUT);
+  }
+
+  /**
+   * Turns on TCP keepalive, the only liveness backstop the wire protocols have.
+   * <p>
+   * {@code PostgresNetworkExecutor} and {@code RedisNetworkExecutor} both set {@code SO_TIMEOUT} to 0 once a
+   * connection is authenticated - correctly, because an authenticated client is entitled to hold an idle connection
+   * open - and neither protocol carries an application-level heartbeat. A peer that disappears without a FIN/RST
+   * (host crash, silent partition) therefore left the server thread parked in {@code read()} for the life of the
+   * JVM, leaking a thread and a file descriptor per event, with nothing able to notice. With keepalive on, the OS
+   * probes the dead peer and the read fails (issue #6761).
+   * <p>
+   * The probe timings are applied through {@code jdk.net.ExtendedSocketOptions}, which the JDK only supports where
+   * the platform does (Linux and macOS); anywhere else - and for any value left at 0 - the system-wide defaults
+   * stand, which still detect the dead peer, just far later. Failures are non-fatal: keepalive is a backstop, and a
+   * platform that refuses an option must not stop the connection from being served.
+   */
+  private static void enableKeepAlive(final Socket socket) {
+    if (!GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE.getValueAsBoolean())
+      return;
+
+    try {
+      socket.setKeepAlive(true);
+    } catch (final SocketException e) {
+      LogManager.instance().log(Channel.class, Level.FINE, "Cannot enable TCP keepalive on the socket", e);
+      return;
+    }
+
+    if (!EXTENDED_KEEP_ALIVE_AVAILABLE)
+      return; // keepalive is on, just with the system-wide probe timings
+
+    setKeepAliveOption(socket, ExtendedSocketOptions.TCP_KEEPIDLE,
+        GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_IDLE.getValueAsInteger());
+    setKeepAliveOption(socket, ExtendedSocketOptions.TCP_KEEPINTERVAL,
+        GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_INTERVAL.getValueAsInteger());
+    setKeepAliveOption(socket, ExtendedSocketOptions.TCP_KEEPCOUNT,
+        GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_COUNT.getValueAsInteger());
+  }
+
+  /**
+   * Whether {@code jdk.net.ExtendedSocketOptions} can be reached at all. Resolved once, and defensively: the class
+   * lives in the {@code jdk.net} module, which a trimmed jlink image or a native image need not carry. Without it
+   * keepalive still works, it just runs on the system-wide probe timings.
+   */
+  private static boolean extendedKeepAliveAvailable() {
+    try {
+      return ExtendedSocketOptions.TCP_KEEPIDLE != null;
+    } catch (final Throwable e) {
+      return false;
+    }
+  }
+
+  private static void setKeepAliveOption(final Socket socket, final SocketOption<Integer> option, final int value) {
+    if (value <= 0)
+      return; // leave the system-wide default in place
+    try {
+      if (socket.supportedOptions().contains(option))
+        socket.setOption(option, value);
+    } catch (final IOException | UnsupportedOperationException | IllegalArgumentException e) {
+      LogManager.instance().log(Channel.class, Level.FINE, "Cannot set the TCP keepalive option %s", e, option.name());
+    }
   }
 
   public static String getLocalIpAddress(final boolean iFavoriteIp4) throws SocketException {
@@ -82,14 +147,21 @@ public abstract class Channel {
       outStream.flush();
   }
 
+  /**
+   * Closes the output side first, then the input side, then the socket (issue #6761).
+   * <p>
+   * Order matters: closing a socket - or its input stream, which closes the socket with it - discards whatever is
+   * still sitting in the output buffer, so the {@code out.close()} that would have flushed it fails instead and the
+   * bytes are dropped with only a FINE log to show for it.
+   */
   public synchronized void close() {
     try {
-      if (socket != null) {
-        socket.close();
-        socket = null;
+      if (outStream != null) {
+        outStream.close();
+        outStream = null;
       }
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.FINE, "Error during socket close", e);
+      LogManager.instance().log(this, Level.FINE, "Error during closing of output stream", e);
     }
 
     try {
@@ -102,12 +174,12 @@ public abstract class Channel {
     }
 
     try {
-      if (outStream != null) {
-        outStream.close();
-        outStream = null;
+      if (socket != null) {
+        socket.close();
+        socket = null;
       }
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.FINE, "Error during closing of output stream", e);
+      LogManager.instance().log(this, Level.FINE, "Error during socket close", e);
     }
   }
 

--- a/network/src/main/java/com/arcadedb/network/binary/ChannelBinary.java
+++ b/network/src/main/java/com/arcadedb/network/binary/ChannelBinary.java
@@ -275,22 +275,27 @@ public abstract class ChannelBinary extends Channel implements ChannelDataInput,
       super.flush();
   }
 
+  /**
+   * Closes the output side before the input side (issue #6761): {@code in.close()} closes the underlying socket, so
+   * closing it first turned the {@code out.close()} that should have flushed the last buffered bytes into a failed
+   * write, silently dropping them with a FINE log.
+   */
   @Override
   public synchronized void close() {
-    try {
-      if (in != null) {
-        in.close();
-      }
-    } catch (final IOException e) {
-      LogManager.instance().log(this, Level.FINE, "Error during closing of input stream", e);
-    }
-
     try {
       if (out != null) {
         out.close();
       }
     } catch (final IOException e) {
       LogManager.instance().log(this, Level.FINE, "Error during closing of output stream", e);
+    }
+
+    try {
+      if (in != null) {
+        in.close();
+      }
+    } catch (final IOException e) {
+      LogManager.instance().log(this, Level.FINE, "Error during closing of input stream", e);
     }
 
     super.close();

--- a/network/src/main/java/com/arcadedb/network/binary/ChannelBinaryClient.java
+++ b/network/src/main/java/com/arcadedb/network/binary/ChannelBinaryClient.java
@@ -61,9 +61,18 @@ public class ChannelBinaryClient extends ChannelBinary {
         throw new NetworkProtocolException("Error on reading data from remote server " + socket.getRemoteSocketAddress() + ": ", e);
       }
 
-    } catch (final RuntimeException e) {
-      if (socket.isConnected())
+    } catch (final Throwable e) {
+      // Every failure path above throws a CHECKED exception (IOException / SocketException / the wrapping
+      // NetworkProtocolException), so a catch limited to RuntimeException never ran at all, and the
+      // isConnected() guard inside it was wrong anyway: a connect that failed leaves the socket unconnected.
+      // On JDK 21 the descriptor is not actually leaked - NioSocketImpl releases it itself when connect()
+      // fails - so this closes a dead code path rather than a live leak, and keeps the cleanup honest for any
+      // socket implementation (SSL, a future JDK) that does hold on to it (issue #6761).
+      try {
         socket.close();
+      } catch (final IOException ignore) {
+        // closing a socket that never connected is best-effort; the original failure is what the caller needs
+      }
       throw e;
     }
   }

--- a/network/src/test/java/com/arcadedb/network/binary/ChannelSocketOptionsTest.java
+++ b/network/src/test/java/com/arcadedb/network/binary/ChannelSocketOptionsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.network.binary;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6761: the socket options and the close order the wire protocols depend on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ChannelSocketOptionsTest {
+
+  /**
+   * The Postgres and Redis executors set SO_TIMEOUT to 0 after authentication, so keepalive is the only thing that
+   * can ever unblock a read from a peer that died without a FIN/RST.
+   */
+  @Test
+  void keepAliveIsEnabledOnEveryChannel() throws Exception {
+    try (final ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+        final Socket client = new Socket(InetAddress.getLoopbackAddress(), server.getLocalPort());
+        final Socket accepted = server.accept()) {
+
+      final ChannelBinaryServer channel = new ChannelBinaryServer(accepted, new ContextConfiguration());
+      try {
+        assertThat(accepted.getKeepAlive()).isTrue();
+      } finally {
+        channel.close();
+      }
+      assertThat(client.isConnected()).isTrue();
+    }
+  }
+
+  /** The switch has to actually switch it off, otherwise it is not a knob. */
+  @Test
+  void keepAliveCanBeDisabled() throws Exception {
+    GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE.setValue(false);
+    try (final ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+        final Socket client = new Socket(InetAddress.getLoopbackAddress(), server.getLocalPort());
+        final Socket accepted = server.accept()) {
+
+      final ChannelBinaryServer channel = new ChannelBinaryServer(accepted, new ContextConfiguration());
+      try {
+        assertThat(accepted.getKeepAlive()).isFalse();
+      } finally {
+        channel.close();
+      }
+      assertThat(client.isConnected()).isTrue();
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE.reset();
+    }
+  }
+
+  /**
+   * close() used to shut the input stream - and with it the socket - before the output stream, so the buffered bytes
+   * the out.close() should have flushed were dropped instead.
+   */
+  @Test
+  void closeFlushesTheBufferedOutputInsteadOfDroppingIt() throws Exception {
+    try (final ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+        final Socket client = new Socket(InetAddress.getLoopbackAddress(), server.getLocalPort());
+        final Socket accepted = server.accept()) {
+
+      final ChannelBinaryServer channel = new ChannelBinaryServer(accepted, new ContextConfiguration());
+      // written into the BufferedOutputStream and deliberately NOT flushed: only close() can get it onto the wire
+      channel.writeUnsignedInt(0xCAFEBABE);
+      channel.close();
+
+      final DataInputStream in = new DataInputStream(client.getInputStream());
+      assertThat(in.readInt()).isEqualTo(0xCAFEBABE);
+    }
+  }
+
+}

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -1298,7 +1298,7 @@ public class RedisNetworkExecutor extends Thread {
         final String k = key.toString();
         final Object[] compositeKey;
         if (k.startsWith("[")) {
-          compositeKey = new JSONArray((String[]) key).toList().toArray();
+          compositeKey = new JSONArray(k).toList().toArray();
         } else if (k.startsWith("\"")) {
           compositeKey = new String[]{k.substring(1, k.length() - 1)};
         } else

--- a/redisw/src/test/java/com/arcadedb/redis/RedisWTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisWTest.java
@@ -529,6 +529,46 @@ public class RedisWTest extends BaseGraphServerTest {
     assertThat(results.get(3)).isNull();
   }
 
+  /**
+   * Issue #6762 sibling (#6757): HMGET on a persistent composite index used to cast the key Object to String[]
+   * before handing it to JSONArray, so a bracketed composite key threw a ClassCastException while the very same
+   * key worked through the single-key HGET path. Both are asserted here so the two can never drift again.
+   */
+  @Test
+  void hmgetWithBracketedCompositeIndexKey() {
+    final Jedis jedis = new Jedis("localhost", DEF_PORT);
+    jedis.auth("root", DEFAULT_PASSWORD_FOR_TESTS);
+
+    final Database database = getServerDatabase(0, getDatabaseName());
+    database.command("sqlscript", "CREATE DOCUMENT TYPE Person;" +//
+        "CREATE PROPERTY Person.firstName STRING;" +//
+        "CREATE PROPERTY Person.lastName STRING;" +//
+        "CREATE INDEX ON Person (firstName, lastName) UNIQUE;");
+
+    jedis.hset(getDatabaseName(), "Person", "{'firstName':'Jay','lastName':'Miner'}");
+    jedis.hset(getDatabaseName(), "Person", "{'firstName':'Bill','lastName':'Herd'}");
+
+    final String indexKey = getDatabaseName() + ".Person[firstName,lastName]";
+
+    // HGET has always worked: it is the reference behaviour HMGET has to match.
+    final JSONObject viaHGet = new JSONObject(jedis.hget(indexKey, "[\"Jay\",\"Miner\"]"));
+    assertThat(viaHGet.getString("firstName")).isEqualTo("Jay");
+    assertThat(viaHGet.getString("lastName")).isEqualTo("Miner");
+
+    final List<String> results = jedis.hmget(indexKey, "[\"Jay\",\"Miner\"]", "[\"Bill\",\"Herd\"]", "[\"No\",\"Body\"]");
+    assertThat(results).hasSize(3);
+
+    final JSONObject jay = new JSONObject(results.get(0));
+    assertThat(jay.getString("firstName")).isEqualTo("Jay");
+    assertThat(jay.getString("lastName")).isEqualTo("Miner");
+
+    final JSONObject bill = new JSONObject(results.get(1));
+    assertThat(bill.getString("firstName")).isEqualTo("Bill");
+    assertThat(bill.getString("lastName")).isEqualTo("Herd");
+
+    assertThat(results.get(2)).isNull();
+  }
+
   @Override
   protected void populateDatabase() {
   }

--- a/server/src/main/java/com/arcadedb/server/http/ws/DatabaseEventWatcherThread.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/DatabaseEventWatcherThread.java
@@ -65,18 +65,31 @@ final public class DatabaseEventWatcherThread extends Thread {
   }
 
   /**
+   * Stops accepting events, without waiting for the thread to terminate.
+   * <p>
+   * Split out of {@link #shutdown()} so the event bus can flip this watcher off while it still holds the
+   * per-database lock (issue #6762). It used to flip it off only outside the lock, so a re-subscribe landing in that
+   * gap started a SECOND watcher while this one was still running with its listeners attached, and a commit in the
+   * window was enqueued on both and published twice to the same subscriber.
+   */
+  public void signalStop() {
+    this.running = false;
+  }
+
+  /**
    * Sends the shutdown signal to the thread and waits for termination.
    * <p>
    * When invoked from the watcher thread itself (e.g. {@code publish()} cleans up the last subscriber as a zombie and
    * ends up stopping its own watcher), the wait is skipped: the {@code run()} loop unwinds and unregisters the database
    * listeners on its own as soon as it observes {@code running == false}. Awaiting here would park the thread on a latch
    * that only its own {@code run()} finally-block can count down, deadlocking it forever.
+   * <p>
+   * Deliberately no "already stopped, nothing to do" shortcut: {@link #signalStop()} may have run first, and returning
+   * on that would skip the join this method exists for. Once {@code run()} has finished the latch is already down, so
+   * a repeated call still returns immediately.
    */
   public void shutdown() {
-    if (!running)
-      return;
-
-    this.running = false;
+    signalStop();
 
     if (Thread.currentThread() == this)
       return;
@@ -84,7 +97,7 @@ final public class DatabaseEventWatcherThread extends Thread {
     try {
       runningLock.await();
     } catch (final InterruptedException e) {
-      // IGNORE IT
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/ws/EventWatcherSubscription.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/EventWatcherSubscription.java
@@ -84,9 +84,16 @@ public class EventWatcherSubscription {
     return false;
   }
 
-  /** Releases a reservation made by {@link #reservePending(int, long)} once Undertow reports the frame done. */
+  /**
+   * Releases a reservation made by {@link #reservePending(int, long)} once Undertow reports the frame done.
+   * <p>
+   * Floored at zero: a client that unsubscribes and re-subscribes while a frame is still in flight has its
+   * completion callback land on the REPLACEMENT subscription, which never reserved anything. Letting that drive
+   * the counter negative would give the replacement a negative baseline and silently let it hold several times
+   * the configured budget before {@link #reservePending(int, long)} noticed.
+   */
   public void releasePending(final int bytes) {
-    pendingBytes.addAndGet(-bytes);
+    pendingBytes.updateAndGet(pending -> Math.max(0L, pending - bytes));
   }
 
   // @VisibleForTesting

--- a/server/src/main/java/com/arcadedb/server/http/ws/EventWatcherSubscription.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/EventWatcherSubscription.java
@@ -24,12 +24,20 @@ import io.undertow.websockets.core.WebSocketChannel;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public class EventWatcherSubscription {
   private final String                             database;
   private final WebSocketChannel                   channel;
   private final Map<String, Set<ChangeEvent.TYPE>> typeSubscriptions = new ConcurrentHashMap<>();
+  /**
+   * Bytes handed to Undertow for this channel that it has not reported as sent yet (issue #6762). Change events are
+   * fanned out fire-and-forget, so without this a subscriber that never reads accumulates frames in the server's
+   * send buffer indefinitely: the producer-side queue is bounded, but a slow consumer is charged to the server's
+   * heap rather than to its own.
+   */
+  private final AtomicLong                         pendingBytes      = new AtomicLong();
 
   private final static Set<ChangeEvent.TYPE> allTypes = Arrays.stream(ChangeEvent.TYPE.values()).collect(Collectors.toSet());
 
@@ -58,6 +66,36 @@ public class EventWatcherSubscription {
 
   public WebSocketChannel getChannel() {
     return channel;
+  }
+
+  /**
+   * Charges {@code bytes} to this subscriber's outstanding-send budget.
+   *
+   * @param maxPendingBytes the budget, or {@code 0} (or less) to disable the cap
+   *
+   * @return {@code false} when the send would push the subscriber past its budget, in which case nothing is charged
+   *         and the caller must evict it instead of sending
+   */
+  public boolean reservePending(final int bytes, final long maxPendingBytes) {
+    final long pending = pendingBytes.addAndGet(bytes);
+    if (maxPendingBytes <= 0 || pending <= maxPendingBytes)
+      return true;
+    pendingBytes.addAndGet(-bytes);
+    return false;
+  }
+
+  /** Releases a reservation made by {@link #reservePending(int, long)} once Undertow reports the frame done. */
+  public void releasePending(final int bytes) {
+    pendingBytes.addAndGet(-bytes);
+  }
+
+  // @VisibleForTesting
+  public long getPendingBytes() {
+    return pendingBytes.get();
+  }
+
+  public String getDatabase() {
+    return database;
   }
 
   public boolean isMatch(final ChangeEvent event) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
@@ -21,6 +21,8 @@ package com.arcadedb.server.http.ws;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.security.ServerSecurity;
+import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.WebSocketCallback;
 import io.undertow.websockets.core.WebSocketChannel;
 import io.undertow.websockets.core.WebSockets;
@@ -71,8 +73,15 @@ public class WebSocketEventBus {
       if (databaseSubscribers == null)
         return;
       databaseSubscribers.remove(channelId);
-      if (databaseSubscribers.isEmpty())
+      if (databaseSubscribers.isEmpty()) {
         toStop = this.databaseWatchers.remove(databaseName);
+        // Flip the watcher off while still holding the lock (issue #6762): a subscribe() that wins the lock in the
+        // gap between here and the shutdown() below would otherwise start a second watcher and register its
+        // listeners while this one is still running with its own attached, so a commit in that window would be
+        // enqueued on both and published twice to the very same subscriber.
+        if (toStop != null)
+          toStop.signalStop();
+      }
     }
     // Join the watcher OUTSIDE the lock: shutdown() blocks until the watcher thread terminates, and that thread may need
     // the same per-database lock (unsubscribeAll during publish). Holding the lock across the join would deadlock them.
@@ -94,16 +103,25 @@ public class WebSocketEventBus {
     // onError may run on an XNIO IO thread after sendText returns, so the zombie collector must be thread-safe.
     final var zombieConnections = new ConcurrentLinkedQueue<UUID>();
 
+    // Charged per subscriber before the send and released when Undertow reports the frame done, so a subscriber that
+    // stops reading cannot accumulate an unbounded send backlog on the server's heap (issue #6762).
+    final int messageSize = json.length();
+    final long maxPendingBytes = this.arcadeServer != null ?
+        this.arcadeServer.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES) :
+        GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES.getValueAsLong();
+
     // A single callback shared by every subscriber of this event: onError reads the failing channel from its argument,
     // so there is no need to allocate a new callback per subscriber per event.
     final WebSocketCallback<Void> callback = new WebSocketCallback<>() {
       @Override
       public void complete(final WebSocketChannel webSocketChannel, final Void unused) {
+        releasePending(webSocketChannel);
         webSocketChannel.flush();
       }
 
       @Override
       public void onError(final WebSocketChannel webSocketChannel, final Void unused, final Throwable throwable) {
+        releasePending(webSocketChannel);
         final var channelId = (UUID) webSocketChannel.getAttribute(CHANNEL_ID);
         if (throwable instanceof IOException) {
           LogManager.instance().log(this, Level.FINE, "Closing zombie connection: %s", null, channelId);
@@ -112,12 +130,49 @@ public class WebSocketEventBus {
           LogManager.instance().log(this, Level.SEVERE, "Unexpected error while sending message.", throwable);
         }
       }
+
+      private void releasePending(final WebSocketChannel webSocketChannel) {
+        final var subscription = databaseSubscribers.get((UUID) webSocketChannel.getAttribute(CHANNEL_ID));
+        if (subscription != null)
+          subscription.releasePending(messageSize);
+      }
     };
 
-    databaseSubscribers.values().forEach(subscription -> {
+    databaseSubscribers.forEach((channelId, subscription) -> {
       try {
-        if (subscription.isMatch(event))
+        if (!subscription.isMatch(event))
+          return;
+
+        // Authorization is re-checked on DELIVERY, not only at SUBSCRIBE time (issue #6762): the identity is
+        // captured once at the handshake, so revoking a user's access to the database - or dropping the user
+        // outright - otherwise left the change stream flowing until the client happened to disconnect.
+        if (!isStillAuthorized(subscription, databaseName)) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Dropping change-stream subscription %s: the user is no longer authorized on database '%s'", null,
+              channelId, databaseName);
+          zombieConnections.add(channelId);
+          subscription.close();
+          return;
+        }
+
+        if (!subscription.reservePending(messageSize, maxPendingBytes)) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Evicting slow change-stream subscriber %s on database '%s': more than %d bytes are still outstanding "
+                  + "towards it. Raise " + GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES.getKey()
+                  + " if this is a legitimately bursty consumer", null, channelId, databaseName, maxPendingBytes);
+          zombieConnections.add(channelId);
+          subscription.close();
+          return;
+        }
+
+        try {
           WebSockets.sendText(json, subscription.getChannel(), callback);
+        } catch (final Exception e) {
+          // The frame never reached Undertow, so nothing is outstanding: give the reservation back rather than let
+          // a channel that fails synchronously look like a slow consumer.
+          subscription.releasePending(messageSize);
+          throw e;
+        }
       } catch (final Exception e) {
         // NEVER LET A SINGLE SUBSCRIPTION FAILURE KILL THE WATCHER THREAD AND STOP THE WHOLE CHANGE STREAM (ISSUE #4479).
         LogManager.instance().log(this, Level.SEVERE, "Error while publishing change event to subscription %s", e, subscription);
@@ -140,14 +195,39 @@ public class WebSocketEventBus {
       DatabaseEventWatcherThread toStop = null;
       synchronized (lockFor(databaseName)) {
         channels.remove(channelId);
-        if (channels.isEmpty())
+        if (channels.isEmpty()) {
           toStop = this.databaseWatchers.remove(databaseName);
+          // See unsubscribe(): stop accepting events while the lock still excludes a concurrent subscribe.
+          if (toStop != null)
+            toStop.signalStop();
+        }
       }
       // shutdown() outside the lock. When this runs on the watcher thread (zombie cleanup during publish), shutdown()
       // detects the self-call and returns without awaiting, so the run() loop can unwind and unregister its listeners.
       if (toStop != null)
         toStop.shutdown();
     });
+  }
+
+  /**
+   * Whether the identity that opened this channel may still read {@code databaseName}.
+   * <p>
+   * The {@link ServerSecurityUser} captured at the handshake is a snapshot: {@code ServerSecurity.updateUser}
+   * replaces the instance and {@code dropUser} removes it, so the current grant has to be re-resolved by name. A
+   * channel with no identity attached (embedded/test wiring, where no security is installed) is left alone.
+   */
+  private boolean isStillAuthorized(final EventWatcherSubscription subscription, final String databaseName) {
+    final WebSocketChannel channel = subscription.getChannel();
+    if (channel == null || this.arcadeServer == null)
+      return true;
+    final var connectedUser = (ServerSecurityUser) channel.getAttribute(USER);
+    if (connectedUser == null)
+      return true;
+    final ServerSecurity security = this.arcadeServer.getSecurity();
+    if (security == null)
+      return true;
+    final ServerSecurityUser current = security.getUser(connectedUser.getName());
+    return current != null && current.canAccessToDatabase(databaseName);
   }
 
   private Object lockFor(final String database) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
@@ -105,7 +105,12 @@ public class WebSocketEventBus {
 
     // Charged per subscriber before the send and released when Undertow reports the frame done, so a subscriber that
     // stops reading cannot accumulate an unbounded send backlog on the server's heap (issue #6762).
-    final int messageSize = json.length();
+    //
+    // The UTF-8 BYTE length, not json.length(): the cap is expressed in bytes and what actually sits in Undertow's
+    // send buffer is the UTF-8 encoding WebSockets.sendText produces, which is up to 3 bytes per char for CJK and
+    // 4 for an emoji. Counting chars would let a non-ASCII change stream hold several times the configured budget.
+    // Computed in one pass rather than via getBytes(UTF_8).length, which would copy the whole payload per event.
+    final int messageSize = utf8Length(json);
     final long maxPendingBytes = this.arcadeServer != null ?
         this.arcadeServer.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES) :
         GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES.getValueAsLong();
@@ -132,6 +137,13 @@ public class WebSocketEventBus {
       }
 
       private void releasePending(final WebSocketChannel webSocketChannel) {
+        // Looks the subscription up rather than capturing it, so this callback stays shared by the whole fan-out
+        // instead of being allocated per subscriber per event. That is safe because releasePending() floors at
+        // zero: if the client unsubscribed and re-subscribed before this frame completed, the reservation is
+        // released against the REPLACEMENT subscription, which never made it - and a release that would drive a
+        // counter negative is dropped instead, so the replacement cannot end up with a negative baseline that
+        // silently lets it exceed the cap. The original subscription is unreachable by then, so its own
+        // outstanding bytes die with it.
         final var subscription = databaseSubscribers.get((UUID) webSocketChannel.getAttribute(CHANNEL_ID));
         if (subscription != null)
           subscription.releasePending(messageSize);
@@ -228,6 +240,27 @@ public class WebSocketEventBus {
       return true;
     final ServerSecurityUser current = security.getUser(connectedUser.getName());
     return current != null && current.canAccessToDatabase(databaseName);
+  }
+
+  /**
+   * The number of bytes {@code s} occupies once UTF-8 encoded, without allocating the encoded copy.
+   */
+  private static int utf8Length(final String s) {
+    int bytes = 0;
+    for (int i = 0; i < s.length(); i++) {
+      final char c = s.charAt(i);
+      if (c < 0x80)
+        bytes += 1;
+      else if (c < 0x800)
+        bytes += 2;
+      else if (Character.isHighSurrogate(c) && i + 1 < s.length() && Character.isLowSurrogate(s.charAt(i + 1))) {
+        // one code point spread over a surrogate pair encodes as 4 bytes, not 3 + 3
+        bytes += 4;
+        i++;
+      } else
+        bytes += 3;
+    }
+    return bytes;
   }
 
   private Object lockFor(final String database) {

--- a/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
+++ b/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
@@ -247,7 +247,17 @@ public class PluginManager {
 
           // Configure and start the plugin
           plugin.configure(server, configuration);
-          plugin.startService();
+          try {
+            plugin.startService();
+          } catch (final Exception | Error e) {
+            // startService() is free to acquire resources before it fails - AutoBackupSchedulerPlugin starts its
+            // ScheduledThreadPool and only then schedules the databases - and the descriptor is not marked started
+            // yet, so stopPlugins() would skip it and those resources would live as long as the JVM. Release them
+            // here and let the original failure propagate (issue #6762).
+            CodeUtils.executeIgnoringExceptions(plugin::stopService,
+                "Error stopping plugin '" + pluginName + "' after a failed start", false);
+            throw e;
+          }
 
           if (plugin.isActive()) {
             descriptor.setStarted(true);

--- a/server/src/test/java/com/arcadedb/server/http/ws/Issue6762WebSocketEventBusTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/Issue6762WebSocketEventBusTest.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.security.ServerSecurity;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.websockets.core.WebSocketChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for the WebSocket change-stream defects grouped under issue #6762: the duplicate-delivery race
+ * on a last-unsubscribe / re-subscribe, and the unbounded send backlog a slow subscriber could accrue.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6762WebSocketEventBusTest {
+  private DatabaseFactory factory;
+  private Database        database;
+  private Document        record;
+
+  @BeforeEach
+  void setUp() {
+    final String path = "./target/databases/issue6762_" + UUID.randomUUID();
+    factory = new DatabaseFactory(path);
+    database = factory.create();
+    database.getSchema().createDocumentType("Doc");
+    database.begin();
+    final MutableDocument doc = database.newDocument("Doc").set("k", "v");
+    doc.save();
+    database.commit();
+    record = doc;
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+    if (factory != null)
+      factory.close();
+  }
+
+  /**
+   * The duplicate-delivery race: the watcher was removed from the maps inside the per-database lock but only told
+   * to stop OUTSIDE it, so a subscribe() winning the lock in that gap started a second watcher while the first was
+   * still {@code running} with its listeners attached, and a commit in the window was enqueued on both.
+   * <p>
+   * Driven at the point of the race rather than by hitting it with threads: what makes the window harmless is that
+   * the outgoing watcher stops accepting events at removal time, which is a property {@code signalStop()} either
+   * has or does not.
+   */
+  @Test
+  void aWatcherStopsAcceptingEventsAsSoonAsItIsSignalled() throws Exception {
+    final CopyOnWriteArrayList<ChangeEvent> published = new CopyOnWriteArrayList<>();
+    final WebSocketEventBus bus = new WebSocketEventBus(null) {
+      @Override
+      public void publish(final ChangeEvent event) {
+        published.add(event);
+      }
+    };
+
+    final DatabaseEventWatcherThread watcher = new DatabaseEventWatcherThread(bus, database, 16);
+    watcher.start();
+
+    // This is the state the outgoing watcher is in while the lock is still held: removed from the maps, told to
+    // stop, but its run() loop and its database listeners still very much alive.
+    watcher.signalStop();
+    watcher.push(new ChangeEvent(ChangeEvent.TYPE.CREATE, record));
+
+    watcher.join(TimeUnit.SECONDS.toMillis(5));
+    assertThat(watcher.isAlive()).isFalse();
+    assertThat(published)
+        .as("an event pushed after the stop signal must be dropped, not published a second time alongside the "
+            + "replacement watcher's copy")
+        .isEmpty();
+  }
+
+  /**
+   * {@code shutdown()} used to return early when {@code running} was already false, so once {@code signalStop()}
+   * exists the join it is there to perform would be skipped - and the caller would carry on while the watcher's
+   * listeners were still registered.
+   */
+  @Test
+  void shutdownStillJoinsAfterASeparateStopSignal() throws Exception {
+    final WebSocketEventBus bus = new WebSocketEventBus(null);
+    final DatabaseEventWatcherThread watcher = new DatabaseEventWatcherThread(bus, database, 16);
+    watcher.start();
+
+    watcher.signalStop();
+    watcher.shutdown();
+
+    assertThat(watcher.isAlive())
+        .as("shutdown() must have waited for run() to unwind and unregister its listeners")
+        .isFalse();
+  }
+
+  /**
+   * The unbounded send backlog: frames are handed to Undertow fire-and-forget, so a subscriber that stops reading
+   * used to accumulate them on the server's heap without limit. Past the cap the subscription is dropped instead.
+   */
+  @Test
+  void aSlowSubscriberIsEvictedInsteadOfAccruingAnUnboundedBacklog() throws Exception {
+    final long cap = 512;
+    GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES.setValue(cap);
+    try {
+      final WebSocketEventBus bus = new WebSocketEventBus(null);
+      final String db = record.getDatabase().getName();
+
+      // A subscriber whose sends never complete: nothing releases the reservation, exactly like a peer that has
+      // stopped reading while its TCP window stays shut.
+      final EventWatcherSubscription slow = neverCompletingSubscription();
+      final ConcurrentHashMap<UUID, EventWatcherSubscription> subscriptions = new ConcurrentHashMap<>();
+      final UUID channelId = UUID.randomUUID();
+      subscriptions.put(channelId, slow);
+      injectSubscribers(bus, db, subscriptions);
+
+      for (int i = 0; i < 200; i++)
+        bus.publish(new ChangeEvent(ChangeEvent.TYPE.CREATE, record));
+
+      assertThat(slow.getPendingBytes())
+          .as("the backlog charged to one subscriber must stay inside its budget")
+          .isLessThanOrEqualTo(cap);
+      assertThat(bus.getDatabaseSubscriptions(db))
+          .as("and the subscriber that could not keep up is dropped rather than carried forever")
+          .isEmpty();
+    } finally {
+      GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES.reset();
+    }
+  }
+
+  /** The cap is opt-out: 0 restores the pre-26.9.1 behaviour of never evicting on backlog alone. */
+  @Test
+  void aZeroCapDisablesTheEviction() throws Exception {
+    GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES.setValue(0L);
+    try {
+      final WebSocketEventBus bus = new WebSocketEventBus(null);
+      final String db = record.getDatabase().getName();
+
+      final EventWatcherSubscription slow = neverCompletingSubscription();
+      final ConcurrentHashMap<UUID, EventWatcherSubscription> subscriptions = new ConcurrentHashMap<>();
+      subscriptions.put(UUID.randomUUID(), slow);
+      injectSubscribers(bus, db, subscriptions);
+
+      for (int i = 0; i < 50; i++)
+        bus.publish(new ChangeEvent(ChangeEvent.TYPE.CREATE, record));
+
+      assertThat(bus.getDatabaseSubscriptions(db)).hasSize(1);
+      assertThat(slow.getPendingBytes()).isGreaterThan(0);
+    } finally {
+      GlobalConfiguration.SERVER_WS_EVENT_BUS_MAX_PENDING_BYTES.reset();
+    }
+  }
+
+  /**
+   * Authorization was checked only at SUBSCRIBE time, and the identity is captured once at the handshake, so
+   * revoking a user's access to the database - or dropping the user outright - left the change stream flowing
+   * until the client happened to disconnect. It has to be re-checked on delivery.
+   */
+  @Test
+  void aSubscriberWhoseAccessWasRevokedStopsReceivingEvents() throws Exception {
+    final String db = record.getDatabase().getName();
+
+    final ServerSecurityUser revoked = mock(ServerSecurityUser.class);
+    when(revoked.getName()).thenReturn("someone");
+    when(revoked.canAccessToDatabase(db)).thenReturn(false);
+
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.getUser("someone")).thenReturn(revoked);
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    when(server.getSecurity()).thenReturn(security);
+
+    final WebSocketChannel channel = mock(WebSocketChannel.class);
+    final UUID channelId = UUID.randomUUID();
+    when(channel.getAttribute(WebSocketEventBus.CHANNEL_ID)).thenReturn(channelId);
+    when(channel.getAttribute(WebSocketEventBus.USER)).thenReturn(revoked);
+
+    final WebSocketEventBus bus = new WebSocketEventBus(server);
+    final ConcurrentHashMap<UUID, EventWatcherSubscription> subscriptions = new ConcurrentHashMap<>();
+    subscriptions.put(channelId, matchAllSubscription(channel));
+    injectSubscribers(bus, db, subscriptions);
+
+    bus.publish(new ChangeEvent(ChangeEvent.TYPE.CREATE, record));
+
+    assertThat(bus.getDatabaseSubscriptions(db))
+        .as("the stream must stop as soon as the grant is gone, not when the client happens to disconnect")
+        .isEmpty();
+  }
+
+  /** Control: a user who still holds the grant keeps receiving events. */
+  @Test
+  void aSubscriberWhoStillHasAccessKeepsReceivingEvents() throws Exception {
+    final String db = record.getDatabase().getName();
+
+    final ServerSecurityUser allowed = mock(ServerSecurityUser.class);
+    when(allowed.getName()).thenReturn("someone");
+    when(allowed.canAccessToDatabase(db)).thenReturn(true);
+
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.getUser("someone")).thenReturn(allowed);
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    when(server.getSecurity()).thenReturn(security);
+
+    final WebSocketChannel channel = mock(WebSocketChannel.class);
+    final UUID channelId = UUID.randomUUID();
+    when(channel.getAttribute(WebSocketEventBus.CHANNEL_ID)).thenReturn(channelId);
+    when(channel.getAttribute(WebSocketEventBus.USER)).thenReturn(allowed);
+
+    final WebSocketEventBus bus = new WebSocketEventBus(server);
+    final ConcurrentHashMap<UUID, EventWatcherSubscription> subscriptions = new ConcurrentHashMap<>();
+    subscriptions.put(channelId, matchAllSubscription(channel));
+    injectSubscribers(bus, db, subscriptions);
+
+    bus.publish(new ChangeEvent(ChangeEvent.TYPE.CREATE, record));
+
+    assertThat(bus.getDatabaseSubscriptions(db)).hasSize(1);
+  }
+
+  /**
+   * A user that was DROPPED, not merely narrowed: the captured snapshot still answers yes, so the check has to
+   * re-resolve the principal by name rather than trust the object it was handed at the handshake.
+   */
+  @Test
+  void aSubscriberWhoseUserWasDroppedStopsReceivingEvents() throws Exception {
+    final String db = record.getDatabase().getName();
+
+    final ServerSecurityUser captured = mock(ServerSecurityUser.class);
+    when(captured.getName()).thenReturn("gone");
+    when(captured.canAccessToDatabase(db)).thenReturn(true); // the stale snapshot still says yes
+
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.getUser("gone")).thenReturn(null); // ...but the principal no longer exists
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    when(server.getSecurity()).thenReturn(security);
+
+    final WebSocketChannel channel = mock(WebSocketChannel.class);
+    final UUID channelId = UUID.randomUUID();
+    when(channel.getAttribute(WebSocketEventBus.CHANNEL_ID)).thenReturn(channelId);
+    when(channel.getAttribute(WebSocketEventBus.USER)).thenReturn(captured);
+
+    final WebSocketEventBus bus = new WebSocketEventBus(server);
+    final ConcurrentHashMap<UUID, EventWatcherSubscription> subscriptions = new ConcurrentHashMap<>();
+    subscriptions.put(channelId, matchAllSubscription(channel));
+    injectSubscribers(bus, db, subscriptions);
+
+    bus.publish(new ChangeEvent(ChangeEvent.TYPE.CREATE, record));
+
+    assertThat(bus.getDatabaseSubscriptions(db)).isEmpty();
+  }
+
+  private EventWatcherSubscription matchAllSubscription(final WebSocketChannel channel) {
+    return new EventWatcherSubscription("db", channel) {
+      @Override
+      public boolean isMatch(final ChangeEvent event) {
+        return true;
+      }
+    };
+  }
+
+  /**
+   * A subscription that always matches and whose frames Undertow never reports done: the reservation is made and
+   * never released, which is exactly what a peer that has stopped reading looks like to the accounting.
+   */
+  private EventWatcherSubscription neverCompletingSubscription() {
+    return new EventWatcherSubscription("db", null) {
+      @Override
+      public boolean isMatch(final ChangeEvent event) {
+        return true;
+      }
+
+      @Override
+      public WebSocketChannel getChannel() {
+        return null;
+      }
+
+      @Override
+      public void releasePending(final int bytes) {
+        // the frames stay outstanding forever
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void injectSubscribers(final WebSocketEventBus bus, final String databaseName,
+      final ConcurrentHashMap<UUID, EventWatcherSubscription> dbSubs) throws Exception {
+    final Field field = WebSocketEventBus.class.getDeclaredField("subscribers");
+    field.setAccessible(true);
+    ((ConcurrentHashMap<String, ConcurrentHashMap<UUID, EventWatcherSubscription>>) field.get(bus))
+        .put(databaseName, dbSubs);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/ws/Issue6762WebSocketEventBusTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/Issue6762WebSocketEventBusTest.java
@@ -186,6 +186,53 @@ class Issue6762WebSocketEventBusTest {
   }
 
   /**
+   * The cap is expressed in bytes and what sits in the send buffer is the UTF-8 encoding, so a non-ASCII change
+   * stream must be charged its real byte cost - counting chars would let it hold several times the budget
+   * (PR #6783 review).
+   */
+  @Test
+  void theBacklogIsChargedInUtf8BytesNotCharacters() throws Exception {
+    final String db = record.getDatabase().getName();
+    // One emoji per record property value: 1 char in Java's count once, but 4 UTF-8 bytes on the wire.
+    database.begin();
+    ((com.arcadedb.database.MutableDocument) record.asDocument().modify()).set("k", "😀".repeat(64)).save();
+    database.commit();
+
+    final WebSocketEventBus bus = new WebSocketEventBus(null);
+    final EventWatcherSubscription slow = neverCompletingSubscription();
+    final ConcurrentHashMap<UUID, EventWatcherSubscription> subscriptions = new ConcurrentHashMap<>();
+    subscriptions.put(UUID.randomUUID(), slow);
+    injectSubscribers(bus, db, subscriptions);
+
+    final ChangeEvent event = new ChangeEvent(ChangeEvent.TYPE.UPDATE, record);
+    bus.publish(event);
+
+    assertThat(slow.getPendingBytes())
+        .as("the emoji payload must be charged its UTF-8 byte cost, which exceeds its character count")
+        .isGreaterThan(event.toJSON().length());
+  }
+
+  /**
+   * A client that unsubscribes and re-subscribes while a frame is still in flight lands its completion callback on
+   * the REPLACEMENT subscription. That release must not drive the replacement's counter negative, which would give
+   * it a negative baseline and silently let it hold far more than the cap (PR #6783 review).
+   */
+  @Test
+  void aReleaseOnAReplacementSubscriptionCannotDriveItsBacklogNegative() {
+    final EventWatcherSubscription replacement = new EventWatcherSubscription("db", null);
+
+    replacement.releasePending(10_000); // a frame the ORIGINAL subscription reserved, completing late
+
+    assertThat(replacement.getPendingBytes()).isZero();
+    assertThat(replacement.reservePending(512, 1024))
+        .as("the replacement still has its full budget, not a negative head start")
+        .isTrue();
+    assertThat(replacement.reservePending(1024, 1024))
+        .as("and the cap still bites at the configured value")
+        .isFalse();
+  }
+
+  /**
    * Authorization was checked only at SUBSCRIBE time, and the identity is captured once at the handshake, so
    * revoking a user's access to the database - or dropping the user outright - left the change stream flowing
    * until the client happened to disconnect. It has to be re-checked on delivery.

--- a/server/src/test/java/com/arcadedb/server/plugin/PluginManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/plugin/PluginManagerTest.java
@@ -297,6 +297,30 @@ class PluginManagerTest {
     assertThat(plugins).contains(plugin);
   }
 
+  /**
+   * Issue #6762: a plugin whose startService() throws is never marked started, so stopPlugins() skips it and
+   * whatever it acquired before failing (AutoBackupSchedulerPlugin starts a ScheduledThreadPool and only then
+   * schedules the databases) lives as long as the JVM. The failure itself must still reach the caller.
+   */
+  @Test
+  void aPluginThatFailsToStartIsStoppedAnyway() {
+    LeakyFailingPlugin.stopped.set(false);
+    final LeakyFailingPlugin plugin = new LeakyFailingPlugin();
+    pluginManager.registerPlugin("leaky-failing-plugin", plugin);
+
+    assertThatExceptionOfType(ServerException.class).isThrownBy(
+        () -> pluginManager.startPlugins(ServerPlugin.PluginInstallationPriority.BEFORE_HTTP_ON));
+
+    assertThat(LeakyFailingPlugin.stopped.get()).isTrue();
+
+    // it is still not "started", so the later stopPlugins() must not stop it a second time
+    final PluginDescriptor descriptor = pluginManager.getPluginDescriptor("leaky-failing-plugin");
+    assertThat(descriptor.isStarted()).isFalse();
+    LeakyFailingPlugin.stopped.set(false);
+    pluginManager.stopPlugins();
+    assertThat(LeakyFailingPlugin.stopped.get()).isFalse();
+  }
+
   @Test
   void classLoaderIsolation() throws Exception {
     final Path pluginsDir = tempDir.resolve("lib/plugins");
@@ -411,6 +435,21 @@ class PluginManagerTest {
     @Override
     public void startService() {
       throw new RuntimeException("Plugin failed to start");
+    }
+  }
+
+  /** A plugin that acquires something (here: sets a flag) and then fails, like AutoBackupSchedulerPlugin can. */
+  public static class LeakyFailingPlugin implements ServerPlugin {
+    public static final AtomicBoolean stopped = new AtomicBoolean(false);
+
+    @Override
+    public void startService() {
+      throw new RuntimeException("Plugin failed to start after acquiring its resources");
+    }
+
+    @Override
+    public void stopService() {
+      stopped.set(true);
     }
   }
 


### PR DESCRIPTION
Closes #6758, closes #6759, closes #6760, closes #6761, closes #6762.

Five small-to-medium issues that came out of the same audit pass. Each is independent; they are batched because
none of them is large on its own.

> **#6757 dropped from this PR.** It was fixed on main by #6774 while this PR was open, and that fix is the better
> one: it extracts a single `RedisIndexKeys` parser shared by all four index-lookup call sites (`HGET` / `HMGET` /
> `HEXISTS` / `HDEL` and the `redis` query engine) instead of correcting only the copy that had drifted, and it
> answers a malformed composite key with an error reply instead of letting `JSONArray` throw. Its
> `RedisCompositeIndexKeyTest` already covers the HMGET-matches-HGET case, so the test this branch added went with
> it. `redisw/` is now byte-identical to main.

## #6758 - Python bindings: unescaped JSON header in `ColumnBatcher`

The columnar header was built by string concatenation of raw column names, which are arbitrary query projection
aliases. An alias carrying a `"` emitted invalid JSON and killed the decode of the whole batch; one carrying a
`;` was additionally split into two bogus columns by the `';'`-joined column spec that pins the column set across
batches.

The header now goes through `JSONObject`/`JSONArray`, exactly as the sibling `RowBatcher` already does. **Better
than the suggested fix:** rather than escaping the separator, the column spec itself is now a JSON array on both
sides, so the separator problem cannot come back for any character. The legacy `';'` form is still parsed, so an
older Python side paired with a newer bridge jar keeps working.

## #6759 - Polyglot: parameters leaking across invocations, cooperative-only cancellation

`PolyglotQueryEngine` is a reusable engine, so one `GraalPolyglotEngine.context` serves every caller on a
database - and parameters were bound to it and never removed. `command("js", "return x", Map.of("x", 5))` followed
by `command("js", "return x")` returned `5`.

**Better than the suggested fix** (`bindings.removeMember(key)` in a `finally`): a plain removal breaks the case
where a parameter shadows a binding the engine owns - a parameter literally named `database`, or a function
declared through `registerFunctions`. The parameters are now *scoped*: `setAttributes` snapshots whatever each one
displaces and `restoreAttributes` puts it back, removing only names that were not bound before. Both behaviours
are pinned by tests.

Cancellation: a timed-out script is now cancelled through GraalVM's supported `Context.interrupt(Duration)` in
addition to `Future.cancel(true)`, which is what actually unwinds a guest loop and releases the context every
command on the database serialises on; a context that does not come to rest within the grace period is reported
at WARNING. The interrupt is only issued when `cancel(true)` reports the task was really still running, so it
cannot hit whichever command acquired the lock next. Alongside that, `polyglotEngine` is `volatile` and guarded by
a stable lock instead of being its own monitor (`unregisterFunctions()` replaces it, so `synchronized` on the field
was serialising nothing across a replacement), and `unregisterFunctions()` now closes the context it replaces
rather than leaking it.

On the disabled memory limit: it cannot come back. GraalVM CE's only `ResourceLimits` knob is `statementLimit()`,
which is cumulative over a context's life and permanently cancels it once reached, so on a context that serves
every command of a database it would eventually kill the engine on a legitimate workload; CE exposes no allocation
bound at all. The stale `// DISABLED LIMIT BECAUSE...` comment is replaced with that reasoning.

## #6760 - HA: a snapshot install that gives up on a database still ACKs the snapshot index

Confirmed as described. The reconciler stops failing the whole install for a database that has failed 3 times in a
row - correct for the *retry*, since otherwise Ratis re-downloads every healthy database on the follower each pass
because of one bad one. But the install then wrote `snapshotIndex` as applied for **every** database, cleared the
global read floor and the diverged marks, and returned the installed `TermIndex`, after which Ratis purges the
log. The node re-entered the ready set advertising itself fully caught up while one database was still on its old
copy, and a LINEARIZABLE (or RYW with a bookmark below the index) read of that database passed the apply wait
instantly.

**The fix takes all three of the issue's suggestions rather than the minimum**, because each covers a different
half of the problem:

- `reconcileDatabasesFromLeader` now returns the set of databases it gave up on (giving up on the *retry* is not
  the same statement as "installed").
- The install writes the persisted applied index for every database **except** those - leaving them at the
  position they genuinely reached, so `reinitialize()` still re-detects the gap on the next restart.
- Each keeps its diverged mark, so `isResyncInProgress()` stays true and the node does not advertise readiness.
- Each publishes a **per-database** read floor. `getTrustedAppliedIndex(String)` clamps to it, so reads of that
  database fail (LINEARIZABLE) or degrade (RYW) while its healthy co-located databases stay completely unclamped -
  which is the whole reason the give-up threshold exists. The database name is threaded from
  `RaftReplicatedDatabase`, the only production caller of the read gate; the no-arg overloads are unchanged.
- `retryUnfilledSnapshotGap()` (the HealthMonitor backstop, already throttled to one attempt per watchdog interval)
  now treats a per-database floor as an unfilled gap, so recovery is re-armed instead of waiting for the next
  leader change or the next write to that database.

The global `#6111` floor is deliberately left as it is: it is derived from a global signal and has to clamp
everything. This one is derived from a per-database verdict, so it does not.

Not executed against a live cluster (HA is not runnable here); the install path, the bookkeeping and the read gate
are covered by 8 new deterministic tests, 3 of which fail against the previous behaviour.

## #6761 - No TCP keepalive on the wire-protocol sockets

Confirmed. `SO_KEEPALIVE` is now enabled in the `Channel` constructor - the network-layer owner of socket options -
with configurable probe timings (`arcadedb.network.socketKeepAlive{,Idle,Interval,Count}`, defaults detecting a
dead peer about 3 minutes after the connection goes idle). The timings go through `jdk.net.ExtendedSocketOptions`
where the platform supports them, resolved once and defensively so a trimmed jlink image or a native image falls
back to the system-wide defaults rather than failing to serve the connection.

The two smaller items in the same report:

- **`close()` ordering: real, fixed.** Both `ChannelBinary.close()` and `Channel.close()` shut the input side (and,
  in `Channel`, the socket) before the output side, so the `out.close()` that should have flushed the last buffered
  bytes failed instead and dropped them with a FINE log. A test writes without flushing, closes, and reads the
  bytes on the other end; it fails against the old order with an `EOFException`.
- **`ChannelBinaryClient` FD leak: not reproducible, fixed anyway.** The catch really was dead code (it handled
  only `RuntimeException` while every connect failure path throws checked), and the `isConnected()` guard really
  was wrong for cleanup. But on JDK 21 `NioSocketImpl` releases the descriptor itself when `connect()` fails -
  measured at 200 failed connects with `getOpenFileDescriptorCount()`, zero growth - so there is no live leak to
  regress against. The catch is corrected and the reasoning recorded in the comment; no test, because the one I
  wrote first passed against the unfixed code and a vacuous test is worse than none.

## #6762 - Robustness batch

1. **`PluginManager` never stopped a plugin whose `startService()` threw.** Fixed: `stopService()` is called
   (guarded) before the failure is rethrown, and the descriptor stays "not started" so `stopPlugins()` does not
   stop it a second time - both asserted.
2. **WebSocket duplicate delivery on a last-unsubscribe / re-subscribe race.** The watcher is now told to stop
   *inside* the per-database lock (`signalStop()`), leaving only the blocking join outside it. `shutdown()` lost
   its "already stopped, nothing to do" shortcut, which would otherwise skip the join it exists for.
3. **WebSocket authorization was checked only at SUBSCRIBE time.** Re-checked on delivery. The identity captured
   at the handshake is a snapshot - `updateUser` replaces the instance and `dropUser` removes it - so the grant is
   re-resolved by name, which catches a dropped principal as well as a narrowed one.
4. **Unbounded send backlog for a slow subscriber.** Outstanding bytes are now charged per channel and released
   when Undertow reports the frame done; past `arcadedb.server.eventBusMaxPendingBytes` (16 MB, `0` disables) the
   subscription is dropped and the channel closed.
5. **Vector index `nextId` after a failed materialisation.** The one-attempt contract is kept, but the allocator is
   now advanced over whatever was read before the failure - in `materializeLocations()`'s `finally`, so it covers
   every failure path rather than only the one the report named, and in `loadVectorsFromPages()`'s catch for its
   other caller. Without it the next insert supersedes a live vector instead of adding one.
6. **`RemoteGrpcServer.channel`** is `volatile` (with `eventLoopGroup`), and `channel()` reads it once per decision
   - re-reading after the null check let a concurrent `close()` turn the return value into `null` between the two
   reads, surfacing as an NPE inside gRPC.
7. **MCP input bounds.** `profiler_start` re-validates its declared range; `query` and `execute_command` cap
   `limit` (every row is accumulated into an in-memory `JSONArray` first), and the declared schema advertises the
   same window the server enforces.

## Verification

New tests, all of which were run against the unfixed code first where the defect is observable:

| Issue | Test |
|---|---|
| #6758 | `test_core.py::test_to_columns_survives_json_metacharacters_in_aliases` (+ verified against the engine directly, since the bridge classes have no Maven module) |
| #6759 | 3 new cases in `PolyglotQueryTest` |
| #6760 | `Issue6760PartialSnapshotInstallTest` (8), `DatabaseReconcilerTest` (+2) |
| #6761 | `ChannelSocketOptionsTest` (3) |
| #6762 | `PluginManagerTest.aPluginThatFailsToStartIsStoppedAnyway`, `Issue6762WebSocketEventBusTest` (7), `Issue6762VectorIdAllocatorAfterFailedLoadTest`, `Issue6762ToolInputBoundsTest` (5) |

Suites run green: `ha-raft` 969, `server` 835 + `WebSocketEventBusIT` 20, `network` 461, `bolt` 319, `postgresw`
426, `mcp` 300, `grpc-client` 147, `redisw` 78, `engine` 13587 with the single known pre-existing flake
`CypherGAVBoundTargetCardinalityTest.theViewFallsBackToTheEdgeListWhenADeletionMasksThePair` (green in isolation,
unrelated to anything here).

## Follow-up

Four new `GlobalConfiguration` settings are introduced (`arcadedb.network.socketKeepAlive`, `...Idle`,
`...Interval`, `...Count`) plus `arcadedb.server.eventBusMaxPendingBytes`. The settings reference in
`arcadedb-docs` should get a matching entry - happy to prepare that PR separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TCP keepalive configuration options for network connections.
  * Added limits for MCP query and command results, plus profiler timeout validation.
  * Added safeguards for WebSocket event delivery, including authorization checks and slow-connection eviction.
  * Added database-scoped consistency handling for high-availability reads and recovery.

* **Bug Fixes**
  * Preserved projection aliases containing special characters in Python and Arrow results.
  * Prevented vector ID reuse after interrupted index loading.
  * Improved polyglot timeout isolation and parameter cleanup.
  * Improved channel, plugin, and snapshot installation cleanup and lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
