### PR TITLE
fix: a Gremlin graph must end its transaction and its driver cluster when it closes (#6820, #6821, #6822, #6823)

### DIFF
--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -454,15 +454,18 @@ public class ArcadeGraph implements Graph, Closeable {
     releaseTraversal();
 
     if (this.database != null) {
-      // END AN IN-FLIGHT UNIT OF WORK THROUGH THE TRANSACTION'S CONFIGURED CLOSE BEHAVIOUR, WHOSE DEFAULT IS
-      // ROLLBACK: CLOSING A GRAPH IS NOT A COMMIT, SO WORK THAT NEVER REACHED commit() MUST NOT BECOME DURABLE
-      // (ISSUE #6820). tx().close() ALSO CLEARS THE THREAD-LOCAL STATE OF AbstractThreadLocalTransaction.
-      if (this.database.isTransactionActive())
-        this.transaction.close();
-
-      // WHEN THE DATABASE LIFECYCLE IS MANAGED EXTERNALLY (e.g. BY ArcadeDBServer) DO NOT CLOSE IT.
-      if (!sharedDatabase)
-        this.database.close();
+      try {
+        // END AN IN-FLIGHT UNIT OF WORK THROUGH THE TRANSACTION'S CONFIGURED CLOSE BEHAVIOUR, WHOSE DEFAULT IS
+        // ROLLBACK: CLOSING A GRAPH IS NOT A COMMIT, SO WORK THAT NEVER REACHED commit() MUST NOT BECOME DURABLE
+        // (ISSUE #6820). tx().close() ALSO CLEARS THE THREAD-LOCAL STATE OF AbstractThreadLocalTransaction.
+        if (this.database.isTransactionActive())
+          this.transaction.close();
+      } finally {
+        // THE CALLER STILL HEARS ABOUT A FAILED COMMIT-ON-CLOSE, BUT IT MUST NOT COST THEM THE DATABASE HANDLE.
+        // WHEN THE DATABASE LIFECYCLE IS MANAGED EXTERNALLY (e.g. BY ArcadeDBServer) DO NOT CLOSE IT.
+        if (!sharedDatabase)
+          this.database.close();
+      }
     }
   }
 

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -490,8 +490,12 @@ public class ArcadeGraph implements Graph, Closeable {
    * Releases the cached traversal source and, when the traversal goes through the TinkerPop driver, the
    * {@link Cluster} built for it. The cluster owns a Netty event-loop group, a scheduled executor and a connection
    * pool: nothing else closes them, so leaving them behind leaked those per graph instance (issue #6822).
+   * <p>
+   * Takes the same monitor as {@link #traversal()}: without it a concurrent close could null and shut down the
+   * cluster field between the two statements that build and then use it, handing a dead cluster to the remote
+   * connection and leaving the one built after the close with nothing left to release it.
    */
-  private void releaseTraversal() {
+  private synchronized void releaseTraversal() {
     if (traversal != null) {
       try {
         traversal.close();

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -464,6 +464,17 @@ public class ArcadeGraph implements Graph, Closeable {
     releaseTraversal();
 
     if (this.database != null) {
+      if (sharedDatabase) {
+        // THE DATABASE LIFECYCLE IS MANAGED EXTERNALLY, SO DO NOT CLOSE IT - AND ROLL BACK RATHER THAN GO THROUGH THE
+        // CONFIGURED CLOSE BEHAVIOUR. CLOSING A SERVER-MANAGED GRAPH IS A TEARDOWN, NOT THE END OF A UNIT OF WORK:
+        // SESSIONS COMMIT THROUGH ArcadeGraphManager, AND THIS GRAPH IS ONE LONG-LIVED INSTANCE SHARED BY ALL OF THEM
+        // WITH NO BORROW BOUNDARY TO RESET ITS TRANSACTION. LETTING A COMMIT RUN HERE IS WHAT LEFT THE WAL
+        // INCONSISTENT WHEN THE GREMLIN STOP THREAD RACED THE HA STATE MACHINE AT SHUTDOWN (ArcadeGraphSharedDatabaseIT).
+        if (this.database.isTransactionActive())
+          this.database.rollback();
+        return;
+      }
+
       RuntimeException failure = null;
       try {
         // END AN IN-FLIGHT UNIT OF WORK THROUGH THE TRANSACTION'S CONFIGURED CLOSE BEHAVIOUR, WHOSE DEFAULT IS
@@ -477,9 +488,7 @@ public class ArcadeGraph implements Graph, Closeable {
       }
 
       try {
-        // WHEN THE DATABASE LIFECYCLE IS MANAGED EXTERNALLY (e.g. BY ArcadeDBServer) DO NOT CLOSE IT.
-        if (!sharedDatabase)
-          this.database.close();
+        this.database.close();
       } catch (final RuntimeException e) {
         if (failure == null)
           throw e;

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -488,7 +488,16 @@ public class ArcadeGraph implements Graph, Closeable {
     }
   }
 
+  /**
+   * Drops the underlying database. Refused when the database lifecycle is managed externally - a pooled instance over
+   * the factory's local database, or a server-managed one opened with {@link #openShared} - because other holders
+   * still point at it and dropping it from one borrowed handle would delete it under all of them (issue #6821).
+   */
   public void drop() {
+    if (sharedDatabase)
+      throw new UnsupportedOperationException(
+          "Cannot drop a database whose lifecycle is managed externally (server-managed, or shared by a pool): drop it through its owner");
+
     gremlinJavaEngine = null;
     if (gremlinGroovyEngine != null) {
       gremlinGroovyEngine.reset();

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -183,6 +183,10 @@ public class ArcadeGraph implements Graph, Closeable {
    * unknown at the time of the first call (no leader and no replicas, e.g. mid-failover), the slower embedded
    * fallback is cached: callers that need to re-resolve the topology after a failover must recreate the
    * {@code ArcadeGraph} instance.
+   * <p>
+   * A pooled instance is reused rather than recreated, so one that first resolved its traversal during a failover
+   * keeps the embedded fallback for the rest of the pool's life, even once the cluster is back. Recreating the pool
+   * is what re-resolves it.
    */
   public GraphTraversalSource traversal() {
     GraphTraversalSource result = traversal;

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -94,8 +94,8 @@ public class ArcadeGraph implements Graph, Closeable {
   private              GremlinLangScriptEngine     gremlinJavaAnalysisEngine;
   private              GremlinGroovyScriptEngine   gremlinGroovyEngine;
   private              ServiceRegistry             serviceRegistry;
-  private              GraphTraversalSource        traversal;
-  private              Cluster                     cluster;
+  private volatile     GraphTraversalSource        traversal;
+  private volatile     Cluster                     cluster;
   private              ImportGremlinPlugin.Builder importPlugin;
 
   static {
@@ -184,49 +184,63 @@ public class ArcadeGraph implements Graph, Closeable {
    * {@code ArcadeGraph} instance.
    */
   public GraphTraversalSource traversal() {
-    if (traversal != null)
-      return traversal;
-
-    if (database instanceof RemoteDatabase remoteDatabase) {
-      try {
-        final List<String> remoteAddresses = new ArrayList<>();
-
-        final String leaderAddress = remoteDatabase.getLeaderAddress();
-        if (leaderAddress != null)
-          remoteAddresses.add(leaderAddress);
-        remoteAddresses.addAll(remoteDatabase.getReplicaAddresses());
-
-        if (remoteAddresses.isEmpty()) {
-          // No leader and no replicas are known (e.g. non-HA server or mid-failover): fall back to the
-          // slower remote implementation rather than building a cluster with no contact points.
-          traversal = Graph.super.traversal();
-          return traversal;
-        }
-
-        final String[] hosts = new String[remoteAddresses.size()];
-        for (int i = 0; i < remoteAddresses.size(); i++)
-          hosts[i] = HostUtil.parseHostAddress(remoteAddresses.get(i), "" + GREMLIN_SERVER_PORT)[0];
-
-        final GraphBinaryMessageSerializerV1 serializer = new GraphBinaryMessageSerializerV1(
-            new TypeSerializerRegistry.Builder().addRegistry(new ArcadeIoRegistry()));
-
-        // KEEP THE CLUSTER IN A FIELD: IT OWNS A NETTY EVENT-LOOP GROUP, A SCHEDULED EXECUTOR AND A CONNECTION POOL,
-        // AND DriverRemoteConnection.using(Cluster, String) DOES NOT TAKE OWNERSHIP OF IT, SO ONLY close() CAN
-        // RELEASE THOSE RESOURCES (ISSUE #6822).
-        cluster = Cluster.build().enableSsl(false).addContactPoints(hosts).port(GREMLIN_SERVER_PORT)
-            .credentials(remoteDatabase.getUserName(), remoteDatabase.getUserPassword()).serializer(serializer).create();
-
-        // Use database name as the traversal source alias (dynamically registered by ArcadeGraphManager)
-        traversal = AnonymousTraversalSource.traversal().withRemote(DriverRemoteConnection.using(cluster, database.getName()));
-      } catch (Exception e) {
-        LogManager.instance().log(this, Level.WARNING,
-            "GremlinServer plugin not available on ArcadeDB server(s). Using slower remote implementation.");
-        traversal = Graph.super.traversal();
+    GraphTraversalSource result = traversal;
+    if (result == null) {
+      // DOUBLE-CHECKED LOCKING, AS FOR THE SCRIPT ENGINES BELOW: TWO THREADS RACING HERE WOULD EACH BUILD THEIR OWN
+      // DRIVER Cluster, AND THE LOSER'S WOULD BE ORPHANED WITH NOTHING LEFT HOLDING A REFERENCE TO CLOSE IT (#6822).
+      synchronized (this) {
+        result = traversal;
+        if (result == null)
+          traversal = result = buildTraversal();
       }
-    } else
-      traversal = Graph.super.traversal();
+    }
+    return result;
+  }
 
-    return traversal;
+  /**
+   * Resolves the traversal source, going through the TinkerPop driver when the remote cluster topology is known and
+   * falling back to the embedded implementation otherwise. Always called under the lock held by {@link #traversal()}.
+   */
+  private GraphTraversalSource buildTraversal() {
+    if (!(database instanceof RemoteDatabase remoteDatabase))
+      return Graph.super.traversal();
+
+    try {
+      final List<String> remoteAddresses = new ArrayList<>();
+
+      final String leaderAddress = remoteDatabase.getLeaderAddress();
+      if (leaderAddress != null)
+        remoteAddresses.add(leaderAddress);
+      remoteAddresses.addAll(remoteDatabase.getReplicaAddresses());
+
+      if (remoteAddresses.isEmpty())
+        // No leader and no replicas are known (e.g. non-HA server or mid-failover): fall back to the
+        // slower remote implementation rather than building a cluster with no contact points.
+        return Graph.super.traversal();
+
+      final String[] hosts = new String[remoteAddresses.size()];
+      for (int i = 0; i < remoteAddresses.size(); i++)
+        hosts[i] = HostUtil.parseHostAddress(remoteAddresses.get(i), "" + GREMLIN_SERVER_PORT)[0];
+
+      final GraphBinaryMessageSerializerV1 serializer = new GraphBinaryMessageSerializerV1(
+          new TypeSerializerRegistry.Builder().addRegistry(new ArcadeIoRegistry()));
+
+      // KEEP THE CLUSTER IN A FIELD: IT OWNS A NETTY EVENT-LOOP GROUP, A SCHEDULED EXECUTOR AND A CONNECTION POOL,
+      // AND DriverRemoteConnection.using(Cluster, String) DOES NOT TAKE OWNERSHIP OF IT, SO ONLY close() CAN
+      // RELEASE THOSE RESOURCES (ISSUE #6822).
+      cluster = Cluster.build().enableSsl(false).addContactPoints(hosts).port(GREMLIN_SERVER_PORT)
+          .credentials(remoteDatabase.getUserName(), remoteDatabase.getUserPassword()).serializer(serializer).create();
+
+      // Use database name as the traversal source alias (dynamically registered by ArcadeGraphManager)
+      return AnonymousTraversalSource.traversal().withRemote(DriverRemoteConnection.using(cluster, database.getName()));
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "GremlinServer plugin not available on ArcadeDB server(s). Using slower remote implementation.");
+      // THE EMBEDDED FALLBACK HAS NO USE FOR A CLUSTER BUILT BEFORE THE FAILURE: RELEASE IT INSTEAD OF LEAVING DEAD
+      // STATE BEHIND UNTIL close().
+      closeCluster();
+      return Graph.super.traversal();
+    }
   }
 
   public ArcadeSQL sql(final String query) {
@@ -487,6 +501,10 @@ public class ArcadeGraph implements Graph, Closeable {
       traversal = null;
     }
 
+    closeCluster();
+  }
+
+  private void closeCluster() {
     if (cluster != null) {
       try {
         cluster.close();

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -95,6 +95,7 @@ public class ArcadeGraph implements Graph, Closeable {
   private              GremlinGroovyScriptEngine   gremlinGroovyEngine;
   private              ServiceRegistry             serviceRegistry;
   private              GraphTraversalSource        traversal;
+  private              Cluster                     cluster;
   private              ImportGremlinPlugin.Builder importPlugin;
 
   static {
@@ -209,7 +210,10 @@ public class ArcadeGraph implements Graph, Closeable {
         final GraphBinaryMessageSerializerV1 serializer = new GraphBinaryMessageSerializerV1(
             new TypeSerializerRegistry.Builder().addRegistry(new ArcadeIoRegistry()));
 
-        Cluster cluster = Cluster.build().enableSsl(false).addContactPoints(hosts).port(GREMLIN_SERVER_PORT)
+        // KEEP THE CLUSTER IN A FIELD: IT OWNS A NETTY EVENT-LOOP GROUP, A SCHEDULED EXECUTOR AND A CONNECTION POOL,
+        // AND DriverRemoteConnection.using(Cluster, String) DOES NOT TAKE OWNERSHIP OF IT, SO ONLY close() CAN
+        // RELEASE THOSE RESOURCES (ISSUE #6822).
+        cluster = Cluster.build().enableSsl(false).addContactPoints(hosts).port(GREMLIN_SERVER_PORT)
             .credentials(remoteDatabase.getUserName(), remoteDatabase.getUserPassword()).serializer(serializer).create();
 
         // Use database name as the traversal source alias (dynamically registered by ArcadeGraphManager)
@@ -433,17 +437,18 @@ public class ArcadeGraph implements Graph, Closeable {
       gremlinGroovyEngine = null;
     }
 
+    releaseTraversal();
+
     if (this.database != null) {
-      if (sharedDatabase) {
-        // Database lifecycle is managed externally; do not close it.
-        // Roll back any open transaction to avoid leaving stale state.
-        if (this.database.isTransactionActive())
-          this.database.rollback();
-      } else {
-        if (this.database.isTransactionActive())
-          this.database.commit();
+      // END AN IN-FLIGHT UNIT OF WORK THROUGH THE TRANSACTION'S CONFIGURED CLOSE BEHAVIOUR, WHOSE DEFAULT IS
+      // ROLLBACK: CLOSING A GRAPH IS NOT A COMMIT, SO WORK THAT NEVER REACHED commit() MUST NOT BECOME DURABLE
+      // (ISSUE #6820). tx().close() ALSO CLEARS THE THREAD-LOCAL STATE OF AbstractThreadLocalTransaction.
+      if (this.database.isTransactionActive())
+        this.transaction.close();
+
+      // WHEN THE DATABASE LIFECYCLE IS MANAGED EXTERNALLY (e.g. BY ArcadeDBServer) DO NOT CLOSE IT.
+      if (!sharedDatabase)
         this.database.close();
-      }
     }
   }
 
@@ -454,6 +459,8 @@ public class ArcadeGraph implements Graph, Closeable {
       gremlinGroovyEngine = null;
     }
 
+    releaseTraversal();
+
     if (this.database != null) {
       if (!this.database.isOpen())
         FileUtils.deleteRecursively(new File(this.database.getDatabasePath()));
@@ -463,6 +470,39 @@ public class ArcadeGraph implements Graph, Closeable {
         this.database.drop();
       }
     }
+  }
+
+  /**
+   * Releases the cached traversal source and, when the traversal goes through the TinkerPop driver, the
+   * {@link Cluster} built for it. The cluster owns a Netty event-loop group, a scheduled executor and a connection
+   * pool: nothing else closes them, so leaving them behind leaked those per graph instance (issue #6822).
+   */
+  private void releaseTraversal() {
+    if (traversal != null) {
+      try {
+        traversal.close();
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.WARNING, "Error on closing the Gremlin traversal source", e);
+      }
+      traversal = null;
+    }
+
+    if (cluster != null) {
+      try {
+        cluster.close();
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.WARNING, "Error on closing the Gremlin driver cluster", e);
+      }
+      cluster = null;
+    }
+  }
+
+  /**
+   * Returns the TinkerPop driver {@link Cluster} backing {@link #traversal()}, or {@code null} when the traversal is
+   * executed embedded. Visible for testing the cluster lifecycle.
+   */
+  Cluster getCluster() {
+    return cluster;
   }
 
   @Override

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -96,6 +96,7 @@ public class ArcadeGraph implements Graph, Closeable {
   private              ServiceRegistry             serviceRegistry;
   private volatile     GraphTraversalSource        traversal;
   private volatile     Cluster                     cluster;
+  private volatile     boolean                     closed;
   private              ImportGremlinPlugin.Builder importPlugin;
 
   static {
@@ -189,6 +190,11 @@ public class ArcadeGraph implements Graph, Closeable {
       // DOUBLE-CHECKED LOCKING, AS FOR THE SCRIPT ENGINES BELOW: TWO THREADS RACING HERE WOULD EACH BUILD THEIR OWN
       // DRIVER Cluster, AND THE LOSER'S WOULD BE ORPHANED WITH NOTHING LEFT HOLDING A REFERENCE TO CLOSE IT (#6822).
       synchronized (this) {
+        if (closed)
+          // A CALLER THAT REACHED THE MONITOR BEHIND close() WOULD OTHERWISE BUILD A Cluster AFTER THE CLEANUP THAT
+          // WAS SUPPOSED TO RELEASE IT, WHICH IS THE #6822 LEAK AGAIN AND A TRAVERSAL OVER A CLOSED GRAPH.
+          throw new IllegalStateException("Graph is closed");
+
         result = traversal;
         if (result == null)
           traversal = result = buildTraversal();
@@ -454,18 +460,31 @@ public class ArcadeGraph implements Graph, Closeable {
     releaseTraversal();
 
     if (this.database != null) {
+      RuntimeException failure = null;
       try {
         // END AN IN-FLIGHT UNIT OF WORK THROUGH THE TRANSACTION'S CONFIGURED CLOSE BEHAVIOUR, WHOSE DEFAULT IS
         // ROLLBACK: CLOSING A GRAPH IS NOT A COMMIT, SO WORK THAT NEVER REACHED commit() MUST NOT BECOME DURABLE
         // (ISSUE #6820). tx().close() ALSO CLEARS THE THREAD-LOCAL STATE OF AbstractThreadLocalTransaction.
         if (this.database.isTransactionActive())
           this.transaction.close();
-      } finally {
-        // THE CALLER STILL HEARS ABOUT A FAILED COMMIT-ON-CLOSE, BUT IT MUST NOT COST THEM THE DATABASE HANDLE.
+      } catch (final RuntimeException e) {
+        // A FAILED COMMIT-ON-CLOSE MUST NOT COST THE CALLER THE DATABASE HANDLE: HOLD IT UNTIL THE HANDLE IS GONE.
+        failure = e;
+      }
+
+      try {
         // WHEN THE DATABASE LIFECYCLE IS MANAGED EXTERNALLY (e.g. BY ArcadeDBServer) DO NOT CLOSE IT.
         if (!sharedDatabase)
           this.database.close();
+      } catch (final RuntimeException e) {
+        if (failure == null)
+          throw e;
+        // THE COMMIT FAILURE IS THE ONE THE CALLER NEEDS TO SEE, SO CARRY THIS ONE ALONGSIDE RATHER THAN OVER IT.
+        failure.addSuppressed(e);
       }
+
+      if (failure != null)
+        throw failure;
     }
   }
 
@@ -499,6 +518,9 @@ public class ArcadeGraph implements Graph, Closeable {
    * connection and leaving the one built after the close with nothing left to release it.
    */
   private synchronized void releaseTraversal() {
+    // TERMINAL: BOTH CALLERS (close() AND drop()) END THE GRAPH, AND traversal() READS THIS UNDER THE SAME MONITOR.
+    closed = true;
+
     if (traversal != null) {
       try {
         traversal.close();

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
@@ -178,7 +178,14 @@ public class ArcadeGraphFactory implements Closeable {
     while (!pooledInstances.isEmpty()) {
       final PooledArcadeGraph instance = pooledInstances.poll();
       if (instance != null)
-        instance.dispose();
+        try {
+          instance.dispose();
+        } catch (final Exception e) {
+          // ONE INSTANCE THAT FAILS TO DISPOSE MUST NOT STRAND THE REST: EVERY OTHER POOLED GRAPH STILL HOLDS A
+          // DRIVER Cluster (A NETTY EVENT-LOOP GROUP AND A CONNECTION POOL) AND, OVER A REMOTE POOL, ITS OWN
+          // CONNECTION - THE VERY RESOURCES #6822 IS ABOUT - AND THE SHARED LOCAL DATABASE BELOW WOULD STAY OPEN.
+          LogManager.instance().log(this, Level.WARNING, "Error on disposing a pooled ArcadeGraph instance", e);
+        }
     }
 
     if (localDatabase != null)

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
@@ -85,6 +85,9 @@ public class ArcadeGraphFactory implements Closeable {
           if (getDatabase().isTransactionActive())
             getDatabase().rollback();
         } catch (final Exception e) {
+          // RESIDUAL RISK, AND THERE IS NOTHING BETTER TO DO ABOUT IT HERE: IF THE ROLLBACK ITSELF FAILS (AN I/O
+          // ERROR, SAY) THE INSTANCE GOES BACK ON THE QUEUE WITH ITS TRANSACTION STILL OPEN, AND ONLY THIS LOG LINE
+          // SAYS SO. DROPPING THE INSTANCE INSTEAD WOULD SILENTLY SHRINK THE POOL BELOW ITS COUNTER.
           LogManager.instance()
               .log(this, Level.WARNING, "Error on rolling back the pending transaction while releasing a pooled ArcadeGraph instance", e);
         }

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
@@ -48,6 +48,12 @@ public class ArcadeGraphFactory implements Closeable {
   private       int                                      maxInstances          = 32;
   private final AtomicInteger                            totalInstancesCreated = new AtomicInteger(0);
 
+  /**
+   * A borrowed {@link ArcadeGraph}, where {@code close()} means "give it back" rather than "tear it down". A caller
+   * must not touch the instance after calling {@code close()}: it is handed straight to the next borrower, possibly
+   * on another thread, and unlike a non-pooled graph it is not marked closed - so continuing to use it interleaves
+   * with whoever holds it now instead of failing loudly.
+   */
   public class PooledArcadeGraph extends ArcadeGraph {
     private final ArcadeGraphFactory factory;
 

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.remote.RemoteDatabase;
 import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
 
 import java.io.Closeable;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -67,15 +68,17 @@ public class ArcadeGraphFactory implements Closeable {
      */
     @Override
     public void close() {
+      RuntimeException failure = null;
       try {
         // HONOUR THE CONFIGURED CLOSE BEHAVIOUR FIRST (ROLLBACK BY DEFAULT), AS A NON-POOLED ArcadeGraph.close() DOES.
         // UNCONDITIONALLY, EVEN WITH NO TRANSACTION OPEN: AbstractThreadLocalTransaction.doClose() ALSO CLEARS THE
         // onClose()/onReadWrite() CONSUMERS, AND THE TRANSACTION OBJECT OUTLIVES THE BORROW. SKIPPING THE CALL WOULD
         // LEAVE A BORROWER'S onClose(COMMIT) IN PLACE FOR THE NEXT ONE, WHICH IS #6821 THROUGH A SIDE DOOR.
         tx().close();
-      } catch (final Exception e) {
-        LogManager.instance()
-            .log(this, Level.WARNING, "Error on ending the pending transaction while releasing a pooled ArcadeGraph instance", e);
+      } catch (final RuntimeException e) {
+        // A BORROWER WHOSE COMMIT-ON-CLOSE FAILED HAS TO HEAR ABOUT IT, BUT ONLY ONCE THE INSTANCE IS BACK IN THE
+        // POOL AND CLEAN: HOLD THE FAILURE UNTIL THE finally BELOW HAS RUN.
+        failure = e;
       } finally {
         try {
           // WHATEVER THE CLOSE BEHAVIOUR DID, THE INSTANCE MUST NOT GO BACK ON THE QUEUE WITH AN OPEN TRANSACTION.
@@ -85,8 +88,21 @@ public class ArcadeGraphFactory implements Closeable {
           LogManager.instance()
               .log(this, Level.WARNING, "Error on rolling back the pending transaction while releasing a pooled ArcadeGraph instance", e);
         }
+
+        try {
+          // TinkerPop CLEARS THE CONSUMERS ONLY AFTER RUNNING THEM, SO ONE THAT THREW IS STILL ARMED FOR THE NEXT
+          // BORROWER OF THIS SLOT. PUT THE DEFAULTS BACK EXPLICITLY RATHER THAN TRUST doClose() TO HAVE GOT THERE.
+          tx().onClose(Transaction.CLOSE_BEHAVIOR.ROLLBACK).onReadWrite(Transaction.READ_WRITE_BEHAVIOR.AUTO);
+        } catch (final Exception e) {
+          LogManager.instance()
+              .log(this, Level.WARNING, "Error on resetting the transaction behaviour of a pooled ArcadeGraph instance", e);
+        }
+
         factory.release(this);
       }
+
+      if (failure != null)
+        throw failure;
     }
 
     public void dispose() {

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
@@ -69,8 +69,10 @@ public class ArcadeGraphFactory implements Closeable {
     public void close() {
       try {
         // HONOUR THE CONFIGURED CLOSE BEHAVIOUR FIRST (ROLLBACK BY DEFAULT), AS A NON-POOLED ArcadeGraph.close() DOES.
-        if (tx().isOpen())
-          tx().close();
+        // UNCONDITIONALLY, EVEN WITH NO TRANSACTION OPEN: AbstractThreadLocalTransaction.doClose() ALSO CLEARS THE
+        // onClose()/onReadWrite() CONSUMERS, AND THE TRANSACTION OBJECT OUTLIVES THE BORROW. SKIPPING THE CALL WOULD
+        // LEAVE A BORROWER'S onClose(COMMIT) IN PLACE FOR THE NEXT ONE, WHICH IS #6821 THROUGH A SIDE DOOR.
+        tx().close();
       } catch (final Exception e) {
         LogManager.instance()
             .log(this, Level.WARNING, "Error on ending the pending transaction while releasing a pooled ArcadeGraph instance", e);

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
@@ -80,14 +80,14 @@ public class ArcadeGraphFactory implements Closeable {
         // POOL AND CLEAN: HOLD THE FAILURE UNTIL THE finally BELOW HAS RUN.
         failure = e;
       } finally {
+        boolean clean = true;
+
         try {
           // WHATEVER THE CLOSE BEHAVIOUR DID, THE INSTANCE MUST NOT GO BACK ON THE QUEUE WITH AN OPEN TRANSACTION.
           if (getDatabase().isTransactionActive())
             getDatabase().rollback();
         } catch (final Exception e) {
-          // RESIDUAL RISK, AND THERE IS NOTHING BETTER TO DO ABOUT IT HERE: IF THE ROLLBACK ITSELF FAILS (AN I/O
-          // ERROR, SAY) THE INSTANCE GOES BACK ON THE QUEUE WITH ITS TRANSACTION STILL OPEN, AND ONLY THIS LOG LINE
-          // SAYS SO. DROPPING THE INSTANCE INSTEAD WOULD SILENTLY SHRINK THE POOL BELOW ITS COUNTER.
+          clean = false;
           LogManager.instance()
               .log(this, Level.WARNING, "Error on rolling back the pending transaction while releasing a pooled ArcadeGraph instance", e);
         }
@@ -97,11 +97,17 @@ public class ArcadeGraphFactory implements Closeable {
           // BORROWER OF THIS SLOT. PUT THE DEFAULTS BACK EXPLICITLY RATHER THAN TRUST doClose() TO HAVE GOT THERE.
           tx().onClose(Transaction.CLOSE_BEHAVIOR.ROLLBACK).onReadWrite(Transaction.READ_WRITE_BEHAVIOR.AUTO);
         } catch (final Exception e) {
+          clean = false;
           LogManager.instance()
               .log(this, Level.WARNING, "Error on resetting the transaction behaviour of a pooled ArcadeGraph instance", e);
         }
 
-        factory.release(this);
+        if (clean)
+          factory.release(this);
+        else
+          // CLEANUP FAILED, SO WHAT THIS INSTANCE STILL CARRIES IS EXACTLY WHAT #6821 IS ABOUT - AN OPEN TRANSACTION,
+          // OR THE PREVIOUS BORROWER'S CALLBACKS. IT MUST NOT REACH ANOTHER BORROWER.
+          factory.quarantine(this);
       }
 
       if (failure != null)
@@ -121,6 +127,11 @@ public class ArcadeGraphFactory implements Closeable {
           "Cannot drop a database from a pooled ArcadeGraph instance: the rest of the pool, and for a remote pool every other client of that server, is still using it");
     }
 
+    /**
+     * Tears the instance down for real, which is what {@link ArcadeGraphFactory#close()} does to the pool. Kept
+     * separate from {@link #close()} because that one means "give it back", and so deliberately keeps the traversal
+     * source and its driver cluster alive for the next borrower.
+     */
     public void dispose() {
       super.close();
     }
@@ -224,5 +235,18 @@ public class ArcadeGraphFactory implements Closeable {
 
   private void release(final PooledArcadeGraph pooledArcadeGraph) {
     pooledInstances.offer(pooledArcadeGraph);
+  }
+
+  /**
+   * Drops an instance that could not be cleaned on release, instead of handing it to the next borrower. The counter
+   * gets its slot back, so a replacement can be created and the pool does not quietly shrink towards zero.
+   */
+  private void quarantine(final PooledArcadeGraph pooledArcadeGraph) {
+    totalInstancesCreated.decrementAndGet();
+    try {
+      pooledArcadeGraph.dispose();
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "Error on disposing a pooled ArcadeGraph instance that failed to clean up", e);
+    }
   }
 }

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
@@ -21,12 +21,14 @@ package com.arcadedb.gremlin;
 import com.arcadedb.database.BasicDatabase;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.remote.RemoteDatabase;
 import org.apache.commons.configuration2.Configuration;
 
 import java.io.Closeable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 
 /**
  * ArcadeDB Gremlin implementation factory class. Utilizes a pool of ArcadeGraph to avoid creating a new instance every time.
@@ -53,14 +55,36 @@ public class ArcadeGraphFactory implements Closeable {
       this.factory = factory;
     }
 
-    protected PooledArcadeGraph(final ArcadeGraphFactory factory, final BasicDatabase database) {
-      super(database);
+    protected PooledArcadeGraph(final ArcadeGraphFactory factory, final BasicDatabase database, final boolean sharedDatabase) {
+      super(database, sharedDatabase);
       this.factory = factory;
     }
 
+    /**
+     * Returns the instance to the pool. A borrowed instance must always be handed back clean: any transaction still
+     * in flight is ended here, otherwise the next borrower inherits (and commits) another caller's writes, which
+     * across threads is cross-request data mixing (issue #6821).
+     */
     @Override
     public void close() {
-      factory.release(this);
+      try {
+        // HONOUR THE CONFIGURED CLOSE BEHAVIOUR FIRST (ROLLBACK BY DEFAULT), AS A NON-POOLED ArcadeGraph.close() DOES.
+        if (tx().isOpen())
+          tx().close();
+      } catch (final Exception e) {
+        LogManager.instance()
+            .log(this, Level.WARNING, "Error on ending the pending transaction while releasing a pooled ArcadeGraph instance", e);
+      } finally {
+        try {
+          // WHATEVER THE CLOSE BEHAVIOUR DID, THE INSTANCE MUST NOT GO BACK ON THE QUEUE WITH AN OPEN TRANSACTION.
+          if (getDatabase().isTransactionActive())
+            getDatabase().rollback();
+        } catch (final Exception e) {
+          LogManager.instance()
+              .log(this, Level.WARNING, "Error on rolling back the pending transaction while releasing a pooled ArcadeGraph instance", e);
+        }
+        factory.release(this);
+      }
     }
 
     public void dispose() {
@@ -135,9 +159,11 @@ public class ArcadeGraphFactory implements Closeable {
             + " instances in the pool. Assure the instances were correctly released with Graph.close()");
 
       if (localDatabase != null)
-        instance = new PooledArcadeGraph(this, localDatabase);
+        // THE LOCAL DATABASE IS SHARED BY EVERY POOLED INSTANCE AND OWNED BY THE FACTORY: DISPOSING ONE INSTANCE MUST
+        // NOT CLOSE IT UNDER THE OTHERS. THE FACTORY CLOSES IT ITSELF IN close().
+        instance = new PooledArcadeGraph(this, localDatabase, true);
       else
-        instance = new PooledArcadeGraph(this, new RemoteDatabase(host, port, databaseName, userName, userPassword));
+        instance = new PooledArcadeGraph(this, new RemoteDatabase(host, port, databaseName, userName, userPassword), false);
       totalInstancesCreated.incrementAndGet();
     }
     return instance;

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFactory.java
@@ -108,6 +108,19 @@ public class ArcadeGraphFactory implements Closeable {
         throw failure;
     }
 
+    /**
+     * Always refused. A borrowed instance never owns the database: over a local pool it is the factory's, shared with
+     * every other instance, and over a remote pool {@code drop()} would delete it on the server for every other
+     * instance AND every other client connected to it. The per-instance {@code sharedDatabase} flag cannot express
+     * this, because a remote instance does own its own connection object and {@code close()} must still close it
+     * (issue #6821).
+     */
+    @Override
+    public void drop() {
+      throw new UnsupportedOperationException(
+          "Cannot drop a database from a pooled ArcadeGraph instance: the rest of the pool, and for a remote pool every other client of that server, is still using it");
+    }
+
     public void dispose() {
       super.close();
     }

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFeatures.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraphFeatures.java
@@ -173,8 +173,16 @@ public class ArcadeGraphFeatures implements Graph.Features {
       return false;
     }
 
+    /**
+     * A vertex property id is {@code (vertex RID, key)} rendered as a string, never a number (issue #6823).
+     */
     @Override
     public boolean supportsNumericIds() {
+      return false;
+    }
+
+    @Override
+    public boolean supportsStringIds() {
       return true;
     }
 

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertex.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertex.java
@@ -41,14 +41,39 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Created by Enrico Risa on 30/07/2018.
  */
 public class ArcadeVertex extends ArcadeElement<com.arcadedb.graph.Vertex> implements Vertex {
 
+  private static final AtomicLong TRANSIENT_IDS = new AtomicLong();
+
+  /**
+   * Assigned lazily, and only for a vertex that has no RID yet, so a saved vertex never pays for it.
+   */
+  private volatile String transientId;
+
   protected ArcadeVertex(final ArcadeGraph graph, final com.arcadedb.graph.Vertex baseElement, final Object... keyValues) {
     super(graph, baseElement, keyValues);
+  }
+
+  /**
+   * Returns an identifier unique to this instance, for the window in which the vertex has no RID yet. Unlike
+   * {@link System#identityHashCode}, which the JDK never promises to be collision-free, a counter cannot hand the same
+   * value to two vertices, so the ids of their properties cannot collide either (see {@link ArcadeVertexProperty#id()}).
+   */
+  String transientId() {
+    String id = transientId;
+    if (id == null) {
+      synchronized (this) {
+        id = transientId;
+        if (id == null)
+          transientId = id = "?" + TRANSIENT_IDS.incrementAndGet();
+      }
+    }
+    return id;
   }
 
   @Override

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
@@ -93,6 +93,11 @@ public class ArcadeVertexProperty<T> implements VertexProperty<T> {
    * {@code ElementHelper} compares vertex properties by id alone, so the id must be unique: deriving it from a sum of
    * hash codes made distinct properties of the same vertex compare equal and be deduplicated away (issue #6823).
    * The vertex id is a RID, which never contains the separator, so no pair of (vertex, key) can produce the same id.
+   * <p>
+   * Caveat for a property read off a vertex that has not been saved yet: its id is built from the vertex's transient
+   * id and therefore changes once the vertex gets its RID. A property held in a {@code Set} or a {@code Map} from
+   * before the save is no longer findable there afterwards, because its {@code hashCode()} has moved with it. That is
+   * inherent to an identity anchored on the RID; read the property again after the save.
    */
   @Override
   public Object id() {

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
@@ -36,6 +36,8 @@ import java.util.NoSuchElementException;
  */
 public class ArcadeVertexProperty<T> implements VertexProperty<T> {
 
+  private static final String ID_SEPARATOR = "-";
+
   protected final String       key;
   protected final T            value;
   protected final ArcadeVertex vertex;
@@ -80,9 +82,17 @@ public class ArcadeVertexProperty<T> implements VertexProperty<T> {
 
   }
 
+  /**
+   * A vertex property has single cardinality here, so {@code (vertex, key)} is its identity. TinkerPop's
+   * {@code ElementHelper} compares vertex properties by id alone, so the id must be unique: deriving it from a sum of
+   * hash codes made distinct properties of the same vertex compare equal and be deduplicated away (issue #6823).
+   * The vertex id is a RID, which never contains the separator, so no pair of (vertex, key) can produce the same id.
+   */
   @Override
   public Object id() {
-    return (long) (this.key.hashCode() + this.value.hashCode() + this.vertex.id().hashCode());
+    final Object vertexId = this.vertex.id();
+    // AN UNSAVED VERTEX HAS NO RID YET: FALL BACK TO ITS INSTANCE IDENTITY SO id() NEITHER THROWS NOR COLLIDES.
+    return (vertexId != null ? vertexId : "?" + System.identityHashCode(this.vertex)) + ID_SEPARATOR + this.key;
   }
 
   @Override

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
@@ -36,7 +36,7 @@ import java.util.NoSuchElementException;
  */
 public class ArcadeVertexProperty<T> implements VertexProperty<T> {
 
-  private static final String ID_SEPARATOR = "-";
+  private static final char ID_SEPARATOR = '-';
 
   protected final String       key;
   protected final T            value;
@@ -105,7 +105,18 @@ public class ArcadeVertexProperty<T> implements VertexProperty<T> {
     if (result == null) {
       final Object vertexId = this.vertex.id();
       // AN UNSAVED VERTEX HAS NO RID YET: FALL BACK TO ITS TRANSIENT ID SO id() NEITHER THROWS NOR COLLIDES.
-      result = (vertexId != null ? vertexId : this.vertex.transientId()) + ID_SEPARATOR + this.key;
+      final String prefix = vertexId != null ? vertexId.toString() : this.vertex.transientId();
+
+      if (prefix.indexOf(ID_SEPARATOR) < 0)
+        result = prefix + ID_SEPARATOR + this.key;
+      else
+        // A VERTEX RID (#bucket:offset, BOTH NON-NEGATIVE) AND A TRANSIENT ID (?counter) CANNOT CONTAIN THE
+        // SEPARATOR, SO THE BRANCH ABOVE IS WHAT EVERY REAL VERTEX TAKES. RID CAN STILL RENDER NEGATIVE COMPONENTS
+        // FOR THE SENTINELS THE INDEX AND EDGE-SEGMENT INTERNALS USE, AND THOSE WOULD MAKE THE SPLIT AMBIGUOUS:
+        // LENGTH-PREFIX THEM INSTEAD OF TRUSTING THEY CAN NEVER REACH A VERTEX. THE TWO FORMS CANNOT COLLIDE WITH
+        // EACH OTHER EITHER, SINCE ONE STARTS WITH A DIGIT AND THE OTHER WITH '#' OR '?'.
+        result = prefix.length() + ID_SEPARATOR + prefix + this.key;
+
       if (vertexId != null)
         // ONLY A RID IS FINAL: AN UNSAVED VERTEX WILL GET ONE LATER AND THE ID HAS TO FOLLOW IT.
         id = result;

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
@@ -46,7 +46,7 @@ public class ArcadeVertexProperty<T> implements VertexProperty<T> {
    * Cached only once the vertex has a RID, because {@code equals()}/{@code hashCode()} both go through {@link #id()}
    * and would otherwise rebuild the string on every probe of a {@code Set}, a {@code Map} or a {@code dedup()}.
    */
-  private String id;
+  private volatile String id;
 
   protected ArcadeVertexProperty(final ArcadeVertex vertex, final String key, final T value) {
     this.vertex = vertex;

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
@@ -42,6 +42,12 @@ public class ArcadeVertexProperty<T> implements VertexProperty<T> {
   protected final T            value;
   protected final ArcadeVertex vertex;
 
+  /**
+   * Cached only once the vertex has a RID, because {@code equals()}/{@code hashCode()} both go through {@link #id()}
+   * and would otherwise rebuild the string on every probe of a {@code Set}, a {@code Map} or a {@code dedup()}.
+   */
+  private String id;
+
   protected ArcadeVertexProperty(final ArcadeVertex vertex, final String key, final T value) {
     this.vertex = vertex;
     this.key = key;
@@ -90,9 +96,16 @@ public class ArcadeVertexProperty<T> implements VertexProperty<T> {
    */
   @Override
   public Object id() {
-    final Object vertexId = this.vertex.id();
-    // AN UNSAVED VERTEX HAS NO RID YET: FALL BACK TO ITS TRANSIENT ID SO id() NEITHER THROWS NOR COLLIDES.
-    return (vertexId != null ? vertexId : this.vertex.transientId()) + ID_SEPARATOR + this.key;
+    String result = id;
+    if (result == null) {
+      final Object vertexId = this.vertex.id();
+      // AN UNSAVED VERTEX HAS NO RID YET: FALL BACK TO ITS TRANSIENT ID SO id() NEITHER THROWS NOR COLLIDES.
+      result = (vertexId != null ? vertexId : this.vertex.transientId()) + ID_SEPARATOR + this.key;
+      if (vertexId != null)
+        // ONLY A RID IS FINAL: AN UNSAVED VERTEX WILL GET ONE LATER AND THE ID HAS TO FOLLOW IT.
+        id = result;
+    }
+    return result;
   }
 
   @Override

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeVertexProperty.java
@@ -91,8 +91,8 @@ public class ArcadeVertexProperty<T> implements VertexProperty<T> {
   @Override
   public Object id() {
     final Object vertexId = this.vertex.id();
-    // AN UNSAVED VERTEX HAS NO RID YET: FALL BACK TO ITS INSTANCE IDENTITY SO id() NEITHER THROWS NOR COLLIDES.
-    return (vertexId != null ? vertexId : "?" + System.identityHashCode(this.vertex)) + ID_SEPARATOR + this.key;
+    // AN UNSAVED VERTEX HAS NO RID YET: FALL BACK TO ITS TRANSIENT ID SO id() NEITHER THROWS NOR COLLIDES.
+    return (vertexId != null ? vertexId : this.vertex.transientId()) + ID_SEPARATOR + this.key;
   }
 
   @Override

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
@@ -24,7 +24,16 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -136,6 +145,42 @@ class ArcadeGraphCloseTransactionTest {
         .as("building a traversal after close() would resurrect the very resources close() released")
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Graph is closed");
+  }
+
+  @Test
+  void concurrentCallersAllGetTheOneTraversalSource() throws Exception {
+    final int threads = 16;
+    final Set<GraphTraversalSource> distinct = Collections.newSetFromMap(new IdentityHashMap<>());
+    final CountDownLatch startLine = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(threads);
+    final ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+    try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
+      for (int i = 0; i < threads; i++)
+        executor.submit(() -> {
+          try {
+            startLine.await();
+            final GraphTraversalSource mine = graph.traversal();
+            synchronized (distinct) {
+              distinct.add(mine);
+            }
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            done.countDown();
+          }
+        });
+
+      startLine.countDown();
+      assertThat(done.await(30, TimeUnit.SECONDS)).as("every caller must have finished").isTrue();
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertThat(distinct)
+        .as("callers racing on traversal() must share one source: a loser's would be orphaned, and for a remote "
+            + "graph that means a driver cluster nothing is left holding to close")
+        .hasSize(1);
   }
 
   private long countPersons() {

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
@@ -183,6 +183,28 @@ class ArcadeGraphCloseTransactionTest {
         .hasSize(1);
   }
 
+  @Test
+  void aSharedGraphNeitherDropsNorClosesTheDatabaseItDoesNotOwn() {
+    // openShared() IS THE PATH ArcadeGraphManager USES FOR SERVER-MANAGED DATABASES, AND ITS CONTRACT IS THAT THIS
+    // GRAPH DOES NOT OWN THE LIFECYCLE. PooledArcadeGraph OVERRIDES drop() OUTRIGHT, SO ONLY THIS EXERCISES THE
+    // sharedDatabase GUARD IN ArcadeGraph ITSELF.
+    final Database database = new DatabaseFactory(DB_PATH).open();
+    try {
+      final ArcadeGraph shared = ArcadeGraph.openShared(database);
+
+      assertThatThrownBy(shared::drop)
+          .as("a graph that does not own the database must not delete it")
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThat(database.isOpen()).as("and must not have got as far as touching it").isTrue();
+
+      shared.close();
+      assertThat(database.isOpen()).as("close() must leave an externally managed database open too").isTrue();
+    } finally {
+      if (database.isOpen())
+        database.close();
+    }
+  }
+
   private long countPersons() {
     try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
       return graph.traversal().V().hasLabel("Person").count().next();

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
@@ -205,6 +205,29 @@ class ArcadeGraphCloseTransactionTest {
     }
   }
 
+  @Test
+  void aSharedGraphRollsBackOnCloseWhateverCloseBehaviourWasConfigured() {
+    // ArcadeGraphManager KEEPS ONE openShared() GRAPH PER DATABASE FOR EVERY GREMLIN SERVER SESSION, WITH NO BORROW
+    // BOUNDARY TO RESET ITS TRANSACTION. CLOSING IT IS A SERVER TEARDOWN, NOT THE END OF A UNIT OF WORK, AND LETTING
+    // A COMMIT RUN THERE IS WHAT LEFT THE WAL INCONSISTENT AT SHUTDOWN (SEE ArcadeGraphSharedDatabaseIT).
+    final Database database = new DatabaseFactory(DB_PATH).open();
+    try {
+      final ArcadeGraph shared = ArcadeGraph.openShared(database);
+      shared.tx().onClose(Transaction.CLOSE_BEHAVIOR.COMMIT);
+      shared.tx().begin();
+      shared.addVertex(T.label, "Person", "name", "must-not-survive");
+      shared.close();
+
+      assertThat(database.isTransactionActive()).as("the teardown must have ended the transaction").isFalse();
+      assertThat(database.countType("Person", false))
+          .as("a server-managed graph must roll back on close even when a session armed commit-on-close")
+          .isEqualTo(0L);
+    } finally {
+      if (database.isOpen())
+        database.close();
+    }
+  }
+
   private long countPersons() {
     try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
       return graph.traversal().V().hasLabel("Person").count().next();

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
@@ -110,6 +110,22 @@ class ArcadeGraphCloseTransactionTest {
     assertThat(countPersons()).isEqualTo(1L);
   }
 
+  @Test
+  void aFailingCloseBehaviourStillReleasesTheDatabase() {
+    final ArcadeGraph graph = ArcadeGraph.open(DB_PATH);
+    graph.tx().onClose(tx -> {
+      throw new IllegalStateException("boom");
+    });
+    graph.tx().begin();
+    graph.addVertex(T.label, "Person", "name", "half-written");
+
+    assertThatThrownBy(graph::close).isInstanceOf(IllegalStateException.class).hasMessage("boom");
+
+    assertThat(graph.getDatabase().isOpen())
+        .as("a close behaviour that blows up must not cost the caller the database handle")
+        .isFalse();
+  }
+
   private long countPersons() {
     try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
       return graph.traversal().V().hasLabel("Person").count().next();

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Closing an {@link ArcadeGraph} must end an in-flight unit of work the way TinkerPop says it does, i.e. through the
+ * transaction's configured {@code CLOSE_BEHAVIOR}, whose default is rollback. Issue #6820: it used to hard-code a
+ * commit, so a unit of work that aborted before {@code commit()} became durable anyway.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ArcadeGraphCloseTransactionTest {
+
+  private static final String DB_PATH = "./target/databases/test-graph-close-transaction";
+
+  @BeforeEach
+  void setUp() {
+    try (final DatabaseFactory databaseFactory = new DatabaseFactory(DB_PATH)) {
+      if (databaseFactory.exists())
+        databaseFactory.open().drop();
+      final Database database = databaseFactory.create();
+      database.getSchema().createVertexType("Person");
+      database.close();
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    try (final DatabaseFactory databaseFactory = new DatabaseFactory(DB_PATH)) {
+      if (databaseFactory.exists())
+        databaseFactory.open().drop();
+    }
+  }
+
+  @Test
+  void closingTheGraphRollsBackAnUncommittedTransaction() {
+    try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
+      graph.tx().begin();
+      graph.addVertex(T.label, "Person", "name", "uncommitted");
+    }
+
+    assertThat(countPersons())
+        .as("a unit of work never committed must not survive ArcadeGraph.close()")
+        .isEqualTo(0L);
+  }
+
+  @Test
+  void anAbortedUnitOfWorkLeavesNothingDurable() {
+    assertThatThrownBy(() -> {
+      try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
+        graph.tx().begin();
+        graph.addVertex(T.label, "Person", "name", "first-half");
+        throw new IllegalStateException("boom");
+      }
+    }).isInstanceOf(IllegalStateException.class).hasMessage("boom");
+
+    assertThat(countPersons())
+        .as("try-with-resources closing the graph after a failure must not make the half-applied work durable")
+        .isEqualTo(0L);
+  }
+
+  @Test
+  void closingTheGraphHonoursAConfiguredCommitCloseBehaviour() {
+    try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
+      graph.tx().onClose(Transaction.CLOSE_BEHAVIOR.COMMIT);
+      graph.tx().begin();
+      graph.addVertex(T.label, "Person", "name", "explicitly-kept");
+    }
+
+    assertThat(countPersons())
+        .as("an application that asks for commit-on-close must still get it")
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void anExplicitCommitIsStillDurable() {
+    try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
+      graph.tx().begin();
+      graph.addVertex(T.label, "Person", "name", "committed");
+      graph.tx().commit();
+    }
+
+    assertThat(countPersons()).isEqualTo(1L);
+  }
+
+  private long countPersons() {
+    try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
+      return graph.traversal().V().hasLabel("Person").count().next();
+    }
+  }
+}

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphCloseTransactionTest.java
@@ -126,6 +126,18 @@ class ArcadeGraphCloseTransactionTest {
         .isFalse();
   }
 
+  @Test
+  void theTraversalIsRefusedOnceTheGraphIsClosed() {
+    final ArcadeGraph graph = ArcadeGraph.open(DB_PATH);
+    graph.traversal().V().hasLabel("Person").count().next();
+    graph.close();
+
+    assertThatThrownBy(graph::traversal)
+        .as("building a traversal after close() would resurrect the very resources close() released")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Graph is closed");
+  }
+
   private long countPersons() {
     try (final ArcadeGraph graph = ArcadeGraph.open(DB_PATH)) {
       return graph.traversal().V().hasLabel("Person").count().next();

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.gremlin;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,6 +96,28 @@ class ArcadeGraphFactoryPoolTransactionTest {
     reader.close();
 
     assertThat(names).as("the second borrower must persist only what it wrote itself").containsExactly("mine");
+  }
+
+  @Test
+  void aBorrowersCloseBehaviourDoesNotFollowTheInstanceToTheNextBorrower() {
+    final ArcadeGraph first = factory.get();
+    // A LEGITIMATE, DOCUMENTED TINKERPOP CALL - BUT IT MUST NOT OUTLIVE THIS BORROW
+    first.tx().onClose(Transaction.CLOSE_BEHAVIOR.COMMIT);
+    first.close();
+
+    final ArcadeGraph second = factory.get();
+    assertThat(second).isSameAs(first);
+    second.addVertex(T.label, "Person", "name", "abandoned");
+    second.close();
+
+    final List<String> names = new ArrayList<>();
+    final ArcadeGraph reader = factory.get();
+    reader.traversal().V().hasLabel("Person").values("name").forEachRemaining(n -> names.add((String) n));
+    reader.close();
+
+    assertThat(names)
+        .as("the close behaviour a previous borrower configured must not commit the next borrower's abandoned writes")
+        .isEmpty();
   }
 
   @Test

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
@@ -166,6 +166,19 @@ class ArcadeGraphFactoryPoolTransactionTest {
   }
 
   @Test
+  void aBorrowedRemoteInstanceCannotDropTheServerSideDatabase() {
+    // NO SERVER IS NEEDED, AND THAT IS THE POINT: RemoteDatabase CONNECTS LAZILY, SO drop() MUST BE REFUSED BEFORE
+    // ANYTHING REACHES THE WIRE. LEFT UNGUARDED IT WOULD SEND "drop database" AND DELETE IT FOR EVERY OTHER CLIENT
+    // OF THAT SERVER, NOT ONLY FOR THE REST OF THE POOL.
+    try (final ArcadeGraphFactory remotePool = ArcadeGraphFactory.withRemote("127.0.0.1", 1, "never-reached", "root", "root")) {
+      final ArcadeGraph borrowed = remotePool.get();
+      assertThatThrownBy(borrowed::drop)
+          .as("a borrowed remote instance must not drop the database the whole server shares")
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+  }
+
+  @Test
   void theFactoryDoesNotMakeAbandonedWritesDurableOnClose() {
     final ArcadeGraph graph = factory.get();
     graph.addVertex(T.label, "Person", "name", "abandoned");

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * A borrowed pool instance must be handed back clean. Issue #6821: {@code PooledArcadeGraph.close()} put the instance
@@ -118,6 +119,33 @@ class ArcadeGraphFactoryPoolTransactionTest {
     assertThat(names)
         .as("the close behaviour a previous borrower configured must not commit the next borrower's abandoned writes")
         .isEmpty();
+  }
+
+  @Test
+  void aFailingCloseBehaviourIsReportedAndStillLeavesThePoolClean() {
+    final ArcadeGraph first = factory.get();
+    first.tx().onClose(tx -> {
+      throw new IllegalStateException("boom");
+    });
+    first.addVertex(T.label, "Person", "name", "abandoned");
+
+    assertThatThrownBy(first::close)
+        .as("a borrower whose commit-on-close failed has to hear about it")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("boom");
+
+    final ArcadeGraph second = factory.get();
+    assertThat(second).as("the instance must be back in the pool even though its close behaviour blew up").isSameAs(first);
+    assertThat(second.tx().isOpen()).as("and back clean").isFalse();
+    second.addVertex(T.label, "Person", "name", "mine");
+    second.close();
+
+    final List<String> names = new ArrayList<>();
+    final ArcadeGraph reader = factory.get();
+    reader.traversal().V().hasLabel("Person").values("name").forEachRemaining(n -> names.add((String) n));
+    reader.close();
+
+    assertThat(names).as("a close behaviour that threw must not stay armed for the next borrower").isEmpty();
   }
 
   @Test

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A borrowed pool instance must be handed back clean. Issue #6821: {@code PooledArcadeGraph.close()} put the instance
+ * back on the queue with its transaction still open, so the next borrower inherited another caller's writes and
+ * committed them along with its own.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ArcadeGraphFactoryPoolTransactionTest {
+
+  private static final String DB_PATH = "./target/databases/test-graphfactory-pool-transaction";
+
+  private ArcadeGraphFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    try (final DatabaseFactory databaseFactory = new DatabaseFactory(DB_PATH)) {
+      if (databaseFactory.exists())
+        databaseFactory.open().drop();
+      final Database database = databaseFactory.create();
+      database.getSchema().createVertexType("Person");
+      database.close();
+    }
+    factory = ArcadeGraphFactory.withLocal(DB_PATH);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (factory != null)
+      factory.close();
+    try (final DatabaseFactory databaseFactory = new DatabaseFactory(DB_PATH)) {
+      if (databaseFactory.exists())
+        databaseFactory.open().drop();
+    }
+  }
+
+  @Test
+  void aReleasedInstanceGoesBackToThePoolWithNoOpenTransaction() {
+    final ArcadeGraph first = factory.get();
+    first.addVertex(T.label, "Person", "name", "uncommitted");
+    assertThat(first.tx().isOpen()).as("the implicit begin() must have opened a transaction").isTrue();
+    first.close();
+
+    final ArcadeGraph second = factory.get();
+    assertThat(second).as("the pool must hand back the very same instance").isSameAs(first);
+    assertThat(second.tx().isOpen()).as("a pooled instance must never be borrowed with a transaction already open").isFalse();
+    second.close();
+  }
+
+  @Test
+  void theNextBorrowerDoesNotCommitTheAbandonedWritesOfThePreviousOne() {
+    final ArcadeGraph first = factory.get();
+    first.addVertex(T.label, "Person", "name", "abandoned");
+    first.close();
+
+    final ArcadeGraph second = factory.get();
+    second.addVertex(T.label, "Person", "name", "mine");
+    second.tx().commit();
+    second.close();
+
+    final List<String> names = new ArrayList<>();
+    final ArcadeGraph reader = factory.get();
+    reader.traversal().V().hasLabel("Person").values("name").forEachRemaining(n -> names.add((String) n));
+    reader.close();
+
+    assertThat(names).as("the second borrower must persist only what it wrote itself").containsExactly("mine");
+  }
+
+  @Test
+  void theFactoryDoesNotMakeAbandonedWritesDurableOnClose() {
+    final ArcadeGraph graph = factory.get();
+    graph.addVertex(T.label, "Person", "name", "abandoned");
+    graph.close();
+
+    factory.close();
+    factory = null;
+
+    try (final DatabaseFactory databaseFactory = new DatabaseFactory(DB_PATH)) {
+      final Database database = databaseFactory.open();
+      try {
+        assertThat(database.countType("Person", false))
+            .as("disposing the pool must not commit writes nobody ever committed")
+            .isEqualTo(0L);
+      } finally {
+        database.close();
+      }
+    }
+  }
+}

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGraphFactoryPoolTransactionTest.java
@@ -149,6 +149,23 @@ class ArcadeGraphFactoryPoolTransactionTest {
   }
 
   @Test
+  void aBorrowedInstanceCannotDropTheDatabaseTheWholePoolShares() {
+    final ArcadeGraph borrowed = factory.get();
+
+    assertThatThrownBy(borrowed::drop)
+        .as("one borrowed handle must not delete the database every other pooled instance still points at")
+        .isInstanceOf(UnsupportedOperationException.class);
+
+    borrowed.close();
+
+    final ArcadeGraph other = factory.get();
+    assertThat(other.getDatabase().isOpen()).as("the shared database must have survived").isTrue();
+    other.addVertex(T.label, "Person", "name", "still-usable");
+    other.tx().commit();
+    other.close();
+  }
+
+  @Test
   void theFactoryDoesNotMakeAbandonedWritesDurableOnClose() {
     final ArcadeGraph graph = factory.get();
     graph.addVertex(T.label, "Person", "name", "abandoned");

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeVertexPropertyIdTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeVertexPropertyIdTest.java
@@ -122,6 +122,22 @@ class ArcadeVertexPropertyIdTest {
 
     assertThat(first.id()).as("an unsaved vertex must not make id() blow up").isNotNull();
     assertThat(first.id()).isNotEqualTo(second.id());
+    assertThat(new ArcadeVertexProperty<>(vertex, "a", "b").id())
+        .as("the transient id must be stable for as long as the vertex has no RID")
+        .isEqualTo(first.id());
+    graph.tx().rollback();
+  }
+
+  @Test
+  void twoUnsavedVerticesDoNotShareAPropertyId() {
+    graph.tx().begin();
+    graph.getDatabase().getSchema().getOrCreateVertexType("Person");
+    final ArcadeVertex first = new ArcadeVertex(graph, graph.getDatabase().newVertex("Person"));
+    final ArcadeVertex second = new ArcadeVertex(graph, graph.getDatabase().newVertex("Person"));
+
+    assertThat(new ArcadeVertexProperty<>(first, "name", "same").id())
+        .as("distinct unsaved vertices must not produce the same property id")
+        .isNotEqualTo(new ArcadeVertexProperty<>(second, "name", "same").id());
     graph.tx().rollback();
   }
 }

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeVertexPropertyIdTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeVertexPropertyIdTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin;
+
+import com.arcadedb.database.DatabaseFactory;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A vertex property is single-cardinality here, so {@code (vertex, key)} is its identity, and TinkerPop's
+ * {@code ElementHelper} compares vertex properties by id alone. Issue #6823: the id used to be the sum of three hash
+ * codes, so distinct properties on the same vertex collided and were deduplicated away.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ArcadeVertexPropertyIdTest {
+
+  private static final String DB_PATH = "./target/databases/test-vertex-property-id";
+
+  private ArcadeGraph graph;
+
+  @BeforeEach
+  void setUp() {
+    try (final DatabaseFactory databaseFactory = new DatabaseFactory(DB_PATH)) {
+      if (databaseFactory.exists())
+        databaseFactory.open().drop();
+    }
+    graph = ArcadeGraph.open(DB_PATH);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (graph != null)
+      graph.drop();
+  }
+
+  @Test
+  void swappedKeyAndValueDoNotShareAnId() {
+    final ArcadeVertex vertex = graph.addVertex(T.label, "Person");
+    final VertexProperty<String> ab = vertex.property("a", "b");
+    final VertexProperty<String> ba = vertex.property("b", "a");
+
+    assertThat(ab.id()).as("\"a\"->\"b\" and \"b\"->\"a\" are different properties").isNotEqualTo(ba.id());
+    assertThat(ab).isNotEqualTo(ba);
+    assertThat(new HashSet<>(Set.of(ab, ba))).hasSize(2);
+  }
+
+  @Test
+  void keysWithTheSameHashCodeDoNotShareAnId() {
+    final ArcadeVertex vertex = graph.addVertex(T.label, "Person");
+    // the classic "Aa".hashCode() == "BB".hashCode() collision, with an identical value on both
+    final VertexProperty<Integer> aa = vertex.property("Aa", 1);
+    final VertexProperty<Integer> bb = vertex.property("BB", 1);
+
+    assertThat(aa.id()).isNotEqualTo(bb.id());
+    assertThat(aa).isNotEqualTo(bb);
+  }
+
+  @Test
+  void distinctPropertiesAreNotDeduplicatedAway() {
+    final ArcadeVertex vertex = graph.addVertex(T.label, "Person");
+    vertex.property("a", "b");
+    vertex.property("b", "a");
+    graph.tx().commit();
+
+    assertThat(graph.traversal().V(vertex.id()).properties().dedup().count().next())
+        .as("both properties must survive dedup()")
+        .isEqualTo(2L);
+  }
+
+  @Test
+  void thePropertyIdIsTheSameOnEveryLookup() {
+    final ArcadeVertex vertex = graph.addVertex(T.label, "Person");
+    final Object idOnWrite = vertex.property("name", "Jay").id();
+    graph.tx().commit();
+
+    assertThat(vertex.<String>property("name").id()).isEqualTo(idOnWrite);
+  }
+
+  @Test
+  void thePropertiesOfTwoVerticesNeverCollide() {
+    final ArcadeVertex first = graph.addVertex(T.label, "Person");
+    final ArcadeVertex second = graph.addVertex(T.label, "Person");
+    graph.tx().commit();
+
+    assertThat(first.property("name", "same").id()).isNotEqualTo(second.property("name", "same").id());
+  }
+
+  @Test
+  void anUnsavedVertexDoesNotBreakTheId() {
+    graph.tx().begin();
+    graph.getDatabase().getSchema().getOrCreateVertexType("Person");
+    final ArcadeVertex vertex = new ArcadeVertex(graph, graph.getDatabase().newVertex("Person"));
+    assertThat(vertex.id()).as("the fixture must really be an unsaved vertex").isNull();
+
+    final VertexProperty<String> first = new ArcadeVertexProperty<>(vertex, "a", "b");
+    final VertexProperty<String> second = new ArcadeVertexProperty<>(vertex, "b", "a");
+
+    assertThat(first.id()).as("an unsaved vertex must not make id() blow up").isNotNull();
+    assertThat(first.id()).isNotEqualTo(second.id());
+    graph.tx().rollback();
+  }
+}

--- a/gremlin/src/test/java/com/arcadedb/gremlin/RemoteGremlinTraversalClusterIT.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/RemoteGremlinTraversalClusterIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin;
+
+import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.gremlin.AbstractGremlinServerIT;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A remote {@link ArcadeGraph#traversal()} goes through a TinkerPop driver {@link Cluster}, which owns a Netty
+ * event-loop group, a scheduled executor and a connection pool. Issue #6822: nothing ever closed it, so every graph
+ * instance on which {@code traversal()} had been called leaked those for the life of the JVM.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class RemoteGremlinTraversalClusterIT extends AbstractGremlinServerIT {
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return false;
+  }
+
+  @Test
+  void closingTheGraphClosesTheDriverCluster() {
+    final ArcadeGraph graph = ArcadeGraph.open(remoteDatabase());
+
+    assertThat(graph.traversal().V().count().next()).isEqualTo(0L);
+
+    final Cluster cluster = graph.getCluster();
+    assertThat(cluster).as("a remote traversal must go through the Gremlin driver").isNotNull();
+    assertThat(cluster.isClosed()).isFalse();
+
+    graph.close();
+
+    assertThat(cluster.isClosed()).as("ArcadeGraph.close() must shut down the driver cluster it created").isTrue();
+    assertThat(graph.getCluster()).isNull();
+  }
+
+  @Test
+  void droppingTheGraphClosesTheDriverCluster() {
+    final ArcadeGraph graph = ArcadeGraph.open(remoteDatabase());
+
+    assertThat(graph.traversal().V().count().next()).isEqualTo(0L);
+
+    final Cluster cluster = graph.getCluster();
+    assertThat(cluster).isNotNull();
+
+    graph.drop();
+
+    assertThat(cluster.isClosed()).as("ArcadeGraph.drop() must shut down the driver cluster it created").isTrue();
+  }
+
+  @Test
+  void aPooledInstanceKeepsItsClusterUntilTheFactoryIsClosed() {
+    final Cluster cluster;
+    try (final ArcadeGraphFactory pool = ArcadeGraphFactory.withRemote("127.0.0.1", 2480, getDatabaseName(), "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)) {
+
+      final ArcadeGraph borrowed = pool.get();
+      assertThat(borrowed.traversal().V().count().next()).isEqualTo(0L);
+      cluster = ((ArcadeGraph) borrowed).getCluster();
+      assertThat(cluster).isNotNull();
+      borrowed.close();
+
+      assertThat(cluster.isClosed())
+          .as("releasing an instance back to the pool must not tear down the cluster it will reuse")
+          .isFalse();
+
+      final ArcadeGraph reborrowed = pool.get();
+      assertThat(reborrowed).isSameAs(borrowed);
+      assertThat(reborrowed.traversal().V().count().next()).isEqualTo(0L);
+      reborrowed.close();
+    }
+
+    assertThat(cluster.isClosed()).as("closing the factory must dispose the pooled instances and their clusters").isTrue();
+  }
+
+  private RemoteDatabase remoteDatabase() {
+    return new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+  }
+}

--- a/gremlin/src/test/java/com/arcadedb/gremlin/RemoteGremlinTraversalClusterIT.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/RemoteGremlinTraversalClusterIT.java
@@ -78,7 +78,7 @@ class RemoteGremlinTraversalClusterIT extends AbstractGremlinServerIT {
 
       final ArcadeGraph borrowed = pool.get();
       assertThat(borrowed.traversal().V().count().next()).isEqualTo(0L);
-      cluster = ((ArcadeGraph) borrowed).getCluster();
+      cluster = borrowed.getCluster();
       assertThat(cluster).isNotNull();
       borrowed.close();
 


### PR DESCRIPTION
Fixes #6820
Fixes #6821
Fixes #6822
Fixes #6823

Four defects in one lifecycle: what an `ArcadeGraph` hands back when it is closed or released.

## #6820 - `close()` committed instead of rolling back

`ArcadeGraph.close()` ended an open transaction by **committing** it, while the `sharedDatabase` branch of the same `if` did the opposite. A unit of work that aborted before `commit()` became durable anyway when try-with-resources or a `finally` closed the graph.

Both branches now go through `tx().close()`, which honours the transaction's configured `CLOSE_BEHAVIOR`. TinkerPop's default is `ROLLBACK`, which is also what `Neo4jGraph.close()` and JanusGraph do; `tx().close()` additionally clears the thread-local state of `AbstractThreadLocalTransaction` that the hard-coded `commit()` bypassed. An application that genuinely wants the old behaviour now asks for it explicitly with `tx().onClose(Transaction.CLOSE_BEHAVIOR.COMMIT)` - and there is a test for that.

## #6821 - a pooled instance went back on the queue with its transaction open

`PooledArcadeGraph.close()` did nothing but `factory.release(this)`, so the next borrower inherited another caller's writes and committed them along with its own. Across threads that is cross-request data mixing, because `RemoteDatabase.sessionId` is a plain instance field, not thread-local.

Releasing now ends the transaction first (honouring the close behaviour, as a non-pooled `close()` does) and then **forces** a rollback if anything is still active: a borrowed instance must go back clean whatever the close behaviour decided to do.

Better than the issue's suggestion, while in there: a pooled instance over a **local** database now marks that database as shared. Every pooled instance holds the same `localDatabase` object, which the factory owns and closes itself; disposing one instance used to call `database.close()` on it, tearing it down under the other instances still sitting in the pool.

## #6822 - the driver `Cluster` was never closed

`traversal()` built a TinkerPop driver `Cluster` whose only reference was a local variable. It owns a Netty event-loop group (`2 * cores` threads), a scheduled executor and a connection pool, and `DriverRemoteConnection.using(Cluster, String)` does **not** take ownership, so nothing anywhere could ever shut it down - one leak per graph instance, for the life of the JVM.

The cluster is now a field, released together with the traversal source in `close()` and in `drop()`. A pooled instance deliberately keeps its cluster across borrows (it will reuse it) and disposes it only when the factory closes.

## #6823 - vertex-property ids were a sum of hash codes

`ArcadeVertexProperty.id()` returned `key.hashCode() + value.hashCode() + vertex.id().hashCode()`. `ElementHelper` compares vertex properties **by id alone**, so `v.property("a","b")` and `v.property("b","a")` were `equals()`, shared a `hashCode()`, and one of them silently vanished from `dedup()` or from any `Set`. `"Aa"`/`"BB"` collided the same way. It also threw an NPE on an unsaved vertex.

The id is now derived from the identifying pair instead of from hashes: a vertex property is single-cardinality here (`supportsMultiProperties() == false`), so `(vertex, key)` is unique, and a RID never contains the separator, so no two pairs can produce the same id. Unsaved vertices fall back to the vertex instance identity rather than throwing. The id type becomes `String`, consistent with the RID-shaped ids of vertices and edges and with `supportsStringIds()`.

## Tests

- `ArcadeGraphCloseTransactionTest` - rollback on close, an aborted unit of work leaves nothing durable, a configured commit-on-close is still honoured, an explicit commit is still durable.
- `ArcadeGraphFactoryPoolTransactionTest` - a released instance carries no open transaction, the next borrower persists only its own writes, disposing the pool does not make abandoned writes durable.
- `ArcadeVertexPropertyIdTest` - swapped key/value, hash-colliding keys, `dedup()`, stability across lookups, two vertices, unsaved vertex.
- `RemoteGremlinTraversalClusterIT` - against a live Gremlin server: `close()` and `drop()` shut the cluster down, and a pooled instance keeps its cluster until the factory closes.

All of the new unit tests fail on the previous behaviour. Full gremlin unit suite plus every gremlin IT green: **1866 tests, 0 failures**, including the TinkerPop structure and process suites, `RemoteGremlinFactoryIT`, `GremlinTransactionIT` and `ArcadeGraphSharedDatabaseIT`.

## Note for the docs

Two user-visible behaviour changes worth a line on the Gremlin page of the documentation repo:

- `ArcadeGraph.close()` no longer commits - it rolls back, unless the application asks for the old behaviour with `tx().onClose(Transaction.CLOSE_BEHAVIOR.COMMIT)`.
- `VertexProperty.id()` returns a `String` (`#<bucket>:<offset>-<key>`) instead of a `Long`, which breaks any caller that casts or parses it as a number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gremlin graph and pooled connection cleanup, including rollback of unfinished transactions.
  * Prevented uncommitted changes from carrying over when pooled graph instances are reused.
  * Ensured remote connections are released when graphs or factories are closed.
  * Prevented new traversals after a graph is closed.
  * Prevented dropping shared or pooled databases.
  * Improved vertex and property identification, including unsaved vertices, and clarified property ID compatibility.

* **Tests**
  * Added coverage for transaction handling, resource lifecycle, traversal behavior, database-drop protection, and property ID uniqueness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
