### PR TITLE
fix(#6772): a session that writes before it searches reaches the persisted vector graph too

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -62,6 +62,7 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryComparator;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.LockManager;
 import com.arcadedb.utility.Pair;
 import com.arcadedb.utility.RidHashSet;
@@ -202,6 +203,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   private volatile GraphState                    graphState;
+  // ISSUE #6772: whether this instance has still to decide what to do with whatever graph is on disk - load it,
+  // reuse it as a prefix, or discard it for a rebuild. NOT derivable from graphState, and that is the whole point:
+  // LOADING means "no graph in memory yet", but put()/putBatch()/remove() promote LOADING straight to MUTABLE on
+  // the first write, and after that promotion "a loaded graph now has pending deltas" and "no graph has been
+  // loaded yet and there are pending deltas" are the same state. ensureGraphAvailable() used to gate on LOADING
+  // alone, so a session that wrote before it searched skipped the load entirely, left graphIndex null, and had
+  // rebuildGraphBeforeSearch() read that null as "small graph" and rebuild the WHOLE index synchronously on the
+  // search thread - the ordinary ingest-then-query shape paying exactly the cost issues #6067 and #6655 removed
+  // for the sessions that happen not to write first. needsGraphBuild()'s javadoc already draws this distinction
+  // for the close path ("LOADING means not loaded into memory, which is not the same as not persisted on disk");
+  // this field is that distinction made explicit for the search path, so the promotion can no longer erase it.
+  // Starts true - a freshly constructed index has resolved nothing - and is cleared exactly once, by whichever of
+  // ensureGraphAvailable() or buildGraphFromScratchWithRetry() first settles the question under graphBuildLock.
+  private volatile boolean                       persistedGraphUnresolved = true;
   private volatile ImmutableGraphIndex           graphIndex;        // Current graph (OnHeap or OnDisk)
   private volatile int[]                         ordinalToVectorId; // Maps graph ordinals to vector IDs
   // Lightweight pointer index. Volatile and swapped as a whole (never cleared and refilled in place) so the
@@ -1493,11 +1508,35 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * {@code true} while {@link #ensureGraphAvailable()} still has work to do: either no graph has been materialised
+   * in memory for this instance yet ({@link GraphState#LOADING}), or one has not been but a write already promoted
+   * the state past LOADING ({@link #persistedGraphUnresolved} - issue #6772).
+   * <p>
+   * The second disjunct is the one that makes an ingest-then-query session reach the same persisted-graph load and
+   * prefix reuse (issue #6655) a query-only session gets. Without it the promotion {@code put()}/{@code putBatch()}
+   * /{@code remove()} perform on the first write closes the door on the load for the rest of the session, and the
+   * first search pays a full synchronous rebuild through {@link #rebuildGraphBeforeSearch()}'s null-graph arm
+   * instead.
+   * <p>
+   * That disjunct is additionally conditioned on {@link #graphIndex} being null, which is the structural half of
+   * the answer: whatever the latch says, an index that already has a graph in memory has nothing left for
+   * {@link #ensureGraphAvailable()} to do, and this is what keeps a publish path that forgets to clear the latch
+   * (the chunked initial build reaches one through {@link #buildGraphFromScratchWithRetry}, but nothing forces a
+   * future one to) from making every search reload and re-validate a graph that is already resident.
+   */
+  private boolean graphNotYetMaterialised() {
+    return graphState == GraphState.LOADING || (persistedGraphUnresolved && graphIndex == null);
+  }
+
+  /**
    * Ensure graph is available for searching. Lazy-loads from disk if needed.
    * This is the entry point for all search operations.
+   * <p>
+   * Reached on the first search of a session whether or not that session has already written to the index
+   * (issue #6772): see {@link #graphNotYetMaterialised()}.
    */
   private void ensureGraphAvailable() {
-    if (graphState != GraphState.LOADING)
+    if (!graphNotYetMaterialised())
       return; // Graph already available or being built
 
     // Materialise the locations before graphBuildLock rather than through the vectorIndex() calls below, which
@@ -1526,7 +1565,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     graphBuildLock.lock();
     try {
       // Double-check after acquiring the lock
-      if (graphState != GraphState.LOADING)
+      if (!graphNotYetMaterialised())
         return; // Another thread already resolved this while we waited for graphBuildLock
 
       // Try to load persisted graph from disk
@@ -1756,6 +1795,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
       if (prefixReuseCandidate == null)
         buildGraphFromScratch();
     } finally {
+      // Cleared here rather than in each branch above, and in a finally rather than on the success paths only,
+      // because the latch means "still to be decided", not "decided successfully" (issue #6772). Every exit from
+      // this section - graph loaded, prefix queued for reuse, rebuilt from scratch, or a load that threw and fell
+      // through to the rebuild - has settled the question of what happens to the on-disk graph, and leaving the
+      // latch set on any of them would make the NEXT search redo the O(live vector count) validation scan above.
+      // A build that fails outright still leaves graphState at LOADING, and graphNotYetMaterialised() keeps
+      // answering true on that alone, so the retry this method has always offered is unaffected.
+      persistedGraphUnresolved = false;
       graphBuildLock.unlock();
     }
 
@@ -1784,12 +1831,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * the end takes {@code lock.writeLock()}, to make the state change visible/consistent to concurrent readers -
    * not to protect the read.
    * <p>
-   * The vectors past {@code graphSize} are not yet in the graph, and are not in {@link #deltaVectors} either:
-   * that buffer is in-memory only (issue #3722) and this is a session that never wrote them, it is only now
-   * discovering them on reopen. Queuing them here - the same re-queue {@link #buildGraphFromScratch()} performs
-   * for a node its own build left unreachable - is what keeps every live vector searchable immediately through
-   * the ordinary delta scan, rather than trading this fix's latency win for a window where they silently do not
-   * come back.
+   * The vectors past {@code graphSize} are not yet in the graph, and for a session that is only now discovering
+   * them on reopen they are not in {@link #deltaVectors} either: that buffer is in-memory only (issue #3722).
+   * Queuing them here - the same re-queue {@link #buildGraphFromScratch()} performs for a node its own build left
+   * unreachable - is what keeps every live vector searchable immediately through the ordinary delta scan, rather
+   * than trading this fix's latency win for a window where they silently do not come back.
+   * <p>
+   * A session that WROTE before it searched (issue #6772) reaches this method with some of that gap already in
+   * {@link #deltaVectors} - its own writes, which went into the location index as well - so the gap is filtered
+   * against the buffer twice: once before the read, to avoid fetching back from disk what is already in memory,
+   * and once under the publish lock, to catch anything a concurrent writer queued while the read ran unlocked.
    *
    * @param candidate the eligibility decision {@link #ensureGraphAvailable()} made under its write lock
    */
@@ -1801,20 +1852,52 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     graphBuildLock.lock();
     try {
-      // Double-check: graphState is volatile and this is the same fast-path re-check ensureGraphAvailable()
-      // itself does after acquiring a lock. Another thread may have already published - a concurrent
-      // buildGraphFromScratch(), or a second reuseStalePrefixGraph() call that queued behind this same mutex and
-      // ran first - while this call waited for graphBuildLock.
-      if (graphState != GraphState.LOADING)
+      // Double-check that nobody published a graph while this call waited for graphBuildLock - a concurrent
+      // buildGraphFromScratch(), or a second reuseStalePrefixGraph() that queued behind this same mutex and ran
+      // first. Asked of graphIndex rather than of graphState (issue #6772): graphState is no longer LOADING on
+      // the ingest-then-query path this method now also serves - the session's own writes promoted it to MUTABLE
+      // before the first search - so the old graphState test would have refused every reuse it exists to perform.
+      // graphIndex is the thing a publisher actually sets, which makes it the exact question. The IMMUTABLE arm
+      // catches the one publisher that leaves it null: a from-scratch build that found no valid vectors at all,
+      // after which reusing a graph built over vectors that are evidently gone would be wrong rather than stale.
+      if (graphIndex != null || graphState == GraphState.IMMUTABLE)
         return;
+
+      // Vector ids the caller's own session already queued into the delta buffer (issue #6772). The ordinary
+      // ingest-then-query shape reaches this method with its own writes sitting in deltaVectors AND, because
+      // those writes went into the location index too, sitting inside the gap past graphSize - so queuing the
+      // gap wholesale would duplicate every one of them in the delta scan and double-count them in
+      // mutationsSinceSerialize. Excluded BEFORE the read rather than filtered after it, because skipping the
+      // read is most of the point: a session that inserted a million vectors before its first query would
+      // otherwise pay a page lookup per vector to fetch back what is already in memory beside it.
+      final IntHashSet alreadyQueued;
+      lock.readLock().lock();
+      try {
+        // Sized in TABLE SLOTS, not elements: IntHashSet resizes at a 0.75 load factor, so handing it the
+        // element count alone would guarantee one rehash of the whole table on the way in.
+        alreadyQueued = new IntHashSet(deltaVectors.size() * 4 / 3 + 1);
+        for (final DeltaVectorEntry entry : deltaVectors)
+          alreadyQueued.add(entry.vectorId);
+      } finally {
+        lock.readLock().unlock();
+      }
 
       // Trimmed to the gap before it is handed anywhere else: snapshotOf() and computeGraphBuildCacheCapacity()
       // both size their work off whatever array they are given, and only ordinals [graphSize, length) are ever
       // read below. Handing them the full live-vector array (as an earlier version of this fix did) made the
       // snapshot and the build reader's cache scale with the WHOLE index - exactly the O(index size) cost this
       // fix exists to avoid - rather than with how much is actually missing from the graph (PR #6712 review).
-      final int[] gapOrdinalToVectorId = Arrays.copyOfRange(rebuiltOrdinalToVectorId, graphSize,
-          rebuiltOrdinalToVectorId.length);
+      // Ascending order is preserved by the filter, which is what snapshotOf() and the ordinal mapping below
+      // both assume.
+      int gapCount = 0;
+      final int[] gapCandidates = new int[rebuiltOrdinalToVectorId.length - graphSize];
+      for (int i = graphSize; i < rebuiltOrdinalToVectorId.length; i++) {
+        final int vectorId = rebuiltOrdinalToVectorId[i];
+        if (!alreadyQueued.contains(vectorId))
+          gapCandidates[gapCount++] = vectorId;
+      }
+      final int[] gapOrdinalToVectorId = gapCount == gapCandidates.length ? gapCandidates :
+          Arrays.copyOf(gapCandidates, gapCount);
 
       final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
           metadata.dimensions, vectorProp,
@@ -1837,17 +1920,31 @@ public class LSMVectorIndex implements Index, IndexInternal {
         gapEntries.add(new DeltaVectorEntry(vectorId, rid, vector));
       }
 
-      // Publish. graphState stays LOADING for the whole unlocked read above - insert() does not wait on it - so
-      // a concurrent write could have landed on this index in the meantime and already appended its own entries
-      // to deltaVectors and its own count to mutationsSinceSerialize. addAll()/addAndGet() rather than a replace
-      // or a plain set() is what keeps those, instead of silently dropping them.
+      // Publish. The graph is not published for the whole unlocked read above - insert() does not wait on it -
+      // so a concurrent write could have landed on this index in the meantime and already appended its own
+      // entries to deltaVectors and its own count to mutationsSinceSerialize. Appending to the buffer rather
+      // than replacing it, and addAndGet() rather than a plain set(), is what keeps those instead of silently
+      // dropping them.
+      int queuedIntoDelta = 0;
       lock.writeLock().lock();
       try {
         this.graphIndex = loadedGraph;
         this.ordinalToVectorId = Arrays.copyOf(rebuiltOrdinalToVectorId, graphSize);
-        this.deltaVectors.addAll(gapEntries);
+        // Re-checked here against the buffer as it stands NOW, not only against the pre-read snapshot taken
+        // above: a concurrent put() could have queued one of these ids while the gap was being read unlocked,
+        // and queuing it a second time is the same duplicate the pre-filter exists to avoid (issue #6772).
+        if (!gapEntries.isEmpty()) {
+          final IntHashSet queued = new IntHashSet((deltaVectors.size() + gapEntries.size()) * 4 / 3 + 1);
+          for (final DeltaVectorEntry entry : deltaVectors)
+            queued.add(entry.vectorId);
+          for (final DeltaVectorEntry entry : gapEntries)
+            if (queued.add(entry.vectorId)) {
+              this.deltaVectors.add(entry);
+              queuedIntoDelta++;
+            }
+        }
         this.graphState = GraphState.MUTABLE;
-        this.mutationsSinceSerialize.addAndGet(gapEntries.size());
+        this.mutationsSinceSerialize.addAndGet(queuedIntoDelta);
       } finally {
         lock.writeLock().unlock();
       }
@@ -1855,8 +1952,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
       metrics.incrementStalePrefixGraphReuses();
       LogManager.instance().log(this, Level.INFO,
           "Reusing persisted graph for index %s as a stale prefix: %d of %d live vectors are already in the "
-              + "graph, %d queued into the delta buffer pending an async rebuild (issue #6655)",
-          indexName, graphSize, rebuiltOrdinalToVectorId.length, gapEntries.size());
+              + "graph, %d queued into the delta buffer pending an async rebuild (issues #6655, #6772)",
+          indexName, graphSize, rebuiltOrdinalToVectorId.length, queuedIntoDelta);
     } finally {
       graphBuildLock.unlock();
     }
@@ -2119,6 +2216,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // and inserts never touch it, so it does not reintroduce the stall.
     graphBuildLock.lock();
     try {
+      // Whatever is on disk is about to be superseded by this build, so there is nothing left for
+      // ensureGraphAvailable() to resolve (issue #6772). Set before the build rather than after it so a search
+      // that arrives mid-build and finds graphState already promoted to MUTABLE does not queue behind this mutex
+      // to re-validate a graph file this build is replacing; a build that fails leaves graphState at LOADING,
+      // which graphNotYetMaterialised() still answers true on, so the retry path is unaffected.
+      persistedGraphUnresolved = false;
       buildGraphFromScratchExclusively(graphCallback, compactDataFile, releaseResidentGraphFirst);
     } finally {
       graphBuildLock.unlock();
@@ -3507,7 +3610,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
   /**
    * Check if the graph needs rebuilding before a search, and trigger the appropriate rebuild strategy.
    * <ul>
-   *   <li>If graph was never built (graphIndex == null): synchronous build (no existing graph to search).</li>
+   *   <li>If graph was never built (graphIndex == null): synchronous build (no existing graph to search).
+   *       {@link #ensureGraphAvailable()} runs immediately before this on every search path, so by the time this
+   *       test is made a null graph really does mean "nothing was persisted either" - it no longer also means
+   *       "a graph is on disk but this session wrote before it searched, so it was never loaded" (issue #6772).</li>
    *   <li>If threshold reached and graph is small (&lt; 1000 vectors): synchronous rebuild (fast enough).</li>
    *   <li>If threshold reached and graph is large (&ge; 1000 vectors): async rebuild + search the current graph
    *       (valid but excludes the newest vectors not yet incorporated into the graph topology).</li>

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -214,8 +214,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // for the sessions that happen not to write first. needsGraphBuild()'s javadoc already draws this distinction
   // for the close path ("LOADING means not loaded into memory, which is not the same as not persisted on disk");
   // this field is that distinction made explicit for the search path, so the promotion can no longer erase it.
-  // Starts true - a freshly constructed index has resolved nothing - and is cleared exactly once, by whichever of
-  // ensureGraphAvailable() or buildGraphFromScratchWithRetry() first settles the question under graphBuildLock.
+  // Starts true - a freshly constructed index has resolved nothing - and is cleared under graphBuildLock by
+  // whichever of ensureGraphAvailable(), reuseStalePrefixGraph() or buildGraphFromScratchWithRetry() first settles
+  // the question. Cleared at PUBLISH time, not at decision time: see ensureGraphAvailable()'s finally for why the
+  // prefix-reuse branch hands ownership of this flag to reuseStalePrefixGraph() instead of clearing it itself.
   private volatile boolean                       persistedGraphUnresolved = true;
   private volatile ImmutableGraphIndex           graphIndex;        // Current graph (OnHeap or OnDisk)
   private volatile int[]                         ordinalToVectorId; // Maps graph ordinals to vector IDs
@@ -1795,20 +1797,34 @@ public class LSMVectorIndex implements Index, IndexInternal {
       if (prefixReuseCandidate == null)
         buildGraphFromScratch();
     } finally {
-      // Cleared here rather than in each branch above, and in a finally rather than on the success paths only,
-      // because the latch means "still to be decided", not "decided successfully" (issue #6772). Every exit from
-      // this section - graph loaded, prefix queued for reuse, rebuilt from scratch, or a load that threw and fell
-      // through to the rebuild - has settled the question of what happens to the on-disk graph, and leaving the
-      // latch set on any of them would make the NEXT search redo the O(live vector count) validation scan above.
+      // Cleared in a finally rather than on the success paths only, because the latch means "still to be decided",
+      // not "decided successfully" (issue #6772): a graph loaded, a rebuild from scratch, and a load that threw and
+      // fell through to the rebuild have all settled the question of what happens to the on-disk graph, and leaving
+      // the latch set on any of them would make the NEXT search redo the O(live vector count) validation scan above.
       // A build that fails outright still leaves graphState at LOADING, and graphNotYetMaterialised() keeps
       // answering true on that alone, so the retry this method has always offered is unaffected.
-      persistedGraphUnresolved = false;
+      //
+      // The prefix-reuse branch is the exception, and it is deliberately NOT cleared here: it has decided but not
+      // yet PUBLISHED - reuseStalePrefixGraph() runs after this lock is released and only sets graphIndex there.
+      // Clearing at decision time would open a window in which graphState is already MUTABLE (this session wrote
+      // before it searched - the very case this fix exists for), the latch is false, and graphIndex is still null,
+      // so a SECOND search thread would find graphNotYetMaterialised() false, fall through to
+      // rebuildGraphBeforeSearch(), read that null as "small graph" and run the whole synchronous rebuild this fix
+      // removes - the same cost back, gated on a race instead of on a promotion (PR #6784 review). Ownership of the
+      // latch passes to reuseStalePrefixGraph(), which clears it under the same mutex once the graph is published.
+      if (prefixReuseCandidate == null)
+        persistedGraphUnresolved = false;
       graphBuildLock.unlock();
     }
 
     if (prefixReuseCandidate != null) {
       // Unlocked with respect to lock.writeLock(): reuseStalePrefixGraph() does its own graphBuildLock-serialized
-      // I/O and a brief re-lock only to publish (see its javadoc).
+      // I/O and a brief re-lock only to publish (see its javadoc). A second search thread that slips in between
+      // this unlock and that method's own lock() still sees the latch set, so the worst it can do is repeat the
+      // validation scan and reach the same decision - one of the two then loses the graphIndex double-check and
+      // discards its work. That is exactly what a racing pair already does on the query-only path of issue #6655,
+      // where graphState stays LOADING across the same window, and it is bounded by a scan rather than by a
+      // rebuild.
       reuseStalePrefixGraph(prefixReuseCandidate);
     }
   }
@@ -1955,6 +1971,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
               + "graph, %d queued into the delta buffer pending an async rebuild (issues #6655, #6772)",
           indexName, graphSize, rebuiltOrdinalToVectorId.length, queuedIntoDelta);
     } finally {
+      // ensureGraphAvailable() handed the latch over rather than clearing it at decision time, so this is where it
+      // is released - after the publish above and, crucially, still under graphBuildLock, so the next thread to
+      // take that mutex sees the cleared latch and the published graphIndex together rather than one without the
+      // other (PR #6784 review). In the finally for the same reason it is one there: the early return above and any
+      // exception have both settled the question just as much as the publish has, and a latch left set would make
+      // every later search redo ensureGraphAvailable()'s O(live vector count) validation scan.
+      persistedGraphUnresolved = false;
       graphBuildLock.unlock();
     }
 

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
@@ -36,8 +36,15 @@ import org.junit.jupiter.api.TestInfo;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -101,38 +108,7 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
 
   @Test
   void aSessionThatInsertsBeforeItSearchesStillReusesThePersistedGraphAsAPrefix() throws Exception {
-    // Session 1: build and persist a graph over exactly NUM_VECTORS, then close cleanly - the persisted graph and
-    // its manifest end up describing precisely the first NUM_VECTORS records.
-    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
-      final Database db = factory.create();
-      try {
-        populate(db, 0, NUM_VECTORS);
-        final LSMVectorIndex index = vectorIndex(db);
-        index.buildVectorGraphNow();
-        assertThat(index.getStats().get("graphState")).as("precondition: graph must be built and IMMUTABLE first")
-            .isEqualTo(1L); // GraphState.IMMUTABLE
-        db.close();
-      } finally {
-        if (db.isOpen())
-          db.close();
-      }
-    }
-
-    // Session 2: write GAP_VECTORS more records (committed, so WAL-durable), then crash instead of closing
-    // cleanly, so the persisted graph and manifest stay exactly as session 1 left them - describing only the
-    // first NUM_VECTORS records - while the live vector count grows. Same setup as
-    // Issue6655StaleGraphPrefixReuseTest, which is deliberate: this test differs from that one in session 3 only.
-    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
-      final Database db = factory.open();
-      try {
-        populate(db, NUM_VECTORS, NUM_VECTORS + GAP_VECTORS);
-        ((DatabaseInternal) db).kill();
-        db.close();
-      } finally {
-        if (db.isOpen())
-          db.close();
-      }
-    }
+    buildStalePersistedGraphFixture();
 
     // Session 3: reopen, INSERT ONE VECTOR, and only then search. That single insert is the difference between
     // this test and Issue6655StaleGraphPrefixReuseTest, and on the pre-fix code it is enough to lose the reuse
@@ -237,6 +213,113 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
             .contains(inSessionDocRid);
       } finally {
         db.drop();
+      }
+    }
+  }
+
+  /**
+   * The same reopen, with several searchers hitting the index at once instead of one.
+   * <p>
+   * The reuse decision is made under {@code graphBuildLock} but the graph is published later, in
+   * {@code reuseStalePrefixGraph()}, after that mutex has been released and re-acquired. The latch is therefore
+   * cleared at PUBLISH time, not at decision time: clearing it at decision time would leave a window in which
+   * {@code graphState} is already MUTABLE (this session wrote before it searched), the latch is false, and
+   * {@code graphIndex} is still null - and a second search thread landing in it would skip
+   * {@code ensureGraphAvailable()} entirely, read the null graph as "small" and run the whole synchronous rebuild
+   * this fix exists to remove, on a race rather than on a promotion (PR #6784 review).
+   * <p>
+   * What is pinned here is what survives that window either way: every concurrent searcher gets a correct answer,
+   * exactly one reuse is published no matter how many threads reached the decision, and each pending vector is
+   * still buffered exactly once - the dedup in {@code reuseStalePrefixGraph()} has to hold when two callers race
+   * for the publish lock, not only when one runs alone.
+   */
+  @Test
+  void concurrentSearchersOnAWroteFirstReopenStillPublishExactlyOneReuse() throws Exception {
+    buildStalePersistedGraphFixture();
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+        populate(db, IN_SESSION_DOC_ID, IN_SESSION_DOC_ID + 1);
+        final RID inSessionDocRid = ridOf(db, IN_SESSION_DOC_ID);
+
+        final int searchers = 8;
+        final CyclicBarrier startTogether = new CyclicBarrier(searchers);
+        final List<Callable<List<Pair<RID, Float>>>> tasks = new ArrayList<>(searchers);
+        for (int i = 0; i < searchers; i++)
+          tasks.add(() -> {
+            startTogether.await(30, TimeUnit.SECONDS);
+            return index.findNeighborsFromVector(embedding(IN_SESSION_DOC_ID), 5, 64);
+          });
+
+        final ExecutorService pool = Executors.newFixedThreadPool(searchers);
+        try {
+          for (final Future<List<Pair<RID, Float>>> future : pool.invokeAll(tasks))
+            assertThat(future.get(60, TimeUnit.SECONDS).stream().map(Pair::getFirst))
+                .as("every concurrent searcher must find the vector this session wrote before searching, whether "
+                    + "it published the reuse, waited for it, or was served from the delta buffer alone")
+                .contains(inSessionDocRid);
+        } finally {
+          pool.shutdownNow();
+        }
+
+        assertThat(index.getStats().get("stalePrefixGraphReuses"))
+            .as("exactly one reuse must be published however many threads reached the decision - the losers must "
+                + "discard their work on the graphIndex double-check, not publish a second time")
+            .isEqualTo(1L);
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("and the gap must still be buffered exactly once under contention: %d from the crashed session "
+                + "plus the 1 this session wrote", GAP_VECTORS)
+            .isEqualTo((long) (GAP_VECTORS + 1));
+        assertThat(index.getStats().get("mutationsSinceRebuild"))
+            .as("counted exactly once each, for the same reason")
+            .isEqualTo((long) (GAP_VECTORS + 1));
+
+        // Teardown hygiene, not an assertion about the fix: the reuse kicks off an async rebuild, and dropping the
+        // database out from under it leaves it persisting a graph into files that are going away.
+        Awaitility.await("the async rebuild kicked off by the stale-prefix reuse settles before the drop")
+            .atMost(Duration.ofSeconds(60))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * Sessions 1 and 2, shared by both tests: build and persist a graph over exactly {@code NUM_VECTORS} and close
+   * cleanly, then write {@code GAP_VECTORS} more committed records and CRASH instead of closing, so the persisted
+   * graph and its manifest stay exactly as session 1 left them - describing only the first {@code NUM_VECTORS}
+   * records - while the live vector count grows. Same fixture as {@code Issue6655StaleGraphPrefixReuseTest}, which
+   * is deliberate: these tests differ from that one only in what the reopening session does.
+   */
+  private void buildStalePersistedGraphFixture() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db, 0, NUM_VECTORS);
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState")).as("precondition: graph must be built and IMMUTABLE first")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        populate(db, NUM_VECTORS, NUM_VECTORS + GAP_VECTORS);
+        ((DatabaseInternal) db).kill();
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
       }
     }
   }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6772: the ingest-then-query arm of issue #6655's stale-prefix reuse.
+ * <p>
+ * {@code put()}/{@code putBatch()}/{@code remove()} promote {@code graphState} from {@code LOADING} straight to
+ * {@code MUTABLE} on the first write of a session. {@code ensureGraphAvailable()} used to return at its first
+ * statement on anything but {@code LOADING}, so a session that wrote before it searched never loaded the persisted
+ * graph at all: {@code graphIndex} stayed null, #6655's prefix test was unreachable - not because any of its guards
+ * failed, but because the method exited before reaching them - and {@code rebuildGraphBeforeSearch()} then read that
+ * null as "small graph" and rebuilt the WHOLE index synchronously on the search thread. Which is the ordinary
+ * ingest-then-query shape, and the one #6655's own test does not cover: its searches follow writes made by a
+ * PREVIOUS session, never one in the searching session.
+ * <p>
+ * Three things are pinned, because no one of them alone would fail on the pre-fix code for the right reason:
+ * <ul>
+ *   <li>the reuse counter and the graph's node count, which say the persisted prefix was reused rather than the
+ *       whole live set rebuilt - the two state facts the issue reports as stable across runs while wall clock is
+ *       not;</li>
+ *   <li>the delta buffer holding each pending vector exactly once, which is what a naive "make the gate reachable"
+ *       fix gets wrong: this session's own writes are already in the buffer AND inside the gap past the persisted
+ *       prefix, so queuing the gap wholesale would duplicate every one of them;</li>
+ *   <li>the answer itself - both a vector written by the crashed session and one written by THIS session, before
+ *       the search, must come back from the very first query.</li>
+ * </ul>
+ * <p>
+ * Same fixture as {@code Issue6655StaleGraphPrefixReuseTest} (128 dimensions, {@code maxConnections=64},
+ * {@code beamWidth=400}, 20,000 vectors), for the same reason: a full rebuild has to reliably take multiple real
+ * seconds, or the timing tripwire cannot fail on the pre-fix code by accident.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+// Spends most of its time waiting on the async rebuild LSMVectorIndex.REBUILD_SEMAPHORE serializes
+// JVM-wide (see CLAUDE.md's @Tag("vector") note) - the vector lane is where that convoy costs nobody
+// else anything; the slow lane still has other REBUILD_SEMAPHORE waiters this one would convoy against.
+@Tag("vector")
+class Issue6772WriteBeforeSearchPrefixReuseTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6772WriteBeforeSearchPrefixReuseTest";
+  private static final int    DIMENSIONS      = 128;
+  private static final int    NUM_VECTORS     = 20_000;
+  private static final int    GAP_VECTORS     = 200;
+  private static final int    MAX_CONNECTIONS = 64;
+  private static final int    BEAM_WIDTH      = 400;
+
+  /** The single record the searching session writes before it searches - the whole point of this test. */
+  private static final int IN_SESSION_DOC_ID = NUM_VECTORS + GAP_VECTORS;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void aSessionThatInsertsBeforeItSearchesStillReusesThePersistedGraphAsAPrefix() throws Exception {
+    // Session 1: build and persist a graph over exactly NUM_VECTORS, then close cleanly - the persisted graph and
+    // its manifest end up describing precisely the first NUM_VECTORS records.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db, 0, NUM_VECTORS);
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState")).as("precondition: graph must be built and IMMUTABLE first")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Session 2: write GAP_VECTORS more records (committed, so WAL-durable), then crash instead of closing
+    // cleanly, so the persisted graph and manifest stay exactly as session 1 left them - describing only the
+    // first NUM_VECTORS records - while the live vector count grows. Same setup as
+    // Issue6655StaleGraphPrefixReuseTest, which is deliberate: this test differs from that one in session 3 only.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        populate(db, NUM_VECTORS, NUM_VECTORS + GAP_VECTORS);
+        ((DatabaseInternal) db).kill();
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Session 3: reopen, INSERT ONE VECTOR, and only then search. That single insert is the difference between
+    // this test and Issue6655StaleGraphPrefixReuseTest, and on the pre-fix code it is enough to lose the reuse
+    // entirely: the write promotes graphState to MUTABLE, ensureGraphAvailable() returns at its first statement
+    // for the rest of the session, and the first search rebuilds all 20,201 vectors synchronously.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("cnt"))
+              .as("precondition: WAL recovery must have restored every record from the crashed session")
+              .isEqualTo((long) (NUM_VECTORS + GAP_VECTORS));
+        }
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("precondition: nothing must have rebuilt yet in this fresh session").isZero();
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: the graph is still unloaded - no search has run in this session yet")
+            .isEqualTo(0L); // GraphState.LOADING
+
+        populate(db, IN_SESSION_DOC_ID, IN_SESSION_DOC_ID + 1);
+
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: the in-session write must have promoted the state past LOADING - that promotion "
+                + "is exactly what used to make the persisted graph unreachable")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("precondition: only this session's own write is buffered so far").isEqualTo(1L);
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: above the async-rebuild threshold, otherwise this is the pre-existing small-graph "
+                + "synchronous path, unaffected by this fix")
+            .isGreaterThanOrEqualTo(1000L);
+
+        final RID crashedSessionDocRid = ridOf(db, NUM_VECTORS); // first record written after the persisted build
+        final RID inSessionDocRid = ridOf(db, IN_SESSION_DOC_ID);
+
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        final List<Pair<RID, Float>> results = index.findNeighborsFromVector(embedding(IN_SESSION_DOC_ID), 5, 64);
+        // The stopwatch keeps running across the cheap getStats() assertions below and is asserted on after
+        // them - see the comment there.
+        // The state facts are asserted before the wall clock, deliberately: the issue reports the elapsed time
+        // moving between runs (7.5x to 15.9x) while these two counters do not, so they are what should name the
+        // regression when this test goes red, with the timing tripwire below as the corroborating - not the
+        // leading - signal.
+        assertThat(index.getStats().get("stalePrefixGraphReuses"))
+            .as("the reuse path must run for a session that wrote before it searched, exactly as it does for one "
+                + "that did not (issue #6772)")
+            .isEqualTo(1L);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("no synchronous rebuild may have run on the calling thread for this search to have returned "
+                + "already").isZero();
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("the graph in memory must be the persisted PREFIX, not a graph rebuilt over the whole live set")
+            .isEqualTo((long) NUM_VECTORS);
+
+        // The duplicate check. This session's own write is already in the delta buffer AND inside the gap past
+        // the persisted prefix, so a reuse that queued the gap wholesale would buffer it twice - and count it
+        // twice in mutationsSinceRebuild.
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("every vector missing from the persisted prefix must be buffered exactly once: the %d written by "
+                + "the crashed session plus the 1 written by this one, with no duplicate of this session's own "
+                + "write", GAP_VECTORS)
+            .isEqualTo((long) (GAP_VECTORS + 1));
+        assertThat(index.getStats().get("mutationsSinceRebuild"))
+            .as("and counted exactly once each, for the same reason")
+            .isEqualTo((long) (GAP_VECTORS + 1));
+
+        // Measured on this fixture: a prefix reuse returns in well under a second; a full synchronous rebuild of
+        // 20,201 vectors at these build parameters takes several real seconds. The bound is a tripwire between
+        // the two, wide on both sides.
+        stopwatch.assertGaveUpWithin(2_000,
+            "a search that reuses a stale prefix graph from one that ran a full synchronous rebuild to completion");
+
+        // Both kinds of pending vector must already be findable by their own embedding - a record is always its
+        // own nearest neighbour - proving the reuse did not trade correctness for the latency win.
+        assertThat(results.stream().map(Pair::getFirst))
+            .as("the vector this session wrote before searching must be found by the very first query")
+            .contains(inSessionDocRid);
+        assertThat(index.findNeighborsFromVector(embedding(NUM_VECTORS), 5, 64).stream().map(Pair::getFirst))
+            .as("so must a vector written by the crashed session, which only the queued gap makes searchable")
+            .contains(crashedSessionDocRid);
+
+        // The async rebuild kicked off by the reuse eventually folds everything into the graph proper.
+        Awaitility.await("the async rebuild kicked off by the stale-prefix reuse completes")
+            .atMost(Duration.ofSeconds(60))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isEqualTo(1L));
+
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("once the deferred rebuild completes the graph covers every live vector")
+            .isEqualTo((long) (NUM_VECTORS + GAP_VECTORS + 1));
+
+        final List<Pair<RID, Float>> afterRebuild = index.findNeighborsFromVector(embedding(IN_SESSION_DOC_ID), 5,
+            64);
+        assertThat(afterRebuild.stream().map(Pair::getFirst))
+            .as("and the in-session vector must still be found once it is folded into the graph proper, not only "
+                + "while it sat in the delta buffer")
+            .contains(inSessionDocRid);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static void populate(final Database db, final int fromInclusive, final int toExclusive) {
+    db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+      if ((i - fromInclusive) % 1000 == 999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  /** Deterministic per-id embedding, so any record's own vector can be reconstructed independently at query time. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x6655L * 31 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static RID ridOf(final Database db, final int id) {
+    try (final ResultSet rs = db.query("sql", "SELECT @rid FROM Doc WHERE id = ?", id)) {
+      assertThat(rs.hasNext()).as("the record must exist").isTrue();
+      return rs.next().getProperty("@rid");
+    }
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
@@ -141,7 +141,10 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
     try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
       final Database db = factory.open();
       try {
-        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+        // count(`@rid`) rather than count(*): the latter answers from the maintained counter, which is written by
+        // the very session kill() interrupted, so it can agree with the expected number while the records are
+        // absent. This precondition is about what WAL recovery actually restored, so it has to count records.
+        try (final ResultSet rs = db.query("sql", "SELECT count(`@rid`) as cnt FROM Doc")) {
           assertThat(rs.next().<Long>getProperty("cnt"))
               .as("precondition: WAL recovery must have restored every record from the crashed session")
               .isEqualTo((long) (NUM_VECTORS + GAP_VECTORS));


### PR DESCRIPTION
Fixes #6772

## The bug

`put()`/`putBatch()`/`remove()` promote `graphState` from `LOADING` straight to `MUTABLE` on the first write of a session. `ensureGraphAvailable()` returned at its first statement on anything but `LOADING`:

```java
if (graphState != GraphState.LOADING)
  return; // Graph already available or being built
```

So a session that INSERTS before it SEARCHES - the ordinary ingest-then-query shape - never loaded the persisted graph at all. `graphIndex` stayed null, #6655's prefix-reuse test was unreachable (not because any of its guards failed, but because the method exited before reaching them), and `rebuildGraphBeforeSearch()` then read that null as "small graph":

```java
final boolean isSmallGraph = graphIndex == null || graphIndex.size() < ASYNC_REBUILD_MIN_GRAPH_SIZE;
if (isSmallGraph)
  buildGraphFromScratch();   // the WHOLE index, synchronously, on the search thread
```

The reporter measures 10M vectors, one insert, one search: 2,496,097 ms after #6067's deferral against 2,360,720 ms before it. The same session without the search is 49.8 ms. At 20,000 vectors the read-only arm returns in 215 ms with `stalePrefixGraphReuses=1`; the wrote-first arm takes 2,618 ms with `stalePrefixGraphReuses=0` and ends with a graph over every live vector rather than over the persisted prefix.

Not a regression in #6067 or #6655. What changed is that it is now the whole remaining cost, and that #6655 built the fast path this session cannot get to.

## Root cause

The promotion is the bug. After it, "a loaded graph now has pending deltas" and "no graph has been loaded yet and there are pending deltas" are the same state. `needsGraphBuild()`'s javadoc already names exactly this distinction for the close path:

> LOADING means "not loaded into memory", which is not the same as "not persisted on disk"

## The fix

**Make the distinction explicit rather than derived.** A dedicated latch, `persistedGraphUnresolved`, answers "has this instance decided yet what to do with whatever graph is on disk?" - a question `graphState` cannot answer once a write has promoted it. The three gates the issue identifies (`ensureGraphAvailable()`'s entry, its post-lock recheck, and `reuseStalePrefixGraph()`'s own) now consult `graphNotYetMaterialised()`:

```java
return graphState == GraphState.LOADING || (persistedGraphUnresolved && graphIndex == null);
```

The `graphIndex == null` conjunct is the structural half: whatever the latch says, an index with a graph already in memory has nothing left to resolve, so a publish path that forgets to clear the latch cannot make every search reload and re-validate a resident graph. The latch is cleared exactly once, in `ensureGraphAvailable()`'s `graphBuildLock` finally (every exit has settled the question, including a load that threw and fell through) and at the head of `buildGraphFromScratchWithRetry()` (whatever is on disk is about to be superseded). A build that fails outright leaves `graphState` at `LOADING`, which the first disjunct still answers true on, so the retry path is unaffected.

### Why reaching the reuse was only half of it

A session that wrote before it searched arrives with its own writes already in `deltaVectors` AND, because those writes went into the location index too, inside the gap past the persisted prefix. Queuing the gap wholesale - which is exactly what a minimal "make the gate reachable" fix does - would buffer every one of them twice and double-count them in `mutationsSinceSerialize`. `reuseStalePrefixGraph()` now filters the gap against the buffer twice:

- **before the read**, because skipping the read is most of the point: a session that inserted a million vectors before its first query would otherwise pay a page lookup per vector to fetch back what is already in memory beside it;
- **again under the publish lock**, to catch anything a concurrent writer queued while the gap was being read unlocked.

Its double-check moves from `graphState` to `graphIndex` for the same reason the entry gate did - `graphState` is no longer `LOADING` on the path it now also serves - with an `IMMUTABLE` arm for the one publisher that leaves `graphIndex` null (a from-scratch build that found no valid vectors at all).

`IntHashSet` rather than a `HashSet<Integer>` for both filters: primitive, no boxing, sized in table slots so neither rehashes on the way in.

### On the alternative the issue rules out

The issue is right that stopping `:3525` from treating a null `graphIndex` as small is unsound - the search would fall into the delta-only branch and answer from `deltaVectors` alone. This fix does not leave `graphIndex` null; it fills it with the persisted prefix, which is what makes the async arm correct to take.

## Test

`Issue6772WriteBeforeSearchPrefixReuseTest` is `Issue6655StaleGraphPrefixReuseTest`'s fixture (128 dimensions, `maxConnections=64`, `beamWidth=400`, 20,000 vectors, a crashed session leaving 200 more) differing in one thing: session 3 inserts one vector before it searches. It pins, in this order:

1. `stalePrefixGraphReuses == 1` and `graphNodeCount == 20,000` - the two state facts the issue reports as stable across runs while wall clock is not, so they are what names the regression when this goes red;
2. `deltaVectorsCount == 201` and `mutationsSinceRebuild == 201` - each pending vector buffered and counted exactly once, the duplicate check a naive fix fails;
3. the answer: both a vector written by the crashed session and the one written by THIS session, before the search, come back from the very first query;
4. only then the `assertGaveUpWithin(2_000, ...)` tripwire.

Verified failing on `main`'s code for reason (1) - "the reuse path must run for a session that wrote before it searched" - and passing with the fix.

Tagged `@Tag("vector")`, same lane and same reason as the #6655 test.

## Verification

- `Issue6772WriteBeforeSearchPrefixReuseTest`: fails without the main-source change, passes with it
- `com.arcadedb.index.vector.**` with no group exclusions: **429 tests, 0 failures**
- `com.arcadedb.function.sql.vector.**`, `SelectVectorTest`, `CypherCallVectorNeighborsTest`, `DatabaseLifecycleBackgroundThreadsTest`: **323 tests, 0 failures**

## Files changed

- `engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java`
- `engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector index recovery after writes made before the first search.
  * Reuses persisted graph data instead of triggering unnecessary synchronous rebuilds.
  * Prevents duplicate vectors and preserves concurrent writes during index updates.
  * Ensures newly added vectors remain searchable across reopened sessions.
* **Tests**
  * Added regression coverage for prefix reuse, deduplication, search performance, and eventual asynchronous rebuilding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->