### PR TITLE
fix(#6798): the inactivity timer must not read an unloaded graph as a small one

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -7526,6 +7526,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final LSMVectorIndexGraphManifest.Content manifestContent =
         statsGraphFile != null ? statsGraphFile.getManifest().read() : null;
     stats.put("closeTimeRebuildPending", manifestContent != null && manifestContent.closeDeferredRebuild() ? 1L : 0L);
+    // How large the graph ON DISK is, as opposed to graphNodeCount just above, which reports how much of it this
+    // session has loaded - 0 until something searches, however many vectors are persisted (issue #6798). Read
+    // from the same manifest content: the two are the only stats here that survive a reopen before a first
+    // search, and telling "no graph exists" apart from "no graph is loaded" needs both of them.
+    stats.put("persistedGraphNodeCount",
+        manifestContent != null && manifestContent.vectorCount() > 0
+            && statsGraphFile.hasPersistedGraph() ? (long) manifestContent.vectorCount() : 0L);
 
     // Calculate mutations threshold (use configured value or default)
     final int defaultMutationsThreshold = getDatabase().getConfiguration()
@@ -8344,6 +8351,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * away the guarantee that a handful of buffered vectors get flushed out of the linear-scan delta
    * buffer promptly - but to apply the same threshold the search path uses, and only where the search
    * path would also apply it: once the graph is large enough that a rebuild is no longer free.
+   * <p>
+   * "How large is the graph" is asked through {@link #inactivityRebuildScopeSize()} rather than off
+   * {@link #graphIndex} directly, because on this path a null graph does not mean what it means on the search
+   * path (issue #6798).
    *
    * @return {@code true} when pending mutations justify (or exceed) a rebuild
    */
@@ -8352,8 +8363,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (pending <= 0)
       return false;
 
-    final ImmutableGraphIndex graph = this.graphIndex;
-    if (graph == null || graph.size() < ASYNC_REBUILD_MIN_GRAPH_SIZE)
+    if (inactivityRebuildScopeSize() < ASYNC_REBUILD_MIN_GRAPH_SIZE)
       // Small graph (or none yet): a rebuild is cheap regardless of how many mutations are
       // pending, same as rebuildGraphBeforeSearch()'s unconditional synchronous rebuild for this
       // case. Any pending mutation is worth flushing promptly.
@@ -8369,6 +8379,61 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // on every quiet period while still eventually absorbing a trickle of writes.
     final int floor = Math.max(threshold / 10, 1);
     return pending >= floor;
+  }
+
+  /**
+   * How many vectors a rebuild triggered by the inactivity timer would actually have to cover - which is the
+   * question both {@link #inactivityRebuildIsWorthIt()} and the timer task's sync/async arm choice are really
+   * asking when they compare against {@link #ASYNC_REBUILD_MIN_GRAPH_SIZE}.
+   * <p>
+   * They used to ask it of {@link #graphIndex} alone, and {@code graphIndex == null} counted as "small". Null
+   * carries three meanings, though, and only two of them are small (issue #6798):
+   * <ol>
+   *   <li>no graph has ever been built for this index - a first build, which must run whatever it costs, since
+   *       nothing else will ever produce a graph;</li>
+   *   <li>a graph was built and is genuinely tiny (or emptied out by deletions) - cheap by definition;</li>
+   *   <li><b>a large graph is fully persisted and this session has simply never loaded it</b>, because the load
+   *       is lazy on the first search and this session has not searched.</li>
+   * </ol>
+   * The third is the ordinary shape of a loader process - open, write, go quiet - and it was being read as the
+   * first two: the mutation threshold was skipped entirely and one insert rebuilt every vector in the index,
+   * synchronously, on the timer thread. It is the same conflation issue #6772 fixed for a session that searches;
+   * that fix works by loading the persisted graph inside {@link #ensureGraphAvailable()}, which the timer never
+   * calls, so it does not reach here.
+   * <p>
+   * The answer for that third case is the <b>live</b> vector count rather than the persisted graph's node count,
+   * because {@link #buildGraphFromScratch()} covers the live set, not the graph it replaces - so the live count
+   * is the direct measure of the cost being gated, where a graph size is only ever a proxy for it. It also gives
+   * the right answer where the two diverge: a large persisted graph whose vectors have since been deleted really
+   * is cheap to rebuild, and gets flushed promptly like any other small index.
+   * <p>
+   * Deliberately confined to the case {@link #graphNotYetMaterialised()} identifies - this session has not yet
+   * resolved what is on disk - so that everything downstream of a resolution keeps answering exactly as before,
+   * including the window inside {@code buildGraphFromScratchExclusively()} where a rebuild nulls the resident
+   * graph before publishing its replacement. {@link #rebuildGraphBeforeSearch()} is left reading
+   * {@link #graphIndex} directly for a related reason: {@link #ensureGraphAvailable()} always runs immediately
+   * before it, so a null there really is case 1 or 2, and routing a search down the large-graph arm would hand
+   * it the async rebuild and an empty result set instead of a slow but correct one.
+   *
+   * @return the number of vectors a rebuild would build over, or 0 when that is a first build
+   */
+  private int inactivityRebuildScopeSize() {
+    final ImmutableGraphIndex resident = this.graphIndex;
+    if (resident != null)
+      return resident.size();
+
+    if (!graphNotYetMaterialised())
+      // Already resolved: nothing is on disk that this session has not accounted for, so a null graph here is a
+      // first build or an emptied index, and both are cheap.
+      return 0;
+
+    final LSMVectorIndexGraphFile gf = graphFile;
+    if (gf == null || !gf.hasPersistedGraph())
+      return 0; // Case 1: no graph anywhere. A first build must not be gated - see the javadoc above.
+
+    // Case 3. getActiveCount() is O(allocated chunks) over an already-materialised location index: this method is
+    // only ever reached with pending mutations outstanding, and recording those materialised it.
+    return (int) Math.min(vectorIndex().getActiveCount(), Integer.MAX_VALUE);
   }
 
   /**
@@ -8413,8 +8478,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
             timeoutMs, mutationsSinceSerialize.get(), indexName);
 
         try {
-          if (graphIndex != null && graphIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
-            // Large graph: async rebuild (semaphore acquired inside the async thread)
+          if (inactivityRebuildScopeSize() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
+            // Large graph: async rebuild (semaphore acquired inside the async thread).
+            // Asked through inactivityRebuildScopeSize() so a large graph this session has never loaded takes
+            // this arm rather than the synchronous one below (issue #6798) - the timer thread is shared with
+            // every other index's inactivity task, and a full O(N) build on it stalls all of them.
             startAsyncGraphRebuild();
           } else {
             // Small graph: synchronous rebuild on the timer thread.

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -8431,9 +8431,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (gf == null || !gf.hasPersistedGraph())
       return 0; // Case 1: no graph anywhere. A first build must not be gated - see the javadoc above.
 
-    // Case 3. getActiveCount() is O(allocated chunks) over an already-materialised location index: this method is
-    // only ever reached with pending mutations outstanding, and recording those materialised it.
-    return (int) Math.min(vectorIndex().getActiveCount(), Integer.MAX_VALUE);
+    // Case 3. size(), not getActiveCount(): the two agree on this backend - markDeleted() drops the location and
+    // keeps only the id in the tombstone set, so a resident location IS a live vector, the same equivalence
+    // estimatePagesForLiveSet() relies on - but size() is O(1) where getActiveCount() popcounts every allocated
+    // chunk. That matters here specifically: inactivityRebuildIsWorthIt() runs from scheduleInactivityRebuild(),
+    // which put() calls after EVERY single insert, and graphNotYetMaterialised() stays true for a whole
+    // ingest-then-idle load - so a per-chunk scan here would make an O(N) load O(N^2), on exactly the workload
+    // this fix exists to protect, and would do it inside the instance monitor every other insert serializes on.
+    // The location index is already materialised: this is only reached with pending mutations, and recording
+    // those materialised it.
+    return vectorIndex().size();
   }
 
   /**
@@ -8478,6 +8485,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
             timeoutMs, mutationsSinceSerialize.get(), indexName);
 
         try {
+          // Asked again rather than reusing what inactivityRebuildIsWorthIt() just computed: the two questions
+          // are "is a rebuild worth it" and "which arm", and answering the second from a value read before the
+          // first would pin the arm to a graph size that a concurrent rebuild may already have moved on from.
+          // O(1) either way - see inactivityRebuildScopeSize() on why it does not walk anything.
           if (inactivityRebuildScopeSize() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
             // Large graph: async rebuild (semaphore acquired inside the async thread).
             // Asked through inactivityRebuildScopeSize() so a large graph this session has never loaded takes

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6798InactivityTimerUnloadedGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6798InactivityTimerUnloadedGraphTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -104,6 +105,11 @@ class Issue6798InactivityTimerUnloadedGraphTest {
    * pending mutation against a threshold of {@value #THRESHOLD}, which is precisely what issue #6496 established
    * must not happen on a large index. Nothing about that changes because the graph happens to be on disk rather
    * than in this session's heap.
+   * <p>
+   * The idle window is measured with {@link StallAwareStopwatch} rather than slept through, and is followed by a
+   * positive control: the same timer on the same index must still rebuild once the pending mutations reach the
+   * floor. A negative assertion after a wait is otherwise vacuous - it would hold just as well on a build where
+   * the timer never ran at all.
    */
   @Test
   void oneInsertIntoALargeUnloadedIndexMustNotRebuildAnything() throws Exception {
@@ -136,8 +142,14 @@ class Issue6798InactivityTimerUnloadedGraphTest {
                 + "exercising the already-fixed resident-graph path instead")
             .isZero();
 
-        // Idle, comfortably past the inactivity timeout.
-        Thread.sleep(TIMEOUT_MS * 6L);
+        // Idle, comfortably past the inactivity timeout. Measured with StallAwareStopwatch rather than slept
+        // through: a plain sleep returns on wall clock, and a stop-the-world pause covering most of it would
+        // leave the timer no CPU to fire on - the assertions below would then hold because nothing ran at all,
+        // not because the gate declined. effectiveMs() discounts the JVM-wide stall, so the window really did
+        // contain that much running time.
+        final StallAwareStopwatch idle = StallAwareStopwatch.start();
+        while (idle.effectiveMs() < TIMEOUT_MS * 6L)
+          Thread.sleep(50);
 
         assertThat(index.getStats().get("graphRebuildCount"))
             .as("a single pending mutation must not rebuild a large index just because this session has not "
@@ -149,6 +161,21 @@ class Issue6798InactivityTimerUnloadedGraphTest {
         assertThat(index.getStats().get("asyncRebuildInProgress"))
             .as("no rebuild of either kind - the async arm must not have been taken either")
             .isZero();
+
+        // The positive control, and the real answer to "did anything actually run in that window": top the
+        // pending mutations up to the floor and the very same timer, on the very same index, must now rebuild.
+        // Without this the three assertions above would still hold on a build where the inactivity timer were
+        // broken outright, which is not what this test is about.
+        insert(db, LARGE_COUNT + 1, LARGE_COUNT + FLOOR);
+        Awaitility.await("the same timer still fires once the pending mutations reach the floor")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isPositive());
+
+        Awaitility.await("the rebuild settles before the drop")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
       } finally {
         db.drop();
       }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6798InactivityTimerUnloadedGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6798InactivityTimerUnloadedGraphTest.java
@@ -185,6 +185,11 @@ class Issue6798InactivityTimerUnloadedGraphTest {
   /**
    * The other half of the same gate: reaching the floor on a large-but-unloaded index must still rebuild, or the
    * fix would trade a wasteful rebuild for a delta buffer that never drains.
+   * <p>
+   * Written as one transaction per vector rather than one transaction for all of them, deliberately: that drives
+   * the mutation through {@code put()} - and so through {@code scheduleInactivityRebuild()}, and so through the
+   * gate - once per vector instead of once per batch. It is the shape a loader process actually has, and the one
+   * that makes what the gate costs per insert matter (PR #6857 review).
    */
   @Test
   void reachingTheFloorOnALargeUnloadedIndexStillRebuilds() {
@@ -196,7 +201,9 @@ class Issue6798InactivityTimerUnloadedGraphTest {
         configure(db);
         final LSMVectorIndex index = vectorIndex(db);
 
-        insert(db, LARGE_COUNT, LARGE_COUNT + FLOOR);
+        for (int i = LARGE_COUNT; i < LARGE_COUNT + FLOOR; i++)
+          insert(db, i, i + 1);
+
         assertThat(index.getStats().get("mutationsSinceRebuild")).isEqualTo((long) FLOOR);
 
         Awaitility.await("the inactivity timer rebuilds once pending mutations reach the floor")

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6798InactivityTimerUnloadedGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6798InactivityTimerUnloadedGraphTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6798: the inactivity rebuild timer repeated the null-graph conflation that issue
+ * #6772 fixed on the search path.
+ * <p>
+ * {@code graphIndex} is null in three distinct situations, and only two of them mean "a rebuild here is cheap":
+ * no graph has ever been built, or the graph is genuinely small. The third is a large graph that is fully
+ * persisted and that this session simply has not loaded, because loading is lazy on the first search - and a
+ * session that ingests and then goes idle never searches, so it never loads. Both the "is a rebuild worth it"
+ * gate ({@code inactivityRebuildIsWorthIt()}) and the sync/async arm choice inside the timer task read that third
+ * null as the first two, so the mutation threshold was bypassed entirely and a single insert into a reopened
+ * 10M-vector index rebuilt every vector, synchronously, on the timer thread.
+ * <p>
+ * Issue #6772's fix does not reach this path: it works by loading the persisted graph inside
+ * {@code ensureGraphAvailable()}, which only a search calls.
+ * <p>
+ * Three behaviours are pinned, because fixing only the first is what broke three existing tests the last time
+ * this gate was touched (PR #6510 for issue #6496):
+ * <ul>
+ *   <li>a single insert into a large-but-unloaded index must not rebuild anything at all;</li>
+ *   <li>once pending mutations reach the threshold-derived floor the timer must still rebuild, so nothing is
+ *       deferred forever;</li>
+ *   <li>a genuinely small persisted index must keep flushing on any pending mutation, which is the case the
+ *       threshold must never be applied to.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+// Builds and persists a graph over a few thousand vectors and then waits on the inactivity timer, so it spends
+// most of its time waiting on work LSMVectorIndex.REBUILD_SEMAPHORE serializes JVM-wide - see CLAUDE.md's
+// @Tag("vector") note.
+@Tag("vector")
+class Issue6798InactivityTimerUnloadedGraphTest {
+  private static final String DB_ROOT     = "target/test-databases/Issue6798InactivityTimerUnloadedGraphTest";
+  private static final int    DIMENSIONS  = 32;
+  /** Must exceed {@code LSMVectorIndex.ASYNC_REBUILD_MIN_GRAPH_SIZE} (1000), or none of this applies. */
+  private static final int    LARGE_COUNT = 1_500;
+  /** Must stay well under it, so the timer's cheap-rebuild arm is the one under test. */
+  private static final int    SMALL_COUNT = 50;
+
+  private static final int THRESHOLD  = 100;
+  /** {@code inactivityRebuildIsWorthIt()}'s {@code Math.max(threshold / 10, 1)}. */
+  private static final int FLOOR      = THRESHOLD / 10;
+  private static final int TIMEOUT_MS = 500;
+
+  private static final Duration REBUILD_SETTLE_TIMEOUT =
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsLong() + 60_000L);
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  /**
+   * The scenario the issue reports: build a large index, close, reopen, write one vector, never search, go idle.
+   * <p>
+   * The rebuild that used to run here is the whole point - it covered every vector in the index for a single
+   * pending mutation against a threshold of {@value #THRESHOLD}, which is precisely what issue #6496 established
+   * must not happen on a large index. Nothing about that changes because the graph happens to be on disk rather
+   * than in this session's heap.
+   */
+  @Test
+  void oneInsertIntoALargeUnloadedIndexMustNotRebuildAnything() throws Exception {
+    buildAndPersistFixture(LARGE_COUNT);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        configure(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: nothing has loaded the graph in this session yet")
+            .isEqualTo(0L); // GraphState.LOADING
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("precondition: and no graph node is resident, though a complete graph is on disk")
+            .isZero();
+        assertThat(index.getStats().get("persistedGraphNodeCount"))
+            .as("precondition: which the index can tell apart from having no graph at all - this is the "
+                + "distinction the whole fix rests on")
+            .isEqualTo((long) LARGE_COUNT);
+
+        insert(db, LARGE_COUNT, LARGE_COUNT + 1);
+
+        assertThat(index.getStats().get("mutationsSinceRebuild"))
+            .as("precondition: exactly one pending mutation, far below the floor of %d", FLOOR)
+            .isEqualTo(1L);
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("precondition: the write must NOT have loaded the graph - if it had, this test would be "
+                + "exercising the already-fixed resident-graph path instead")
+            .isZero();
+
+        // Idle, comfortably past the inactivity timeout.
+        Thread.sleep(TIMEOUT_MS * 6L);
+
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("a single pending mutation must not rebuild a large index just because this session has not "
+                + "loaded its graph (issue #6798)")
+            .isZero();
+        assertThat(index.getStats().get("mutationsSinceRebuild"))
+            .as("and the mutation must still be pending, waiting for the threshold like any other")
+            .isEqualTo(1L);
+        assertThat(index.getStats().get("asyncRebuildInProgress"))
+            .as("no rebuild of either kind - the async arm must not have been taken either")
+            .isZero();
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * The other half of the same gate: reaching the floor on a large-but-unloaded index must still rebuild, or the
+   * fix would trade a wasteful rebuild for a delta buffer that never drains.
+   */
+  @Test
+  void reachingTheFloorOnALargeUnloadedIndexStillRebuilds() {
+    buildAndPersistFixture(LARGE_COUNT);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        configure(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        insert(db, LARGE_COUNT, LARGE_COUNT + FLOOR);
+        assertThat(index.getStats().get("mutationsSinceRebuild")).isEqualTo((long) FLOOR);
+
+        Awaitility.await("the inactivity timer rebuilds once pending mutations reach the floor")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertThat(index.getStats().get("mutationsSinceRebuild")).isZero());
+
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("and the rebuilt graph covers every live vector")
+            .isEqualTo((long) (LARGE_COUNT + FLOOR));
+
+        Awaitility.await("the rebuild settles before the drop")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * The over-correction guard. A genuinely small persisted index is still cheap to rebuild, so the timer must
+   * keep flushing it on any pending mutation - applying the threshold there would only leave a handful of
+   * vectors in the linear-scan delta buffer for no benefit, which is the regression PR #6510 introduced and
+   * issue #6496's fix was reshaped to avoid.
+   */
+  @Test
+  void oneInsertIntoASmallUnloadedIndexStillFlushesPromptly() {
+    buildAndPersistFixture(SMALL_COUNT);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        configure(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("persistedGraphNodeCount"))
+            .as("precondition: a small graph is on disk and unloaded, the same shape as the large case")
+            .isEqualTo((long) SMALL_COUNT);
+
+        insert(db, SMALL_COUNT, SMALL_COUNT + 1);
+        assertThat(index.getStats().get("mutationsSinceRebuild")).isEqualTo(1L);
+
+        Awaitility.await("the inactivity timer flushes a small index on any pending mutation")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertThat(index.getStats().get("mutationsSinceRebuild")).isZero());
+
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("and the flushed graph covers every live vector")
+            .isEqualTo((long) (SMALL_COUNT + 1));
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * Session 1: write {@code count} vectors, build and persist the graph, close cleanly. The reopening session
+   * then finds a complete, valid persisted graph that nothing in it has loaded.
+   */
+  private void buildAndPersistFixture(final int count) {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        insert(db, 0, count);
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: the graph must be built and IMMUTABLE before the close that persists it")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  /**
+   * Pinned per-database rather than globally: the absolute threshold with graph-size scaling disabled, so the
+   * floor is a known {@value #FLOOR}, and an inactivity window short enough to wait out.
+   */
+  private static void configure(final Database db) {
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, THRESHOLD);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, TIMEOUT_MS);
+  }
+
+  private static void insert(final Database db, final int fromInclusive, final int toExclusive) {
+    db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"EUCLIDEAN\" }");
+    });
+
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+      if ((i - fromInclusive) % 500 == 499) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  /** Deterministic per-id embedding, so a fixture is reproducible run to run. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x6798L * 31 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}


### PR DESCRIPTION
Closes #6798.

## The defect

The graph loads lazily on the first search, so `graphIndex == null` carries three meanings, and only two of them mean *a rebuild here is cheap*:

1. no graph has ever been built - a first build, which must run whatever it costs;
2. a graph was built and is genuinely tiny - cheap by definition;
3. **a large graph is fully persisted and this session has simply never loaded it.**

`inactivityRebuildIsWorthIt()` and the timer task's sync/async arm choice both read the third as the first two. The mutation threshold was therefore skipped entirely, and one insert into a reopened index rebuilt every vector, synchronously, on the timer thread.

Ingest-then-idle - open, write, go quiet - is the ordinary shape of a loader process, and it is the one shape that never loads the graph. This is the same conflation #6772 fixed for a session that *searches*; that fix works by loading the persisted graph inside `ensureGraphAvailable()`, which the timer never calls, so it does not reach this path.

## The fix

Both call sites ask `inactivityRebuildScopeSize()` how many vectors a rebuild would actually have to cover.

The issue suggested either loading the persisted graph before the gate reads it, or falling back to the persisted graph's node count. **This does neither**, and both alternatives are worse here:

- *Loading the graph on the timer* makes an ingest-then-idle process pay for a load and a validation scan it never asked for, on a thread shared with every other index's inactivity task - it defeats the lazy load rather than accounting for it.
- *The persisted node count* is a proxy for the wrong quantity. `buildGraphFromScratch()` covers the **live** vector set, not the graph it replaces, so the live count is the direct measure of the cost being gated. It also gives the right answer where the two diverge: a large persisted graph whose vectors have since been deleted really is cheap to rebuild, and keeps getting flushed promptly instead of being deferred behind a threshold it will never reach.

The new behaviour is confined to the case `graphNotYetMaterialised()` identifies - this session has not yet resolved what is on disk - so everything downstream of a resolution answers exactly as before, including the window inside `buildGraphFromScratchExclusively()` where a rebuild nulls the resident graph before publishing its replacement.

`rebuildGraphBeforeSearch()` is deliberately left reading `graphIndex` directly. `ensureGraphAvailable()` always runs immediately before it (#6772), so a null there really is case 1 or 2 - and routing a search down the large-graph arm would hand it the async rebuild and an **empty** result set instead of a slow but correct one.

New `persistedGraphNodeCount` stat, alongside the existing `graphNodeCount` (which reports what this session has *loaded*), so "no graph exists" and "no graph is loaded" can be told apart from outside. That distinction is what the whole fix rests on.

## Verification

`Issue6798InactivityTimerUnloadedGraphTest` (`@Tag("vector")`) pins three behaviours, because fixing only the first is what broke three existing tests the last time this gate was touched (PR #6510 for #6496):

- one insert into a large-but-unloaded index must rebuild nothing at all - fails on the pre-fix decision, asserting on `graphRebuildCount`/`mutationsSinceRebuild` rather than on a wall clock;
- reaching the threshold-derived floor must still rebuild, so nothing is deferred forever;
- a genuinely small persisted index must still flush on any pending mutation - the over-correction guard.

`mvn -o -pl engine -am test -Dtest='com.arcadedb.index.vector.*Test'`: **434/434 green**, including `Issue6496InactivityRebuildThresholdTest`, `LSMVectorIndexRebuildTest`, `Issue6772WriteBeforeSearchPrefixReuseTest` and `Issue6655StaleGraphPrefixReuseTest`.

## Follow-up, deliberately not in this PR

When the floor *is* legitimately reached on a large-but-unloaded index, the async rebuild still builds from scratch rather than reusing the persisted prefix the way #6655/#6772 do on the search path. That is a separate optimisation (it applies equally to the search path's own async rebuild) and reaching it from the rebuild thread would drag `ensureGraphAvailable()`'s `graphBuildLock` under `startAsyncGraphRebuild()`'s monitor, adding a lock-ordering edge PR #6784's review explicitly avoided. Worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vector index size reporting by distinguishing persisted data from data currently loaded in memory.
  - Prevented large, lazily loaded indexes from rebuilding prematurely after minimal activity.
  - Rebuilds for affected indexes now run asynchronously, improving timer responsiveness.
  - Preserved immediate flushing behavior for small indexes.

- **Tests**
  - Added coverage for inactivity-timer behavior across unloaded large indexes and small indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->