### PR TITLE
fix: four small engine/SQL defects (#6818, #6819, #6825, #6826)

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DetachedDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/DetachedDocument.java
@@ -22,7 +22,9 @@ import com.arcadedb.schema.Property;
 import com.arcadedb.serializer.JsonSerializer;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -163,9 +165,16 @@ public class DetachedDocument extends BaseDocument {
     return result.toString();
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * A copy, for the same reason as {@link MutableDocument#getPropertyNames()}: this is the one {@link Document}
+   * accessor whose two implementations disagreed on whether the caller was holding a snapshot or a live view of the
+   * record's own key set (issue #6818).
+   */
   @Override
   public synchronized Set<String> getPropertyNames() {
-    return map.keySet();
+    return Collections.unmodifiableSet(new LinkedHashSet<>(map.keySet()));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/Document.java
+++ b/engine/src/main/java/com/arcadedb/database/Document.java
@@ -113,6 +113,20 @@ public interface Document extends Record {
 
   EmbeddedDocument getEmbedded(String propertyName);
 
+  /**
+   * Returns the names of the properties set on this document, in the order they were set.
+   * <p>
+   * The returned set is an unmodifiable <b>snapshot</b>: it neither reflects later changes to the document nor
+   * allows changing the document through it, and it stays valid while the caller mutates the record - so the
+   * natural {@code for (name : getPropertyNames()) remove(name)} prune loop works. That contract is the only one
+   * every implementation can honour: {@link ImmutableDocument} reads its names out of the serialized buffer and has
+   * no live view to hand back, so a caller holding a {@code Document} could not tell whether the set it got was a
+   * snapshot or a window onto the record's own key set. {@link MutableDocument} used to return the latter, which let
+   * a {@code remove()} on the returned set strip properties while bypassing {@link MutableDocument#remove(String)}
+   * entirely - no dirty flag, no validation (issue #6818).
+   *
+   * @return the property names, as an unmodifiable snapshot
+   */
   Set<String> getPropertyNames();
 
   DocumentType getType();

--- a/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
@@ -232,10 +232,21 @@ public class ImmutableDocument extends BaseDocument {
     return output.toString();
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Already a snapshot - it is decoded out of the serialized buffer, so there is no live view to leak - but the
+   * serializer hands back a plain {@link java.util.LinkedHashSet}, so the wrapper is what makes the second half of
+   * {@link Document#getPropertyNames()}'s contract true here as well: a {@code remove()}/{@code clear()} on it fails
+   * loudly instead of silently succeeding against a copy the caller may believe is the record. This is the most
+   * common path of the three - a plain {@code select} result is an {@code ImmutableDocument} until {@code modify()}
+   * or {@code detach()} is called (issue #6818).
+   */
   @Override
   public Set<String> getPropertyNames() {
     checkForLazyLoading();
-    return database.getSerializer().getPropertyNames(database, requireBuffer("read the property names of"), rid);
+    return Collections.unmodifiableSet(
+        database.getSerializer().getPropertyNames(database, requireBuffer("read the property names of"), rid));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/MutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/MutableDocument.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -437,10 +438,18 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
     return result.toString();
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * A copy, not {@code map.keySet()}: see {@link Document#getPropertyNames()} for why the contract has to be a
+   * snapshot. {@link LinkedHashSet} rather than {@code Set.copyOf} because the insertion order is part of the
+   * contract - {@link #toMap(boolean)} and the SQL {@code keys()}/{@code values()} methods stay index-aligned with
+   * it.
+   */
   @Override
   public Set<String> getPropertyNames() {
     checkForLazyLoadingProperties();
-    return map.keySet();
+    return Collections.unmodifiableSet(new LinkedHashSet<>(map.keySet()));
   }
 
   public MutableDocument modify() {
@@ -489,30 +498,9 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
         // hashed the stored one (issue #5595), hence the shared helper rather than an inline switch.
         final Class javaImplementation = propType.getJavaImplementation(database);
 
-        if (javaImplementation.equals(Document.class)) {
-          // EMBEDDED DOCUMENT
-          if (value instanceof Map) {
-            final Map<String, Object> map = (Map<String, Object>) value;
-            final String embType = (String) map.get("@type");
-
-            final String ofType = property.getOfType();
-            if (ofType != null) {
-              // VALIDATE CONSTRAINT
-              if (!ofType.equals(embType)) {
-                // CHECK INHERITANCE
-                final DocumentType schemaType = database.getSchema().getType(embType);
-                if (!schemaType.instanceOf(ofType))
-                  throw new ValidationException(
-                      "Embedded type '" + embType + "' is not compatible with the type defined in the schema " +
-                          "constraint '"
-                          + ofType + "'");
-              }
-            }
-
-            return newEmbeddedDocument(embType, name);
-          }
-        }
-
+        // A MAP DESTINED FOR AN EMBEDDED PROPERTY NEVER REACHES HERE: setTransformValue(), WHICH EVERY CALLER RUNS
+        // FIRST, HAS ALREADY MATERIALISED IT INTO A MutableEmbeddedDocument (OR REFUSED IT), SO THE TYPE RESOLUTION
+        // AND THE "ofType" CONSTRAINT LIVE IN ONE PLACE RATHER THAN IN TWO THAT COULD ONLY EVER DISAGREE (#6819).
         return Type.convert(database, value, javaImplementation, property);
       } catch (final Exception e) {
         throw new IllegalArgumentException(
@@ -573,13 +561,65 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
         }
       }
 
-      final String embType = (String) map.get("@type");
-      if (embType != null) {
-        final MutableEmbeddedDocument embedded = newEmbeddedDocument(embType, propertyName);
-        embedded.fromMap(map);
-        return embedded;
-      }
+      return transformMapToEmbedded(map, propertyName);
     }
     return value;
+  }
+
+  /**
+   * Materialises a plain {@link Map} assigned to a property into a {@link MutableEmbeddedDocument}, resolving the
+   * embedded type name from the map's own {@code "@type"} entry or, failing that, from the {@code ofType} the schema
+   * declares for the property.
+   * <p>
+   * The {@code ofType} fallback is issue #6819: the type name used to come from {@code "@type"} exclusively, so
+   * {@code set("address", Map.of("city", "Rome"))} on a property declared {@code EMBEDDED OF Address} failed with
+   * {@code "Type with name 'null' was not found"} wrapped in a convert error that named neither the missing key nor
+   * the declared type - a requirement both undiscoverable and, since the schema already pins the type, redundant.
+   * <p>
+   * A map on a property the schema says nothing about, or on one of any other type, is left alone: it is a value,
+   * not an embedded document.
+   *
+   * @param map          the map to convert; also the source of the embedded document's properties
+   * @param propertyName the property the map is being assigned to
+   *
+   * @return the embedded document, or {@code map} itself when the property does not call for one
+   */
+  private Object transformMapToEmbedded(final Map<String, Object> map, final String propertyName) {
+    if (database == null)
+      // A REMOTE DOCUMENT HAS NO LOCAL DATABASE TO MATERIALISE AN EMBEDDED RECORD IN, AND WANTS NONE: the remote
+      // client ships the map as JSON and lets the server do the schema conversion, which is why the three Remote*
+      // subclasses override convertValueToSchemaType() to a pass-through
+      return map;
+
+    final Object declaredType = map.get("@type");
+
+    final Property property = type != null ? type.getPolymorphicPropertyIfExists(propertyName) : null;
+    final String ofType = property != null && property.getType() == Type.EMBEDDED ? property.getOfType() : null;
+
+    final String embType;
+    if (declaredType != null) {
+      embType = declaredType.toString();
+      if (ofType != null && !ofType.equals(embType)) {
+        // VALIDATE THE SCHEMA CONSTRAINT HERE, WHERE THE PROPERTY NAME IS STILL IN HAND, RATHER THAN LEAVING IT ALL
+        // TO DocumentValidator AT SAVE TIME
+        final DocumentType embSchemaType = database.getSchema().getType(embType);
+        if (!embSchemaType.instanceOf(ofType))
+          throw new ValidationException(
+              "Embedded type '" + embType + "' is not compatible with the type defined in the schema constraint '"
+                  + ofType + "' for property '" + propertyName + "'");
+      }
+    } else if (ofType != null)
+      embType = ofType;
+    else if (property != null && property.getType() == Type.EMBEDDED)
+      throw new ValidationException("Cannot determine the type of the embedded document to store in property '"
+          + propertyName + "': the map carries no '@type' entry and the property declares no 'ofType'. Either add "
+          + "an \"@type\" entry to the map, or declare the embedded type on the property with `ofType`");
+    else
+      // NOT AN EMBEDDED PROPERTY: THE MAP IS THE VALUE
+      return map;
+
+    final MutableEmbeddedDocument embedded = newEmbeddedDocument(embType, propertyName);
+    embedded.fromMap(map);
+    return embedded;
   }
 }

--- a/engine/src/main/java/com/arcadedb/database/MutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/MutableDocument.java
@@ -576,13 +576,22 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
    * {@code "Type with name 'null' was not found"} wrapped in a convert error that named neither the missing key nor
    * the declared type - a requirement both undiscoverable and, since the schema already pins the type, redundant.
    * <p>
-   * A map on a property the schema says nothing about, or on one of any other type, is left alone: it is a value,
-   * not an embedded document.
+   * The two sources are <em>not</em> symmetric, and deliberately so:
+   * <ul>
+   * <li>An explicit {@code "@type"} materialises an embedded document <b>whatever the property is declared as</b>,
+   * including a property the schema says nothing about. That is long-standing behaviour and the idiom by which a
+   * nested typed object survives a JSON round-trip onto a schemaless type - {@code toMap()}/{@code toJSON()} write
+   * the {@code "@type"} back out, and this is what reads it. Narrowing it to declared {@code EMBEDDED} properties
+   * would silently store those nested objects as plain maps.</li>
+   * <li>The {@code ofType} fallback applies only to a property declared {@code EMBEDDED}, because that is the only
+   * declaration that says a map <em>is</em> an embedded document. On a {@code MAP} property {@code ofType} names the
+   * type of the values, not of the map, so a map there stays a map.</li>
+   * </ul>
    *
    * @param map          the map to convert; also the source of the embedded document's properties
    * @param propertyName the property the map is being assigned to
    *
-   * @return the embedded document, or {@code map} itself when the property does not call for one
+   * @return the embedded document, or {@code map} itself when neither source names an embedded type
    */
   private Object transformMapToEmbedded(final Map<String, Object> map, final String propertyName) {
     if (database == null)
@@ -591,14 +600,15 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
       // subclasses override convertValueToSchemaType() to a pass-through
       return map;
 
-    final Object declaredType = map.get("@type");
+    final Object explicitType = map.get("@type");
 
     final Property property = type != null ? type.getPolymorphicPropertyIfExists(propertyName) : null;
-    final String ofType = property != null && property.getType() == Type.EMBEDDED ? property.getOfType() : null;
+    final boolean embeddedProperty = property != null && property.getType() == Type.EMBEDDED;
+    final String ofType = embeddedProperty ? property.getOfType() : null;
 
     final String embType;
-    if (declaredType != null) {
-      embType = declaredType.toString();
+    if (explicitType != null) {
+      embType = explicitType.toString();
       if (ofType != null && !ofType.equals(embType)) {
         // VALIDATE THE SCHEMA CONSTRAINT HERE, WHERE THE PROPERTY NAME IS STILL IN HAND, RATHER THAN LEAVING IT ALL
         // TO DocumentValidator AT SAVE TIME
@@ -610,12 +620,12 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
       }
     } else if (ofType != null)
       embType = ofType;
-    else if (property != null && property.getType() == Type.EMBEDDED)
+    else if (embeddedProperty)
       throw new ValidationException("Cannot determine the type of the embedded document to store in property '"
           + propertyName + "': the map carries no '@type' entry and the property declares no 'ofType'. Either add "
           + "an \"@type\" entry to the map, or declare the embedded type on the property with `ofType`");
     else
-      // NOT AN EMBEDDED PROPERTY: THE MAP IS THE VALUE
+      // NEITHER SOURCE NAMES AN EMBEDDED TYPE: THE MAP IS THE VALUE
       return map;
 
     final MutableEmbeddedDocument embedded = newEmbeddedDocument(embType, propertyName);

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIf.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIf.java
@@ -19,11 +19,8 @@
 package com.arcadedb.function.sql.misc;
 
 import com.arcadedb.database.Identifiable;
-import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
-
-import java.util.logging.Level;
 
 /**
  * Returns different values based on the condition. If it's true the first value is returned, otherwise the second one.
@@ -56,30 +53,40 @@ public class SQLFunctionIf extends SQLFunctionAbstract {
     super(NAME);
   }
 
+  /**
+   * Two, as {@link #getSyntax()} has always said: the false branch is optional.
+   */
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 3;
+  }
+
   @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
-
     final boolean result;
 
-    try {
-      final Object condition = params[0];
-      switch (condition) {
-      case Boolean boolean1 -> result = boolean1;
-      case String s -> result = Boolean.parseBoolean(condition.toString());
-      case Number number -> result = number.intValue() > 0;
-      case null, default -> {
-        return null;
-      }
-      }
-
-      return result ? params[1] : params[2];
-
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error during if execution", e);
-
+    final Object condition = params[0];
+    switch (condition) {
+    case Boolean boolean1 -> result = boolean1;
+    case String s -> result = Boolean.parseBoolean(s);
+    case Number number -> result = number.intValue() > 0;
+    case null, default -> {
       return null;
     }
+    }
+
+    // AN OMITTED FALSE BRANCH IS A null, WHICH IS WHAT THE DOCUMENTED TWO-ARGUMENT FORM MEANS. THE BODY USED TO READ
+    // params[2] UNCONDITIONALLY AND HAND THE RESULTING ArrayIndexOutOfBoundsException TO A catch (Exception) THAT
+    // LOGGED IT AT SEVERE AND ANSWERED null: ONE FULL STACK TRACE PER EVALUATED ROW (issue #6826). THAT catch IS GONE
+    // WITH THE OVER-READ - A GENUINE ERROR RAISED WHILE PRODUCING THE CHOSEN BRANCH IS THE CALLER'S TO SEE - AND THE
+    // WRONG ARGUMENT COUNTS IT ALSO HID ARE NOW A CLEAN 400 FROM checkArity()
+    return result ? params[1] : params.length > 2 ? params[2] : null;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
@@ -124,6 +124,31 @@ public abstract class AbstractSQLMethod implements SQLMethod {
             param));
   }
 
+  /**
+   * Reads the receiver of a numeric conversion method ({@code asInteger()}, {@code asLong()}, ...) as the text to
+   * parse, answering {@code null} when there is nothing to parse: a {@code null} value, an empty string, or a string
+   * of nothing but whitespace.
+   * <p>
+   * The seven conversion methods each did their own triage and only {@code asInteger()} had a blank guard at all, so
+   * {@code ''.asInteger()} answered {@code null} while {@code ''.asLong()} threw a NumberFormatException and failed
+   * the whole query - and an empty string is the ordinary representation of a blank field in imported CSV/JSON, so a
+   * cast that worked at one width broke at every other one. {@code asInteger()}'s guard also tested the untrimmed
+   * string and parsed the trimmed one, which let {@code ' '.asInteger()} through to {@code Integer.valueOf("")}
+   * (issue #6825). Trimming before the blank test is what closes that gap, and having one helper is what keeps the
+   * next hardening from reaching only one of the seven - the same move {@code SQLAggregatedFunction} made for the
+   * aggregates in #6390.
+   *
+   * @param value the value the method was invoked on
+   *
+   * @return the trimmed text to parse, or {@code null} when the value is null or blank
+   */
+  protected String numericTextOrNull(final Object value) {
+    if (value == null)
+      return null;
+    final String text = value.toString().trim();
+    return text.isEmpty() ? null : text;
+  }
+
   protected Object getParameterValue(final Identifiable iRecord, final String iValue) {
     if (iValue == null) {
       return null;

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsByte.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsByte.java
@@ -40,6 +40,7 @@ public class SQLMethodAsByte extends AbstractSQLMethod {
       final Object[] params) {
     if (value instanceof Number number)
       return number.byteValue();
-    return value != null ? Byte.valueOf(value.toString().trim()) : null;
+    final String text = numericTextOrNull(value);
+    return text != null ? Byte.valueOf(text) : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsDecimal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsDecimal.java
@@ -50,6 +50,7 @@ public class SQLMethodAsDecimal extends AbstractSQLMethod {
     if (value instanceof Date date)
       return new BigDecimal(date.getTime());
 
-    return value != null ? new BigDecimal(value.toString().trim()) : null;
+    final String text = numericTextOrNull(value);
+    return text != null ? new BigDecimal(text) : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsDouble.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsDouble.java
@@ -40,6 +40,7 @@ public class SQLMethodAsDouble extends AbstractSQLMethod {
       final Object[] params) {
     if (value instanceof Number number)
       return number.doubleValue();
-    return value != null ? Double.valueOf(value.toString().trim()) : null;
+    final String text = numericTextOrNull(value);
+    return text != null ? Double.valueOf(text) : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsFloat.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsFloat.java
@@ -39,6 +39,7 @@ public class SQLMethodAsFloat extends AbstractSQLMethod {
       final Object[] params) {
     if (value instanceof Number number)
       return number.floatValue();
-    return value != null ? Float.valueOf(value.toString().trim()) : null;
+    final String text = numericTextOrNull(value);
+    return text != null ? Float.valueOf(text) : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsInteger.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsInteger.java
@@ -41,6 +41,7 @@ public class SQLMethodAsInteger extends AbstractSQLMethod {
       final Object[] params) {
     if (value instanceof Number number)
       return number.intValue();
-    return value != null && !value.toString().isEmpty() ? Integer.valueOf(value.toString().trim()) : null;
+    final String text = numericTextOrNull(value);
+    return text != null ? Integer.valueOf(text) : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsLong.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsLong.java
@@ -48,8 +48,10 @@ public class SQLMethodAsLong extends AbstractSQLMethod {
       value = date.getTime();
     else if (DateUtils.isDate(value))
       value = DateUtils.dateTimeToTimestamp(value, ChronoUnit.MILLIS);
-    else
-      value = value != null ? Long.valueOf(value.toString().trim()) : null;
+    else {
+      final String text = numericTextOrNull(value);
+      value = text != null ? Long.valueOf(text) : null;
+    }
 
     return value;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsShort.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsShort.java
@@ -40,6 +40,7 @@ public class SQLMethodAsShort extends AbstractSQLMethod {
       final Object[] params) {
     if (value instanceof Number number)
       return number.shortValue();
-    return value != null ? Short.valueOf(value.toString().trim()) : null;
+    final String text = numericTextOrNull(value);
+    return text != null ? Short.valueOf(text) : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodExclude.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodExclude.java
@@ -139,14 +139,11 @@ public class SQLMethodExclude extends AbstractSQLMethod {
         final String fieldName = iFieldName.toString();
         if (fieldName.endsWith("*")) {
           final String fieldPart = fieldName.substring(0, fieldName.length() - 1);
-          final List<String> toExclude = new ArrayList<>();
-          for (final String f : doc.getPropertyNames()) {
+          // getPropertyNames() is a snapshot (issue #6818), so pruning while iterating it is safe: the separate
+          // "collect the names first" list this used to need was a workaround for the live key set it returned
+          for (final String f : doc.getPropertyNames())
             if (f.startsWith(fieldPart))
-              toExclude.add(f);
-          }
-
-          for (final String f : toExclude)
-            doc.remove(f);
+              doc.remove(f);
 
         } else
           doc.remove(fieldName);

--- a/engine/src/test/java/com/arcadedb/database/Issue6818PropertyNamesSnapshotTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6818PropertyNamesSnapshotTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduces issue #6818: {@code MutableDocument.getPropertyNames()} used to hand out the record's own
+ * {@code map.keySet()}, so a {@code remove()}/{@code clear()} on the returned set structurally modified the record
+ * behind the back of {@link MutableDocument#remove(String)} - no {@code dirty} flag, no validation - while the
+ * read-only sibling {@code ImmutableDocument.getPropertyNames()} returned a snapshot. Same {@code Document} call,
+ * two incompatible contracts.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6818PropertyNamesSnapshotTest extends TestHelper {
+
+  @Test
+  void mutableDocumentPropertyNamesCannotBeMutated() {
+    database.getSchema().createDocumentType("Doc6818");
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Doc6818").set("a", 1).set("b", 2);
+
+      final Set<String> names = doc.getPropertyNames();
+      assertThatThrownBy(names::clear).isInstanceOf(UnsupportedOperationException.class);
+      assertThatThrownBy(() -> names.remove("a")).isInstanceOf(UnsupportedOperationException.class);
+      assertThatThrownBy(() -> names.add("c")).isInstanceOf(UnsupportedOperationException.class);
+
+      assertThat(doc.has("a")).isTrue();
+      assertThat(doc.has("b")).isTrue();
+    });
+  }
+
+  @Test
+  void propertyNamesAreASnapshotSoIterateAndPruneWorks() {
+    database.getSchema().createDocumentType("Doc6818b");
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Doc6818b").set("keep", 1).set("tmp1", 2).set("tmp2", 3);
+
+      // The natural iterate-and-prune loop: it used to throw ConcurrentModificationException.
+      for (final String p : doc.getPropertyNames())
+        if (p.startsWith("tmp"))
+          doc.remove(p);
+
+      assertThat(doc.getPropertyNames()).containsExactly("keep");
+    });
+  }
+
+  @Test
+  void snapshotDoesNotSeeLaterChanges() {
+    database.getSchema().createDocumentType("Doc6818c");
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Doc6818c").set("a", 1);
+
+      final Set<String> names = doc.getPropertyNames();
+      doc.set("b", 2);
+
+      assertThat(names).containsExactly("a");
+      assertThat(doc.getPropertyNames()).containsExactly("a", "b");
+    });
+  }
+
+  @Test
+  void propertyNamesKeepInsertionOrder() {
+    database.getSchema().createDocumentType("Doc6818d");
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Doc6818d").set("z", 1).set("m", 2).set("a", 3);
+      assertThat(doc.getPropertyNames()).containsExactly("z", "m", "a");
+    });
+  }
+
+  @Test
+  void detachedDocumentPropertyNamesCannotBeMutatedEither() {
+    database.getSchema().createDocumentType("Doc6818e");
+
+    database.transaction(() -> database.newDocument("Doc6818e").set("a", 1).set("b", 2).save());
+
+    final Document detached = database.query("sql", "select from Doc6818e").next().getElement().get().detach();
+
+    final Set<String> names = detached.getPropertyNames();
+    assertThat(names).containsExactly("a", "b");
+    assertThatThrownBy(names::clear).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(detached.has("a")).isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue6818PropertyNamesSnapshotTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6818PropertyNamesSnapshotTest.java
@@ -95,6 +95,31 @@ class Issue6818PropertyNamesSnapshotTest extends TestHelper {
     });
   }
 
+  /**
+   * The most common path of the three: a plain {@code select} result is an {@link ImmutableDocument} until
+   * {@code modify()} or {@code detach()} is called. It was already a snapshot - the names are decoded out of the
+   * serialized buffer - but the serializer hands back a plain {@code LinkedHashSet}, so without the wrapper a
+   * {@code remove()} silently succeeded against a copy the caller could believe was the record.
+   */
+  @Test
+  void immutableDocumentPropertyNamesCannotBeMutatedEither() {
+    database.getSchema().createDocumentType("Doc6818f");
+
+    database.transaction(() -> database.newDocument("Doc6818f").set("a", 1).set("b", 2).save());
+
+    database.transaction(() -> {
+      final Document immutable = database.query("sql", "select from Doc6818f").next().getElement().get();
+      assertThat(immutable).isInstanceOf(ImmutableDocument.class);
+
+      final Set<String> names = immutable.getPropertyNames();
+      assertThat(names).containsExactly("a", "b");
+      assertThatThrownBy(names::clear).isInstanceOf(UnsupportedOperationException.class);
+      assertThatThrownBy(() -> names.remove("a")).isInstanceOf(UnsupportedOperationException.class);
+
+      assertThat(immutable.getPropertyNames()).containsExactly("a", "b");
+    });
+  }
+
   @Test
   void detachedDocumentPropertyNamesCannotBeMutatedEither() {
     database.getSchema().createDocumentType("Doc6818e");

--- a/engine/src/test/java/com/arcadedb/function/sql/misc/Issue6826FunctionIfArityTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/misc/Issue6826FunctionIfArityTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.misc;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduces issue #6826: {@code SQLFunctionIf.getSyntax()} documents the third argument as optional, but the body
+ * read {@code params[2]} unconditionally and the class declared no arity. The documented two-argument form therefore
+ * answered {@code null} and wrote an ArrayIndexOutOfBoundsException stack trace at SEVERE <em>once per evaluated
+ * row</em>, and {@code if()} / {@code if(true)} did the same instead of reporting a clean syntax error.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6826FunctionIfArityTest extends TestHelper {
+
+  @Test
+  void twoArgumentFormReturnsNullOnTheFalseBranch() {
+    database.getSchema().createDocumentType("Doc6826");
+    database.transaction(() -> database.newDocument("Doc6826").set("rich", false).save());
+
+    try (final ResultSet rs = database.query("sql", "select if(rich, 'yes') as v from Doc6826")) {
+      final Result row = rs.next();
+      assertThat(row.<Object>getProperty("v")).isNull();
+    }
+  }
+
+  @Test
+  void twoArgumentFormReturnsTheValueOnTheTrueBranch() {
+    database.getSchema().createDocumentType("Doc6826b");
+    database.transaction(() -> database.newDocument("Doc6826b").set("rich", true).save());
+
+    try (final ResultSet rs = database.query("sql", "select if(rich, 'yes') as v from Doc6826b")) {
+      assertThat(rs.next().<String>getProperty("v")).isEqualTo("yes");
+    }
+  }
+
+  @Test
+  void threeArgumentFormIsUnchanged() {
+    database.getSchema().createDocumentType("Doc6826c");
+    database.transaction(() -> database.newDocument("Doc6826c").set("rich", false).save());
+
+    try (final ResultSet rs = database.query("sql", "select if(rich, 'rich', 'poor') as v from Doc6826c")) {
+      assertThat(rs.next().<String>getProperty("v")).isEqualTo("poor");
+    }
+  }
+
+  @Test
+  void tooFewArgumentsIsACleanSyntaxError() {
+    database.getSchema().createDocumentType("Doc6826d");
+    database.transaction(() -> database.newDocument("Doc6826d").set("rich", true).save());
+
+    assertThatThrownBy(() -> {
+      try (final ResultSet rs = database.query("sql", "select if(rich) as v from Doc6826d")) {
+        rs.next();
+      }
+    }).isInstanceOf(CommandSemanticException.class).hasMessageContaining("2-3 arguments");
+  }
+
+  @Test
+  void tooManyArgumentsIsACleanSyntaxError() {
+    database.getSchema().createDocumentType("Doc6826e");
+    database.transaction(() -> database.newDocument("Doc6826e").set("rich", true).save());
+
+    assertThatThrownBy(() -> {
+      try (final ResultSet rs = database.query("sql", "select if(rich, 1, 2, 3) as v from Doc6826e")) {
+        rs.next();
+      }
+    }).isInstanceOf(CommandSemanticException.class).hasMessageContaining("2-3 arguments");
+  }
+
+  @Test
+  void arityIsDeclared() {
+    final SQLFunctionIf function = new SQLFunctionIf();
+    assertThat(function.getMinArgs()).isEqualTo(2);
+    assertThat(function.getMaxArgs()).isEqualTo(3);
+  }
+
+  @Test
+  void anErrorRaisedByTheChosenBranchIsNotSwallowed() {
+    final SQLFunctionIf function = new SQLFunctionIf();
+    assertThat(function.execute(null, null, null, new Object[] { true, "yes" }, null)).isEqualTo("yes");
+    assertThat(function.execute(null, null, null, new Object[] { false, "yes" }, null)).isNull();
+    assertThat(function.execute(null, null, null, new Object[] { false, "yes", "no" }, null)).isEqualTo("no");
+    // A condition of an unsupported kind stays a null, as before.
+    assertThat(function.execute(null, null, null, new Object[] { new Object(), "yes", "no" }, null)).isNull();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/conversion/Issue6825BlankNumericConversionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/conversion/Issue6825BlankNumericConversionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.conversion;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.executor.SQLMethod;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces issue #6825: {@code asInteger()} alone special-cased the empty string and answered {@code null}, while
+ * its six siblings handed {@code ""} straight to {@code Long.valueOf}/{@code Short.valueOf}/... and blew the whole
+ * query up with a NumberFormatException. The one guard that existed was also inconsistent with itself: it tested the
+ * untrimmed string and parsed the trimmed one, so {@code ' '.asInteger()} still threw.
+ * <p>
+ * An empty string is the normal representation of a blank field in imported CSV/JSON, so a cast that worked at one
+ * width broke the query at every other width.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6825BlankNumericConversionTest extends TestHelper {
+
+  static Stream<SQLMethod> numericMethods() {
+    return Stream.of(new SQLMethodAsInteger(), new SQLMethodAsLong(), new SQLMethodAsShort(), new SQLMethodAsByte(),
+        new SQLMethodAsFloat(), new SQLMethodAsDouble(), new SQLMethodAsDecimal());
+  }
+
+  @ParameterizedTest
+  @MethodSource("numericMethods")
+  void blankStringConvertsToNull(final SQLMethod method) {
+    assertThat(method.execute(null, null, null, null)).as("null").isNull();
+    assertThat(method.execute("", null, null, null)).as("empty string").isNull();
+    assertThat(method.execute("   ", null, null, null)).as("whitespace only").isNull();
+    assertThat(method.execute("\t\n ", null, null, null)).as("whitespace only").isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("numericMethods")
+  void nonBlankStringStillConverts(final SQLMethod method) {
+    final Object result = method.execute(" 42 ", null, null, null);
+    assertThat(result).isInstanceOf(Number.class);
+    assertThat(((Number) result).intValue()).isEqualTo(42);
+  }
+
+  @Test
+  void everyWidthAgreesOverAnEmptyProperty() {
+    database.getSchema().createDocumentType("Doc6825");
+    database.transaction(() -> database.newDocument("Doc6825").set("s", "").save());
+
+    try (final ResultSet rs = database.query("sql", """
+        select s.asInteger() as i, s.asLong() as l, s.asShort() as sh, s.asByte() as b, \
+        s.asFloat() as f, s.asDouble() as d, s.asDecimal() as dec from Doc6825""")) {
+      final var row = rs.next();
+      assertThat(row.<Object>getProperty("i")).isNull();
+      assertThat(row.<Object>getProperty("l")).isNull();
+      assertThat(row.<Object>getProperty("sh")).isNull();
+      assertThat(row.<Object>getProperty("b")).isNull();
+      assertThat(row.<Object>getProperty("f")).isNull();
+      assertThat(row.<Object>getProperty("d")).isNull();
+      assertThat(row.<Object>getProperty("dec")).isNull();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue6819EmbeddedOfTypeFromMapTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6819EmbeddedOfTypeFromMapTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.EmbeddedDocument;
+import com.arcadedb.database.MutableDocument;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduces issue #6819: an {@code EMBEDDED} property that declares an {@code ofType} still rejected a plain
+ * {@link Map}, because the embedded type name was taken exclusively from the map's own {@code "@type"} entry even
+ * though the schema already pinned it. The failure surfaced as {@code "Type with name 'null' was not found"} wrapped
+ * in a generic convert error that named neither the missing key nor the declared {@code ofType}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6819EmbeddedOfTypeFromMapTest extends TestHelper {
+
+  @Test
+  void plainMapUsesTheDeclaredOfType() {
+    database.getSchema().createDocumentType("Address6819").createProperty("city", Type.STRING);
+    database.getSchema().createDocumentType("Person6819").createProperty("address", Type.EMBEDDED).setOfType("Address6819");
+
+    database.transaction(() -> {
+      final MutableDocument person = database.newDocument("Person6819").set("address", Map.of("city", "Rome"));
+      person.save();
+
+      final EmbeddedDocument address = person.getEmbedded("address");
+      assertThat(address).isNotNull();
+      assertThat(address.getTypeName()).isEqualTo("Address6819");
+      assertThat(address.getString("city")).isEqualTo("Rome");
+    });
+
+    final EmbeddedDocument reloaded = database.query("sql", "select from Person6819").next().getElement().get()
+        .getEmbedded("address");
+    assertThat(reloaded.getTypeName()).isEqualTo("Address6819");
+    assertThat(reloaded.getString("city")).isEqualTo("Rome");
+  }
+
+  @Test
+  void explicitTypeStillWinsOverTheDeclaredOfTypeWhenCompatible() {
+    database.getSchema().createDocumentType("Address6819b").createProperty("city", Type.STRING);
+    database.getSchema().createDocumentType("HomeAddress6819b").addSuperType("Address6819b").createProperty("floor", Type.INTEGER);
+    database.getSchema().createDocumentType("Person6819b").createProperty("address", Type.EMBEDDED).setOfType("Address6819b");
+
+    database.transaction(() -> {
+      final Map<String, Object> map = new LinkedHashMap<>();
+      map.put("@type", "HomeAddress6819b");
+      map.put("city", "Rome");
+      map.put("floor", 3);
+
+      final MutableDocument person = database.newDocument("Person6819b").set("address", map);
+      person.save();
+
+      final EmbeddedDocument address = person.getEmbedded("address");
+      assertThat(address.getTypeName()).isEqualTo("HomeAddress6819b");
+      assertThat(address.getString("city")).isEqualTo("Rome");
+      assertThat(address.getInteger("floor")).isEqualTo(3);
+    });
+  }
+
+  @Test
+  void incompatibleExplicitTypeIsStillRejected() {
+    database.getSchema().createDocumentType("Address6819c").createProperty("city", Type.STRING);
+    database.getSchema().createDocumentType("Other6819c").createProperty("city", Type.STRING);
+    database.getSchema().createDocumentType("Person6819c").createProperty("address", Type.EMBEDDED).setOfType("Address6819c");
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      final Map<String, Object> map = new LinkedHashMap<>();
+      map.put("@type", "Other6819c");
+      map.put("city", "Rome");
+      database.newDocument("Person6819c").set("address", map).save();
+    })).hasMessageContaining("Address6819c");
+  }
+
+  @Test
+  void missingTypeAndMissingOfTypeReportsTheMissingKey() {
+    database.getSchema().createDocumentType("Person6819d").createProperty("address", Type.EMBEDDED);
+
+    assertThatThrownBy(() -> database.transaction(
+        () -> database.newDocument("Person6819d").set("address", Map.of("city", "Rome")).save()))
+        .hasMessageContaining("@type")
+        .hasMessageContaining("address");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue6819EmbeddedOfTypeFromMapTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6819EmbeddedOfTypeFromMapTest.java
@@ -96,6 +96,48 @@ class Issue6819EmbeddedOfTypeFromMapTest extends TestHelper {
     })).hasMessageContaining("Address6819c");
   }
 
+  /**
+   * The {@code "@type"} source is deliberately not restricted to declared {@code EMBEDDED} properties: it is how a
+   * nested typed object survives a JSON round-trip onto a schemaless type, since {@code toMap()}/{@code toJSON()}
+   * write the {@code "@type"} back out. Narrowing it would silently downgrade those nested objects to plain maps,
+   * so this pins the behaviour rather than leaving it to be "tidied up" later.
+   */
+  @Test
+  void explicitTypeMaterialisesEvenOnAnUndeclaredProperty() {
+    database.getSchema().createDocumentType("Address6819e").createProperty("city", Type.STRING);
+    database.getSchema().createDocumentType("Person6819e");
+
+    database.transaction(() -> {
+      final Map<String, Object> map = new LinkedHashMap<>();
+      map.put("@type", "Address6819e");
+      map.put("city", "Rome");
+
+      final MutableDocument person = database.newDocument("Person6819e").set("address", map);
+      person.save();
+
+      assertThat(person.getEmbedded("address").getTypeName()).isEqualTo("Address6819e");
+      assertThat(person.getEmbedded("address").getString("city")).isEqualTo("Rome");
+    });
+  }
+
+  /**
+   * On a {@code MAP} property the {@code ofType} names the type of the <em>values</em>, not of the map itself, so a
+   * map assigned there stays a map: only a property declared {@code EMBEDDED} makes the declaration a statement
+   * about the map as a whole.
+   */
+  @Test
+  void aMapPropertyKeepsItsMap() {
+    database.getSchema().createDocumentType("Person6819f").createProperty("attributes", Type.MAP).setOfType("STRING");
+
+    database.transaction(() -> {
+      final MutableDocument person = database.newDocument("Person6819f").set("attributes", Map.of("city", "Rome"));
+      person.save();
+
+      assertThat(person.get("attributes")).isInstanceOf(Map.class);
+      assertThat(person.getMap("attributes")).containsEntry("city", "Rome");
+    });
+  }
+
   @Test
   void missingTypeAndMissingOfTypeReportsTheMissingKey() {
     database.getSchema().createDocumentType("Person6819d").createProperty("address", Type.EMBEDDED);

--- a/engine/src/test/java/com/arcadedb/schema/Issue6819EmbeddedOfTypeFromMapTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6819EmbeddedOfTypeFromMapTest.java
@@ -19,8 +19,10 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
 import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
@@ -112,11 +114,28 @@ class Issue6819EmbeddedOfTypeFromMapTest extends TestHelper {
       map.put("@type", "Address6819e");
       map.put("city", "Rome");
 
-      final MutableDocument person = database.newDocument("Person6819e").set("address", map);
-      person.save();
+      database.newDocument("Person6819e").set("address", map).save();
+    });
 
-      assertThat(person.getEmbedded("address").getTypeName()).isEqualTo("Address6819e");
-      assertThat(person.getEmbedded("address").getString("city")).isEqualTo("Rome");
+    // Round-trip through the boundary the behaviour exists for: reload, write the record back out with toJSON()
+    // (which re-emits the "@type"), and feed that JSON to a fresh document. A regression that dropped the "@type"
+    // on the way out, or ignored it on the way back in, would leave a plain map here.
+    final Document reloaded = database.query("sql", "select from Person6819e").next().getElement().get();
+    assertThat(reloaded.getEmbedded("address").getTypeName()).isEqualTo("Address6819e");
+    assertThat(reloaded.getEmbedded("address").getString("city")).isEqualTo("Rome");
+
+    final JSONObject json = reloaded.toJSON(false);
+    assertThat(json.getJSONObject("address").getString("@type")).isEqualTo("Address6819e");
+
+    database.transaction(() -> {
+      final MutableDocument rebuilt = database.newDocument("Person6819e");
+      rebuilt.fromJSON(json);
+      rebuilt.save();
+
+      final EmbeddedDocument address = rebuilt.getEmbedded("address");
+      assertThat(address).as("the \"@type\" survived the JSON round-trip").isNotNull();
+      assertThat(address.getTypeName()).isEqualTo("Address6819e");
+      assertThat(address.getString("city")).isEqualTo("Rome");
     });
   }
 


### PR DESCRIPTION
Closes #6818, closes #6819, closes #6825, closes #6826.

Four independent small defects, each with a regression test that fails on `main`.

## #6818 - `getPropertyNames()` handed out the live internal key set

`MutableDocument.getPropertyNames()` returned the record's own `map.keySet()` unwrapped, so a `remove()`/`clear()` on the returned set structurally modified the record while bypassing `MutableDocument.remove()` entirely: no `dirty` flag, no schema or validation path. `ImmutableDocument.getPropertyNames()` already returned a snapshot, so the same `Document.getPropertyNames()` call meant two incompatible things depending on which implementation the caller happened to hold.

The issue suggested `Collections.unmodifiableSet(map.keySet())`. That closes the mutation hole but leaves the second half of the defect: the returned set is still a live view, so the natural `for (name : getPropertyNames()) remove(name)` prune loop still throws `ConcurrentModificationException` - the hazard `SQLMethodExclude.copy()` already worked around with a defensive `ArrayList`. **A snapshot is the stronger fix and also the only contract every implementation can honour**: `ImmutableDocument` reads its names out of the serialized buffer and physically has no live view to hand back, so "snapshot" is what the interface can promise and "live view" is what it never could. `MutableDocument` and `DetachedDocument` now return `Collections.unmodifiableSet(new LinkedHashSet<>(map.keySet()))` - `LinkedHashSet` because insertion order is part of the contract that keeps `toMap()` and the SQL `keys()`/`values()` methods index-aligned - and `Document.getPropertyNames()` documents it. The `SQLMethodExclude` workaround is deleted as a result.

The read path already paid this allocation (`ImmutableDocument` builds a fresh set per call) and no in-tree caller reads `getPropertyNames()` on a serialization hot path.

## #6819 - EMBEDDED `ofType` did not supply the embedded type

The embedded type name came exclusively from the map's own `"@type"` entry, so `set("address", Map.of("city", "Rome"))` on a property declared `EMBEDDED OF Address` failed with `SchemaException: Type with name 'null' was not found`, rewritten by the surrounding `catch` into a message naming neither the missing key nor the declared `ofType`.

The issue suggested a one-line fallback in `convertValueToSchemaType`. **That line is in the wrong method**: `setTransformValue()` runs before it on every call site and already materialises a map into an embedded document when `"@type"` is present, which is exactly why the `convertValueToSchemaType` branch only ever sees the complement case - and why its `ofType` compatibility check had become dead code. So the whole thing (type resolution, the `ofType` constraint, the materialisation) is consolidated into one new `transformMapToEmbedded()`, and the duplicate branch is removed rather than fixed in parallel. Resolution is `"@type"` first, then the property's declared `ofType`; when neither exists the error names both ways to fix it. A map on a property the schema says nothing about, or on one of any other type, is still just a value.

A remote document short-circuits: it has no local database to materialise an embedded record in and wants none, which is why the three `Remote*` subclasses override `convertValueToSchemaType()` to a pass-through.

## #6825 - blank strings converted at one width and threw at every other

`asInteger()` alone guarded the empty string; its six siblings handed `""` straight to `Long.valueOf`/`Short.valueOf`/... and failed the whole query. The one guard that existed was inconsistent with itself - it tested the untrimmed string and parsed the trimmed one, so `' '.asInteger()` still threw. All seven now route through a single `AbstractSQLMethod.numericTextOrNull()` that trims *before* the blank test, next to the existing `indexArgument()` helper that plays the same role for the string methods.

## #6826 - `if(cond, value)` logged a SEVERE stack trace per row

The two-argument form `getSyntax()` documents read `params[2]` unconditionally and handed the resulting `ArrayIndexOutOfBoundsException` to a `catch (Exception)` that logged it at SEVERE and answered `null`. Over a table scan that is one full stack trace per evaluated row. `getMinArgs()`/`getMaxArgs()` now declare `2..3` so `checkArity()` answers a clean 400 for `if()` and `if(true)`, and the omitted false branch is a `null`. The `catch` goes with the over-read: it also swallowed genuine errors raised while producing the chosen branch.

## Verification

New regression tests, all failing on `main` first:

- `engine/.../database/Issue6818PropertyNamesSnapshotTest` (5 tests)
- `engine/.../schema/Issue6819EmbeddedOfTypeFromMapTest` (4 tests)
- `engine/.../query/sql/method/conversion/Issue6825BlankNumericConversionTest` (15 tests, parameterized over all seven methods)
- `engine/.../function/sql/misc/Issue6826FunctionIfArityTest` (7 tests)

Full lanes green with the final tree: `engine` 13693, `server` 868, `network` 461, `integration` 166, `console` 96, `graphql` 53.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Property-name collections now preserve insertion order and are independent, read-only snapshots.
  - Embedded map properties correctly honor declared and explicit types, with clearer validation errors.
  - Numeric conversion methods consistently return `null` for blank values while accepting padded numbers.
  - The `if()` function validates argument counts and properly surfaces branch errors.

- **Improvements**
  - Wildcard property exclusion remains reliable while removing document properties.
  - Expanded coverage for document snapshots, embedded maps, conditional expressions, and numeric conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Behaviour changes beyond the four fixes

Review asked that these be stated explicitly rather than left to be discovered. All four are intended.

**`Document.getPropertyNames()` is a public API contract change.** The returned set is now an unmodifiable snapshot on every implementation. An external caller that mutated it was mutating the record behind `remove()`'s back - that was #6818 itself - and now gets an `UnsupportedOperationException`. A caller that held the result expecting it to track later changes now sees a fixed snapshot. Both are the point of the fix, but they are visible to embedders.

**A latent NPE on the remote path is incidentally fixed.** `RemoteMutableDocument`/`Vertex`/`Edge` construct with `database == null` and override `convertValueToSchemaType()` to a pass-through, but they do not override `setTransformValue()` - so before this PR a remote `set("prop", mapWithAtType)` reached `newEmbeddedDocument()`, which dereferences `database` unconditionally, and threw NPE. The `database == null` early return in `transformMapToEmbedded()` was added to keep the new `ofType` fallback off the remote path, and closes that as a side effect. Deliberate: the remote client ships the map as JSON and lets the server do the schema conversion.

**The embedded-type error is now a `ValidationException`, not an `IllegalArgumentException` wrapping a cause.** The throw site moved out of `convertValueToSchemaType()`'s `catch (Exception)` wrapper, which is what made the old message name neither the missing `"@type"` key nor the declared `ofType`. Grepped for callers matching on the old wrapper type and found none.

**A non-`String` `"@type"` is now stringified rather than throwing `ClassCastException`.** The old code did a hard `(String) map.get("@type")` cast. Reading it as `Object` and calling `toString()` means a malformed value now produces `"Type with name 'X' was not found"`, which names the offending value, instead of a raw CCE that names nothing. JSON parsing only ever produces a `String` here, so this only affects hand-built maps.

**`SQLFunctionIf` no longer swallows errors from the chosen branch.** Removing the `catch (Exception)` was necessary to stop the per-row SEVERE stack trace, and it also means a genuine failure while evaluating `params[1]`/`params[2]` propagates instead of being logged and turned into `null`. That is the intended half of the fix, not a side effect.

## Local verification

`engine` 13696 tests / 0 failures on the final tree, plus `server` 868, `network` 461, `integration` 166, `console` 96, `graphql` 53.
