### PR TITLE
fix(#6813): XML import - an empty or self-closing sub-element inherits the previous sibling's text

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -98,6 +98,10 @@ public class XMLImporterFormat implements FormatImporter {
               object.put(lastName, lastContent);
 
             lastName = getQualifiedName(xmlReader.getName());
+            // START OF A NEW SUB-ELEMENT: THE PREVIOUS SIBLING'S TEXT MUST NOT LEAK INTO IT (ISSUE #6813).
+            // THIS DOES NOT REGRESS ISSUE #2759: THE WHITESPACE BETWEEN TWO ELEMENTS IS SKIPPED BY THE CHARACTERS
+            // HANDLER, SO THE TEXT OF THE ELEMENT CURRENTLY BEING READ IS STILL SAFE FROM PRETTY-PRINTING
+            lastContent = null;
           }
 
           ++nestLevel;
@@ -241,18 +245,22 @@ public class XMLImporterFormat implements FormatImporter {
               entityName = "v_" + qualifiedName;  // v_ prefix for vertices (including DATABASE for backward compatibility)
             }
 
+            // START OF A NEW RECORD: RESET THE PENDING SUB-ELEMENT, AS load() DOES
+            lastName = null;
+            lastContent = null;
+
             // GET ELEMENT'S ATTRIBUTES AS PROPERTIES (with namespace prefix if present)
-            for (int i = 0; i < xmlReader.getAttributeCount(); ++i) {
+            for (int i = 0; i < xmlReader.getAttributeCount(); ++i)
               analyzedSchema.getOrCreateEntity(entityName, entityType)
                   .getOrCreateProperty(getQualifiedName(xmlReader.getAttributeName(i)), xmlReader.getAttributeValue(i));
-              lastName = null;
-            }
           } else if (nestLevel == objectNestLevel + 1) {
             // GET ELEMENT'S SUB-NODES AS PROPERTIES
             if (lastName != null)
               analyzedSchema.getOrCreateEntity(entityName, entityType).getOrCreateProperty(lastName, lastContent);
 
             lastName = getQualifiedName(xmlReader.getName());
+            // START OF A NEW SUB-ELEMENT: THE PREVIOUS SIBLING'S TEXT MUST NOT BE SAMPLED AS THIS ONE'S (ISSUE #6813)
+            lastContent = null;
           }
 
           ++nestLevel;

--- a/integration/src/test/java/com/arcadedb/integration/importer/XMLImporterFormatTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/XMLImporterFormatTest.java
@@ -19,13 +19,17 @@
 package com.arcadedb.integration.importer;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.integration.importer.format.XMLImporterFormat;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -147,6 +151,139 @@ class XMLImporterFormatTest extends TestHelper {
       }
     } finally {
       xmlFile.delete();
+    }
+  }
+
+  /**
+   * Regression test for issue #6813: an empty or self-closing sub-element must not inherit the text value of the
+   * previous sibling.
+   * <p>
+   * {@code lastContent} used to be cleared only when a new record started, never when a new sub-element started, so
+   * {@code <city></city>} following {@code <name>Bob</name>} was imported as {@code city="Bob"}.
+   * <p>
+   * The file is deliberately pretty-printed: the whitespace CHARACTERS events between the elements are what issue
+   * #2759 taught the CHARACTERS handler to ignore, and that behaviour must survive this fix.
+   */
+  @Test
+  void noContentCarryoverBetweenSubElements() throws Exception {
+    final File xmlFile = createTempXMLFile("test-subelement-carryover.xml",
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <users>
+          <user>
+            <id>u1</id>
+            <name>Alice</name>
+            <city>Rome</city>
+          </user>
+          <user>
+            <id>u2</id>
+            <name>Bob</name>
+            <city></city>
+          </user>
+          <user>
+            <id>u3</id>
+            <name>Charlie</name>
+            <city/>
+          </user>
+          <user>
+            <id>u4</id>
+            <city></city>
+            <name>Diana</name>
+          </user>
+        </users>""");
+
+    try {
+      database.command("sql",
+          "IMPORT DATABASE file://" + xmlFile.getAbsolutePath() + " WITH objectNestLevel=1, entityType='VERTEX'");
+
+      assertThat(database.countType("v_user", true)).isEqualTo(4);
+
+      // A POPULATED SUB-ELEMENT STILL KEEPS ITS OWN TEXT, DESPITE THE FORMATTING WHITESPACE AROUND IT (ISSUE #2759)
+      final Result user1 = selectUser("u1");
+      assertThat(user1.<String>getProperty("name")).isEqualTo("Alice");
+      assertThat(user1.<String>getProperty("city")).isEqualTo("Rome");
+
+      // AN EMPTY SUB-ELEMENT MUST NOT INHERIT THE PREVIOUS SIBLING'S TEXT
+      final Result user2 = selectUser("u2");
+      assertThat(user2.<String>getProperty("name")).isEqualTo("Bob");
+      assertThat(user2.<String>getProperty("city")).isNull();
+
+      // SAME FOR A SELF-CLOSING SUB-ELEMENT
+      final Result user3 = selectUser("u3");
+      assertThat(user3.<String>getProperty("name")).isEqualTo("Charlie");
+      assertThat(user3.<String>getProperty("city")).isNull();
+
+      // AN EMPTY SUB-ELEMENT MUST NOT SWALLOW THE TEXT OF THE SIBLING THAT FOLLOWS IT EITHER
+      final Result user4 = selectUser("u4");
+      assertThat(user4.<String>getProperty("name")).isEqualTo("Diana");
+      assertThat(user4.<String>getProperty("city")).isNull();
+
+    } finally {
+      xmlFile.delete();
+    }
+  }
+
+  /**
+   * Regression test for issue #6813, schema-analysis half: {@code analyze()} carried the same stale
+   * {@code lastContent} across sibling sub-elements, so an empty {@code <score/>} sampled the value of the
+   * {@code <name>} that preceded it and demoted the inferred type from LONG to STRING.
+   */
+  @Test
+  void analyzeDoesNotCarryContentBetweenSubElements() throws Exception {
+    final String xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rows>
+          <row>
+            <name>Alice</name>
+            <score>10</score>
+          </row>
+          <row>
+            <name>Bob</name>
+            <score/>
+          </row>
+        </rows>""";
+
+    final AnalyzedSchema analyzedSchema = new AnalyzedSchema(100);
+    final SourceSchema sourceSchema = new XMLImporterFormat().analyze(AnalyzedEntity.EntityType.VERTEX,
+        newParser(xml), new ImporterSettings(), analyzedSchema);
+
+    assertThat(sourceSchema).isNotNull();
+
+    final AnalyzedEntity entity = analyzedSchema.getEntity("v_row");
+    assertThat(entity).isNotNull();
+
+    final AnalyzedProperty score = entity.getProperty("score");
+    assertThat(score).isNotNull();
+    // "Bob" MUST NEVER BE SAMPLED AS A VALUE OF score
+    assertThat(score.getContents()).containsExactly("10");
+    assertThat(score.getType()).isEqualTo(Type.LONG);
+
+    final AnalyzedProperty name = entity.getProperty("name");
+    assertThat(name).isNotNull();
+    assertThat(name.getContents()).containsExactlyInAnyOrder("Alice", "Bob");
+  }
+
+  /**
+   * Builds a {@link Parser} over an in-memory XML document, re-openable so {@code analyze()} can reset it.
+   */
+  private static Parser newParser(final String xml) throws IOException {
+    final byte[] bytes = xml.getBytes(StandardCharsets.UTF_8);
+    final Source source = new Source("memory", new ByteArrayInputStream(bytes), bytes.length, false, s -> {
+      s.inputStream = new ByteArrayInputStream(bytes);
+      return null;
+    }, null);
+    return new Parser(source, 0);
+  }
+
+  /**
+   * Returns the single v_user vertex with the given id, failing if there is not exactly one.
+   */
+  private Result selectUser(final String id) {
+    try (final ResultSet rs = database.query("sql", "SELECT FROM v_user WHERE id = ?", id)) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result user = rs.next();
+      assertThat(rs.hasNext()).isFalse();
+      return user;
     }
   }
 


### PR DESCRIPTION
Closes #6813

## Summary

`XMLImporterFormat` cleared its `lastContent` cursor only when a new **record** started, never when a new **sub-element** started, so an empty (`<b></b>`) or self-closing (`<b/>`) sub-element inherited the text of the sibling that preceded it. Walked event by event for `<row><a>1</a><b/></row>` at `objectNestLevel=1`: the START of `<b>` flushes `a=1` and sets `lastName="b"` while leaving `lastContent="1"`, and the END of `</b>` then runs `object.put("b", lastContent)` with that stale `"1"`. The fix sets `lastContent = null` at the two points where `lastName` is assigned to a new sub-element - `load()` and `analyze()` - so a sub-element can only ever be filled by CHARACTERS events that arrived after its own START.

This is the sub-element twin of #2759, whose regression test (`noPropertyCarryoverBetweenRecords`) uses attributes exclusively and therefore never exercised this path.

`analyze()` is patched the same way, since the identical omission polluted the inferred schema: an empty `<score/>` sampled the value of the `<name>` before it, which demoted the inferred type of `score` from LONG to STRING. While there, its record-start reset is corrected too - `lastName = null` sat **inside** the attribute loop, so it never fired for a record element without attributes. It now clears both `lastName` and `lastContent` unconditionally at record start, mirroring what `load()` has always done.

### Why this does not regress #2759

#2759 taught the CHARACTERS handler to ignore whitespace-only text, so that pretty-printing between two elements cannot erase the content of the element currently open. That guard (`trimmedText.isEmpty()`) is untouched. The new clear fires on START_ELEMENT, i.e. at the moment the reader moves *into a different* element, which is exactly when the previous element's text stops being relevant. The regression test deliberately uses a pretty-printed document so the whitespace CHARACTERS events are present in the stream.

### Why the fix is not also applied after `object.put(...)` in END_ELEMENT

The issue text suggested additionally nulling `lastContent` after each `put` in the END_ELEMENT handler. That alone would break the importer: END_ELEMENT leaves `lastName` set, so the next sub-element's START would run `object.put(lastName, null)` and overwrite the value just captured. Clearing at the `lastName` assignment site is both sufficient and minimal.

## Changes

- `integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java`
  - `load()`: clear `lastContent` when a new sub-element becomes the current `lastName`.
  - `analyze()`: same clear, plus an unconditional `lastName`/`lastContent` reset at record start (was trapped inside the attribute loop).
- `integration/src/test/java/com/arcadedb/integration/importer/XMLImporterFormatTest.java`
  - `noContentCarryoverBetweenSubElements` - end-to-end `IMPORT DATABASE` over a pretty-printed file covering an empty element, a self-closing element, an empty element *followed* by a populated sibling, and a populated element that must keep its own text.
  - `analyzeDoesNotCarryContentBetweenSubElements` - drives `analyze()` directly and asserts on the sampled values and the inferred `Type`.

Both tests were confirmed to fail on the unfixed code (`Tests run: 4, Failures: 2`) and pass after the change.

## Test plan

- [ ] `mvn -o -pl integration verify` - `Tests run: 169, Failures: 0, Errors: 0, Skipped: 9`
- [ ] `mvn -o -pl integration verify -DskipITs=false -DskipTests=true` - `Tests run: 118, Failures: 0, Errors: 0`
- [ ] `XMLImporterIT.importXMLWithNamespace` still green: it reads nested `<datafield><subfield>` content, the shape most likely to be affected by a `lastContent` reset, and the last datafield's text is still captured.
- [ ] `XMLImporterFormatTest.noPropertyCarryoverBetweenRecords` (#2759) still green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XML imports so empty and self-closing sibling elements no longer inherit text from adjacent elements.
  * Improved schema analysis to prevent empty XML elements from affecting inferred property values or numeric types.

* **Tests**
  * Added regression coverage for XML importing and schema inference, including UTF-8 content and parser scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->