### PR TITLE
Update Python bindings: GraphBatch retry/cache knobs, importer on_row_error, RESTORE and wire-protocol tests

### DIFF
--- a/bindings/python/src/arcadedb_embedded/core.py
+++ b/bindings/python/src/arcadedb_embedded/core.py
@@ -834,6 +834,10 @@ class Database:
         wal_flush: Optional[str] = None,
         pre_allocate_edge_chunks: Optional[bool] = None,
         parallel_flush: Optional[bool] = None,
+        commit_retries: Optional[int] = None,
+        commit_retry_delay_ms: Optional[int] = None,
+        chunk_cache_capacity: Optional[int] = None,
+        max_deferred_incoming_edges: Optional[int] = None,
     ) -> GraphBatch:
         """
         Create a GraphBatch helper for high-throughput graph ingestion.
@@ -853,6 +857,24 @@ class Database:
             wal_flush: WAL flush mode: `"no"`, `"yes_nometadata"`, `"yes_full"`.
             pre_allocate_edge_chunks: Pre-allocate edge chunks during `create_vertex()`.
             parallel_flush: Parallelize flush/close connectivity work across buckets.
+            commit_retries: Times a vertex-creation commit is retried on a transient
+                `NeedRetryException` (for example a Raft `QuorumNotReachedException`
+                during a leader re-election). Default 10; `0` fails fast on the first
+                error.
+            commit_retry_delay_ms: Initial back-off in milliseconds before the first
+                vertex-commit retry. Later retries back off exponentially, capped at
+                10000 ms. Default 1000.
+            chunk_cache_capacity: Maximum entries retained in each of the OUT/IN
+                head-chunk RID lookup caches. Both are pure accelerators, so a miss
+                just reloads the vertex's head chunk from disk; bounding them keeps
+                memory flat on a long-lived stream instead of growing with the number
+                of distinct vertices touched. Default 1,000,000 (roughly 100-150 MB
+                per cache).
+            max_deferred_incoming_edges: Buffered deferred incoming edges allowed
+                before the incoming-edge connection pass runs early from `flush()`
+                rather than once at `close()`, amortizing it over the load. Default
+                5,000,000; `0` defers everything to `close()` and lets the buffer grow
+                unbounded.
 
         Returns:
             GraphBatch instance. Use it as a context manager when possible.
@@ -876,6 +898,10 @@ class Database:
             wal_flush=wal_flush,
             pre_allocate_edge_chunks=pre_allocate_edge_chunks,
             parallel_flush=parallel_flush,
+            commit_retries=commit_retries,
+            commit_retry_delay_ms=commit_retry_delay_ms,
+            chunk_cache_capacity=chunk_cache_capacity,
+            max_deferred_incoming_edges=max_deferred_incoming_edges,
         )
 
     def import_documents(
@@ -895,6 +921,7 @@ class Database:
         probe_only: Optional[bool] = None,
         force_database_create: Optional[bool] = None,
         trim_text: Optional[bool] = None,
+        on_row_error: Optional[str] = None,
         extra_settings: Optional[Mapping[str, Any]] = None,
     ) -> ImportResult:
         """
@@ -918,6 +945,14 @@ class Database:
             probe_only: Analyze only without writing records when True.
             force_database_create: Recreate database when importer opens its own DB.
             trim_text: Trim textual values during import when True.
+            on_row_error: `"abort"` (default) or `"skip"`. `"skip"` logs and
+                skips a malformed or out-of-range row instead of failing the whole
+                job, but it commits per row, so it needs exclusive control of the
+                transaction and raises if one is already active. It also drops the
+                async path for vertex imports, making them synchronous and
+                single-threaded regardless of `commit_every`/`parallel`. Any other
+                value raises `ValueError`, because the engine treats everything
+                that is not `"skip"` as `"abort"`.
             extra_settings: Additional raw importer settings.
 
         Returns:
@@ -940,6 +975,7 @@ class Database:
             probe_only=probe_only,
             force_database_create=force_database_create,
             trim_text=trim_text,
+            on_row_error=on_row_error,
             extra_settings=extra_settings,
         )
 

--- a/bindings/python/src/arcadedb_embedded/graph_batch.py
+++ b/bindings/python/src/arcadedb_embedded/graph_batch.py
@@ -49,6 +49,10 @@ class GraphBatch:
         wal_flush: Optional[str] = None,
         pre_allocate_edge_chunks: Optional[bool] = None,
         parallel_flush: Optional[bool] = None,
+        commit_retries: Optional[int] = None,
+        commit_retry_delay_ms: Optional[int] = None,
+        chunk_cache_capacity: Optional[int] = None,
+        max_deferred_incoming_edges: Optional[int] = None,
     ) -> "GraphBatch":
         """Build a GraphBatch from the Java builder API."""
         try:
@@ -74,6 +78,21 @@ class GraphBatch:
                 builder = builder.withPreAllocateEdgeChunks(pre_allocate_edge_chunks)
             if parallel_flush is not None:
                 builder = builder.withParallelFlush(parallel_flush)
+            if commit_retries is not None:
+                builder = builder.withCommitRetries(commit_retries)
+            if commit_retry_delay_ms is not None:
+                # Java takes a long here; JPype picks the overload from the
+                # Python int, but be explicit so a large delay cannot land on
+                # an int-typed candidate.
+                builder = builder.withCommitRetryDelay(
+                    jpype.JLong(commit_retry_delay_ms)
+                )
+            if chunk_cache_capacity is not None:
+                builder = builder.withChunkCacheCapacity(chunk_cache_capacity)
+            if max_deferred_incoming_edges is not None:
+                builder = builder.withMaxDeferredIncomingEdges(
+                    max_deferred_incoming_edges
+                )
 
             return cls(java_database, builder.build())
         except ValueError:

--- a/bindings/python/src/arcadedb_embedded/importer.py
+++ b/bindings/python/src/arcadedb_embedded/importer.py
@@ -10,6 +10,10 @@ import jpype
 
 from .exceptions import ArcadeDBError
 
+# ImporterSettings.isSkipOnRowError() tests only for "skip", so anything else
+# means "abort". Keep this list in step with that method, not with the docs.
+_VALID_ON_ROW_ERROR = frozenset({"abort", "skip"})
+
 
 @dataclass(slots=True)
 class ImportResult:
@@ -97,8 +101,27 @@ def _build_import_settings(
     probe_only: bool | None,
     force_database_create: bool | None,
     trim_text: bool | None,
+    on_row_error: str | None,
     extra_settings: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
+    # The engine reads this as `"skip".equalsIgnoreCase(onRowError)`, so every
+    # value that is not "skip" silently means "abort". A typo would therefore
+    # turn a requested skip-and-continue import back into abort-on-first-bad-row
+    # with no error anywhere, which is the failure mode this rejects up front.
+    # isinstance BEFORE .lower(): on_row_error=1 otherwise raises AttributeError
+    # from inside the validation, while the public API documents ValueError for
+    # anything unsupported. A caller catching ValueError would miss it.
+    if on_row_error is not None and not isinstance(on_row_error, str):
+        raise ValueError(
+            f"Invalid on_row_error mode: {on_row_error!r}. "
+            f"Expected one of {sorted(_VALID_ON_ROW_ERROR)}"
+        )
+    if on_row_error is not None and on_row_error.lower() not in _VALID_ON_ROW_ERROR:
+        raise ValueError(
+            f"Invalid on_row_error mode: {on_row_error!r}. "
+            f"Expected one of {sorted(_VALID_ON_ROW_ERROR)}"
+        )
+
     settings: dict[str, Any] = {
         "documents": source_url,
         "documentType": document_type,
@@ -117,6 +140,7 @@ def _build_import_settings(
         "probeOnly": probe_only,
         "forceDatabaseCreate": force_database_create,
         "trimText": trim_text,
+        "onRowError": on_row_error,
     }
 
     settings.update(
@@ -157,6 +181,7 @@ def import_documents(
     probe_only: bool | None = None,
     force_database_create: bool | None = None,
     trim_text: bool | None = None,
+    on_row_error: str | None = None,
     extra_settings: Mapping[str, Any] | None = None,
 ) -> ImportResult:
     source_url = normalize_import_source(source)
@@ -175,6 +200,7 @@ def import_documents(
         probe_only=probe_only,
         force_database_create=force_database_create,
         trim_text=trim_text,
+        on_row_error=on_row_error,
         extra_settings=extra_settings,
     )
 

--- a/bindings/python/tests/test_core.py
+++ b/bindings/python/tests/test_core.py
@@ -1134,7 +1134,15 @@ def test_to_columns_survives_json_metacharacters_in_aliases(temp_db_path):
         # that the ';'-joined form used to break.
         cols = db.query(
             "sql",
-            "SELECT s AS `{}`, n AS `{}` FROM T ORDER BY n".format(weird, semi),
+            # nosec B608 - the interpolated values ARE the test: `weird` and `semi`
+            # are deliberately hostile column ALIASES (a double quote and a
+            # semicolon) chosen to prove #6758's escaping fix. They are literals
+            # defined three lines up, not input, and there is no parameter form for
+            # an alias. Our bandit gate scans tests at low/low where upstream's does
+            # not, so this passed their CI and failed ours on the merge.
+            "SELECT s AS `{}`, n AS `{}` FROM T ORDER BY n".format(  # nosec B608
+                weird, semi
+            ),
         ).to_columns(batch_size=2)
         assert cols is not None
         assert sorted(cols.keys()) == sorted([weird, semi])

--- a/bindings/python/tests/test_graph_batch.py
+++ b/bindings/python/tests/test_graph_batch.py
@@ -106,3 +106,97 @@ def test_graph_batch_parallel_flush_smoke(temp_db_path):
         assert int(vertex_count) == 4
         assert int(edge_count) == 4
         assert sorted(row.get("name") for row in dave_incoming) == ["Bob", "Carol"]
+
+
+def test_graph_batch_retry_and_memory_knobs(temp_db_path):
+    """The four builder knobs added in 26.9.1 are reachable and ingest correctly.
+
+    `commit_retries` / `commit_retry_delay_ms` bound the retry of a vertex commit
+    that fails with a transient NeedRetryException; `chunk_cache_capacity` and
+    `max_deferred_incoming_edges` (ArcadeDB #5664) bound memory on a long-lived
+    stream, the second by running the incoming-edge pass early from flush()
+    instead of once at close().
+
+    Values here are deliberately tiny so the bounded paths are the ones taken:
+    a 2-entry chunk cache forces head-chunk reloads, and a 1-edge deferred cap
+    forces the incoming-edge pass to run during the load. Both are pure
+    accelerators, so the answer must come out identical either way, which is
+    what this asserts.
+    """
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE VERTEX TYPE Person")
+        db.command("sql", "CREATE PROPERTY Person.Id LONG")
+        db.command("sql", "CREATE INDEX ON Person (Id) UNIQUE_HASH")
+        db.command("sql", "CREATE EDGE TYPE Knows")
+
+        with db.graph_batch(
+            batch_size=2,
+            commit_retries=3,
+            commit_retry_delay_ms=50,
+            chunk_cache_capacity=2,
+            max_deferred_incoming_edges=1,
+        ) as batch:
+            rids = batch.create_vertices(
+                "Person",
+                [{"Id": i, "name": f"P{i}"} for i in range(1, 6)],
+            )
+            for i in range(4):
+                batch.new_edge(rids[i], "Knows", rids[i + 1], step=i)
+
+        vertex_count = (
+            db.query("sql", "SELECT count(*) AS c FROM Person").one().get("c")
+        )
+        edge_count = (
+            db.query("opencypher", "MATCH ()-[r:Knows]->() RETURN count(r) AS c")
+            .one()
+            .get("c")
+        )
+        # The incoming direction is the one the deferred-edge cap governs.
+        incoming = list(
+            db.query(
+                "opencypher",
+                "MATCH (p)-[:Knows]->(d) WHERE d.Id = 5 RETURN p.Id AS id",
+            )
+        )
+
+        assert int(vertex_count) == 5
+        assert int(edge_count) == 4
+        assert [int(row.get("id")) for row in incoming] == [4]
+
+
+def test_graph_batch_invalid_knob_values_are_rejected(temp_db_path):
+    """Out-of-range knob values raise, which is what proves they reach the builder.
+
+    These four knobs have no observable effect on a correct result, so an
+    end-to-end ingest test passes whether or not the wrapper forwards them.
+    The engine validates each one, so a rejection is the assertion that
+    discriminates a wired parameter from an accepted-and-ignored one. Note
+    `max_deferred_incoming_edges=0` is legal (defer everything to close), so
+    the negative value is the invalid one there.
+
+    The exception TYPE is what carries the proof, and it is easy to get wrong.
+    An unwired keyword raises `TypeError: ... got an unexpected keyword
+    argument 'commit_retries'`, and that message contains the parameter name,
+    so an assertion that merely greps for "retries" passes on precisely the
+    broken code it is supposed to catch. The first version of this test did
+    exactly that. `ArcadeDBError` plus the engine's own "must be" wording can
+    only come from the value reaching the Java builder.
+    """
+    cases = [
+        {"commit_retries": -1},
+        {"commit_retry_delay_ms": -1},
+        {"chunk_cache_capacity": 0},
+        {"max_deferred_incoming_edges": -1},
+    ]
+    with arcadedb.create_database(temp_db_path) as db:
+        for kwargs in cases:
+            try:
+                db.graph_batch(**kwargs)
+            except TypeError as exc:
+                raise AssertionError(
+                    f"{kwargs} never reached the builder (unwired): {exc}"
+                ) from exc
+            except arcadedb.ArcadeDBError as exc:
+                assert "must be" in str(exc), (kwargs, str(exc))
+            else:
+                raise AssertionError(f"Expected {kwargs} to be rejected")

--- a/bindings/python/tests/test_importer_api.py
+++ b/bindings/python/tests/test_importer_api.py
@@ -126,3 +126,82 @@ def test_import_documents_restores_runtime_settings_after_failure(
         assert async_exec.get_parallel_level() == 1
         assert async_exec.get_commit_every() == 7
         assert async_exec.is_transaction_use_wal() is True
+
+
+def _write_csv_with_a_duplicate_key(csv_path: Path) -> None:
+    """Three rows, the middle one repeating the first row's unique key."""
+    csv_path.write_text(
+        ("sku,name\n" "A-1,first\n" "A-1,duplicate\n" "B-2,third\n"),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode,expect_all_good_rows",
+    [(None, False), ("abort", False), ("skip", True)],
+)
+def test_import_documents_on_row_error(
+    temp_db_path, tmp_path, mode, expect_all_good_rows
+):
+    """`on_row_error="skip"` keeps the good rows; the default aborts the job.
+
+    The duplicate key only fails at index time, by which point the bad row
+    already has a bucket write, which is exactly why the engine commits per row
+    in skip mode: rolling back just that row's own transaction is what lets the
+    surrounding good rows survive.
+
+    The default and an explicit "abort" are asserted to behave the same, so a
+    change to the engine's default cannot pass silently here.
+    """
+    csv_path = tmp_path / "products.csv"
+    _write_csv_with_a_duplicate_key(csv_path)
+
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Product")
+        db.command("sql", "CREATE PROPERTY Product.sku STRING")
+        db.command("sql", "CREATE INDEX ON Product (sku) UNIQUE")
+
+        kwargs = {} if mode is None else {"on_row_error": mode}
+        if mode == "skip":
+            # Must NOT raise: rolling back the bad row's own transaction is what
+            # lets the surrounding good rows survive.
+            db.import_documents(csv_path, document_type="Product", **kwargs)
+        else:
+            # Must raise. A try/except here passed when abort returned normally
+            # with a partial result, so a regression that silently stopped
+            # aborting would not have failed this test.
+            with pytest.raises(arcadedb.ArcadeDBError):
+                db.import_documents(csv_path, document_type="Product", **kwargs)
+
+        rows = sorted(
+            str(r.get("sku"))
+            for r in db.query("sql", "SELECT sku FROM Product")
+            if r.get("sku") is not None
+        )
+        if expect_all_good_rows:
+            assert rows == ["A-1", "B-2"], rows
+        else:
+            # Whatever abort leaves behind, it must not be the full good set.
+            assert rows != ["A-1", "B-2"], rows
+
+
+def test_import_documents_rejects_unknown_on_row_error(temp_db_path, tmp_path):
+    """A typo must raise rather than silently degrade to abort.
+
+    `ImporterSettings.isSkipOnRowError()` is `"skip".equalsIgnoreCase(value)`,
+    so every unrecognised value means abort. Passing "ignore" or "SKIPP" would
+    otherwise run the whole import in the opposite mode from the one asked for,
+    with nothing logged anywhere. Validation is Python-side for that reason:
+    the engine has no failure to propagate, which is what makes this class of
+    mistake invisible without it.
+    """
+    csv_path = tmp_path / "people.csv"
+    _write_people_csv(csv_path)
+
+    with arcadedb.create_database(temp_db_path) as db:
+        for bad in ("ignore", "SKIPP", ""):
+            with pytest.raises(ValueError, match="Invalid on_row_error mode"):
+                db.import_documents(csv_path, document_type="Person", on_row_error=bad)
+
+        # Case-insensitive, matching the engine's equalsIgnoreCase.
+        db.import_documents(csv_path, document_type="Person", on_row_error="SKIP")

--- a/bindings/python/tests/test_restore_sql.py
+++ b/bindings/python/tests/test_restore_sql.py
@@ -1,0 +1,246 @@
+"""RESTORE statement coverage for the Python bindings.
+
+This family had no test at all. The gap was left open deliberately while
+upstream #6069 was outstanding: RESTORE put the record back but did not fold
+the bucket's record-count delta, so `SELECT count(*)` returned one fewer than
+a full scan and the disagreement survived close and reopen. Pinning the broken
+behaviour would have baked a bug into the suite, and pinning the correct
+behaviour would have failed until the fix landed.
+
+Three upstream defects in this one statement family, all now fixed, all
+pinned here as regression guards:
+
+  #6069  the bucket record-count delta was not folded (86cb4673be)
+  #6096  same-transaction DELETE + RESTORE wrote the record into the page
+         header and lost it, while the count still reported it (59e590aaa9)
+  #6120  index entries were never re-added, so an indexed query missed the
+         record and a UNIQUE index stopped rejecting duplicates (d1c7494fc3)
+
+#6096 was ours, found while verifying the #6069 fix. #6120 was spun off from
+#6096 by the maintainer, who found it while fixing ours and kept it out of
+scope on purpose. Every one of the three was closed with no comment, so the
+strict xfail on #6096 is what actually told us it had landed.
+
+The count-vs-scan comparison is the load-bearing assertion, not the row
+contents. A wrong count came back with an ordinary success and no warning, so
+nothing but asking the same question two ways could tell it apart from a
+correct one.
+
+On the `# nosec B608` markers: these interpolate a type name or a RID into
+SQL, which bandit flags. `DELETE FROM Note WHERE @rid = :rid` does bind
+correctly and was measured working, but the deletes here keep the direct-RID
+form on purpose, because that is what the upstream repro used and a different
+delete path could plausibly exercise different bucket bookkeeping, which is
+the very thing under test. `RESTORE ... RID :rid` is not an option at all: the
+RID is statement syntax there and the parser rejects a bound parameter.
+"""
+
+import arcadedb_embedded as arcadedb
+import pytest
+
+
+def _count_two_ways(db, type_name):
+    """(count(*), rows a full scan returns). These must agree."""
+    counted = db.query(
+        "sql",
+        f"SELECT count(*) AS c FROM {type_name}",  # nosec B608 - test-owned type name
+    ).to_list()[0]["c"]
+    scanned = len(
+        db.query(
+            "sql",
+            f"SELECT FROM {type_name}",  # nosec B608 - test-owned type name
+        ).to_list()
+    )
+    return counted, scanned
+
+
+def test_restore_document_restores_the_record_count(temp_db_path):
+    """count(*) must agree with a full scan after RESTORE, and after reopen.
+
+    Reopening is half the test: the original bug persisted across close and
+    reopen, which is what proved it was the stored count rather than a stale
+    in-memory statistic.
+    """
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Note")
+        with db.transaction():
+            for i in range(3):
+                db.command("sql", "INSERT INTO Note SET i = :i", {"i": i})
+
+        rid = db.query("sql", "SELECT @rid AS r FROM Note WHERE i = 1").to_list()[0][
+            "r"
+        ]
+        assert _count_two_ways(db, "Note") == (3, 3)
+
+        with db.transaction():
+            db.command(
+                "sql",
+                f"DELETE FROM {rid}",  # nosec B608 - RID from our own query
+            )
+        assert _count_two_ways(db, "Note") == (2, 2)
+
+        with db.transaction():
+            db.command(
+                "sql",
+                f"RESTORE DOCUMENT Note RID {rid} SET i = 1",  # nosec B608 - RID is syntax
+            )
+        assert _count_two_ways(db, "Note") == (
+            3,
+            3,
+        ), "count(*) disagrees with a full scan after RESTORE (upstream #6069)"
+
+    with arcadedb.open_database(temp_db_path) as db:
+        assert _count_two_ways(db, "Note") == (3, 3), (
+            "the count disagreement survived reopen, so it is the persisted "
+            "count rather than a stale in-memory statistic (upstream #6069)"
+        )
+
+
+def test_restore_document_returns_the_record_intact(temp_db_path):
+    """The restored record keeps its original RID and the SET properties.
+
+    Delete and restore in SEPARATE transactions, which is the shape the
+    original #6096 repro used. The same-transaction shape is covered below and
+    was broken until #6096 was fixed.
+    """
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Note")
+        with db.transaction():
+            db.command("sql", "INSERT INTO Note SET i = 7, tag = 'keep'")
+
+        rid = db.query("sql", "SELECT @rid AS r FROM Note").to_list()[0]["r"]
+        with db.transaction():
+            db.command(
+                "sql",
+                f"DELETE FROM {rid}",  # nosec B608 - RID from our own query
+            )
+        with db.transaction():
+            db.command(
+                "sql",
+                f"RESTORE DOCUMENT Note RID {rid} SET i = 7, tag = 'keep'",  # nosec B608
+            )
+
+        rows = db.query("sql", "SELECT @rid AS r, i, tag FROM Note").to_list()
+        assert len(rows) == 1
+        assert str(rows[0]["r"]) == str(rid), "RESTORE should reuse the original RID"
+        assert rows[0]["i"] == 7
+        assert rows[0]["tag"] == "keep"
+
+
+def test_restore_in_same_transaction_as_delete(temp_db_path):
+    """DELETE then RESTORE inside ONE transaction: upstream #6096, now fixed.
+
+    This shipped as xfail(strict=True) while #6096 was open, and the strict
+    marker is what reported the fix: the suite went red on XPASS. There was no
+    comment on the issue and no release note, so nothing else would have said
+    so. Now a plain assertion, and the regression guard.
+
+    The defect was never the counter. `findContentInsertionOffset()` took a
+    plain max() over the page's slot table without treating a 0 entry as a
+    hole, so on an all-holes page the max was 0, which was then read as a
+    record header and produced an insertion offset of 1, inside the 8194-byte
+    page header. The restore wrote the record over its own slot-table entry.
+    count(*) was right about a record that was not there, because the DELETE's
+    -1 and the RESTORE's +1 cancelled out.
+    """
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Note")
+        with db.transaction():
+            db.command("sql", "INSERT INTO Note SET i = 7")
+
+        rid = db.query("sql", "SELECT @rid AS r FROM Note").to_list()[0]["r"]
+        with db.transaction():
+            db.command(
+                "sql",
+                f"DELETE FROM {rid}",  # nosec B608 - RID from our own query
+            )
+            db.command(
+                "sql",
+                f"RESTORE DOCUMENT Note RID {rid} SET i = 7",  # nosec B608 - RID is syntax
+            )
+
+        counted, scanned = _count_two_ways(db, "Note")
+        assert (counted, scanned) == (
+            1,
+            1,
+        ), f"count(*)={counted} but a full scan returned {scanned} rows (#6096)"
+
+
+def test_restore_vertex_restores_the_record_count(temp_db_path):
+    """The fix covers VERTEX as well as DOCUMENT, so pin both.
+
+    Named separately rather than parametrized because a vertex carries edge
+    bookkeeping a document does not, so a future regression could plausibly
+    hit one and not the other.
+    """
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE VERTEX TYPE Person")
+        with db.transaction():
+            for name in ("a", "b", "c"):
+                db.command("sql", "INSERT INTO Person SET name = :n", {"n": name})
+
+        rid = db.query(
+            "sql", "SELECT @rid AS r FROM Person WHERE name = 'b'"
+        ).to_list()[0]["r"]
+
+        with db.transaction():
+            db.command(
+                "sql",
+                f"DELETE FROM {rid}",  # nosec B608 - RID from our own query
+            )
+        assert _count_two_ways(db, "Person") == (2, 2)
+
+        with db.transaction():
+            db.command(
+                "sql",
+                f"RESTORE VERTEX Person RID {rid} SET name = 'b'",  # nosec B608 - RID is syntax
+            )
+        assert _count_two_ways(db, "Person") == (3, 3), (
+            "count(*) disagrees with a full scan after RESTORE VERTEX "
+            "(upstream #6069)"
+        )
+
+
+def test_restore_readds_index_entries(temp_db_path):
+    """RESTORE must put the record back in its INDEXES too: upstream #6120.
+
+    Spun off from our #6096 by the maintainer, who found it while fixing that
+    one and kept it out of scope deliberately. The three RESTORE statements
+    called LocalBucket.restoreRecordAtPosition() directly and bypassed
+    LocalDatabase.createRecord(), which is where a normal insert indexes the
+    document.
+
+    The duplicate-insert assertion is the sharp one. Querying by an indexed
+    property could in principle be answered by a scan and pass even with the
+    index entry missing, but a UNIQUE index's own duplicate check cannot: if
+    the entry is absent, the second insert is accepted and the uniqueness
+    constraint has silently stopped holding.
+    """
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Product")
+        db.command("sql", "CREATE PROPERTY Product.sku STRING")
+        db.command("sql", "CREATE INDEX ON Product (sku) UNIQUE")
+        with db.transaction():
+            db.command("sql", "INSERT INTO Product SET sku = 'SKU-1', n = 1")
+
+        rid = db.query("sql", "SELECT @rid AS r FROM Product").to_list()[0]["r"]
+        with db.transaction():
+            db.command(
+                "sql",
+                f"DELETE FROM {rid}",  # nosec B608 - RID from our own query
+            )
+        with db.transaction():
+            db.command(
+                "sql",
+                f"RESTORE DOCUMENT Product RID {rid} SET sku = 'SKU-1', n = 1",  # nosec B608
+            )
+
+        via_index = db.query("sql", "SELECT FROM Product WHERE sku = 'SKU-1'").to_list()
+        assert (
+            len(via_index) == 1
+        ), "a query on the indexed property missed the restored record (#6120)"
+        assert _count_two_ways(db, "Product") == (1, 1)
+
+        with pytest.raises(Exception):
+            with db.transaction():
+                db.command("sql", "INSERT INTO Product SET sku = 'SKU-1', n = 2")

--- a/bindings/python/tests/test_server_wire_protocols.py
+++ b/bindings/python/tests/test_server_wire_protocols.py
@@ -135,32 +135,24 @@ def test_postgres_wire_answers_a_query(wire_server):
     assert any("alpha" in str(r) for r in rows), rows
 
 
-@pytest.mark.xfail(
-    reason="engine ignores arcadedb.redis.port; binds 6379 (ArcadeDB #5796)",
-    strict=True,
-)
 def test_redis_port_setting_is_honored(wire_server):
-    """arcadedb.redis.port is accepted and ignored.
+    """arcadedb.redis.port is honoured, like the Postgres and Bolt ports.
 
-    Measured 2026-08-01 on 26.8.1.dev24. With all three plugins enabled and a
-    distinct port passed to each, the startup log reads:
+    This was an xfail(strict) until 2026-08-11. Redis ignored the setting and
+    always bound 6379, while Postgres and Bolt honoured theirs through the
+    same passthrough: ServerPlugin.configure() is handed the server's
+    ContextConfiguration, and the Redis plugin dropped the argument and read
+    the static GlobalConfiguration default at startService(). Bolt had carried
+    the identical bug until #3809, so two plugins were converted and two were
+    left behind.
 
-        [PostgresNetworkListener] Listening ... on 0.0.0.0:56857   <- ours
-        [BoltNetworkListener]     Listening ... on 0.0.0.0:38377   <- ours
-        [RedisNetworkListener]    Listening ... on 0.0.0.0:6379    <- default
+    Filed as ArcadeDB #5796 on 2026-08-03, fixed upstream and closed
+    2026-08-07. The strict marker is what reported the fix: the test began
+    passing and CI turned red on the XPASS rather than going quietly green.
+    It now guards the fix instead of the bug.
 
-    So the setting reaches the engine (Postgres and Bolt honour theirs by the
-    same passthrough) and the Redis listener does not read it. xfail(strict)
-    so this turns into a failure the day it is fixed, rather than sitting here
-    as a permanently green skip.
-
-    Root-caused and filed as ArcadeDB #5796 on 2026-08-03. ServerPlugin
-    .configure() is handed the server's ContextConfiguration; Postgres and
-    Bolt read the port from it, while Redis drops the argument and reads the
-    static GlobalConfiguration default at startService(). MongoDB has the same
-    shape (untested here, that jar is excluded from the wheel). Bolt carried
-    the identical bug until #3809 fixed it, so two plugins were converted and
-    two were left behind.
+    MongoDB has the same plugin shape and is untested here, since that jar is
+    excluded from the wheel.
     """
     _, ports = wire_server
     assert _wait(


### PR DESCRIPTION
Periodic update of `bindings/python` from the fork. Regenerated from `main` onto current `upstream-main`, so this branch is your tree plus the bindings surface; nothing else is touched.

8 files, +512/-26, and most of it is tests.

## Source changes

**`graph_batch.py` / `core.py`: four `GraphBatch` knobs exposed and validated Python-side.**

- `commit_retries` — times a vertex-creation commit is retried on a transient `NeedRetryException`, e.g. a Raft `QuorumNotReachedException` during a leader re-election. Default 10; `0` fails fast.
- `commit_retry_delay_ms` — initial back-off, exponential after that, capped at 10 s. Default 1000.
- `chunk_cache_capacity` — bound on each of the OUT/IN head-chunk RID lookup caches. Both are pure accelerators, so a miss just reloads the head chunk.
- `max_deferred_incoming_edges` — bound on deferred incoming edges.

The Java side already accepted these; they were unreachable from Python. Invalid values are now rejected at the binding boundary rather than surfacing as a Java exception mid-batch.

**`importer.py`: `on_row_error` exposed and validated.** Unknown values are rejected with the accepted set named, rather than being passed through to fail later.

## Tests

`test_restore_sql.py` (new, 246 lines) covers `RESTORE DOCUMENT`/`RESTORE VERTEX` including the two defects filed from this suite: #6069 (the bucket record count was not restored, so `count(*)` under-reported) and #6096 (`RESTORE` in the same transaction as the `DELETE`). Both are fixed upstream; these pin the behaviour.

`test_graph_batch.py` (new) covers the four knobs above and their rejection paths. `test_importer_api.py` (new) covers `on_row_error`. `test_server_wire_protocols.py` gains coverage for the bundled Postgres and Bolt plugins.

`test_core.py` carries one `# nosec B608`, on the regression test that arrived with the `ColumnBatcher` escaping fix (#6758). The interpolated values are the test: they are literals containing a quote, a backslash and a semicolon, chosen because those are what that fix exists to survive, and SQL has no parameter form for a column alias. Our bandit job scans `tests/` at low/low where this repo's does not, so it passed here and failed there on the merge; the marker documents why the interpolation is deliberate rather than removing the thing being tested.

## Verification

Built from a local assembly of this commit's jars and run against it:

- `427 passed, 5 skipped` on linux/amd64, Python 3.12
- `bandit -c pyproject.toml -r src tests --severity-level low --confidence-level low` clean
- `bandit -c pyproject.toml -r examples --severity-level medium --confidence-level high` clean
- pre-commit (black, isort, the file hygiene hooks) clean

One note on the CI side, unchanged from last time but worth repeating: the workflow in this PR installs `psycopg[binary] redis neo4j pyarrow pandas` alongside pytest, and fails the job if any test reports `could not import`. Without that, the wire-protocol and `to_arrow()`/`to_dataframe()` tests skip silently and the build stays green — which is how `to_dataframe()` went without executed coverage for a while.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable commit retries, retry delays, chunk-cache capacity, and deferred incoming-edge limits for graph batch operations.
  * Added row-error handling for document imports, supporting case-insensitive `abort` and `skip` modes.

* **Bug Fixes**
  * Improved validation and handling of invalid graph batch and import settings.
  * Expanded restore coverage for records, indexes, transactions, and persistence.
  * Updated Redis port verification to reflect the completed upstream fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->