### PR TITLE
fix(#6777): DeltaOverlay's RID-keyed deletion dedup is unsafe across bucket slot reuse

### DIFF
--- a/docs/6777-deltaoverlay-rid-reuse-dedup.md
+++ b/docs/6777-deltaoverlay-rid-reuse-dedup.md
@@ -1,0 +1,74 @@
+# Issue #6777: DeltaOverlay's RID-keyed deletion dedup is unsafe across bucket slot reuse
+
+https://github.com/ArcadeData/arcadedb/issues/6777
+
+## Root cause
+
+`DeltaOverlay.merge()` dedups edge deletions by the deleted edge's own RID
+(`deletedEdgeRIDsPerType: Map<String, Set<RID>>`), to tell "this exact deletion event
+replayed" apart from "two distinct parallel edges between the same pair, each deleted"
+(#6769). RIDs are not permanently unique identities: `LocalBucket` reuses a slot freed by
+a delete for a later insert ("hole reuse", #5279).
+
+Traced the actual reachable window (the issue asked to pin this down before choosing a
+fix):
+
+- In the **live, non-compaction** merge path (`merge(delta, baseMapping)`), every
+  genuinely new edge add is unconditionally recorded in `addedEdgesPerType`, keyed by its
+  own RID. So a later deletion of that same RID **always** finds it there and takes the
+  "withdraw the add" branch (#6775) — which is safe regardless of what
+  `deletedEdgeRIDsPerType` already holds. The dedup Set is never consulted for a
+  same-window add+delete pair.
+- The **only** way an edge's add is *not* recorded in `addedEdgesPerType` is the
+  post-compaction buffered-delta re-application path (`merge(delta, baseMapping,
+  baseCsrPerType)`, #4588): if the freshly built base CSR already contains the edge's
+  pair (the read-committed scan crossed its bucket after the edge committed), the add is
+  skipped as "already represented by the fresh base CSR" — the edge is treated as part of
+  the base, not tracked by identity.
+
+Combining these: if an edge E1 is deleted (RID `r` recorded in
+`deletedEdgeRIDsPerType`), and — within the same buffered-delta replay, in commit order —
+a **different** edge E2 is created reusing RID `r` (physically possible only after E1's
+delete freed the slot) and the fresh base CSR already reflects E2 (so its add is skipped
+per #4588), then E2's own later deletion looks up `r` in `deletedEdgeRIDsPerType`, finds
+it already present (from E1), and is silently dropped by `Set.add()` returning `false`.
+
+The window is exactly the post-compaction buffered-delta replay of one compaction cycle —
+narrower than "the whole overlay lifetime" the issue worried about, but real.
+
+## Fix
+
+When an edge add is skipped in the `baseCsrPerType != null` branch because the fresh base
+CSR already represents it (the "already represented by the fresh base CSR" `continue`
+path), also drop that RID from `deletedEdgeRIDsPerType` for the edge type, if present.
+Going forward, that RID's dedup identity belongs to the edge the fresh base now says is
+live at that physical slot, not to whatever edge originally recorded a deletion under it.
+This does not disturb the earlier deletion's already-recorded exclusion budget
+(`deletedEdgesPerType`, keyed by pair, not RID) — only the identity-dedup Set entry that
+would otherwise falsely absorb a later, unrelated deletion under the same reused RID.
+
+## Test plan
+
+- `DeltaOverlayCompactionDedupTest.deletionOfDifferentEdgeReusingAReplayedRidIsNotDropped()`
+  (new): reproduces the exact 3-step buffered-delta sequence above — delete E1 (pair
+  0→1, RID r), add E2 (pair 0→2, RID r, already in the fresh base CSR so skipped), delete
+  E2 (pair 0→2, RID r) — and asserts E2's deletion is recorded (count, `isEdgeDeleted`,
+  `deltaEdgeCount`) without disturbing E1's own recorded exclusion.
+- Full `DeltaOverlayTest` + `DeltaOverlayCompactionDedupTest` suites, to confirm the #4587
+  and #6769/#6775 regression coverage stays green.
+- `mvn -o -pl engine -am test -Dtest=DeltaOverlayTest,DeltaOverlayCompactionDedupTest`
+
+## Verification
+
+- New test `deletionOfDifferentEdgeReusingAReplayedRidIsNotDropped` confirmed the bug
+  pre-fix (`isEdgeDeleted(EDGE_TYPE, 0, 2)` was `false`), and passes post-fix.
+- `DeltaOverlayTest` (11) + `DeltaOverlayCompactionDedupTest` (7): all green, including the
+  #4587 replay-dedup and #6769/#6775 parallel-edge/withdraw regression tests - the fix
+  does not weaken any of that existing coverage.
+- Full `com.arcadedb.graph.olap` package (268 tests, excluding benchmark/slow/vector
+  lanes): all green.
+- `mvn -o -pl engine -am compile`: clean.
+
+## Status
+
+Done. Ready for PR.

--- a/docs/6777-deltaoverlay-rid-reuse-dedup.md
+++ b/docs/6777-deltaoverlay-rid-reuse-dedup.md
@@ -69,6 +69,25 @@ would otherwise falsely absorb a later, unrelated deletion under the same reused
   lanes): all green.
 - `mvn -o -pl engine -am compile`: clean.
 
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/6787
+
+## Review cycles
+
+- Cycle 1: head `2eb1899871a5edebf2df71e7efeba014fcc3b283`. `claude` reviewed: no
+  blocking issues, clean approval. `coderabbitai` flagged one actionable item: em dashes
+  in `docs/6777-deltaoverlay-rid-reuse-dedup.md` (repo convention forbids them). Applied
+  directly (commit `afc3c417a4`).
+- Cycle 2: head `afc3c417a452110e93a97e06fa985832636beec5`. `claude` reviewed: no
+  blocking issues, clean approval (traced the fix's correctness against the buffered-delta
+  replay invariants, confirmed the regression test's expected values by hand). No
+  actionable items from any reviewer on this head. Working tree clean, no deferred items.
+
+## Deferred items
+
+None.
+
 ## Status
 
-Done. Ready for PR.
+`clean-approval`. Ready for developer merge.

--- a/docs/6777-deltaoverlay-rid-reuse-dedup.md
+++ b/docs/6777-deltaoverlay-rid-reuse-dedup.md
@@ -16,24 +16,24 @@ fix):
 - In the **live, non-compaction** merge path (`merge(delta, baseMapping)`), every
   genuinely new edge add is unconditionally recorded in `addedEdgesPerType`, keyed by its
   own RID. So a later deletion of that same RID **always** finds it there and takes the
-  "withdraw the add" branch (#6775) — which is safe regardless of what
+  "withdraw the add" branch (#6775), which is safe regardless of what
   `deletedEdgeRIDsPerType` already holds. The dedup Set is never consulted for a
   same-window add+delete pair.
 - The **only** way an edge's add is *not* recorded in `addedEdgesPerType` is the
   post-compaction buffered-delta re-application path (`merge(delta, baseMapping,
   baseCsrPerType)`, #4588): if the freshly built base CSR already contains the edge's
   pair (the read-committed scan crossed its bucket after the edge committed), the add is
-  skipped as "already represented by the fresh base CSR" — the edge is treated as part of
+  skipped as "already represented by the fresh base CSR", the edge is treated as part of
   the base, not tracked by identity.
 
 Combining these: if an edge E1 is deleted (RID `r` recorded in
-`deletedEdgeRIDsPerType`), and — within the same buffered-delta replay, in commit order —
+`deletedEdgeRIDsPerType`), and, within the same buffered-delta replay, in commit order,
 a **different** edge E2 is created reusing RID `r` (physically possible only after E1's
 delete freed the slot) and the fresh base CSR already reflects E2 (so its add is skipped
 per #4588), then E2's own later deletion looks up `r` in `deletedEdgeRIDsPerType`, finds
 it already present (from E1), and is silently dropped by `Set.add()` returning `false`.
 
-The window is exactly the post-compaction buffered-delta replay of one compaction cycle —
+The window is exactly the post-compaction buffered-delta replay of one compaction cycle,
 narrower than "the whole overlay lifetime" the issue worried about, but real.
 
 ## Fix
@@ -44,15 +44,15 @@ path), also drop that RID from `deletedEdgeRIDsPerType` for the edge type, if pr
 Going forward, that RID's dedup identity belongs to the edge the fresh base now says is
 live at that physical slot, not to whatever edge originally recorded a deletion under it.
 This does not disturb the earlier deletion's already-recorded exclusion budget
-(`deletedEdgesPerType`, keyed by pair, not RID) — only the identity-dedup Set entry that
+(`deletedEdgesPerType`, keyed by pair, not RID), only the identity-dedup Set entry that
 would otherwise falsely absorb a later, unrelated deletion under the same reused RID.
 
 ## Test plan
 
 - `DeltaOverlayCompactionDedupTest.deletionOfDifferentEdgeReusingAReplayedRidIsNotDropped()`
-  (new): reproduces the exact 3-step buffered-delta sequence above — delete E1 (pair
-  0→1, RID r), add E2 (pair 0→2, RID r, already in the fresh base CSR so skipped), delete
-  E2 (pair 0→2, RID r) — and asserts E2's deletion is recorded (count, `isEdgeDeleted`,
+  (new): reproduces the exact 3-step buffered-delta sequence above: delete E1 (pair
+  0→1, RID r); add E2 (pair 0→2, RID r, already in the fresh base CSR so skipped); delete
+  E2 (pair 0→2, RID r). Asserts E2's deletion is recorded (count, `isEdgeDeleted`,
   `deltaEdgeCount`) without disturbing E1's own recorded exclusion.
 - Full `DeltaOverlayTest` + `DeltaOverlayCompactionDedupTest` suites, to confirm the #4587
   and #6769/#6775 regression coverage stays green.

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -238,8 +238,21 @@ class DeltaOverlay {
           final Map<Long, Integer> prevDel = newDeletedEdges.get(ed.edgeType);
           final boolean masked = (prevDel != null && prevDel.containsKey(packed))
               || (sameDeltaDeleted != null && sameDeltaDeleted.contains(packed));
-          if (!masked)
+          if (!masked) {
+            // The fresh base CSR already represents this edge, so it is not tracked by identity here
+            // (issue #4588) - which means a LATER deletion of this exact RID cannot be withdrawn by
+            // identity either. Drop any stale reservation of this RID from the identity-dedup Set: RIDs
+            // are reused for a later, unrelated insert once their original record is deleted ("hole
+            // reuse", #5279), so an earlier deletion recorded under this same RID belongs to whatever
+            // edge previously occupied the slot, not to this one. Leaving it in place would make this
+            // edge's own eventual deletion look like a replay of that unrelated one and get silently
+            // absorbed by Set.add() returning false (issue #6777). The earlier deletion's own exclusion
+            // budget (deletedEdgesPerType, keyed by pair, not RID) is untouched by this.
+            final Set<RID> ridsForType = newDeletedEdgeRIDs.get(ed.edgeType);
+            if (ridsForType != null)
+              ridsForType.remove(ed.rid);
             continue; // already represented by the fresh base CSR
+          }
         }
       }
       // Keyed by the edge's own identity, so a replayed add of an edge the overlay already holds is
@@ -260,8 +273,8 @@ class DeltaOverlay {
       // deleted counts below are a budget spent against the BASE CSR's run for the pair: recording one here
       // would mask a base edge nobody deleted, while leaving the phantom add in place - which is exactly how
       // the append-only added index used to surface an added-then-deleted edge as a live neighbour. Done by
-      // identity, before the dedup guard below, so a RID recycled onto a new edge (the #6777 hole-reuse gap)
-      // still cancels its own add rather than having the whole deletion dropped.
+      // identity, before the dedup guard below, so a RID recycled onto a new edge (see #6777) still cancels
+      // its own add rather than having the whole deletion dropped.
       final Map<RID, long[]> addedForType = newAddedEdges.get(ed.edgeType);
       if (addedForType != null && addedForType.remove(ed.rid) != null) {
         newDeltaEdgeCount--; // undo the +1 the withdrawn add contributed
@@ -278,14 +291,13 @@ class DeltaOverlay {
       // compaction trigger (Math.abs(deltaEdgeCount) > threshold, issue #4587) - and, since the per-pair
       // count below feeds copyBaseExcludingDeleted's exclusion budget, it would also mask a second, still
       // live, parallel edge that was never actually deleted (issue #6769).
-      // KNOWN GAP (issue #6777): this assumes an edge's RID is never reused while it sits in this set,
-      // but LocalBucket deliberately reuses a slot freed by a delete for a later insert ("hole reuse",
-      // #5279). A different, unrelated edge landing on the same freed slot and later being deleted too
-      // would collide here and have ITS deletion silently dropped. The window this can happen in is
-      // bounded by the same compaction trigger #4587 protects: a full rebuild clears this set entirely
-      // (see the no-delta constructor), so the exposure is at most GraphAnalyticalView.compactionThreshold
-      // (default GraphAnalyticalView.DEFAULT_COMPACTION_THRESHOLD = 10,000) net edge deltas of churn on
-      // one covered edge type - not unbounded, but wide enough to be reachable on a busy graph.
+      // This relies on a reused RID ("hole reuse", #5279) always being visible to THIS overlay window by
+      // identity before its own deletion is processed - which holds for every edge added through the
+      // normal (non-compaction) merge path, since an add always lands in newAddedEdges above and is caught
+      // by the withdraw branch first. The one path where an add is deliberately NOT tracked by identity is
+      // the post-compaction re-application skip a few lines up (issue #4588): there, a reused RID's stale
+      // entry in this set is explicitly cleared at the point the add is skipped, so it cannot be mistaken
+      // for a replay of the unrelated edge that originally freed the slot (issue #6777).
       if (newDeletedEdgeRIDs.computeIfAbsent(ed.edgeType, k -> new HashSet<>()).add(ed.rid)) {
         newDeletedEdges.computeIfAbsent(ed.edgeType, k -> new HashMap<>())
             .merge(packEdge(srcId, tgtId), 1, Integer::sum);

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDedupTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDedupTest.java
@@ -208,4 +208,51 @@ class DeltaOverlayCompactionDedupTest {
     assertThat(merged.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
     assertThat(merged.getDeltaEdgeCount()).isZero();
   }
+
+  /**
+   * Issue #6777: RIDs are not permanently unique identities - {@code LocalBucket} reuses a slot freed by
+   * a delete for a later insert ("hole reuse", #5279). Reproduces the exact buffered-delta sequence a
+   * compaction replay can produce, in commit order:
+   * <ol>
+   *   <li>E1 (pair 0-&gt;1) is deleted, RID {@code r}. {@code r} is recorded in the identity-dedup Set.</li>
+   *   <li>E2 (pair 0-&gt;2), a genuinely different edge, is created reusing the now-freed RID {@code r}.
+   *       The freshly built base CSR already contains E2's pair (the read-committed scan crossed its
+   *       bucket after E2 committed), so per #4588 the add is skipped rather than tracked by identity -
+   *       E2's RID never enters {@code addedEdgesPerType}.</li>
+   *   <li>E2 is deleted, same RID {@code r}. Since {@code r} is not in {@code addedEdgesPerType} (step 2
+   *       skipped it), the withdraw-the-add branch (#6775) does not apply, and the deletion falls through
+   *       to the identity-dedup Set - which already holds {@code r} from E1's unrelated deletion in step 1.
+   *       Before the fix, {@code Set.add()} returns false and E2's deletion is silently dropped.</li>
+   * </ol>
+   */
+  @Test
+  void deletionOfDifferentEdgeReusingAReplayedRidIsNotDropped() {
+    final NodeIdMapping mapping = baseMappingWith(3);
+    // The fresh base CSR reflects E2's pair (0->2) as already live, but NOT E1's pair (0->1) - E1 was
+    // already gone by the time the compaction scan ran.
+    final Map<String, CSRAdjacencyIndex> csr = csrWithEdge(3, 0, 2);
+    final RID reusedRid = rid(10);
+
+    final TxDelta deleteE1 = new TxDelta();
+    deleteE1.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), reusedRid));
+    final DeltaOverlay afterE1Delete = new DeltaOverlay(mapping.size()).merge(deleteE1, mapping, csr);
+    assertThat(afterE1Delete.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
+
+    final TxDelta addE2 = new TxDelta();
+    addE2.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(2), reusedRid));
+    final DeltaOverlay afterE2Add = afterE1Delete.merge(addE2, mapping, csr);
+    // Skipped: already represented by the fresh base CSR, so not tracked by identity.
+    assertThat(afterE2Add.getAddedOutNeighbors(0, EDGE_TYPE)).isEmpty();
+
+    final TxDelta deleteE2 = new TxDelta();
+    deleteE2.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(2), reusedRid));
+    final DeltaOverlay afterE2Delete = afterE2Add.merge(deleteE2, mapping, csr);
+
+    // E2's own deletion must be recorded, not absorbed by E1's unrelated deletion under the same reused RID.
+    assertThat(afterE2Delete.isEdgeDeleted(EDGE_TYPE, 0, 2)).isTrue();
+    assertThat(afterE2Delete.countDeletedEdges(EDGE_TYPE, 0, 2)).isEqualTo(1);
+    // E1's own exclusion budget must be untouched.
+    assertThat(afterE2Delete.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(afterE2Delete.getDeltaEdgeCount()).isEqualTo(-2);
+  }
 }


### PR DESCRIPTION
Closes #6777

## What does this PR do?

`DeltaOverlay.merge()` dedups edge deletions by the deleted edge's own RID
(`deletedEdgeRIDsPerType`), to tell "this exact deletion event replayed" apart from "two
distinct parallel edges between the same pair, each deleted" (#6769). RIDs are not
permanently unique identities: `LocalBucket` reuses a bucket slot freed by a delete for a
later insert ("hole reuse", #5279).

Traced the actual reachable window (the issue asked to pin this down before choosing a
fix): in the live, non-compaction merge path every genuinely new edge add is
unconditionally tracked by identity in `addedEdgesPerType`, so a later deletion of the
same RID always finds it there and takes the safe "withdraw the add" branch (#6775). The
only path where an add is *not* tracked by identity is the post-compaction buffered-delta
re-application (#4588): when the freshly built base CSR already represents the edge, its
add is skipped. If that skipped edge's RID had already been recorded as a deletion by an
unrelated edge earlier in the same replay window, the new edge's own later deletion
collided with that stale entry and was silently dropped - not counted, not excluded from
the base CSR's neighbour list.

The fix clears the RID's entry in the identity-dedup set at the exact point its add is
skipped for that reason, so a later deletion of that RID is attributed to the edge that
now occupies the slot, not to whatever edge freed it. The earlier deletion's own exclusion
budget (`deletedEdgesPerType`, keyed by pair, not RID) is untouched.

## Motivation

Found and documented as a known gap during the #6769/PR #6773 review, filed as its own
issue rather than folded into that PR, since a correct fix needed its own investigation
into how narrow the #4587 replay window actually is.

## Related issues

- #6769 / PR #6773 - where the RID-keyed dedup was introduced
- #4587 - the original reason RID-based dedup exists
- #4588 - the post-compaction buffered-delta re-application mechanism this fix touches
- #5279 - bucket slot ("hole") reuse

## Additional Notes

New regression test `DeltaOverlayCompactionDedupTest.deletionOfDifferentEdgeReusingAReplayedRidIsNotDropped`
reproduces the exact 3-step buffered-delta sequence (delete E1, add E2 on a reused RID
that the fresh base CSR already reflects, delete E2) and fails on `main` before this fix.

## Test plan

- [x] New test confirmed the bug pre-fix (`isEdgeDeleted` false when it should be true),
      passes post-fix
- [x] `DeltaOverlayTest` (11) + `DeltaOverlayCompactionDedupTest` (7): all green, including
      existing #4587/#6769/#6775 regression coverage
- [x] Full `com.arcadedb.graph.olap` package (268 tests): all green
- [x] `mvn -o -pl engine -am compile`: clean

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected edge deletion handling after compaction when record identifiers are reused.
  * Ensured separate deletions are preserved instead of being incorrectly treated as duplicates.

* **Tests**
  * Added regression coverage for record identifier reuse during compaction replay.

* **Documentation**
  * Documented the issue, resolution, verification results, and regression test plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->