### PR TITLE
fix(#6810): importing any ZIP source silently yields 0 records

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/Source.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Source.java
@@ -43,13 +43,15 @@ public class Source {
     this.closeCallback = closeCallback;
   }
 
+  /**
+   * Rebuilds {@link #inputStream} from the beginning of the source.
+   * <p>
+   * A failure here is propagated on purpose: swallowing it leaves the caller reading a stream that is closed or not
+   * positioned on any entry, which reads as an empty - but successful - import instead of as an error (issue #6810).
+   */
   public void reset() throws IOException {
     if (resetCallback != null)
-      try {
-        resetCallback.call(this);
-      } catch (final Exception e) {
-        LogManager.instance().log(this, Level.SEVERE, "Error on resetting source %s", e, this);
-      }
+      resetCallback.call(this);
   }
 
   public void close() {

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -148,7 +148,7 @@ public class SourceDiscovery {
           currentConnection.get().getContentLengthLong(), resource,
           source -> {
             try {
-              source.inputStream.close();
+              closeBestEffort(source.inputStream);
               currentConnection.get().disconnect();
 
               final HttpURLConnection reopened = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
@@ -210,7 +210,7 @@ public class SourceDiscovery {
     try {
       return getSourceFromContent(fis, file.length(), resource, source -> {
         try {
-          source.inputStream.close();
+          closeBestEffort(source.inputStream);
           if (source.inputStream instanceof GZIPInputStream)
             source.inputStream = new GZIPInputStream(new FileInputStream(file), 2048);
           else if (source.inputStream instanceof ZipInputStream)
@@ -589,6 +589,19 @@ public class SourceDiscovery {
       closeable.close();
     } catch (final IOException e) {
       pending.addSuppressed(e);
+    }
+  }
+
+  /**
+   * Closes the stream a reset is about to replace. A stream that refuses to close must not abort the reset: the
+   * replacement is what the caller will read, and on the remote path the connection behind the old stream still has to
+   * be disconnected afterwards.
+   */
+  private void closeBestEffort(final Closeable closeable) {
+    try {
+      closeable.close();
+    } catch (final IOException e) {
+      LogManager.instance().log(this, Level.FINE, "Error on closing the previous stream while resetting source '%s'", e, url);
     }
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
@@ -137,29 +138,35 @@ public class SourceDiscovery {
     final boolean blockLocalNetworks = allowLocalUrls != null ?
         !allowLocalUrls : GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.getValueAsBoolean();
 
-    final HttpURLConnection connection = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
+    // EVERY RESET REPLACES THE CONNECTION, SO THE CLOSE CALLBACK HAS TO TEAR DOWN THE ONE THE STREAM CURRENTLY COMES
+    // FROM, NOT THE FIRST ONE EVER OPENED
+    final AtomicReference<HttpURLConnection> currentConnection = new AtomicReference<>(
+        ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks));
 
     try {
-      return getSourceFromContent(new BufferedInputStream(connection.getInputStream()), connection.getContentLengthLong(), resource,
+      return getSourceFromContent(new BufferedInputStream(currentConnection.get().getInputStream()),
+          currentConnection.get().getContentLengthLong(), resource,
           source -> {
             try {
               source.inputStream.close();
-              connection.disconnect();
+              currentConnection.get().disconnect();
 
-              final HttpURLConnection connection1 = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
+              final HttpURLConnection reopened = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
               try {
                 if (source.inputStream instanceof GZIPInputStream)
-                  source.inputStream = new GZIPInputStream(connection1.getInputStream(), 2048);
+                  source.inputStream = new GZIPInputStream(reopened.getInputStream(), 2048);
                 else if (source.inputStream instanceof ZipInputStream)
                   // THE NEW STREAM MUST BE POSITIONED ON THE ENTRY TO READ, THE OLD ONE IS GONE (issue #6810)
-                  source.inputStream = reopenZip(new BufferedInputStream(connection1.getInputStream()), resource);
+                  source.inputStream = reopenZip(new BufferedInputStream(reopened.getInputStream()), resource);
                 else
-                  source.inputStream = new BufferedInputStream(connection1.getInputStream());
+                  source.inputStream = new BufferedInputStream(reopened.getInputStream());
               } catch (final IOException | RuntimeException e) {
                 // THE REPLACEMENT STREAM WAS NEVER INSTALLED ON THE SOURCE, SO NOTHING ELSE WOULD EVER DISCONNECT IT
-                connection1.disconnect();
+                reopened.disconnect();
                 throw e;
               }
+
+              currentConnection.set(reopened);
             } catch (final ImportException e) {
               throw e;
             } catch (final Exception e) {
@@ -167,12 +174,12 @@ public class SourceDiscovery {
             }
             return null;
           }, () -> {
-            connection.disconnect();
+            currentConnection.get().disconnect();
             return null;
           });
     } catch (final IOException | RuntimeException e) {
       // THE SOURCE THAT WOULD HAVE OWNED (AND EVENTUALLY DISCONNECTED) THE CONNECTION WAS NEVER BUILT
-      connection.disconnect();
+      currentConnection.get().disconnect();
       throw e;
     }
   }

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -33,6 +33,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.FileUtils;
 
 import java.io.BufferedInputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -138,31 +139,42 @@ public class SourceDiscovery {
 
     final HttpURLConnection connection = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
 
-    return getSourceFromContent(new BufferedInputStream(connection.getInputStream()), connection.getContentLengthLong(), resource,
-        source -> {
-          try {
-            source.inputStream.close();
+    try {
+      return getSourceFromContent(new BufferedInputStream(connection.getInputStream()), connection.getContentLengthLong(), resource,
+          source -> {
+            try {
+              source.inputStream.close();
+              connection.disconnect();
+
+              final HttpURLConnection connection1 = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
+              try {
+                if (source.inputStream instanceof GZIPInputStream)
+                  source.inputStream = new GZIPInputStream(connection1.getInputStream(), 2048);
+                else if (source.inputStream instanceof ZipInputStream)
+                  // THE NEW STREAM MUST BE POSITIONED ON THE ENTRY TO READ, THE OLD ONE IS GONE (issue #6810)
+                  source.inputStream = reopenZip(new BufferedInputStream(connection1.getInputStream()), resource);
+                else
+                  source.inputStream = new BufferedInputStream(connection1.getInputStream());
+              } catch (final IOException | RuntimeException e) {
+                // THE REPLACEMENT STREAM WAS NEVER INSTALLED ON THE SOURCE, SO NOTHING ELSE WOULD EVER DISCONNECT IT
+                connection1.disconnect();
+                throw e;
+              }
+            } catch (final ImportException e) {
+              throw e;
+            } catch (final Exception e) {
+              throw new ImportException("Error on reset remote resource", e);
+            }
+            return null;
+          }, () -> {
             connection.disconnect();
-
-            final HttpURLConnection connection1 = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
-
-            if (source.inputStream instanceof GZIPInputStream)
-              source.inputStream = new GZIPInputStream(connection1.getInputStream(), 2048);
-            else if (source.inputStream instanceof ZipInputStream)
-              // THE NEW STREAM MUST BE POSITIONED ON THE ENTRY TO READ, THE OLD ONE IS GONE (issue #6810)
-              source.inputStream = reopenZip(new BufferedInputStream(connection1.getInputStream()), resource);
-            else
-              source.inputStream = new BufferedInputStream(connection1.getInputStream());
-          } catch (final ImportException e) {
-            throw e;
-          } catch (final Exception e) {
-            throw new ImportException("Error on reset remote resource", e);
-          }
-          return null;
-        }, () -> {
-          connection.disconnect();
-          return null;
-        });
+            return null;
+          });
+    } catch (final IOException | RuntimeException e) {
+      // THE SOURCE THAT WOULD HAVE OWNED (AND EVENTUALLY DISCONNECTED) THE CONNECTION WAS NEVER BUILT
+      connection.disconnect();
+      throw e;
+    }
   }
 
   private Source getSourceFromFile(final String path) throws IOException {
@@ -188,24 +200,33 @@ public class SourceDiscovery {
         throw new FileNotFoundException(filePath);
     }
 
-    return getSourceFromContent(fis, file.length(), resource, source -> {
-      try {
-        source.inputStream.close();
-        if (source.inputStream instanceof GZIPInputStream)
-          source.inputStream = new GZIPInputStream(new FileInputStream(file), 2048);
-        else if (source.inputStream instanceof ZipInputStream)
-          // THE NEW STREAM MUST BE POSITIONED ON THE ENTRY TO READ, THE OLD ONE IS CLOSED (issue #6810)
-          source.inputStream = reopenZip(new BufferedInputStream(new FileInputStream(file)), resource);
-        else
-          source.inputStream = new BufferedInputStream(new FileInputStream(file));
-      } catch (final IOException e) {
-        throw new ImportException("Error on reset local resource", e);
-      }
-      return null;
-    }, () -> {
-      fis.close();
-      return null;
-    });
+    try {
+      return getSourceFromContent(fis, file.length(), resource, source -> {
+        try {
+          source.inputStream.close();
+          if (source.inputStream instanceof GZIPInputStream)
+            source.inputStream = new GZIPInputStream(new FileInputStream(file), 2048);
+          else if (source.inputStream instanceof ZipInputStream)
+            // THE NEW STREAM MUST BE POSITIONED ON THE ENTRY TO READ, THE OLD ONE IS CLOSED (issue #6810)
+            source.inputStream = reopenZip(new BufferedInputStream(new FileInputStream(file)), resource);
+          else
+            source.inputStream = new BufferedInputStream(new FileInputStream(file));
+        } catch (final ImportException e) {
+          throw e;
+        } catch (final Exception e) {
+          // SAME SHAPE AS THE REMOTE CALLBACK ABOVE, SO THE TWO STAY EASY TO KEEP IN SYNC
+          throw new ImportException("Error on reset local resource", e);
+        }
+        return null;
+      }, () -> {
+        fis.close();
+        return null;
+      });
+    } catch (final IOException | RuntimeException e) {
+      // THE SOURCE THAT WOULD HAVE OWNED (AND EVENTUALLY CLOSED) THE STREAM WAS NEVER BUILT
+      closeSuppressing(fis, e);
+      throw e;
+    }
   }
 
   private FormatImporter analyzeSourceContent(final Parser parser, final AnalyzedEntity.EntityType entityType,
@@ -546,10 +567,22 @@ public class SourceDiscovery {
       if (positionOnZipEntry(zip, resource) == null)
         throw new ImportException("Error on resetting source '" + url + "': no entry found in the zip archive");
     } catch (final IOException | RuntimeException e) {
-      zip.close();
+      closeSuppressing(zip, e);
       throw e;
     }
     return zip;
+  }
+
+  /**
+   * Closes {@code closeable} while unwinding on {@code pending}, so a failure to close cannot replace - and hide - the
+   * exception that actually caused the unwind.
+   */
+  private static void closeSuppressing(final Closeable closeable, final Throwable pending) {
+    try {
+      closeable.close();
+    } catch (final IOException e) {
+      pending.addSuppressed(e);
+    }
   }
 
   private String getFormatFromExtension(String fileName) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -141,17 +141,20 @@ public class SourceDiscovery {
     return getSourceFromContent(new BufferedInputStream(connection.getInputStream()), connection.getContentLengthLong(), resource,
         source -> {
           try {
+            source.inputStream.close();
             connection.disconnect();
 
             final HttpURLConnection connection1 = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
 
             if (source.inputStream instanceof GZIPInputStream)
               source.inputStream = new GZIPInputStream(connection1.getInputStream(), 2048);
-            else if (source.inputStream instanceof ZipInputStream stream) {
-              source.inputStream = new ZipInputStream(connection1.getInputStream());
-              stream.getNextEntry();
-            } else
+            else if (source.inputStream instanceof ZipInputStream)
+              // THE NEW STREAM MUST BE POSITIONED ON THE ENTRY TO READ, THE OLD ONE IS GONE (issue #6810)
+              source.inputStream = reopenZip(new BufferedInputStream(connection1.getInputStream()), resource);
+            else
               source.inputStream = new BufferedInputStream(connection1.getInputStream());
+          } catch (final ImportException e) {
+            throw e;
           } catch (final Exception e) {
             throw new ImportException("Error on reset remote resource", e);
           }
@@ -190,10 +193,10 @@ public class SourceDiscovery {
         source.inputStream.close();
         if (source.inputStream instanceof GZIPInputStream)
           source.inputStream = new GZIPInputStream(new FileInputStream(file), 2048);
-        else if (source.inputStream instanceof ZipInputStream stream) {
-          source.inputStream = new ZipInputStream(new FileInputStream(file));
-          stream.getNextEntry();
-        } else
+        else if (source.inputStream instanceof ZipInputStream)
+          // THE NEW STREAM MUST BE POSITIONED ON THE ENTRY TO READ, THE OLD ONE IS CLOSED (issue #6810)
+          source.inputStream = reopenZip(new BufferedInputStream(new FileInputStream(file)), resource);
+        else
           source.inputStream = new BufferedInputStream(new FileInputStream(file));
       } catch (final IOException e) {
         throw new ImportException("Error on reset local resource", e);
@@ -480,24 +483,9 @@ public class SourceDiscovery {
     in.mark(0);
 
     final ZipInputStream zip = new ZipInputStream(in);
-    ZipEntry entry = zip.getNextEntry();
-    if (entry != null) {
+    if (positionOnZipEntry(zip, resource) != null)
       // ZIPPED FILE
-      if (resource != null) {
-        // SEARCH FOR THE RIGHT ENTRY
-        while (entry != null) {
-          if (resource.equals(entry.getName()))
-            return new Source(url, zip, totalSize, true, resetCallback, closeCallback);
-
-          zip.closeEntry();
-          entry = zip.getNextEntry();
-        }
-
-        throw new IllegalArgumentException("Resource '" + resource + "' not found");
-      }
-
       return new Source(url, zip, totalSize, true, resetCallback, closeCallback);
-    }
 
     in.reset();
     in.mark(in.available());
@@ -513,6 +501,55 @@ public class SourceDiscovery {
 
     // ANALYZE THE INPUT AS TEXT
     return new Source(url, in, totalSize, false, resetCallback, closeCallback);
+  }
+
+  /**
+   * Positions a freshly built {@link ZipInputStream} on the entry the import has to read: the one named
+   * {@code resource} when specified, otherwise the first entry of the archive.
+   * <p>
+   * This has to be repeated every time the stream is rebuilt (see the reset callbacks above), because a
+   * {@link ZipInputStream} sitting on no entry is not an error condition: {@link ZipInputStream#read()} just returns
+   * {@code -1}, so the import reads an empty input and reports success on 0 records (issue #6810).
+   *
+   * @return the entry the stream is now positioned on, or {@code null} if the content is not a zip archive at all
+   *
+   * @throws IllegalArgumentException if {@code resource} is not contained in the archive
+   */
+  private static ZipEntry positionOnZipEntry(final ZipInputStream zip, final String resource) throws IOException {
+    ZipEntry entry = zip.getNextEntry();
+    if (entry == null)
+      // NOT A ZIP ARCHIVE
+      return null;
+
+    if (resource == null)
+      return entry;
+
+    // SEARCH FOR THE RIGHT ENTRY
+    while (entry != null) {
+      if (resource.equals(entry.getName()))
+        return entry;
+
+      zip.closeEntry();
+      entry = zip.getNextEntry();
+    }
+
+    throw new IllegalArgumentException("Resource '" + resource + "' not found");
+  }
+
+  /**
+   * Rebuilds a zip source from the given (re-opened) raw stream, positioned on the same entry the original stream was
+   * reading. The raw stream is closed if the archive turns out to be unreadable, so the caller cannot leak it.
+   */
+  private ZipInputStream reopenZip(final InputStream in, final String resource) throws IOException {
+    final ZipInputStream zip = new ZipInputStream(in);
+    try {
+      if (positionOnZipEntry(zip, resource) == null)
+        throw new ImportException("Error on resetting source '" + url + "': no entry found in the zip archive");
+    } catch (final IOException | RuntimeException e) {
+      zip.close();
+      throw e;
+    }
+    return zip;
   }
 
   private String getFormatFromExtension(String fileName) {

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6810ZipSourceResetTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6810ZipSourceResetTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.utility.FileUtils;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6810: importing any ZIP source silently yielded 0 records.
+ * <p>
+ * Both reset callbacks in {@link SourceDiscovery} rebuilt the {@link java.util.zip.ZipInputStream} but then called
+ * {@code getNextEntry()} on the *old* (already closed, on the local-file path) stream instead of the new one. The new
+ * stream was therefore left with no current entry, and {@link java.util.zip.ZipInputStream#read()} returns {@code -1}
+ * while no entry is current, so the import read an empty input. {@link Source#reset()} only logged the resulting
+ * {@code IOException("Stream closed")}, which is what turned a hard failure into a "successful" import of 0 records.
+ * <p>
+ * The reset path is not optional: {@code Importer.loadFromSource()} always calls {@code parser.reset()}, and so do
+ * {@code SourceDiscovery.getSchema()} and {@code CSVImporterFormat.analyze()}.
+ */
+class Issue6810ZipSourceResetTest {
+
+  private static final String CSV_CONTENT   = """
+      Id,First Name,Last Name
+      0,Jay,Miner
+      1,John,Red
+      2,Steve,Jobs
+      3,Isaac,Newton
+      4,Nikola,Tesla
+      5,Albert,Einstein
+      """;
+  private static final String OTHER_CONTENT = """
+      Id,First Name,Last Name
+      10,Grace,Hopper
+      """;
+
+  private File tempDir;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    tempDir = Files.createTempDirectory("issue6810").toFile();
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(tempDir);
+  }
+
+  @Test
+  void localZipSourceResetsToTheStartOfTheEntry() throws IOException {
+    final File zip = writeZip("importer-vertices.csv.zip", "importer-vertices.csv", CSV_CONTENT);
+
+    final Source source = new SourceDiscovery("file://" + zip.getAbsolutePath()).getSource();
+    try {
+      assertThat(readAfterReset(source)).isEqualTo(CSV_CONTENT);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  void localZipSourceResetsToTheRequestedEntryOfAMultiEntryArchive() throws IOException {
+    final File zip = writeZip("multi.zip", "first.csv", OTHER_CONTENT, "importer-vertices.csv", CSV_CONTENT);
+
+    // The second entry is the one requested: a reset that rebuilds the stream must seek to it again, not stop at the
+    // first entry of the archive.
+    final Source source = new SourceDiscovery(
+        "file://" + zip.getAbsolutePath() + ":::importer-vertices.csv").getSource();
+    try {
+      assertThat(readAfterReset(source)).isEqualTo(CSV_CONTENT);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  void remoteZipSourceResetsToTheStartOfTheEntry() throws IOException {
+    final byte[] zipped = Files.readAllBytes(writeZip("remote.csv.zip", "remote.csv", CSV_CONTENT).toPath());
+
+    final HttpServer server = startHttpServer(zipped);
+    try {
+      final String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/remote.csv.zip";
+      // allowLocalUrls=true: the loopback address is otherwise refused by the SSRF guard (#6474).
+      final Source source = new SourceDiscovery(url, true).getSource();
+      try {
+        assertThat(readAfterReset(source)).isEqualTo(CSV_CONTENT);
+      } finally {
+        source.close();
+      }
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void localGzipSourceStillResetsToTheStartOfTheStream() throws IOException {
+    final File gz = new File(tempDir, "importer-vertices.csv.gz");
+    try (final OutputStream out = new GZIPOutputStream(new FileOutputStream(gz))) {
+      out.write(CSV_CONTENT.getBytes(StandardCharsets.UTF_8));
+    }
+
+    final Source source = new SourceDiscovery("file://" + gz.getAbsolutePath()).getSource();
+    try {
+      assertThat(readAfterReset(source)).isEqualTo(CSV_CONTENT);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  void localPlainSourceStillResetsToTheStartOfTheStream() throws IOException {
+    final File csv = new File(tempDir, "importer-vertices.csv");
+    Files.writeString(csv.toPath(), CSV_CONTENT);
+
+    final Source source = new SourceDiscovery("file://" + csv.getAbsolutePath()).getSource();
+    try {
+      assertThat(readAfterReset(source)).isEqualTo(CSV_CONTENT);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  void importDatabaseFromZipLoadsEveryRow() throws IOException {
+    final File zip = writeZip("importer-vertices.csv.zip", "importer-vertices.csv", CSV_CONTENT);
+    final String databasePath = new File(tempDir, "db-zip").getAbsolutePath();
+
+    try (final Database db = new DatabaseFactory(databasePath).create()) {
+      db.command("sql", "IMPORT DATABASE file://" + zip.getAbsolutePath());
+      assertThat(db.countType("Document", true)).isEqualTo(6);
+    }
+  }
+
+  @Test
+  void importDatabaseFromMultiEntryZipLoadsTheRequestedEntry() throws IOException {
+    final File zip = writeZip("multi.zip", "first.csv", OTHER_CONTENT, "importer-vertices.csv", CSV_CONTENT);
+    final String databasePath = new File(tempDir, "db-multi-zip").getAbsolutePath();
+
+    try (final Database db = new DatabaseFactory(databasePath).create()) {
+      db.command("sql", "IMPORT DATABASE file://" + zip.getAbsolutePath() + ":::importer-vertices.csv");
+      assertThat(db.countType("Document", true)).isEqualTo(6);
+    }
+  }
+
+  @Test
+  void resetPropagatesACallbackFailureInsteadOfSwallowingIt() {
+    // Before the fix a broken reset was logged at SEVERE and swallowed, so the caller went on reading a stream that
+    // was left in an unusable state and reported an empty - but successful - import.
+    final Source source = new Source("test", InputStream.nullInputStream(), 0, false, s -> {
+      throw new ImportException("boom");
+    }, () -> null);
+
+    assertThatThrownBy(source::reset).isInstanceOf(ImportException.class).hasMessageContaining("boom");
+  }
+
+  /**
+   * Reads the whole source the way {@code Importer.loadFromSource()} does: wrap it in a {@link Parser}, reset it, then
+   * consume it.
+   */
+  private static String readAfterReset(final Source source) throws IOException {
+    final Parser parser = new Parser(source, 0);
+    parser.reset();
+    return new String(parser.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+  }
+
+  private File writeZip(final String zipName, final String... entryNameAndContent) throws IOException {
+    final File zip = new File(tempDir, zipName);
+    try (final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip))) {
+      for (int i = 0; i < entryNameAndContent.length; i += 2) {
+        out.putNextEntry(new ZipEntry(entryNameAndContent[i]));
+        out.write(entryNameAndContent[i + 1].getBytes(StandardCharsets.UTF_8));
+        out.closeEntry();
+      }
+    }
+    return zip;
+  }
+
+  private static HttpServer startHttpServer(final byte[] payload) throws IOException {
+    final HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.createContext("/", exchange -> {
+      exchange.sendResponseHeaders(200, payload.length);
+      try (final OutputStream out = exchange.getResponseBody()) {
+        out.write(payload);
+      }
+    });
+    server.start();
+    return server;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6810ZipSourceResetTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6810ZipSourceResetTest.java
@@ -36,6 +36,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -130,6 +131,26 @@ class Issue6810ZipSourceResetTest {
   }
 
   @Test
+  void remoteZipResetFailsLoudlyWhenTheArchiveNoLongerHoldsTheEntry() throws IOException {
+    final byte[] zipped = Files.readAllBytes(writeZip("remote.zip", "wanted.csv", CSV_CONTENT).toPath());
+    // The re-fetch that the reset performs gets a body that is not a zip at all, the way a remote file replaced
+    // between the two requests would behave. That must surface as an error, never as an empty import.
+    final HttpServer server = startHttpServer(zipped, "not a zip any more".getBytes(StandardCharsets.UTF_8));
+    try {
+      final String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/remote.zip:::wanted.csv";
+      final Source source = new SourceDiscovery(url, true).getSource();
+      try {
+        assertThatThrownBy(() -> readAfterReset(source)).isInstanceOf(ImportException.class)
+            .hasMessageContaining("no entry found in the zip archive");
+      } finally {
+        source.close();
+      }
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
   void localGzipSourceStillResetsToTheStartOfTheStream() throws IOException {
     final File gz = new File(tempDir, "importer-vertices.csv.gz");
     try (final OutputStream out = new GZIPOutputStream(new FileOutputStream(gz))) {
@@ -212,9 +233,15 @@ class Issue6810ZipSourceResetTest {
     return zip;
   }
 
-  private static HttpServer startHttpServer(final byte[] payload) throws IOException {
+  /**
+   * Serves {@code payloads} one per request, repeating the last one once they run out. More than one payload lets a
+   * test change what the reset's re-fetch gets back.
+   */
+  private static HttpServer startHttpServer(final byte[]... payloads) throws IOException {
     final HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    final AtomicInteger requests = new AtomicInteger();
     server.createContext("/", exchange -> {
+      final byte[] payload = payloads[Math.min(requests.getAndIncrement(), payloads.length - 1)];
       exchange.sendResponseHeaders(200, payload.length);
       try (final OutputStream out = exchange.getResponseBody()) {
         out.write(payload);


### PR DESCRIPTION
Closes #6810

## Summary

`SourceDiscovery`'s two reset callbacks rebuilt the `ZipInputStream` from a freshly re-opened raw stream but then called `getNextEntry()` on the **old** local variable rather than on the new stream. On the local-file path that old stream had been closed two lines above, so the call threw `IOException("Stream closed")`; on the remote path it silently advanced a stream nobody would read again. Either way the *new* `ZipInputStream` was left sitting on no entry, and `ZipInputStream.read()` returns `-1` while no entry is current - so the import read an empty input. `Source.reset()` logged the exception at SEVERE and returned, which is what turned a hard failure into a "completed" import of 0 records. Because `Importer.loadFromSource()`, `SourceDiscovery.getSchema()` and `CSVImporterFormat.analyze()` all call `reset()`, the path was unavoidable: **every** ZIP source imported as 0 records. A second defect on the same lines meant the rebuilt stream was never seeked back to the `:::<resource>` entry the user asked for, so a multi-entry archive resumed on the wrong entry.

The fix extracts the entry-seeking logic that `getSourceFromContent()` already had into `positionOnZipEntry(zip, resource)` and calls it from a new `reopenZip()` helper that both reset callbacks now use, so a rebuilt stream is positioned on exactly the entry the original one was reading. The remote callback also closes the old stream before disconnecting (it previously leaked it), and `Source.reset()` no longer swallows a callback failure - a broken reset can no longer be mistaken for an empty input.

### Changed

- `integration/.../importer/SourceDiscovery.java`
  - new `positionOnZipEntry(ZipInputStream, String)`: seeks to the named entry, or the first one when no `:::resource` was given; returns `null` when the content is not a zip at all (the "not a zip archive" signal `getSourceFromContent()` needs)
  - new `reopenZip(InputStream, String)`: builds the replacement stream, positions it, and closes the raw stream if the archive turns out unreadable so it cannot leak
  - both reset callbacks (local file and remote URL) now call `reopenZip` instead of poking the dead stream; the remote one also closes the previous stream first
  - `getSourceFromContent()` refactored onto the same helper - one implementation of the entry search instead of two
- `integration/.../importer/Source.java` - `reset()` propagates the callback failure instead of logging it at SEVERE and returning

## Test plan

New `integration/src/test/java/com/arcadedb/integration/importer/Issue6810ZipSourceResetTest.java` (8 tests). All 6 zip-related ones fail on `main` and pass with the fix; the two non-zip ones are non-regression guards that pass on both.

- [x] `localZipSourceResetsToTheStartOfTheEntry` - single-entry `.csv.zip` read through `Parser`+`reset()` exactly as `Importer.loadFromSource()` does; was `""`, now the full CSV
- [x] `localZipSourceResetsToTheRequestedEntryOfAMultiEntryArchive` - `file://multi.zip:::importer-vertices.csv`, proves the reset re-seeks past the first entry
- [x] `remoteZipSourceResetsToTheStartOfTheEntry` - covers the second (remote-URL) callback, serving the archive from a loopback `com.sun.net.httpserver.HttpServer` with `allowLocalUrls=true` so the SSRF guard from #6474 is not in the way
- [x] `localGzipSourceStillResetsToTheStartOfTheStream` / `localPlainSourceStillResetsToTheStartOfTheStream` - the two branches that were already correct stay correct
- [x] `importDatabaseFromZipLoadsEveryRow` / `importDatabaseFromMultiEntryZipLoadsTheRequestedEntry` - end-to-end `IMPORT DATABASE file://...zip`; previously died with "Type with name 'Document' was not found" (nothing was created), now imports all 6 rows
- [x] `resetPropagatesACallbackFailureInsteadOfSwallowingIt` - a throwing reset callback now reaches the caller

Regression runs (all green, `-Dmaven.repo.local` isolated):

- [x] `mvn -o -pl integration verify -DskipITs=false -DskipTests=false` - 174 unit + 118 IT, 0 failures (includes `CSVImporterIT`, `JsonLImporterIT`, `Neo4jImporterIT`, `OrientDBImporterIT`, `XMLImporterIT`, `SQLLocalImporterIT`, `SQLRemoteImporterIT`, `Word2Vec*`, `GloVeImporterIT` - i.e. every format that goes through `Source.reset()`)
- [x] `mvn -o -pl gremlin-it verify -DskipITs=false -Dit.test='GraphMLImporterIT,GraphSONImporterIT,GraphMLExporterIT,GraphSONExporterIT'` - 360 unit + 10 IT, 0 failures (the `.tgz`-backed GraphML/GraphSON importers also reset the source)

Not run locally: the `server` module ITs (`ServerImportDatabaseIT`, which imports `classpath://orientdb-export-small.gz`) - port 2480 was already held by another process on this machine, which makes that module fail spuriously. That path is the gzip branch, covered by `localGzipSourceStillResetsToTheStartOfTheStream` and by `SQLLocalImporterIT`; CI will run it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ZIP archive imports after source resets, including local, multi-entry, and remote archives.
  * Ensured requested ZIP entries remain selected when streams are reopened.
  * Reset failures now surface as import errors instead of being silently logged.
  * Preserved reset behavior for GZIP-compressed and plain files.
  * Improved cleanup when source setup or reset fails, preventing connection and stream leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->