### PR TITLE
fix(#6811): stop SourceDiscovery from destroying the user's CSV delimiter option

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterSettings.java
@@ -30,6 +30,19 @@ public class ImporterSettings {
   public int     verboseLevel = 2;
   public boolean probeOnly    = false;
 
+  /**
+   * The generic {@code -delimiter} / {@code WITH delimiter = ';'} setting: the fallback used by any CSV source that
+   * carries no per-source delimiter of its own ({@code -documentsDelimiter}, {@code -verticesDelimiter},
+   * {@code -edgesDelimiter}), and the only delimiter source available to the main {@code -url}, which is analyzed as
+   * {@code EntityType.DATABASE} and has no per-source setting at all.
+   * <p>
+   * It is held in its own field rather than read back from {@link #options} because {@code SourceDiscovery} resolves
+   * a delimiter per source and writes the answer into {@code options["delimiter"]}, where {@code CSVImporterFormat}
+   * reads it. Keeping the user's own value only in that same entry made it collateral damage of the first source
+   * analyzed (issue #6811).
+   */
+  public String delimiter;
+
   public String documents;
   public String documentsFileType;
   public String documentsDelimiter;
@@ -185,6 +198,7 @@ public class ImporterSettings {
     case "parsingLimitBytes" -> parsingLimitBytes = FileUtils.getSizeAsNumber(value);
     case "parsingLimitEntries" -> parsingLimitEntries = Long.parseLong(value);
     case "mapping" -> mapping = value;
+    case "delimiter" -> delimiter = value;
     case "probeOnly" -> probeOnly = Boolean.parseBoolean(value);
     case "onRowError" -> {
       if (!"abort".equalsIgnoreCase(value) && !"skip".equalsIgnoreCase(value))

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -233,7 +233,7 @@ public class SourceDiscovery {
       break;
 
     case DATABASE:
-      // NO SPECIAL SETTINGS
+      // NO PER-SOURCE SETTINGS: THE GENERIC `delimiter` IS THE ONLY ONE THIS SOURCE CAN HAVE
       knownFileType = getFileTypeByExtension(settings.url);
       break;
 
@@ -241,9 +241,20 @@ public class SourceDiscovery {
       throw new IllegalArgumentException("entityType '" + entityType + "' not supported");
     }
 
+    if (knownDelimiter == null)
+      // FALL BACK TO THE GENERIC `-delimiter` / `WITH delimiter = ...`: THE PER-SOURCE SETTING WINS WHEN PRESENT
+      knownDelimiter = settings.delimiter;
+
     if (knownFileType != null) {
       if ("csv".equalsIgnoreCase(knownFileType)) {
-        settings.options.put("delimiter", knownDelimiter);
+        // RESOLVE THE DELIMITER FOR *THIS* SOURCE. WRITING null HERE USED TO DESTROY THE USER'S OWN SETTING, WHICH
+        // LANDS IN THE VERY SAME MAP ENTRY, LEAVING NO WAY AT ALL TO IMPORT A NON-COMMA CSV VIA -url (issue #6811).
+        // REMOVING INSTEAD OF LEAVING THE ENTRY ALONE MATTERS TOO: EACH SOURCE OF A MULTI-SOURCE IMPORT IS ANALYZED
+        // AGAINST THE SAME SETTINGS, SO A PREVIOUS SOURCE'S DELIMITER MUST NOT LEAK INTO THIS ONE'S DEFAULT.
+        if (knownDelimiter != null)
+          settings.options.put("delimiter", knownDelimiter);
+        else
+          settings.options.remove("delimiter");
         return new CSVImporterFormat();
       } else if ("json".equalsIgnoreCase(knownFileType)) {
         return new JSONImporterFormat();

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6811DelimiterOptionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6811DelimiterOptionTest.java
@@ -109,10 +109,10 @@ class Issue6811DelimiterOptionTest {
 
   /**
    * The generic {@code -delimiter} also has to reach a source that has its own setting name but no value for it,
-   * here the vertices file, while a per-source delimiter still wins over it.
+   * here the vertices file.
    */
   @Test
-  void genericDelimiterAppliesToVerticesAndPerSourceOneWins() {
+  void genericDelimiterAppliesToVertices() {
     final String databasePath = "target/databases/test-import-6811-generic";
     FileUtils.deleteRecursively(new File(databasePath));
 
@@ -124,6 +124,39 @@ class Issue6811DelimiterOptionTest {
         "-vertices", "src/test/resources/importer-vertices-semicolon.csv",//
         "-database", databasePath,//
         "-delimiter", ";",//
+        "-typeIdProperty", "Id",//
+        "-typeIdType", "Long",//
+        "-typeIdUnique", "true",//
+        "-forceDatabaseCreate", "true" }).load();
+
+    try (final Database db = databaseFactory.open()) {
+      assertThat(db.countType("Node", true)).isEqualTo(6);
+      assertThat(db.lookupByKey("Node", "Id", 0).next().getRecord().asVertex().<Object>get("First Name")).isEqualTo("Jay");
+    }
+
+    databaseFactory.open().drop();
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * The other half of the precedence rule: a per-source delimiter wins over the generic one, so the semicolon
+   * vertices file is still parsed on {@code ;} even though the generic setting says comma. A fallback applied in the
+   * wrong order would parse the whole line as one column here and lose the {@code First Name} property.
+   */
+  @Test
+  void perSourceDelimiterWinsOverTheGenericOne() {
+    final String databasePath = "target/databases/test-import-6811-precedence";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    new Importer(new String[] {//
+        "-vertices", "src/test/resources/importer-vertices-semicolon.csv",//
+        "-verticesDelimiter", ";",//
+        "-database", databasePath,//
+        "-delimiter", ",",//
         "-typeIdProperty", "Id",//
         "-typeIdType", "Long",//
         "-typeIdUnique", "true",//

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6811DelimiterOptionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6811DelimiterOptionTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6811: {@code SourceDiscovery.analyzeSourceContent()} used to write {@code null} into
+ * {@code settings.options["delimiter"]} for every CSV source whose entity type carries no per-source delimiter,
+ * destroying the value the user had supplied via {@code -delimiter} / {@code WITH delimiter = ';'}. A semicolon CSV
+ * was then parsed as a single column, and the import still reported success.
+ */
+class Issue6811DelimiterOptionTest {
+
+  /**
+   * The reported repro: {@code IMPORT DATABASE file://...csv WITH delimiter = ';'}. The main {@code -url} is routed
+   * as {@code EntityType.DATABASE}, which has no per-source delimiter setting at all, so before the fix the user's
+   * {@code ;} was overwritten with {@code null} and the parser fell back to a comma.
+   */
+  @Test
+  void importDatabaseHonorsTheDelimiterOption() {
+    final String databasePath = "target/databases/test-import-6811-database";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", """
+          IMPORT DATABASE file://src/test/resources/importer-delimiter-semicolon.csv
+          WITH delimiter = ';'
+          """);
+
+      assertThat(db.countType("Document", true)).isEqualTo(3);
+
+      final Iterator<Document> it = db.iterateType("Document", true);
+      final Document first = it.next();
+
+      // BEFORE THE FIX THE WHOLE LINE LANDED IN A SINGLE PROPERTY LITERALLY NAMED "id;name;age"
+      assertThat(first.getPropertyNames()).containsExactlyInAnyOrder("id", "name", "age");
+      assertThat(db.getSchema().getType("Document").getPropertyNames()).doesNotContain("id;name;age");
+
+      assertThat(db.query("sql", "SELECT FROM Document WHERE id = 1").next().<Object>getProperty("name")).isEqualTo("Alice");
+      assertThat(db.query("sql", "SELECT FROM Document WHERE id = 3").next().<Object>getProperty("age")).isEqualTo(28L);
+    } finally {
+      db.drop();
+    }
+
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * Same defect through the command-line/API form: {@code -delimiter} was equally destroyed, and there was no
+   * alternative for a plain {@code -url} source.
+   */
+  @Test
+  void urlImportHonorsTheDelimiterOption() {
+    final String databasePath = "target/databases/test-import-6811-url";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    new Importer(new String[] {//
+        "-url", "src/test/resources/importer-delimiter-semicolon.csv",//
+        "-database", databasePath,//
+        "-delimiter", ";",//
+        "-forceDatabaseCreate", "true" }).load();
+
+    try (final Database db = databaseFactory.open()) {
+      assertThat(db.countType("Document", true)).isEqualTo(3);
+
+      final Iterator<Document> it = db.iterateType("Document", true);
+      assertThat(it.next().getPropertyNames()).containsExactlyInAnyOrder("id", "name", "age");
+    }
+
+    databaseFactory.open().drop();
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * The generic {@code -delimiter} also has to reach a source that has its own setting name but no value for it,
+   * here the vertices file, while a per-source delimiter still wins over it.
+   */
+  @Test
+  void genericDelimiterAppliesToVerticesAndPerSourceOneWins() {
+    final String databasePath = "target/databases/test-import-6811-generic";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    new Importer(new String[] {//
+        "-vertices", "src/test/resources/importer-vertices-semicolon.csv",//
+        "-database", databasePath,//
+        "-delimiter", ";",//
+        "-typeIdProperty", "Id",//
+        "-typeIdType", "Long",//
+        "-typeIdUnique", "true",//
+        "-forceDatabaseCreate", "true" }).load();
+
+    try (final Database db = databaseFactory.open()) {
+      assertThat(db.countType("Node", true)).isEqualTo(6);
+      assertThat(db.lookupByKey("Node", "Id", 0).next().getRecord().asVertex().<Object>get("First Name")).isEqualTo("Jay");
+    }
+
+    databaseFactory.open().drop();
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * Guards the fix itself: the resolved delimiter is per source, so a semicolon vertices file followed by a
+   * comma-separated edges file in the SAME import must not let the vertices' {@code ;} leak into the edges parse.
+   */
+  @Test
+  void aPerSourceDelimiterDoesNotLeakIntoTheNextSource() {
+    final String databasePath = "target/databases/test-import-6811-noleak";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    new Importer(new String[] {//
+        "-vertices", "src/test/resources/importer-vertices-semicolon.csv",//
+        "-verticesDelimiter", ";",//
+        "-edges", "src/test/resources/importer-edges.csv",//
+        "-database", databasePath,//
+        "-typeIdProperty", "Id",//
+        "-typeIdType", "Long",//
+        "-typeIdUnique", "true",//
+        "-edgeFromField", "From",//
+        "-edgeToField", "To",//
+        "-forceDatabaseCreate", "true" }).load();
+
+    try (final Database db = databaseFactory.open()) {
+      assertThat(db.countType("Node", true)).isEqualTo(6);
+      assertThat(db.countType("Relationship", true)).isEqualTo(3);
+      assertThat(db.lookupByKey("Node", "Id", 0).next().getRecord().asVertex().<Object>get("First Name")).isEqualTo("Jay");
+    }
+
+    databaseFactory.open().drop();
+    TestHelper.checkActiveDatabases();
+  }
+}

--- a/integration/src/test/resources/importer-delimiter-semicolon.csv
+++ b/integration/src/test/resources/importer-delimiter-semicolon.csv
@@ -1,0 +1,4 @@
+id;name;age
+1;Alice;30
+2;Bob;41
+3;Carol;28

--- a/integration/src/test/resources/importer-vertices-semicolon.csv
+++ b/integration/src/test/resources/importer-vertices-semicolon.csv
@@ -1,0 +1,7 @@
+Id;First Name;Last Name
+0;Jay;Miner
+1;John;Red
+2;Steve;Jobs
+3;Isaac;Newton
+4;Nikola;Tesla
+5;Albert;Einstein


### PR DESCRIPTION
Closes #6811

## Problem

`SourceDiscovery.analyzeSourceContent()` resolved a per-source delimiter and then wrote it into
`settings.options["delimiter"]` unconditionally - including when it had resolved nothing. That map entry is also
where `ImporterSettings.parseParameter()` stores the user's own `-delimiter` / `WITH delimiter = ';'`, and
`CSVImporterFormat` (both `analyze()` and `createCSVParser()`) reads exactly that key, so every CSV source whose
entity type carries no per-source delimiter had the user's value overwritten with `null` and silently fell back to a
comma.

`EntityType.DATABASE` - the entity type the main `-url` is analyzed as - has no per-source delimiter setting at all,
so `IMPORT DATABASE file://data.csv WITH delimiter = ';'` on a semicolon file parsed the whole line as one column:
the analyzed schema got a single property literally named `id;name;age`, every record got one property holding
`1;Alice;30`, and the import reported success. There was no workaround: `-documentsDelimiter` and friends are never
consulted for `DATABASE`, and the auto-detection path is short-circuited by the `.csv` extension (and `isSeparator()`
does not list `;` anyway).

## Fix

- `ImporterSettings` gains a `delimiter` field, populated from the generic `-delimiter` / `WITH delimiter = ...`
  setting. It is held in its own field rather than read back from `options` precisely because `SourceDiscovery`
  overwrites that entry per source, which is what made the user's value collateral damage of the first source
  analyzed.
- `SourceDiscovery` falls back to that generic delimiter whenever the entity type resolves none of its own, which
  gives `EntityType.DATABASE` a delimiter source for the first time while keeping `-documentsDelimiter` /
  `-verticesDelimiter` / `-edgesDelimiter` authoritative for their own sources.
- The write into `options["delimiter"]` is now a resolve rather than a blind put: the value when there is one,
  `remove()` when there is not. `remove()` rather than "leave it alone" matters because every source of a
  multi-source import is analyzed against the same `ImporterSettings`, so a previous source's delimiter must not leak
  into the next source's default. For the no-delimiter-anywhere case the observable behaviour is unchanged
  (`getValue("delimiter", ",")` returned the `,` default for a `null` value just as it does for an absent key).

## Test plan

New `integration/.../Issue6811DelimiterOptionTest` (4 tests, plus fixtures `importer-delimiter-semicolon.csv` and
`importer-vertices-semicolon.csv`):

- [x] `importDatabaseHonorsTheDelimiterOption` - the reported repro via SQL `IMPORT DATABASE ... WITH delimiter = ';'`;
      asserts the properties are `id`/`name`/`age`, that no property named `id;name;age` exists, and that the values
      round-trip. **Fails on `main`.**
- [x] `urlImportHonorsTheDelimiterOption` - the same defect through the CLI/API `-url` + `-delimiter` form.
      **Fails on `main`.**
- [x] `genericDelimiterAppliesToVerticesAndPerSourceOneWins` - the generic `-delimiter` reaches a vertices source that
      has no `-verticesDelimiter`. **Fails on `main`.**
- [x] `aPerSourceDelimiterDoesNotLeakIntoTheNextSource` - a semicolon vertices file followed by a comma edges file in
      the same import; guards the `remove()` half of the fix (passes before and after by construction).
- [x] Verified the three repro tests fail with the two `src/main` files stashed and pass with them restored.
- [x] `mvn -pl integration verify -DexcludedGroups=benchmark,vector,slow` - 170 tests, 0 failures.
- [x] `mvn -pl integration verify -DskipITs=false -Dit.test='CSVImporterIT,SQLLocalImporterIT,XMLImporterIT,JSONImporterIT,JsonLImporterIT,Word2VecImporterIT,GloVeImporterIT,OrientDBImporterIT,Neo4jImporterIT'` - 50 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a generic CSV delimiter during imports.
  - Delimiter settings now apply consistently across database, URL, vertex, and mixed vertex/edge imports.
- **Bug Fixes**
  - Fixed parsing of semicolon-separated data with generic delimiter settings.
  - Prevented delimiter settings from one source from affecting subsequent imports.
  - Improved precedence and clearing behavior for source-specific delimiter settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->