### PR TITLE
fix(#6753): one backup at a time per database, and a target path that is claimed, not checked

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
@@ -86,7 +86,9 @@ public class BackupSettings {
     }
 
     if (file == null)
-      // ASSIGN DEFAULT FILENAME
+      // ASSIGN DEFAULT FILENAME. THE SERVER REPEATS THIS CONVENTION IN BackupCoordinator - IT CANNOT DEPEND ON THIS
+      // MODULE - AND ITS RETENTION READS BACK BOTH, SO CHANGE ONE AND CHANGE THE OTHER;
+      // theDefaultNameOfACliOrSqlBackupFollowsTheSameConvention FAILS THE MOMENT THEY DRIFT
       if ("full".equals(format)) {
         final DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmssSSS");
         file = "%s-backup-%s.zip".formatted(databaseName, dateFormat.format(System.currentTimeMillis()));

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -321,7 +321,9 @@ public class FullBackupFormat extends AbstractBackupFormat {
     try {
       Files.createFile(backupFile.toPath());
     } catch (final FileAlreadyExistsException e) {
-      throw new BackupException("The backup file '%s' already exist and '-o' setting is false".formatted(settings.file));
+      // THE RESOLVED PATH, NOT settings.file: THE POINT OF THIS MESSAGE IS TO TELL AN OPERATOR WHICH ARCHIVE IS IN
+      // THE WAY, AND THE NAME THE CALLER TYPED IS RELATIVE TO A DIRECTORY THEY DID NOT NECESSARILY CHOOSE
+      throw new BackupException("The backup file '%s' already exist and '-o' setting is false".formatted(backupFile));
     } catch (final IOException e) {
       throw new BackupException("The backup file '%s' cannot be created".formatted(backupFile), e);
     }

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -44,6 +44,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.security.SecureRandom;
 import java.security.spec.KeySpec;
 import java.util.ArrayList;
@@ -75,11 +77,8 @@ public class FullBackupFormat extends AbstractBackupFormat {
 
     final File backupFile = new File(fileName);
 
-    if (backupFile.exists() && !settings.overwriteFile)
-      throw new BackupException("The backup file '%s' already exist and '-o' setting is false".formatted(settings.file));
-
     if (backupFile.getParentFile() != null && !backupFile.getParentFile().exists()) {
-      if (!backupFile.getParentFile().mkdirs())
+      if (!backupFile.getParentFile().mkdirs() && !backupFile.getParentFile().isDirectory())
         throw new BackupException("The backup file '%s' cannot be created".formatted(backupFile));
     }
 
@@ -89,6 +88,10 @@ public class FullBackupFormat extends AbstractBackupFormat {
     final int compressionLevel = resolveSetting(settings.compressionLevel, GlobalConfiguration.BACKUP_COMPRESSION_LEVEL);
     final int compressionThreads = resolveThreads();
     final int maxMBPerSecond = resolveSetting(settings.maxMBPerSecond, GlobalConfiguration.BACKUP_MAX_MB_PER_SECOND);
+
+    // LAST THING BEFORE THE WRITE, SO THAT A BACKUP REJECTED BY ONE OF THE CHECKS ABOVE LEAVES NO EMPTY ARCHIVE FOR
+    // RETENTION TO COUNT AND FOR AN OPERATOR TO MISTAKE FOR A BACKUP
+    claimBackupFile(backupFile);
 
     logger.logLine(0, "Executing full backup of database to '%s' (compression level %d, %s%s)...", backupFile,
         compressionLevel, compressionThreads > 0 ? compressionThreads + " threads" : "single threaded",
@@ -134,10 +137,16 @@ public class FullBackupFormat extends AbstractBackupFormat {
         // SAFETY NETS ONLY TEACH THE NEXT READER THAT THE THROW ABOVE MIGHT NOT HAPPEN
         break;
       } catch (final PageSnapshotException e) {
-        // A PARTIAL ARCHIVE MUST NOT SURVIVE: LEAVING ONE BEHIND INVITES A RESTORE FROM IT
-        backupFile.delete();
-        if (!snapshotAttempt)
+        if (!snapshotAttempt) {
+          // A PARTIAL ARCHIVE MUST NOT SURVIVE: LEAVING ONE BEHIND INVITES A RESTORE FROM IT
+          backupFile.delete();
           throw e;
+        }
+        // ON THE WAY TO A RETRY THE PARTIAL ARCHIVE IS KEPT, NOT DELETED: DELETING IT WOULD HAND THE PATH BACK TO
+        // ANYBODY ELSE RACING FOR IT (SEE claimBackupFile), AND THE RETRY OPENS THE SAME FILE WITH TRUNCATE, SO THE
+        // PARTIAL CONTENT IS GONE THE MOMENT THE SECOND ATTEMPT STARTS WRITING. A RETRY THAT FAILS IN TURN LANDS IN
+        // ONE OF THE TWO BRANCHES THAT DO DELETE, SO A PARTIAL ARCHIVE STILL NEVER SURVIVES THE CALL
+        //
         // THE WINDOW COULD NOT HOLD THE POINT IN TIME (THE SHADOW BREACHED ITS CAP, OR A PRE-IMAGE COULD NOT BE READ).
         // A STREAMED ARCHIVE CANNOT BE REPAIRED IN PLACE, SO THE WHOLE BACKUP RESTARTS ON THE PATH THAT ALWAYS
         // COMPLETES - AT THE COST OF THROTTLING WRITERS, WHICH IS STILL BETTER THAN NOT HAVING A BACKUP
@@ -287,6 +296,30 @@ public class FullBackupFormat extends AbstractBackupFormat {
           archive.abort();
       }
     });
+  }
+
+  /**
+   * Takes ownership of the target path before a single byte is written, by creating the file itself rather than by
+   * asking whether it exists. The check-then-create it replaces was a TOCTOU: two backups of the same database landing
+   * on the same name - the scheduler's periodic tick and an operator's "backup now", two nodes writing to a shared
+   * directory - both saw a free path, both opened their own stream on it, and interleaved their output into one
+   * unreadable archive that each of them reported as a success (issue #6753). Whoever loses the create now fails
+   * before it can touch the winner's file, including its delete-on-failure cleanup.
+   * <p>
+   * With {@code -o} the caller has asked for the existing file to be replaced, so there is nothing to claim and the
+   * write below truncates whatever is there.
+   */
+  private void claimBackupFile(final File backupFile) {
+    if (settings.overwriteFile)
+      return;
+
+    try {
+      Files.createFile(backupFile.toPath());
+    } catch (final FileAlreadyExistsException e) {
+      throw new BackupException("The backup file '%s' already exist and '-o' setting is false".formatted(settings.file));
+    } catch (final IOException e) {
+      throw new BackupException("The backup file '%s' cannot be created".formatted(backupFile), e);
+    }
   }
 
   private interface StreamCallback {

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -77,9 +77,14 @@ public class FullBackupFormat extends AbstractBackupFormat {
 
     final File backupFile = new File(fileName);
 
-    if (backupFile.getParentFile() != null && !backupFile.getParentFile().exists()) {
-      if (!backupFile.getParentFile().mkdirs() && !backupFile.getParentFile().isDirectory())
-        throw new BackupException("The backup file '%s' cannot be created".formatted(backupFile));
+    if (backupFile.getParentFile() != null) {
+      // createDirectories, not mkdirs: it is idempotent and does not report "already there" as a failure, so a
+      // concurrent backup creating the same directory first is not mistaken for one that could not be created
+      try {
+        Files.createDirectories(backupFile.getParentFile().toPath());
+      } catch (final IOException e) {
+        throw new BackupException("The backup file '%s' cannot be created".formatted(backupFile), e);
+      }
     }
 
     if (database.isTransactionActive() && database.getTransaction().hasChanges())

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue6753ConcurrentBackupTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue6753ConcurrentBackupTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.backup;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Two backups of the same database that resolve to the same archive path must not both write to it: the
+ * {@code exists()} pre-check is a TOCTOU, so both used to open their own stream on the same file and interleave their
+ * output into a single, unreadable archive - or, when one of them failed, delete the other one's finished work
+ * (issue #6753).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6753ConcurrentBackupTest extends TestHelper {
+  private static final String BACKUP_DIRECTORY = "target/backups/issue6753";
+  private static final String ARCHIVE_NAME     = "same-name-backup.zip";
+
+  @BeforeEach
+  void populateAndCleanBackupDirectory() {
+    FileUtils.deleteRecursively(Path.of(BACKUP_DIRECTORY).toFile());
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("payload", Type.STRING);
+      for (int i = 0; i < 20_000; i++)
+        database.newDocument("Doc").set("payload", "payload-" + i).save();
+    });
+  }
+
+  @AfterEach
+  void cleanBackupDirectory() {
+    FileUtils.deleteRecursively(Path.of(BACKUP_DIRECTORY).toFile());
+  }
+
+  @Test
+  void twoBackupsRacingOnTheSameArchiveNameLeaveOneReadableArchive() throws Exception {
+    final CyclicBarrier startTogether = new CyclicBarrier(2);
+    final AtomicInteger succeeded = new AtomicInteger();
+    final AtomicInteger refused = new AtomicInteger();
+
+    final ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      final Future<?>[] runs = new Future<?>[2];
+      for (int i = 0; i < 2; i++)
+        runs[i] = executor.submit(() -> {
+          startTogether.await();
+          try {
+            new Backup(database, ARCHIVE_NAME).setDirectory(BACKUP_DIRECTORY).setVerboseLevel(0).backupDatabase();
+            succeeded.incrementAndGet();
+          } catch (final BackupException e) {
+            refused.incrementAndGet();
+          }
+          return null;
+        });
+
+      for (final Future<?> run : runs)
+        run.get(120, TimeUnit.SECONDS);
+    } finally {
+      executor.shutdownNow();
+    }
+
+    // EXACTLY ONE OF THE TWO OWNS THE PATH: THE OTHER HAS TO BE TURNED AWAY, NOT LET INTO THE SAME FILE
+    assertThat(succeeded.get()).isEqualTo(1);
+    assertThat(refused.get()).isEqualTo(1);
+
+    final File archive = new File(BACKUP_DIRECTORY, ARCHIVE_NAME);
+    assertThat(archive).exists();
+    assertThat(archive.length()).isGreaterThan(0);
+
+    // AND WHAT IT LEFT BEHIND IS A REAL ARCHIVE, NOT TWO INTERLEAVED ONES
+    try (final ZipFile zip = new ZipFile(archive)) {
+      assertThat(zip.size()).isGreaterThan(0);
+    }
+  }
+
+  @Test
+  void aBackupRejectedBeforeItWritesLeavesNoEmptyArchiveBehind() {
+    database.begin();
+    database.newDocument("Doc").set("payload", "uncommitted").save();
+    try {
+      assertThatThrownBy(
+          () -> new Backup(database, ARCHIVE_NAME).setDirectory(BACKUP_DIRECTORY).setVerboseLevel(0).backupDatabase())
+          .isInstanceOf(BackupException.class)
+          .rootCause()
+          .hasMessageContaining("Transaction in progress");
+    } finally {
+      database.rollback();
+    }
+
+    // THE PATH IS CLAIMED BY CREATING THE FILE, SO IT HAS TO BE CLAIMED AFTER THE CHECKS THAT CAN REFUSE THE BACKUP:
+    // AN EMPTY ARCHIVE IS ONE RETENTION WOULD COUNT AND AN OPERATOR WOULD MISTAKE FOR A BACKUP
+    assertThat(new File(BACKUP_DIRECTORY, ARCHIVE_NAME)).doesNotExist();
+  }
+
+  @Test
+  void anExistingArchiveIsNeverDeletedByAnotherBackupThatFindsItInTheWay() throws Exception {
+    Files.createDirectories(Path.of(BACKUP_DIRECTORY));
+    final Path finished = Path.of(BACKUP_DIRECTORY, ARCHIVE_NAME);
+    Files.writeString(finished, "an archive somebody else already finished");
+
+    assertThatThrownBy(
+        () -> new Backup(database, ARCHIVE_NAME).setDirectory(BACKUP_DIRECTORY).setVerboseLevel(0).backupDatabase())
+        .isInstanceOf(BackupException.class)
+        .rootCause()
+        .hasMessageContaining("already exist");
+
+    assertThat(Files.readString(finished)).isEqualTo("an archive somebody else already finished");
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue6753ConcurrentBackupTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue6753ConcurrentBackupTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -68,6 +69,9 @@ class Issue6753ConcurrentBackupTest extends TestHelper {
   }
 
   @Test
+  // PLAIN HANG DETECTOR, NOT A LATENCY BOUND: THE TWO BACKUPS TAKE A FRACTION OF A SECOND EACH, AND ONLY A DEADLOCK
+  // BETWEEN THEM COULD REACH THIS
+  @Timeout(value = 300, unit = TimeUnit.SECONDS)
   void twoBackupsRacingOnTheSameArchiveNameLeaveOneReadableArchive() throws Exception {
     final CyclicBarrier startTogether = new CyclicBarrier(2);
     final AtomicInteger succeeded = new AtomicInteger();
@@ -89,7 +93,7 @@ class Issue6753ConcurrentBackupTest extends TestHelper {
         });
 
       for (final Future<?> run : runs)
-        run.get(120, TimeUnit.SECONDS);
+        run.get();
     } finally {
       executor.shutdownNow();
     }

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -36,6 +36,7 @@ import com.arcadedb.query.QueryEngineManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ai.AiConfiguration;
+import com.arcadedb.server.backup.BackupCoordinator;
 import com.arcadedb.server.event.FileServerEventLog;
 import com.arcadedb.server.event.ServerEventLog;
 import com.arcadedb.server.http.HttpServer;
@@ -132,6 +133,11 @@ public class ArcadeDBServer {
   private volatile    HttpServer                            httpServer;
   private             AiConfiguration                       aiConfiguration;
   private             ServerQueryProfiler                   queryProfiler;
+  // Admission for backups of a database, shared by every entry point that can start one on this server: the
+  // auto-backup schedule, its immediate trigger, and the HTTP "trigger backup" command (issue #6753). Created with
+  // the server rather than with the auto-backup plugin, because the HTTP command backs a database up whether or not
+  // that plugin is enabled.
+  private final       BackupCoordinator                     backupCoordinator                    = new BackupCoordinator();
   private final       ConcurrentMap<String, ServerDatabase> databases                            = new ConcurrentHashMap<>();
   // Monitor serialising every check-then-act on the database registry (load, create, register, reopen). The HA
   // snapshot installer also holds it across close->file-swap->reopen so no concurrent open observes the transient
@@ -993,6 +999,14 @@ public class ArcadeDBServer {
 
   public ServerQueryProfiler getQueryProfiler() {
     return queryProfiler;
+  }
+
+  /**
+   * Admits one backup at a time per database, across every backup entry point this server has, and names the archives
+   * they write (issue #6753).
+   */
+  public BackupCoordinator getBackupCoordinator() {
+    return backupCoordinator;
   }
 
   public void registerTestEventListener(final ReplicationCallback callback) {

--- a/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Admits one backup at a time per database across every backup entry point a server has, and names the archives they
+ * produce.
+ * <p>
+ * Before this existed each entry point was on its own: the scheduler's periodic chain never overlapped itself, but an
+ * immediate trigger was an independent submit on the same pool, and the HTTP "trigger backup" command ran its own
+ * backup inline on the request thread. Any two of them could therefore back up one database at the same time - and
+ * because both built the archive name from a second-precision timestamp, two starting in the same second resolved to
+ * the same path (issue #6753).
+ * <p>
+ * There are two answers to that here, and both are needed. The names carry milliseconds, matching what
+ * {@code BackupSettings} has always used for the default name of a CLI or SQL backup, so the three server-side
+ * conventions agree instead of being coarser than the one they imitate. And an in-progress database is admitted only
+ * once, which is what stops the second backup from being started at all: two full backups of one database running
+ * together read and compress the same data twice for one usable archive, so the redundant one is refused rather than
+ * queued - the caller is told, and a periodic schedule simply covers it on the next tick.
+ * <p>
+ * The admission is per server instance, not per JVM: an HA test - and a co-located pair of nodes - runs several
+ * servers with the same database names in one process, and those backups are genuinely independent.
+ * <p>
+ * This is an admission policy, not the integrity guarantee. A backup started outside this server (the CLI, another
+ * node writing into a shared directory) cannot be seen from here; what keeps THAT from corrupting an archive is
+ * {@code FullBackupFormat} creating the target file atomically, so the loser of any race fails before it writes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class BackupCoordinator {
+  private static final DateTimeFormatter ARCHIVE_TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmssSSS");
+  /**
+   * Matches the archives this class names, and the second-precision ones every release before it wrote: retention and
+   * the backup listing run over directories that hold both, and a name they cannot parse is a file they silently stop
+   * managing - it would never be listed and never be rotated out.
+   */
+  private static final Pattern           ARCHIVE_NAME_PATTERN     = Pattern.compile(".*-backup-(\\d{8})-(\\d{6}(?:\\d{3})?)\\.zip$");
+  private static final DateTimeFormatter ARCHIVE_TIMESTAMP_PARSER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss[SSS]");
+
+  private final Set<String> inProgress = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Reserves this database for a backup. Returns {@code false} when one is already running, in which case the caller
+   * must not start a backup and must not call {@link #end(String)}.
+   */
+  public boolean begin(final String databaseName) {
+    return inProgress.add(databaseName);
+  }
+
+  /**
+   * Releases the reservation taken by a successful {@link #begin(String)}. Always call it from a {@code finally}: a
+   * reservation leaked by a failed backup would block every later backup of that database until the server restarts.
+   */
+  public void end(final String databaseName) {
+    inProgress.remove(databaseName);
+  }
+
+  public boolean isInProgress(final String databaseName) {
+    return inProgress.contains(databaseName);
+  }
+
+  /**
+   * The name of the archive a backup of this database starting now writes to.
+   */
+  public String newArchiveName(final String databaseName) {
+    return databaseName + "-backup-" + LocalDateTime.now().format(ARCHIVE_TIMESTAMP_FORMAT) + ".zip";
+  }
+
+  /**
+   * The instant encoded in a backup archive's name, or {@code null} when the name does not follow the convention
+   * {@link #newArchiveName(String)} produces. Milliseconds are optional, so an archive written by an older release
+   * still reads back.
+   */
+  public static LocalDateTime parseArchiveTimestamp(final String fileName) {
+    final Matcher matcher = ARCHIVE_NAME_PATTERN.matcher(fileName);
+    if (!matcher.matches())
+      return null;
+
+    try {
+      return LocalDateTime.parse(matcher.group(1) + "-" + matcher.group(2), ARCHIVE_TIMESTAMP_PARSER);
+    } catch (final RuntimeException e) {
+      return null;
+    }
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
@@ -37,7 +37,10 @@ import java.util.regex.Pattern;
  * <p>
  * There are two answers to that here, and both are needed. The names carry milliseconds, matching what
  * {@code BackupSettings} has always used for the default name of a CLI or SQL backup, so the three server-side
- * conventions agree instead of being coarser than the one they imitate. And an in-progress database is admitted only
+ * conventions agree instead of being coarser than the one they imitate - the convention is written down twice, since
+ * the server cannot depend on the integration module, and
+ * {@code BackupCoordinatorTest#theDefaultNameOfACliOrSqlBackupFollowsTheSameConvention} fails if the two drift. And
+ * an in-progress database is admitted only
  * once, which is what stops the second backup from being started at all: two full backups of one database running
  * together read and compress the same data twice for one usable archive, so the redundant one is refused rather than
  * queued - the caller is told, and a periodic schedule simply covers it on the next tick.

--- a/server/src/main/java/com/arcadedb/server/backup/BackupRetentionManager.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupRetentionManager.java
@@ -26,14 +26,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.WeekFields;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Manages backup retention with support for both simple max-files and tiered retention policies.
@@ -48,10 +45,6 @@ import java.util.regex.Pattern;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class BackupRetentionManager {
-  private static final Pattern           BACKUP_FILENAME_PATTERN =
-      Pattern.compile(".*-backup-(\\d{8})-(\\d{6})\\.zip$");
-  private static final DateTimeFormatter TIMESTAMP_PARSER        =
-      DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
   private static final FilenameFilter    BACKUP_FILE_FILTER      =
       (dir, name) -> name.endsWith(".zip") && name.contains("-backup-");
 
@@ -199,18 +192,14 @@ public class BackupRetentionManager {
    * Parses the timestamp from a backup filename.
    */
   private LocalDateTime parseBackupTimestamp(final String filename) {
-    final Matcher matcher = BACKUP_FILENAME_PATTERN.matcher(filename);
-    if (!matcher.matches())
-      return null;
-
-    try {
-      final String timestampStr = matcher.group(1) + "-" + matcher.group(2);
-      return LocalDateTime.parse(timestampStr, TIMESTAMP_PARSER);
-    } catch (final Exception e) {
+    // The convention lives on BackupCoordinator, which is also what writes these names: a parser that drifted from
+    // the writer would drop every archive it could not read out of the retention set, which is to say never rotate
+    // them out again (issue #6753).
+    final LocalDateTime timestamp = BackupCoordinator.parseArchiveTimestamp(filename);
+    if (timestamp == null)
       LogManager.instance().log(this, Level.WARNING,
           "Could not parse timestamp from backup filename: %s", filename);
-      return null;
-    }
+    return timestamp;
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/backup/BackupTask.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupTask.java
@@ -32,9 +32,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 
 /**
@@ -43,8 +41,6 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class BackupTask implements Runnable {
-  private static final DateTimeFormatter BACKUP_TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
-
   // Cached reflection objects for better performance
   private static volatile Class<?>                     backupClass;
   private static volatile Constructor<?>               backupConstructor;
@@ -107,6 +103,18 @@ public class BackupTask implements Runnable {
       return;
     }
 
+    // One backup of a database at a time, whichever entry point asked for it: a periodic tick, an immediate trigger
+    // and the HTTP "trigger backup" command are three independent submissions, and two of them running together read
+    // and compress the same database twice for one usable archive - and, when they resolve to the same archive name,
+    // write into the same file (issue #6753). A refused tick costs nothing: the schedule covers this database again
+    // on the next one.
+    final BackupCoordinator coordinator = server.getBackupCoordinator();
+    if (!coordinator.begin(databaseName)) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Skipping backup for database '%s' - a backup of it is already in progress", databaseName);
+      return;
+    }
+
     // Perform the backup
     try {
       LogManager.instance().log(this, Level.INFO, "Starting scheduled backup for database '%s'...", databaseName);
@@ -136,6 +144,8 @@ public class BackupTask implements Runnable {
 
       server.getEventLog().reportEvent(ServerEventLog.EVENT_TYPE.CRITICAL, "Auto-Backup", databaseName,
           "Scheduled backup failed: " + e.getMessage());
+    } finally {
+      coordinator.end(databaseName);
     }
   }
 
@@ -206,9 +216,9 @@ public class BackupTask implements Runnable {
       return null;
     }
 
-    // Generate backup filename
-    final String timestamp = LocalDateTime.now().format(BACKUP_TIMESTAMP_FORMAT);
-    final String backupFileName = databaseName + "-backup-" + timestamp + ".zip";
+    // Generate backup filename. The convention lives on the coordinator so that this task, the HTTP "trigger backup"
+    // command and the default name a CLI or SQL backup gets all agree - and all carry milliseconds (issue #6753).
+    final String backupFileName = server.getBackupCoordinator().newArchiveName(databaseName);
 
     // Prepare backup directory for this database - use Files.createDirectories to avoid TOCTOU
     final Path dbBackupPath = Paths.get(backupDirectory, databaseName);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -34,6 +34,7 @@ import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
 import com.arcadedb.server.backup.AutoBackupConfig;
 import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
+import com.arcadedb.server.backup.BackupCoordinator;
 import com.arcadedb.server.backup.BackupRetentionManager;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.HAServerPlugin;
@@ -64,14 +65,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class PostServerCommandHandler extends AbstractServerHttpHandler {
   private static final HttpClient HTTP_CLIENT           = HttpClient.newHttpClient();
@@ -1038,9 +1036,6 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
         final Path dbBackupDir = Paths.get(backupDirectory, databaseName);
         if (Files.exists(dbBackupDir) && Files.isDirectory(dbBackupDir)) {
-          final Pattern pattern = Pattern.compile(".*-backup-(\\d{8})-(\\d{6})\\.zip$");
-          final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
-
           try (var stream = Files.list(dbBackupDir)) {
             stream.filter(p -> p.toString().endsWith(".zip") && p.getFileName().toString().contains("-backup-"))
                 .sorted(Comparator.reverseOrder())
@@ -1055,17 +1050,9 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
                     backup.put("lastModified", 0);
                   }
 
-                  // Parse timestamp from filename
-                  final Matcher matcher = pattern.matcher(p.getFileName().toString());
-                  if (matcher.matches()) {
-                    try {
-                      final String timestampStr = matcher.group(1) + "-" + matcher.group(2);
-                      final LocalDateTime timestamp = LocalDateTime.parse(timestampStr, formatter);
-                      backup.put("timestamp", timestamp.toString());
-                    } catch (final Exception e) {
-                      backup.put("timestamp", JSONObject.NULL);
-                    }
-                  }
+                  // Parse timestamp from filename, through the same convention that wrote it (issue #6753)
+                  final LocalDateTime timestamp = BackupCoordinator.parseArchiveTimestamp(p.getFileName().toString());
+                  backup.put("timestamp", timestamp != null ? timestamp.toString() : JSONObject.NULL);
 
                   backups.put(backup);
                 });
@@ -1097,6 +1084,25 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     Metrics.counter("http.trigger-backup").increment();
 
     final ArcadeDBServer server = httpServer.getServer();
+
+    // This command runs the backup inline, so it is one of the entry points that can have a database being backed up
+    // at the same time as the auto-backup schedule does - down to resolving to the same archive name and writing into
+    // the same file. Refusing outright is the honest answer to "back up a database that is already being backed up":
+    // a second full backup of the same data produces nothing the first one will not, and the caller gets told rather
+    // than silently handed the other run's archive (issue #6753).
+    final BackupCoordinator coordinator = server.getBackupCoordinator();
+    if (!coordinator.begin(databaseName))
+      return new ExecutionResponse(409, new JSONObject().put("error",
+          "A backup of database '" + databaseName + "' is already in progress").toString());
+
+    try {
+      return executeImmediateBackup(server, databaseName);
+    } finally {
+      coordinator.end(databaseName);
+    }
+  }
+
+  private ExecutionResponse executeImmediateBackup(final ArcadeDBServer server, final String databaseName) {
     final AutoBackupSchedulerPlugin plugin = getBackupPlugin(server);
 
     // Try to get backup directory from config (plugin or file)
@@ -1136,9 +1142,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
         final Database database = server.getDatabase(databaseName);
         final Class<?> clazz = Class.forName("com.arcadedb.integration.backup.Backup");
 
-        final String timestamp = LocalDateTime.now()
-            .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
-        final String backupFileName = databaseName + "-backup-" + timestamp + ".zip";
+        final String backupFileName = server.getBackupCoordinator().newArchiveName(databaseName);
 
         final Path dbBackupPath = Paths.get(backupDirectory, databaseName);
         // Use Files.createDirectories to avoid TOCTOU race condition

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -1169,7 +1169,10 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       }
     }
 
-    // Fallback: use SQL command (uses GlobalConfiguration.SERVER_BACKUP_DIRECTORY)
+    // Fallback: use SQL command (uses GlobalConfiguration.SERVER_BACKUP_DIRECTORY). This one does not name the
+    // archive through the coordinator: with no target the SQL statement lets BackupSettings apply its own default,
+    // which is the same convention down to the milliseconds - the coordinator is where that convention was copied
+    // from in the first place.
     try {
       final Database database = server.getDatabase(databaseName);
       try (final var result = database.command("sql", "backup database")) {

--- a/server/src/test/java/com/arcadedb/server/backup/BackupCoordinatorTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupCoordinatorTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Admission and archive naming, the two halves of what keeps two backups of one database off the same file
+ * (issue #6753).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BackupCoordinatorTest {
+
+  @Test
+  void onlyOneBackupPerDatabaseIsAdmittedAtATime() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+
+    assertThat(coordinator.begin("db")).isTrue();
+    assertThat(coordinator.isInProgress("db")).isTrue();
+    assertThat(coordinator.begin("db")).isFalse();
+
+    coordinator.end("db");
+
+    assertThat(coordinator.isInProgress("db")).isFalse();
+    assertThat(coordinator.begin("db")).isTrue();
+    coordinator.end("db");
+  }
+
+  @Test
+  void adifferentDatabaseIsNeverHeldUp() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+
+    assertThat(coordinator.begin("db1")).isTrue();
+    assertThat(coordinator.begin("db2")).isTrue();
+
+    coordinator.end("db1");
+    coordinator.end("db2");
+  }
+
+  @Test
+  void exactlyOneOfManyConcurrentCallersIsAdmitted() throws Exception {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+    final int callers = 8;
+    final CountDownLatch startTogether = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(callers);
+    final AtomicInteger admitted = new AtomicInteger();
+
+    final ExecutorService executor = Executors.newFixedThreadPool(callers);
+    try {
+      for (int i = 0; i < callers; i++)
+        executor.submit(() -> {
+          try {
+            startTogether.await();
+            if (coordinator.begin("db"))
+              admitted.incrementAndGet();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            done.countDown();
+          }
+          return null;
+        });
+
+      startTogether.countDown();
+      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertThat(admitted.get()).isEqualTo(1);
+  }
+
+  @Test
+  void archiveNamesCarryMilliseconds() {
+    final String name = new BackupCoordinator().newArchiveName("mydb");
+
+    // 8 DIGITS OF DATE, 6 OF TIME AND 3 OF MILLISECONDS: THE SECOND-PRECISION NAME THIS REPLACES MADE TWO BACKUPS
+    // STARTING IN THE SAME SECOND RESOLVE TO ONE PATH
+    assertThat(name).matches("mydb-backup-\\d{8}-\\d{9}\\.zip");
+  }
+
+  @Test
+  void archiveNamesAreReadBackByTheSameConvention() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+    final LocalDateTime before = LocalDateTime.now().minusSeconds(1);
+
+    final LocalDateTime parsed = BackupCoordinator.parseArchiveTimestamp(coordinator.newArchiveName("mydb"));
+
+    assertThat(parsed).isNotNull();
+    assertThat(parsed).isAfterOrEqualTo(before);
+  }
+
+  @Test
+  void secondPrecisionArchivesFromOlderReleasesStillParse() {
+    // RETENTION AND THE BACKUP LISTING RUN OVER DIRECTORIES HOLDING BOTH CONVENTIONS: A NAME THEY CANNOT READ IS A
+    // FILE THEY WOULD NEVER LIST AND NEVER ROTATE OUT
+    assertThat(BackupCoordinator.parseArchiveTimestamp("mydb-backup-20260826-143000.zip"))
+        .isEqualTo(LocalDateTime.of(2026, 8, 26, 14, 30, 0));
+
+    assertThat(BackupCoordinator.parseArchiveTimestamp("mydb-backup-20260826-143000456.zip"))
+        .isEqualTo(LocalDateTime.of(2026, 8, 26, 14, 30, 0, 456_000_000));
+  }
+
+  @Test
+  void aNameThatIsNotAnArchiveHasNoTimestamp() {
+    assertThat(BackupCoordinator.parseArchiveTimestamp("mydb.zip")).isNull();
+    assertThat(BackupCoordinator.parseArchiveTimestamp("mydb-backup-20260826-1430.zip")).isNull();
+    assertThat(BackupCoordinator.parseArchiveTimestamp("mydb-backup-20260826-143000.zip.tmp")).isNull();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/backup/BackupCoordinatorTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupCoordinatorTest.java
@@ -19,8 +19,10 @@
 package com.arcadedb.server.backup;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -64,6 +66,9 @@ class BackupCoordinatorTest {
   }
 
   @Test
+  // PLAIN HANG DETECTOR, NOT A LATENCY BOUND: THE CALLERS DO ONE Set.add EACH, SO ANY REAL RUN FINISHES IN
+  // MICROSECONDS AND ONLY A DEADLOCK COULD REACH THIS
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void exactlyOneOfManyConcurrentCallersIsAdmitted() throws Exception {
     final BackupCoordinator coordinator = new BackupCoordinator();
     final int callers = 8;
@@ -88,7 +93,7 @@ class BackupCoordinatorTest {
         });
 
       startTogether.countDown();
-      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+      done.await();
     } finally {
       executor.shutdownNow();
     }
@@ -107,13 +112,16 @@ class BackupCoordinatorTest {
 
   @Test
   void archiveNamesAreReadBackByTheSameConvention() {
-    final BackupCoordinator coordinator = new BackupCoordinator();
-    final LocalDateTime before = LocalDateTime.now().minusSeconds(1);
+    final String name = new BackupCoordinator().newArchiveName("mydb");
 
-    final LocalDateTime parsed = BackupCoordinator.parseArchiveTimestamp(coordinator.newArchiveName("mydb"));
+    final LocalDateTime parsed = BackupCoordinator.parseArchiveTimestamp(name);
 
+    // A ROUND TRIP RATHER THAN A COMPARISON AGAINST now(): WHAT HAS TO HOLD IS THAT THE PARSER AGREES WITH THE WRITER
+    // DIGIT FOR DIGIT - ONE THAT DRIFTED WOULD DROP EVERY NEW ARCHIVE OUT OF THE RETENTION SET - AND THAT IS A
+    // PROPERTY OF THE TWO SIDES, NOT OF WHAT THE CLOCK SAID IN BETWEEN
     assertThat(parsed).isNotNull();
-    assertThat(parsed).isAfterOrEqualTo(before);
+    assertThat(name).isEqualTo(
+        "mydb-backup-" + parsed.format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmssSSS")) + ".zip");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/backup/BackupCoordinatorTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupCoordinatorTest.java
@@ -55,7 +55,7 @@ class BackupCoordinatorTest {
   }
 
   @Test
-  void adifferentDatabaseIsNeverHeldUp() {
+  void aDifferentDatabaseIsNeverHeldUp() {
     final BackupCoordinator coordinator = new BackupCoordinator();
 
     assertThat(coordinator.begin("db1")).isTrue();

--- a/server/src/test/java/com/arcadedb/server/backup/BackupCoordinatorTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupCoordinatorTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.backup;
 
+import com.arcadedb.integration.backup.BackupSettings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -133,6 +134,24 @@ class BackupCoordinatorTest {
 
     assertThat(BackupCoordinator.parseArchiveTimestamp("mydb-backup-20260826-143000456.zip"))
         .isEqualTo(LocalDateTime.of(2026, 8, 26, 14, 30, 0, 456_000_000));
+  }
+
+  /**
+   * The convention exists twice - here, for everything the server writes, and as the default {@code BackupSettings}
+   * assigns a CLI or SQL backup that names no target, because the server cannot depend on the integration module
+   * (it reaches {@code Backup} reflectively so it stays buildable without it). Both write into the same directories,
+   * and retention reads both through the parser above, so the day one of them changes and the other does not is the
+   * day retention silently stops rotating half the archives. A comment asking the next editor to change both is not
+   * enforcement; this is.
+   */
+  @Test
+  void theDefaultNameOfACliOrSqlBackupFollowsTheSameConvention() {
+    final BackupSettings settings = new BackupSettings();
+    settings.databaseName = "mydb";
+    settings.validateSettings();
+
+    assertThat(settings.file).matches("mydb-backup-\\d{8}-\\d{9}\\.zip");
+    assertThat(BackupCoordinator.parseArchiveTimestamp(settings.file)).isNotNull();
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/backup/BackupRetentionManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupRetentionManagerTest.java
@@ -39,7 +39,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class BackupRetentionManagerTest {
-  private static final DateTimeFormatter BACKUP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+  private static final DateTimeFormatter BACKUP_FORMAT        = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+  /** What every release before #6753 wrote is the one above; this is what the server writes now. */
+  private static final DateTimeFormatter BACKUP_FORMAT_MILLIS = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmssSSS");
   private static final String            DATABASE_NAME = "testdb";
 
   @TempDir
@@ -264,6 +266,43 @@ class BackupRetentionManagerTest {
   /**
    * Creates backup files with timestamps starting from the given date.
    */
+  /**
+   * The directory an upgraded server inherits: archives named by every release before #6753, at second precision,
+   * next to the millisecond-precision ones it writes from now on. Retention decides what is still under management
+   * by parsing these names, so a parser that read only one of the two conventions would quietly stop rotating the
+   * other half - and nobody finds out until the disk is full.
+   */
+  @Test
+  void retentionRotatesAcrossBothNamingConventions() throws Exception {
+    final LocalDateTime oldest = LocalDateTime.now().minusDays(10);
+    final List<File> files = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      final LocalDateTime timestamp = oldest.plusHours(i);
+      // ALTERNATING, SO NEITHER CONVENTION IS ENTIRELY IN THE KEPT HALF OR ENTIRELY IN THE DELETED ONE
+      files.add(i % 2 == 0 ?
+          createBackupFile(timestamp) :
+          writeBackupFile(DATABASE_NAME + "-backup-" + timestamp.format(BACKUP_FORMAT_MILLIS) + ".zip"));
+    }
+
+    final DatabaseBackupConfig config = new DatabaseBackupConfig(DATABASE_NAME);
+    final DatabaseBackupConfig.RetentionConfig retention = new DatabaseBackupConfig.RetentionConfig();
+    retention.setMaxFiles(5);
+    config.setRetention(retention);
+    retentionManager.registerDatabase(DATABASE_NAME, config);
+
+    assertThat(retentionManager.getBackupCount(DATABASE_NAME)).isEqualTo(10);
+
+    // A NAME RETENTION CANNOT PARSE IS NOT MERELY UNSORTED, IT IS INVISIBLE: WERE THE FIVE MILLISECOND ONES
+    // UNREADABLE, THE FIVE THAT REMAIN WOULD ALREADY BE WITHIN maxFiles AND THIS WOULD DELETE NOTHING
+    assertThat(retentionManager.applyRetention(DATABASE_NAME)).isEqualTo(5);
+
+    // AND THE SURVIVORS ARE THE FIVE MOST RECENT BY TIMESTAMP, ACROSS BOTH CONVENTIONS
+    for (int i = 0; i < 5; i++)
+      assertThat(files.get(i)).doesNotExist();
+    for (int i = 5; i < 10; i++)
+      assertThat(files.get(i)).exists();
+  }
+
   private List<File> createBackupFiles(final int count, final LocalDateTime startDate) throws IOException {
     final List<File> files = new ArrayList<>();
     for (int i = 0; i < count; i++) {
@@ -277,7 +316,10 @@ class BackupRetentionManagerTest {
    * Creates a single backup file with the given timestamp.
    */
   private File createBackupFile(final LocalDateTime timestamp) throws IOException {
-    final String filename = DATABASE_NAME + "-backup-" + timestamp.format(BACKUP_FORMAT) + ".zip";
+    return writeBackupFile(DATABASE_NAME + "-backup-" + timestamp.format(BACKUP_FORMAT) + ".zip");
+  }
+
+  private File writeBackupFile(final String filename) throws IOException {
     final File file = new File(dbBackupDir, filename);
     Files.write(file.toPath(), "test backup content".getBytes());
     return file;

--- a/server/src/test/java/com/arcadedb/server/backup/Issue6753ConcurrentBackupIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue6753ConcurrentBackupIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A database is backed up by one backup at a time, whichever entry point asked for it. The auto-backup schedule, its
+ * immediate trigger and the HTTP "trigger backup" command used to be three independent submissions, all naming their
+ * archive from a second-precision timestamp: two of them starting in the same second resolved to the same path and
+ * wrote into the same file (issue #6753).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6753ConcurrentBackupIT extends BaseGraphServerTest {
+  private static final String BACKUP_DIRECTORY = "./target/issue6753-backups";
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return true;
+  }
+
+  @BeforeEach
+  @AfterEach
+  void cleanBackupDirectory() {
+    FileUtils.deleteRecursively(Path.of(BACKUP_DIRECTORY).toFile());
+  }
+
+  @Test
+  void aScheduledBackupIsSkippedWhileAnotherBackupOfTheSameDatabaseRuns() {
+    final ArcadeDBServer server = getServer(0);
+    final BackupCoordinator coordinator = server.getBackupCoordinator();
+    final File dbBackupDir = new File(BACKUP_DIRECTORY, getDatabaseName());
+
+    final BackupTask task = new BackupTask(server, getDatabaseName(), backupConfig(), BACKUP_DIRECTORY, null);
+
+    // SOMEBODY ELSE IS ALREADY BACKING THIS DATABASE UP
+    assertThat(coordinator.begin(getDatabaseName())).isTrue();
+    try {
+      task.run();
+      assertThat(archives(dbBackupDir)).isEmpty();
+    } finally {
+      coordinator.end(getDatabaseName());
+    }
+
+    // AND THE VERY SAME TASK GOES THROUGH ONCE THE OTHER BACKUP IS DONE: THE SKIP ABOVE IS THE GUARD, NOT A TASK
+    // THAT COULD NEVER HAVE RUN
+    task.run();
+
+    final String[] archives = archives(dbBackupDir);
+    assertThat(archives).hasSize(1);
+    // AND THE NAME IT CHOSE IS THE ONE RETENTION AND THE BACKUP LISTING READ BACK
+    assertThat(archives[0]).matches(getDatabaseName() + "-backup-\\d{8}-\\d{9}\\.zip");
+    assertThat(BackupCoordinator.parseArchiveTimestamp(archives[0])).isNotNull();
+  }
+
+  @Test
+  void theHttpTriggerRefusesWhileAnotherBackupOfTheSameDatabaseRuns() throws Exception {
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    assertThat(coordinator.begin(getDatabaseName())).isTrue();
+    try {
+      final HttpURLConnection connection = postServerCommand("trigger backup " + getDatabaseName());
+      try {
+        assertThat(connection.getResponseCode()).isEqualTo(409);
+        final String error = new JSONObject(readError(connection)).getString("error");
+        assertThat(error).contains("already in progress");
+      } finally {
+        connection.disconnect();
+      }
+    } finally {
+      coordinator.end(getDatabaseName());
+    }
+
+    // NOTHING WAS LEAKED BY THE REFUSAL: THE NEXT TRIGGER IS ADMITTED
+    final HttpURLConnection connection = postServerCommand("trigger backup " + getDatabaseName());
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private HttpURLConnection postServerCommand(final String command) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:2480/api/v1/server").toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+    connection.getOutputStream().write(new JSONObject().put("command", command).toString().getBytes());
+    connection.connect();
+    return connection;
+  }
+
+  private DatabaseBackupConfig backupConfig() {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig(getDatabaseName());
+    final DatabaseBackupConfig.ScheduleConfig schedule = new DatabaseBackupConfig.ScheduleConfig();
+    schedule.setType(DatabaseBackupConfig.ScheduleConfig.Type.FREQUENCY);
+    schedule.setFrequencyMinutes(60);
+    config.setSchedule(schedule);
+    return config;
+  }
+
+  private String[] archives(final File directory) {
+    if (!directory.exists())
+      return new String[0];
+    final String[] names = directory.list((dir, name) -> name.endsWith(".zip"));
+    return names != null ? names : new String[0];
+  }
+}


### PR DESCRIPTION
Closes #6753

## The problem

Two backups of the same database could run at once and, when they landed on the same archive name, write into the same file. Reproduced by `Issue6753ConcurrentBackupTest#twoBackupsRacingOnTheSameArchiveNameLeaveOneReadableArchive`, which before the fix reports **two** successful backups over one file.

Three things made it reachable:

1. **Second-precision names.** `BackupTask` and the HTTP `trigger backup` command each built `db-backup-yyyyMMdd-HHmmss.zip`. That is coarser than the millisecond default `BackupSettings` has always given a CLI or SQL backup, so two server-side backups starting in the same second resolved to one path.
2. **No mutual exclusion.** The periodic chain never overlaps itself, but `triggerImmediateBackup` is an independent `submit` on the same 2-thread pool, and `PostServerCommandHandler.triggerBackup` runs its own backup inline on the request thread - the path Studio's "backup now" uses.
3. **A TOCTOU in the writer.** `FullBackupFormat` decided the path was free with `backupFile.exists()` and opened the stream later. So even the `overwriteFile == false` guard, whose whole job is to not clobber an existing archive, let both racers through - and the loser's `backupFile.delete()` cleanup could delete the winner's finished work.

## The fix

**Write side, `FullBackupFormat` - the path is claimed, not checked.** `Files.createFile` takes the path atomically, so the loser of any race fails before it writes and before its cleanup can touch the winner's file. This holds for callers no in-process guard can see: the CLI, a second node writing into a shared backup directory. The claim happens *after* the checks that can still refuse the backup, so a rejected one leaves no empty archive behind for retention to count. On the snapshot -> frozen-files retry the partial archive is kept rather than deleted (handing the path back would let somebody else take it); the retry truncates it on reopen, and both hard-failure branches still delete, so a partial archive never survives the call.

**Policy side, new `BackupCoordinator` on `ArcadeDBServer`.** One backup per database at a time across all three entry points, and it owns the archive naming in both directions.
- A second full backup of the same data produces nothing the first will not, so the redundant one is **refused, not queued**: a scheduled tick logs a warning and the schedule covers the database on the next one; the HTTP command answers **409** with `{"error": "A backup of database '...' is already in progress"}`.
- Admission is per server instance, not per JVM - HA tests and co-located nodes run several servers with the same database names in one process.
- It lives on the server rather than on `AutoBackupSchedulerPlugin` because the HTTP command backs a database up whether or not that plugin is enabled.

**Naming, one convention in one place.** Names now carry milliseconds, matching `BackupSettings`. Critically, `BackupRetentionManager` and the `list backups` handler now parse through the same class that writes - a parser left at `(\d{6})` would have stopped matching every new archive, which means silently dropping them out of the retention set and never rotating them out again. Second-precision names written by earlier releases still parse (the millisecond group is optional).

## Why not just what the issue suggested

The issue proposed an in-progress flag plus a uniqueness suffix. A flag alone leaves the actual reported repro - Studio "backup now" while a cron tick fires - unfixed, because that path never goes through `BackupScheduler`; and neither a flag nor a suffix closes the TOCTOU for the CLI or a second node. Hence the two layers: the atomic claim is the integrity guarantee that holds for everybody, the coordinator is the admission policy that stops the waste and gives the operator a real answer.

## What this deliberately does not cover

**Two backups both passed `-o` (`overwriteFile`), racing on the same explicit path, can still interleave.** `-o` means "replace whatever is there", so there is nothing to claim and the claim is skipped - that was true before this change too. `BackupCoordinator` cannot help either: two CLI processes are not visible to a per-server admission set. The auto-backup scheduler, the HTTP command and SQL `BACKUP DATABASE` never pass `-o`, so none of the paths in #6753 are in this hole; a caller that does pass it has opted out of the guarantee by asking to overwrite.

**SQL `BACKUP DATABASE`, run directly rather than through the HTTP `trigger backup` command, is not admitted by the coordinator.** It can therefore still run alongside a scheduled backup and do the redundant work the admission layer exists to avoid. It is not a corruption risk - the atomic claim covers it like every other caller - and wiring it in would mean the engine module reaching into `ArcadeDBServer`, which is the dependency direction the whole reflective `Backup` boundary exists to avoid. The three entry points the issue is about (the periodic tick, the immediate trigger, the HTTP command) are all admitted.

**`list backups` now always emits the `timestamp` key**, set to `null` when the name does not follow the convention, where before the key was omitted entirely for such names. This is a deliberate consequence of routing through one parser - a stable response shape - but it is an observable change for a consumer that tests for key presence rather than for null.

## Tests

- `integration` `Issue6753ConcurrentBackupTest` - two backups racing on one name leave exactly one readable archive; an existing archive is never deleted by a backup that finds it in the way; a backup rejected before it writes leaves no empty archive.
- `server` `BackupCoordinatorTest` - admission (including 8 concurrent callers, exactly one admitted), name shape, round-trip parse, and that second-precision names from older releases still parse.
- `server` `Issue6753ConcurrentBackupIT` - a scheduled `BackupTask` skips while another backup of the database runs and goes through once it ends; the HTTP trigger answers 409 and leaks no reservation.

Existing suites green: all of `server`'s `com.arcadedb.server.backup` package, `PostServerCommandHandlerIT`, `ServerBackupDatabaseIT`, `ServerRestoreDatabaseIT`, `BackupHttpErrorHandlingIT`, and `integration`'s backup + restore tests including `Issue6075SnapshotBackupIT` and `BackupCompressionIT`.

## Notes for the docs

The auto-backup archive name gains milliseconds (`db-backup-20260826-143000456.zip`), and `trigger backup` gains a 409 response. Worth a line in the backup docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved backup coordination to prevent overlapping backups for the same database.
  * Added millisecond-precision archive naming with backward-compatible timestamp parsing.
  * HTTP-triggered backups now report when a backup is already in progress.
  * Scheduled backups are skipped while another backup is active.
  * Backup retention now supports both legacy and millisecond-precision archive names.

* **Bug Fixes**
  * Prevented concurrent backups from overwriting or sharing the same archive.
  * Preserved existing backup files and safely cleaned up failed backups.
  * Improved backup directory creation, validation, and snapshot retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

