### PR TITLE
fix(#6814): AnalyzedProperty keeps refuting LONG/DOUBLE after sampling stops

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/AnalyzedProperty.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/AnalyzedProperty.java
@@ -24,6 +24,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class AnalyzedProperty {
+  /** A value longer than this is not worth keeping as a sample, but it is still evidence about the type. */
+  private static final int MAX_SAMPLE_LENGTH = 100;
+
   private final String      name;
   private final long        maxValueSampling;
   private final int         index;
@@ -61,44 +64,48 @@ public class AnalyzedProperty {
     return index;
   }
 
+  /**
+   * Sampling and type refutation are two independent concerns and are handled in that order here. Sample collection is
+   * a memory bound and legitimately stops - on an oversized value or once enough distinct values have been seen. Type
+   * refutation is evidence: skipping it for a value, or stopping it for the rest of the column, is how a text column
+   * used to end up declared LONG and blow the import up on the very value the analysis never looked at (issue #6814).
+   */
   public void setLastContent(final String lastContent) {
-    if (!collectingSamples)
+    if (lastContent == null)
       return;
 
-    if (lastContent != null) {
-      if (lastContent.length() > 100) {
-        collectingSamples = false;
-        contents.clear();
-        return;
-      }
+    this.lastContent = lastContent;
 
-      this.lastContent = lastContent;
-      if (contents.size() > maxValueSampling) {
-        collectingSamples = false;
-        contents.clear();
-        return;
-      }
-
-      contents.add(lastContent);
-
-      if (!lastContent.isEmpty()) {
-        if (candidateForInteger) {
-          try {
-            Long.parseLong(lastContent);
-          } catch (final NumberFormatException e) {
-            candidateForInteger = false;
-          }
+    if (!lastContent.isEmpty()) {
+      // EVERY VALUE IS PROBED, NO MATTER ITS LENGTH OR HOW MANY CAME BEFORE IT. THE PROBES COST NOTHING ONCE THE
+      // CANDIDATE HAS ALREADY BEEN REFUTED, WHICH IS THE COMMON CASE FOR A TEXT COLUMN.
+      if (candidateForInteger) {
+        try {
+          Long.parseLong(lastContent);
+        } catch (final NumberFormatException e) {
+          candidateForInteger = false;
         }
+      }
 
-        if (candidateForDecimal) {
-          try {
-            Double.parseDouble(lastContent);
-          } catch (final NumberFormatException e) {
-            candidateForDecimal = false;
-          }
+      if (candidateForDecimal) {
+        try {
+          Double.parseDouble(lastContent);
+        } catch (final NumberFormatException e) {
+          candidateForDecimal = false;
         }
       }
     }
+
+    if (!collectingSamples)
+      return;
+
+    if (lastContent.length() > MAX_SAMPLE_LENGTH || contents.size() > maxValueSampling) {
+      collectingSamples = false;
+      contents.clear();
+      return;
+    }
+
+    contents.add(lastContent);
   }
 
   public Set<String> getContents() {

--- a/integration/src/main/java/com/arcadedb/integration/importer/AnalyzedProperty.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/AnalyzedProperty.java
@@ -77,8 +77,7 @@ public class AnalyzedProperty {
     this.lastContent = lastContent;
 
     if (!lastContent.isEmpty()) {
-      // EVERY VALUE IS PROBED, NO MATTER ITS LENGTH OR HOW MANY CAME BEFORE IT. THE PROBES COST NOTHING ONCE THE
-      // CANDIDATE HAS ALREADY BEEN REFUTED, WHICH IS THE COMMON CASE FOR A TEXT COLUMN.
+      // A REFUTED CANDIDATE IS NEVER PROBED AGAIN, SO A TEXT COLUMN PAYS FOR ONE FAILED PARSE EACH AND NOTHING MORE
       if (candidateForInteger) {
         try {
           Long.parseLong(lastContent);

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6814AnalyzedPropertyTypeRefutationTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6814AnalyzedPropertyTypeRefutationTest.java
@@ -203,7 +203,10 @@ class Issue6814AnalyzedPropertyTypeRefutationTest {
         assertThat(descriptions).containsExactlyInAnyOrder("42", LONG_TEXT, "99");
       }
     } finally {
-      databaseFactory.open().drop();
+      // Guarded: if the import throws before the database is on disk, an unconditional open() here would raise a
+      // second exception and mask the assertion failure that actually matters.
+      if (databaseFactory.exists())
+        databaseFactory.open().drop();
     }
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6814AnalyzedPropertyTypeRefutationTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6814AnalyzedPropertyTypeRefutationTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6814. {@link AnalyzedProperty} used to conflate two unrelated decisions: "stop collecting samples" and
+ * "stop looking at values at all". A value longer than the 100-character sampling limit - or simply one value too
+ * many - flipped {@code collectingSamples} off and returned <i>before</i> the {@code Long}/{@code Double} probes, so
+ * that value never disproved anything and no later value was examined either. A column whose first value happened to
+ * look numeric was then declared {@code LONG}, and the import blew up converting the very value the analysis had
+ * skipped.
+ * <p>
+ * Sampling is a memory bound and still stops; type refutation is evidence and must not.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6814AnalyzedPropertyTypeRefutationTest {
+
+  /** 120 characters: past the 100-character sampling limit, and the same text the CSV fixture carries. */
+  private static final String LONG_TEXT =
+      "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua";
+
+  private static AnalyzedProperty newProperty(final long maxValueSampling) {
+    return new AnalyzedProperty("description", Type.STRING, maxValueSampling, 0);
+  }
+
+  /**
+   * The core of the report: "42" makes the column a LONG candidate, the long sentence must refute it. Before the fix
+   * the sentence was never probed and the column ended up LONG.
+   */
+  @Test
+  void aValueLongerThanTheSamplingLimitDisprovesLong() {
+    final AnalyzedProperty property = newProperty(100);
+
+    property.setLastContent("42");
+    property.setLastContent(LONG_TEXT);
+    property.endParsing();
+
+    assertThat(property.getType()).isEqualTo(Type.STRING);
+  }
+
+  /**
+   * The long value stops sample collection but must not stop analysis: every value after it still counts as evidence.
+   */
+  @Test
+  void valuesAfterTheSamplingLimitStillRefuteTheNumericTypes() {
+    final AnalyzedProperty property = newProperty(100);
+
+    property.setLastContent("42");
+    property.setLastContent(LONG_TEXT);
+    assertThat(property.isCollectingSamples()).isFalse();
+
+    // "99" alone would leave the column a LONG candidate: it is the values around it that must still be heard.
+    property.setLastContent("99");
+    property.setLastContent("not a number");
+    property.endParsing();
+
+    assertThat(property.getType()).isEqualTo(Type.STRING);
+  }
+
+  /**
+   * Refutation is a real probe, not a blanket "long means text": 150 digits overflow a {@code Long} but are a
+   * perfectly good {@code Double}, so the column narrows to DOUBLE rather than staying STRING.
+   */
+  @Test
+  void aLongNumericValueNarrowsToDoubleInsteadOfLong() {
+    final AnalyzedProperty property = newProperty(100);
+
+    property.setLastContent("1");
+    property.setLastContent("1".repeat(150));
+    property.endParsing();
+
+    assertThat(property.getType()).isEqualTo(Type.DOUBLE);
+  }
+
+  /**
+   * The second short-circuit called out in the report: once {@code maxValueSampling} values have been collected,
+   * later values used to be ignored too, so a text value arriving after the limit could not undo a LONG verdict.
+   */
+  @Test
+  void valuesArrivingAfterTheSampleCountLimitStillRefuteTheNumericTypes() {
+    final AnalyzedProperty property = newProperty(2);
+
+    property.setLastContent("1");
+    property.setLastContent("2");
+    property.setLastContent("3");
+    property.setLastContent("4");
+    assertThat(property.isCollectingSamples()).isFalse();
+
+    property.setLastContent("not a number");
+    property.endParsing();
+
+    assertThat(property.getType()).isEqualTo(Type.STRING);
+  }
+
+  /**
+   * Sampling remains bounded: hitting the limit still drops the collected samples and stops adding new ones, so the
+   * fix does not trade a type bug for a memory one.
+   */
+  @Test
+  void samplingStillStopsAndDiscardsCollectedValues() {
+    final AnalyzedProperty property = newProperty(100);
+
+    property.setLastContent("alpha");
+    assertThat(property.getContents()).containsExactly("alpha");
+
+    property.setLastContent(LONG_TEXT);
+
+    assertThat(property.isCollectingSamples()).isFalse();
+    assertThat(property.getContents()).isEmpty();
+
+    property.setLastContent("beta");
+    assertThat(property.getContents()).isEmpty();
+  }
+
+  /** A column made only of long text is still text, and a null value is still no evidence at all. */
+  @Test
+  void aColumnOfOnlyLongTextIsStringAndNullsAreIgnored() {
+    final AnalyzedProperty onlyLongText = newProperty(100);
+    onlyLongText.setLastContent(LONG_TEXT);
+    onlyLongText.endParsing();
+    assertThat(onlyLongText.getType()).isEqualTo(Type.STRING);
+
+    final AnalyzedProperty onlyNulls = newProperty(100);
+    onlyNulls.setLastContent(null);
+    onlyNulls.endParsing();
+    assertThat(onlyNulls.getType()).isEqualTo(Type.STRING);
+  }
+
+  /** The happy paths the analysis exists for must be untouched. */
+  @Test
+  void purelyNumericColumnsAreStillTypedNumeric() {
+    final AnalyzedProperty integers = newProperty(100);
+    integers.setLastContent("1");
+    integers.setLastContent("");
+    integers.setLastContent("2");
+    integers.endParsing();
+    assertThat(integers.getType()).isEqualTo(Type.LONG);
+
+    final AnalyzedProperty decimals = newProperty(100);
+    decimals.setLastContent("1");
+    decimals.setLastContent("2.5");
+    decimals.endParsing();
+    assertThat(decimals.getType()).isEqualTo(Type.DOUBLE);
+  }
+
+  /**
+   * End to end: the CSV fixture is exactly the report's repro - a numeric-looking first value, then a sentence past
+   * the sampling limit, then another numeric value. The schema property must be created as STRING and the import must
+   * carry every row, instead of failing with "Cannot convert type 'java.lang.String' to 'LONG'".
+   */
+  @Test
+  void csvImportKeepsALongTextColumnAsString() {
+    final String databasePath = "target/databases/test-import-6814-long-text";
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+
+    try {
+      final Importer importer = new Importer(
+          ("-documents src/test/resources/importer-documents-long-text.csv -database " + databasePath
+              + " -documentType Doc -o").split(" "));
+
+      // toMap() only reports non-zero counters, so a clean run carries no "errors" key at all.
+      final Map<String, Object> result = importer.load();
+      assertThat(result).doesNotContainKey("errors");
+      assertThat(result.get("createdDocuments")).isEqualTo(3L);
+
+      try (final Database db = databaseFactory.open()) {
+        assertThat(db.getSchema().getType("Doc").getProperty("description").getType()).isEqualTo(Type.STRING);
+
+        final List<String> descriptions = new ArrayList<>();
+        try (final ResultSet resultSet = db.query("sql", "select description from Doc")) {
+          resultSet.forEachRemaining(row -> descriptions.add(row.getProperty("description")));
+        }
+        assertThat(descriptions).containsExactlyInAnyOrder("42", LONG_TEXT, "99");
+      }
+    } finally {
+      databaseFactory.open().drop();
+    }
+  }
+}

--- a/integration/src/test/resources/importer-documents-long-text.csv
+++ b/integration/src/test/resources/importer-documents-long-text.csv
@@ -1,0 +1,4 @@
+id,description
+1,42
+2,"Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
+3,99


### PR DESCRIPTION
Closes #6814

## Problem

`AnalyzedProperty.setLastContent()` conflated two unrelated decisions: *"stop collecting samples"* and *"stop looking at values at all"*. A value longer than the 100-character sampling limit flipped `collectingSamples` off and `return`ed **before** the `Long`/`Double` probes, so that value never disproved anything; because `collectingSamples` is never re-armed, the guard at the top of the method then made every subsequent value for that column a no-op too. `endParsing()` only checks `lastContent != null && candidateForInteger`, so a column whose first value happened to look numeric was declared `Type.LONG`, and `AbstractImporter.updateDatabaseSchema()` created the schema property with that type. `CSVImporterFormat.loadDocuments()` then set the long text value on it and `MutableDocument.convertValueToSchemaType()` threw:

```
IllegalArgumentException: Cannot convert type 'java.lang.String' to 'LONG' found in property 'description'
```

In the default `-onRowError abort` mode that killed the whole import; under `-onRowError skip` every long-text row was silently dropped. The same short-circuit existed on the `contents.size() > maxValueSampling` branch, so a text value arriving after the sample-count limit could not undo a LONG verdict either.

## Fix

`setLastContent()` is reordered so the two concerns are independent, in this order:

1. **Type refutation runs for every non-empty value**, unconditionally. It is evidence and must never be short-circuited.
2. **Sample collection** then stops as before, on an oversized value or once `maxValueSampling` distinct values have been collected, and still clears `contents`. Sampling is a memory bound and legitimately stops.

The probes are the real `Long.parseLong` / `Double.parseDouble` calls rather than a blanket "long value means text": 150 digits overflow a `Long` but are a perfectly good `Double`, so such a column now narrows to `DOUBLE` instead of failing on a `LONG` it cannot hold. The 100-character limit is now the named constant `MAX_SAMPLE_LENGTH`.

`this.lastContent` is now also assigned for oversized values. That only feeds `endParsing()`'s "did this column ever have a value" check, and a column made only of long text still ends up `STRING` because both candidates are refuted by those same values.

### Cost

Each probe runs only while its candidate is still true, so the first non-numeric value in a text column refutes both and every later value costs nothing. For a column that stays numeric, the extra work is bounded by the analysis window itself (`analysisLimitBytes=100000`, `analysisLimitEntries=10000` in `CSVImporterFormat.analyze()`), so worst-case total parsing stays within the ~100 KB the analyzer already reads.

## Tests

New `Issue6814AnalyzedPropertyTypeRefutationTest` (8 tests). All 5 bug-facing tests fail on `main` and pass with the fix; the 3 control tests pass on both, proving the assertions are wired to the right behaviour.

| Test | What it pins |
|---|---|
| `aValueLongerThanTheSamplingLimitDisprovesLong` | the report's core: `"42"` then a 120-char sentence must yield `STRING`, not `LONG` |
| `valuesAfterTheSamplingLimitStillRefuteTheNumericTypes` | analysis does not go permanently deaf after the oversized value |
| `aLongNumericValueNarrowsToDoubleInsteadOfLong` | 150 digits refute `LONG` (overflow) but not `DOUBLE` - a real probe, not a blanket rule |
| `valuesArrivingAfterTheSampleCountLimitStillRefuteTheNumericTypes` | the second short-circuit, on `maxValueSampling` |
| `csvImportKeepsALongTextColumnAsString` | end-to-end repro through `Importer`: schema property is `STRING`, all 3 rows land, no errors |
| `samplingStillStopsAndDiscardsCollectedValues` | control - the memory bound is intact (`isCollectingSamples()` false, `contents` empty and staying empty) |
| `aColumnOfOnlyLongTextIsStringAndNullsAreIgnored` | control - all-long-text stays `STRING`, `null` is still no evidence |
| `purelyNumericColumnsAreStillTypedNumeric` | control - `LONG`/`DOUBLE` inference still works, empty strings still ignored |

Fixture `integration/src/test/resources/importer-documents-long-text.csv` is exactly the repro from the issue: numeric-looking first value, a 120-character sentence, then another numeric value.

Before the fix:

```
Tests run: 8, Failures: 4, Errors: 1
  aLongNumericValueNarrowsToDoubleInsteadOfLong: expected DOUBLE but was LONG
  aValueLongerThanTheSamplingLimitDisprovesLong: expected STRING but was LONG
  valuesAfterTheSamplingLimitStillRefuteTheNumericTypes: expected STRING but was LONG
  valuesArrivingAfterTheSampleCountLimitStillRefuteTheNumericTypes: expected STRING but was LONG
  csvImportKeepsALongTextColumnAsString: Cannot convert type 'java.lang.String' to 'LONG'
```

## Test plan

- [x] `mvn -pl integration test -Dtest=Issue6814AnalyzedPropertyTypeRefutationTest` fails 5/8 on `main` (bug reproduced)
- [x] Same run is 8/8 green with the fix
- [x] Full `integration` unit suite: `Tests run: 175, Failures: 0, Errors: 0, Skipped: 9`
- [x] Importer integration tests: `-DskipITs=false -Dit.test='CSVImporterIT,XMLImporterIT,JSONImporterIT,JsonLImporterIT,OrientDBImporterIT,SQLLocalImporterIT'` -> `Tests run: 37, Failures: 0, Errors: 0`
- [x] Confirmed no cross-module impact: `AnalyzedProperty` has no consumers outside `integration`; gremlin's `GraphMLImporterFormat`/`GraphSONImporterFormat` implement `analyze()` without touching it

## Not in scope

The issue also notes that `CSVImporterFormat.loadDocuments()` (`:184`) rethrows the conversion failure raw, with no line number. That is a separate diagnostics improvement and is left untouched here so the fix stays minimal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data type detection during imports, including numeric values encountered after sampling limits are reached.
  * Correctly narrows long numeric values to compatible decimal types.
  * Prevents oversized or excessive samples from consuming unbounded storage.
  * Preserves accurate handling of null and long-text values.

* **Tests**
  * Added coverage for numeric type detection, sampling limits, long values, nulls, and end-to-end CSV import scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->