### PR TITLE
fix(#6315): remove the positional edge-property accessor from the traversal SPI, resolve the overlay instead

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -268,10 +268,10 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     if (provider != null) {
       final int nodeId = provider.getNodeId(node.getIdentity());
       // edgeWeightsOf() answers null unless the provider can serve THIS property for EVERY type in play, and it
-      // is the only thing that pairs a CSR edge with its own weight correctly. Reading getNeighborIds and
-      // getEdgeProperty side by side here got it wrong twice over (issue #6301): the neighbour list is merged and
-      // sorted across types while the property column is per type, and a BOTH lookup has no column at all, so it
-      // answered null for every edge and quietly priced the whole neighbourhood at MIN - free.
+      // is the only thing that pairs a CSR edge with its own weight correctly. Assembling the neighbourhood here
+      // got it wrong twice over (issue #6301): the neighbour list is merged and sorted across types while the
+      // values are served per type, and a BOTH lookup has no adjacency slice at all, so it found no value for
+      // any edge and quietly priced the whole neighbourhood at MIN - free.
       final NodeEdgeWeights edges = nodeId >= 0 ?
           provider.edgeWeightsOf(nodeId, paramDirection, paramWeightFieldName, MIN, paramEdgeTypeNames) : null;
       if (edges != null) {

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -111,11 +111,11 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
 
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db);
     // The columnar path is taken per node and only when edgeWeightsOf() can answer - i.e. when the provider can
-    // serve THIS property for every type it holds. Pairing getNeighborIds with getEdgeProperty by hand was wrong
-    // in two ways (issue #6301): the neighbour list is merged and sorted across types while the columns are per
-    // type, and `direction` defaults to BOTH here, which has no column at all - so the plain three-argument call
-    // read a null property value for every edge and silently unit-weighted the whole graph. Anything the
-    // provider cannot answer exactly falls to the edge records below, which are.
+    // serve THIS property for every type it holds. Assembling the neighbourhood by hand was wrong in two ways
+    // (issue #6301): the neighbour list is merged and sorted across types while the values are served per type,
+    // and `direction` defaults to BOTH here, which has no adjacency slice at all - so the hand-rolled version
+    // read no property value for any edge and silently unit-weighted the whole graph. Anything the provider
+    // cannot answer exactly falls to the edge records below, which are.
     final String weightColumn = weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null;
 
     for (int i = 0; i < n; i++) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -161,8 +161,8 @@ public interface GraphTraversalProvider {
   /**
    * Returns the edge types this provider actually holds, or {@code null} when it cannot enumerate them.
    * <p>
-   * {@link #getEdgeProperty} is addressed per edge type, so a caller that was given no type filter but needs
-   * edge properties has to ask which types exist rather than pass "all types" down. A provider that answers
+   * {@link #edgeWeightsForSlice} is addressed per edge type, so a caller that was given no type filter but
+   * needs edge properties has to ask which types exist rather than pass "all types" down. A provider that answers
    * {@code null} simply cannot serve such a caller, which then falls back to reading the edge records.
    */
   default String[] getMaterializedEdgeTypes() {

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -170,17 +170,14 @@ public interface GraphTraversalProvider {
   }
 
   /**
-   * Returns true if this provider has edge property columns materialized <em>and</em> the positional mapping
-   * {@link #getEdgeProperty} relies on is exact.
+   * Returns true if this provider has edge property values it can serve at all, through
+   * {@link #edgeWeightsOf}.
    * <p>
-   * The second half is what makes the answer usable. {@code getEdgeProperty} addresses an edge by its position
-   * in the node's neighbour list for a direction, so it means something only while that position identifies the
-   * same edge {@link #getNeighborIds} reports there. A provider whose neighbour lists no longer line up with its
-   * property columns - because pending changes are served from a side structure, say - must answer {@code false}
-   * rather than hand back a weight belonging to another edge. The caller holds the edge records and can always
-   * read the property itself; a plausible wrong number is the one outcome it cannot recover from. Same
-   * "say unknown rather than guess" convention as {@link #countEdgesBetween} and
-   * {@link #getMeanEdgesPerConnectedPair}.
+   * A provider that cannot pair every edge it reports in {@link #getNeighborIds} with that edge's own property
+   * value - because its columns have gone out of step with its adjacency, say - must answer {@code false} rather
+   * than hand back a value belonging to another edge. The caller holds the edge records and can always read the
+   * property itself; a plausible wrong number is the one outcome it cannot recover from. Same "say unknown rather
+   * than guess" convention as {@link #countEdgesBetween} and {@link #getMeanEdgesPerConnectedPair}.
    */
   default boolean hasEdgeProperties() {
     return false;
@@ -188,13 +185,13 @@ public interface GraphTraversalProvider {
 
   /**
    * Returns true if this provider can serve {@code propertyName} for {@code edgeType} through
-   * {@link #getEdgeProperty}.
+   * {@link #edgeWeightsOf}.
    * <p>
    * {@link #hasEdgeProperties()} answers the coarser question - are there edge property columns at all - and a
-   * caller that asks only that one gets {@code null} back from every {@link #getEdgeProperty} call when the view
-   * happens to materialise a <em>different</em> property than the one requested. Since a {@code null} property
-   * value is also the ordinary way of saying "this edge has no value", the caller cannot tell the two apart and
-   * silently treats the whole graph as unweighted. That is the same failure as reading a weight that belongs to
+   * caller that asks only that one gets the default weight back for every edge when the view happens to
+   * materialise a <em>different</em> property than the one requested. Since that default is also the ordinary
+   * way of saying "this edge has no value for the property", the caller cannot tell the two apart and silently
+   * treats the whole graph as unweighted. That is the same failure as reading a weight that belongs to
    * another edge, arrived at from the other direction, so the question a weighted algorithm has to ask is this
    * one: can you serve <em>this</em> property?
    *
@@ -229,40 +226,70 @@ public interface GraphTraversalProvider {
   }
 
   /**
-   * Returns an edge property value from columnar storage, or null if not materialized.
+   * Returns one node's neighbours of a single edge type and direction, together with the weight of the edge
+   * reaching each of them - or {@code null} when this provider cannot answer exactly.
    * <p>
-   * The {@code neighborIndex} is the position within the node's adjacency list for the given direction
-   * (0-based, matching the order returned by {@link #getNeighborIds}).
+   * <b>This is the provider's only edge-property primitive, and it deliberately hands back no index.</b> It used
+   * to be {@code getEdgeProperty(nodeId, neighborIndex, direction, edgeType, propertyName)}, addressing an edge
+   * by its position in the node's neighbour list, which meant something only while that position identified the
+   * same edge {@link #getNeighborIds} reported there. It stopped identifying it as soon as a provider served
+   * pending changes from a side structure - a deleted edge dropped from the neighbour list shifts every entry
+   * after it, so the n-th neighbour is no longer the n-th column slot - and the method had no way to notice:
+   * it returned a weight belonging to a different edge, which is a wrong shortest path, a wrong MST, a wrong
+   * Steiner tree, and never an exception (issues #6301 and #6315). The rule that kept it correct lived in its
+   * callers, where the next one written against this SPI could not discover it.
+   * <p>
+   * Returning the two arrays together removes the rule instead of restating it: the pairing is made where the
+   * provider's own adjacency is walked, by whoever knows how that adjacency is put together, and nothing
+   * downstream can re-derive it wrongly. Answering "I cannot" costs the caller a read of the edge records,
+   * which are exact; answering with a plausible wrong number costs it the result.
    *
-   * @param nodeId         the source node's dense ID
-   * @param neighborIndex  the index within the node's neighbor list for the given direction
-   * @param direction      OUT or IN
-   * @param edgeType       the edge type name
-   * @param propertyName   the property to retrieve
+   * {@code edgeCheckpoint}, when not {@code null}, must be called once per edge as the slice is built, with a
+   * counter that restarts at zero for every call. That is what keeps a supernode from being one unabortable
+   * unit of work: this method returns a fully-built row, so a caller walking every node of the graph has no
+   * other place to notice that it should stop (issue #6715). Restarting the counter rather than threading a
+   * running total through is the same choice {@link com.arcadedb.query.sql.executor.WorkGuard#checkPeriodically}
+   * documents for a loop whose counter restarts - it bounds the worst case to about one checkpoint stride into
+   * the largest slice, whatever the slice before it looked like.
    *
-   * @return the property value, or null if not available
+   * @param nodeId         the node whose edges to read
+   * @param direction      {@link Vertex.DIRECTION#OUT} or {@link Vertex.DIRECTION#IN}, never
+   *                       {@link Vertex.DIRECTION#BOTH} - a direction has an adjacency slice, {@code BOTH} does
+   *                       not, and {@link #edgeWeightsOf} splits it before calling here
+   * @param edgeType       a single materialised edge type, never "all types"
+   * @param propertyName   the edge property to read
+   * @param defaultWeight  value for an edge carrying no numeric value for that property
+   * @param edgeCheckpoint called with the edge index within this slice (0-based), or {@code null} to skip it
+   *
+   * @return the neighbours - the same ones, in the same order, {@code getNeighborIds(nodeId, direction,
+   * edgeType)} reports - each beside its own edge's weight, or {@code null} if this provider cannot serve the
+   * property for this type
    */
-  default Object getEdgeProperty(final int nodeId, final int neighborIndex,
-      final Vertex.DIRECTION direction, final String edgeType, final String propertyName) {
+  default NodeEdgeWeights edgeWeightsForSlice(final int nodeId, final Vertex.DIRECTION direction,
+      final String edgeType, final String propertyName, final double defaultWeight,
+      final IntConsumer edgeCheckpoint) {
     return null;
   }
 
   /**
    * Returns one node's neighbours together with the edge-property value of each edge reaching them, or
-   * {@code null} when this provider cannot serve {@code propertyName} for every type in play.
+   * {@code null} when this provider cannot serve {@code propertyName} for every type in play - or cannot
+   * answer exactly for this particular node, which a caller reaching this method across a long walk has to
+   * handle too: a provider that absorbs committed changes as it goes can lose the ability to answer partway
+   * through one.
    * <p>
-   * <b>This is the only correct way to read an edge property positionally, and the reason it lives here rather
-   * than in each caller.</b> {@link #getEdgeProperty} is addressed by (type, direction, position), and two things
-   * break a caller that pairs it with {@link #getNeighborIds} by hand:
+   * <b>This is the only way in, and the reason the composition lives here rather than in each caller.</b>
+   * {@link #edgeWeightsForSlice} answers for one (type, direction) pair, and two things break a caller that
+   * tries to assemble the whole neighbourhood itself:
    * <ul>
-   *   <li>a multi-type neighbour list is <em>merged and sorted</em> across types, so position {@code j} in it is
-   *       not position {@code j} in any one type's column - the weight lands on another edge, or on none;</li>
-   *   <li>{@link Vertex.DIRECTION#BOTH} has no column of its own at all. A provider resolves {@code OUT} and
-   *       {@code IN}, so a {@code BOTH} lookup answers {@code null} for every edge and the caller silently reads
-   *       the whole neighbourhood at its default weight.</li>
+   *   <li>a multi-type neighbour list is <em>merged and sorted</em> across types, so entry {@code j} of it is
+   *       not entry {@code j} of any one type's slice - the weight lands on another edge, or on none;</li>
+   *   <li>{@link Vertex.DIRECTION#BOTH} has no adjacency slice of its own at all. A provider resolves
+   *       {@code OUT} and {@code IN}, so a {@code BOTH} lookup would answer for neither and the caller would
+   *       silently read the whole neighbourhood at its default weight.</li>
    * </ul>
-   * Both are handled here once: the walk takes one slice per (type, direction) pair, each of which <em>is</em>
-   * positional, and concatenates them.
+   * Both are handled here once: the walk takes one slice per (type, direction) pair, each of which arrives with
+   * its weights already paired, and concatenates them.
    *
    * @param nodeId        the node whose edges to read
    * @param direction     traversal direction; {@code BOTH} walks the outgoing and incoming slices in turn
@@ -277,8 +304,9 @@ public interface GraphTraversalProvider {
 
   /**
    * Same as {@link #edgeWeightsOf(int, Vertex.DIRECTION, String, double, String...)}, with one addition:
-   * {@code edgeCheckpoint}, if not {@code null}, is called once per edge as the per-(type, direction) slices are
-   * copied into the returned arrays, with a counter that restarts at zero for every call to this method.
+   * {@code edgeCheckpoint}, if not {@code null}, is handed to {@link #edgeWeightsForSlice} for each
+   * (type, direction) slice, which calls it once per edge as that slice is built, with a counter that restarts
+   * at zero for every slice.
    * <p>
    * A caller that visits every node of the graph in turn - {@code AbstractAlgoProcedure}'s columnar adjacency
    * build does, once per node - has no other way to stay abortable mid-node: this method already returns one
@@ -314,33 +342,35 @@ public interface GraphTraversalProvider {
         new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN } :
         new Vertex.DIRECTION[] { direction };
 
-    final int[][] slices = new int[types.length * directions.length][];
+    final NodeEdgeWeights[] slices = new NodeEdgeWeights[types.length * directions.length];
     int degree = 0;
     int s = 0;
     for (final String type : types)
       for (final Vertex.DIRECTION d : directions) {
-        final int[] slice = getNeighborIds(nodeId, d, type);
+        final NodeEdgeWeights slice = edgeWeightsForSlice(nodeId, d, type, propertyName, defaultWeight, edgeCheckpoint);
+        // One slice this provider cannot answer makes the whole node unanswerable: a partial row would be a
+        // neighbourhood with edges missing from it, which reads as a graph that is simply shaped differently -
+        // the one failure the caller cannot detect. Same convention as this method's own contract.
+        if (slice == null)
+          return null;
         slices[s++] = slice;
-        degree += slice.length;
+        degree += slice.neighbors().length;
       }
+
+    // A single slice is already exactly what this method returns, and it was built for this call alone - and
+    // its edges were checkpointed as it was built - so it can be handed straight back.
+    if (slices.length == 1)
+      return slices[0];
 
     final int[] neighbors = new int[degree];
     final double[] weights = new double[degree];
     int pos = 0;
-    int edgeCount = 0;
-    s = 0;
-    for (final String type : types)
-      for (final Vertex.DIRECTION d : directions) {
-        final int[] slice = slices[s++];
-        for (int j = 0; j < slice.length; j++) {
-          if (edgeCheckpoint != null)
-            edgeCheckpoint.accept(edgeCount++);
-          neighbors[pos] = slice[j];
-          final Object value = getEdgeProperty(nodeId, j, d, type, propertyName);
-          weights[pos] = value instanceof Number num ? num.doubleValue() : defaultWeight;
-          pos++;
-        }
-      }
+    for (final NodeEdgeWeights slice : slices) {
+      final int[] sliceNeighbors = slice.neighbors();
+      System.arraycopy(sliceNeighbors, 0, neighbors, pos, sliceNeighbors.length);
+      System.arraycopy(slice.weights(), 0, weights, pos, sliceNeighbors.length);
+      pos += sliceNeighbors.length;
+    }
     return new NodeEdgeWeights(neighbors, weights);
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/NodeEdgeWeights.java
+++ b/engine/src/main/java/com/arcadedb/graph/NodeEdgeWeights.java
@@ -22,9 +22,10 @@ package com.arcadedb.graph;
  * One node's neighbours and the edge-property value of each edge reaching them, produced together.
  * <p>
  * {@code weights[j]} belongs to the edge to {@code neighbors[j]} <em>by construction</em>: both arrays are filled
- * from one walk of the same per-type, per-direction adjacency slices, each of which is positional against
- * {@link GraphTraversalProvider#getEdgeProperty}. Handing the two back together is what removes the reconciliation
- * step - and every place that reconciled them afterwards got it wrong, which is issue #6301.
+ * from one walk of the same edges, by {@link GraphTraversalProvider#edgeWeightsForSlice} for a single (type,
+ * direction) slice and by {@link GraphTraversalProvider#edgeWeightsOf} for the concatenation of them. Handing the
+ * two back together is what removes the reconciliation step - and every place that reconciled them afterwards got
+ * it wrong, which is issues #6301 and #6315.
  *
  * @param neighbors dense neighbour ids
  * @param weights   the property value of the edge to the neighbour at the same index

--- a/engine/src/main/java/com/arcadedb/graph/NodeEdgeWeights.java
+++ b/engine/src/main/java/com/arcadedb/graph/NodeEdgeWeights.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.graph;
 
+import java.util.Arrays;
+
 /**
  * One node's neighbours and the edge-property value of each edge reaching them, produced together.
  * <p>
@@ -33,4 +35,28 @@ package com.arcadedb.graph;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public record NodeEdgeWeights(int[] neighbors, double[] weights) {
+  /**
+   * By content, not by array identity. A record's generated {@code equals} compares its components with
+   * {@code Object.equals}, which for two arrays is identity - so two separately built rows describing the very
+   * same neighbourhood would answer "not equal", and one used as a map key would never be found again. Nobody
+   * relies on that today; the point of writing it out is that the reader who eventually does will not have to
+   * discover it first.
+   */
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other)
+      return true;
+    return other instanceof NodeEdgeWeights that
+        && Arrays.equals(neighbors, that.neighbors) && Arrays.equals(weights, that.weights);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * Arrays.hashCode(neighbors) + Arrays.hashCode(weights);
+  }
+
+  @Override
+  public String toString() {
+    return "NodeEdgeWeights[neighbors=" + Arrays.toString(neighbors) + ", weights=" + Arrays.toString(weights) + "]";
+  }
 }

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
@@ -225,6 +225,16 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
    * regardless, and until it lands the view serves no edge properties at all, so no stale one can escape.
    */
   private void trackEdgeUpdate(final TxDelta delta, final Edge edge) {
+    // A view that materialises no edge property columns has nothing that can go out of date when an edge's
+    // properties change, and nothing to rebuild them from - the base CSR holds the topology, which an update
+    // does not touch. It was rebuilt anyway, on every single edge update, because #4513's flag was raised
+    // before anyone asked whether there were columns at all. Which property changed is still not asked, and
+    // cannot be: the listener is handed the record, not a diff against its previous values, so a view that
+    // materialises `weight` cannot tell an update of `weight` from an update of `label` and has to assume the
+    // worse of the two.
+    final String[] materialised = view.getEdgePropertyFilter();
+    if (materialised == null || materialised.length == 0)
+      return;
     if (delta.forceEdgePropertyRebuild)
       return;
     if (delta.updatedEdges.size() >= MAX_TRACKED_EDGE_UPDATES) {
@@ -250,6 +260,7 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
     final String[] materialised = view.getEdgePropertyFilter();
     if (materialised == null || materialised.length == 0)
       return null;
+
     Map<String, Object> props = null;
     for (final String name : materialised) {
       final Object value = edge.get(name);

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
@@ -20,6 +20,7 @@ package com.arcadedb.graph.olap;
 
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.event.AfterRecordCreateListener;
 import com.arcadedb.event.AfterRecordDeleteListener;
@@ -53,9 +54,10 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
 
   private static final AtomicInteger ANONYMOUS_COUNTER = new AtomicInteger();
 
-  // Past this many edge property changes in one transaction, they stop being tracked individually. See
-  // trackEdgeUpdate().
-  private static final int          MAX_TRACKED_EDGE_UPDATES = 1024;
+  // Past this many DISTINCT edges' property changes in one transaction, they stop being tracked individually.
+  // See trackEdgeUpdate(). Package-private so a test can reach the boundary without writing the number down
+  // itself: the contract is "a repeat update never trips it", and retuning the number must not break that.
+  static final int                  MAX_TRACKED_EDGE_UPDATES = 1024;
 
   private final GraphAnalyticalView view;
   private final String              callbackKey;
@@ -237,13 +239,17 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
       return;
     if (delta.forceEdgePropertyRebuild)
       return;
-    if (delta.updatedEdges.size() >= MAX_TRACKED_EDGE_UPDATES) {
+    final RID rid = edge.getIdentity();
+    // Asked before the cap, not after: an edge already tracked does not grow the map, so a repeat update of
+    // one - the accumulator this cap counts distinct edges precisely to tolerate - must not trip it merely
+    // because the transaction has touched enough OTHER edges to fill it.
+    if (!delta.updatedEdges.containsKey(rid) && delta.updatedEdges.size() >= MAX_TRACKED_EDGE_UPDATES) {
       delta.forceEdgePropertyRebuild = true;
       delta.updatedEdges.clear();
       return;
     }
-    delta.updatedEdges.put(edge.getIdentity(), new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(),
-        edge.getIn(), edge.getIdentity(), extractMaterialisedEdgeProperties(edge)));
+    delta.updatedEdges.put(rid, new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(),
+        edge.getIn(), rid, extractMaterialisedEdgeProperties(edge)));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
@@ -53,6 +53,10 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
 
   private static final AtomicInteger ANONYMOUS_COUNTER = new AtomicInteger();
 
+  // Past this many edge property changes in one transaction, they stop being tracked individually. See
+  // trackEdgeUpdate().
+  private static final int          MAX_TRACKED_EDGE_UPDATES = 1024;
+
   private final GraphAnalyticalView view;
   private final String              callbackKey;
 
@@ -80,7 +84,8 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
       if (record instanceof Vertex vertex)
         delta.addedVertices.add(new TxDelta.VertexDelta(vertex.getIdentity(), extractProperties(vertex)));
       else if (record instanceof Edge edge)
-        delta.addedEdges.add(new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(), edge.getIn(), edge.getIdentity()));
+        delta.addedEdges.add(new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(), edge.getIn(), edge.getIdentity(),
+            extractMaterialisedEdgeProperties(edge)));
       scheduleSyncCallback(delta);
     } else {
       scheduleAsyncCallback();
@@ -98,13 +103,14 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
         final TxDelta delta = getOrCreateDelta();
         delta.updatedProperties.put(vertex.getIdentity(), extractProperties(vertex));
         scheduleSyncCallback(delta);
-      } else if (record instanceof Edge) {
-        // Edge property updates have no overlay representation (the columnar edge stores are read
-        // directly by the array-based algorithms, bypassing the overlay), so flag the delta to
-        // force a rebuild on commit. Without this, edge property changes (e.g. weight updates read
-        // by Dijkstra) would be silently dropped until the next compaction. See issue #4513.
+      } else if (record instanceof Edge edge) {
+        // Reported with its new values rather than as a bare "something changed" flag: an edge the overlay
+        // itself holds carries its values there and can simply take the new ones, while an edge in the base
+        // CSR is addressed by a column slot nothing maps back from its RID and needs the rebuild the flag used
+        // to force unconditionally. DeltaOverlay.merge() is where the two are told apart, since it is what
+        // knows which edges the overlay holds. See issues #4513 and #6315.
         final TxDelta delta = getOrCreateDelta();
-        delta.edgePropertiesUpdated = true;
+        trackEdgeUpdate(delta, edge);
         scheduleSyncCallback(delta);
       }
     } else {
@@ -155,7 +161,8 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
           frozen.addedEdges.addAll(delta.addedEdges);
           frozen.deletedEdges.addAll(delta.deletedEdges);
           frozen.updatedProperties.putAll(delta.updatedProperties);
-          frozen.edgePropertiesUpdated = delta.edgePropertiesUpdated;
+          frozen.updatedEdges.addAll(delta.updatedEdges);
+          frozen.forceEdgePropertyRebuild = delta.forceEdgePropertyRebuild;
           delta.clear();
           perThreadDeltas.remove(Thread.currentThread().threadId());
           if (!frozen.isEmpty())
@@ -205,6 +212,54 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
   void close() {
     if (perThreadDeltas != null)
       perThreadDeltas.clear();
+  }
+
+  /**
+   * Records one edge property change, or gives up on recording them individually.
+   * <p>
+   * Tracking each one is what lets {@link DeltaOverlay#merge} apply an update to an edge the overlay itself
+   * holds without marking the base columns out of date (issue #6315). It is worth an entry per edge only while
+   * there are few of them: a transaction rewriting a million edges' weights would otherwise hold a million of
+   * these, where the old boolean flag held nothing. Past the cap the delta says only "the columns are out of
+   * date", which is what a bulk rewrite means anyway - the rebuild it forces is going to reread every value
+   * regardless, and until it lands the view serves no edge properties at all, so no stale one can escape.
+   */
+  private void trackEdgeUpdate(final TxDelta delta, final Edge edge) {
+    if (delta.forceEdgePropertyRebuild)
+      return;
+    if (delta.updatedEdges.size() >= MAX_TRACKED_EDGE_UPDATES) {
+      delta.forceEdgePropertyRebuild = true;
+      delta.updatedEdges.clear();
+      return;
+    }
+    delta.updatedEdges.add(new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(), edge.getIn(),
+        edge.getIdentity(), extractMaterialisedEdgeProperties(edge)));
+  }
+
+  /**
+   * Reads the values of the edge properties the view materialises columns for, or {@code null} when it
+   * materialises none.
+   * <p>
+   * Captured here, at commit time, rather than looked up from the record when an algorithm asks: the overlay
+   * outlives the transaction, and an added edge has no column slot to be read from - the columns were built
+   * with the base CSR - so this is what lets the view answer for it exactly instead of at a default weight
+   * (issue #6315). Only the materialised names are kept, so an edge with fifty properties on a view that
+   * indexes one costs one entry.
+   */
+  private Map<String, Object> extractMaterialisedEdgeProperties(final Edge edge) {
+    final String[] materialised = view.getEdgePropertyFilter();
+    if (materialised == null || materialised.length == 0)
+      return null;
+    Map<String, Object> props = null;
+    for (final String name : materialised) {
+      final Object value = edge.get(name);
+      if (value == null)
+        continue;
+      if (props == null)
+        props = new HashMap<>(materialised.length);
+      props.put(name, value);
+    }
+    return props;
   }
 
   private static Map<String, Object> extractProperties(final Document doc) {

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
@@ -161,7 +161,7 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
           frozen.addedEdges.addAll(delta.addedEdges);
           frozen.deletedEdges.addAll(delta.deletedEdges);
           frozen.updatedProperties.putAll(delta.updatedProperties);
-          frozen.updatedEdges.addAll(delta.updatedEdges);
+          frozen.updatedEdges.putAll(delta.updatedEdges);
           frozen.forceEdgePropertyRebuild = delta.forceEdgePropertyRebuild;
           delta.clear();
           perThreadDeltas.remove(Thread.currentThread().threadId());
@@ -242,8 +242,8 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
       delta.updatedEdges.clear();
       return;
     }
-    delta.updatedEdges.add(new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(), edge.getIn(),
-        edge.getIdentity(), extractMaterialisedEdgeProperties(edge)));
+    delta.updatedEdges.put(edge.getIdentity(), new TxDelta.EdgeDelta(edge.getTypeName(), edge.getOut(),
+        edge.getIn(), edge.getIdentity(), extractMaterialisedEdgeProperties(edge)));
   }
 
   /**
@@ -266,8 +266,10 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
       final Object value = edge.get(name);
       if (value == null)
         continue;
+      // Sized so the whole filter fits without a resize: HashMap's argument is the bucket count, and it grows
+      // once past load factor x capacity, not past capacity.
       if (props == null)
-        props = new HashMap<>(materialised.length);
+        props = new HashMap<>((int) (materialised.length / 0.75f) + 1);
       props.put(name, value);
     }
     return props;

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaCollector.java
@@ -253,26 +253,27 @@ class DeltaCollector implements AfterRecordCreateListener, AfterRecordUpdateList
    * Captured here, at commit time, rather than looked up from the record when an algorithm asks: the overlay
    * outlives the transaction, and an added edge has no column slot to be read from - the columns were built
    * with the base CSR - so this is what lets the view answer for it exactly instead of at a default weight
-   * (issue #6315). Only the materialised names are kept, so an edge with fifty properties on a view that
-   * indexes one costs one entry.
+   * (issue #6315). One slot per materialised name, in the filter's own order, so an edge with fifty properties
+   * on a view that indexes one costs one slot - and the reader resolves the name to a position once per slice
+   * rather than hashing it per edge.
    */
-  private Map<String, Object> extractMaterialisedEdgeProperties(final Edge edge) {
+  private Object[] extractMaterialisedEdgeProperties(final Edge edge) {
     final String[] materialised = view.getEdgePropertyFilter();
     if (materialised == null || materialised.length == 0)
       return null;
 
-    Map<String, Object> props = null;
-    for (final String name : materialised) {
-      final Object value = edge.get(name);
+    Object[] values = null;
+    for (int i = 0; i < materialised.length; i++) {
+      final Object value = edge.get(materialised[i]);
       if (value == null)
         continue;
-      // Sized so the whole filter fits without a resize: HashMap's argument is the bucket count, and it grows
-      // once past load factor x capacity, not past capacity.
-      if (props == null)
-        props = new HashMap<>((int) (materialised.length / 0.75f) + 1);
-      props.put(name, value);
+      // Allocated only once a value is actually found, so an edge carrying none of the materialised
+      // properties - and a bulk insert of them - costs nothing here.
+      if (values == null)
+        values = new Object[materialised.length];
+      values[i] = value;
     }
-    return props;
+    return values;
   }
 
   private static Map<String, Object> extractProperties(final Document doc) {

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -48,16 +48,18 @@ class DeltaOverlay {
   // Deleted overflow nodes (indexed by overflowIdx = globalId - baseNodeCount)
   private final BitSet                      deletedOverflowNodes;
 
-  // Added edges per type: edgeType -> the added edge's own identity -> (srcGlobalId, tgtGlobalId) pair.
+  // Added edges per type: edgeType -> the added edge's own identity -> its endpoints and materialised
+  // property values.
   // Keyed by RID rather than held in a plain list so that an edge added and later deleted within the SAME
   // not-yet-compacted overlay window can be withdrawn from here by identity, instead of being masked with a
   // pair-keyed deletion it has no right to spend (issue #6775 - see merge()). Insertion-ordered, because
   // the neighbour index below is built from it and parallel edges must keep their addition order.
-  private final Map<String, Map<RID, long[]>> addedEdgesPerType;
+  private final Map<String, Map<RID, AddedEdge>> addedEdgesPerType;
 
-  // Secondary indexes for O(1) neighbor lookup: edgeType -> nodeId -> neighbor list
-  private final Map<String, Map<Integer, int[]>> outNeighborIndex;
-  private final Map<String, Map<Integer, int[]>> inNeighborIndex;
+  // Secondary indexes for O(1) neighbor lookup: edgeType -> nodeId -> neighbor list (with the edges' own
+  // property values beside it, when the view materialises any)
+  private final Map<String, Map<Integer, AddedNeighbors>> outNeighborIndex;
+  private final Map<String, Map<Integer, AddedNeighbors>> inNeighborIndex;
 
   // Deleted edges per type: edgeType -> packed (src << 32 | tgt) -> number of distinct edges deleted for
   // that pair. A count rather than a presence flag: two parallel edges between the same pair, only one of
@@ -83,6 +85,15 @@ class DeltaOverlay {
   private final int overflowCount;
   private final int deltaEdgeCount;
 
+  // True once a transaction has changed a covered edge's properties. Such a change has no overlay
+  // representation - an edge already in the base CSR is addressed by its column slot, and nothing maps that
+  // slot back from the edge's RID - so the base columns are simply out of date until the rebuild
+  // GraphAnalyticalView.applyDelta() forces for it lands. Until then the view answers "no edge properties"
+  // rather than a stale weight: the added edges below carry their own values and could be served exactly, but
+  // a base edge whose weight was just updated could not, and there is no honest way to serve one without the
+  // other (issues #4513 and #6315).
+  private final boolean edgePropertiesDirty;
+
   @SuppressWarnings("unchecked")
   DeltaOverlay(final int baseNodeCount) {
     this.baseNodeCount = baseNodeCount;
@@ -101,6 +112,7 @@ class DeltaOverlay {
     this.inNeighborIndex = Collections.emptyMap();
     this.overflowCount = 0;
     this.deltaEdgeCount = 0;
+    this.edgePropertiesDirty = false;
   }
 
   // The private constructor takes ownership of all passed collections — callers MUST NOT
@@ -111,15 +123,15 @@ class DeltaOverlay {
       final Map<RID, Integer> overflowNodeIds, final RID[] overflowIdToRID,
       final Map<String, Object>[] overflowProperties,
       final BitSet deletedBaseNodes, final BitSet deletedOverflowNodes,
-      final Map<String, Map<RID, long[]>> addedEdgesPerType,
+      final Map<String, Map<RID, AddedEdge>> addedEdgesPerType,
       final Map<String, Map<Long, Integer>> deletedEdgesPerType,
       final Map<String, Set<RID>> deletedEdgeRIDsPerType,
       final Map<String, IntIntHashMap> deletedOutEdgeCounts,
       final Map<String, IntIntHashMap> deletedInEdgeCounts,
       final Map<Integer, Map<String, Object>> propertyOverrides,
-      final Map<String, Map<Integer, int[]>> outNeighborIndex,
-      final Map<String, Map<Integer, int[]>> inNeighborIndex,
-      final int overflowCount, final int deltaEdgeCount) {
+      final Map<String, Map<Integer, AddedNeighbors>> outNeighborIndex,
+      final Map<String, Map<Integer, AddedNeighbors>> inNeighborIndex,
+      final int overflowCount, final int deltaEdgeCount, final boolean edgePropertiesDirty) {
     this.baseNodeCount = baseNodeCount;
     this.overflowNodeIds = overflowNodeIds;
     this.overflowIdToRID = overflowIdToRID;
@@ -136,6 +148,7 @@ class DeltaOverlay {
     this.inNeighborIndex = inNeighborIndex;
     this.overflowCount = overflowCount;
     this.deltaEdgeCount = deltaEdgeCount;
+    this.edgePropertiesDirty = edgePropertiesDirty;
   }
 
   /**
@@ -166,7 +179,7 @@ class DeltaOverlay {
     final List<Map<String, Object>> overflowPropsList = new ArrayList<>(Arrays.asList(overflowProperties));
     final BitSet newDeleted = (BitSet) deletedBaseNodes.clone();
     final BitSet newDeletedOverflow = (BitSet) deletedOverflowNodes.clone();
-    final Map<String, Map<RID, long[]>> newAddedEdges = new HashMap<>();
+    final Map<String, Map<RID, AddedEdge>> newAddedEdges = new HashMap<>();
     for (final var entry : addedEdgesPerType.entrySet())
       newAddedEdges.put(entry.getKey(), new LinkedHashMap<>(entry.getValue()));
     final Map<String, Map<Long, Integer>> newDeletedEdges = new HashMap<>();
@@ -258,8 +271,24 @@ class DeltaOverlay {
       // Keyed by the edge's own identity, so a replayed add of an edge the overlay already holds is
       // absorbed instead of appending a second, phantom, occurrence of the same edge.
       if (newAddedEdges.computeIfAbsent(ed.edgeType, k -> new LinkedHashMap<>())
-          .put(ed.rid, new long[] { srcId, tgtId }) == null)
+          .put(ed.rid, new AddedEdge(srcId, tgtId, ed.properties)) == null)
         newDeltaEdgeCount++;
+    }
+
+    // Process edge property updates. An edge this overlay window holds as an addition takes the new values
+    // straight into its own entry - it has no column slot to be out of step with, and the ordinary
+    // `newEdge(...).save()` reports exactly this, one create and one update of the same edge. Anything else is
+    // an edge the base CSR holds, whose column slot cannot be found from its RID, so the columns are now out of
+    // date and only the rebuild GraphAnalyticalView.applyDelta() forces can repair them (issues #4513, #6315).
+    // Runs after the additions above so that an edge added and updated within the same transaction is found.
+    boolean newEdgePropertiesDirty = delta.forceEdgePropertyRebuild;
+    for (final TxDelta.EdgeDelta ed : delta.updatedEdges) {
+      final Map<RID, AddedEdge> addedForType = newAddedEdges.get(ed.edgeType);
+      final AddedEdge added = addedForType != null ? addedForType.get(ed.rid) : null;
+      if (added != null)
+        addedForType.put(ed.rid, new AddedEdge(added.src(), added.tgt(), ed.properties));
+      else
+        newEdgePropertiesDirty = true;
     }
 
     // Process deleted edges
@@ -275,7 +304,7 @@ class DeltaOverlay {
       // the append-only added index used to surface an added-then-deleted edge as a live neighbour. Done by
       // identity, before the dedup guard below, so a RID recycled onto a new edge (see #6777) still cancels
       // its own add rather than having the whole deletion dropped.
-      final Map<RID, long[]> addedForType = newAddedEdges.get(ed.edgeType);
+      final Map<RID, AddedEdge> addedForType = newAddedEdges.get(ed.edgeType);
       if (addedForType != null && addedForType.remove(ed.rid) != null) {
         newDeltaEdgeCount--; // undo the +1 the withdrawn add contributed
         if (addedForType.isEmpty())
@@ -313,8 +342,8 @@ class DeltaOverlay {
     }
 
     // Build secondary neighbor indexes for O(1) lookup
-    final Map<String, Map<Integer, int[]>> newOutIndex = buildNeighborIndex(newAddedEdges, true);
-    final Map<String, Map<Integer, int[]>> newInIndex = buildNeighborIndex(newAddedEdges, false);
+    final Map<String, Map<Integer, AddedNeighbors>> newOutIndex = buildNeighborIndex(newAddedEdges, true);
+    final Map<String, Map<Integer, AddedNeighbors>> newInIndex = buildNeighborIndex(newAddedEdges, false);
 
     // Build per-node deleted edge count indexes for O(1) lookup
     final Map<String, IntIntHashMap> newDelOutCounts = buildDeletedEdgeCounts(newDeletedEdges, true);
@@ -327,7 +356,7 @@ class DeltaOverlay {
         newDeleted, newDeletedOverflow, newAddedEdges, newDeletedEdges, newDeletedEdgeRIDs,
         newDelOutCounts, newDelInCounts, newPropOverrides,
         newOutIndex, newInIndex,
-        newOverflowCount, newDeltaEdgeCount);
+        newOverflowCount, newDeltaEdgeCount, edgePropertiesDirty || newEdgePropertiesDirty);
   }
 
   // --- Query helpers ---
@@ -362,12 +391,40 @@ class DeltaOverlay {
   }
 
   private int[] getAddedNeighbors(final int nodeId, final String edgeType, final boolean outgoing) {
-    final Map<String, Map<Integer, int[]>> index = outgoing ? outNeighborIndex : inNeighborIndex;
-    final Map<Integer, int[]> typeIndex = index.get(edgeType);
-    if (typeIndex == null)
-      return EMPTY_INT;
-    final int[] result = typeIndex.get(nodeId);
-    return result != null ? result : EMPTY_INT;
+    final AddedNeighbors added = getAdded(nodeId, edgeType, outgoing);
+    return added != null ? added.nodeIds() : EMPTY_INT;
+  }
+
+  /**
+   * Returns the property values of the added outgoing edges of {@code nodeId}, one entry per entry of
+   * {@link #getAddedOutNeighbors}, or {@code null} when none of them carries any.
+   */
+  Map<String, Object>[] getAddedOutEdgeProperties(final int nodeId, final String edgeType) {
+    final AddedNeighbors added = getAdded(nodeId, edgeType, true);
+    return added != null ? added.properties() : null;
+  }
+
+  /**
+   * Returns the property values of the added incoming edges of {@code nodeId}, one entry per entry of
+   * {@link #getAddedInNeighbors}, or {@code null} when none of them carries any.
+   */
+  Map<String, Object>[] getAddedInEdgeProperties(final int nodeId, final String edgeType) {
+    final AddedNeighbors added = getAdded(nodeId, edgeType, false);
+    return added != null ? added.properties() : null;
+  }
+
+  private AddedNeighbors getAdded(final int nodeId, final String edgeType, final boolean outgoing) {
+    final Map<String, Map<Integer, AddedNeighbors>> index = outgoing ? outNeighborIndex : inNeighborIndex;
+    final Map<Integer, AddedNeighbors> typeIndex = index.get(edgeType);
+    return typeIndex == null ? null : typeIndex.get(nodeId);
+  }
+
+  /**
+   * True once a covered edge's properties were changed by a committed transaction, which leaves the base
+   * columns holding a value the database no longer has. See the field's own comment.
+   */
+  boolean isEdgePropertiesDirty() {
+    return edgePropertiesDirty;
   }
 
   boolean isEdgeDeleted(final String edgeType, final int srcId, final int tgtId) {
@@ -456,7 +513,7 @@ class DeltaOverlay {
   boolean hasChanges() {
     return overflowCount > 0 || !deletedBaseNodes.isEmpty()
         || !addedEdgesPerType.isEmpty() || !deletedEdgesPerType.isEmpty()
-        || !propertyOverrides.isEmpty();
+        || !propertyOverrides.isEmpty() || edgePropertiesDirty;
   }
 
   // --- Internals ---
@@ -471,38 +528,52 @@ class DeltaOverlay {
   }
 
   /**
-   * Builds a secondary index: edgeType -> nodeId -> int[] neighbors, for O(1) lookup.
+   * Builds a secondary index: edgeType -> nodeId -> its added neighbours, for O(1) lookup.
    * Uses a two-pass approach: first counts the degree per node to allocate exact-size arrays,
    * then fills them in a second pass. This avoids repeated doubling and trimming allocations
    * that would occur with a growable-array approach for high-degree nodes.
+   * <p>
+   * The edges' own property values are filled in the same pass as the neighbour ids and into an array of the
+   * same length, so an added edge's weight is found at the index its neighbour is found at - the pairing
+   * {@link GraphAnalyticalView#edgeWeightsForSlice} hands on to its caller, and the reason it can serve an
+   * overlay-added edge exactly rather than at a default weight (issue #6315). The property array is left
+   * {@code null} for a type no added edge of which carries any value, which is every type of a view that
+   * materialises no edge property columns at all - the common case, and it costs nothing there.
    */
-  private static Map<String, Map<Integer, int[]>> buildNeighborIndex(
-      final Map<String, Map<RID, long[]>> addedEdges, final boolean outgoing) {
+  @SuppressWarnings("unchecked")
+  private static Map<String, Map<Integer, AddedNeighbors>> buildNeighborIndex(
+      final Map<String, Map<RID, AddedEdge>> addedEdges, final boolean outgoing) {
     if (addedEdges.isEmpty())
       return Collections.emptyMap();
-    final Map<String, Map<Integer, int[]>> result = new HashMap<>();
+    final Map<String, Map<Integer, AddedNeighbors>> result = new HashMap<>();
     for (final var entry : addedEdges.entrySet()) {
-      final Collection<long[]> edges = entry.getValue().values();
+      final Collection<AddedEdge> edges = entry.getValue().values();
 
       // Pass 1: count neighbors per node
       final IntIntHashMap counts = new IntIntHashMap();
-      for (final long[] pair : edges) {
-        final int key = (int) (outgoing ? pair[0] : pair[1]);
-        counts.increment(key);
+      boolean anyProperties = false;
+      for (final AddedEdge edge : edges) {
+        counts.increment(outgoing ? edge.src() : edge.tgt());
+        if (edge.properties() != null && !edge.properties().isEmpty())
+          anyProperties = true;
       }
 
       // Allocate exact-size arrays
-      final Map<Integer, int[]> perNode = new HashMap<>(counts.size());
-      counts.forEach((key, count) -> perNode.put(key, new int[count]));
+      final boolean withProperties = anyProperties;
+      final Map<Integer, AddedNeighbors> perNode = new HashMap<>(counts.size());
+      counts.forEach((key, count) -> perNode.put(key,
+          new AddedNeighbors(new int[count], withProperties ? new Map[count] : null)));
 
       // Pass 2: fill arrays (use a fresh map as fill-position tracker)
       final IntIntHashMap positions = new IntIntHashMap(counts.size());
-      for (final long[] pair : edges) {
-        final int key = (int) (outgoing ? pair[0] : pair[1]);
-        final int neighbor = (int) (outgoing ? pair[1] : pair[0]);
-        final int[] arr = perNode.get(key);
+      for (final AddedEdge edge : edges) {
+        final int key = outgoing ? edge.src() : edge.tgt();
+        final int neighbor = outgoing ? edge.tgt() : edge.src();
+        final AddedNeighbors added = perNode.get(key);
         final int pos = positions.get(key, 0);
-        arr[pos] = neighbor;
+        added.nodeIds()[pos] = neighbor;
+        if (added.properties() != null)
+          added.properties()[pos] = edge.properties();
         positions.put(key, pos + 1);
       }
 
@@ -538,6 +609,29 @@ class DeltaOverlay {
 
   private static long packEdge(final int src, final int tgt) {
     return ((long) src << 32) | (tgt & UNSIGNED_INT_MASK);
+  }
+
+  /**
+   * One edge the overlay holds that the base CSR does not: its endpoints as dense ids, and the values of the
+   * edge properties the view materialises columns for, captured at commit time by {@link DeltaCollector}.
+   * <p>
+   * The values are carried rather than re-read from the record later because the overlay outlives the
+   * transaction that produced it, and by the time an algorithm asks for the weight the edge may be gone. They
+   * are also what makes an overlay-added edge answerable at all: it has no column slot to be addressed by.
+   *
+   * @param properties the materialised edge properties' values, or {@code null} when the view materialises none
+   */
+  record AddedEdge(int src, int tgt, Map<String, Object> properties) {
+  }
+
+  /**
+   * One node's added neighbours of one edge type and direction, each beside its own edge's property values.
+   *
+   * @param nodeIds    the added neighbours' dense ids
+   * @param properties the property values of the edge reaching the neighbour at the same index, or {@code null}
+   *                   when no added edge of this type carries any
+   */
+  record AddedNeighbors(int[] nodeIds, Map<String, Object>[] properties) {
   }
 
   static final Object UNSET = new Object();

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -292,17 +292,20 @@ class DeltaOverlay {
     // date and only the rebuild GraphAnalyticalView.applyDelta() forces can repair them (issues #4513, #6315).
     // Runs after the additions above so that an edge added and updated within the same transaction is found.
     final boolean newAllDirty = allEdgeTypesDirty || delta.forceEdgePropertyRebuild;
+    // Copied on the first type this delta actually dirties and not before, so an overlay whose updates all
+    // resolved against its own additions - the ordinary insert - keeps sharing the previous set.
     Set<String> newDirtyTypes = dirtyEdgeTypes;
+    boolean dirtyTypesCopied = false;
     for (final TxDelta.EdgeDelta ed : delta.updatedEdges.values()) {
       final Map<RID, AddedEdge> addedForType = newAddedEdges.get(ed.edgeType);
       final AddedEdge added = addedForType != null ? addedForType.get(ed.rid) : null;
       if (added != null)
         addedForType.put(ed.rid, new AddedEdge(added.src(), added.tgt(), ed.properties));
       else if (!newDirtyTypes.contains(ed.edgeType)) {
-        // Copied on the first type this delta actually dirties, so an overlay whose updates all resolved
-        // against its own additions - the ordinary insert - keeps sharing the previous set.
-        if (newDirtyTypes == dirtyEdgeTypes)
+        if (!dirtyTypesCopied) {
           newDirtyTypes = new HashSet<>(dirtyEdgeTypes);
+          dirtyTypesCopied = true;
+        }
         newDirtyTypes.add(ed.edgeType);
       }
     }

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -245,6 +245,7 @@ class DeltaOverlay {
     }
 
     // Process added edges
+    Set<RID> alreadyInFreshBase = null;
     for (final TxDelta.EdgeDelta ed : delta.addedEdges) {
       final int srcId = resolveNodeId(ed.source, baseMapping, newOverflowIds);
       final int tgtId = resolveNodeId(ed.target, baseMapping, newOverflowIds);
@@ -262,6 +263,13 @@ class DeltaOverlay {
           final boolean masked = (prevDel != null && prevDel.containsKey(packed))
               || (sameDeltaDeleted != null && sameDeltaDeleted.contains(packed));
           if (!masked) {
+            // Remembered for the update loop below: the fresh base CSR already carries this edge, scan and
+            // all, so a property change to it in this same delta is already in the columns and dirties
+            // nothing. Without this the ordinary insert - one create and one update of the same edge - would
+            // force a second full rebuild after every compaction that happened to buffer one.
+            if (alreadyInFreshBase == null)
+              alreadyInFreshBase = new HashSet<>();
+            alreadyInFreshBase.add(ed.rid);
             // The fresh base CSR already represents this edge, so it is not tracked by identity here
             // (issue #4588) - which means a LATER deletion of this exact RID cannot be withdrawn by
             // identity either. Drop any stale reservation of this RID from the identity-dedup Set: RIDs
@@ -301,7 +309,10 @@ class DeltaOverlay {
       final AddedEdge added = addedForType != null ? addedForType.get(ed.rid) : null;
       if (added != null)
         addedForType.put(ed.rid, new AddedEdge(added.src(), added.tgt(), ed.properties));
-      else if (!newDirtyTypes.contains(ed.edgeType)) {
+      else if (alreadyInFreshBase != null && alreadyInFreshBase.contains(ed.rid)) {
+        // Nothing to do: the freshly built base CSR scanned this edge after the transaction that made both
+        // the add and this update committed, so its columns already hold the value this update set.
+      } else if (!newDirtyTypes.contains(ed.edgeType)) {
         if (!dirtyTypesCopied) {
           newDirtyTypes = new HashSet<>(dirtyEdgeTypes);
           dirtyTypesCopied = true;

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -282,7 +282,7 @@ class DeltaOverlay {
     // date and only the rebuild GraphAnalyticalView.applyDelta() forces can repair them (issues #4513, #6315).
     // Runs after the additions above so that an edge added and updated within the same transaction is found.
     boolean newEdgePropertiesDirty = delta.forceEdgePropertyRebuild;
-    for (final TxDelta.EdgeDelta ed : delta.updatedEdges) {
+    for (final TxDelta.EdgeDelta ed : delta.updatedEdges.values()) {
       final Map<RID, AddedEdge> addedForType = newAddedEdges.get(ed.edgeType);
       final AddedEdge added = addedForType != null ? addedForType.get(ed.rid) : null;
       if (added != null)

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -85,14 +85,21 @@ class DeltaOverlay {
   private final int overflowCount;
   private final int deltaEdgeCount;
 
-  // True once a transaction has changed a covered edge's properties. Such a change has no overlay
-  // representation - an edge already in the base CSR is addressed by its column slot, and nothing maps that
-  // slot back from the edge's RID - so the base columns are simply out of date until the rebuild
-  // GraphAnalyticalView.applyDelta() forces for it lands. Until then the view answers "no edge properties"
-  // rather than a stale weight: the added edges below carry their own values and could be served exactly, but
-  // a base edge whose weight was just updated could not, and there is no honest way to serve one without the
-  // other (issues #4513 and #6315).
-  private final boolean edgePropertiesDirty;
+  // The edge types whose property columns a committed transaction has left out of date. Such a change has no
+  // overlay representation - an edge already in the base CSR is addressed by its column slot, and nothing maps
+  // that slot back from the edge's RID - so those columns are stale until the rebuild
+  // GraphAnalyticalView.applyDelta() forces for them lands. Until then the view answers "no edge properties"
+  // for those types rather than a stale weight: the added edges below carry their own values and could be
+  // served exactly, but a base edge whose weight was just updated could not, and there is no honest way to
+  // serve one without the other (issues #4513 and #6315).
+  //
+  // Per type rather than one flag for the overlay, so that an update to one materialised edge type does not
+  // cost the columnar path for every other type the view holds.
+  private final Set<String> dirtyEdgeTypes;
+
+  // True when the columns are out of date for types unknown - the bulk case, where DeltaCollector gave up on
+  // naming the edges individually. Every type is then out of date.
+  private final boolean     allEdgeTypesDirty;
 
   @SuppressWarnings("unchecked")
   DeltaOverlay(final int baseNodeCount) {
@@ -112,7 +119,8 @@ class DeltaOverlay {
     this.inNeighborIndex = Collections.emptyMap();
     this.overflowCount = 0;
     this.deltaEdgeCount = 0;
-    this.edgePropertiesDirty = false;
+    this.dirtyEdgeTypes = Collections.emptySet();
+    this.allEdgeTypesDirty = false;
   }
 
   // The private constructor takes ownership of all passed collections — callers MUST NOT
@@ -131,7 +139,8 @@ class DeltaOverlay {
       final Map<Integer, Map<String, Object>> propertyOverrides,
       final Map<String, Map<Integer, AddedNeighbors>> outNeighborIndex,
       final Map<String, Map<Integer, AddedNeighbors>> inNeighborIndex,
-      final int overflowCount, final int deltaEdgeCount, final boolean edgePropertiesDirty) {
+      final int overflowCount, final int deltaEdgeCount, final Set<String> dirtyEdgeTypes,
+      final boolean allEdgeTypesDirty) {
     this.baseNodeCount = baseNodeCount;
     this.overflowNodeIds = overflowNodeIds;
     this.overflowIdToRID = overflowIdToRID;
@@ -148,7 +157,8 @@ class DeltaOverlay {
     this.inNeighborIndex = inNeighborIndex;
     this.overflowCount = overflowCount;
     this.deltaEdgeCount = deltaEdgeCount;
-    this.edgePropertiesDirty = edgePropertiesDirty;
+    this.dirtyEdgeTypes = dirtyEdgeTypes;
+    this.allEdgeTypesDirty = allEdgeTypesDirty;
   }
 
   /**
@@ -281,14 +291,20 @@ class DeltaOverlay {
     // an edge the base CSR holds, whose column slot cannot be found from its RID, so the columns are now out of
     // date and only the rebuild GraphAnalyticalView.applyDelta() forces can repair them (issues #4513, #6315).
     // Runs after the additions above so that an edge added and updated within the same transaction is found.
-    boolean newEdgePropertiesDirty = delta.forceEdgePropertyRebuild;
+    final boolean newAllDirty = allEdgeTypesDirty || delta.forceEdgePropertyRebuild;
+    Set<String> newDirtyTypes = dirtyEdgeTypes;
     for (final TxDelta.EdgeDelta ed : delta.updatedEdges.values()) {
       final Map<RID, AddedEdge> addedForType = newAddedEdges.get(ed.edgeType);
       final AddedEdge added = addedForType != null ? addedForType.get(ed.rid) : null;
       if (added != null)
         addedForType.put(ed.rid, new AddedEdge(added.src(), added.tgt(), ed.properties));
-      else
-        newEdgePropertiesDirty = true;
+      else if (!newDirtyTypes.contains(ed.edgeType)) {
+        // Copied on the first type this delta actually dirties, so an overlay whose updates all resolved
+        // against its own additions - the ordinary insert - keeps sharing the previous set.
+        if (newDirtyTypes == dirtyEdgeTypes)
+          newDirtyTypes = new HashSet<>(dirtyEdgeTypes);
+        newDirtyTypes.add(ed.edgeType);
+      }
     }
 
     // Process deleted edges
@@ -356,7 +372,7 @@ class DeltaOverlay {
         newDeleted, newDeletedOverflow, newAddedEdges, newDeletedEdges, newDeletedEdgeRIDs,
         newDelOutCounts, newDelInCounts, newPropOverrides,
         newOutIndex, newInIndex,
-        newOverflowCount, newDeltaEdgeCount, edgePropertiesDirty || newEdgePropertiesDirty);
+        newOverflowCount, newDeltaEdgeCount, newDirtyTypes, newAllDirty);
   }
 
   // --- Query helpers ---
@@ -412,11 +428,16 @@ class DeltaOverlay {
   }
 
   /**
-   * True once a covered edge's properties were changed by a committed transaction, which leaves the base
-   * columns holding a value the database no longer has. See the field's own comment.
+   * True when a committed transaction left {@code edgeType}'s property columns holding a value the database no
+   * longer has. See the field's own comment.
    */
+  boolean isEdgePropertiesDirty(final String edgeType) {
+    return allEdgeTypesDirty || dirtyEdgeTypes.contains(edgeType);
+  }
+
+  /** True when any edge type's property columns are out of date. */
   boolean isEdgePropertiesDirty() {
-    return edgePropertiesDirty;
+    return allEdgeTypesDirty || !dirtyEdgeTypes.isEmpty();
   }
 
   boolean isEdgeDeleted(final String edgeType, final int srcId, final int tgtId) {
@@ -505,7 +526,7 @@ class DeltaOverlay {
   boolean hasChanges() {
     return overflowCount > 0 || !deletedBaseNodes.isEmpty()
         || !addedEdgesPerType.isEmpty() || !deletedEdgesPerType.isEmpty()
-        || !propertyOverrides.isEmpty() || edgePropertiesDirty;
+        || !propertyOverrides.isEmpty() || isEdgePropertiesDirty();
   }
 
   // --- Internals ---
@@ -532,7 +553,6 @@ class DeltaOverlay {
    * {@code null} for a type no added edge of which carries any value, which is every type of a view that
    * materialises no edge property columns at all - the common case, and it costs nothing there.
    */
-  @SuppressWarnings("unchecked")
   private static Map<String, Map<Integer, AddedNeighbors>> buildNeighborIndex(
       final Map<String, Map<RID, AddedEdge>> addedEdges, final boolean outgoing) {
     if (addedEdges.isEmpty())
@@ -546,7 +566,7 @@ class DeltaOverlay {
       boolean anyProperties = false;
       for (final AddedEdge edge : edges) {
         counts.increment(outgoing ? edge.src() : edge.tgt());
-        if (edge.properties() != null && !edge.properties().isEmpty())
+        if (edge.properties() != null)
           anyProperties = true;
       }
 
@@ -554,7 +574,7 @@ class DeltaOverlay {
       final boolean withProperties = anyProperties;
       final Map<Integer, AddedNeighbors> perNode = new HashMap<>(counts.size());
       counts.forEach((key, count) -> perNode.put(key,
-          new AddedNeighbors(new int[count], withProperties ? new Map[count] : null)));
+          new AddedNeighbors(new int[count], withProperties ? new Object[count][] : null)));
 
       // Pass 2: fill arrays (use a fresh map as fill-position tracker)
       final IntIntHashMap positions = new IntIntHashMap(counts.size());
@@ -611,9 +631,10 @@ class DeltaOverlay {
    * transaction that produced it, and by the time an algorithm asks for the weight the edge may be gone. They
    * are also what makes an overlay-added edge answerable at all: it has no column slot to be addressed by.
    *
-   * @param properties the materialised edge properties' values, or {@code null} when the view materialises none
+   * @param properties the materialised edge properties' values, one slot per name of the view's edge property
+   *                   filter in its order, or {@code null} when the view materialises none
    */
-  record AddedEdge(int src, int tgt, Map<String, Object> properties) {
+  record AddedEdge(int src, int tgt, Object[] properties) {
   }
 
   /**
@@ -623,7 +644,7 @@ class DeltaOverlay {
    * @param properties the property values of the edge reaching the neighbour at the same index, or {@code null}
    *                   when no added edge of this type carries any
    */
-  record AddedNeighbors(int[] nodeIds, Map<String, Object>[] properties) {
+  record AddedNeighbors(int[] nodeIds, Object[][] properties) {
   }
 
   static final Object UNSET = new Object();

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -396,24 +396,16 @@ class DeltaOverlay {
   }
 
   /**
-   * Returns the property values of the added outgoing edges of {@code nodeId}, one entry per entry of
-   * {@link #getAddedOutNeighbors}, or {@code null} when none of them carries any.
+   * Returns one node's added edges of a type and direction - the neighbours and, beside them, each edge's own
+   * property values - or {@code null} when it has none.
+   * <p>
+   * The two together rather than one accessor each, because a caller that needs both (
+   * {@link GraphAnalyticalView#edgeWeightsForSlice} does) would otherwise walk the same index twice for one
+   * slice.
+   *
+   * @param outgoing true for the added edges leaving {@code nodeId}, false for those reaching it
    */
-  Map<String, Object>[] getAddedOutEdgeProperties(final int nodeId, final String edgeType) {
-    final AddedNeighbors added = getAdded(nodeId, edgeType, true);
-    return added != null ? added.properties() : null;
-  }
-
-  /**
-   * Returns the property values of the added incoming edges of {@code nodeId}, one entry per entry of
-   * {@link #getAddedInNeighbors}, or {@code null} when none of them carries any.
-   */
-  Map<String, Object>[] getAddedInEdgeProperties(final int nodeId, final String edgeType) {
-    final AddedNeighbors added = getAdded(nodeId, edgeType, false);
-    return added != null ? added.properties() : null;
-  }
-
-  private AddedNeighbors getAdded(final int nodeId, final String edgeType, final boolean outgoing) {
+  AddedNeighbors getAdded(final int nodeId, final String edgeType, final boolean outgoing) {
     final Map<String, Map<Integer, AddedNeighbors>> index = outgoing ? outNeighborIndex : inNeighborIndex;
     final Map<Integer, AddedNeighbors> typeIndex = index.get(edgeType);
     return typeIndex == null ? null : typeIndex.get(nodeId);

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -1173,14 +1173,16 @@ public final class GraphAlgorithms {
    */
   public static double[] dijkstraSingleSource(final GraphAnalyticalView view, final int source,
       final String weightProperty, final Vertex.DIRECTION direction, final String... edgeTypes) {
-    // Point-in-time, not a pin: the CSR arrays and weight columns below are each fetched by their own
-    // accessor, so a commit landing between here and them is not caught. That is this whole class's existing
-    // shape - every algorithm in it reads the view through several independent accessor calls rather than one
-    // captured snapshot - and the window this narrows was wide open before.
-    if (view.hasActiveOverlay())
+    // One snapshot for the whole kernel, not one accessor call per part of it. Checking for an overlay and
+    // then fetching the offsets, the neighbours and the weight columns through four more reads of the field
+    // would let a commit land between any two of them, and the arrays either side of it are halves of two
+    // different graphs - out of which this would compute a plausible wrong distance rather than fail, which is
+    // the failure class issue #6315 exists to close, not to move.
+    final GraphAnalyticalView.Snapshot snap = view.captureSnapshot();
+    if (snap.overlay != null)
       return null;
 
-    final int n = view.getNodeMapping().size();
+    final int n = snap.nodeMapping.size();
     final double[] dist = new double[n];
     Arrays.fill(dist, Double.POSITIVE_INFINITY);
 
@@ -1188,7 +1190,8 @@ public final class GraphAlgorithms {
       return dist;
 
     dist[source] = 0.0;
-    final String[] types = resolveEdgeTypes(view, edgeTypes);
+    final String[] types = edgeTypes != null && edgeTypes.length > 0 ? edgeTypes
+        : snap.csrPerType.keySet().toArray(new String[0]);
 
     // Pre-load CSR arrays and weight columns for each edge type (avoid map lookups in hot loop)
     final int typeCount = types.length;
@@ -1200,10 +1203,10 @@ public final class GraphAlgorithms {
     final int[][] bwdToFwds = new int[typeCount][];
 
     for (int t = 0; t < typeCount; t++) {
-      csrs[t] = view.getCSRIndex(types[t]);
+      csrs[t] = snap.csrPerType.get(types[t]);
       if (csrs[t] == null)
         continue;
-      final ColumnStore edgeStore = view.getEdgeColumnStore(types[t]);
+      final ColumnStore edgeStore = snap.edgeColumnStores != null ? snap.edgeColumnStores.get(types[t]) : null;
       if (edgeStore != null) {
         final Column wCol = edgeStore.getColumn(weightProperty);
         if (wCol != null) {
@@ -1224,7 +1227,7 @@ public final class GraphAlgorithms {
         }
       }
       if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH)
-        bwdToFwds[t] = view.getBwdToFwdMapping(types[t]);
+        bwdToFwds[t] = snap.bwdToFwd != null ? snap.bwdToFwd.get(types[t]) : null;
     }
 
     // Dijkstra with binary min-heap (PriorityQueue)

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -1155,15 +1155,27 @@ public final class GraphAlgorithms {
    * Computes single-source shortest paths using Dijkstra's algorithm directly on CSR arrays
    * with edge weights from columnar storage. Zero OLTP access.
    *
+   * <b>Answers {@code null} while a delta overlay is active</b>, and the caller must then read the edges
+   * itself. This kernel reads the CSR offset and neighbour arrays directly - that is what makes it worth
+   * having - and those arrays are the graph as it stood at the last build: the edges a committed transaction
+   * has since added or deleted live in the overlay, which nothing here consults. Refusing is decided here
+   * rather than left to the caller because the caller cannot see the difference in the result; it used to be
+   * decided for it, as a side effect of the view reporting no edge properties whenever an overlay was active,
+   * and that reason went away when the view learned to serve them exactly through it (issue #6315).
+   *
    * @param view           the analytical view (must be built with edge properties)
    * @param source         source dense node ID
    * @param weightProperty edge property name for weights (must be numeric)
    * @param direction      traversal direction (OUT, IN, or BOTH)
    * @param edgeTypes      edge types to traverse (null or empty = all)
-   * @return double[] of distances indexed by dense node ID (POSITIVE_INFINITY = unreachable)
+   * @return double[] of distances indexed by dense node ID (POSITIVE_INFINITY = unreachable), or {@code null}
+   * if the base CSR arrays are not the whole graph right now
    */
   public static double[] dijkstraSingleSource(final GraphAnalyticalView view, final int source,
       final String weightProperty, final Vertex.DIRECTION direction, final String... edgeTypes) {
+    if (view.hasActiveOverlay())
+      return null;
+
     final int n = view.getNodeMapping().size();
     final double[] dist = new double[n];
     Arrays.fill(dist, Double.POSITIVE_INFINITY);

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -1173,6 +1173,10 @@ public final class GraphAlgorithms {
    */
   public static double[] dijkstraSingleSource(final GraphAnalyticalView view, final int source,
       final String weightProperty, final Vertex.DIRECTION direction, final String... edgeTypes) {
+    // Point-in-time, not a pin: the CSR arrays and weight columns below are each fetched by their own
+    // accessor, so a commit landing between here and them is not caught. That is this whole class's existing
+    // shape - every algorithm in it reads the view through several independent accessor calls rather than one
+    // captured snapshot - and the window this narrows was wide open before.
     if (view.hasActiveOverlay())
       return null;
 

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -764,7 +764,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     final Snapshot snap = checkBuilt();
 
     // Cannot provide zero-copy view when overlay is active (delta edges modify topology)
-    if (snap.overlay != null)
+    if (hasActiveOverlay(snap))
       return null;
 
     final int n = snap.nodeMapping.size();
@@ -1194,7 +1194,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * {@link #getVertices} applies the overlay itself and needs no such check.
    */
   boolean hasActiveOverlay() {
-    final Snapshot snap = this.snapshot;
+    return hasActiveOverlay(this.snapshot);
+  }
+
+  /**
+   * The same question asked of a snapshot a caller has already captured, which is how every method that goes
+   * on to read that snapshot must ask it: re-reading the field would let a commit land between the check and
+   * the read and hand back base arrays belonging to a snapshot that does have an overlay.
+   */
+  private static boolean hasActiveOverlay(final Snapshot snap) {
     return snap != null && snap.overlay != null;
   }
 
@@ -1457,6 +1465,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     final CSRAdjacencyIndex csr = snap.csrPerType.get(edgeType);
 
     // The base slice this node's edges of this type occupy, as offsets into the CSR's own neighbour array.
+    //
+    // A missing CSR is not a reason to refuse, unlike in the positional accessor this replaced - that one had
+    // to compute an index into the slice and had none without it. Here the base slice is simply empty, which
+    // for a node with no base edges of this type is the truth, and the overlay's own additions below are
+    // answerable regardless: they carry their values rather than being addressed by a column slot. A type with
+    // a column store but no CSR is not a state a build produces (Snapshot builds the two together), and if it
+    // ever were, an edge type whose edges all arrived after the build would answer for them exactly rather
+    // than sending the caller to the records for nothing.
     int[] baseNeighbors = null;
     int baseStart = 0;
     int baseEnd = 0;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1454,7 +1454,8 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
 
     // The base slice this node's edges of this type occupy, as offsets into the CSR's own neighbour array.
     int[] baseNeighbors = null;
-    int baseStart = 0, baseEnd = 0;
+    int baseStart = 0;
+    int baseEnd = 0;
     if (csr != null && nodeId < snap.nodeMapping.size()) {
       baseStart = outgoing ? csr.outOffset(nodeId) : csr.inOffset(nodeId);
       baseEnd = outgoing ? csr.outOffsetEnd(nodeId) : csr.inOffsetEnd(nodeId);
@@ -2297,7 +2298,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
                       // Edge property updates have no overlay representation, so a delta buffered
                       // during this rebuild may not be reflected in the fresh CSR (if it committed
                       // after the relevant bucket was scanned). Flag a follow-up rebuild (#4513).
-                      if (!d.updatedEdges.isEmpty())
+                      if (d.hasEdgePropertyChanges())
                         edgePropRebuildNeeded = true;
                     }
                     if (overlay.hasChanges())

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1545,6 +1545,25 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     if (degree == 0)
       return EMPTY_EDGE_WEIGHTS;
 
+    // Deletions but nothing added: the survivors are a subsequence of a sorted slice, so they are already in
+    // the order the merge below would have sorted them into. One linear pass, the same one
+    // copyBaseExcludingDeleted makes for the neighbour list, with each survivor's column slot read as it goes.
+    if (addedNeighbors.length == 0) {
+      final int[] keptNeighbors = new int[degree];
+      final double[] keptWeights = new double[degree];
+      int kept = 0;
+      for (int i = baseStart; i < baseEnd; i++) {
+        if (deleted[i - baseStart])
+          continue;
+        if (edgeCheckpoint != null)
+          edgeCheckpoint.accept(kept);
+        keptNeighbors[kept] = baseNeighbors[i];
+        keptWeights[kept] = columnWeight(column, outgoing ? i : bwdToFwd[i], defaultWeight);
+        kept++;
+      }
+      return new NodeEdgeWeights(keptNeighbors, keptWeights);
+    }
+
     // The neighbours as getNeighborsFromCSR would list them - base survivors then overlay additions, sorted -
     // with each entry's provenance carried through the sort beside it, so no weight can be left behind by the
     // re-sort. CSRBuilder.parallelSort is that exact permutation-carrying sort, already written and already

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -31,6 +31,7 @@ import com.arcadedb.exception.TransactionException;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.NeighborView;
+import com.arcadedb.graph.NodeEdgeWeights;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
@@ -48,6 +49,7 @@ import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntConsumer;
 import java.util.logging.Level;
 
 /**
@@ -1179,6 +1181,20 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   // --- Metadata ---
 
   /**
+   * True while pending committed changes are being served from the delta overlay rather than from the base CSR.
+   * <p>
+   * The predicate a kernel that reads the CSR arrays directly - {@link GraphAlgorithms#dijkstraSingleSource},
+   * and {@link #getNeighborView} for the same reason - has to consult before it may believe them: the overlay
+   * is where the additions, the deletions and the new vertices are until the next compaction, and the arrays
+   * alone are the graph as it stood at the last build. Every method on this class that goes through
+   * {@link #getVertices} applies the overlay itself and needs no such check.
+   */
+  boolean hasActiveOverlay() {
+    final Snapshot snap = this.snapshot;
+    return snap != null && snap.overlay != null;
+  }
+
+  /**
    * Returns the CSR index for a specific edge type, or null if not present.
    */
   public CSRAdjacencyIndex getCSRIndex(final String edgeType) {
@@ -1359,56 +1375,189 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   /**
    * {@inheritDoc}
    * <p>
-   * An active delta overlay makes the answer no rather than yes. The edge property columns are aligned with the
-   * base CSR's forward edge slots, while {@link #getNeighborIds} serves the overlay's view of the node: deleted
-   * edges dropped, added ones merged in, the whole list re-sorted. The n-th neighbour of that list is then not
-   * the n-th edge of the column store, and {@link #getEdgeProperty}'s positional contract - the reason a caller
-   * may ask by index at all - no longer holds. Reporting "no edge properties" sends the caller to the edge
-   * records, which are exact; reporting "yes" would hand it a weight belonging to some other edge. Same reading
-   * as {@link #getMeanEdgesPerConnectedPair}, which answers unknown for the same overlay.
+   * An active delta overlay no longer makes the answer no. It used to: the columns are aligned with the base
+   * CSR's forward edge slots, while {@link #getNeighborIds} serves the overlay's view of the node - deleted
+   * edges dropped, added ones merged in, the whole list re-sorted - so the n-th neighbour of that list is not
+   * the n-th edge of the column store, and the SPI's old positional accessor answered against the wrong one of
+   * the two. That accessor is gone (issue #6315): {@link #edgeWeightsForSlice} resolves the alignment here,
+   * where the overlay is applied, and pairs every neighbour with its own edge's value before handing the two
+   * back together. An added edge, which has no column slot at all, is served from the value the overlay
+   * captured for it at commit time.
+   * <p>
+   * What the answer still turns on is {@link DeltaOverlay#isEdgePropertiesDirty()}: a committed change to a
+   * base edge's own properties leaves the columns holding a value the database no longer has, and unlike an
+   * addition or a deletion it has nothing in the overlay to correct it with - an edge already in the base CSR
+   * is addressed by a column slot, and nothing maps that slot back from its RID. The rebuild
+   * {@link #applyDelta} forces for it is what repairs the columns; until it lands the honest answer is no, the
+   * same reading {@link #getMeanEdgesPerConnectedPair} gives when it cannot answer exactly.
    */
   @Override
   public boolean hasEdgeProperties() {
     final Snapshot snap = this.snapshot;
-    return snap != null && snap.edgeColumnStores != null && !snap.edgeColumnStores.isEmpty() && snap.overlay == null;
+    return snap != null && snap.edgeColumnStores != null && !snap.edgeColumnStores.isEmpty()
+        && !hasStaleEdgeColumns(snap);
   }
 
   @Override
   public boolean hasEdgeProperty(final String edgeType, final String propertyName) {
     final Snapshot snap = this.snapshot;
-    if (snap == null || snap.edgeColumnStores == null || snap.overlay != null)
+    if (snap == null || snap.edgeColumnStores == null || hasStaleEdgeColumns(snap))
       return false;
     final ColumnStore edgeColStore = snap.edgeColumnStores.get(edgeType);
     return edgeColStore != null && edgeColStore.getColumn(propertyName) != null;
   }
 
+  /**
+   * True when a committed transaction changed a covered edge's properties and the rebuild that repairs the
+   * columns has not landed yet. See {@link #hasEdgeProperties()}.
+   */
+  private static boolean hasStaleEdgeColumns(final Snapshot snap) {
+    return snap.overlay != null && snap.overlay.isEdgePropertiesDirty();
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * The neighbours are the ones {@link #getNeighborIds} reports for this type and direction - the same
+   * arithmetic, run once here so that each of them can carry its own edge's weight out with it:
+   * <ul>
+   *   <li>a base edge the overlay has not deleted takes the value of its own forward column slot, which the
+   *       walk knows because it is the walk that decided to keep it;</li>
+   *   <li>an edge the overlay added takes the value {@link DeltaCollector} captured for it at commit time - it
+   *       has no column slot, the columns having been built with the base CSR.</li>
+   * </ul>
+   * The two are merged and sorted together, exactly as {@link #getNeighborsFromCSR} merges them, with each
+   * entry's provenance riding in the low half of the sort key so that no weight can be left behind by the
+   * re-sort. That re-sort is what the SPI's old positional accessor was addressing across (issue #6315).
+   */
   @Override
-  public Object getEdgeProperty(final int nodeId, final int neighborIndex,
-      final Vertex.DIRECTION direction, final String edgeType, final String propertyName) {
+  public NodeEdgeWeights edgeWeightsForSlice(final int nodeId, final Vertex.DIRECTION direction,
+      final String edgeType, final String propertyName, final double defaultWeight,
+      final IntConsumer edgeCheckpoint) {
+    // BOTH has no adjacency slice of its own to be aligned with; edgeWeightsOf() splits it before calling here.
+    if (direction != Vertex.DIRECTION.OUT && direction != Vertex.DIRECTION.IN)
+      return null;
+
     final Snapshot snap = checkBuilt();
-    if (snap.edgeColumnStores == null)
+    if (snap.edgeColumnStores == null || hasStaleEdgeColumns(snap))
       return null;
     final ColumnStore edgeColStore = snap.edgeColumnStores.get(edgeType);
     if (edgeColStore == null)
       return null;
-    final CSRAdjacencyIndex csr = snap.csrPerType.get(edgeType);
-    if (csr == null)
+    final Column column = edgeColStore.getColumn(propertyName);
+    if (column == null)
       return null;
 
-    final int fwdIdx;
-    if (direction == Vertex.DIRECTION.OUT) {
-      fwdIdx = csr.outOffset(nodeId) + neighborIndex;
-    } else if (direction == Vertex.DIRECTION.IN) {
-      final int[] bwdToFwd = snap.bwdToFwd != null ? snap.bwdToFwd.get(edgeType) : null;
-      if (bwdToFwd == null)
-        return null;
-      final int bwdIdx = csr.inOffset(nodeId) + neighborIndex;
-      fwdIdx = bwdToFwd[bwdIdx];
-    } else {
-      return null;
+    final boolean outgoing = direction == Vertex.DIRECTION.OUT;
+    final DeltaOverlay ov = snap.overlay;
+    final CSRAdjacencyIndex csr = snap.csrPerType.get(edgeType);
+
+    // The base slice this node's edges of this type occupy, as offsets into the CSR's own neighbour array.
+    int[] baseNeighbors = null;
+    int baseStart = 0, baseEnd = 0;
+    if (csr != null && nodeId < snap.nodeMapping.size()) {
+      baseStart = outgoing ? csr.outOffset(nodeId) : csr.inOffset(nodeId);
+      baseEnd = outgoing ? csr.outOffsetEnd(nodeId) : csr.inOffsetEnd(nodeId);
+      baseNeighbors = outgoing ? csr.getForwardNeighbors() : csr.getBackwardNeighbors();
     }
 
-    return edgeColStore.getValue(fwdIdx, propertyName);
+    // Incoming edges are listed in backward order while the columns are aligned with the forward one, so
+    // without the mapping between the two there is no honest answer for a node that has any.
+    final int[] bwdToFwd = outgoing || snap.bwdToFwd == null ? null : snap.bwdToFwd.get(edgeType);
+    if (!outgoing && baseEnd > baseStart && bwdToFwd == null)
+      return null;
+
+    if (ov == null) {
+      final int degree = baseEnd - baseStart;
+      if (degree == 0)
+        return EMPTY_EDGE_WEIGHTS;
+      final double[] weights = new double[degree];
+      for (int i = 0; i < degree; i++) {
+        if (edgeCheckpoint != null)
+          edgeCheckpoint.accept(i);
+        weights[i] = columnWeight(column, outgoing ? baseStart + i : bwdToFwd[baseStart + i], defaultWeight);
+      }
+      return new NodeEdgeWeights(Arrays.copyOfRange(baseNeighbors, baseStart, baseEnd), weights);
+    }
+
+    final boolean[] deleted = baseEnd > baseStart
+        ? deletedSliceMask(baseNeighbors, baseStart, baseEnd, ov, edgeType, nodeId, outgoing) : null;
+    // The one thing the overlay cannot resolve. Its deletions are counted per PAIR, which is all the neighbour
+    // list needs - drop any one of a pair's parallel edges and the remaining neighbours are the same either way
+    // - but not enough to say WHICH of them died, and parallel edges need not weigh the same. The surviving
+    // weights would then be a plausible wrong multiset, so the slice is refused and the caller reads the edge
+    // records, which know. A pair whose parallel edges were deleted outright is not ambiguous, and neither is
+    // the ordinary pair joined by a single edge.
+    if (deleted != null && isPartialDeletionOfParallelEdges(baseNeighbors, baseStart, baseEnd, deleted))
+      return null;
+    final int[] addedNeighbors = outgoing ? ov.getAddedOutNeighbors(nodeId, edgeType)
+        : ov.getAddedInNeighbors(nodeId, edgeType);
+    final Map<String, Object>[] addedProperties = outgoing ? ov.getAddedOutEdgeProperties(nodeId, edgeType)
+        : ov.getAddedInEdgeProperties(nodeId, edgeType);
+
+    int keptBase = baseEnd - baseStart;
+    if (deleted != null)
+      for (final boolean d : deleted)
+        if (d)
+          keptBase--;
+
+    final int degree = keptBase + addedNeighbors.length;
+    if (degree == 0)
+      return EMPTY_EDGE_WEIGHTS;
+
+    // (neighbour id, provenance) packed into one long each, so that sorting by neighbour - which is all
+    // getNeighborsFromCSR does to the merged list - cannot separate an entry from the edge it came from.
+    // Neighbour ids are non-negative, so the packed value sorts by neighbour first and by provenance second.
+    final long[] merged = new long[degree];
+    final int[] baseSlots = keptBase > 0 ? new int[keptBase] : EMPTY_INT;
+    int pos = 0;
+    for (int i = baseStart; i < baseEnd; i++) {
+      if (deleted != null && deleted[i - baseStart])
+        continue;
+      baseSlots[pos] = outgoing ? i : bwdToFwd[i];
+      merged[pos] = ((long) baseNeighbors[i] << 32) | pos;
+      pos++;
+    }
+    for (final int addedNeighbor : addedNeighbors) {
+      merged[pos] = ((long) addedNeighbor << 32) | pos;
+      pos++;
+    }
+    Arrays.sort(merged);
+
+    final int[] neighbors = new int[degree];
+    final double[] weights = new double[degree];
+    for (int i = 0; i < degree; i++) {
+      if (edgeCheckpoint != null)
+        edgeCheckpoint.accept(i);
+      final int provenance = (int) merged[i];
+      neighbors[i] = (int) (merged[i] >>> 32);
+      weights[i] = provenance < keptBase ? columnWeight(column, baseSlots[provenance], defaultWeight)
+          : overlayWeight(addedProperties, provenance - keptBase, propertyName, defaultWeight);
+    }
+    return new NodeEdgeWeights(neighbors, weights);
+  }
+
+  /**
+   * Reads one edge's weight out of its column slot, without boxing it on the way.
+   * A slot the column has no value for weighs {@code defaultWeight}, the same as an edge that has no value.
+   */
+  private static double columnWeight(final Column column, final int slot, final double defaultWeight) {
+    if (column.isNull(slot))
+      return defaultWeight;
+    return switch (column.getType()) {
+      case DOUBLE -> column.getDouble(slot);
+      case INT -> column.getInt(slot);
+      case LONG -> column.getLong(slot);
+      default -> defaultWeight;
+    };
+  }
+
+  /** Reads an overlay-added edge's weight out of the values captured for it at commit time. */
+  private static double overlayWeight(final Map<String, Object>[] addedProperties, final int index,
+      final String propertyName, final double defaultWeight) {
+    if (addedProperties == null || addedProperties[index] == null)
+      return defaultWeight;
+    return addedProperties[index].get(propertyName) instanceof Number number ? number.doubleValue() : defaultWeight;
   }
 
   /**
@@ -2077,10 +2226,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
         pendingDeltas.add(delta);
     }
 
-    // An edge property change (e.g. weight) has no overlay representation, so it can only be made
-    // visible by rebuilding the base columns. Force a rebuild regardless of the edge-count
-    // threshold; otherwise the change would be silently dropped until the next compaction (#4513).
-    final boolean forceRebuild = delta.edgePropertiesUpdated;
+    // A change to a base edge's own properties can only be made visible by rebuilding the base columns: the
+    // edge is addressed there by a column slot, and nothing maps that slot back from its RID. Force a rebuild
+    // regardless of the edge-count threshold; otherwise the change would be silently dropped until the next
+    // compaction (#4513). Asked of the merged overlay rather than of the delta because the two are not the
+    // same question: an update to an edge the overlay itself holds is applied there and dirties nothing, and
+    // that is the ordinary `newEdge(...).save()` (issue #6315). Sticky while the columns are still out of
+    // date, so that a rebuild discarded as superseded is retried by the next commit rather than leaving the
+    // view unable to serve edge properties until the compaction threshold happens to be crossed.
+    final boolean forceRebuild = merged.isEdgePropertiesDirty();
 
     if (forceRebuild || (compactionThreshold > 0 && Math.abs(merged.getDeltaEdgeCount()) > compactionThreshold)) {
       // Guard: only one compaction thread at a time
@@ -2143,7 +2297,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
                       // Edge property updates have no overlay representation, so a delta buffered
                       // during this rebuild may not be reflected in the fresh CSR (if it committed
                       // after the relevant bucket was scanned). Flag a follow-up rebuild (#4513).
-                      if (d.edgePropertiesUpdated)
+                      if (!d.updatedEdges.isEmpty())
                         edgePropRebuildNeeded = true;
                     }
                     if (overlay.hasChanges())
@@ -2177,7 +2331,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
             if (edgePropRebuildNeeded) {
               edgePropRebuildNeeded = false;
               final TxDelta forced = new TxDelta();
-              forced.edgePropertiesUpdated = true;
+              forced.forceEdgePropertyRebuild = true;
               applyDelta(forced);
             }
             // #4956: drop this worker's DatabaseContext entry (see buildAsync). Last statement because
@@ -2471,12 +2625,66 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    */
   private static int[] copyBaseExcludingDeleted(final int[] neighbors, final int start, final int end,
       final DeltaOverlay ov, final String edgeType, final int nodeId, final boolean outgoing) {
-    // Single pass over the slice. One countDeletedEdges() lookup per distinct neighbour value (cached for the
-    // run), not per slot. The mask is allocated lazily, only once the first deleted edge is found, so the
-    // common no-deletion case stays allocation-free.
+    final boolean[] deletedMask = deletedSliceMask(neighbors, start, end, ov, edgeType, nodeId, outgoing);
+    if (deletedMask == null)
+      return Arrays.copyOfRange(neighbors, start, end);
+
+    int kept = 0;
+    for (final boolean deleted : deletedMask)
+      if (!deleted)
+        kept++;
+    if (kept == 0)
+      return EMPTY_INT;
+
+    final int[] result = new int[kept];
+    int pos = 0;
+    for (int i = 0; i < deletedMask.length; i++)
+      if (!deletedMask[i])
+        result[pos++] = neighbors[start + i];
+    return result;
+  }
+
+  /**
+   * True when the overlay deleted some but not all of a run of parallel edges between the same pair, which
+   * leaves no way to tell which of that run's column slots the surviving edges hold. See the call site.
+   */
+  private static boolean isPartialDeletionOfParallelEdges(final int[] neighbors, final int start, final int end,
+      final boolean[] deleted) {
+    // The slice is sorted, so a pair's parallel edges are one contiguous run.
+    final int len = end - start;
+    int runStart = 0;
+    while (runStart < len) {
+      int runEnd = runStart + 1;
+      while (runEnd < len && neighbors[start + runEnd] == neighbors[start + runStart])
+        runEnd++;
+      int deletedInRun = 0;
+      for (int i = runStart; i < runEnd; i++)
+        if (deleted[i])
+          deletedInRun++;
+      if (deletedInRun > 0 && deletedInRun < runEnd - runStart)
+        return true;
+      runStart = runEnd;
+    }
+    return false;
+  }
+
+  /**
+   * Marks which slots of the base slice {@code [start, end)} the overlay has deleted, or returns {@code null}
+   * when it has deleted none of them.
+   * <p>
+   * Shared by {@link #copyBaseExcludingDeleted} and {@link #edgeWeightsForSlice} rather than written out twice:
+   * both have to reach the same set of surviving edges, and the second one then reads a column slot per
+   * survivor - two spellings of this budget would put those weights on the wrong edges the first time they
+   * disagreed, which is the failure mode issue #6315 exists to remove.
+   * <p>
+   * Single pass over the slice. One {@link DeltaOverlay#countDeletedEdges} lookup per distinct neighbour value
+   * (cached for the run), not per slot. The mask is allocated lazily, only once the first deleted edge is
+   * found, so the common no-deletion case stays allocation-free.
+   */
+  private static boolean[] deletedSliceMask(final int[] neighbors, final int start, final int end,
+      final DeltaOverlay ov, final String edgeType, final int nodeId, final boolean outgoing) {
     final int len = end - start;
     boolean[] deletedMask = null;
-    int kept = 0;
     int runValue = 0;
     int runIndex = 0;
     int runDeletedBudget = 0;
@@ -2490,29 +2698,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       final boolean deleted = runIndex < runDeletedBudget;
       runIndex++;
       if (deleted) {
-        if (deletedMask == null) {
+        if (deletedMask == null)
           deletedMask = new boolean[len];
-          kept = i; // every neighbour seen so far was kept
-        }
         deletedMask[i] = true;
-      } else if (deletedMask != null) {
-        kept++;
       }
     }
-    if (deletedMask == null)
-      return Arrays.copyOfRange(neighbors, start, end);
-    if (kept == 0)
-      return EMPTY_INT;
-
-    final int[] result = new int[kept];
-    int pos = 0;
-    for (int i = 0; i < len; i++)
-      if (!deletedMask[i])
-        result[pos++] = neighbors[start + i];
-    return result;
+    return deletedMask;
   }
 
   private static final int[] EMPTY_INT = new int[0];
+  private static final NodeEdgeWeights EMPTY_EDGE_WEIGHTS = new NodeEdgeWeights(EMPTY_INT, new double[0]);
 
   /**
    * Checks the view is built and returns a consistent snapshot for the caller to use.

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -112,6 +112,10 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   /** Semaphore bounding concurrent CPU-intensive build operations. */
   private static final Semaphore BUILD_PERMITS = new Semaphore(MAX_CONCURRENT_BUILDS);
 
+  /** The answer for a node with no edges of the type and direction asked for. */
+  private static final int[]            EMPTY_INT          = new int[0];
+  private static final NodeEdgeWeights  EMPTY_EDGE_WEIGHTS = new NodeEdgeWeights(EMPTY_INT, new double[0]);
+
   /** Shared executor for all GAV async builds and compactions. Uses virtual threads for lightweight scheduling. */
   private static volatile ExecutorService EXECUTOR;
 
@@ -2706,9 +2710,6 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     }
     return deletedMask;
   }
-
-  private static final int[] EMPTY_INT = new int[0];
-  private static final NodeEdgeWeights EMPTY_EDGE_WEIGHTS = new NodeEdgeWeights(EMPTY_INT, new double[0]);
 
   /**
    * Checks the view is built and returns a consistent snapshot for the caller to use.

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1198,6 +1198,19 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
+   * The snapshot this view is currently serving, for a caller that has to read several of its parts and needs
+   * them to be parts of the same one.
+   * <p>
+   * Every accessor on this class re-reads the field, which is right for a caller asking one question and wrong
+   * for a kernel reading a CSR's offsets, its neighbours and its weight columns in turn: a commit landing
+   * between two of those reads would hand it halves of two different graphs, and it would compute a plausible
+   * wrong answer out of them rather than fail. Capture once, read everything through it.
+   */
+  Snapshot captureSnapshot() {
+    return checkBuilt();
+  }
+
+  /**
    * The same question asked of a snapshot a caller has already captured, which is how every method that goes
    * on to read that snapshot must ask it: re-reading the field would let a commit land between the check and
    * the read and hand back base arrays belonging to a snapshot that does have an overlay.
@@ -1396,12 +1409,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * back together. An added edge, which has no column slot at all, is served from the value the overlay
    * captured for it at commit time.
    * <p>
-   * What the answer still turns on is {@link DeltaOverlay#isEdgePropertiesDirty()}: a committed change to a
-   * base edge's own properties leaves the columns holding a value the database no longer has, and unlike an
-   * addition or a deletion it has nothing in the overlay to correct it with - an edge already in the base CSR
-   * is addressed by a column slot, and nothing maps that slot back from its RID. The rebuild
+   * What the answer still turns on is {@link DeltaOverlay#isEdgePropertiesDirty(String)}: a committed change to
+   * a base edge's own properties leaves that type's columns holding a value the database no longer has, and
+   * unlike an addition or a deletion it has nothing in the overlay to correct it with - an edge already in the
+   * base CSR is addressed by a column slot, and nothing maps that slot back from its RID. The rebuild
    * {@link #applyDelta} forces for it is what repairs the columns; until it lands the honest answer is no, the
-   * same reading {@link #getMeanEdgesPerConnectedPair} gives when it cannot answer exactly.
+   * same reading {@link #getMeanEdgesPerConnectedPair} gives when it cannot answer exactly. This method asks
+   * the coarse form of that question - is ANY type out of date - because it is itself the coarse question;
+   * {@link #hasEdgeProperty} and {@link #edgeWeightsForSlice}, which are asked about one type, ask about that
+   * type alone.
    */
   @Override
   public boolean hasEdgeProperties() {
@@ -1413,16 +1429,21 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   @Override
   public boolean hasEdgeProperty(final String edgeType, final String propertyName) {
     final Snapshot snap = this.snapshot;
-    if (snap == null || snap.edgeColumnStores == null || hasStaleEdgeColumns(snap))
+    if (snap == null || snap.edgeColumnStores == null || hasStaleEdgeColumns(snap, edgeType))
       return false;
     final ColumnStore edgeColStore = snap.edgeColumnStores.get(edgeType);
     return edgeColStore != null && edgeColStore.getColumn(propertyName) != null;
   }
 
   /**
-   * True when a committed transaction changed a covered edge's properties and the rebuild that repairs the
-   * columns has not landed yet. See {@link #hasEdgeProperties()}.
+   * True when a committed transaction changed one of {@code edgeType}'s edges' properties and the rebuild that
+   * repairs its columns has not landed yet. See {@link #hasEdgeProperties()}.
    */
+  private static boolean hasStaleEdgeColumns(final Snapshot snap, final String edgeType) {
+    return snap.overlay != null && snap.overlay.isEdgePropertiesDirty(edgeType);
+  }
+
+  /** True when any edge type's columns are out of date - the coarser question {@link #hasEdgeProperties()} asks. */
   private static boolean hasStaleEdgeColumns(final Snapshot snap) {
     return snap.overlay != null && snap.overlay.isEdgePropertiesDirty();
   }
@@ -1451,7 +1472,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       return null;
 
     final Snapshot snap = checkBuilt();
-    if (snap.edgeColumnStores == null || hasStaleEdgeColumns(snap))
+    if (snap.edgeColumnStores == null || hasStaleEdgeColumns(snap, edgeType))
       return null;
     final ColumnStore edgeColStore = snap.edgeColumnStores.get(edgeType);
     if (edgeColStore == null)
@@ -1488,18 +1509,9 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     if (!outgoing && baseEnd > baseStart && bwdToFwd == null)
       return null;
 
-    if (ov == null) {
-      final int degree = baseEnd - baseStart;
-      if (degree == 0)
-        return EMPTY_EDGE_WEIGHTS;
-      final double[] weights = new double[degree];
-      for (int i = 0; i < degree; i++) {
-        if (edgeCheckpoint != null)
-          edgeCheckpoint.accept(i);
-        weights[i] = columnWeight(column, outgoing ? baseStart + i : bwdToFwd[baseStart + i], defaultWeight);
-      }
-      return new NodeEdgeWeights(Arrays.copyOfRange(baseNeighbors, baseStart, baseEnd), weights);
-    }
+    if (ov == null)
+      return baseSliceWeights(column, baseNeighbors, baseStart, baseEnd, outgoing, bwdToFwd, defaultWeight,
+          edgeCheckpoint);
 
     final boolean[] deleted = baseEnd > baseStart
         ? deletedSliceMask(baseNeighbors, baseStart, baseEnd, ov, edgeType, nodeId, outgoing) : null;
@@ -1514,7 +1526,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // One lookup for both halves: the neighbours and their weights come out of the same index entry.
     final DeltaOverlay.AddedNeighbors added = ov.getAdded(nodeId, edgeType, outgoing);
     final int[] addedNeighbors = added != null ? added.nodeIds() : EMPTY_INT;
-    final Map<String, Object>[] addedProperties = added != null ? added.properties() : null;
+
+    // An overlay somewhere in the graph is not an overlay on THIS node. One unrelated edit keeps an overlay
+    // alive until the next compaction, and a full-graph walk would otherwise pay the merge below for every
+    // node in it; a node the overlay has neither deleted from nor added to has the base slice for its answer,
+    // arrived at by the same arithmetic and byte for byte the same.
+    if (deleted == null && addedNeighbors.length == 0)
+      return baseSliceWeights(column, baseNeighbors, baseStart, baseEnd, outgoing, bwdToFwd, defaultWeight,
+          edgeCheckpoint);
 
     int keptBase = baseEnd - baseStart;
     if (deleted != null)
@@ -1526,36 +1545,72 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     if (degree == 0)
       return EMPTY_EDGE_WEIGHTS;
 
-    // (neighbour id, provenance) packed into one long each, so that sorting by neighbour - which is all
-    // getNeighborsFromCSR does to the merged list - cannot separate an entry from the edge it came from.
-    // Neighbour ids are non-negative, so the packed value sorts by neighbour first and by provenance second.
-    final long[] merged = new long[degree];
+    // The neighbours as getNeighborsFromCSR would list them - base survivors then overlay additions, sorted -
+    // with each entry's provenance carried through the sort beside it, so no weight can be left behind by the
+    // re-sort. CSRBuilder.parallelSort is that exact permutation-carrying sort, already written and already
+    // relied upon by the build; a second copy of it here would be one more place for a future fix to miss.
+    final int[] neighbors = new int[degree];
+    final int[] provenance = new int[degree];
     final int[] baseSlots = keptBase > 0 ? new int[keptBase] : EMPTY_INT;
     int pos = 0;
     for (int i = baseStart; i < baseEnd; i++) {
       if (deleted != null && deleted[i - baseStart])
         continue;
       baseSlots[pos] = outgoing ? i : bwdToFwd[i];
-      merged[pos] = ((long) baseNeighbors[i] << 32) | pos;
+      neighbors[pos] = baseNeighbors[i];
+      provenance[pos] = pos;
       pos++;
     }
     for (final int addedNeighbor : addedNeighbors) {
-      merged[pos] = ((long) addedNeighbor << 32) | pos;
+      neighbors[pos] = addedNeighbor;
+      provenance[pos] = pos;
       pos++;
     }
-    Arrays.sort(merged);
+    CSRBuilder.parallelSort(neighbors, provenance, 0, degree);
 
-    final int[] neighbors = new int[degree];
+    // The property's position in the filter, resolved once for the whole slice rather than per added edge:
+    // the overlay stores an added edge's values by that position, in the filter's own order.
+    final Object[][] addedProperties = added != null ? added.properties() : null;
+    final int propertyIndex = addedProperties == null ? -1 : indexOfMaterialisedProperty(propertyName);
+
     final double[] weights = new double[degree];
     for (int i = 0; i < degree; i++) {
       if (edgeCheckpoint != null)
         edgeCheckpoint.accept(i);
-      final int provenance = (int) merged[i];
-      neighbors[i] = (int) (merged[i] >>> 32);
-      weights[i] = provenance < keptBase ? columnWeight(column, baseSlots[provenance], defaultWeight)
-          : overlayWeight(addedProperties, provenance - keptBase, propertyName, defaultWeight);
+      final int origin = provenance[i];
+      weights[i] = origin < keptBase ? columnWeight(column, baseSlots[origin], defaultWeight)
+          : overlayWeight(addedProperties, origin - keptBase, propertyIndex, defaultWeight);
     }
     return new NodeEdgeWeights(neighbors, weights);
+  }
+
+  /**
+   * The answer for a node whose edges of this type and direction are all in the base CSR: the slice verbatim,
+   * each neighbour beside the value of its own forward column slot.
+   */
+  private static NodeEdgeWeights baseSliceWeights(final Column column, final int[] baseNeighbors,
+      final int baseStart, final int baseEnd, final boolean outgoing, final int[] bwdToFwd,
+      final double defaultWeight, final IntConsumer edgeCheckpoint) {
+    final int degree = baseEnd - baseStart;
+    if (degree == 0)
+      return EMPTY_EDGE_WEIGHTS;
+    final double[] weights = new double[degree];
+    for (int i = 0; i < degree; i++) {
+      if (edgeCheckpoint != null)
+        edgeCheckpoint.accept(i);
+      weights[i] = columnWeight(column, outgoing ? baseStart + i : bwdToFwd[baseStart + i], defaultWeight);
+    }
+    return new NodeEdgeWeights(Arrays.copyOfRange(baseNeighbors, baseStart, baseEnd), weights);
+  }
+
+  /** The position of {@code propertyName} in this view's edge property filter, or -1 if it holds no such name. */
+  private int indexOfMaterialisedProperty(final String propertyName) {
+    if (edgePropertyFilter == null)
+      return -1;
+    for (int i = 0; i < edgePropertyFilter.length; i++)
+      if (edgePropertyFilter[i].equals(propertyName))
+        return i;
+    return -1;
   }
 
   /**
@@ -1574,11 +1629,11 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /** Reads an overlay-added edge's weight out of the values captured for it at commit time. */
-  private static double overlayWeight(final Map<String, Object>[] addedProperties, final int index,
-      final String propertyName, final double defaultWeight) {
-    if (addedProperties == null || addedProperties[index] == null)
+  private static double overlayWeight(final Object[][] addedProperties, final int index,
+      final int propertyIndex, final double defaultWeight) {
+    if (addedProperties == null || propertyIndex < 0 || addedProperties[index] == null)
       return defaultWeight;
-    return addedProperties[index].get(propertyName) instanceof Number number ? number.doubleValue() : defaultWeight;
+    return addedProperties[index][propertyIndex] instanceof Number number ? number.doubleValue() : defaultWeight;
   }
 
   /**
@@ -2315,12 +2370,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
                       // crossed its bucket is already in the new base, so re-merging it blindly would
                       // create duplicate neighbours. See issue #4588.
                       overlay = overlay.merge(d, result.getMapping(), result.getCsrPerType());
-                      // Edge property updates have no overlay representation, so a delta buffered
-                      // during this rebuild may not be reflected in the fresh CSR (if it committed
-                      // after the relevant bucket was scanned). Flag a follow-up rebuild (#4513).
-                      if (d.hasEdgePropertyChanges())
-                        edgePropRebuildNeeded = true;
                     }
+                    // A change to a base edge's properties has no overlay representation, so a delta buffered
+                    // during this rebuild may not be reflected in the fresh CSR (if it committed after the
+                    // relevant bucket was scanned): flag a follow-up rebuild (#4513). Asked of the overlay the
+                    // merges arrived at rather than of the deltas that went into them - an update to an edge
+                    // the overlay itself holds is applied there and leaves nothing stale, so asking the deltas
+                    // would force a rebuild for the ordinary insert, which reports one create and one update
+                    // of the same edge (issue #6315).
+                    if (overlay.isEdgePropertiesDirty())
+                      edgePropRebuildNeeded = true;
                     if (overlay.hasChanges())
                       fresh = fresh.withOverlay(overlay);
                   }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1495,10 +1495,10 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // the ordinary pair joined by a single edge.
     if (deleted != null && isPartialDeletionOfParallelEdges(baseNeighbors, baseStart, baseEnd, deleted))
       return null;
-    final int[] addedNeighbors = outgoing ? ov.getAddedOutNeighbors(nodeId, edgeType)
-        : ov.getAddedInNeighbors(nodeId, edgeType);
-    final Map<String, Object>[] addedProperties = outgoing ? ov.getAddedOutEdgeProperties(nodeId, edgeType)
-        : ov.getAddedInEdgeProperties(nodeId, edgeType);
+    // One lookup for both halves: the neighbours and their weights come out of the same index entry.
+    final DeltaOverlay.AddedNeighbors added = ov.getAdded(nodeId, edgeType, outgoing);
+    final int[] addedNeighbors = added != null ? added.nodeIds() : EMPTY_INT;
+    final Map<String, Object>[] addedProperties = added != null ? added.properties() : null;
 
     int keptBase = baseEnd - baseStart;
     if (deleted != null)

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java
@@ -103,7 +103,7 @@ public class GraphAnalyticalViewBuilder {
    * Specifies the edge properties to materialize in columnar storage alongside the CSR adjacency.
    * If not called or null, no edge properties are stored (default — zero overhead).
    * When specified, edge properties are stored aligned to the forward CSR arrays and accessible
-   * via {@link GraphTraversalProvider#getEdgeProperty} for both forward and backward traversals.
+   * via {@link GraphTraversalProvider#edgeWeightsForSlice} for both forward and backward traversals.
    * <p>
    * Example: {@code .withEdgeProperties("weight")} to store edge weights for Dijkstra/SSSP.
    */

--- a/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
@@ -36,16 +36,24 @@ class TxDelta {
   final List<EdgeDelta>            deletedEdges     = new ArrayList<>();
   final Map<RID, Map<String, Object>> updatedProperties = new HashMap<>();
 
-  // Set when a covered edge had a property change. Edge property overrides cannot be represented
-  // in the overlay (the columnar edge stores are read directly by the array-based algorithms,
-  // bypassing the overlay), so this flag forces a rebuild on commit instead of silently dropping
-  // the update. See issue #4513.
-  boolean edgePropertiesUpdated = false;
+  // Covered edges whose properties changed, with the values they changed to. An edge THIS overlay window
+  // added carries its values in its own overlay entry, so such an update is applied there and costs nothing
+  // (which is the ordinary `newEdge(...).save()`, an insert that reports one create and one update). An edge
+  // already in the base CSR is addressed by a column slot instead, and nothing maps that slot back from its
+  // RID, so an update to one leaves the columns holding a value the database no longer has and only a rebuild
+  // can repair them - which DeltaOverlay.merge() decides, being the one place that knows which of the two this
+  // is. See issues #4513 and #6315.
+  final List<EdgeDelta>            updatedEdges     = new ArrayList<>();
+
+  // Set only by the synthetic delta GraphAnalyticalView uses to schedule the follow-up rebuild an edge
+  // property update buffered during a compaction needs (#4513). It stands for no edge in particular, so it
+  // marks the columns out of date outright rather than being resolved against the overlay's own additions.
+  boolean                          forceEdgePropertyRebuild = false;
 
   boolean isEmpty() {
     return addedVertices.isEmpty() && deletedVertices.isEmpty()
         && addedEdges.isEmpty() && deletedEdges.isEmpty()
-        && updatedProperties.isEmpty() && !edgePropertiesUpdated;
+        && updatedProperties.isEmpty() && updatedEdges.isEmpty() && !forceEdgePropertyRebuild;
   }
 
   void clear() {
@@ -54,7 +62,8 @@ class TxDelta {
     addedEdges.clear();
     deletedEdges.clear();
     updatedProperties.clear();
-    edgePropertiesUpdated = false;
+    updatedEdges.clear();
+    forceEdgePropertyRebuild = false;
   }
 
   static class VertexDelta {
@@ -76,12 +85,23 @@ class TxDelta {
     // must not double-count) apart from "two distinct parallel edges between the same pair" (must each
     // count, see issue #6769).
     final RID    rid;
+    // For addedEdges and updatedEdges, the values of the edge properties the view materialises columns for, or
+    // null when it materialises none. An added edge has no column slot of its own - the columns were built with
+    // the base CSR - so this is the only place its weight can be read from while the overlay is the view's
+    // representation of it (issue #6315). Null for deletedEdges, which are never asked for a value.
+    final Map<String, Object> properties;
 
     EdgeDelta(final String edgeType, final RID source, final RID target, final RID rid) {
+      this(edgeType, source, target, rid, null);
+    }
+
+    EdgeDelta(final String edgeType, final RID source, final RID target, final RID rid,
+        final Map<String, Object> properties) {
       this.edgeType = edgeType;
       this.source = source;
       this.target = target;
       this.rid = rid;
+      this.properties = properties;
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
@@ -50,10 +50,22 @@ class TxDelta {
   // marks the columns out of date outright rather than being resolved against the overlay's own additions.
   boolean                          forceEdgePropertyRebuild = false;
 
+  /**
+   * True when this transaction changed a covered edge's properties, however the change is spelled: the
+   * individual edges while there were few enough of them to track, or the bare flag {@link DeltaCollector}
+   * falls back to past its cap. Asked through one method rather than open-coded, because a caller that
+   * remembers only the first spelling silently skips exactly the deltas that need the rebuild most - a bulk
+   * rewrite - and the view is then left unable to serve edge properties until some later commit happens to
+   * re-trigger it.
+   */
+  boolean hasEdgePropertyChanges() {
+    return !updatedEdges.isEmpty() || forceEdgePropertyRebuild;
+  }
+
   boolean isEmpty() {
     return addedVertices.isEmpty() && deletedVertices.isEmpty()
         && addedEdges.isEmpty() && deletedEdges.isEmpty()
-        && updatedProperties.isEmpty() && updatedEdges.isEmpty() && !forceEdgePropertyRebuild;
+        && updatedProperties.isEmpty() && !hasEdgePropertyChanges();
   }
 
   void clear() {

--- a/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
@@ -102,18 +102,24 @@ class TxDelta {
     // must not double-count) apart from "two distinct parallel edges between the same pair" (must each
     // count, see issue #6769).
     final RID    rid;
-    // For addedEdges and updatedEdges, the values of the edge properties the view materialises columns for, or
-    // null when it materialises none. An added edge has no column slot of its own - the columns were built with
-    // the base CSR - so this is the only place its weight can be read from while the overlay is the view's
-    // representation of it (issue #6315). Null for deletedEdges, which are never asked for a value.
-    final Map<String, Object> properties;
+    // For addedEdges and updatedEdges, the values of the edge properties the view materialises columns for -
+    // one slot per name of the view's edge property filter, in its order - or null when it materialises none.
+    // An added edge has no column slot of its own, the columns having been built with the base CSR, so this is
+    // the only place its weight can be read from while the overlay is the view's representation of it (issue
+    // #6315). Null for deletedEdges, which are never asked for a value.
+    //
+    // An array rather than a map because there is one of these per added edge and a bulk insert makes as many
+    // of them as it inserts edges: the names are a small fixed list known before the first edge arrives, so
+    // carrying them again per edge would be paying for a hash table per edge to look up a position the caller
+    // can compute once for a whole slice.
+    final Object[] properties;
 
     EdgeDelta(final String edgeType, final RID source, final RID target, final RID rid) {
       this(edgeType, source, target, rid, null);
     }
 
     EdgeDelta(final String edgeType, final RID source, final RID target, final RID rid,
-        final Map<String, Object> properties) {
+        final Object[] properties) {
       this.edgeType = edgeType;
       this.source = source;
       this.target = target;

--- a/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/TxDelta.java
@@ -43,7 +43,12 @@ class TxDelta {
   // RID, so an update to one leaves the columns holding a value the database no longer has and only a rebuild
   // can repair them - which DeltaOverlay.merge() decides, being the one place that knows which of the two this
   // is. See issues #4513 and #6315.
-  final List<EdgeDelta>            updatedEdges     = new ArrayList<>();
+  // Keyed by the edge's own identity so that a transaction updating one edge's weight repeatedly - an
+  // accumulator, say - holds one entry rather than one per call. Last write wins, which is what
+  // DeltaOverlay.merge() would have arrived at anyway by overwriting as it walked the list, and it keeps the
+  // cap below a count of the edges actually touched instead of of the calls made. Insertion-ordered, so the
+  // merge walks them in the order the transaction made them.
+  final Map<RID, EdgeDelta>        updatedEdges     = new LinkedHashMap<>();
 
   // Set only by the synthetic delta GraphAnalyticalView uses to schedule the follow-up rebuild an edge
   // property update buffered during a compaction needs (#4513). It stands for no edge in particular, so it

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -962,9 +962,9 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       // columnar path can be used at all. A provider that cannot enumerate its
       // types, or cannot serve THIS property for every one of them, sends us to the edge records - which are
       // exact. Asking only whether the provider has edge properties at all is not enough: a view built over
-      // `distance` answers yes to a call asking for `cost`, and then every getEdgeProperty returns null and the
-      // whole graph is silently unweighted - the same wrong answer as a misaligned weight, reached from the
-      // other direction.
+      // `distance` answers yes to a call asking for `cost`, and then every edge comes back at its default
+      // weight and the whole graph is silently unweighted - the same wrong answer as a misaligned weight,
+      // reached from the other direction.
       if (provider != null && provider.servesEdgeProperty(weightProperty, relTypes)) {
         final String[] types = relTypes != null && relTypes.length > 0 ? relTypes
             : provider.getMaterializedEdgeTypes();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -958,8 +958,8 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         return new WeightedAdjacency(neighbors, weights, totalEntries);
       }
 
-      // getEdgeProperty() addresses an edge by (type, direction, position), so "all types" has to be resolved
-      // to the actual list before the columnar path can be used at all. A provider that cannot enumerate its
+      // Edge properties are served per type, so "all types" has to be resolved to the actual list before the
+      // columnar path can be used at all. A provider that cannot enumerate its
       // types, or cannot serve THIS property for every one of them, sends us to the edge records - which are
       // exact. Asking only whether the provider has edge properties at all is not enough: a view built over
       // `distance` answers yes to a call asking for `cost`, and then every getEdgeProperty returns null and the
@@ -1028,9 +1028,19 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       final long maxEntryCheckpoint = ADJACENCY_CHECKPOINT_ENTRIES / 3;
       long entries = 0;
       long totalEntries = 0;
+      RecordRowReader fallback = null;
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
-        final NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, guard::checkPeriodically, types);
+        NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, guard::checkPeriodically, types);
+        if (edges == null) {
+          // The provider could serve the property when this walk started and cannot serve this node now - a
+          // view that absorbs committed changes as it goes can lose the ability partway through (issue #6315).
+          // One row read from the records is the whole cost of that, and it is the same row: both builds
+          // produce the same multiset of (neighbour, weight) pairs for a node.
+          if (fallback == null)
+            fallback = new RecordRowReader();
+          edges = fallback.readRow(guard, i, dir, weightProperty, types);
+        }
         neighbors[i] = edges.neighbors();
         weights[i] = edges.weights();
         entries += edges.neighbors().length;
@@ -1055,22 +1065,46 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       reserveWeightedAdjacency(nodeCount, 0);
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
-      // One growable pair of scratch buffers for the whole graph rather than a list per node: the degree is
-      // unknown before the walk, and a per-node ArrayList<Double> would box every weight.
-      int[] scratchNeighbors = new int[16];
-      double[] scratchWeights = new double[16];
-      int edgeStep = 0;
+      final RecordRowReader reader = new RecordRowReader();
       long entries = 0;
       long totalEntries = 0;
 
       for (int i = 0; i < nodeCount; i++) {
-        final Vertex vertex = getVertex(i);
-        if (vertex == null) {
-          // Deleted since the CSR was built: no edges to read, and every other caller in this package skips it.
-          neighbors[i] = EMPTY_NEIGHBORS;
-          weights[i] = EMPTY_WEIGHTS;
-          continue;
+        final NodeEdgeWeights row = reader.readRow(guard, i, dir, weightProperty, relTypes);
+        neighbors[i] = row.neighbors();
+        weights[i] = row.weights();
+        entries += row.neighbors().length;
+        totalEntries += row.neighbors().length;
+        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
+          reserveWeightedAdjacency(0, entries);
+          entries = 0;
         }
+      }
+      reserveWeightedAdjacency(0, entries);
+      return new WeightedAdjacency(neighbors, weights, totalEntries);
+    }
+
+    /**
+     * Reads one node's neighbours and their edge weights off the edge records, which are exact.
+     * <p>
+     * A class rather than a method so that the scratch buffers and the edge-checkpoint counter live across the
+     * nodes of one walk: the degree is unknown before the walk, and a per-node {@code ArrayList<Double>} would
+     * box every weight. It is also the reason the whole-graph record build and the per-node fallback the
+     * columnar build needs (issue #6315) are the same code: two spellings of "read this node's weighted
+     * neighbourhood" would eventually answer differently, and a fallback that answers differently from the
+     * path it stands in for is worse than no fallback.
+     */
+    private class RecordRowReader {
+      private int[]    scratchNeighbors = new int[16];
+      private double[] scratchWeights   = new double[16];
+      private int      edgeStep;
+
+      private NodeEdgeWeights readRow(final WorkGuard guard, final int i, final Vertex.DIRECTION dir,
+          final String weightProperty, final String[] relTypes) {
+        final Vertex vertex = getVertex(i);
+        if (vertex == null)
+          // Deleted since the CSR was built: no edges to read, and every other caller in this package skips it.
+          return new NodeEdgeWeights(EMPTY_NEIGHBORS, EMPTY_WEIGHTS);
 
         final RID vertexRid = vertex.getIdentity();
         final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
@@ -1099,17 +1133,8 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
             GhostEdgeReporter.reportSkipped(rnf);
           }
         }
-        neighbors[i] = Arrays.copyOf(scratchNeighbors, degree);
-        weights[i] = Arrays.copyOf(scratchWeights, degree);
-        entries += degree;
-        totalEntries += degree;
-        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
-          reserveWeightedAdjacency(0, entries);
-          entries = 0;
-        }
+        return new NodeEdgeWeights(Arrays.copyOf(scratchNeighbors, degree), Arrays.copyOf(scratchWeights, degree));
       }
-      reserveWeightedAdjacency(0, entries);
-      return new WeightedAdjacency(neighbors, weights, totalEntries);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
@@ -116,8 +116,14 @@ public class AlgoDijkstraSingleSource extends AbstractAlgoProcedure {
     // to a unit weight when it is missing, so a view materialising some OTHER property would silently answer an
     // unweighted shortest path to a weighted question (issue #6301).
     if (provider instanceof GraphAnalyticalView gav && gav.servesEdgeProperty(weightProperty, relTypes)) {
-      context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
-      return executeWithCSR(context, gav, startNode.getIdentity(), relTypes, weightProperty, dir);
+      final Stream<Result> accelerated = executeWithCSR(context, gav, startNode.getIdentity(), relTypes, weightProperty, dir);
+      // Null means the kernel refused: it reads the CSR arrays directly, and a delta overlay holds edges those
+      // arrays do not have (issue #6315). Serving edge properties and being readable array-by-array are two
+      // different claims, and this one is the second.
+      if (accelerated != null) {
+        context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
+        return accelerated;
+      }
     }
 
     // Fall back to OLTP path
@@ -136,6 +142,8 @@ public class AlgoDijkstraSingleSource extends AbstractAlgoProcedure {
 
     final double[] dist = GraphAlgorithms.dijkstraSingleSource(
         gav, src, weightProperty, dir, relTypes);
+    if (dist == null)
+      return null; // the CSR arrays are not the whole graph right now; the caller reads the edges instead
     long reachable = 0;
     for (int i = 0; i < n; i++)
       if (i != src && dist[i] < Double.POSITIVE_INFINITY) reachable++;

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6301CsrEdgeWeightAlignmentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6301CsrEdgeWeightAlignmentTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Analytical View: {@code astar()} and {@code bellmanFord()}.
  * <p>
  * Both paired {@link com.arcadedb.graph.GraphTraversalProvider#getNeighborIds} with
- * {@link com.arcadedb.graph.GraphTraversalProvider#getEdgeProperty} by hand, which is wrong in two independent
+ * {@link com.arcadedb.graph.GraphTraversalProvider#edgeWeightsForSlice} by hand, which was wrong in two independent
  * ways and silently so - a wrong weight produces a wrong path, never an exception:
  * <ul>
  *   <li><b>a multi-type neighbour list is merged and sorted across types</b>, while the property columns are per
@@ -136,7 +136,7 @@ class Issue6301CsrEdgeWeightAlignmentTest {
   @Test
   void aViewMaterialisingAnotherPropertyDoesNotUnweightTheGraph() {
     // The other half of the same question: the view holds `other`, the call asks for `weight`. Every
-    // getEdgeProperty then answers null, which is indistinguishable from "this edge has no value", so the only
+    // the view then has no value to answer with, which is indistinguishable from "this edge has no value", so the only
     // safe reading is that the provider cannot serve the request at all.
     database.getSchema().getType("road").createProperty("other", Type.DOUBLE);
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayTest.java
@@ -330,4 +330,60 @@ class DeltaOverlayTest {
     assertThat(afterDeleteAll.getOverflowCount()).isEqualTo(0);
     assertThat(afterDeleteAll.getTotalNodeCount()).isEqualTo(2); // only base nodes remain
   }
+
+  /**
+   * Issue #6315: a change to one edge type's properties leaves that type's columns out of date and no other
+   * type's. Serving the columnar path is decided per type, so disqualifying every type for an update to one of
+   * them would cost a view that materialises several of them the fast path it could still honestly offer.
+   */
+  @Test
+  void anEdgePropertyUpdateDirtiesOnlyItsOwnEdgeType() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final TxDelta delta = new TxDelta();
+    delta.updatedEdges.put(rid(10), new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(10), null));
+
+    final DeltaOverlay overlay = new DeltaOverlay(mapping.size()).merge(delta, mapping);
+
+    assertThat(overlay.isEdgePropertiesDirty(EDGE_TYPE)).isTrue();
+    assertThat(overlay.isEdgePropertiesDirty("SomeOtherType")).isFalse();
+    assertThat(overlay.isEdgePropertiesDirty()).as("some type is out of date").isTrue();
+  }
+
+  /**
+   * Issue #6315: the bulk case, where the collector gave up on naming the edges individually, has to leave
+   * every type out of date - it no longer knows which ones it would otherwise have named.
+   */
+  @Test
+  void aBulkEdgePropertyRewriteDirtiesEveryEdgeType() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final TxDelta delta = new TxDelta();
+    delta.forceEdgePropertyRebuild = true;
+
+    final DeltaOverlay overlay = new DeltaOverlay(mapping.size()).merge(delta, mapping);
+
+    assertThat(overlay.isEdgePropertiesDirty(EDGE_TYPE)).isTrue();
+    assertThat(overlay.isEdgePropertiesDirty("SomeOtherType")).isTrue();
+  }
+
+  /**
+   * Issue #6315: an update to an edge the overlay itself holds is applied to that edge's own entry, so nothing
+   * about the base columns went out of date - which is what keeps the ordinary insert, reported as one create
+   * and one update of the same edge, from forcing a rebuild.
+   */
+  @Test
+  void updatingAnEdgeTheOverlayHoldsDirtiesNothing() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final RID edgeRid = rid(10);
+
+    final TxDelta delta = new TxDelta();
+    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid, new Object[] { 1.0 }));
+    delta.updatedEdges.put(edgeRid, new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid, new Object[] { 2.0 }));
+
+    final DeltaOverlay overlay = new DeltaOverlay(mapping.size()).merge(delta, mapping);
+
+    assertThat(overlay.isEdgePropertiesDirty(EDGE_TYPE)).isFalse();
+    assertThat(overlay.getAdded(0, EDGE_TYPE, true).properties()[0])
+        .as("the added edge's own entry carries the value the update set")
+        .isEqualTo(new Object[] { 2.0 });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayTest.java
@@ -19,6 +19,8 @@
 package com.arcadedb.graph.olap;
 
 import com.arcadedb.database.RID;
+
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -385,5 +387,35 @@ class DeltaOverlayTest {
     assertThat(overlay.getAdded(0, EDGE_TYPE, true).properties()[0])
         .as("the added edge's own entry carries the value the update set")
         .isEqualTo(new Object[] { 2.0 });
+  }
+
+  /**
+   * Issue #6315: on the post-compaction re-application path, an add the freshly built base CSR already carries
+   * is skipped (#4588) - and a property change to that same edge in the same delta is then already in the
+   * fresh columns, so it must not mark the type out of date. Missing this forced a second full rebuild after
+   * every compaction that happened to buffer an ordinary insert, which reports one create and one update of
+   * the same edge.
+   */
+  @Test
+  void anUpdateToAnEdgeTheFreshBaseCsrAlreadyCarriesDirtiesNothing() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final RID edgeRid = rid(10);
+
+    // A fresh base CSR that already contains the edge 0 -> 1, as a compaction scan crossing its bucket after
+    // the transaction committed would have produced.
+    final CSRAdjacencyIndex csr = new CSRAdjacencyIndex(new int[] { 0, 1, 1 }, new int[] { 1 },
+        new int[] { 0, 0, 1 }, new int[] { 0 }, 2, 1);
+
+    final TxDelta delta = new TxDelta();
+    delta.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid, new Object[] { 1.0 }));
+    delta.updatedEdges.put(edgeRid, new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid, new Object[] { 2.0 }));
+
+    final DeltaOverlay overlay = new DeltaOverlay(mapping.size())
+        .merge(delta, mapping, Map.of(EDGE_TYPE, csr));
+
+    assertThat(overlay.isEdgePropertiesDirty(EDGE_TYPE))
+        .as("the fresh base CSR scanned this edge after the whole transaction committed, values and all")
+        .isFalse();
+    assertThat(overlay.getDeltaEdgeCount()).as("and the add itself stays deduped against that base").isZero();
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -29,6 +29,7 @@ import com.arcadedb.engine.TransactionManager;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.NeighborView;
+import com.arcadedb.graph.NodeEdgeWeights;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
@@ -2398,7 +2399,7 @@ class GraphAnalyticalViewTest extends TestHelper {
     Arrays.sort(expectedP0Out);
     final Object expectedName = gav.getProperty(p1, "name");
     final Object expectedAge = gav.getProperty(p1, "age");
-    final Object expectedWeight = gav.getEdgeProperty(p0, 0, Vertex.DIRECTION.OUT, "FOLLOWS", "weight");
+    final double[] expectedWeights = gav.edgeWeightsForSlice(p0, Vertex.DIRECTION.OUT, "FOLLOWS", "weight", -1.0, null).weights();
 
     final String dbPath = database.getDatabasePath();
     database.close();
@@ -2424,7 +2425,8 @@ class GraphAnalyticalViewTest extends TestHelper {
       assertThat(restoredP0Out).isEqualTo(expectedP0Out);
       assertThat(restored.getProperty(restoredP1, "name")).isEqualTo(expectedName);
       assertThat(restored.getProperty(restoredP1, "age")).isEqualTo(expectedAge);
-      assertThat(restored.getEdgeProperty(restoredP0, 0, Vertex.DIRECTION.OUT, "FOLLOWS", "weight")).isEqualTo(expectedWeight);
+      assertThat(restored.edgeWeightsForSlice(restoredP0, Vertex.DIRECTION.OUT, "FOLLOWS", "weight", -1.0, null).weights())
+          .isEqualTo(expectedWeights);
 
       restored.drop();
     } finally {
@@ -5426,25 +5428,28 @@ class GraphAnalyticalViewTest extends TestHelper {
     // Forward (OUT) edge properties
     // A has 1 outgoing edge to B with weight 1.0
     assertThat(gav.countEdges(idA, Vertex.DIRECTION.OUT, "ROAD")).isEqualTo(1);
-    final Object weightAB = gav.getEdgeProperty(idA, 0, Vertex.DIRECTION.OUT, "ROAD", "weight");
-    assertThat(weightAB).isInstanceOf(Double.class);
-    assertThat((Double) weightAB).isEqualTo(1.0);
+    final NodeEdgeWeights outA = gav.edgeWeightsForSlice(idA, Vertex.DIRECTION.OUT, "ROAD", "weight", -1.0, null);
+    assertThat(outA.neighbors()).containsExactly(idB);
+    assertThat(outA.weights()).containsExactly(1.0);
 
     // B has 1 outgoing edge to C with weight 2.5
     assertThat(gav.countEdges(idB, Vertex.DIRECTION.OUT, "ROAD")).isEqualTo(1);
-    final Object weightBC = gav.getEdgeProperty(idB, 0, Vertex.DIRECTION.OUT, "ROAD", "weight");
-    assertThat((Double) weightBC).isEqualTo(2.5);
+    final NodeEdgeWeights outB = gav.edgeWeightsForSlice(idB, Vertex.DIRECTION.OUT, "ROAD", "weight", -1.0, null);
+    assertThat(outB.neighbors()).containsExactly(idC);
+    assertThat(outB.weights()).containsExactly(2.5);
 
     // Backward (IN) edge properties — should resolve via bwdToFwd indirection
     // B has 1 incoming edge from A with weight 1.0
     assertThat(gav.countEdges(idB, Vertex.DIRECTION.IN, "ROAD")).isEqualTo(1);
-    final Object weightBA = gav.getEdgeProperty(idB, 0, Vertex.DIRECTION.IN, "ROAD", "weight");
-    assertThat((Double) weightBA).isEqualTo(1.0);
+    final NodeEdgeWeights inB = gav.edgeWeightsForSlice(idB, Vertex.DIRECTION.IN, "ROAD", "weight", -1.0, null);
+    assertThat(inB.neighbors()).containsExactly(idA);
+    assertThat(inB.weights()).containsExactly(1.0);
 
     // C has 1 incoming edge from B with weight 2.5
     assertThat(gav.countEdges(idC, Vertex.DIRECTION.IN, "ROAD")).isEqualTo(1);
-    final Object weightCB = gav.getEdgeProperty(idC, 0, Vertex.DIRECTION.IN, "ROAD", "weight");
-    assertThat((Double) weightCB).isEqualTo(2.5);
+    final NodeEdgeWeights inC = gav.edgeWeightsForSlice(idC, Vertex.DIRECTION.IN, "ROAD", "weight", -1.0, null);
+    assertThat(inC.neighbors()).containsExactly(idB);
+    assertThat(inC.weights()).containsExactly(2.5);
 
     // C has no outgoing edges
     assertThat(gav.countEdges(idC, Vertex.DIRECTION.OUT, "ROAD")).isEqualTo(0);
@@ -5471,8 +5476,8 @@ class GraphAnalyticalViewTest extends TestHelper {
 
     assertThat(gav.hasEdgeProperties()).isFalse();
     final int idA = gav.getNodeId(a.getIdentity());
-    // getEdgeProperty should return null gracefully
-    assertThat(gav.getEdgeProperty(idA, 0, Vertex.DIRECTION.OUT, "ROAD", "weight")).isNull();
+    // no columns at all: the view says it cannot serve the property rather than answering at a default weight
+    assertThat(gav.edgeWeightsForSlice(idA, Vertex.DIRECTION.OUT, "ROAD", "weight", -1.0, null)).isNull();
 
     gav.drop();
   }
@@ -5503,13 +5508,17 @@ class GraphAnalyticalViewTest extends TestHelper {
     final int hubId = gav.getNodeId(hub.getIdentity());
     assertThat(gav.countEdges(hubId, Vertex.DIRECTION.OUT, "LINK")).isEqualTo(5);
 
-    // Verify all 5 edge properties are correct (order may differ due to CSR sorting)
-    final int[] neighbors = gav.getNeighborIds(hubId, Vertex.DIRECTION.OUT, "LINK");
+    // Verify all 5 edge properties are correct, and that each lands on its own spoke: the neighbours come back
+    // sorted by dense id while the edges were created in spoke order, so a build that paired them by position
+    // would put spoke i's cost on whichever spoke sorted i-th
+    final NodeEdgeWeights hubEdges = gav.edgeWeightsForSlice(hubId, Vertex.DIRECTION.OUT, "LINK", "cost", -1.0, null);
+    assertThat(hubEdges.neighbors()).isEqualTo(gav.getNeighborIds(hubId, Vertex.DIRECTION.OUT, "LINK"));
     final Set<Double> retrievedWeights = new HashSet<>();
-    for (int i = 0; i < neighbors.length; i++) {
-      final Object cost = gav.getEdgeProperty(hubId, i, Vertex.DIRECTION.OUT, "LINK", "cost");
-      assertThat(cost).isNotNull();
-      retrievedWeights.add((Double) cost);
+    for (int i = 0; i < hubEdges.neighbors().length; i++) {
+      retrievedWeights.add(hubEdges.weights()[i]);
+      for (int spoke = 0; spoke < 5; spoke++)
+        if (hubEdges.neighbors()[i] == gav.getNodeId(spokes[spoke].getIdentity()))
+          assertThat(hubEdges.weights()[i]).isEqualTo(expectedWeights[spoke]);
     }
     assertThat(retrievedWeights).containsExactlyInAnyOrder(0.1, 0.2, 0.3, 0.4, 0.5);
 
@@ -5517,9 +5526,9 @@ class GraphAnalyticalViewTest extends TestHelper {
     for (int i = 0; i < 5; i++) {
       final int spokeId = gav.getNodeId(spokes[i].getIdentity());
       assertThat(gav.countEdges(spokeId, Vertex.DIRECTION.IN, "LINK")).isEqualTo(1);
-      final Object cost = gav.getEdgeProperty(spokeId, 0, Vertex.DIRECTION.IN, "LINK", "cost");
-      assertThat(cost).isNotNull();
-      assertThat(expectedWeights).contains((Double) cost);
+      final NodeEdgeWeights spokeEdges = gav.edgeWeightsForSlice(spokeId, Vertex.DIRECTION.IN, "LINK", "cost", -1.0, null);
+      assertThat(spokeEdges.neighbors()).containsExactly(hubId);
+      assertThat(spokeEdges.weights()).containsExactly(expectedWeights[i]);
     }
 
     gav.drop();

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
@@ -583,6 +583,60 @@ class Issue6315EdgeWeightsUnderOverlayTest {
     }
   }
 
+  /**
+   * The same contract at the boundary, which is where the check's order matters rather than its number: with
+   * exactly the cap's worth of distinct edges already tracked, a repeat update of one of them does not grow the
+   * set at all and so must not trip it either. Sized from the constant rather than from a literal, so retuning
+   * the cap is a decision rather than a test failure.
+   */
+  @Test
+  void aRepeatUpdateDoesNotTripTheCapEvenWithItAlreadyFull() {
+    final int distinctEdges = DeltaCollector.MAX_TRACKED_EDGE_UPDATES;
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      // One edge at build time, so the view materialises a `w` column to begin with.
+      a.newEdge("ROAD", b, true, new Object[] { "w", 1.0 }).save();
+    });
+
+    final GraphAnalyticalView view = syncView("overlay-repeat-update-at-the-cap");
+    try {
+      // Added in their own transaction, so the overlay holds them and their updates resolve against it.
+      database.transaction(() -> {
+        final Vertex a = vertex("A");
+        for (int i = 0; i < distinctEdges; i++) {
+          final MutableVertex target = database.newVertex("N").set("name", "T" + i).save();
+          a.newEdge("ROAD", target, true, new Object[] { "w", 1.0 }).save();
+        }
+      });
+      assertThat(view.hasEdgeProperty("ROAD", "w")).isTrue();
+
+      // Only the overlay-held ones: the edge that was there at build time is a base edge, and updating it
+      // would put the columns out of date for a reason that has nothing to do with the cap.
+      database.transaction(() -> {
+        Edge first = null;
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD")) {
+          if ("B".equals(edge.getInVertex().get("name")))
+            continue;
+          edge.modify().set("w", 2.0).save();
+          if (first == null)
+            first = edge;
+        }
+        // The cap is now exactly full of distinct edges. This one is already in it.
+        first.modify().set("w", 3.0).save();
+      });
+
+      assertThat(view.hasEdgeProperty("ROAD", "w"))
+          .as("a repeat update grows nothing, so it cannot be what tips the set over its cap")
+          .isTrue();
+      assertThat(weightsByName(view, view.getNodeId(vertex("A").getIdentity())).values())
+          .as("every edge took the update, one of them twice")
+          .containsOnlyOnce(3.0);
+    } finally {
+      view.drop();
+    }
+  }
+
   // ── Helpers ──────────────────────────────────────────────────────────────
 
   /** The {@code algo.dijkstra.singleSource} cost from A to B over the {@code w} property. */

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
@@ -497,6 +497,55 @@ class Issue6315EdgeWeightsUnderOverlayTest {
     }
   }
 
+  /**
+   * A view that materialises no edge property columns has nothing that can go out of date when an edge's
+   * properties change - the base CSR holds the topology, which an update does not touch - so the full rebuild
+   * #4513 forces for such an update has nothing to repair. It was forced anyway, on every edge update, because
+   * the flag was raised before anyone asked whether there were columns at all. The overlay surviving is the
+   * observable half of that: a rebuild would have compacted it away.
+   */
+  @Test
+  void anEdgeUpdateOnAViewWithoutEdgeColumnsDoesNotForceARebuild() throws InterruptedException {
+    starGraph();
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("no-edge-columns-update")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+    try {
+      assertThat(view.hasEdgeProperties()).as("no edge property columns were asked for").isFalse();
+
+      // An added edge, so there is an overlay for the rebuild to compact away if one is forced.
+      database.transaction(() -> {
+        final MutableVertex e = database.newVertex("N").set("name", "E").save();
+        vertex("A").newEdge("ROAD", e, true, new Object[] { "w", 99.0 }).save();
+      });
+      assertThat(view.getStats().get("overlayActive")).isEqualTo(true);
+
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if ("B".equals(edge.getInVertex().get("name")))
+            edge.modify().set("w", 77.0).save();
+      });
+
+      // Long enough for a rebuild of a five-vertex graph to have finished several times over.
+      final long deadline = System.currentTimeMillis() + 1_000;
+      while (System.currentTimeMillis() < deadline) {
+        assertThat(view.getStats().get("overlayActive"))
+            .as("nothing was rebuilt, so the overlay is still the one the added edge went into")
+            .isEqualTo(true);
+        Thread.sleep(25);
+      }
+      assertThat(view.getNeighborIds(view.getNodeId(vertex("A").getIdentity()), Vertex.DIRECTION.OUT, "ROAD"))
+          .as("and the topology still has all four outgoing edges")
+          .hasSize(4);
+    } finally {
+      view.drop();
+    }
+  }
+
   // ── Helpers ──────────────────────────────────────────────────────────────
 
   /** The {@code algo.dijkstra.singleSource} cost from A to B over the {@code w} property. */

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
@@ -1,0 +1,526 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.NodeEdgeWeights;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6315 - the Graph Analytical View answered edge properties from the base CSR while
+ * a delta overlay was active, so a caller reading them by neighbour position got a weight belonging to a
+ * different edge.
+ * <p>
+ * The columns are aligned with the base CSR's forward edge slots. {@code getNeighborIds} serves the overlay's
+ * view of the node instead: deleted edges dropped, added ones merged in, the whole list re-sorted. Delete the
+ * first of three outgoing edges and every remaining neighbour shifts down one position, while the columns do
+ * not - so position 1 answered with the deleted edge's weight, which is a wrong shortest path, a wrong MST and
+ * a wrong Steiner tree, and never an exception. PR #6306 had closed that for the callers that existed by
+ * narrowing {@code hasEdgeProperties()} to {@code false} whenever an overlay was active, which left the sharp
+ * accessor in the SPI for the next caller to find.
+ * <p>
+ * The accessor is gone. {@link com.arcadedb.graph.GraphTraversalProvider#edgeWeightsForSlice} hands back the
+ * neighbours and their weights together, paired where the overlay is applied, so there is no position to
+ * address across and no rule for a caller to remember. Resolving the two rather than refusing them also keeps
+ * the columnar path alive while a view is being updated, which is the state {@code UpdateMode.SYNCHRONOUS}
+ * leaves it in after every single commit:
+ * <ul>
+ *   <li>a base edge the overlay has not deleted answers from its own column slot;</li>
+ *   <li>an edge the overlay added answers from the value captured for it at commit time;</li>
+ *   <li>an edge whose property was <em>updated</em> has neither - nothing maps a column slot back from an RID -
+ *       so the view reports no edge properties until the rebuild that repairs the columns lands.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6315EdgeWeightsUnderOverlayTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6315-edge-weights-overlay");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    database.getSchema().createEdgeType("ROAD").createProperty("w", Type.DOUBLE);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * The shape the issue is about: A has three outgoing edges of distinct weight, one of them is deleted in a
+   * committed transaction, and the two that survive must still each answer with their own weight. Positionally
+   * they no longer sit where they sat: dropping the first neighbour shifts the other two down one slot each.
+   */
+  @Test
+  void aDeletedEdgeDoesNotShiftItsNeighboursOntoTheWrongWeights() {
+    starGraph();
+
+    final GraphAnalyticalView view = syncView("overlay-deleted-edge");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+      assertThat(weightsByName(view, a)).containsExactlyInAnyOrderEntriesOf(Map.of("B", 10.0, "C", 20.0, "D", 30.0));
+
+      deleteEdge("A", "B");
+
+      assertThat(view.hasEdgeProperty("ROAD", "w"))
+          .as("the overlay is resolved against the columns, not a reason to stop serving them")
+          .isTrue();
+      assertThat(weightsByName(view, a))
+          .as("B is gone; C and D moved down a slot each and must keep their own weights, not B's and C's")
+          .containsExactlyInAnyOrderEntriesOf(Map.of("C", 20.0, "D", 30.0));
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * The same for the incoming direction, which reaches its columns through the backward-to-forward slot
+   * mapping - a second addressing step the merge has to survive.
+   */
+  @Test
+  void aDeletedEdgeDoesNotShiftIncomingNeighboursEither() {
+    // B and C and D all point at A, so A's incoming slice is the one the deletion re-shapes.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      final MutableVertex c = database.newVertex("N").set("name", "C").save();
+      final MutableVertex d = database.newVertex("N").set("name", "D").save();
+      b.newEdge("ROAD", a, true, new Object[] { "w", 10.0 }).save();
+      c.newEdge("ROAD", a, true, new Object[] { "w", 20.0 }).save();
+      d.newEdge("ROAD", a, true, new Object[] { "w", 30.0 }).save();
+    });
+
+    final GraphAnalyticalView view = syncView("overlay-deleted-incoming-edge");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+      deleteEdge("B", "A");
+
+      final Map<String, Double> incoming = new HashMap<>();
+      final NodeEdgeWeights edges = view.edgeWeightsForSlice(a, Vertex.DIRECTION.IN, "ROAD", "w", -1.0, null);
+      for (int i = 0; i < edges.neighbors().length; i++)
+        incoming.put((String) view.getRID(edges.neighbors()[i]).asVertex().get("name"), edges.weights()[i]);
+
+      assertThat(incoming).containsExactlyInAnyOrderEntriesOf(Map.of("C", 20.0, "D", 30.0));
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * An edge the overlay added has no column slot at all - the columns were built with the base CSR - and used to
+   * be the reason the whole node could not be answered for. It carries the value captured for it at commit time
+   * instead, so the answer stays exact rather than defaulting the new edge to a unit weight.
+   */
+  @Test
+  void anEdgeTheOverlayAddedAnswersWithItsOwnWeight() {
+    starGraph();
+
+    final GraphAnalyticalView view = syncView("overlay-added-edge");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+
+      database.transaction(() -> {
+        final MutableVertex e = database.newVertex("N").set("name", "E").save();
+        vertex("A").newEdge("ROAD", e, true, new Object[] { "w", 99.0 }).save();
+      });
+
+      assertThat(weightsByName(view, a))
+          .as("the added edge weighs what it was created with, not the default")
+          .containsExactlyInAnyOrderEntriesOf(Map.of("B", 10.0, "C", 20.0, "D", 30.0, "E", 99.0));
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * The limit of what the overlay can resolve, pinned so that it is refused rather than guessed. Deletions are
+   * counted per pair - all the neighbour list needs, since dropping any one of a pair's parallel edges leaves
+   * the same neighbours behind - but parallel edges need not weigh the same, and nothing says which of them
+   * died. Answering would mean handing back a plausible wrong multiset of weights, which is the failure this
+   * whole issue is about, so the view says it cannot serve the node and the caller reads the records.
+   */
+  @Test
+  void aPartiallyDeletedRunOfParallelEdgesIsRefusedRatherThanGuessed() {
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 2.0 }).save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 3.0 }).save();
+    });
+
+    final GraphAnalyticalView view = syncView("overlay-parallel-edges");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+
+      // Delete the 2.0 edge and add a 4.0 one, both between the same pair.
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if (Double.valueOf(2.0).equals(edge.get("w")))
+            edge.delete();
+        vertex("A").newEdge("ROAD", vertex("B"), true, new Object[] { "w", 4.0 }).save();
+      });
+
+      assertThat(view.edgeWeightsForSlice(a, Vertex.DIRECTION.OUT, "ROAD", "w", -1.0, null))
+          .as("which of the three parallel edges was deleted is not recoverable from a per-pair count")
+          .isNull();
+      assertThat(view.edgeWeightsOf(a, Vertex.DIRECTION.OUT, "w", -1.0, "ROAD"))
+          .as("and a node the provider cannot answer for makes the whole call fall back, not half of it")
+          .isNull();
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * The counterweight: parallel edges are only ambiguous while some of a pair's run survives a deletion.
+   * Deleting the whole run leaves nothing to be ambiguous about, and adding to it identifies each new edge by
+   * its own captured value, so both keep answering.
+   */
+  @Test
+  void parallelEdgesStillAnswerWhenTheDeletionIsNotAmbiguous() {
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      final MutableVertex c = database.newVertex("N").set("name", "C").save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 2.0 }).save();
+      a.newEdge("ROAD", c, true, new Object[] { "w", 5.0 }).save();
+    });
+
+    final GraphAnalyticalView view = syncView("overlay-parallel-edges-unambiguous");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+
+      // Both A->B edges go, and two more parallel ones are added between the same pair.
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if ("B".equals(edge.getInVertex().get("name")))
+            edge.delete();
+        vertex("A").newEdge("ROAD", vertex("B"), true, new Object[] { "w", 7.0 }).save();
+        vertex("A").newEdge("ROAD", vertex("B"), true, new Object[] { "w", 8.0 }).save();
+      });
+
+      final NodeEdgeWeights edges = view.edgeWeightsForSlice(a, Vertex.DIRECTION.OUT, "ROAD", "w", -1.0, null);
+      assertThat(edges.neighbors()).isEqualTo(view.getNeighborIds(a, Vertex.DIRECTION.OUT, "ROAD"));
+      assertThat(edges.weights()).containsExactlyInAnyOrder(5.0, 7.0, 8.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * The one thing the overlay cannot repair. An edge already in the base CSR is addressed by a column slot and
+   * nothing maps that slot back from its RID, so a committed change to its weight leaves the columns holding a
+   * value the database no longer has. Serving the added edges exactly while quietly serving this one from a
+   * stale column would be the same silent wrong number the issue is about, reached from the other side, so the
+   * view reports no edge properties until the rebuild it forces for the update lands.
+   */
+  @Test
+  void anUpdatedEdgeWeightStopsTheColumnsFromBeingServedUntilTheRebuildLands() {
+    starGraph();
+
+    final GraphAnalyticalView view = syncView("overlay-updated-weight");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if ("B".equals(edge.getInVertex().get("name")))
+            edge.modify().set("w", 77.0).save();
+      });
+
+      // Either the rebuild has not landed yet - and then the columns are refused rather than served stale - or
+      // it has, and then they carry the new value. Never the old one.
+      if (view.hasEdgeProperty("ROAD", "w"))
+        assertThat(weightsByName(view, a).get("B")).isEqualTo(77.0);
+      else
+        assertThat(view.edgeWeightsForSlice(a, Vertex.DIRECTION.OUT, "ROAD", "w", -1.0, null)).isNull();
+
+      // The forced rebuild makes it visible for good.
+      assertThat(view.awaitReady(30, TimeUnit.SECONDS)).isTrue();
+      waitUntilServed(view);
+      assertThat(weightsByName(view, view.getNodeId(vertex("A").getIdentity())).get("B")).isEqualTo(77.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * The neighbours {@code edgeWeightsForSlice} pairs its weights with have to be the very ones
+   * {@code getNeighborIds} reports, or a caller that mixes the two - and everything reading a Graph Analytical
+   * View has both in hand - sees two different graphs.
+   */
+  @Test
+  void theNeighboursAreTheOnesGetNeighborIdsReports() {
+    starGraph();
+
+    final GraphAnalyticalView view = syncView("overlay-neighbour-agreement");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+      deleteEdge("A", "C");
+      database.transaction(() -> {
+        final MutableVertex e = database.newVertex("N").set("name", "E").save();
+        vertex("A").newEdge("ROAD", e, true, new Object[] { "w", 99.0 }).save();
+      });
+
+      final NodeEdgeWeights edges = view.edgeWeightsForSlice(a, Vertex.DIRECTION.OUT, "ROAD", "w", -1.0, null);
+      assertThat(edges.neighbors()).isEqualTo(view.getNeighborIds(a, Vertex.DIRECTION.OUT, "ROAD"));
+      assertThat(edges.weights()).hasSize(edges.neighbors().length);
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * A direction has an adjacency slice; {@code BOTH} does not. Answering it here would mean answering for
+   * neither, so the slice accessor refuses it and {@code edgeWeightsOf} splits it into the two that exist -
+   * which is the whole of the multi-slice composition, exercised end to end with an overlay in play.
+   */
+  @Test
+  void bothDirectionsAreSplitIntoTheSlicesThatExist() {
+    starGraph();
+    // A -> B, C, D plus D -> A, so A's BOTH neighbourhood spans the outgoing and the incoming slice alike.
+    database.transaction(() -> vertex("D").newEdge("ROAD", vertex("A"), true, new Object[] { "w", 40.0 }).save());
+
+    final GraphAnalyticalView view = syncView("overlay-both-directions");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+      deleteEdge("A", "B");
+
+      assertThat(view.edgeWeightsForSlice(a, Vertex.DIRECTION.BOTH, "ROAD", "w", -1.0, null))
+          .as("BOTH has no slice of its own to align with")
+          .isNull();
+
+      final NodeEdgeWeights both = view.edgeWeightsOf(a, Vertex.DIRECTION.BOTH, "w", -1.0, "ROAD");
+      assertThat(both.weights()).containsExactlyInAnyOrder(20.0, 30.0, 40.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * The collateral of letting the view serve edge properties through an overlay: {@code algo.dijkstra.singleSource}
+   * routes onto a kernel that reads the CSR offset and neighbour arrays directly, and those arrays are the graph
+   * as it stood at the last build. It used to be kept off them by the view reporting no edge properties whenever
+   * an overlay was active - a gate it never asked for and could not see. The kernel refuses for itself now, so
+   * the answer follows the edges that exist rather than the ones the arrays remember.
+   */
+  @Test
+  void dijkstraDoesNotAnswerFromTheStaleBaseCsrWhileAnOverlayIsActive() {
+    // A -> B costs 10 directly, or 2 the way round through C.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      final MutableVertex c = database.newVertex("N").set("name", "C").save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 10.0 }).save();
+      a.newEdge("ROAD", c, true, new Object[] { "w", 1.0 }).save();
+      c.newEdge("ROAD", b, true, new Object[] { "w", 1.0 }).save();
+    });
+
+    final GraphAnalyticalView view = syncView("overlay-dijkstra-kernel");
+    try {
+      assertThat(shortestPathCostToB()).isEqualTo(2.0);
+
+      deleteEdge("C", "B");
+
+      assertThat(shortestPathCostToB())
+          .as("the shortcut through C is gone; only the base CSR arrays still have it")
+          .isEqualTo(10.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * The other half of a node the provider cannot answer for: the algorithm above it has to notice and read that
+   * node's edges itself, not take the {@code null} for an empty neighbourhood or fall over it. One ambiguous
+   * node in an otherwise columnar graph is exactly the shape that reaches
+   * {@code AbstractAlgoProcedure.weightedAdjacencyFromColumns}'s per-node fallback.
+   */
+  @Test
+  void anAlgorithmReadsTheRecordsForANodeTheViewCannotAnswerFor() {
+    // A reaches B directly over one of two parallel edges (1.0 and 100.0), or for 6.0 the way round through C.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      final MutableVertex c = database.newVertex("N").set("name", "C").save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 100.0 }).save();
+      a.newEdge("ROAD", c, true, new Object[] { "w", 5.0 }).save();
+      c.newEdge("ROAD", b, true, new Object[] { "w", 1.0 }).save();
+    });
+
+    final GraphAnalyticalView view = syncView("overlay-ambiguous-node-fallback");
+    try {
+      // The cheap direct edge goes, leaving the 100.0 one - and leaving A's run of parallel edges partially
+      // deleted, which is the pair the per-pair deletion count cannot tell apart.
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if (Double.valueOf(1.0).equals(edge.get("w"))) {
+            edge.delete();
+            return;
+          }
+      });
+
+      try (final ResultSet rows = database.command("opencypher",
+          "MATCH (a:N {name: 'A'}), (b:N {name: 'B'}) CALL algo.bellmanford(a, b, 'ROAD', 'w') "
+              + "YIELD weight RETURN weight")) {
+        assertThat(rows.hasNext()).isTrue();
+        assertThat(((Number) rows.next().getProperty("weight")).doubleValue())
+            .as("A-C-B at 6.0: the surviving direct edge weighs 100.0, whichever slot it sits in")
+            .isEqualTo(6.0);
+      }
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * An update to an edge the overlay itself holds is applied there, where the edge's values live, and leaves
+   * the base columns alone - they never described that edge to begin with. This is also what keeps the plain
+   * {@code newEdge(...).save()} from forcing a rebuild on every insert: an insert reports one create and one
+   * update of the same edge.
+   */
+  @Test
+  void updatingAnEdgeTheOverlayHoldsDoesNotPutTheColumnsOutOfDate() {
+    starGraph();
+
+    final GraphAnalyticalView view = syncView("overlay-updated-added-edge");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+
+      database.transaction(() -> {
+        final MutableVertex e = database.newVertex("N").set("name", "E").save();
+        vertex("A").newEdge("ROAD", e, true, new Object[] { "w", 99.0 }).save();
+      });
+      // A separate transaction, so the update is resolved against the overlay left behind by the previous one
+      // rather than against this delta's own additions.
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if ("E".equals(edge.getInVertex().get("name")))
+            edge.modify().set("w", 55.0).save();
+      });
+
+      assertThat(view.hasEdgeProperty("ROAD", "w"))
+          .as("nothing about the base columns changed, so they are still exact")
+          .isTrue();
+      assertThat(weightsByName(view, a).get("E"))
+          .as("the overlay carries the new value, so no rebuild is needed to see it")
+          .isEqualTo(55.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /** The {@code algo.dijkstra.singleSource} cost from A to B over the {@code w} property. */
+  private double shortestPathCostToB() {
+    try (final ResultSet rows = database.command("opencypher",
+        "MATCH (a:N {name: 'A'}) CALL algo.dijkstra.singleSource(a, 'ROAD', 'w', 'OUT') YIELD node, cost "
+            + "WITH node, cost WHERE node.name = 'B' RETURN cost")) {
+      assertThat(rows.hasNext()).isTrue();
+      return ((Number) rows.next().getProperty("cost")).doubleValue();
+    }
+  }
+
+  /** A -> B at 10.0, A -> C at 20.0, A -> D at 30.0. */
+  private void starGraph() {
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      final MutableVertex c = database.newVertex("N").set("name", "C").save();
+      final MutableVertex d = database.newVertex("N").set("name", "D").save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 10.0 }).save();
+      a.newEdge("ROAD", c, true, new Object[] { "w", 20.0 }).save();
+      a.newEdge("ROAD", d, true, new Object[] { "w", 30.0 }).save();
+    });
+  }
+
+  private GraphAnalyticalView syncView(final String name) {
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName(name)
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("w")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+    assertThat(view.hasEdgeProperty("ROAD", "w")).isTrue();
+    return view;
+  }
+
+  /** The outgoing ROAD weights of a node, keyed by the neighbour's name. */
+  private Map<String, Double> weightsByName(final GraphAnalyticalView view, final int nodeId) {
+    final NodeEdgeWeights edges = view.edgeWeightsForSlice(nodeId, Vertex.DIRECTION.OUT, "ROAD", "w", -1.0, null);
+    assertThat(edges).isNotNull();
+    final Map<String, Double> byName = new HashMap<>();
+    for (int i = 0; i < edges.neighbors().length; i++)
+      byName.put((String) view.getRID(edges.neighbors()[i]).asVertex().get("name"), edges.weights()[i]);
+    return byName;
+  }
+
+  private Vertex vertex(final String name) {
+    return database.query("sql", "select from N where name = ?", name).next().getRecord().get().asVertex();
+  }
+
+  private void deleteEdge(final String from, final String to) {
+    database.transaction(() -> {
+      for (final Edge edge : vertex(from).getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+        if (to.equals(edge.getInVertex().get("name"))) {
+          edge.delete();
+          return;
+        }
+    });
+  }
+
+  /** Waits for the rebuild an edge-property update forces to have swapped its fresh columns in. */
+  private void waitUntilServed(final GraphAnalyticalView view) {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (!view.hasEdgeProperty("ROAD", "w") && System.currentTimeMillis() < deadline)
+      Thread.yield();
+    assertThat(view.hasEdgeProperty("ROAD", "w"))
+        .as("the rebuild forced by an edge property update must restore the columns")
+        .isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
@@ -546,6 +546,43 @@ class Issue6315EdgeWeightsUnderOverlayTest {
     }
   }
 
+  /**
+   * The cap on individually-tracked edge property changes counts the edges touched, not the calls made, so a
+   * transaction that rewrites one edge's weight over and over - an accumulator - holds one entry and stays
+   * resolvable against the overlay. Counting the calls would trip the cap and force a full rebuild for a
+   * single edge the overlay was holding all along.
+   */
+  @Test
+  void repeatedUpdatesOfOneEdgeCountOnceAgainstTheTrackingCap() {
+    starGraph();
+
+    final GraphAnalyticalView view = syncView("overlay-repeated-updates-of-one-edge");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+      database.transaction(() -> {
+        final MutableVertex e = database.newVertex("N").set("name", "E").save();
+        vertex("A").newEdge("ROAD", e, true, new Object[] { "w", 1.0 }).save();
+      });
+
+      // Well past DeltaCollector's 1024 cap in calls, one edge in edges.
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if ("E".equals(edge.getInVertex().get("name"))) {
+            for (int i = 1; i <= 2000; i++)
+              edge.modify().set("w", (double) i).save();
+            return;
+          }
+      });
+
+      assertThat(view.hasEdgeProperty("ROAD", "w"))
+          .as("one overlay-held edge was touched, so nothing about the base columns went out of date")
+          .isTrue();
+      assertThat(weightsByName(view, a).get("E")).isEqualTo(2000.0);
+    } finally {
+      view.drop();
+    }
+  }
+
   // ── Helpers ──────────────────────────────────────────────────────────────
 
   /** The {@code algo.dijkstra.singleSource} cost from A to B over the {@code w} property. */

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6315EdgeWeightsUnderOverlayTest.java
@@ -453,6 +453,50 @@ class Issue6315EdgeWeightsUnderOverlayTest {
     }
   }
 
+  /**
+   * Past a cap, one transaction's edge property changes stop being tracked individually and the delta says only
+   * that the columns are out of date - a bulk rewrite would otherwise hold one entry per edge where the old
+   * boolean flag held nothing. The view must come back on its own afterwards: the flag has to reach the same
+   * rebuild an individually-tracked update reaches, including the follow-up one scheduled for a delta buffered
+   * during a rebuild already in flight, or a bulk rewrite that is the last write to the graph leaves the view
+   * serving no edge properties for good.
+   */
+  @Test
+  void aBulkEdgePropertyRewriteStopsTrackingIndividuallyAndStillRepairsItself() {
+    final int edgeCount = 1100; // over DeltaCollector's 1024 cap, so the individual tracking is given up on
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      for (int i = 0; i < edgeCount; i++) {
+        final MutableVertex target = database.newVertex("N").set("name", "T" + i).save();
+        a.newEdge("ROAD", target, true, new Object[] { "w", 1.0 }).save();
+      }
+    });
+
+    final GraphAnalyticalView view = syncView("overlay-bulk-edge-property-rewrite");
+    try {
+      final int a = view.getNodeId(vertex("A").getIdentity());
+      assertThat(weightsByName(view, a)).hasSize(edgeCount);
+
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          edge.modify().set("w", 2.0).save();
+      });
+
+      // Nothing is served from the columns while they hold the old weights, whether or not the rebuild that
+      // repairs them has landed yet.
+      if (!view.hasEdgeProperty("ROAD", "w"))
+        assertThat(view.edgeWeightsForSlice(a, Vertex.DIRECTION.OUT, "ROAD", "w", -1.0, null)).isNull();
+
+      // And it lands without any further commit to prompt it.
+      waitUntilServed(view);
+      assertThat(weightsByName(view, view.getNodeId(vertex("A").getIdentity())).values())
+          .as("every edge weighs what the bulk rewrite set it to")
+          .containsOnly(2.0);
+    } finally {
+      view.drop();
+    }
+  }
+
   // ── Helpers ──────────────────────────────────────────────────────────────
 
   /** The {@code algo.dijkstra.singleSource} cost from A to B over the {@code w} property. */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
@@ -310,11 +310,13 @@ class Issue6301AlgoSteinerTreeWeightAlignmentTest {
 
   @Test
   void anActiveOverlayDoesNotLendItsWeightsToTheWrongEdges() {
-    // The overlay case, exercised through algo.bellmanford so the narrowing is pinned for a caller outside the
+    // The overlay case, exercised through algo.bellmanford so the alignment is pinned for a caller outside the
     // procedures rewritten here. Edge property columns are aligned with the base CSR's forward slots, while
     // getNeighborIds serves the overlay's view of the node - deletions dropped, additions merged, the list
-    // re-sorted - so the n-th neighbour is no longer the n-th edge of the column store. The provider now says
-    // it cannot serve edge properties in that state, and the weights come from the records instead.
+    // re-sorted - so the n-th neighbour is not the n-th edge of the column store. This test was written when
+    // the answer to that was for the provider to report no edge properties at all while an overlay was active;
+    // since issue #6315 it resolves the two against each other instead and keeps answering exactly, which is
+    // what the weight assertion below has always been about.
     database.transaction(() -> {
       final MutableVertex x = database.newVertex("N").set("name", "X").save();
       final MutableVertex y = database.newVertex("N").set("name", "Y").save();
@@ -341,10 +343,10 @@ class Issue6301AlgoSteinerTreeWeightAlignmentTest {
       });
 
       assertThat(view.hasEdgeProperties())
-          .as("with an overlay active the positional mapping no longer holds, so the honest answer is no")
-          .isFalse();
-      assertThat(view.hasEdgeProperty("ROAD", "w")).isFalse();
-      assertThat(bellmanFordWeight()).as("X-Y-Z at 2.0, read from the edge records").isEqualTo(2.0);
+          .as("an overlay is resolved against the columns rather than disqualifying them (issue #6315)")
+          .isTrue();
+      assertThat(view.hasEdgeProperty("ROAD", "w")).isTrue();
+      assertThat(bellmanFordWeight()).as("X-Y-Z at 2.0, each weight on its own edge").isEqualTo(2.0);
     } finally {
       view.drop();
     }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
@@ -278,7 +278,7 @@ class Issue6301AlgoSteinerTreeWeightAlignmentTest {
   @Test
   void aViewThatMaterialisedADifferentPropertyDoesNotMakeTheGraphUnweighted() {
     // The narrower half of the same defect, and the one a coarse "does this view have edge properties?" gate
-    // walks straight into: the view materialises `other`, the query asks for `w`, so every getEdgeProperty
+    // walks straight into: the view materialises `other`, the query asks for `w`, so every weight lookup
     // returns null and every edge silently weighs 1.0 - which inverts the answer here, since X-Y-Z costs 2.0
     // and the direct X-Z hop costs 50.0. A null property value is also how "this edge has no value" is
     // reported, so the caller cannot tell the two apart and has to ask the sharper question up front.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -82,8 +82,9 @@ class Issue6715EdgeWeightsOfCheckpointTest {
    * The interrupt is armed from inside the provider itself, once the walk is a handful of edges into the
    * supernode's row - not before the call, which the outer per-node checkpoint would already catch regardless of
    * this fix. Before the fix, {@code edgeWeightsOf} has no checkpoint of its own, so the row is built to
-   * completion (all {@code supernodeDegree} of the supernode's edges) before the interrupt is ever observed. After the fix, the per-edge checkpoint restarts at zero for this call and
-   * fires at the next multiple of 1024, so the walk stops within about one checkpoint stride of where the
+   * completion (all {@code supernodeDegree} of the supernode's edges) before the interrupt is ever observed.
+   * After the fix, the per-edge checkpoint restarts at zero for this call and fires at the next multiple of
+   * 1024, so the walk stops within about one checkpoint stride of where the
    * interrupt was raised - orders of magnitude short of the full degree.
    */
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -178,8 +178,8 @@ class Issue6715EdgeWeightsOfCheckpointTest {
   /**
    * A minimal {@link GraphTraversalProvider} test double serving one weighted edge type/property: every node is
    * empty except {@code supernodeIndex}, whose row has {@code supernodeDegree} edges all reachable through
-   * {@code getEdgeProperty}. Self-interrupts the current thread once {@code getEdgeProperty} on the supernode has
-   * been called {@code selfInterruptAfterCalls} times ({@code -1} disables this).
+   * {@code edgeWeightsForSlice}. Self-interrupts the current thread once the supernode's slice build has
+   * priced {@code selfInterruptAfterCalls} of its edges ({@code -1} disables this).
    */
   private static final class WeightedSupernodeProvider implements GraphTraversalProvider {
     private final int    nodeCount;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6715EdgeWeightsOfCheckpointTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.NodeEdgeWeights;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -80,8 +82,7 @@ class Issue6715EdgeWeightsOfCheckpointTest {
    * The interrupt is armed from inside the provider itself, once the walk is a handful of edges into the
    * supernode's row - not before the call, which the outer per-node checkpoint would already catch regardless of
    * this fix. Before the fix, {@code edgeWeightsOf} has no checkpoint of its own, so the row is built to
-   * completion (all {@code supernodeDegree} calls to {@link WeightedSupernodeProvider#getEdgeProperty}) before
-   * the interrupt is ever observed. After the fix, the per-edge checkpoint restarts at zero for this call and
+   * completion (all {@code supernodeDegree} of the supernode's edges) before the interrupt is ever observed. After the fix, the per-edge checkpoint restarts at zero for this call and
    * fires at the next multiple of 1024, so the walk stops within about one checkpoint stride of where the
    * interrupt was raised - orders of magnitude short of the full degree.
    */
@@ -269,14 +270,21 @@ class Issue6715EdgeWeightsOfCheckpointTest {
     }
 
     @Override
-    public Object getEdgeProperty(final int nodeId, final int neighborIndex, final Vertex.DIRECTION direction,
-        final String edgeType, final String propertyName) {
-      if (nodeId == supernodeIndex) {
+    public NodeEdgeWeights edgeWeightsForSlice(final int nodeId, final Vertex.DIRECTION direction,
+        final String edgeType, final String propertyName, final double defaultWeight,
+        final IntConsumer edgeCheckpoint) {
+      final int degree = nodeId == supernodeIndex ? supernodeDegree : 0;
+      final int[] neighbors = new int[degree];
+      final double[] weights = new double[degree];
+      for (int i = 0; i < degree; i++) {
+        if (edgeCheckpoint != null)
+          edgeCheckpoint.accept(i);
         final int calls = supernodeEdgeCalls.incrementAndGet();
         if (selfInterruptAfterCalls >= 0 && calls == selfInterruptAfterCalls)
           Thread.currentThread().interrupt();
+        weights[i] = 1.0;
       }
-      return 1.0;
+      return new NodeEdgeWeights(neighbors, weights);
     }
   }
 
@@ -369,10 +377,18 @@ class Issue6715EdgeWeightsOfCheckpointTest {
     }
 
     @Override
-    public Object getEdgeProperty(final int nodeId, final int neighborIndex, final Vertex.DIRECTION direction,
-        final String edgeType, final String propertyName) {
-      edgePropertyCalls.incrementAndGet();
-      return 1.0;
+    public NodeEdgeWeights edgeWeightsForSlice(final int nodeId, final Vertex.DIRECTION direction,
+        final String edgeType, final String propertyName, final double defaultWeight,
+        final IntConsumer edgeCheckpoint) {
+      final int[] neighbors = new int[degreePerNode];
+      final double[] weights = new double[degreePerNode];
+      for (int i = 0; i < degreePerNode; i++) {
+        if (edgeCheckpoint != null)
+          edgeCheckpoint.accept(i);
+        edgePropertyCalls.incrementAndGet();
+        weights[i] = 1.0;
+      }
+      return new NodeEdgeWeights(neighbors, weights);
     }
   }
 }


### PR DESCRIPTION
Closes #6315.

## The shape

`GraphTraversalProvider.getEdgeProperty(nodeId, neighborIndex, direction, edgeType, property)` addressed an
edge **by its position in the node's neighbour list**. That position identified the same edge
`getNeighborIds` reported only while nothing else was in play: an active `DeltaOverlay` drops deleted edges,
merges added ones in and re-sorts the list, while the property columns stay aligned with the base CSR's
forward slots.

Reproduced before the change on a three-edge star, one edge deleted in a committed transaction:

```
BEFORE  neighbors=[B, C, D]   weights=[10.0, 20.0, 30.0]
AFTER   neighbors=[C, D]      weights=[10.0, 20.0]      <- C answers with B's weight
```

A wrong shortest path, a wrong MST, a wrong Steiner tree - and never an exception. PR #6306 closed this for
the callers that existed by narrowing `hasEdgeProperties()` to `false` whenever an overlay was active, which
left the accessor in the SPI for the next caller to find and the rule for it to remember.

## What this does

The issue offered three options and suggested "3 now, 2 when someone needs the performance". This does both,
because they are not independent: option 3 alone removes the sharp accessor but leaves a weighted algorithm
reading edge records on every commit of a `SYNCHRONOUS` view, which is the case the CSR exists for.

**The accessor is gone.** In its place `edgeWeightsForSlice()` returns one `(type, direction)` slice's
neighbours and their weights together, produced by the walk that decided which edges the slice holds - no
index crosses the SPI boundary, so there is nothing left to re-derive wrongly. `edgeWeightsOf()` composes the
slices, which is where the multi-type merge and the `BOTH` split already lived, and a slice the provider
cannot answer for makes the whole node unanswerable rather than a neighbourhood with edges silently missing
from it. The per-edge `WorkGuard` checkpoint from #6715 is handed down into the slice build, so a supernode
stays as abortable as it was.

**The overlay is resolved rather than refused.** In `GraphAnalyticalView`:

- a base edge the overlay has not deleted takes its own forward column slot, tracked through the merge by
  packing each entry's provenance into the low half of the sort key, so the re-sort cannot separate a weight
  from its edge;
- an edge the overlay added takes the value `DeltaCollector` captured for it at commit time - it has no column
  slot, the columns having been built with the base CSR;
- a run of parallel edges between one pair, **partially** deleted, is refused. Deletions are counted per pair,
  which is all the neighbour list needs - drop any one of the run and the remaining neighbours are the same -
  but not enough to say which of them died, and parallel edges need not weigh the same. Deleting the whole run
  is not ambiguous, and neither is the ordinary pair joined by a single edge;
- an edge whose properties were **updated** marks the columns out of date until the rebuild that repairs them
  lands, so no stale weight is served in exchange for the added edges now being served exactly. An update to
  an edge the overlay itself holds is applied there and dirties nothing - which is what keeps the ordinary
  `newEdge(...).save()`, one create and one update of the same edge, from forcing a full rebuild per insert
  (it did before). Past 1024 tracked updates in one transaction the delta stops recording them individually
  and just says the columns are out of date, so a bulk rewrite costs no more memory than the old boolean did.

**Two consequences of the view now serving edge properties through an overlay**, both of which used to be
handled by accident:

- `GraphAlgorithms.dijkstraSingleSource` reads the CSR offset and neighbour arrays directly, and was kept off
  them only as a side effect of the #6306 narrowing - a gate it never asked for and could not see. It refuses
  for itself now, and `algo.dijkstra.singleSource` falls back to the edge records;
- `AbstractAlgoProcedure`'s columnar build reads the records for a node the provider cannot answer for, using
  the same row reader its whole-graph record build now uses, so the fallback cannot answer differently from
  the path it stands in for.

## Tests

`Issue6315EdgeWeightsUnderOverlayTest` (11 cases): the deletion shift in both directions, an added edge
answering with its own weight, an update to an overlay-held edge staying columnar, an updated base edge
refusing rather than serving stale, the ambiguous parallel-edge run refused, the unambiguous one still
answered, `edgeWeightsForSlice`'s neighbours agreeing with `getNeighborIds`, the `BOTH` split, the Dijkstra
kernel not answering from the stale base CSR, and an `algo.bellmanford` run over a graph with one unanswerable
node. The last two were checked to fail without their fix rather than pass vacuously.

`Issue6301AlgoSteinerTreeWeightAlignmentTest.anActiveOverlayDoesNotLendItsWeightsToTheWrongEdges` keeps its
weight assertion and now pins the columnar answer instead of the fallback.

Engine suite: 13,634 tests, 0 failures (`-DexcludedGroups=benchmark,slow,vector`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weighted graph traversal across multiple edge types and directions.
  * Preserved edge-weight alignment when analytical views contain additions, deletions, updates, or parallel edges.
  * Ensured edge-property changes are reflected during overlays and rebuilds.
  * Added safer fallbacks for shortest-path queries when accelerated graph data is unavailable or changing.
  * Improved combined incoming/outgoing traversal behavior.

* **Refactor**
  * Updated weighted-edge processing to keep neighbors and weights correctly paired throughout graph algorithms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## For the release notes: a source-breaking SPI change

`GraphTraversalProvider.getEdgeProperty(nodeId, neighborIndex, direction, edgeType, propertyName)` is
**removed**, not deprecated, and `edgeWeightsForSlice(nodeId, direction, edgeType, propertyName, defaultWeight,
edgeCheckpoint)` takes its place. Nothing in the tree implements the SPI besides `GraphAnalyticalView` and two
test doubles, so there is no in-tree breakage - but the interface is a published extension point, and an
out-of-tree provider that implements the old method will no longer compile.

Deprecating it instead was considered and rejected: the removed method *is* the bug. Leaving it in place, even
deprecated, leaves a way to ask for a weight by position that answers with a plausible wrong number whenever an
overlay is active, which is precisely the shape this issue asks to close. A provider that fails to compile
finds out; one that keeps compiling against the old accessor does not.

## Follow-ups filed

- #6791 - `algo.dijkstra.singleSource` is the one weighted procedure that still abandons the CSR on every
  commit: its kernel reads the arrays directly, so it refuses under an overlay rather than resolving against it.
- #6792 - a view's dense node ids can exceed `getNodeCount()` once a base vertex is deleted, so `algo.*`
  silently drops those nodes. Pre-existing and independent of this PR, verified by reproducing it down the
  record path that predates it.
