### PR TITLE
fix: five small defects across the console, the Studio and the plugin lifecycle (#6852, #6830, #6829, #6828, #6827)

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -262,13 +262,18 @@ public class Console {
    * time there is nothing left for the user to do about them.
    */
   public void close() {
-    // COMMITTING NEEDS AN ACTIVE TRANSACTION ON A LIVE PROXY, NOT JUST A NON-ZERO COUNTER: commit() ON AN INACTIVE
-    // TRANSACTION IS NOT A NO-OP, WHICH IS WHY executeCommit()/executeClose() GUARD ON isTransactionActive() TOO
-    if (transactionBatchSize > 0 && currentOperationsInBatch > 0 && databaseProxy != null
-        && databaseProxy.isTransactionActive()) {
+    if (transactionBatchSize > 0 && currentOperationsInBatch > 0 && databaseProxy != null) {
       try {
-        currentOperationsInBatch = 0;
-        databaseProxy.commit();
+        // COMMITTING NEEDS AN ACTIVE TRANSACTION, NOT JUST A NON-ZERO COUNTER: commit() ON AN INACTIVE TRANSACTION IS
+        // NOT A NO-OP, WHICH IS WHY executeCommit()/executeClose() GUARD ON isTransactionActive() TOO. THE GUARD IS
+        // INSIDE THE TRY BECAUSE IT CAN THROW ON ITS OWN: ON THE EMBEDDED PATH isTransactionActive() RESOLVES THE
+        // THREAD'S CACHED TRANSACTION AND RAISES InvalidDatabaseInstanceException WHEN IT BELONGS TO A DIFFERENT
+        // LocalDatabase INSTANCE FOR THE SAME PATH - RECONNECTING TO THE SAME DATABASE IN ONE SESSION DOES THAT. A
+        // THROW HERE WOULD SKIP THE FLUSH AND THE TWO CLOSES ALL OVER AGAIN, JUST FROM ANOTHER TRIGGER (ISSUE #6828)
+        if (databaseProxy.isTransactionActive()) {
+          currentOperationsInBatch = 0;
+          databaseProxy.commit();
+        }
       } catch (Throwable t) {
         errored = true;
         outputError(t);
@@ -1376,7 +1381,25 @@ public class Console {
     if (batchMode || !systemTerminal)
       throw new ConsoleException("Password for user '" + userName + "' is missing");
 
-    final String password = getLineReader().readLine("Password for '" + userName + "': ", '*');
+    final LineReader reader = getLineReader();
+
+    // BELT AND BRACES ON THE ONE LINE THAT IS A BARE PASSWORD. jline ALREADY DROPS A MASKED LINE - ITS
+    // SimpleMaskingCallback.history() RETURNS null AND LineReaderImpl.finish() SKIPS A null - BUT THAT IS A LIBRARY
+    // INTERNAL, AND ConsoleCredentials CANNOT BE THE SAFETY NET HERE: IT RECOGNISES A PASSWORD BY THE COMMAND KEYWORD
+    // IN FRONT OF IT, AND THIS LINE HAS NONE. SAYING IT OUT LOUD KEEPS THE GUARANTEE LOCAL TO THE CODE THAT NEEDS IT
+    final Object previousSetting = reader.getVariable(LineReader.DISABLE_HISTORY);
+    reader.setVariable(LineReader.DISABLE_HISTORY, true);
+    final String password;
+    try {
+      password = reader.readLine("Password for '" + userName + "': ", '*');
+    } catch (final UserInterruptException | EndOfFileException e) {
+      // CTRL-C / CTRL-D AT THE PROMPT IS A DECISION, NOT A FAILURE: SAY SO INSTEAD OF LETTING A jline EXCEPTION
+      // SURFACE AS AN OPAQUE ERROR FROM connect / create user
+      throw new ConsoleException("Password entry cancelled");
+    } finally {
+      reader.setVariable(LineReader.DISABLE_HISTORY, previousSetting);
+    }
+
     if (password == null || password.isEmpty())
       throw new ConsoleException("Password for user '" + userName + "' is empty");
     return password;

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -1351,7 +1351,12 @@ public class Console {
 
     final String[] serverParts = serverUserPassword[0].split("/");
     if ((needsDatabase && serverParts.length != 2) || (!needsDatabase && serverParts.length != 1))
-      throw new ConsoleException("Remote URL '" + url + "' not valid");
+      // REPORT ONLY THE ADDRESS, NEVER THE WHOLE ARGUMENT: `url` STILL CARRIES THE INLINE PASSWORD, AND THIS MESSAGE
+      // GOES TO THE INTERACTIVE OUTPUT AND TO THE BATCH LOG. IT IS ALSO THE MORE PRECISE HALF - THE ADDRESS IS WHAT
+      // FAILED TO SPLIT (ISSUE #6829)
+      throw new ConsoleException(
+          "Remote URL '" + REMOTE_PREFIX + serverUserPassword[0] + "' is not valid, expected " + REMOTE_PREFIX
+              + "<host>[:<port>]" + (needsDatabase ? "/<database>" : ""));
 
     final String remoteServer;
     final int remotePort;

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -43,7 +43,6 @@ import com.arcadedb.remote.RemoteDatabase;
 import com.arcadedb.remote.RemoteServer;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.AnsiCode;
-import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.RecordTableFormatter;
 import com.arcadedb.utility.StringUtils;
 import com.arcadedb.utility.TableFormatter;
@@ -64,6 +63,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -76,6 +76,7 @@ public class Console {
   private static final String               REMOTE_PREFIX            = "remote:";
   private static final String               LOCAL_PREFIX             = "local:";
   private static final String               SQL_LANGUAGE             = "SQL";
+  private static final String               HISTORY_FILE             = ".history";
   private final        Terminal             terminal;
   private final        TerminalParser       parser                   = new TerminalParser();
   private              ConsoleOutput        output;
@@ -95,6 +96,11 @@ public class Console {
   private              boolean              batchMode                = false;
   private              boolean              failAtEnd                = false;
   private static       boolean              errored                  = false;
+  // BUILT LAZILY AND SHARED BY interactiveMode() AND BY THE MASKED PASSWORD PROMPT, SO A PASSWORD CAN BE ASKED FOR
+  // WITHOUT EVER APPEARING ON A LINE THAT GOES TO THE HISTORY FILE (ISSUE #6829)
+  private              LineReader           lineReader;
+  // WHETHER THE PROCESS OWNS A REAL TERMINAL: A MASKED PROMPT IS ONLY POSSIBLE WHEN SOMEBODY IS THERE TO TYPE INTO IT
+  private final        boolean              systemTerminal;
 
   public Console(final DatabaseInternal database) throws IOException {
     this();
@@ -116,20 +122,39 @@ public class Console {
 
     GlobalConfiguration.PROFILE.setValue("low-cpu");
 
-    boolean system = System.console() != null;
-    terminal = TerminalBuilder.builder().system(system).streams(System.in, System.out).jni(true).build();
+    systemTerminal = System.console() != null;
+    terminal = TerminalBuilder.builder().system(systemTerminal).streams(System.in, System.out).jni(true).build();
 
     output(3, "%s Console v%s - %s (%s)", Constants.PRODUCT, Constants.getRawVersion(), Constants.COPYRIGHT, Constants.URL);
     output(3, "%s", Constants.SPONSOR_MSG);
   }
 
-  public void interactiveMode() throws IOException {
-    final Completer completer = new StringsCompleter("align database", "begin", "rollback", "commit", "check database", "close",
-        "connect", "create database", "create user", "drop database", "drop user", "export", "import", "help", "info types",
-        "list databases", "load", "exit", "quit", "set", "match", "select", "insert into", "update", "delete", "pwd");
+  /**
+   * Returns the line reader, building it on first use.
+   * <p>
+   * The history it is given masks the passwords that the `connect` and `create user` syntaxes carry inline before they are
+   * recorded, so they never reach the `.history` file - which is written after every command, in the working directory,
+   * with the process umask, and survives the session indefinitely (issue #6829).
+   */
+  private LineReader getLineReader() {
+    if (lineReader == null) {
+      final Completer completer = new StringsCompleter("align database", "begin", "rollback", "commit", "check database", "close",
+          "connect", "create database", "create user", "drop database", "drop user", "export", "import", "help", "info types",
+          "list databases", "load", "exit", "quit", "set", "match", "select", "insert into", "update", "delete", "pwd");
 
-    final LineReader lineReader = LineReaderBuilder.builder().terminal(terminal).parser(parser).variable("history-file", ".history")
-        .history(new DefaultHistory()).completer(completer).build();
+      lineReader = LineReaderBuilder.builder().terminal(terminal).parser(parser)
+          .variable(LineReader.HISTORY_FILE, HISTORY_FILE).history(new DefaultHistory() {
+            @Override
+            public void add(final Instant time, final String line) {
+              super.add(time, ConsoleCredentials.mask(line));
+            }
+          }).completer(completer).build();
+    }
+    return lineReader;
+  }
+
+  public void interactiveMode() throws IOException {
+    final LineReader lineReader = getLineReader();
 
     Runtime.getRuntime().addShutdownHook(new Thread(this::close));
 
@@ -223,27 +248,60 @@ public class Console {
     }
   }
 
+  /**
+   * Releases everything the console holds: the pending batch, the terminal buffer, the database and the factory.
+   * <p>
+   * Each step gets its own try/catch rather than sharing one. With a single catch the first step decided the fate of the
+   * other three, and the first step is the only one that can realistically fail: in the default batch flow `exit` had
+   * already nulled the database proxy, so committing threw a NullPointerException here and the terminal was never flushed,
+   * losing whatever jline still had buffered when {@code main()} called {@code System.exit} (issue #6828).
+   * <p>
+   * A failed exit-time commit is also reported and marks the process as errored. Swallowing it silently is the worse half
+   * of the same bug: on the interactive Ctrl-D path up to {@code transactionBatchSize} statements are committed right here,
+   * and the process used to exit 0 while that data was never written. The three release steps stay quiet, since at exit
+   * time there is nothing left for the user to do about them.
+   */
   public void close() {
-    try {
-      if (transactionBatchSize > 0 && currentOperationsInBatch > 0) {
+    // COMMITTING NEEDS AN ACTIVE TRANSACTION ON A LIVE PROXY, NOT JUST A NON-ZERO COUNTER: commit() ON AN INACTIVE
+    // TRANSACTION IS NOT A NO-OP, WHICH IS WHY executeCommit()/executeClose() GUARD ON isTransactionActive() TOO
+    if (transactionBatchSize > 0 && currentOperationsInBatch > 0 && databaseProxy != null
+        && databaseProxy.isTransactionActive()) {
+      try {
         currentOperationsInBatch = 0;
         databaseProxy.commit();
+      } catch (Throwable t) {
+        errored = true;
+        outputError(t);
       }
+    }
+    currentOperationsInBatch = 0;
 
-      if (terminal != null)
+    if (terminal != null) {
+      try {
         flushOutput();
+      } catch (Throwable t) {
+        // IGNORE: THERE IS NOWHERE LEFT TO REPORT IT TO
+      }
+    }
 
-      if (databaseProxy != null) {
+    if (databaseProxy != null) {
+      try {
         databaseProxy.close();
+      } catch (Throwable t) {
+        // IGNORE ANY EXCEPTION AT CLOSING
+      } finally {
         databaseProxy = null;
       }
+    }
 
-      if (databaseFactory != null) {
+    if (databaseFactory != null) {
+      try {
         databaseFactory.close();
+      } catch (Throwable t) {
+        // IGNORE ANY EXCEPTION AT CLOSING
+      } finally {
         databaseFactory = null;
       }
-    } catch (Throwable t) {
-      // IGNORE ANY EXCEPTION AT CLOSING
     }
   }
 
@@ -386,32 +444,50 @@ public class Console {
 
   /**
    * Strips one matching pair of surrounding quotes (' or ") from a {@code SET} value, so {@code set language = 'sql'} stores
-   * {@code sql} rather than the literal quotes. A value that does not start with a quote character is returned unchanged. A
-   * value that opens with a quote character but never closes it, or ends in something other than that character, is always a
-   * typo, so it is rejected rather than stored half-quoted (issue #6439).
+   * {@code sql} rather than the literal quotes, and unescapes the backslash escapes inside that pair. A value that does not
+   * start with a quote character is returned unchanged. A value that opens with a quote character but never closes it, or
+   * ends in something other than that character, is always a typo, so it is rejected rather than stored half-quoted
+   * (issue #6439).
    * <p>
-   * A value whose first and last characters are the SAME quote character is always accepted as that pair, even if the quote
-   * character also occurs in between - for example {@code 'it\'s a test'}. That inner quote reaches this method already
-   * stripped of its escaping backslash by {@link TerminalParser#parse}, indistinguishable here from a real closing quote
-   * followed by unrelated trailing text that happens to also end in a quote character. Between silently accepting that rare,
-   * contrived input and rejecting the far more plausible escaped-quote value, this favors the value the parser's own escape
-   * handling was built to support.
+   * This is the one place in the console where shell-like unescaping is wanted, and since {@link TerminalParser#parse} now
+   * keeps the escape characters it sees (issue #6827) it is also the one place that can do it unambiguously: the closing
+   * quote is the first UNESCAPED occurrence of the opening one, so {@code 'it\'s a test'} yields {@code it's a test} and
+   * {@code 'a' b'} is still rejected as trailing garbage. Only {@code \'}, {@code \"} and {@code \\} are unescaped - any
+   * other backslash is data and is kept as typed, which is what makes {@code set foo = 'C:\Users'} store the path.
    */
   private static String stripMatchingQuotes(final String value) {
     if (value.isEmpty())
       return value;
 
-    final char first = value.charAt(0);
-    if (first != '\'' && first != '"')
+    final char quote = value.charAt(0);
+    if (quote != '\'' && quote != '"')
       return value;
 
-    if (value.length() >= 2 && value.charAt(value.length() - 1) == first)
-      return value.substring(1, value.length() - 1);
+    final StringBuilder content = new StringBuilder(value.length());
+    for (int i = 1; i < value.length(); ++i) {
+      final char c = value.charAt(i);
 
-    if (value.indexOf(first, 1) < 0)
-      throw new ConsoleException("Invalid value for SET: missing closing quote in " + value);
+      if (c == '\\' && i + 1 < value.length()) {
+        final char next = value.charAt(i + 1);
+        if (next == '\'' || next == '"' || next == '\\') {
+          content.append(next);
+          ++i;
+          continue;
+        }
+        content.append(c);
+        continue;
+      }
 
-    throw new ConsoleException("Invalid value for SET: unexpected content after the closing quote in " + value);
+      if (c == quote) {
+        if (i == value.length() - 1)
+          return content.toString();
+        throw new ConsoleException("Invalid value for SET: unexpected content after the closing quote in " + value);
+      }
+
+      content.append(c);
+    }
+
+    throw new ConsoleException("Invalid value for SET: missing closing quote in " + value);
   }
 
   private void executeTransactionStatus() {
@@ -439,11 +515,15 @@ public class Console {
   private void executeCommit() {
     checkDatabaseIsOpen();
     databaseProxy.commit();
+    // THE PENDING BATCH IS GONE WITH THE TRANSACTION: LEAVING THE COUNTER SET MADE close() TRY TO COMMIT IT AGAIN
+    // (ISSUE #6828)
+    currentOperationsInBatch = 0;
   }
 
   private void executeRollback() {
     checkDatabaseIsOpen();
     databaseProxy.rollback();
+    currentOperationsInBatch = 0;
   }
 
   private void executeClose() {
@@ -453,6 +533,7 @@ public class Console {
       databaseProxy.close();
       databaseProxy = null;
     }
+    currentOperationsInBatch = 0;
   }
 
   private void executeListDatabases(final String url) {
@@ -492,7 +573,9 @@ public class Console {
       databaseName = databaseProxy.getName();
 
     } else {
-      final String[] urlParts = url.split(" ");
+      // SPLIT ON RUNS OF WHITESPACE, LIKE THE REMOTE BRANCH: WITH `split(" ")` A SECOND BLANK BEFORE THE MODE PRODUCED
+      // AN EMPTY TOKEN AND `MODE.valueOf("")` FAILED WITH AN ERROR THAT NAMES NEITHER THE MODE NOR THE BLANK (#6830)
+      final String[] urlParts = url.split("\\s+");
 
       final String localUrl = parseLocalUrl(urlParts[0]);
 
@@ -557,7 +640,7 @@ public class Console {
     Map<String, String> databases = new HashMap<String, String>();
 
     if (databasesByPos > -1) {
-      password = params.substring(identifiedByPos + "IDENTIFIED BY".length() + 1, databasesByPos).trim();
+      password = params.substring(identifiedByPos + "IDENTIFIED BY".length(), databasesByPos).trim();
       final String databasesList = params.substring(databasesByPos + " GRANT CONNECT TO ".length()).trim();
       final String[] databasesArray = databasesList.split(",");
       final List<String> databasesName = List.of(databasesArray);
@@ -572,13 +655,14 @@ public class Console {
         }
       }
     } else {
-      password = params.substring(identifiedByPos + "IDENTIFIED BY".length() + 1).trim();
+      password = params.substring(identifiedByPos + "IDENTIFIED BY".length()).trim();
     }
 
-    checkIsEmpty("User password", password);
-    checkHasSpaces("User password", password);
-
-    getRemoteServer().createUser(userName, password, databases);
+    // AN OMITTED PASSWORD IS ASKED FOR WITH THE ECHO MASKED INSTEAD OF BEING REJECTED, SO `create user bob identified by`
+    // IS THE FORM THAT NEVER WRITES THE PASSWORD TO `.history` OR TO A BUILD LOG (ISSUE #6829). SPACES ARE NO LONGER
+    // REJECTED EITHER: `IDENTIFIED BY` AND `GRANT CONNECT TO` DELIMIT THE PASSWORD POSITIONALLY, THE SERVER AND STUDIO
+    // BOTH ACCEPT IT, AND REJECTING IT ONLY HERE MADE AN ACCOUNT THE CONSOLE COULD NOT CREATE (ISSUE #6830)
+    getRemoteServer().createUser(userName, password.isEmpty() ? askPassword(userName) : password, databases);
 
     outputLine(3, "User '%s' created (on the server)", userName);
     flushOutput();
@@ -800,7 +884,11 @@ public class Console {
 
     try (final BufferedReader bufferedReader = new BufferedReader(new FileReader(file, DatabaseFactory.getDefaultCharset()))) {
       while (bufferedReader.ready()) {
-        final String line = FileUtils.decodeFromFile(bufferedReader.readLine());
+        // READ AS TYPED. THE LINE USED TO GO THROUGH FileUtils.decodeFromFile(), WHOSE ONLY JOB WAS TO DOUBLE EVERY `\\`
+        // SO THAT THE LEVEL OF ESCAPING TerminalParser THEN CONSUMED CAME BACK OUT EVEN. THAT PAIR CANCELLED OUT ONLY
+        // FOR AN EVEN NUMBER OF BACKSLASHES: A LONE `\` IN A SCRIPT WAS STILL SWALLOWED. NOW THAT THE PARSER KEEPS WHAT
+        // IT READS (ISSUE #6827), NEITHER HALF IS NEEDED AND A SCRIPT MEANS WHAT IT SAYS
+        final String line = bufferedReader.readLine();
         ++fileLineNumber;
 
         if (pending.isEmpty())
@@ -893,8 +981,9 @@ public class Console {
 
       if (printCommand)
         // USE THE TRIMMED WORD: AN UNTERMINATED LAST COMMAND CARRIES ITS TRAILING NEWLINE AS PART OF THE WORD, WHICH
-        // WOULD OTHERWISE PUSH THE RESULT DOWN BY AN EXTRA BLANK LINE (issue #6372)
-        output(3, getPrompt() + trimmedWord);
+        // WOULD OTHERWISE PUSH THE RESULT DOWN BY AN EXTRA BLANK LINE (issue #6372). MASK ANY INLINE PASSWORD: THIS
+        // ECHO IS WHAT BATCH MODE WRITES TO STDOUT, I.E. STRAIGHT INTO A CI LOG (issue #6829)
+        output(3, getPrompt() + ConsoleCredentials.mask(trimmedWord));
 
       // THE UNCLOSED BRACE, IF ANY, IS ALWAYS SOMEWHERE INSIDE THE LAST WORD: EVERY SEMICOLON FROM THE BRACE ONWARD FAILED
       // TO SEPARATE ANYTHING, SO THE REST OF THE INPUT WAS NEVER SPLIT
@@ -1237,9 +1326,23 @@ public class Console {
         url.substring((REMOTE_PREFIX + "//").length()) :
         url.substring(REMOTE_PREFIX.length());
 
-    final String[] serverUserPassword = conn.trim().split(" ");
-    if (serverUserPassword.length != 3)
-      throw new ConsoleException("URL username and password are missing");
+    // SPLIT ON RUNS OF WHITESPACE AND STOP AT THE PASSWORD. `split(" ")` PRODUCED AN EMPTY TOKEN FOR EVERY EXTRA BLANK,
+    // AND THE LIMIT KEEPS THE PASSWORD IN ONE PIECE: A PASSWORD CONTAINING A SPACE IS ACCEPTED BY THE SERVER AND BY
+    // STUDIO, SO SUCH AN ACCOUNT MUST NOT BE UNUSABLE FROM THE CONSOLE (ISSUE #6830)
+    final String[] serverUserPassword = conn.trim().split("\\s+", 3);
+    if (serverUserPassword.length < 2)
+      // SAY WHICH HALF IS MISSING RATHER THAN SENDING THE USER LOOKING FOR THE WRONG PROBLEM
+      throw new ConsoleException(
+          "User name is missing, use `" + REMOTE_PREFIX + "<host>[:<port>]" + (needsDatabase ? "/<database>" : "")
+              + " <user> [<password>]`");
+
+    final String userName = serverUserPassword[1];
+    if (userName.isEmpty())
+      throw new ConsoleException("User name is empty");
+
+    // AN OMITTED PASSWORD IS ASKED FOR WITH THE ECHO MASKED, SO IT NEVER APPEARS ON A LINE THAT IS SAVED TO THE HISTORY
+    // FILE OR ECHOED INTO A BUILD LOG (ISSUE #6829)
+    final String password = serverUserPassword.length == 3 ? serverUserPassword[2] : askPassword(userName);
 
     final String[] serverParts = serverUserPassword[0].split("/");
     if ((needsDatabase && serverParts.length != 2) || (!needsDatabase && serverParts.length != 1))
@@ -1257,9 +1360,26 @@ public class Console {
       remotePort = Integer.parseInt(serverParts[0].substring(portPos + 1));
     }
 
-    databaseProxy = new RemoteDatabase(remoteServer, remotePort, needsDatabase ? serverParts[1] : "", serverUserPassword[1],
-        serverUserPassword[2]);
-    this.remoteServer = new RemoteServer(remoteServer, remotePort, serverUserPassword[1], serverUserPassword[2]);
+    databaseProxy = new RemoteDatabase(remoteServer, remotePort, needsDatabase ? serverParts[1] : "", userName, password);
+    this.remoteServer = new RemoteServer(remoteServer, remotePort, userName, password);
+  }
+
+  /**
+   * Reads a password from the terminal with the echo masked.
+   * <p>
+   * This is the only way to authenticate without writing the password down somewhere that outlives the command: the
+   * `connect` syntax carries it inline, the line reader saves every line to `.history`, and batch mode echoes the same
+   * line to stdout (issue #6829). Without a real terminal there is nobody to type it, so the caller gets the same
+   * "password is missing" it would have got before.
+   */
+  private String askPassword(final String userName) {
+    if (batchMode || !systemTerminal)
+      throw new ConsoleException("Password for user '" + userName + "' is missing");
+
+    final String password = getLineReader().readLine("Password for '" + userName + "': ", '*');
+    if (password == null || password.isEmpty())
+      throw new ConsoleException("Password for user '" + userName + "' is empty");
+    return password;
   }
 
   private void flushOutput() {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -270,10 +270,8 @@ public class Console {
         // THREAD'S CACHED TRANSACTION AND RAISES InvalidDatabaseInstanceException WHEN IT BELONGS TO A DIFFERENT
         // LocalDatabase INSTANCE FOR THE SAME PATH - RECONNECTING TO THE SAME DATABASE IN ONE SESSION DOES THAT. A
         // THROW HERE WOULD SKIP THE FLUSH AND THE TWO CLOSES ALL OVER AGAIN, JUST FROM ANOTHER TRIGGER (ISSUE #6828)
-        if (databaseProxy.isTransactionActive()) {
-          currentOperationsInBatch = 0;
+        if (databaseProxy.isTransactionActive())
           databaseProxy.commit();
-        }
       } catch (Throwable t) {
         errored = true;
         outputError(t);
@@ -457,8 +455,9 @@ public class Console {
    * This is the one place in the console where shell-like unescaping is wanted, and since {@link TerminalParser#parse} now
    * keeps the escape characters it sees (issue #6827) it is also the one place that can do it unambiguously: the closing
    * quote is the first UNESCAPED occurrence of the opening one, so {@code 'it\'s a test'} yields {@code it's a test} and
-   * {@code 'a' b'} is still rejected as trailing garbage. Only {@code \'}, {@code \"} and {@code \\} are unescaped - any
-   * other backslash is data and is kept as typed, which is what makes {@code set foo = 'C:\Users'} store the path.
+   * {@code 'a' b'} is still rejected as trailing garbage. Only the quote character that DELIMITS this value and the
+   * backslash itself are unescaped: the other quote character never needed escaping in here, so a backslash in front of
+   * it is data, and so is every other backslash - which is what makes {@code set foo = 'C:\Users'} store the path.
    */
   private static String stripMatchingQuotes(final String value) {
     if (value.isEmpty())
@@ -474,7 +473,7 @@ public class Console {
 
       if (c == '\\' && i + 1 < value.length()) {
         final char next = value.charAt(i + 1);
-        if (next == '\'' || next == '"' || next == '\\') {
+        if (next == quote || next == '\\') {
           content.append(next);
           ++i;
           continue;

--- a/console/src/main/java/com/arcadedb/console/ConsoleCredentials.java
+++ b/console/src/main/java/com/arcadedb/console/ConsoleCredentials.java
@@ -73,13 +73,6 @@ public class ConsoleCredentials {
     return masked.toString();
   }
 
-  /**
-   * Returns true when {@link #mask} would change the text, i.e. when it carries a password in plaintext.
-   */
-  public static boolean carriesPassword(final String text) {
-    return text != null && !text.equals(mask(text));
-  }
-
   private static String maskStatement(final String statement) {
     final String lowerCase = statement.trim().toLowerCase(Locale.ENGLISH);
 

--- a/console/src/main/java/com/arcadedb/console/ConsoleCredentials.java
+++ b/console/src/main/java/com/arcadedb/console/ConsoleCredentials.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.console;
+
+import java.util.Locale;
+
+/**
+ * Hides the plaintext password that the console's own command syntax carries inline, so it does not reach the two places
+ * that outlive the session: the `.history` file the line reader saves after every command, and the command echo that batch
+ * mode writes to stdout - straight into a build log (issue #6829).
+ * <p>
+ * Two command shapes carry a password. Anything that opens a remote connection (`connect`, but also `list databases`,
+ * `create database` and `drop database` against a `remote:` URL) takes it as the third whitespace-separated token after the
+ * URL, and `create user ... identified by ...` takes everything between `identified by` and the optional
+ * `grant connect to`.
+ * <p>
+ * The password is replaced with {@link #MASK} rather than the line being dropped: history keeps the host and the user name,
+ * which is the part worth recalling, and a `***` in a build log says plainly that something was hidden instead of leaving
+ * the reader to wonder whether the command was simply typed without credentials. A recalled masked line is not runnable as
+ * is - it would send `***` as the password - which is why {@code Console} accepts the credentials-less form of both
+ * commands and asks for the password with the echo masked instead.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class ConsoleCredentials {
+  public static final  String   MASK              = "***";
+  private static final String   REMOTE_PREFIX     = "remote:";
+  private static final String   IDENTIFIED_BY     = "identified by";
+  private static final String   GRANT_CONNECT     = "grant connect to";
+  // THE COMMANDS THAT OPEN A REMOTE CONNECTION, I.E. THE ONES Console.execute() ROUTES TO connectToRemoteServer()
+  private static final String[] REMOTE_COMMANDS   = { "connect", "list databases", "create database", "drop database" };
+  private static final String   CREATE_USER       = "create user";
+
+  private ConsoleCredentials() {
+  }
+
+  /**
+   * Returns the text with every inline password replaced by {@link #MASK}, or the text itself when it carries none.
+   * <p>
+   * The text is examined one statement at a time - a console line can carry several, separated by semicolons - and only a
+   * statement that actually starts with a credential-bearing command is touched. Matching on the command keyword rather
+   * than on `remote:` or `identified by` anywhere in the text is what keeps an ordinary
+   * {@code insert into Doc set note = 'identified by the auditor'} from being mangled on its way to the log.
+   */
+  public static String mask(final String text) {
+    if (text == null || text.isEmpty())
+      return text;
+
+    final StringBuilder masked = new StringBuilder(text.length());
+    for (int pos = 0; pos < text.length(); ) {
+      final int end = endOfStatement(text, pos);
+      masked.append(maskStatement(text.substring(pos, end)));
+      if (end < text.length())
+        masked.append(text.charAt(end));
+      pos = end + 1;
+    }
+    return masked.toString();
+  }
+
+  /**
+   * Returns true when {@link #mask} would change the text, i.e. when it carries a password in plaintext.
+   */
+  public static boolean carriesPassword(final String text) {
+    return text != null && !text.equals(mask(text));
+  }
+
+  private static String maskStatement(final String statement) {
+    final String lowerCase = statement.trim().toLowerCase(Locale.ENGLISH);
+
+    for (final String command : REMOTE_COMMANDS)
+      if (lowerCase.startsWith(command))
+        return maskRemoteCredentials(statement);
+
+    if (lowerCase.startsWith(CREATE_USER))
+      return maskIdentifiedBy(statement);
+
+    return statement;
+  }
+
+  /**
+   * Masks the third token after a `remote:` URL: `connect remote:host/db root secret` -&gt; `connect remote:host/db root ***`.
+   * <p>
+   * The mask runs to the end of the statement rather than to the end of that token, because a password is allowed to
+   * contain spaces (issue #6830) and stopping at the first blank would leave the rest of it in the clear.
+   */
+  private static String maskRemoteCredentials(final String statement) {
+    final int urlStart = indexOfRemoteUrl(statement);
+    if (urlStart < 0)
+      return statement;
+
+    // SKIP THE URL, THEN THE USER NAME: WHAT FOLLOWS IS THE PASSWORD
+    int pos = skipBlanks(statement, endOfToken(statement, urlStart));
+    if (pos == statement.length())
+      return statement;
+
+    pos = skipBlanks(statement, endOfToken(statement, pos));
+    if (pos == statement.length())
+      // NO PASSWORD ON THIS LINE: NOTHING TO HIDE
+      return statement;
+
+    int end = statement.length();
+    while (end > pos && Character.isWhitespace(statement.charAt(end - 1)))
+      --end;
+
+    return statement.substring(0, pos) + MASK + statement.substring(end);
+  }
+
+  /**
+   * Masks everything between `identified by` and either `grant connect to` or the end of the statement.
+   */
+  private static String maskIdentifiedBy(final String statement) {
+    final String lowerCase = statement.toLowerCase(Locale.ENGLISH);
+
+    final int identifiedByPos = lowerCase.indexOf(IDENTIFIED_BY);
+    if (identifiedByPos < 0)
+      return statement;
+
+    final int start = skipBlanks(statement, identifiedByPos + IDENTIFIED_BY.length());
+
+    int end = lowerCase.indexOf(GRANT_CONNECT, start);
+    if (end < 0)
+      end = statement.length();
+    // KEEP THE BLANKS THAT SEPARATE THE PASSWORD FROM WHAT FOLLOWS IT
+    while (end > start && Character.isWhitespace(statement.charAt(end - 1)))
+      --end;
+
+    if (end <= start)
+      // THE PASSWORD WAS ALREADY OMITTED
+      return statement;
+
+    return statement.substring(0, start) + MASK + statement.substring(end);
+  }
+
+  /**
+   * Returns the offset of the first `remote:` token of the statement, or -1. Only a token START counts.
+   */
+  private static int indexOfRemoteUrl(final String statement) {
+    final String lowerCase = statement.toLowerCase(Locale.ENGLISH);
+    for (int pos = lowerCase.indexOf(REMOTE_PREFIX); pos >= 0; pos = lowerCase.indexOf(REMOTE_PREFIX, pos + 1))
+      if (pos == 0 || Character.isWhitespace(statement.charAt(pos - 1)))
+        return pos;
+    return -1;
+  }
+
+  private static int skipBlanks(final String text, int pos) {
+    while (pos < text.length() && Character.isWhitespace(text.charAt(pos)))
+      ++pos;
+    return pos;
+  }
+
+  private static int endOfToken(final String text, int pos) {
+    while (pos < text.length() && !Character.isWhitespace(text.charAt(pos)))
+      ++pos;
+    return pos;
+  }
+
+  /**
+   * Returns the offset of the semicolon that ends the statement starting at {@code pos}, or the length of the text when
+   * there is none. A semicolon inside a quoted string does not end anything, and a backslash escapes the character that
+   * follows it, matching how {@link TerminalParser} splits the very same text into commands.
+   */
+  private static int endOfStatement(final String text, final int pos) {
+    char quote = 0;
+    for (int i = pos; i < text.length(); ++i) {
+      final char c = text.charAt(i);
+      if (c == '\\')
+        ++i;
+      else if (quote != 0) {
+        if (c == quote)
+          quote = 0;
+      } else if (c == '\'' || c == '"')
+        quote = c;
+      else if (c == ';')
+        return i;
+    }
+    return text.length();
+  }
+}

--- a/console/src/main/java/com/arcadedb/console/ConsoleCredentials.java
+++ b/console/src/main/java/com/arcadedb/console/ConsoleCredentials.java
@@ -77,13 +77,26 @@ public class ConsoleCredentials {
     final String lowerCase = statement.trim().toLowerCase(Locale.ENGLISH);
 
     for (final String command : REMOTE_COMMANDS)
-      if (lowerCase.startsWith(command))
+      if (startsWithCommand(lowerCase, command))
         return maskRemoteCredentials(statement);
 
-    if (lowerCase.startsWith(CREATE_USER))
+    if (startsWithCommand(lowerCase, CREATE_USER))
       return maskIdentifiedBy(statement);
 
     return statement;
+  }
+
+  /**
+   * Whether the statement's first word(s) ARE this command, rather than merely starting with its letters. The boundary
+   * matters because this list is a mirror of the console's own dispatch and will drift as commands are added: without
+   * it, a future `connect-cluster` would be routed here by the `connect` entry and have its arguments masked as if the
+   * third one were a password.
+   */
+  private static boolean startsWithCommand(final String lowerCaseStatement, final String command) {
+    if (!lowerCaseStatement.startsWith(command))
+      return false;
+    return lowerCaseStatement.length() == command.length()
+        || Character.isWhitespace(lowerCaseStatement.charAt(command.length()));
   }
 
   /**

--- a/console/src/main/java/com/arcadedb/console/TerminalParser.java
+++ b/console/src/main/java/com/arcadedb/console/TerminalParser.java
@@ -38,6 +38,13 @@ import java.util.Locale;
  * split (issue #6392). The opposite typo, a `{` that is never closed, cannot be clamped the same way: the parser genuinely
  * cannot know it is unbalanced until the input ends, so it instead records the offset of that brace for the caller to report
  * once parsing is done (issue #6439).
+ * <p>
+ * The backslash is an escape character for the purpose of tracking quotes and delimiters - an escaped quote does not close a
+ * string and an escaped semicolon does not split a command - but it is <b>kept</b> in the emitted word rather than consumed.
+ * The words this parser produces are handed to the query engine, and the engine, not the console, owns string-literal
+ * escaping: consuming one level here made `insert into Doc set p = 'C:\Users\bob'` store `C:Usersbob`, and made any `.sql`
+ * script using backslash escaping impossible to replay with `load` (issue #6827). The one place where shell-like unescaping
+ * is genuinely wanted is the value of the console's own {@code SET} command, which unescapes it there.
  */
 public class TerminalParser extends DefaultParser {
   private static final String SQL_LINE_COMMENT   = "--";
@@ -150,7 +157,9 @@ public class TerminalParser extends DefaultParser {
           if (rawWordCursor >= 0 && rawWordLength < 0) {
             rawWordLength = i - rawWordStart + 1;
           }
-        } else if (!this.isEscapeChar(line, i)) {
+        } else {
+          // THE ESCAPE CHARACTER IS KEPT: IT IS PART OF THE TEXT HANDED TO THE QUERY ENGINE, WHICH OWNS STRING-LITERAL
+          // ESCAPING. isEscaped() ABOVE ALREADY STOPPED THE ESCAPED QUOTE FROM CLOSING THE STRING (ISSUE #6827)
           current.append(c);
         }
       } else if (this.isDelimiter(line, i) && braceDepth == 0) {
@@ -163,7 +172,7 @@ public class TerminalParser extends DefaultParser {
         }
 
         rawWordStart = i + 1;
-      } else if (!this.isEscapeChar(line, i)) {
+      } else {
         if (c == '{') {
           if (braceDepth == 0)
             openBraceOffset = i;

--- a/console/src/test/java/com/arcadedb/console/ConsoleCredentialsTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleCredentialsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.console;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue https://github.com/ArcadeData/arcadedb/issues/6829: the console persists every typed line to `./.history` and
+ * echoes it to stdout in batch mode, and its own command syntax carries the password inline. These are the rules that
+ * decide what gets hidden.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ConsoleCredentialsTest {
+  @Test
+  void theConnectPasswordIsMasked() {
+    assertThat(ConsoleCredentials.mask("connect remote:localhost/mydb root MySecret1!"))
+        .isEqualTo("connect remote:localhost/mydb root ***");
+    assertThat(ConsoleCredentials.mask("connect remote://localhost:2480/mydb root MySecret1!"))
+        .isEqualTo("connect remote://localhost:2480/mydb root ***");
+    assertThat(ConsoleCredentials.carriesPassword("connect remote:localhost/mydb root MySecret1!")).isTrue();
+  }
+
+  /**
+   * A password is allowed to contain spaces (issue #6830), so the mask has to run to the end of the statement rather
+   * than to the end of the first blank-delimited token.
+   */
+  @Test
+  void aPasswordWithSpacesIsMaskedWhole() {
+    assertThat(ConsoleCredentials.mask("connect remote:localhost/mydb root my secret pass"))
+        .isEqualTo("connect remote:localhost/mydb root ***");
+  }
+
+  @Test
+  void everyCommandThatOpensARemoteConnectionIsMasked() {
+    assertThat(ConsoleCredentials.mask("list databases remote:localhost root MySecret1!"))
+        .isEqualTo("list databases remote:localhost root ***");
+    assertThat(ConsoleCredentials.mask("create database remote:localhost/mydb root MySecret1!"))
+        .isEqualTo("create database remote:localhost/mydb root ***");
+    assertThat(ConsoleCredentials.mask("drop database remote:localhost/mydb root MySecret1!"))
+        .isEqualTo("drop database remote:localhost/mydb root ***");
+  }
+
+  @Test
+  void theCreateUserPasswordIsMaskedWithAndWithoutTheGrantClause() {
+    assertThat(ConsoleCredentials.mask("create user bob identified by MySecret1!"))
+        .isEqualTo("create user bob identified by ***");
+    assertThat(ConsoleCredentials.mask("create user bob identified by MySecret1! grant connect to mydb"))
+        .isEqualTo("create user bob identified by *** grant connect to mydb");
+    assertThat(ConsoleCredentials.mask("CREATE USER bob IDENTIFIED BY MySecret1! GRANT CONNECT TO mydb"))
+        .isEqualTo("CREATE USER bob IDENTIFIED BY *** GRANT CONNECT TO mydb");
+  }
+
+  @Test
+  void aCommandCarryingNoPasswordIsReturnedUnchanged() {
+    for (final String command : new String[] { "select from V", "connect mydb", "connect remote:localhost/mydb root",
+        "create user bob identified by", "", "close" }) {
+      assertThat(ConsoleCredentials.mask(command)).isEqualTo(command);
+      assertThat(ConsoleCredentials.carriesPassword(command)).isFalse();
+    }
+    assertThat(ConsoleCredentials.mask(null)).isNull();
+  }
+
+  /**
+   * The masking runs over whole console lines, which can carry several statements. Matching on the command keyword of
+   * each statement rather than on `remote:` or `identified by` anywhere in the text is what keeps an ordinary insert
+   * from being mangled on its way to the log.
+   */
+  @Test
+  void onlyTheCredentialBearingStatementOfALineIsTouched() {
+    assertThat(ConsoleCredentials.mask("connect remote:localhost/mydb root MySecret1!; select from V"))
+        .isEqualTo("connect remote:localhost/mydb root ***; select from V");
+    assertThat(ConsoleCredentials.mask("close; connect remote:localhost/mydb root MySecret1!"))
+        .isEqualTo("close; connect remote:localhost/mydb root ***");
+
+    final String insert = "insert into Doc set note = 'identified by the auditor', url = ' remote:h root p'";
+    assertThat(ConsoleCredentials.mask(insert)).isEqualTo(insert);
+  }
+
+  /**
+   * A semicolon inside a string literal does not end a statement, exactly as {@link TerminalParser} sees it, so the
+   * mask must not stop there and leave the rest of the password in the clear.
+   */
+  @Test
+  void aSemicolonInsideThePasswordDoesNotEndTheStatement() {
+    assertThat(ConsoleCredentials.mask("connect remote:localhost/mydb root 'a;b'"))
+        .isEqualTo("connect remote:localhost/mydb root ***");
+  }
+
+  /**
+   * Masking twice must not produce `***` for the mask itself: the history file is loaded and re-added on every session.
+   */
+  @Test
+  void maskingIsIdempotent() {
+    final String masked = ConsoleCredentials.mask("connect remote:localhost/mydb root MySecret1!");
+    assertThat(ConsoleCredentials.mask(masked)).isEqualTo(masked);
+  }
+}

--- a/console/src/test/java/com/arcadedb/console/ConsoleCredentialsTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleCredentialsTest.java
@@ -36,7 +36,6 @@ class ConsoleCredentialsTest {
         .isEqualTo("connect remote:localhost/mydb root ***");
     assertThat(ConsoleCredentials.mask("connect remote://localhost:2480/mydb root MySecret1!"))
         .isEqualTo("connect remote://localhost:2480/mydb root ***");
-    assertThat(ConsoleCredentials.carriesPassword("connect remote:localhost/mydb root MySecret1!")).isTrue();
   }
 
   /**
@@ -74,7 +73,6 @@ class ConsoleCredentialsTest {
     for (final String command : new String[] { "select from V", "connect mydb", "connect remote:localhost/mydb root",
         "create user bob identified by", "", "close" }) {
       assertThat(ConsoleCredentials.mask(command)).isEqualTo(command);
-      assertThat(ConsoleCredentials.carriesPassword(command)).isFalse();
     }
     assertThat(ConsoleCredentials.mask(null)).isNull();
   }
@@ -103,6 +101,17 @@ class ConsoleCredentialsTest {
   void aSemicolonInsideThePasswordDoesNotEndTheStatement() {
     assertThat(ConsoleCredentials.mask("connect remote:localhost/mydb root 'a;b'"))
         .isEqualTo("connect remote:localhost/mydb root ***");
+  }
+
+  /**
+   * The masker keys off the command keyword, so it deliberately does NOT recognise a bare password typed on its own -
+   * which is exactly what the masked `Password for 'root': ` prompt reads. That line must therefore be kept out of the
+   * history by disabling the history around the read (see {@code Console.askPassword}), never by hoping this class will
+   * catch it: there is nothing in `MySecret1!` to key off.
+   */
+  @Test
+  void aBarePasswordIsNotRecognisedAndMustNotBeLeftToThisClass() {
+    assertThat(ConsoleCredentials.mask("MySecret1!")).isEqualTo("MySecret1!");
   }
 
   /**

--- a/console/src/test/java/com/arcadedb/console/ConsoleCredentialsTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleCredentialsTest.java
@@ -115,6 +115,19 @@ class ConsoleCredentialsTest {
   }
 
   /**
+   * The command list mirrors the console's own dispatch and will drift as commands are added, so it matches whole words
+   * rather than prefixes: a future `connect-cluster` must not be routed to the `connect` rule and have its third
+   * argument masked as if it were a password.
+   */
+  @Test
+  void aCommandThatMerelySharesAPrefixIsNotTreatedAsThatCommand() {
+    assertThat(ConsoleCredentials.mask("connect-cluster somehost alpha beta"))
+        .isEqualTo("connect-cluster somehost alpha beta");
+    assertThat(ConsoleCredentials.mask("create username bob identified by x"))
+        .isEqualTo("create username bob identified by x");
+  }
+
+  /**
    * Masking twice must not produce `***` for the mask itself: the history file is loaded and re-added on every session.
    */
   @Test

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -1092,4 +1092,22 @@ class ConsoleTest {
     assertThatThrownBy(() -> console.parse("connect remote:localhost:1/mydb root"))
         .hasMessageContaining("Password for user 'root' is missing");
   }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6829: a malformed remote URL used to be reported by echoing the
+   * whole argument back, password and all - into the interactive output, and into the build log in batch mode, where it
+   * outlives the session just like the history file does. The message must name the address and nothing else.
+   */
+  @Test
+  void aMalformedRemoteUrlIsReportedWithoutTheInlinePassword() throws Exception {
+    final StringBuilder buffer = new StringBuilder();
+    console.setOutput(buffer::append);
+
+    // NO DATABASE IN THE URL, WHICH `connect` REQUIRES: THE ADDRESS FAILS TO SPLIT
+    assertThatThrownBy(() -> console.parse("connect remote:localhost:1 root MySecret1!"))
+        .hasMessageContaining("localhost:1")
+        .hasMessageNotContaining("MySecret1!");
+
+    assertThat(buffer.toString()).as("the reported error reaches the output too").doesNotContain("MySecret1!");
+  }
 }

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.index.IndexCursor;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import com.arcadedb.server.TestServerHelper;
@@ -978,5 +979,117 @@ class ConsoleTest {
 
     assertThat(console.getDatabase().query("sql", "SELECT count(*) AS count FROM index:`doc[num]`").next()
         .<Long>getProperty("count")).isEqualTo(3);
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6827: a backslash could not be typed from the console at all.
+   * The parser consumed one level of escaping before the statement reached the engine, and the engine's own string
+   * literals require `\\` for a literal backslash - so the correctly escaped `'C:\\\\Users\\\\bob'` arrived at the engine as
+   * `'C:\\Users\\bob'` and failed to even tokenize, while the under-escaped `'C:\\Users\\bob'` arrived as `'C:Usersbob'` and
+   * was stored, wrong, with no warning at all.
+   */
+  @Test
+  void aBackslashSurvivesTheConsoleAndReachesTheEngine() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type Doc")).isTrue();
+    assertThat(console.parse("insert into Doc set winPath = 'C:\\\\Users\\\\bob', re = '\\\\d+'")).isTrue();
+
+    final Result record = console.getDatabase().query("sql", "select winPath, re from Doc").next();
+    assertThat(record.<String>getProperty("winPath")).isEqualTo("C:\\Users\\bob");
+    assertThat(record.<String>getProperty("re")).isEqualTo("\\d+");
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6828: `close()` ran four steps under one
+   * `catch (Throwable) { // IGNORE }` and the first one committed on a batch counter that nothing reset. Once the
+   * transaction is gone - here through an explicit `commit` - that first step threw and took the terminal flush, the
+   * database close and the factory close down with it.
+   */
+  @Test
+  void closeStillReleasesTheDatabaseAfterAnExplicitCommitEndedTheBatch() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type Doc")).isTrue();
+    assertThat(console.parse("set transactionBatchSize = 100")).isTrue();
+    assertThat(console.parse("insert into Doc set n = 1")).isTrue();
+    assertThat(console.parse("commit")).isTrue();
+
+    assertThat(console.currentOperationsInBatch).as("the committed batch must not be committed a second time").isZero();
+
+    console.close();
+
+    assertThat(console.getDatabase()).as("close() must release the database even when the first step fails").isNull();
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6828: the same defect on the default batch path, where `exit`
+   * closes the database and nulls the proxy before the `finally console.close()` runs, so the stale counter made the
+   * first step throw a NullPointerException.
+   */
+  @Test
+  void closeAfterExitIsANoOpRatherThanANullPointer() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type Doc")).isTrue();
+    assertThat(console.parse("set transactionBatchSize = 100")).isTrue();
+    assertThat(console.parse("insert into Doc set n = 1")).isTrue();
+    assertThat(console.parse("exit")).isFalse();
+
+    assertThat(console.getDatabase()).isNull();
+    assertThat(console.currentOperationsInBatch).isZero();
+    assertThatCode(() -> console.close()).doesNotThrowAnyException();
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6830: `connect remote:` split the credentials on a single space
+   * and demanded exactly three tokens, so a run of blanks and a password containing a space - both of which the server
+   * accepts - failed with "URL username and password are missing", pointing the user at the wrong problem.
+   */
+  @Test
+  void connectAcceptsExtraBlanksAndReportsWhichHalfIsMissing() throws Exception {
+    // NOTHING IS CONTACTED HERE: RemoteDatabase RESOLVES THE SERVER LAZILY, SO THIS EXERCISES THE PARSING ALONE. BOTH
+    // FORMS USED TO FAIL WITH "URL username and password are missing" ALTHOUGH BOTH VALUES ARE PRESENT
+    assertThatCode(() -> console.parse("connect remote:localhost:1/mydb  root   secret")).doesNotThrowAnyException();
+    assertThat(console.getDatabase().getName()).isEqualTo("mydb");
+    assertThat(console.parse("close")).isTrue();
+
+    assertThatCode(() -> console.parse("connect remote:localhost:1/mydb root my pass phrase")).doesNotThrowAnyException();
+    assertThat(console.getDatabase().getName()).isEqualTo("mydb");
+    assertThat(console.parse("close")).isTrue();
+
+    assertThatThrownBy(() -> console.parse("connect remote:localhost:1/mydb"))
+        .hasMessageContaining("User name is missing");
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6827: a script replayed with `load` lost its backslashes too.
+   * The reader compensated for the parser by doubling every `\\` it read, which cancelled out only for an EVEN number of
+   * them - a lone backslash was still swallowed - and did nothing about the level the parser consumed from the rest.
+   */
+  @Test
+  void aLoadedScriptKeepsItsBackslashes() throws Exception {
+    final File script = new File("./target/issue6827-load.sql");
+    Files.writeString(script.toPath(), """
+        CREATE DOCUMENT TYPE Loaded;
+        INSERT INTO Loaded SET winPath = 'C:\\\\Users\\\\bob', re = '\\\\d+';
+        """);
+    try {
+      assertThat(console.parse("connect " + DB_NAME)).isTrue();
+      assertThat(console.parse("load " + script.getAbsolutePath().replace('\\', '/'))).isTrue();
+
+      final Result record = console.getDatabase().query("sql", "select winPath, re from Loaded").next();
+      assertThat(record.<String>getProperty("winPath")).isEqualTo("C:\\Users\\bob");
+      assertThat(record.<String>getProperty("re")).isEqualTo("\\d+");
+    } finally {
+      script.delete();
+    }
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6829: without a terminal to type into, an omitted password is
+   * still an error - but it names what is missing instead of claiming the user name is missing too.
+   */
+  @Test
+  void connectWithoutAPasswordAndWithoutATerminalSaysSo() {
+    assertThatThrownBy(() -> console.parse("connect remote:localhost:1/mydb root"))
+        .hasMessageContaining("Password for user 'root' is missing");
   }
 }

--- a/console/src/test/java/com/arcadedb/console/TerminalParserTest.java
+++ b/console/src/test/java/com/arcadedb/console/TerminalParserTest.java
@@ -195,4 +195,53 @@ class TerminalParserTest {
     split("SELECT '{' ; SELECT 1");
     assertThat(parser.getUnbalancedBraceOffset()).isEqualTo(-1);
   }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6827: the parser used to consume one level of backslash escaping
+   * from every word before handing it to the query engine, so `'C:\Users\bob'` arrived as `'C:Usersbob'` and was stored
+   * that way - silently, with no warning and no error. The engine, not the console, owns string-literal escaping, so the
+   * backslash has to reach it as typed.
+   */
+  @Test
+  void aBackslashInsideAStringReachesTheEngineAsTyped() {
+    assertThat(split("insert into Doc set winPath = 'C:\\Users\\bob'"))
+        .containsExactly("insert into Doc set winPath = 'C:\\Users\\bob'");
+  }
+
+  /**
+   * Not only inside string literals: `load` takes a file path, and a Windows one is nothing but backslashes.
+   */
+  @Test
+  void aBackslashOutsideAStringIsKeptToo() {
+    assertThat(split("load C:\\scripts\\init.sql")).containsExactly("load C:\\scripts\\init.sql");
+  }
+
+  /**
+   * The escape character keeps doing its structural job: an escaped quote must not close the string, otherwise the rest
+   * of the statement would be parsed as if it were outside one.
+   */
+  @Test
+  void anEscapedQuoteStillDoesNotCloseTheStringAndKeepsItsBackslash() {
+    assertThat(split("select from V where name = 'it\\'s'; select 1"))
+        .containsExactly("select from V where name = 'it\\'s'", " select 1");
+  }
+
+  @Test
+  void anEscapedSemicolonStillDoesNotSplitTheCommand() {
+    assertThat(split("select 'a' \\; select 'b'")).containsExactly("select 'a' \\; select 'b'");
+  }
+
+  /**
+   * A doubled backslash is a single escaped backslash: it used to collapse to one, which turned the literal
+   * `'\\'` a user typed for a single backslash into an unterminated-looking oddity for the engine.
+   */
+  @Test
+  void aDoubledBackslashIsNotCollapsed() {
+    assertThat(split("insert into Doc set sep = '\\\\'")).containsExactly("insert into Doc set sep = '\\\\'");
+  }
+
+  @Test
+  void aTrailingBackslashIsKept() {
+    assertThat(split("select from V where p = 'a\\")).containsExactly("select from V where p = 'a\\");
+  }
 }

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -513,24 +513,6 @@ public class FileUtils {
     return result.toString();
   }
 
-  public static String decodeFromFile(final String line) {
-    final StringBuilder decodedLine = new StringBuilder();
-    boolean backslash = false;
-    for (int i = 0; i < line.length(); i++) {
-      char c = line.charAt(i);
-      if (c == '\\') {
-        if (backslash) {
-          backslash = false;
-          decodedLine.append("\\\\\\");
-          continue;
-        } else
-          backslash = true;
-      }
-      decodedLine.append(c);
-    }
-    return decodedLine.toString();
-  }
-
   public static byte[] readInputStreamAsBytes(final InputStream fis) throws IOException {
     return fis.readAllBytes();
   }

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -910,12 +910,16 @@ public class ArcadeDBServer {
    * callbacks in either order. Plugins are therefore told to reconcile against the registry as it is now instead of
    * replaying the event, which is what {@code AutoBackupSchedulerPlugin} does. A plugin that throws is logged and
    * skipped: the mutation has already happened and cannot be undone by a failing listener.
+   * <p>
+   * Only the plugins that have been configured are notified. Discovery installs every plugin instance up front, but
+   * {@link #loadDatabases()} runs before {@code startPlugins(AFTER_DATABASES_OPEN)}, so a plugin of that priority was
+   * being handed a registration per pre-existing database before it had even been given this server (issue #6852).
    */
   private void notifyPlugins(final String databaseName, final boolean registered) {
     if (pluginManager == null)
       return;
 
-    for (final ServerPlugin plugin : pluginManager.getPlugins()) {
+    for (final ServerPlugin plugin : pluginManager.getInitializedPlugins()) {
       try {
         if (registered)
           plugin.onDatabaseRegistered(databaseName);

--- a/server/src/main/java/com/arcadedb/server/ServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/ServerPlugin.java
@@ -58,6 +58,11 @@ public interface ServerPlugin {
    * demand or re-registered by the HA snapshot installer. A plugin that keeps per-database state (a schedule, a
    * cache, a listener) uses this to pick up a database that did not exist when the plugin started.
    * <p>
+   * Delivered only between {@link #configure} and {@link #stopService}: outside that window a plugin does not hold the
+   * server it would have to reconcile against, and a plugin of the {@code AFTER_DATABASES_OPEN} priority is installed
+   * long before the databases it will manage are opened (issue #6852). Everything that existed at
+   * {@link #startService} time is the plugin's own job to pick up there.
+   * <p>
    * Called on the thread that performed the registration, which may still hold the server's database lock, so the
    * implementation has to be short and non-blocking. The callback is dispatched after the registry mutation rather
    * than under its lock, so two concurrent mutations of the same name can deliver their callbacks in either order:

--- a/server/src/main/java/com/arcadedb/server/backup/AutoBackupSchedulerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/backup/AutoBackupSchedulerPlugin.java
@@ -235,6 +235,12 @@ public class AutoBackupSchedulerPlugin implements ServerPlugin {
     // that interleave their read and their write can otherwise let the stale one land last, which is exactly the
     // outcome reconciling was meant to rule out.
     synchronized (lifecycleLock) {
+      // NOTHING TO RECONCILE BEFORE startService() HAS PUBLISHED A SCHEDULER: scheduleAllDatabases() COVERS EVERY
+      // DATABASE THAT EXISTS BY THEN. THE CHECK COMES FIRST BECAUSE IT IS ALSO THE ONE THAT DOES NOT NEED `server`,
+      // WHICH IS ONLY SET BY configure() (ISSUE #6852)
+      if (!enabled || scheduler == null)
+        return;
+
       if (server.existsDatabase(databaseName))
         scheduleDatabase(databaseName);
       else

--- a/server/src/main/java/com/arcadedb/server/plugin/PluginDescriptor.java
+++ b/server/src/main/java/com/arcadedb/server/plugin/PluginDescriptor.java
@@ -33,11 +33,16 @@ public class PluginDescriptor {
   private final ClassLoader  classLoader;
   private       ServerPlugin pluginInstance;
   private       boolean      started;
+  // WHETHER configure() HAS RETURNED, I.E. WHETHER THE PLUGIN HOLDS ITS SERVER REFERENCE YET. `started` CANNOT ANSWER
+  // THAT QUESTION: IT IS ONLY SET AFTER startService() RETURNS AND ONLY WHEN THE PLUGIN REPORTS ITSELF ACTIVE, SO A
+  // PLUGIN REGISTERING ITS OWN DATABASES FROM startService() WOULD BE HIDDEN FROM ITS OWN CALLBACKS (ISSUE #6852)
+  private       boolean      initialized;
 
   public PluginDescriptor(final String pluginName, final ClassLoader classLoader) {
     this.pluginName = Objects.requireNonNull(pluginName, "Plugin name cannot be null");
     this.classLoader = Objects.requireNonNull(classLoader, "Class loader cannot be null");
     this.started = false;
+    this.initialized = false;
   }
 
   public String getPluginName() {
@@ -64,10 +69,23 @@ public class PluginDescriptor {
     this.started = started;
   }
 
+  /**
+   * Returns true once {@link ServerPlugin#configure} has returned for this plugin, i.e. once it may be handed the
+   * server's lifecycle callbacks.
+   */
+  public boolean isInitialized() {
+    return initialized;
+  }
+
+  public void setInitialized(final boolean initialized) {
+    this.initialized = initialized;
+  }
+
   @Override
   public String toString() {
     return "PluginDescriptor{" +
         "pluginName='" + pluginName + '\'' +
+        ", initialized=" + initialized +
         ", started=" + started +
         '}';
   }

--- a/server/src/main/java/com/arcadedb/server/plugin/PluginDescriptor.java
+++ b/server/src/main/java/com/arcadedb/server/plugin/PluginDescriptor.java
@@ -35,8 +35,12 @@ public class PluginDescriptor {
   private       boolean      started;
   // WHETHER configure() HAS RETURNED, I.E. WHETHER THE PLUGIN HOLDS ITS SERVER REFERENCE YET. `started` CANNOT ANSWER
   // THAT QUESTION: IT IS ONLY SET AFTER startService() RETURNS AND ONLY WHEN THE PLUGIN REPORTS ITSELF ACTIVE, SO A
-  // PLUGIN REGISTERING ITS OWN DATABASES FROM startService() WOULD BE HIDDEN FROM ITS OWN CALLBACKS (ISSUE #6852)
-  private       boolean      initialized;
+  // PLUGIN REGISTERING ITS OWN DATABASES FROM startService() WOULD BE HIDDEN FROM ITS OWN CALLBACKS (ISSUE #6852).
+  // VOLATILE, UNLIKE `started`: THIS ONE IS WRITTEN BY THE STARTING THREAD AND READ BY WHICHEVER THREAD REGISTERS A
+  // DATABASE, WHICH IS ANY HTTP OR HA THREAD. startPlugins() DELIBERATELY DOES NOT HOLD THE `plugins` MONITOR ACROSS
+  // THE PLUGIN LIFECYCLE CALLS (THEY CAN BLOCK), SO THE MONITOR getInitializedPlugins() TAKES ORDERS NOTHING AGAINST
+  // THIS WRITE, AND A READER SEEING A STALE false WOULD SILENTLY DROP THE CALLBACK ISSUE #6752 EXISTS TO DELIVER
+  private volatile boolean   initialized;
 
   public PluginDescriptor(final String pluginName, final ClassLoader classLoader) {
     this.pluginName = Objects.requireNonNull(pluginName, "Plugin name cannot be null");

--- a/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
+++ b/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
@@ -247,6 +247,10 @@ public class PluginManager {
 
           // Configure and start the plugin
           plugin.configure(server, configuration);
+          // FROM HERE ON THE PLUGIN HOLDS ITS SERVER REFERENCE, SO IT CAN TAKE THE DATABASE LIFECYCLE CALLBACKS. MARKING
+          // IT BEFORE startService() IS DELIBERATE: A PLUGIN THAT OPENS OR REGISTERS DATABASES WHILE STARTING MUST SEE
+          // ITS OWN REGISTRATIONS (ISSUE #6852)
+          descriptor.setInitialized(true);
           try {
             plugin.startService();
           } catch (final Exception | Error e) {
@@ -269,6 +273,9 @@ public class PluginManager {
           currentThread.setContextClassLoader(originalClassLoader);
         }
       } catch (final Exception e) {
+        // THE PLUGIN NEVER CAME UP: STOP DELIVERING LIFECYCLE CALLBACKS TO IT, ITS STATE IS WHATEVER THE FAILED START
+        // LEFT BEHIND
+        descriptor.setInitialized(false);
         throw new ServerException("Error starting plugin: " + pluginName + " (priority: " + priority + ")", e);
       }
     }
@@ -302,6 +309,7 @@ public class PluginManager {
         CodeUtils.executeIgnoringExceptions(plugin::stopService,
             "Error stopping plugin: " + pluginName, false);
         descriptor.setStarted(false);
+        descriptor.setInitialized(false);
       } finally {
         currentThread.setContextClassLoader(originalClassLoader);
       }
@@ -338,6 +346,26 @@ public class PluginManager {
           result.add(descriptor.getPluginInstance());
         }
       }
+    }
+    return Collections.unmodifiableCollection(result);
+  }
+
+  /**
+   * Returns the plugins whose {@link ServerPlugin#configure} has already returned, in registration order.
+   * <p>
+   * This is the audience for the database lifecycle callbacks, and it is deliberately narrower than
+   * {@link #getPlugins()}: discovery installs every plugin instance long before the first one is configured, and
+   * databases are opened in between. A plugin that runs {@code AFTER_DATABASES_OPEN} therefore used to be handed a
+   * registration for every pre-existing database while its own {@code server} field was still null - ten databases, ten
+   * NullPointerException stack traces at every single startup (issue #6852). It also stops after a plugin is stopped,
+   * so a callback from a late shutdown step cannot reach a plugin that has already released its state.
+   */
+  public Collection<ServerPlugin> getInitializedPlugins() {
+    final List<ServerPlugin> result = new ArrayList<>();
+    synchronized (plugins) {
+      for (final PluginDescriptor descriptor : plugins.values())
+        if (descriptor.isInitialized() && descriptor.getPluginInstance() != null)
+          result.add(descriptor.getPluginInstance());
     }
     return Collections.unmodifiableCollection(result);
   }

--- a/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
+++ b/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
@@ -272,6 +272,13 @@ public class PluginManager {
         } finally {
           currentThread.setContextClassLoader(originalClassLoader);
         }
+      } catch (final Error e) {
+        // THE INNER HANDLER RETHROWS `Exception | Error`, AND A PLUGIN JAR MISSING A CLASS FAILS WITH THE SECOND ONE.
+        // CATCHING ONLY Exception HERE WOULD LEAVE THE DESCRIPTOR INITIALIZED AFTER stopService() HAS ALREADY RELEASED
+        // THE PLUGIN'S STATE, SO LIFECYCLE CALLBACKS WOULD KEEP ARRIVING AT IT. RETHROWN UNWRAPPED: AN Error IS NOT
+        // THIS LAYER'S TO REINTERPRET
+        descriptor.setInitialized(false);
+        throw e;
       } catch (final Exception e) {
         // THE PLUGIN NEVER CAME UP: STOP DELIVERING LIFECYCLE CALLBACKS TO IT, ITS STATE IS WHATEVER THE FAILED START
         // LEFT BEHIND

--- a/server/src/test/java/com/arcadedb/server/backup/Issue6852AutoBackupUnconfiguredCallbackTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue6852AutoBackupUnconfiguredCallbackTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Issue #6852. The server no longer notifies a plugin before it has been configured, but the plugin must survive such a
+ * callback on its own too: it is the one that logged ten SEVERE stack traces per startup, and a lifecycle callback is
+ * announced from whichever thread mutated the registry, so "nobody would call it that early" is not something this class
+ * can assume. With no scheduler published there is simply nothing to reconcile - {@code startService()} schedules
+ * everything that exists by then - so the callback has to be a no-op rather than a dereference of a null server.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6852AutoBackupUnconfiguredCallbackTest {
+  @Test
+  void lifecycleCallbacksOnAnUnconfiguredPluginAreANoOp() {
+    final AutoBackupSchedulerPlugin plugin = new AutoBackupSchedulerPlugin();
+
+    assertThatCode(() -> plugin.onDatabaseRegistered("neverConfigured")).doesNotThrowAnyException();
+    assertThatCode(() -> plugin.onDatabaseUnregistered("neverConfigured")).doesNotThrowAnyException();
+    assertThatCode(() -> plugin.scheduleDatabase("neverConfigured")).doesNotThrowAnyException();
+    assertThatCode(() -> plugin.cancelDatabase("neverConfigured")).doesNotThrowAnyException();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/plugin/DatabaseLifecycleTestPlugin.java
+++ b/server/src/test/java/com/arcadedb/server/plugin/DatabaseLifecycleTestPlugin.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.plugin;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerPlugin;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Records the database lifecycle callbacks it receives, together with how far its own initialization had got when each
+ * one arrived. It runs at {@link PluginInstallationPriority#AFTER_DATABASES_OPEN}, the priority whose plugins the server
+ * used to notify about every pre-existing database before handing them the server itself (issue #6852).
+ * <p>
+ * Not auto-discovered: it is installed only by a test that names it in {@code SERVER_PLUGINS}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class DatabaseLifecycleTestPlugin implements ServerPlugin {
+  /** One recorded callback: what happened, to which database, and what the plugin held at that moment. */
+  public record Callback(String event, String databaseName, boolean hadServer, boolean hadStarted) {
+  }
+
+  private final List<Callback> callbacks = new CopyOnWriteArrayList<>();
+  private       ArcadeDBServer server;
+  private       boolean        started;
+
+  @Override
+  public void configure(final ArcadeDBServer arcadeDBServer, final ContextConfiguration configuration) {
+    this.server = arcadeDBServer;
+  }
+
+  @Override
+  public void startService() {
+    started = true;
+  }
+
+  @Override
+  public void stopService() {
+    started = false;
+  }
+
+  @Override
+  public PluginInstallationPriority getInstallationPriority() {
+    return PluginInstallationPriority.AFTER_DATABASES_OPEN;
+  }
+
+  @Override
+  public void onDatabaseRegistered(final String databaseName) {
+    callbacks.add(new Callback("registered", databaseName, server != null, started));
+  }
+
+  @Override
+  public void onDatabaseUnregistered(final String databaseName) {
+    callbacks.add(new Callback("unregistered", databaseName, server != null, started));
+  }
+
+  public List<Callback> getCallbacks() {
+    return callbacks;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/plugin/Issue6852PluginLifecycleBeforeConfigureTest.java
+++ b/server/src/test/java/com/arcadedb/server/plugin/Issue6852PluginLifecycleBeforeConfigureTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.plugin;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerPlugin;
+import com.arcadedb.server.StaticBaseServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6852. Plugin discovery installs every plugin instance up front, but {@code loadDatabases()} runs before
+ * {@code startPlugins(AFTER_DATABASES_OPEN)}: a plugin of that priority was therefore handed a "database registered"
+ * callback for every database already on disk while its own {@code server} field was still null. In a deployment with
+ * ten databases that meant ten SEVERE NullPointerException stack traces at every single startup, from
+ * {@code AutoBackupSchedulerPlugin.syncDatabase} -&gt; {@code this.server.existsDatabase(...)}.
+ * <p>
+ * The fix narrows the notification audience to the plugins whose {@code configure()} has returned. This test pins both
+ * halves: nothing arrives before {@code configure()}, and everything that happens afterwards still does - muting the
+ * callbacks entirely would "fix" the stack traces by re-breaking issue #6752.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6852PluginLifecycleBeforeConfigureTest extends StaticBaseServerTest {
+  private static final String DATABASE_DIRECTORY = "./target/databases";
+  private static final String EXISTING_DATABASE  = "issue6852existing";
+  private static final String RUNTIME_DATABASE   = "issue6852runtime";
+
+  @Test
+  void aPluginIsNotNotifiedBeforeItHasBeenConfigured() {
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue(DATABASE_DIRECTORY);
+
+    // A DATABASE THAT ALREADY EXISTS WHEN THE SERVER STARTS: THIS IS WHAT loadDatabases() REGISTERS, AND WHAT USED TO
+    // BE ANNOUNCED TO A PLUGIN THAT HAD NOT BEEN CONFIGURED YET
+    try (final Database db = new DatabaseFactory(DATABASE_DIRECTORY + File.separator + EXISTING_DATABASE).create()) {
+      db.getSchema().createDocumentType("Doc");
+    }
+
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_NAME, "ArcadeDB_0");
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, DATABASE_DIRECTORY);
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, DEFAULT_PASSWORD_FOR_TESTS);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_INCOMING_HOST, "localhost");
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS,
+        "lifecycle-recorder:" + DatabaseLifecycleTestPlugin.class.getName());
+
+    final ArcadeDBServer server = new ArcadeDBServer(config);
+    server.start();
+    try {
+      final DatabaseLifecycleTestPlugin plugin = findPlugin(server);
+      assertThat(server.getDatabaseNames()).contains(EXISTING_DATABASE);
+
+      // THE BUG: ONE CALLBACK PER PRE-EXISTING DATABASE, EVERY ONE OF THEM WITH A NULL SERVER
+      assertThat(plugin.getCallbacks())
+          .as("no callback may be delivered before configure() has handed the plugin its server")
+          .allMatch(DatabaseLifecycleTestPlugin.Callback::hadServer);
+      assertThat(plugin.getCallbacks())
+          .as("the databases open at startup are the plugin's own job to pick up in startService()")
+          .noneMatch(c -> EXISTING_DATABASE.equals(c.databaseName()));
+
+      // ...AND THE CALLBACKS THE PLUGIN IS ACTUALLY THERE FOR STILL ARRIVE (ISSUE #6752)
+      server.createDatabase(RUNTIME_DATABASE, ComponentFile.MODE.READ_WRITE);
+      assertThat(plugin.getCallbacks()).anyMatch(c -> c.event().equals("registered")
+          && c.databaseName().equals(RUNTIME_DATABASE) && c.hadServer() && c.hadStarted());
+
+      server.getDatabase(RUNTIME_DATABASE).getEmbedded().drop();
+      server.removeDatabase(RUNTIME_DATABASE);
+      assertThat(plugin.getCallbacks()).anyMatch(c -> c.event().equals("unregistered")
+          && c.databaseName().equals(RUNTIME_DATABASE) && c.hadServer() && c.hadStarted());
+    } finally {
+      server.stop();
+    }
+  }
+
+  private static DatabaseLifecycleTestPlugin findPlugin(final ArcadeDBServer server) {
+    for (final ServerPlugin plugin : server.getPlugins())
+      if (plugin instanceof final DatabaseLifecycleTestPlugin recorder)
+        return recorder;
+    throw new AssertionError("the lifecycle recorder plugin was not installed");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/plugin/PluginManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/plugin/PluginManagerTest.java
@@ -321,6 +321,58 @@ class PluginManagerTest {
     assertThat(LeakyFailingPlugin.stopped.get()).isFalse();
   }
 
+  /**
+   * Issue #6852: the lifecycle callbacks go only to the plugins whose {@code configure()} has returned, so a plugin
+   * whose start FAILED must have that flag cleared again - otherwise the callbacks keep arriving at a plugin whose
+   * {@code stopService()} has already released its state. {@code startService()} rethrows both {@code Exception} and
+   * {@code Error}, and a plugin jar missing a class fails with the second one, so both paths have to clear it.
+   */
+  @Test
+  void aPluginThatFailsToStartStopsReceivingLifecycleCallbacks() {
+    LeakyFailingPlugin.stopped.set(false);
+    pluginManager.registerPlugin("leaky-failing-plugin", new LeakyFailingPlugin());
+
+    assertThatExceptionOfType(ServerException.class).isThrownBy(
+        () -> pluginManager.startPlugins(ServerPlugin.PluginInstallationPriority.BEFORE_HTTP_ON));
+
+    assertThat(pluginManager.getPluginDescriptor("leaky-failing-plugin").isInitialized()).isFalse();
+    assertThat(pluginManager.getInitializedPlugins()).isEmpty();
+  }
+
+  @Test
+  void aPluginThatFailsToStartWithAnErrorAlsoStopsReceivingLifecycleCallbacks() {
+    ErroringPlugin.stopped.set(false);
+    pluginManager.registerPlugin("erroring-plugin", new ErroringPlugin());
+
+    // THE Error REACHES THE CALLER UNWRAPPED: IT IS NOT THIS LAYER'S TO REINTERPRET
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(
+        () -> pluginManager.startPlugins(ServerPlugin.PluginInstallationPriority.BEFORE_HTTP_ON))
+        .withMessageContaining("Plugin failed to start with an Error");
+
+    assertThat(ErroringPlugin.stopped.get()).as("issue #6762: the resources are released either way").isTrue();
+    assertThat(pluginManager.getPluginDescriptor("erroring-plugin").isInitialized()).isFalse();
+    assertThat(pluginManager.getInitializedPlugins()).isEmpty();
+  }
+
+  /**
+   * Issue #6852: a plugin that started normally IS in the lifecycle audience, and one that has been stopped is not.
+   */
+  @Test
+  void onlyTheConfiguredPluginsAreInTheLifecycleAudience() {
+    final TestPlugin1 plugin = new TestPlugin1();
+    pluginManager.registerPlugin("manual-plugin", plugin);
+
+    // DISCOVERED BUT NOT CONFIGURED YET: THIS IS THE WINDOW IN WHICH loadDatabases() RUNS
+    assertThat(pluginManager.getPlugins()).contains(plugin);
+    assertThat(pluginManager.getInitializedPlugins()).isEmpty();
+
+    pluginManager.startPlugins(ServerPlugin.PluginInstallationPriority.BEFORE_HTTP_ON);
+    assertThat(pluginManager.getInitializedPlugins()).containsExactly(plugin);
+
+    pluginManager.stopPlugins();
+    assertThat(pluginManager.getInitializedPlugins()).isEmpty();
+  }
+
   @Test
   void classLoaderIsolation() throws Exception {
     final Path pluginsDir = tempDir.resolve("lib/plugins");
@@ -445,6 +497,23 @@ class PluginManagerTest {
     @Override
     public void startService() {
       throw new RuntimeException("Plugin failed to start after acquiring its resources");
+    }
+
+    @Override
+    public void stopService() {
+      stopped.set(true);
+    }
+  }
+
+  /**
+   * Fails the way a plugin jar with a missing class does: with an {@link Error}, not an {@link Exception}.
+   */
+  public static class ErroringPlugin implements ServerPlugin {
+    public static final AtomicBoolean stopped = new AtomicBoolean(false);
+
+    @Override
+    public void startService() {
+      throw new AssertionError("Plugin failed to start with an Error");
     }
 
     @Override

--- a/server/src/test/resources/META-INF/services/com.arcadedb.server.ServerPlugin
+++ b/server/src/test/resources/META-INF/services/com.arcadedb.server.ServerPlugin
@@ -1,1 +1,2 @@
 com.arcadedb.server.http.ArrayPayloadTestPlugin
+com.arcadedb.server.plugin.DatabaseLifecycleTestPlugin

--- a/studio/src/main/resources/static/js/studio-ai.js
+++ b/studio/src/main/resources/static/js/studio-ai.js
@@ -853,7 +853,7 @@ function aiExecuteCommand(button, blockId) {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + encodeURIComponent(db),
+    url: "api/v1/command/" + encodeDatabaseName(db),
     data: JSON.stringify({ language: language, command: command }),
     contentType: "application/json",
     beforeSend: function(xhr) {
@@ -925,7 +925,7 @@ function aiRunSequential(commands, index, allBtn) {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + encodeURIComponent(db),
+    url: "api/v1/command/" + encodeDatabaseName(db),
     data: JSON.stringify({ language: language, command: command }),
     contentType: "application/json",
     beforeSend: function(xhr) {

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -544,7 +544,9 @@ function createDatabase() {
     "<input class='form-control mt-2' id='inputCreateDatabaseName' onkeydown='if (event.which === 13) document.getElementById(\"globalModalConfirmBtn\").click()'>";
 
   globalPrompt("Create a new database", html, "Create", function() {
-    let database = encodeURI($("#inputCreateDatabaseName").val().trim());
+    // encodeURI() is the wrong encoder for a command payload, the same mistake as escapeHtml() into a URL: a name
+    // typed as `my db` used to CREATE the database under the name `my%20db` (issue #6830)
+    let database = $("#inputCreateDatabaseName").val().trim();
     if (database == "") {
       globalNotify("Error", "Database name empty", "danger");
       return;
@@ -554,7 +556,7 @@ function createDatabase() {
       .ajax({
         type: "POST",
         url: "api/v1/server",
-        data: "{ 'command': 'create database " + database + "' }",
+        data: JSON.stringify({ command: "create database " + database }),
         beforeSend: function (xhr) {
           xhr.setRequestHeader("Authorization", globalCredentials);
         },
@@ -796,7 +798,7 @@ function dropDatabase() {
             .ajax({
               type: "POST",
               url: "api/v1/server",
-              data: "{ 'command': 'drop database " + database + "' }",
+              data: JSON.stringify({ command: "drop database " + database }),
               beforeSend: function (xhr) {
                 xhr.setRequestHeader("Authorization", globalCredentials);
               },
@@ -829,7 +831,7 @@ function resetDatabase() {
         .ajax({
           type: "POST",
           url: "api/v1/server",
-          data: "{ 'command': 'drop database " + database + "' }",
+          data: JSON.stringify({ command: "drop database " + database }),
           beforeSend: function (xhr) {
             xhr.setRequestHeader("Authorization", globalCredentials);
           },
@@ -839,7 +841,7 @@ function resetDatabase() {
             .ajax({
               type: "POST",
               url: "api/v1/server",
-              data: "{ 'command': 'create database " + database + "' }",
+              data: JSON.stringify({ command: "create database " + database }),
               beforeSend: function (xhr) {
                 xhr.setRequestHeader("Authorization", globalCredentials);
               },

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -768,20 +768,22 @@ function showImportDatasetModal() {
 }
 
 function dropDatabase() {
-  let database = escapeHtml(getCurrentDatabase());
-  if (database == "") {
+  // HOLD THE RAW NAME AND ESCAPE AT THE HTML SINKS: HTML-ESCAPING AT THE SOURCE MADE THE TYPED-NAME CONFIRMATION BELOW
+  // COMPARE AGAINST `a&amp;b` AND SENT THAT NAME TO THE SERVER AS THE ONE TO DROP (ISSUE #6830)
+  let database = getCurrentDatabase();
+  if (database == null || database == "") {
     globalNotify("Error", "Database not selected", "danger");
     return;
   }
 
   globalConfirm(
     "Drop database",
-    "Are you sure you want to drop the database<br><b>" + database + "</b>?<br>WARNING: The operation cannot be undone.",
+    "Are you sure you want to drop the database<br><b>" + escapeHtml(database) + "</b>?<br>WARNING: The operation cannot be undone.",
     "warning",
     function () {
       globalPrompt(
         "Confirm drop database",
-        "Type the database name to confirm:<br><b>" + database + "</b>" +
+        "Type the database name to confirm:<br><b>" + escapeHtml(database) + "</b>" +
         "<input type='text' id='dropDatabaseConfirmInput' class='form-control mt-2' placeholder='Database name'>",
         "Drop",
         function (values) {
@@ -812,15 +814,15 @@ function dropDatabase() {
 }
 
 function resetDatabase() {
-  let database = escapeHtml(getCurrentDatabase());
-  if (database == "") {
+  let database = getCurrentDatabase();
+  if (database == null || database == "") {
     globalNotify("Error", "Database not selected", "danger");
     return;
   }
 
   globalConfirm(
     "Reset database",
-    "Are you sure you want to reset the database '" + database + "' (All data will be deleted)?<br>WARNING: The operation cannot be undone.",
+    "Are you sure you want to reset the database '" + escapeHtml(database) + "' (All data will be deleted)?<br>WARNING: The operation cannot be undone.",
     "warning",
     function () {
       jQuery
@@ -857,21 +859,21 @@ function resetDatabase() {
 }
 
 function backupDatabase() {
-  let database = escapeHtml(getCurrentDatabase());
-  if (database == "") {
+  let database = getCurrentDatabase();
+  if (database == null || database == "") {
     globalNotify("Error", "Database not selected", "danger");
     return;
   }
 
   globalConfirm(
     "Backup database",
-    "Are you sure you want to backup the database '" + database + "'?<br>The database archive will be created under the 'backup' directory of the server.",
+    "Are you sure you want to backup the database '" + escapeHtml(database) + "'?<br>The database archive will be created under the 'backup' directory of the server.",
     "info",
     function () {
       jQuery
         .ajax({
           type: "POST",
-          url: "api/v1/command/" + database,
+          url: "api/v1/command/" + encodeDatabaseName(database),
           data: JSON.stringify({
             language: "sql",
             command: "backup database",
@@ -906,7 +908,7 @@ function dropProperty(type, property) {
       jQuery
         .ajax({
           type: "POST",
-          url: "api/v1/command/" + database,
+          url: "api/v1/command/" + encodeDatabaseName(database),
           data: JSON.stringify({
             language: "sql",
             command: "drop property " + quoteSqlName(type) + "." + quoteSqlName(property),
@@ -943,7 +945,7 @@ function dropIndex(indexName, type) {
       jQuery
         .ajax({
           type: "POST",
-          url: "api/v1/command/" + database,
+          url: "api/v1/command/" + encodeDatabaseName(database),
           data: JSON.stringify({
             language: "sql",
             command: "drop index " + quoteSqlName(indexName),
@@ -999,7 +1001,7 @@ function runRepartition(typeName) {
       jQuery
         .ajax({
           type: "POST",
-          url: "api/v1/command/" + database,
+          url: "api/v1/command/" + encodeDatabaseName(database),
           data: JSON.stringify({
             language: "sql",
             command: "REBUILD TYPE " + quoteSqlName(typeName) + " WITH repartition = true",
@@ -1056,7 +1058,7 @@ function dropType(typeName) {
           jQuery
             .ajax({
               type: "POST",
-              url: "api/v1/command/" + database,
+              url: "api/v1/command/" + encodeDatabaseName(database),
               data: JSON.stringify({
                 language: "sql",
                 command: "drop type " + quoteSqlName(typeName) + " unsafe",
@@ -1253,7 +1255,7 @@ function createProperty(typeName) {
 
     jQuery.ajax({
       type: "POST",
-      url: "api/v1/command/" + database,
+      url: "api/v1/command/" + encodeDatabaseName(database),
       data: JSON.stringify({ language: "sql", command: command, serializer: "record" }),
       beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
     }).done(function (data) {
@@ -1603,7 +1605,7 @@ function createIndex(typeName) {
 
     jQuery.ajax({
       type: "POST",
-      url: "api/v1/command/" + database,
+      url: "api/v1/command/" + encodeDatabaseName(database),
       data: JSON.stringify({ language: "sql", command: command, serializer: "record" }),
       beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
     }).done(function (data) {
@@ -1766,7 +1768,7 @@ function createType(category) {
     jQuery
       .ajax({
         type: "POST",
-        url: "api/v1/command/" + database,
+        url: "api/v1/command/" + encodeDatabaseName(database),
         data: JSON.stringify({
           language: "sql",
           command: command,
@@ -1938,7 +1940,7 @@ function createTimeSeriesType() {
 
     jQuery.ajax({
       type: "POST",
-      url: "api/v1/command/" + database,
+      url: "api/v1/command/" + encodeDatabaseName(database),
       data: JSON.stringify({ language: "sql", command: command, serializer: "record" }),
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);
@@ -2208,7 +2210,8 @@ function deleteSavedQuery(index) {
 function populateHistoryPanel() {
   let container = $("#sidebarPanelHistory");
   let queryHistory = getQueryHistory();
-  let database = escapeHtml(getCurrentDatabase());
+  // THE STORED ENTRIES CARRY THE RAW NAME, SO THE FILTER BELOW HAS TO COMPARE AGAINST THE RAW NAME TOO (ISSUE #6830)
+  let database = getCurrentDatabase();
 
   // Filter for current database
   let filtered = [];
@@ -3068,7 +3071,7 @@ function browseType(typeName) {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + database,
+    url: "api/v1/command/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: query, limit: limit, serializer: "studio" }),
     beforeSend: function(xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
   }).done(function(data) {
@@ -3169,7 +3172,7 @@ function startCommandProgressMonitor(database, command) {
     jQuery
       .ajax({
         type: "GET",
-        url: "api/v1/progress/" + database,
+        url: "api/v1/progress/" + encodeDatabaseName(database),
         beforeSend: function (xhr) {
           xhr.setRequestHeader("Authorization", globalCredentials);
         },
@@ -3221,7 +3224,7 @@ function executeCommandTable() {
   jQuery
     .ajax({
       type: "POST",
-      url: "api/v1/command/" + database,
+      url: "api/v1/command/" + encodeDatabaseName(database),
       data: JSON.stringify({
         language: language,
         command: command,
@@ -3276,7 +3279,7 @@ function executeCommandGraph() {
   jQuery
     .ajax({
       type: "POST",
-      url: "api/v1/command/" + database,
+      url: "api/v1/command/" + encodeDatabaseName(database),
       data: JSON.stringify({
         language: language,
         command: command,
@@ -3331,7 +3334,7 @@ function fetchSchemaTypes(callback) {
   jQuery
     .ajax({
       type: "POST",
-      url: "api/v1/query/" + database,
+      url: "api/v1/query/" + encodeDatabaseName(database),
       data: JSON.stringify({
         language: "sql",
         command: "select from schema:types",
@@ -3968,7 +3971,7 @@ function displayDatabaseSettings() {
   jQuery
     .ajax({
       type: "POST",
-      url: "api/v1/query/" + database,
+      url: "api/v1/query/" + encodeDatabaseName(database),
       data: JSON.stringify({
         language: "sql",
         command: "select expand( settings ) from schema:database",
@@ -4393,7 +4396,7 @@ function fetchMaterializedViews(callback) {
   jQuery
     .ajax({
       type: "POST",
-      url: "api/v1/query/" + database,
+      url: "api/v1/query/" + encodeDatabaseName(database),
       data: JSON.stringify({
         language: "sql",
         command: "select from schema:materializedViews",
@@ -4488,7 +4491,7 @@ function fetchGraphAnalyticalViews(callback) {
   jQuery
     .ajax({
       type: "POST",
-      url: "api/v1/query/" + database,
+      url: "api/v1/query/" + encodeDatabaseName(database),
       data: JSON.stringify({
         language: "sql",
         command: "select from schema:graphAnalyticalViews",
@@ -4777,7 +4780,7 @@ function createGraphAnalyticalView() {
 
     jQuery.ajax({
       type: "POST",
-      url: "api/v1/command/" + database,
+      url: "api/v1/command/" + encodeDatabaseName(database),
       data: JSON.stringify({
         language: "sql",
         command: command,
@@ -4994,7 +4997,7 @@ function dropGav(gavName) {
       let database = getCurrentDatabase();
       jQuery.ajax({
         type: "POST",
-        url: "api/v1/command/" + database,
+        url: "api/v1/command/" + encodeDatabaseName(database),
         data: JSON.stringify({
           language: "sql",
           command: "DROP GRAPH ANALYTICAL VIEW " + quoteSqlName(gavName)
@@ -5019,7 +5022,7 @@ function alterGavUpdateMode(gavName, newMode) {
   let database = getCurrentDatabase();
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + database,
+    url: "api/v1/command/" + encodeDatabaseName(database),
     data: JSON.stringify({
       language: "sql",
       command: "ALTER GRAPH ANALYTICAL VIEW " + quoteSqlName(gavName) + " UPDATE MODE " + newMode
@@ -5041,7 +5044,7 @@ function rebuildGav(gavName) {
   let database = getCurrentDatabase();
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + database,
+    url: "api/v1/command/" + encodeDatabaseName(database),
     data: JSON.stringify({
       language: "sql",
       command: "REBUILD GRAPH ANALYTICAL VIEW " + quoteSqlName(gavName)
@@ -5344,7 +5347,7 @@ function createMaterializedView() {
     jQuery
       .ajax({
         type: "POST",
-        url: "api/v1/command/" + database,
+        url: "api/v1/command/" + encodeDatabaseName(database),
         data: JSON.stringify({
           language: "sql",
           command: command,
@@ -5401,7 +5404,7 @@ function refreshMaterializedView(name) {
       jQuery
         .ajax({
           type: "POST",
-          url: "api/v1/command/" + database,
+          url: "api/v1/command/" + encodeDatabaseName(database),
           data: JSON.stringify({
             language: "sql",
             command: "REFRESH MATERIALIZED VIEW " + quoteSqlName(name),
@@ -5449,7 +5452,7 @@ function alterMaterializedView(name) {
     jQuery
       .ajax({
         type: "POST",
-        url: "api/v1/command/" + database,
+        url: "api/v1/command/" + encodeDatabaseName(database),
         data: JSON.stringify({
           language: "sql",
           command: command,
@@ -5489,7 +5492,7 @@ function dropMaterializedView(name) {
       jQuery
         .ajax({
           type: "POST",
-          url: "api/v1/command/" + database,
+          url: "api/v1/command/" + encodeDatabaseName(database),
           data: JSON.stringify({
             language: "sql",
             command: "DROP MATERIALIZED VIEW " + quoteSqlName(name),
@@ -5715,7 +5718,7 @@ function loadDatabaseMetrics() {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/query/" + database,
+    url: "api/v1/query/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:stats" }),
     beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); },
   }).done(function (data) {
@@ -5727,7 +5730,7 @@ function loadDatabaseMetrics() {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/query/" + database,
+    url: "api/v1/query/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:materializedViews" }),
     beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); },
   }).done(function (data) {
@@ -5838,7 +5841,7 @@ function refreshMvFromMetrics(name) {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + database,
+    url: "api/v1/command/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: "REFRESH MATERIALIZED VIEW " + quoteSqlName(name) }),
     beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); },
   }).done(function () {
@@ -5865,7 +5868,7 @@ function loadStorageBuckets() {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/query/" + database,
+    url: "api/v1/query/" + encodeDatabaseName(database),
     // Hide non-PRIMARY buckets (e.g. paired EXTERNAL_PROPERTY buckets that hold externalised property values).
     // Power users can still see them by running SELECT FROM schema:buckets directly in the Query tab.
     data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:buckets WHERE purpose = 'PRIMARY' OR purpose IS NULL" }),
@@ -5887,7 +5890,7 @@ function loadStorageBuckets() {
       (function (bucket) {
         jQuery.ajax({
           type: "POST",
-          url: "api/v1/query/" + database,
+          url: "api/v1/query/" + encodeDatabaseName(database),
           data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:bucket:" + quoteSqlName(bucket.name) }),
           beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); },
         }).done(function (detailData) {
@@ -5970,7 +5973,7 @@ function loadStorageIndexes() {
   // includes the index internal statistics, is fetched lazily only for the row the user selects.
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/query/" + database,
+    url: "api/v1/query/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:indexes" }),
     beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); },
   }).done(function (data) {
@@ -6045,7 +6048,7 @@ function renderIndexesDataTable(indexes) {
 
     jQuery.ajax({
       type: "POST",
-      url: "api/v1/query/" + database,
+      url: "api/v1/query/" + encodeDatabaseName(database),
       // The name is back-tick quoted: auto-derived compound-index names carry a comma, e.g. `MyType[propA,propB]`.
       data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:index:" + quoteSqlName(name) }),
       beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); },
@@ -6106,7 +6109,7 @@ function loadStorageDictionary() {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/query/" + database,
+    url: "api/v1/query/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:dictionary" }),
     beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); },
   }).done(function (data) {

--- a/studio/src/main/resources/static/js/studio-graph-widget.js
+++ b/studio/src/main/resources/static/js/studio-graph-widget.js
@@ -578,7 +578,7 @@ function removeGraphElement(ele) {
 }
 
 function loadNodeNeighbors(direction, rid) {
-  let database = escapeHtml(getCurrentDatabase());
+  let database = getCurrentDatabase();
 
   $("#executeSpinner").show();
 
@@ -587,7 +587,7 @@ function loadNodeNeighbors(direction, rid) {
   jQuery
     .ajax({
       type: "POST",
-      url: "api/v1/command/" + database,
+      url: "api/v1/command/" + encodeDatabaseName(database),
       data: JSON.stringify({
         language: "sql",
         command: "select expand( " + direction + "E() ) from " + rid,
@@ -693,7 +693,7 @@ function addNodeFromRecord(rid) {
     jQuery
       .ajax({
         type: "POST",
-        url: "api/v1/command/" + escapeHtml(getCurrentDatabase()),
+        url: "api/v1/command/" + encodeDatabaseName(getCurrentDatabase()),
         async: false,
         data: JSON.stringify({
           language: "sql",

--- a/studio/src/main/resources/static/js/studio-profiler.js
+++ b/studio/src/main/resources/static/js/studio-profiler.js
@@ -620,7 +620,7 @@ function profilerAiExecuteCommand(button, blockId) {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + encodeURIComponent(db),
+    url: "api/v1/command/" + encodeDatabaseName(db),
     data: JSON.stringify({ language: language, command: command }),
     contentType: "application/json",
     headers: { Authorization: globalCredentials }
@@ -689,7 +689,7 @@ function profilerAiRunSequential(commands, index, allBtn) {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + encodeURIComponent(db),
+    url: "api/v1/command/" + encodeDatabaseName(db),
     data: JSON.stringify({ language: language, command: command }),
     contentType: "application/json",
     headers: { Authorization: globalCredentials }

--- a/studio/src/main/resources/static/js/studio-record-editor.js
+++ b/studio/src/main/resources/static/js/studio-record-editor.js
@@ -391,11 +391,11 @@ function saveRecordEditor() {
   if (removeParts.length > 0)
     sql += " REMOVE " + removeParts.join(", ");
 
-  var database = escapeHtml(getCurrentDatabase());
+  var database = getCurrentDatabase();
 
   $.ajax({
     type: "POST",
-    url: "api/v1/command/" + database,
+    url: "api/v1/command/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: sql }),
     beforeSend: function (xhr) {
       xhr.setRequestHeader("Authorization", globalCredentials);
@@ -412,11 +412,11 @@ function saveRecordEditor() {
 
 function refreshRecordAfterSave() {
   var rid = globalRecordEditorState.rid;
-  var database = escapeHtml(getCurrentDatabase());
+  var database = getCurrentDatabase();
 
   $.ajax({
     type: "POST",
-    url: "api/v1/command/" + database,
+    url: "api/v1/command/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM " + rid, serializer: "record" }),
     beforeSend: function (xhr) {
       xhr.setRequestHeader("Authorization", globalCredentials);
@@ -462,11 +462,11 @@ function deleteRecord() {
 
   globalConfirm("Delete Record", "Are you sure you want to delete record " + rid + "? This action cannot be undone.", "warning",
     function () {
-      var database = escapeHtml(getCurrentDatabase());
+      var database = getCurrentDatabase();
 
       $.ajax({
         type: "POST",
-        url: "api/v1/command/" + database,
+        url: "api/v1/command/" + encodeDatabaseName(database),
         data: JSON.stringify({ language: "sql", command: "DELETE FROM " + rid }),
         beforeSend: function (xhr) {
           xhr.setRequestHeader("Authorization", globalCredentials);
@@ -542,11 +542,11 @@ function showRecordInGraph() {
 }
 
 function openRecordEditorFromTable(rid) {
-  var database = escapeHtml(getCurrentDatabase());
+  var database = getCurrentDatabase();
 
   $.ajax({
     type: "POST",
-    url: "api/v1/command/" + database,
+    url: "api/v1/command/" + encodeDatabaseName(database),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM " + rid, serializer: "record" }),
     beforeSend: function (xhr) {
       xhr.setRequestHeader("Authorization", globalCredentials);

--- a/studio/src/main/resources/static/js/studio-security.js
+++ b/studio/src/main/resources/static/js/studio-security.js
@@ -468,7 +468,7 @@ function loadTypesForTokenDatabase() {
   jQuery
     .ajax({
       type: "GET",
-      url: "api/v1/query/" + encodeURIComponent(db) + "/sql/SELECT%20name%20FROM%20schema%3Atypes",
+      url: "api/v1/query/" + encodeDatabaseName(db) + "/sql/SELECT%20name%20FROM%20schema%3Atypes",
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);
       },
@@ -824,7 +824,7 @@ function loadTypesForGroupDatabase() {
   jQuery
     .ajax({
       type: "GET",
-      url: "api/v1/query/" + encodeURIComponent(db) + "/sql/SELECT%20name%20FROM%20schema%3Atypes",
+      url: "api/v1/query/" + encodeDatabaseName(db) + "/sql/SELECT%20name%20FROM%20schema%3Atypes",
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);
       },

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -537,7 +537,7 @@ function getServerEvents(file) {
     .ajax({
       type: "POST",
       url: "api/v1/server",
-      data: "{ command: 'get server events" + (file != null ? " " + file : "") + "' }",
+      data: JSON.stringify({ command: "get server events" + (file != null ? " " + file : "") }),
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);
       },

--- a/studio/src/main/resources/static/js/studio-timeseries.js
+++ b/studio/src/main/resources/static/js/studio-timeseries.js
@@ -70,7 +70,7 @@ function tsLoadTypes() {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + db,
+    url: "api/v1/command/" + encodeDatabaseName(db),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:types" }),
     contentType: "application/json",
     beforeSend: function (xhr) {
@@ -109,7 +109,7 @@ function tsTypeChanged() {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + db,
+    url: "api/v1/command/" + encodeDatabaseName(db),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:types WHERE name = '" + typeName + "'" }),
     contentType: "application/json",
     beforeSend: function (xhr) {
@@ -658,7 +658,7 @@ function tsDropType() {
     function () {
       jQuery.ajax({
         type: "POST",
-        url: "api/v1/command/" + db,
+        url: "api/v1/command/" + encodeDatabaseName(db),
         data: JSON.stringify({ language: "sql", command: "DROP TYPE " + quoteSqlName(typeName) + " IF EXISTS" }),
         contentType: "application/json",
         beforeSend: function (xhr) {
@@ -709,7 +709,7 @@ function tsAddDownsamplingPolicy(typeName) {
     var db = getCurrentDatabase();
     jQuery.ajax({
       type: "POST",
-      url: "api/v1/command/" + db,
+      url: "api/v1/command/" + encodeDatabaseName(db),
       data: JSON.stringify({ language: "sql", command: command }),
       contentType: "application/json",
       beforeSend: function (xhr) {
@@ -750,7 +750,7 @@ function tsDropDownsamplingPolicy(typeName) {
       var db = getCurrentDatabase();
       jQuery.ajax({
         type: "POST",
-        url: "api/v1/command/" + db,
+        url: "api/v1/command/" + encodeDatabaseName(db),
         data: JSON.stringify({ language: "sql", command: "ALTER TIMESERIES TYPE " + quoteSqlName(typeName) + " DROP DOWNSAMPLING POLICY" }),
         contentType: "application/json",
         beforeSend: function (xhr) {
@@ -820,7 +820,7 @@ function tsLoadSchema() {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/command/" + db,
+    url: "api/v1/command/" + encodeDatabaseName(db),
     data: JSON.stringify({ language: "sql", command: "SELECT FROM schema:types" }),
     contentType: "application/json",
     beforeSend: function (xhr) {

--- a/studio/src/main/resources/static/js/studio-utils.js
+++ b/studio/src/main/resources/static/js/studio-utils.js
@@ -166,6 +166,20 @@ function escapeHtml(unsafe) {
 }
 
 /**
+ * Encodes a database name so it can be used as a path segment of the `api/v1/...` endpoints.
+ *
+ * A database name is free-form: it may contain `/`, `#`, `?`, `&`, a space or a quote, all of which change the meaning of a
+ * URL when concatenated raw. This is the only correct encoder for that position - `escapeHtml()` is an HTML-entity encoder
+ * and turns `a&b` into the different database name `a&amp;b`, which the server answers with a 404 (issue #6830).
+ *
+ * A missing name encodes to the empty string rather than to the literal "null", so the request fails as a malformed URL
+ * instead of quietly addressing a database called `null`.
+ */
+function encodeDatabaseName(database) {
+  return encodeURIComponent(database == null ? "" : database);
+}
+
+/**
  * Wraps a schema object name (bucket, index, type) in back-ticks so it can be embedded in a SQL command even when it carries
  * characters that are not valid in a bare identifier - e.g. the comma in the auto-derived compound-index name `Type[propA,propB]`.
  *

--- a/studio/test/create-index-command.test.js
+++ b/studio/test/create-index-command.test.js
@@ -72,6 +72,7 @@ function extractFn(src, name) {
 
 eval(extractFn(utilsSrc, "quoteSqlName"));
 eval(extractFn(utilsSrc, "escapeHtml"));
+eval(extractFn(utilsSrc, "encodeDatabaseName"));
 eval(extractFn(dbSrc, "buildCreateIndexCommand"));
 eval(extractFn(dbSrc, "validateCreateIndexOptions"));
 

--- a/studio/test/database-name-url-encoding.test.js
+++ b/studio/test/database-name-url-encoding.test.js
@@ -85,12 +85,15 @@ test("a missing name yields an empty segment rather than the string 'null'", () 
 });
 
 test("every api/v1 URL in the Studio builds its database segment with encodeDatabaseName", () => {
+  // Match the endpoint prefix in ANY form - string concatenation, a template literal, a parenthesized
+  // expression - and require the helper on the same line, rather than matching only the `"..." + identifier`
+  // shape that happens to be written today. The point of this test is the call sites nobody has written yet.
   const offenders = [];
   for (const file of fs.readdirSync(JS_DIR).filter((f) => f.endsWith(".js"))) {
     const src = fs.readFileSync(path.join(JS_DIR, file), "utf8");
     src.split("\n").forEach((line, i) => {
-      const match = line.match(/"api\/v1\/(?:command|query|progress)\/"\s*\+\s*([A-Za-z_$][\w$]*)/);
-      if (match && match[1] !== "encodeDatabaseName") offenders.push(file + ":" + (i + 1) + " -> " + line.trim());
+      if (/api\/v1\/(?:command|query|progress)\//.test(line) && !line.includes("encodeDatabaseName"))
+        offenders.push(file + ":" + (i + 1) + " -> " + line.trim());
     });
   }
   assert.deepEqual(offenders, [], "these call sites build the URL path segment without encodeDatabaseName");

--- a/studio/test/database-name-url-encoding.test.js
+++ b/studio/test/database-name-url-encoding.test.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+
+// Regression test for issue #6830. The graph widget ran the database name through escapeHtml() before
+// concatenating it into an `api/v1/command/` URL. escapeHtml() is an HTML-entity encoder, not a URL
+// encoder: it turns `a&b` into the different database name `a&amp;b`, which the server answers with a
+// 404 - so "add node from record" failed for such a database while every other Studio panel worked.
+// Several other call sites had the mirror-image problem, concatenating the name raw so a `/`, `#` or a
+// space changed the shape of the URL.
+//
+// Both halves are checked here: encodeDatabaseName() itself, and the invariant that no api/v1 URL in
+// the Studio builds its path segment any other way. Run with:
+//
+//     node --test studio/test/database-name-url-encoding.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const JS_DIR = path.join(__dirname, "..", "src", "main", "resources", "static", "js");
+const utilsSrc = fs.readFileSync(path.join(JS_DIR, "studio-utils.js"), "utf8");
+
+function extractFn(src, name) {
+  const start = src.indexOf("function " + name + "(");
+  if (start < 0) throw new Error("function not found: " + name);
+  let i = src.indexOf("{", start);
+  let depth = 1;
+  i++;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    i++;
+  }
+  if (depth !== 0) throw new Error("unbalanced braces while extracting " + name);
+  return src.substring(start, i);
+}
+
+eval(extractFn(utilsSrc, "encodeDatabaseName"));
+eval(extractFn(utilsSrc, "escapeHtml"));
+
+test("a name carrying URL metacharacters survives as one path segment", () => {
+  // The reported case: escapeHtml() produced `a&amp;b`, a different database name.
+  assert.equal(encodeDatabaseName("a&b"), "a%26b");
+  assert.notEqual(encodeDatabaseName("a&b"), escapeHtml("a&b"));
+
+  // The mirror-image problem at the call sites that concatenated the name raw.
+  assert.equal(encodeDatabaseName("a/b"), "a%2Fb");
+  assert.equal(encodeDatabaseName("a#b"), "a%23b");
+  assert.equal(encodeDatabaseName("a b"), "a%20b");
+  assert.equal(encodeDatabaseName("a?b"), "a%3Fb");
+  assert.equal(encodeDatabaseName("a'b"), "a'b");
+  assert.equal(encodeDatabaseName('a"b'), "a%22b");
+});
+
+test("an ordinary name is untouched, so no existing URL changes", () => {
+  assert.equal(encodeDatabaseName("mydb"), "mydb");
+  assert.equal(encodeDatabaseName("Beer-Db_2024.1"), "Beer-Db_2024.1");
+});
+
+test("a missing name yields an empty segment rather than the string 'null'", () => {
+  // getCurrentDatabase() returns null when nothing is selected; the request must fail as a malformed
+  // URL instead of quietly addressing a database literally named "null".
+  assert.equal(encodeDatabaseName(null), "");
+  assert.equal(encodeDatabaseName(undefined), "");
+});
+
+test("every api/v1 URL in the Studio builds its database segment with encodeDatabaseName", () => {
+  const offenders = [];
+  for (const file of fs.readdirSync(JS_DIR).filter((f) => f.endsWith(".js"))) {
+    const src = fs.readFileSync(path.join(JS_DIR, file), "utf8");
+    src.split("\n").forEach((line, i) => {
+      const match = line.match(/"api\/v1\/(?:command|query|progress)\/"\s*\+\s*([A-Za-z_$][\w$]*)/);
+      if (match && match[1] !== "encodeDatabaseName") offenders.push(file + ":" + (i + 1) + " -> " + line.trim());
+    });
+  }
+  assert.deepEqual(offenders, [], "these call sites build the URL path segment without encodeDatabaseName");
+});
+
+test("no database name is HTML-escaped on its way into a URL or a SQL command", () => {
+  const offenders = [];
+  for (const file of fs.readdirSync(JS_DIR).filter((f) => f.endsWith(".js"))) {
+    const src = fs.readFileSync(path.join(JS_DIR, file), "utf8");
+    src.split("\n").forEach((line, i) => {
+      if (line.includes("escapeHtml(getCurrentDatabase())")) offenders.push(file + ":" + (i + 1) + " -> " + line.trim());
+    });
+  }
+  assert.deepEqual(offenders, [], "hold the raw name and escape at the HTML sink, not at the source");
+});

--- a/studio/test/database-name-url-encoding.test.js
+++ b/studio/test/database-name-url-encoding.test.js
@@ -96,6 +96,36 @@ test("every api/v1 URL in the Studio builds its database segment with encodeData
   assert.deepEqual(offenders, [], "these call sites build the URL path segment without encodeDatabaseName");
 });
 
+test("no admin command is sent as a hand-built JSON string", () => {
+  // A database name may contain a single quote - the server rejects only / \\ NUL and .. - and the
+  // `create/drop database` payloads used to be assembled as "{ 'command': '... " + name + "' }". Such a name
+  // made the body malformed, so the database could not be created, dropped or reset at all. JSON.stringify
+  // escapes it; nothing else here needs to, since the server reads the name as the verbatim rest of the command.
+  const offenders = [];
+  for (const file of fs.readdirSync(JS_DIR).filter((f) => f.endsWith(".js"))) {
+    const src = fs.readFileSync(path.join(JS_DIR, file), "utf8");
+    src.split("\n").forEach((line, i) => {
+      if (/data:\s*"\{/.test(line)) offenders.push(file + ":" + (i + 1) + " -> " + line.trim());
+    });
+  }
+  assert.deepEqual(offenders, [], "build the request body with JSON.stringify, not by concatenating JSON text");
+
+  // And the payload a quote-carrying name produces is valid JSON that round-trips to the original name.
+  const body = JSON.stringify({ command: "drop database " + "bob's db" });
+  assert.equal(JSON.parse(body).command, "drop database bob's db");
+});
+
+test("a database name is never URL-encoded on its way into a command payload", () => {
+  // The mirror image of the reported bug: createDatabase() ran the typed name through encodeURI(), so a name
+  // typed as `my db` created a database actually named `my%20db`.
+  const dbSrc = fs.readFileSync(path.join(JS_DIR, "studio-database.js"), "utf8");
+  // Match an assignment rather than the bare call, so the comment explaining this rule is not itself a hit.
+  assert.ok(
+    !/=\s*encodeURI\((?!Component)/.test(dbSrc),
+    "encodeURI() encodes for a URL, not for a command payload - it changes the name that reaches the server"
+  );
+});
+
 test("no database name is HTML-escaped on its way into a URL or a SQL command", () => {
   const offenders = [];
   for (const file of fs.readdirSync(JS_DIR).filter((f) => f.endsWith(".js"))) {


### PR DESCRIPTION
Closes #6852, closes #6830, closes #6829, closes #6828, closes #6827.

Five small, independent defects, grouped because four of them live in the console.

## #6852 - `AutoBackupSchedulerPlugin` NPE on every database registration at startup

**Root cause is one level up from where it was reported.** Plugin discovery installs every plugin instance up front, but `loadDatabases()` runs *before* `startPlugins(AFTER_DATABASES_OPEN)`. So a plugin of that priority was handed a "database registered" callback for every database already on disk while its own `server` field was still null. Ten databases, ten SEVERE stack traces, at every single startup.

The fix narrows the notification audience: `notifyPlugins()` now iterates the plugins whose `configure()` has returned, tracked on `PluginDescriptor` next to `started`. `started` cannot answer that question - it is set only *after* `startService()` returns and only when the plugin reports itself active, so a plugin that opens or registers databases while starting would be hidden from its own callbacks.

`AutoBackupSchedulerPlugin.syncDatabase()` also checks its own scheduler before dereferencing the server. A lifecycle callback is announced from whichever thread mutated the registry, so "nobody would call it that early" is not something that class can assume - and with no scheduler published there is genuinely nothing to reconcile, since `startService()` schedules everything that exists by then.

Both halves are pinned: nothing arrives before `configure()`, **and** everything after it still does. Muting the callbacks entirely would have "fixed" the stack traces by re-breaking #6752, whose IT still passes.

## #6827 - `TerminalParser` drops every backslash

The escape character now stays in the emitted word while still doing its structural job: an escaped quote does not close a string, an escaped semicolon does not split a command. The engine, not the console, owns string-literal escaping.

**The reported repro understates the bug.** The issue says the same statement over `/api/v1/command` stores the correct path - it does not. The engine's SQL lexer rejects a bare `\U` inside a literal, so `'C:\Users\bob'` fails there too; the form that works is `'C:\\Users\\bob'`, which the console turned into the form that fails to tokenize. There was no way to type a backslash from the console at all, in either direction.

`load` had the same defect from the other end. `FileUtils.decodeFromFile()` existed only to double every `\\` it read so that the level the parser then consumed came back out even. That pair cancelled out only for an *even* number of backslashes - a lone `\` in a script was still swallowed - and it is why the existing `console-batch.sql` fixture worked. Both halves are gone, and the helper with them: it had exactly one caller in the tree and no meaning on its own.

`SET` is the one place where shell-like unescaping is actually wanted, so `stripMatchingQuotes()` does it there - and can now be exact about it. With the escapes preserved, the closing quote is the first *unescaped* occurrence of the opening one, which removes the ambiguity the old javadoc had to document and apologise for.

## #6828 - `Console.close()` commits on a stale counter and its blanket catch skips the rest

- `currentOperationsInBatch` is reset wherever the pending batch is disposed of: `executeCommit()`, `executeRollback()`, `executeClose()`.
- The guard requires a live proxy with an active transaction, not just a non-zero counter.
- Each of the four steps gets its own try/catch, so the flush and the two closes cannot be skipped by the commit.
- A failed exit-time commit is reported and sets `errored`, instead of the process exiting 0 over data that was never written - which is the half of this bug that silently loses an interactive Ctrl-D batch.

## #6829 - the console persists and echoes the plaintext password

- The line reader's history masks the password before recording it, so `.history` never receives one.
- The batch-mode command echo masks it too, so it does not land in a CI log.
- **And the part that makes those masks avoidable rather than merely tidy:** both `connect` and `create user` now accept the password-less form and ask for the password with the echo masked. Without that there is no way to authenticate without writing the password down somewhere, so the masking would only have hidden the leak from the person creating it.

The masking rules live in `ConsoleCredentials`, matched per statement on the command keyword rather than on `remote:` or `identified by` anywhere in the text - otherwise an ordinary `insert into Doc set note = 'identified by the auditor'` gets mangled on its way to the log.

## #6830 (1) - `connect remote:` splits on a single space

Now splits on runs of whitespace with the password as the remainder, so a doubled blank and a password containing a space both work, and the diagnostic says which half is missing instead of claiming both are. The local branch of `executeConnect` had the identical defect (`MODE.valueOf(\"\")` on a doubled blank) and gets the same treatment.

`checkHasSpaces(\"User password\", ...)` in `executeCreateUser` is dropped: `IDENTIFIED BY` and `GRANT CONNECT TO` delimit the password positionally, the server and Studio both accept spaces, and rejecting them only there made an account the console could not create.

## #6830 (2) - the Studio HTML-escapes the database name into a URL path

Fixed more broadly than reported. `escapeHtml()` at `studio-graph-widget.js:696` was the reported case, but the neighbouring `:590` had it too (via a variable), and ~40 other call sites had the mirror-image problem of concatenating the name raw. All `api/v1/{command,query,progress}` sites now build the path segment with one `encodeDatabaseName()` helper.

The names that were held HTML-escaped *at the source* are now held raw and escaped at the HTML sinks. That escaping was not only a URL bug: in `dropDatabase()` it made the typed-name confirmation compare against `a&amp;b` and sent that name to the server as the one to drop, and in `populateHistoryPanel()` it made the filter compare against entries stored under the raw name.

## Verification

- `console`: 116 tests green (`ConsoleTest` 62, `TerminalParserTest` 29, new `ConsoleCredentialsTest` 8, `ConsoleBatchTest` 8, ...). The 2 `ConsoleAsyncInsertTest` errors are pre-existing and reproduce identically on unmodified `main`.
- All 6 new `TerminalParserTest` cases fail against the old parser; `Issue6852PluginLifecycleBeforeConfigureTest` fails against the old dispatch with exactly the reported shape (`hadServer=false`).
- `server`: plugin + backup suites green (52 tests), `Issue6752AutoBackupScheduleLifecycleIT` still green.
- `studio`: 55 node tests green, including the new `database-name-url-encoding.test.js`, which also asserts the invariant that no api/v1 URL builds its path segment any other way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console prompts can securely request omitted passwords and mask credentials in command history and output.
  * Console commands and scripts preserve backslashes and support passwords containing spaces.
  * Studio supports database names containing special URL characters across database, graph, security, profiler, and time-series tools.

* **Bug Fixes**
  * Improved console transaction cleanup and shutdown reliability.
  * Prevented unconfigured plugins and backup scheduling from causing errors.
  * Improved database lifecycle callback handling.
  * Studio now excludes non-primary buckets from default bucket loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->