### PR TITLE
fix(#6797): bound the LSM_VECTOR delta scan by measured query cost, not by a fixed mutation count

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1171,7 +1171,13 @@ public enum GlobalConfiguration {
       must have reached what the next build is estimated to cost, both counted in similarity computations. \
       That bounds the extra rebuild CPU this setting can introduce by the query CPU it removes, at any index \
       size and any ingest rate. Both conditions are reported by the index statistics as deltaScanBudget, \
-      deltaScanWorkSinceRebuild and estimatedRebuildWork.""",
+      deltaScanWorkSinceRebuild and estimatedRebuildWork. \
+      Note that this is on by default, so an existing deployment that is both query-heavy and ingest-heavy will \
+      see more background rebuild activity after upgrading - that being the point, since it is the same \
+      deployment that was losing the query time. Set 0 to keep the previous behaviour exactly. \
+      Note also that a query answered by the narrow-allow-list pre-filter plan never walks the graph, so it \
+      produces nothing to measure and leaves the budget unset; an index queried only that way is not covered by \
+      this setting and falls back on the count thresholds.""",
       Float.class, 1.0f),
 
   VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS("arcadedb.vectorIndex.inactivityRebuildTimeoutMs", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1142,8 +1142,37 @@ public enum GlobalConfiguration {
       reached 45,000 entries, and 42,504 even with the rebuild trigger firing continuously. Note also that \
       mutationsBeforeRebuild is applied as a floor afterwards, so an explicit value above this ceiling wins. \
       Nothing here bounds the buffer. mutationsBeforeRebuild and rebuildGraphRatio only change how OFTEN a \
-      rebuild drains it, so its peak follows from how much is written between rebuilds.""",
+      rebuild drains it, so its peak follows from how much is written between rebuilds. \
+      This ceiling is also a fixed count, so it stops scaling once rebuildGraphRatio x graph size reaches it \
+      (at the defaults, 250,000 vectors), from which point the same absolute scan cost lands on an index of any \
+      size (issue #6797). maxDeltaScanRatio is the size-independent bound on that cost and is the knob to reach \
+      for when query latency, rather than rebuild frequency, is what needs protecting.""",
       Integer.class, 50_000),
+
+  VECTOR_INDEX_MAX_DELTA_SCAN_RATIO("arcadedb.vectorIndex.maxDeltaScanRatio", SCOPE.DATABASE,
+      """
+      How much brute-force work a query may spend on the in-memory delta buffer, expressed as a multiple of the \
+      work its HNSW graph walk already does, before a rebuild is triggered to drain the buffer. Vectors ingested \
+      since the last rebuild are answered by a linear scan of that buffer, so this term of a query grows with the \
+      buffer while the graph walk it supplements grows only logarithmically with the corpus: at the default \
+      maxPendingMutations the scan has been measured at four fifths of query time (issue #6797). The count-based \
+      thresholds cannot bound it - mutationsBeforeRebuild and rebuildGraphRatio are denominated in mutations and \
+      maxPendingMutations is a fixed number that stops scaling - so this one is denominated in the quantity that \
+      actually matters and is measured, not assumed: the engine records how many nodes its graph walks actually \
+      visit and compares the buffer against that. 1.0 (the default) lets the scan cost about as much as the walk. \
+      Lower it for latency-sensitive read-heavy workloads, raise it to defer rebuilds further, set 0 to disable \
+      and leave the count thresholds as the only trigger. \
+      Because it is evaluated on the search path against a measured walk cost, a pure-ingest workload never \
+      triggers it and keeps the geometric rebuild amortization of rebuildGraphRatio intact; only a workload that \
+      is actually paying the scan pays for the extra rebuilds that remove it. The absolute mutationsBeforeRebuild \
+      floor still applies, so this can never rebuild more eagerly than that setting allows. \
+      A second condition guards it, so that a buffer refilling immediately after a rebuild cannot ask for \
+      another one straight away: the brute-force work the scans have actually performed since the last build \
+      must have reached what the next build is estimated to cost, both counted in similarity computations. \
+      That bounds the extra rebuild CPU this setting can introduce by the query CPU it removes, at any index \
+      size and any ingest rate. Both conditions are reported by the index statistics as deltaScanBudget, \
+      deltaScanWorkSinceRebuild and estimatedRebuildWork.""",
+      Float.class, 1.0f),
 
   VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS("arcadedb.vectorIndex.inactivityRebuildTimeoutMs", SCOPE.DATABASE,
       """

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2273,6 +2273,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // again (issue #6797). Reset for a FAILED build too, deliberately: the buffer it did not drain is still
       // there and still being scanned, so the counter refills on its own, and making the retry wait out another
       // full window is what stops a build that keeps failing from being retried in a tight loop.
+      //
+      // Racy by design, in one direction only: a query that started before this line can land its addAndGet()
+      // after it, crediting the new window with a scan performed against the buffer this build just drained. The
+      // effect is bounded by the queries in flight at this instant and biases the next rebuild marginally early -
+      // never late - which is the same tolerance graphWalkVisited is documented to have. Closing it would mean
+      // holding a lock across the whole build to bracket a counter that only feeds a heuristic.
       deltaScanWorkSinceRebuild.set(0L);
       graphBuildLock.unlock();
     }
@@ -3692,6 +3698,36 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // or the linear delta scan those mutations left behind has outgrown the graph walk it supplements
       // (issue #6797). Search uses the current graph (valid, just missing newest vectors) while rebuild runs in
       // background.
+      startAsyncGraphRebuild();
+  }
+
+  /**
+   * The delta-scan half of {@link #rebuildGraphBeforeSearch()}, for the approximate search path (issue #6797).
+   * <p>
+   * {@link #findNeighborsFromVectorApproximate} has never called {@code rebuildGraphBeforeSearch()} - only the
+   * exact, grouped and {@code get()} paths do - so no search on it has ever triggered a rebuild of any kind. That
+   * is survivable for the mutation-count thresholds, which the other paths and the inactivity timer reach anyway
+   * on any index that sees more than one kind of query. It is not survivable for a bound whose entire subject is
+   * the cost of a delta scan this path performs on every query: leaving it out would mean the one search mode
+   * sold on microsecond latency is the one mode where the scan still grows without limit.
+   * <p>
+   * Only the new trigger is evaluated here, deliberately, and not by calling {@code rebuildGraphBeforeSearch()}
+   * outright. That method's small-graph arm rebuilds <em>synchronously, on the calling thread</em>, and putting a
+   * synchronous full rebuild into a path whose contract is zero disk I/O and microsecond latency is a change of
+   * a different kind from the one this issue is about. Whether the count thresholds should reach this path too
+   * is a real question, and a separate one.
+   */
+  private void boundDeltaScanBeforeApproximateSearch() {
+    if (graphState != GraphState.MUTABLE || asyncRebuildInProgress)
+      return;
+
+    final ImmutableGraphIndex graph = this.graphIndex;
+    if (graph == null || graph.size() < ASYNC_REBUILD_MIN_GRAPH_SIZE)
+      // Same gate the search path applies: below this size a rebuild is cheap, and the only thing that rebuilds
+      // a small graph here is the synchronous arm this method exists to stay out of.
+      return;
+
+    if (deltaScanOverBudget())
       startAsyncGraphRebuild();
   }
 
@@ -6108,6 +6144,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // Ensure graph is available (lazy-load from disk if needed)
       ensureGraphAvailable();
 
+      // This path scans the delta buffer too - mergeWithDeltaScanApproximate delegates the scan itself to
+      // mergeWithDeltaScan - so the bound on that scan has to apply here as well, or the one search mode sold on
+      // microsecond latency is the one mode where the linear scan still grows without limit (issue #6797).
+      boundDeltaScanBeforeApproximateSearch();
+
       // Issue #5924: see findNeighborsFromVector's matching clamp - k drives the same eager
       // ArrayList/PriorityQueue allocation sizes below, so it needs the same bound.
       k = Math.min(k, Math.max(vectorIndex().size(), 0) + deltaVectors.size());
@@ -7633,8 +7674,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // exceeded and the first of these to have reached the second.
     stats.put("deltaScanWorkSinceRebuild", deltaScanWorkSinceRebuild.get());
     final ImmutableGraphIndex statsGraph = graphIndex;
-    stats.put("estimatedRebuildWork",
-        statsGraph != null ? estimateRebuildWork(statsGraph.size(), maxDeltaScanRatio()) : 0L);
+    stats.put("estimatedRebuildWork", statsGraph != null ? estimateRebuildWork(statsGraph.size()) : 0L);
+    stats.put("deltaScanWorkTarget",
+        statsGraph != null ? deltaScanWorkTarget(statsGraph.size(), maxDeltaScanRatio()) : 0L);
 
     // On-heap cache size of the live incremental builder (bounded, issue #3144)
     stats.put("liveVectorCacheSize", liveVectorValues != null ? (long) liveVectorValues.vectorCount() : 0L);
@@ -8542,7 +8584,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     final ImmutableGraphIndex graph = this.graphIndex;
     return graph != null
-        && deltaScanPaysForARebuild(deltaScanWorkSinceRebuild.get(), estimateRebuildWork(graph.size(), ratio));
+        && deltaScanPaysForARebuild(deltaScanWorkSinceRebuild.get(), deltaScanWorkTarget(graph.size(), ratio));
   }
 
   /**
@@ -8585,9 +8627,23 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * both halves of the trigger: raising it makes the engine more tolerant of the scan and rebuild less often,
    * lowering it does the opposite.
    */
-  private long estimateRebuildWork(final int graphSize, final float ratio) {
-    final double work = (double) Math.max(0, graphSize) * Math.max(1, metadata.beamWidth) * Math.max(0f, ratio);
-    return (long) Math.min(Long.MAX_VALUE, work);
+  private long estimateRebuildWork(final int graphSize) {
+    return (long) Math.max(0, graphSize) * Math.max(1, metadata.beamWidth);
+  }
+
+  /**
+   * {@link #estimateRebuildWork(int)} scaled by {@code maxDeltaScanRatio}: the number the accumulated scan work is
+   * actually compared against, so the setting reads the same way on both halves of the trigger - raising it makes
+   * the engine more tolerant of the scan and rebuild less often, lowering it does the opposite.
+   * <p>
+   * Kept apart from the estimate rather than folded into it so that neither number lies. {@code getStats()}
+   * reports both, and an operator reading {@code estimatedRebuildWork} to answer "how expensive is my next
+   * rebuild" gets an answer that depends on the graph alone - not one that moves when a latency-tuning knob does,
+   * which would make two databases differing only in {@code maxDeltaScanRatio} appear to have differently
+   * expensive rebuilds.
+   */
+  private long deltaScanWorkTarget(final int graphSize, final float ratio) {
+    return (long) Math.min(Long.MAX_VALUE, (double) estimateRebuildWork(graphSize) * Math.max(0f, ratio));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3794,8 +3794,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // instead. Only a rebuild that ran to completion chains, so a failing one cannot spin, and each chained
       // rebuild subtracts the mutations it snapshotted, so the counter cannot be re-served indefinitely without
       // new writes actually arriving.
+      //
+      // Deliberately NOT also chained on deltaScanOverBudget() (issue #6797): the build that just completed reset
+      // the scan-work counter its amortization half reads, so the condition could only be true here in the race
+      // window between that reset and this line - and it SHOULD be false, because a rebuild whose residue nobody
+      // has queried yet has not been paid for. The next search picks it up once it has been.
       if (completed && !Thread.currentThread().isInterrupted() && isValid()
-          && (mutationsSinceSerialize.get() >= getEffectiveMutationsBeforeRebuild() || deltaScanOverBudget()))
+          && mutationsSinceSerialize.get() >= getEffectiveMutationsBeforeRebuild())
         startAsyncGraphRebuild();
     }, "VectorIndex-AsyncRebuild-" + indexName);
     asyncRebuildThread.setDaemon(true);
@@ -4694,10 +4699,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (currentDelta.isEmpty() || k <= 0)
       return;
 
-    // Charged up front, on the size actually about to be walked: what the amortization guard needs to know is
-    // how much brute-force work this query committed to, and the prune below skips allocations, not comparisons.
-    recordDeltaScanWork(currentDelta.size());
-
     // Collect already-seen RIDs from graph results to avoid duplicates
     final RidHashSet seenRIDs = new RidHashSet(results.size());
     for (final Pair<RID, Float> r : results)
@@ -4729,10 +4730,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
     float worst = heapFull ? best.peek().getSecond() : Float.POSITIVE_INFINITY;
 
     boolean added = false;
+    int compared = 0;
     for (final DeltaVectorEntry delta : currentDelta) {
       if (filtered && !allowedRIDs.contains(delta.rid))
         continue;
 
+      compared++;
       final float score = similarity.compare(queryVectorFloat, delta.vector);
       final float distance = scoreToDistance(similarity, score);
 
@@ -4772,6 +4775,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
         worst = best.peek().getSecond();
       added = true;
     }
+
+    // Counted, not assumed to be the buffer size: an allow-list rejects entries before they are ever compared,
+    // and charging the amortization guard for work no core performed would make it rebuild sooner than the CPU
+    // it is trading against justifies. The prune above is not subtracted - it skips the allocation, not the
+    // comparison, which is the expensive half.
+    recordDeltaScanWork(compared);
 
     if (added) {
       results.clear();
@@ -5995,8 +6004,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (buffered == 0)
       return null;
 
-    recordDeltaScanWork(buffered);
-
     final float[] distances = new float[buffered];
     final int[] positions = new int[buffered];
     // Hoisted for the same reason mergeWithDeltaScan hoists them (issue #6797): this loop runs once per buffered
@@ -6019,6 +6026,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
       positions[kept] = i;
       kept++;
     }
+    // `kept`, not `buffered`: the entries an allow-list or a tombstone rejected were never compared, and the
+    // amortization guard has to be charged for comparisons actually performed - see mergeWithDeltaScan.
+    recordDeltaScanWork(kept);
     return kept == 0 ? null : new ScoredCandidateCursor(distances, positions, kept);
   }
 
@@ -8503,10 +8513,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
-   * Whether the delta buffer has outgrown {@link #deltaScanBudget()}. Split out so the search trigger and the
-   * chained-rebuild check at the end of {@link #startAsyncGraphRebuild()} cannot disagree: a rebuild that drains
-   * only part of the buffer - anything ingested while it ran stays behind - has to be able to chain on the same
-   * condition that started it, or the buffer sits over budget until the next search notices.
+   * Whether the delta buffer has outgrown {@link #deltaScanBudget()} <em>and</em> the scans have paid for the
+   * rebuild that would drain it. Split out so the search path and the inactivity timer decide it identically: it
+   * would be odd for a search to judge the scan too expensive and the timer, looking at the same buffer with the
+   * machine idle, to decline.
    */
   private boolean deltaScanOverBudget() {
     final float ratio = maxDeltaScanRatio();
@@ -8564,6 +8574,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     return (long) Math.min(Long.MAX_VALUE, work);
   }
 
+  /**
+   * Visible for tests: the amortization counter, without the manifest read {@link #getStats()} performs. A test
+   * that has to poll this after every query in a loop cannot afford the full snapshot.
+   */
+  long deltaScanWorkForTest() {
+    return deltaScanWorkSinceRebuild.get();
+  }
+
   /** Charges one query's brute-force scan of {@code scanned} buffered vectors to the amortization window. */
   private void recordDeltaScanWork(final int scanned) {
     if (scanned > 0)
@@ -8596,9 +8614,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * buffer promptly - but to apply the same threshold the search path uses, and only where the search
    * path would also apply it: once the graph is large enough that a rebuild is no longer free.
    *
+   * Package-private so a test can put the index into a given state and ask the timer's question directly. Driving
+   * it through a real timer instead would have to race the search path, which evaluates the same condition on
+   * every query and would usually get there first (issue #6797).
+   *
    * @return {@code true} when pending mutations justify (or exceed) a rebuild
    */
-  private boolean inactivityRebuildIsWorthIt() {
+  boolean inactivityRebuildIsWorthIt() {
     final int pending = mutationsSinceSerialize.get();
     if (pending <= 0)
       return false;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -8487,6 +8487,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * untouched; a query-heavy workload trades rebuild CPU it has to spare for the latency it is actually losing.
    * The absolute {@code mutationsBeforeRebuild} floor is applied on top, so this can never rebuild more eagerly
    * than that setting already permits.
+   * <p>
+   * <b>One workload it cannot see.</b> The issue #6502 and #6514 pre-filter plans answer a narrow allow-list by
+   * scanning it directly and return without walking the graph at all, so they produce no {@code visitedCount} to
+   * feed {@link #recordGraphWalkCost(int)}. An index queried <em>only</em> that way therefore keeps a
+   * {@link Integer#MAX_VALUE} budget and this policy stays inert for it, however long its delta buffer gets. That
+   * is deliberate rather than an oversight: the budget's whole claim is that the scan is measured against a walk
+   * this index actually performs, and there is no walk on that path to measure it against. Inventing a
+   * denominator from {@code efSearch} and the corpus size is exactly the assumed-not-measured estimate this
+   * design rejects. Such a workload still has the count thresholds, and its pre-filter scan is bounded by the
+   * allow-list rather than by the corpus.
    *
    * @return buffered-vector count at which the scan is judged to have outgrown the walk
    */
@@ -8519,9 +8529,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * machine idle, to decline.
    */
   private boolean deltaScanOverBudget() {
-    final float ratio = maxDeltaScanRatio();
+    // Buffer size first, before the setting is read: this runs on the search path of every query whose pending
+    // mutations have not reached the count threshold, and an empty buffer - the state an index spends most of its
+    // life in - can be answered with one field read and no configuration lookup at all.
     final int buffered = deltaVectors.size();
-    if (buffered <= 0 || buffered < deltaScanBudget(ratio))
+    if (buffered <= 0)
+      return false;
+
+    final float ratio = maxDeltaScanRatio();
+    if (buffered < deltaScanBudget(ratio))
       return false;
 
     final ImmutableGraphIndex graph = this.graphIndex;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -357,6 +357,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
   private volatile List<DeltaVectorEntry> deltaVectors = new ArrayList<>();
 
+  /**
+   * Exponential moving average of the nodes a graph walk scores per query, from JVector's own
+   * {@code visitedCount}. The denominator of {@link #deltaScanBudget()} (issue #6797); 0 until a search has
+   * actually walked this index's graph. See {@link #recordGraphWalkCost(int)} for why it is measured rather than
+   * derived, and why a plain volatile is enough.
+   */
+  private volatile int graphWalkVisited;
+
+  /**
+   * Similarity computations the brute-force delta scan has performed since the last graph build, summed across
+   * every query. The amortization half of {@link #deltaScanOverBudget()} (issue #6797): a rebuild is only worth
+   * triggering once the scans it would have removed have already cost more than the rebuild itself will, which
+   * is what keeps the extra rebuild CPU this policy introduces bounded by the query CPU it saves.
+   */
+  private final AtomicLong deltaScanWorkSinceRebuild = new AtomicLong();
+
   // Inactivity rebuild timer (issue #3737): when mutations exist but haven't reached the threshold,
   // a timer triggers an async rebuild after a period of inactivity.
   private volatile TimerTask inactivityRebuildTask;
@@ -2253,6 +2269,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
       persistedGraphUnresolved = false;
       buildGraphFromScratchExclusively(graphCallback, compactDataFile, releaseResidentGraphFirst);
     } finally {
+      // The scan work this build was meant to make unnecessary has been paid for; start the amortization window
+      // again (issue #6797). Reset for a FAILED build too, deliberately: the buffer it did not drain is still
+      // there and still being scanned, so the counter refills on its own, and making the retry wait out another
+      // full window is what stops a build that keeps failing from being retried in a tight loop.
+      deltaScanWorkSinceRebuild.set(0L);
       graphBuildLock.unlock();
     }
   }
@@ -3666,9 +3687,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
       if (graphState == GraphState.MUTABLE && mutationsSinceSerialize.get() > 0
           && (graphIndex == null || graphIndex.size() < ASYNC_REBUILD_MIN_GRAPH_SIZE))
         buildGraphFromScratch();
-    } else if (mutations >= threshold && !asyncRebuildInProgress)
-      // Large graph (>= 1000 vectors): async rebuild only when threshold reached.
-      // Search uses the current graph (valid, just missing newest vectors) while rebuild runs in background.
+    } else if (!asyncRebuildInProgress && (mutations >= threshold || deltaScanOverBudget()))
+      // Large graph (>= 1000 vectors): async rebuild once either trigger fires - enough mutations have piled up,
+      // or the linear delta scan those mutations left behind has outgrown the graph walk it supplements
+      // (issue #6797). Search uses the current graph (valid, just missing newest vectors) while rebuild runs in
+      // background.
       startAsyncGraphRebuild();
   }
 
@@ -3772,7 +3795,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // rebuild subtracts the mutations it snapshotted, so the counter cannot be re-served indefinitely without
       // new writes actually arriving.
       if (completed && !Thread.currentThread().isInterrupted() && isValid()
-          && mutationsSinceSerialize.get() >= getEffectiveMutationsBeforeRebuild())
+          && (mutationsSinceSerialize.get() >= getEffectiveMutationsBeforeRebuild() || deltaScanOverBudget()))
         startAsyncGraphRebuild();
     }, "VectorIndex-AsyncRebuild-" + indexName);
     asyncRebuildThread.setDaemon(true);
@@ -4671,6 +4694,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (currentDelta.isEmpty() || k <= 0)
       return;
 
+    // Charged up front, on the size actually about to be walked: what the amortization guard needs to know is
+    // how much brute-force work this query committed to, and the prune below skips allocations, not comparisons.
+    recordDeltaScanWork(currentDelta.size());
+
     // Collect already-seen RIDs from graph results to avoid duplicates
     final RidHashSet seenRIDs = new RidHashSet(results.size());
     for (final Pair<RID, Float> r : results)
@@ -4684,12 +4711,45 @@ public class LSMVectorIndex implements Index, IndexInternal {
     while (best.size() > k)
       best.poll();
 
+    // Hoisted out of the loop, all three of them, because this loop runs once per buffered vector per query and
+    // the buffer reaches tens of thousands of entries (issue #6797):
+    //  - vectorIndex() is a volatile read behind a materialization check, and one snapshot is also more correct
+    //    than one read per entry - the tombstone question has to be asked of a single generation;
+    //  - an index with no tombstones at all cannot answer isDeleted() true for anything, so the per-entry hash
+    //    lookup can be skipped outright rather than performed and discarded;
+    //  - the allow-list test is two branches when there is no allow-list, which is the common case.
+    final VectorLocationIndex locations = vectorIndex();
+    final boolean anyDeleted = locations.getDeletedCount() > 0;
+    final boolean filtered = allowedRIDs != null && !allowedRIDs.isEmpty();
+    final VectorSimilarityFunction similarity = metadata.similarityFunction;
+
+    // The k-th best distance, kept unboxed. Reading it off the heap head per entry costs a pointer chase into a
+    // Pair plus a Float unbox, which on a scan this long is not free.
+    boolean heapFull = best.size() >= k;
+    float worst = heapFull ? best.peek().getSecond() : Float.POSITIVE_INFINITY;
+
     boolean added = false;
     for (final DeltaVectorEntry delta : currentDelta) {
+      if (filtered && !allowedRIDs.contains(delta.rid))
+        continue;
+
+      final float score = similarity.compare(queryVectorFloat, delta.vector);
+      final float distance = scoreToDistance(similarity, score);
+
+      // Prune before allocating: a candidate no better than the current k-th best cannot make the result set.
+      // This is also why the two hash lookups below sit AFTER the prune rather than before it, where they used to
+      // be: they are per-entry random memory accesses that only matter for a candidate that is actually going to
+      // be admitted, and the prune rejects all but a handful of entries. The admitted set is identical either way
+      // - the heap only advances when an entry is added, and neither check can make an entry admissible.
+      if (heapFull && distance >= worst)
+        continue;
+
+      // Already returned by the graph walk. Reachable: a rebuild that leaves a node unreachable re-queues its
+      // vector into the buffer while the node itself stays in the graph (see buildGraphFromScratch), so the same
+      // RID can be offered by both sides of this merge.
       if (seenRIDs.contains(delta.rid))
         continue;
-      if (allowedRIDs != null && !allowedRIDs.isEmpty() && !allowedRIDs.contains(delta.rid))
-        continue;
+
       // Check if deleted after being added to delta.
       //
       // Asked of the tombstone set, because a resident location cannot answer it: since issue #5516 a tombstoned
@@ -4701,19 +4761,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // tombstone in behind the buffer only makes the next rebuild republish the live entry the pages still
       // carry. It stays anyway, at the price of one bit, because it is what the line above says it does and
       // because the buffer and the tombstone set are maintained by different code paths.
-      if (vectorIndex().isDeleted(delta.vectorId))
-        continue;
-
-      final float score = metadata.similarityFunction.compare(queryVectorFloat, delta.vector);
-      final float distance = scoreToDistance(metadata.similarityFunction, score);
-
-      // Prune before allocating: a candidate no better than the current k-th best cannot make the result set.
-      if (best.size() >= k && distance >= best.peek().getSecond())
+      if (anyDeleted && locations.isDeleted(delta.vectorId))
         continue;
 
       best.add(new Pair<>(bindRid(delta.rid), distance));
       if (best.size() > k)
         best.poll();
+      heapFull = best.size() >= k;
+      if (heapFull)
+        worst = best.peek().getSecond();
       added = true;
     }
 
@@ -5243,6 +5299,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
           pool.release(searcher, pooledGraph, poolEpoch);
         }
 
+        recordGraphWalkCost(searchResult.getVisitedCount());
+
         LogManager.instance()
             .log(this, Level.FINE, "GraphSearcher returned %d nodes, graphSize=%d, vectorsSize=%d, ordinalToVectorIdLength=%d",
                 searchResult.getNodes().length, graphIndex.size(), vectors.size(), ordinalMap.length);
@@ -5532,6 +5590,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         //    happens to be an exact multiple of the beam width - so a short final pass is not reliable on its own.
         boolean walkRanDry = false;
         int examined = 0;
+        int visited = 0;
         try {
           final ScoreFunction.ExactScoreFunction exactScoreFunction = liveOnlyScoreFunction(queryVectorFloat, vectors);
           final DefaultSearchScoreProvider ssp = new DefaultSearchScoreProvider(exactScoreFunction, exactScoreFunction);
@@ -5561,6 +5620,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
           while (true) {
             final int returned = searchResult.getNodes().length;
             examined += returned;
+            // Summed over the passes, not read off the last one: resume() continues the same walk, and it is the
+            // whole walk this query paid for that the delta budget is measured against (issue #6797).
+            visited += searchResult.getVisitedCount();
             admitGroupedCandidates(searchResult, ordinalMap, state);
 
             if (state.isFull())
@@ -5583,6 +5645,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         } finally {
           pool.release(searcher, pooledGraph, poolEpoch);
         }
+        recordGraphWalkCost(visited);
         // examined can never exceed graphSize - every pass contributes only nodes resume() had not already visited -
         // so reaching it here means every reachable node was walked, whichever break fired.
         final boolean graphExhausted = walkRanDry || examined >= graphSize;
@@ -5932,19 +5995,27 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (buffered == 0)
       return null;
 
+    recordDeltaScanWork(buffered);
+
     final float[] distances = new float[buffered];
     final int[] positions = new int[buffered];
+    // Hoisted for the same reason mergeWithDeltaScan hoists them (issue #6797): this loop runs once per buffered
+    // vector per grouped query, and vectorIndex() is a volatile read behind a materialization check while
+    // isDeleted() is a hash lookup that an index carrying no tombstones can never answer true.
+    final VectorLocationIndex locations = vectorIndex();
+    final boolean anyDeleted = locations.getDeletedCount() > 0;
+    final boolean filtered = allowedRIDs != null && !allowedRIDs.isEmpty();
+    final VectorSimilarityFunction similarity = metadata.similarityFunction;
     int kept = 0;
     for (int i = 0; i < buffered; i++) {
       final DeltaVectorEntry entry = deltaSnapshot.get(i);
-      if (allowedRIDs != null && !allowedRIDs.isEmpty() && !allowedRIDs.contains(entry.rid))
+      if (filtered && !allowedRIDs.contains(entry.rid))
         continue;
       // The same tombstone check mergeWithDeltaScan applies, asked of the tombstone set for the same reason - see
       // its javadoc for why a resident location cannot answer it and why it stays despite being unreachable today.
-      if (vectorIndex().isDeleted(entry.vectorId))
+      if (anyDeleted && locations.isDeleted(entry.vectorId))
         continue;
-      distances[kept] = scoreToDistance(metadata.similarityFunction,
-          metadata.similarityFunction.compare(queryVectorFloat, entry.vector));
+      distances[kept] = scoreToDistance(similarity, similarity.compare(queryVectorFloat, entry.vector));
       positions[kept] = i;
       kept++;
     }
@@ -6104,6 +6175,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
         } finally {
           pool.release(searcher, pooledGraph, poolEpoch);
         }
+
+        recordGraphWalkCost(searchResult.getVisitedCount());
 
         // Extract RIDs and scores from search results
         final List<Pair<RID, Float>> results = new ArrayList<>(k);
@@ -7539,6 +7612,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // Delta vectors cached in RAM for brute-force scan between rebuilds
     stats.put("deltaVectorsCount", (long) deltaVectors.size());
 
+    // The size-independent bound on that scan and the measured walk cost it is derived from (issue #6797).
+    // deltaScanBudget is Long.MAX_VALUE when the policy is off or no search has walked this graph yet, which is
+    // the same thing the engine means by it: nothing here will trigger a rebuild.
+    stats.put("graphWalkVisitedAvg", (long) graphWalkVisited);
+    final int scanBudget = deltaScanBudget();
+    stats.put("deltaScanBudget", scanBudget == Integer.MAX_VALUE ? Long.MAX_VALUE : (long) scanBudget);
+    // The amortization half of the same trigger: how much brute-force work the scans have cost since the last
+    // build, and what the next build is estimated to cost. The trigger needs BOTH the budget above to be
+    // exceeded and the first of these to have reached the second.
+    stats.put("deltaScanWorkSinceRebuild", deltaScanWorkSinceRebuild.get());
+    final ImmutableGraphIndex statsGraph = graphIndex;
+    stats.put("estimatedRebuildWork",
+        statsGraph != null ? estimateRebuildWork(statsGraph.size(), maxDeltaScanRatio()) : 0L);
+
     // On-heap cache size of the live incremental builder (bounded, issue #3144)
     stats.put("liveVectorCacheSize", liveVectorValues != null ? (long) liveVectorValues.vectorCount() : 0L);
 
@@ -8303,20 +8390,184 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @return Number of pending mutations that trigger a graph rebuild
    */
   private int getEffectiveMutationsBeforeRebuild() {
-    final int absolute = getMutationsBeforeRebuild();
     final ImmutableGraphIndex graph = this.graphIndex;
+    final int absolute = getMutationsBeforeRebuild();
     if (graph == null)
       return absolute;
 
     final ContextConfiguration configuration = mutable.getDatabase().getConfiguration();
-    final float ratio = configuration.getValueAsFloat(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO);
+    return computeRebuildThreshold(absolute, graph.size(),
+        configuration.getValueAsFloat(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO),
+        configuration.getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_MAX_PENDING_MUTATIONS));
+  }
+
+  /**
+   * The arithmetic of {@link #getEffectiveMutationsBeforeRebuild()}, as a pure function of its four inputs.
+   * <p>
+   * Extracted so the shape of the threshold across graph sizes no engine test can build - a million vectors, ten
+   * million - can be asserted directly instead of inferred (issue #6797). The behaviour is unchanged: the
+   * ratio-derived term is capped by {@code maxPending} and the absolute floor is applied last, so an explicit
+   * {@code mutationsBeforeRebuild} above the ceiling still wins.
+   *
+   * @param absolute   the absolute {@code mutationsBeforeRebuild} floor
+   * @param graphSize  number of nodes in the graph the rebuild would re-index
+   * @param ratio      fraction of {@code graphSize} that may accumulate as pending mutations, 0 to disable scaling
+   * @param maxPending ceiling on the ratio-derived term, 0 for no ceiling
+   *
+   * @return number of pending mutations that trigger a graph rebuild
+   */
+  static int computeRebuildThreshold(final int absolute, final long graphSize, final float ratio, final int maxPending) {
     if (ratio <= 0f)
       return absolute;
 
-    final long scaled = (long) (graph.size() * (double) ratio);
-    final int maxPending = configuration.getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_MAX_PENDING_MUTATIONS);
+    final long scaled = (long) (graphSize * (double) ratio);
     final long capped = maxPending > 0 ? Math.min(scaled, maxPending) : scaled;
     return (int) Math.max(absolute, capped);
+  }
+
+  /**
+   * Records what one graph walk actually cost, in nodes whose similarity it computed.
+   * <p>
+   * This is the denominator {@link #deltaScanBudget()} measures the brute-force delta scan against, and it is
+   * taken from JVector's own {@code visitedCount} rather than estimated from {@code efSearch}, {@code
+   * maxConnections} and the graph size: the beam is chosen adaptively per query, a {@code Bits} filter can make a
+   * walk visit far more nodes than the beam suggests, and a degraded graph can make it visit far fewer. Only the
+   * measurement knows.
+   * <p>
+   * Smoothed as an exponential moving average with a weight of 1/4 on the new sample, so a single unusually wide
+   * or narrow query cannot move the rebuild policy on its own, and kept in a plain volatile int rather than an
+   * atomic: this is on the hot path of every search, samples are all of the same order, and a lost update under
+   * concurrency costs nothing but a slightly staler average.
+   *
+   * The unit is node visits, not nanoseconds, and it is compared against a buffered-vector count that is also a
+   * node visit - which is what makes the two comparable at all. It is not a perfect exchange rate: a visit on the
+   * PQ-scored approximate path is cheaper than the exact compare a buffered vector costs, so a query mix that
+   * includes that path raises this average relative to the wall-clock it stands for and leaves the budget more
+   * generous than the ratio literally asks for. That is the side to err on - a too-generous budget only leaves
+   * the engine nearer the behaviour it had before this policy existed, whereas a too-tight one would spend
+   * rebuild CPU nobody asked for - and {@code maxDeltaScanRatio} is there to move it either way.
+   *
+   * @param visited number of nodes the walk scored, from {@link SearchResult#getVisitedCount()}
+   */
+  private void recordGraphWalkCost(final int visited) {
+    if (visited <= 0)
+      return;
+    final int previous = graphWalkVisited;
+    graphWalkVisited = previous <= 0 ? visited : previous + (visited - previous) / 4;
+  }
+
+  /**
+   * The largest delta buffer a query is willing to scan before a rebuild is triggered to drain it, or
+   * {@link Integer#MAX_VALUE} when the policy is disabled or has nothing measured to work from (issue #6797).
+   * <p>
+   * <b>Why a second trigger at all.</b> Every other rebuild trigger is denominated in mutations, and no number of
+   * mutations bounds what a query pays. The delta buffer is answered by a linear scan, so its cost is
+   * {@code O(buffer)}; the graph walk it supplements is {@code O(log corpus)}. {@code rebuildGraphRatio} makes the
+   * buffer a fixed <em>fraction of the corpus</em>, which is asymptotically the wrong shape - 20% of the corpus
+   * scanned linearly dominates a logarithmic walk at every scale - and {@code maxPendingMutations} caps it at a
+   * fixed count, which stops scaling entirely (at the defaults, from 250,000 vectors upward the same absolute scan
+   * cost lands on an index of any size). Measured at that cap on a 200,000-vector index, the scan was roughly four
+   * fifths of query time.
+   * <p>
+   * <b>Why it does not simply cost bulk ingest more rebuilds.</b> The two goals genuinely conflict - a full rebuild
+   * is {@code O(corpus)}, so bounding the buffer by a constant makes ingestion quadratic, which is exactly what
+   * {@code rebuildGraphRatio} exists to prevent - and no single threshold can serve both. What breaks the tie is
+   * that only one of the two workloads is paying: this budget is evaluated on the search path, against a walk cost
+   * that only searches produce. An ingest-only workload never reaches it and keeps the geometric amortization
+   * untouched; a query-heavy workload trades rebuild CPU it has to spare for the latency it is actually losing.
+   * The absolute {@code mutationsBeforeRebuild} floor is applied on top, so this can never rebuild more eagerly
+   * than that setting already permits.
+   *
+   * @return buffered-vector count at which the scan is judged to have outgrown the walk
+   */
+  private int deltaScanBudget() {
+    return deltaScanBudget(maxDeltaScanRatio());
+  }
+
+  private int deltaScanBudget(final float ratio) {
+    if (ratio <= 0f)
+      return Integer.MAX_VALUE;
+
+    final int walkCost = graphWalkVisited;
+    if (walkCost <= 0)
+      // Nothing measured yet: no search has walked this graph, so there is no query latency to protect.
+      return Integer.MAX_VALUE;
+
+    final long budget = (long) Math.max(1.0d, walkCost * (double) ratio);
+    return (int) Math.min(Integer.MAX_VALUE, Math.max(getMutationsBeforeRebuild(), budget));
+  }
+
+  private float maxDeltaScanRatio() {
+    return mutable.getDatabase().getConfiguration()
+        .getValueAsFloat(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO);
+  }
+
+  /**
+   * Whether the delta buffer has outgrown {@link #deltaScanBudget()}. Split out so the search trigger and the
+   * chained-rebuild check at the end of {@link #startAsyncGraphRebuild()} cannot disagree: a rebuild that drains
+   * only part of the buffer - anything ingested while it ran stays behind - has to be able to chain on the same
+   * condition that started it, or the buffer sits over budget until the next search notices.
+   */
+  private boolean deltaScanOverBudget() {
+    final float ratio = maxDeltaScanRatio();
+    final int buffered = deltaVectors.size();
+    if (buffered <= 0 || buffered < deltaScanBudget(ratio))
+      return false;
+
+    final ImmutableGraphIndex graph = this.graphIndex;
+    return graph != null
+        && deltaScanPaysForARebuild(deltaScanWorkSinceRebuild.get(), estimateRebuildWork(graph.size(), ratio));
+  }
+
+  /**
+   * The second half of the trigger, and the one that keeps it honest.
+   * <p>
+   * {@link #deltaScanBudget()} says the scan has outgrown the walk. It is denominated in the cost of ONE query
+   * and knows nothing about what draining the buffer costs, so on its own it would ask for a rebuild the moment
+   * the buffer refilled - seconds after a rebuild that took minutes on a large index, and again after that,
+   * turning a background thread into a permanently busy one. That would be a worse problem than the one being
+   * fixed.
+   * <p>
+   * What decides it instead is the amortized argument, in the one currency both sides can be counted in:
+   * similarity computations. The scan work already spent since the last rebuild is measured
+   * ({@code deltaScanWorkSinceRebuild}); what a rebuild will cost is estimated from the graph. A rebuild is
+   * triggered only once the first has reached the second - so the extra rebuild CPU this policy can introduce is
+   * bounded by the query CPU it removes, whatever the budget or the ingest rate. It also needs no clock and no
+   * arbitrary duty-cycle constant, and self-tunes in both directions at once: a bigger index makes the rebuild
+   * side larger, and a busier query load makes the scan side fill faster.
+   * <p>
+   * The two conditions are complementary, and each blocks a case the other admits: a 50-entry buffer scanned a
+   * million times satisfies this one and buys nothing, which the budget rejects; a buffer far over the budget on
+   * an index nobody is querying satisfies that one and is not worth a rebuild, which this rejects.
+   *
+   * @param scanWorkSinceRebuild similarity computations the delta scan has performed since the last build
+   * @param rebuildWork          similarity computations the next build is expected to perform
+   */
+  static boolean deltaScanPaysForARebuild(final long scanWorkSinceRebuild, final long rebuildWork) {
+    return scanWorkSinceRebuild >= rebuildWork;
+  }
+
+  /**
+   * Order-of-magnitude estimate of the similarity computations a from-scratch build of a graph this size will
+   * perform: one beam search per node, at the construction beam width. The real figure is a few times higher -
+   * JVector's diversity pruning compares each node's candidate neighbours against each other on top of the
+   * search - and deliberately not modelled, because this feeds a policy rather than a report and the factor it
+   * is off by is exactly what {@code ratio} is there to absorb. Erring low makes the amortization guard slightly
+   * more willing to rebuild than a perfect estimate would.
+   * <p>
+   * {@code maxDeltaScanRatio} scales this as well as the per-query budget, so the setting reads the same way on
+   * both halves of the trigger: raising it makes the engine more tolerant of the scan and rebuild less often,
+   * lowering it does the opposite.
+   */
+  private long estimateRebuildWork(final int graphSize, final float ratio) {
+    final double work = (double) Math.max(0, graphSize) * Math.max(1, metadata.beamWidth) * Math.max(0f, ratio);
+    return (long) Math.min(Long.MAX_VALUE, work);
+  }
+
+  /** Charges one query's brute-force scan of {@code scanned} buffered vectors to the amortization window. */
+  private void recordDeltaScanWork(final int scanned) {
+    if (scanned > 0)
+      deltaScanWorkSinceRebuild.addAndGet(scanned);
   }
 
   /**
@@ -8362,6 +8613,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final int threshold = getEffectiveMutationsBeforeRebuild();
     // Rebuild once the mutation-driven threshold is reached...
     if (pending >= threshold)
+      return true;
+
+    // ...or when the buffer those mutations left behind has outgrown what a query can afford to scan
+    // (issue #6797). A quiet period is the best possible moment to pay for that rebuild, and the two policies
+    // have to agree: it would be odd for the search path to judge the scan too expensive and the timer, looking
+    // at the same buffer with the machine idle, to decline.
+    if (deltaScanOverBudget())
       return true;
 
     // ...or when enough of it has accumulated to justify a full rebuild.

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3716,6 +3716,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * synchronous full rebuild into a path whose contract is zero disk I/O and microsecond latency is a change of
    * a different kind from the one this issue is about. Whether the count thresholds should reach this path too
    * is a real question, and a separate one.
+   * <p>
+   * <b>What the calling query can wait on, and what it cannot.</b> Not {@code graphBuildLock}: that is taken by
+   * the spawned daemon thread, never by the thread that spawned it, so no query here ever waits on a build. The
+   * only lock this can reach is the instance monitor {@link #startAsyncGraphRebuild()} holds while it starts that
+   * thread, briefly, and only on the rare query that actually fires the trigger - the {@code asyncRebuildInProgress}
+   * check above turns the common case away before it. That is the identical exposure the exact search path has
+   * carried through {@code rebuildGraphBeforeSearch()} since issue #3679; it is new to this path, not to the class.
    */
   private void boundDeltaScanBeforeApproximateSearch() {
     if (graphState != GraphState.MUTABLE || asyncRebuildInProgress)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -8512,6 +8512,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (visited <= 0)
       return;
     final int previous = graphWalkVisited;
+    // Integer division, deliberately: a sample within three visits of the current average truncates to no change
+    // at all. That is a feature at this resolution - the average is a denominator for a rebuild decision, not a
+    // measurement anyone reads - and it keeps the whole update to one add, one subtract and one shift on a path
+    // every query takes. A float would track those last three visits and buy nothing with them.
     graphWalkVisited = previous <= 0 ? visited : previous + (visited - previous) / 4;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -8538,8 +8538,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * that only one of the two workloads is paying: this budget is evaluated on the search path, against a walk cost
    * that only searches produce. An ingest-only workload never reaches it and keeps the geometric amortization
    * untouched; a query-heavy workload trades rebuild CPU it has to spare for the latency it is actually losing.
-   * The absolute {@code mutationsBeforeRebuild} floor is applied on top, so this can never rebuild more eagerly
-   * than that setting already permits.
+   * The floor applied on top is the <em>absolute</em> {@code mutationsBeforeRebuild}, deliberately, and not the
+   * ratio-scaled {@link #getEffectiveMutationsBeforeRebuild()} the count trigger uses. Flooring at the effective
+   * threshold would make this policy inert by construction: the count trigger already fires there, so a budget
+   * that could never bind below it could never fire first, and firing below it is the entire point. What the
+   * absolute floor buys is the guarantee that no configuration of this setting rebuilds more eagerly than
+   * {@code mutationsBeforeRebuild} already permits, which is the promise an operator tuning that knob is owed.
    * <p>
    * <b>One workload it cannot see.</b> The issue #6502 and #6514 pre-filter plans answer a narrow allow-list by
    * scanning it directly and return without walking the graph at all, so they produce no {@code visitedCount} to

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -286,6 +287,49 @@ class Issue6797DeltaScanScalingTest extends TestHelper {
         .pollInterval(Duration.ofMillis(50))
         .untilAsserted(() -> {
           index.findNeighborsFromVectorApproximate(randomUnitVector(random), 10);
+          assertThat(index.getStats().get("deltaVectorsCount")).isZero();
+        });
+  }
+
+  /**
+   * The grouped path completes the set. It has its own delta scan - {@code scoreDeltaCandidates}, which scores the
+   * whole buffer rather than a top-k slice of it, so it is if anything the costlier of the two - and its own
+   * charge to the amortization counter. Since the value this fix claims is that every search path pays for what
+   * it scans, each of the three paths that scans is asserted end to end rather than two of them plus an
+   * assumption about the third.
+   */
+  @Test
+  void theGroupedSearchPathIsBoundedToo() {
+    disableEveryCountBasedTrigger();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 1.0f);
+
+    final Random random = new Random(6797);
+    final LSMVectorIndex index = createSettledIndex(random);
+
+    // One group per row, so the cap fills within the first beam and the walk stops there. Grouping by something
+    // coarse - a bucket id, say - is a trap this test fell into first: with only a handful of distinct keys the
+    // cap can never fill, the walk resumes until it exhausts its candidate budget, and the measured cost climbs
+    // to most of the graph. The buffer then never exceeds it and no rebuild is triggered - which is the policy
+    // being RIGHT, not a gap: a scan of a thousand vectors does not dominate a walk that visited a thousand nodes.
+    final Function<RID, Object> groupKey = rid -> rid;
+    for (int i = 0; i < 3; i++)
+      assertThat(index.findNeighborsFromVectorGrouped(randomUnitVector(random), 5, 1, -1, null, groupKey))
+          .isNotEmpty();
+
+    final long budget = index.getStats().get("deltaScanBudget");
+    assertThat(budget).as("a grouped walk must feed the measurement the budget is derived from")
+        .isLessThan(Long.MAX_VALUE);
+
+    // Comfortably over, not marginally: the budget tracks an EWMA that keeps moving as the loop below queries,
+    // and a buffer that only just cleared it could be overtaken by its own denominator.
+    insertVectors(random, (int) Math.min(budget * 2 + 200, 5_000));
+    assertThat(index.getStats().get("deltaVectorsCount")).isGreaterThanOrEqualTo(budget);
+
+    Awaitility.await("grouped queries alone must be able to drain a buffer they are paying to scan")
+        .atMost(REBUILD_SETTLE_TIMEOUT)
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> {
+          index.findNeighborsFromVectorGrouped(randomUnitVector(random), 5, 1, -1, null, groupKey);
           assertThat(index.getStats().get("deltaVectorsCount")).isZero();
         });
   }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
@@ -192,6 +192,62 @@ class Issue6797DeltaScanScalingTest extends TestHelper {
   }
 
   /**
+   * The other half of the claim the fix makes: the inactivity timer honours the same condition, because it would
+   * be odd for a search to judge the scan too expensive and the timer, looking at the same buffer with the
+   * machine idle, to decline.
+   * <p>
+   * The timer's decision is asked directly rather than driven through a real timer. Not for speed: the search
+   * path evaluates the identical condition on every query and would usually act on it first, so a test that
+   * waited for a timeout would be racing the thing it is trying to isolate, and would pass or fail on which one
+   * won. Arranging the state under {@code maxDeltaScanRatio = 0} - where the scan work still accumulates but
+   * nothing can trigger on it - and only then turning the policy on isolates the question completely.
+   */
+  @Test
+  void theInactivityTimerHonoursTheSameScanBudget() {
+    disableEveryCountBasedTrigger();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 1.0f);
+
+    final Random random = new Random(6797);
+    final LSMVectorIndex index = createSettledIndex(random);
+    index.findNeighborsFromVector(randomUnitVector(random), 10);
+
+    final long budget = index.getStats().get("deltaScanBudget");
+    final long rebuildWork = index.getStats().get("estimatedRebuildWork");
+    assertThat(budget).isLessThan(Long.MAX_VALUE);
+    assertThat(rebuildWork).isPositive();
+
+    // Policy off while the state is arranged: the scan is charged to the amortization counter regardless of the
+    // ratio, but with the ratio at 0 nothing - search path or timer - can act on what accumulates.
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 0f);
+
+    insertVectors(random, (int) Math.min(budget + 50, 5_000));
+    for (int i = 0; i < 100_000 && index.deltaScanWorkForTest() < rebuildWork; i++)
+      index.findNeighborsFromVector(randomUnitVector(random), 10);
+
+    assertThat(index.deltaScanWorkForTest())
+        .as("the scans must have paid for a rebuild, or there is nothing for the timer to decide")
+        .isGreaterThanOrEqualTo(rebuildWork);
+    assertThat(index.getStats().get("deltaVectorsCount"))
+        .as("with the policy off nothing may have drained the buffer").isGreaterThanOrEqualTo(budget);
+
+    final long pending = index.getStats().get("mutationsSinceRebuild");
+    final long countThreshold = index.getStats().get("effectiveMutationsThreshold");
+    assertThat(pending)
+        .as("the count-based reasons the timer rebuilds must all be out of reach, so only the scan budget is "
+            + "left to explain a true answer")
+        .isLessThan(Math.max(countThreshold / 10, 1));
+
+    assertThat(index.inactivityRebuildIsWorthIt())
+        .as("policy off: the timer sees the pre-#6797 picture and declines, exactly as before").isFalse();
+
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 1.0f);
+
+    assertThat(index.inactivityRebuildIsWorthIt())
+        .as("policy on: the same buffer, on an idle machine, is worth the rebuild the search path would also "
+            + "have asked for (issue #6797)").isTrue();
+  }
+
+  /**
    * The control, and the opt-out: with {@code maxDeltaScanRatio} at 0 the engine behaves exactly as it did before
    * this issue - the count thresholds are the only trigger, and a buffer well past any measured walk cost is
    * scanned query after query without anything draining it.

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.Pair;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6797: every rebuild trigger an {@code LSM_VECTOR} index had was denominated in mutations, and no number
+ * of mutations bounds what a query pays for them.
+ * <p>
+ * Vectors ingested since the last rebuild are answered by a linear scan of the in-memory delta buffer, so that
+ * term of a query is {@code O(buffer)} while the HNSW walk it supplements is {@code O(log corpus)}.
+ * {@code rebuildGraphRatio} sizes the buffer as a fixed fraction of the corpus - asymptotically the wrong shape,
+ * since a fifth of the corpus scanned linearly dominates a logarithmic walk at every scale - and
+ * {@code maxPendingMutations} caps that at a fixed count, so from 250,000 vectors upward (0.2 x 250,000 = 50,000)
+ * the threshold stops scaling altogether and the same absolute scan cost lands on an index of any size. Measured
+ * at that cap on a 200,000-vector index, the scan was roughly four fifths of query time.
+ * <p>
+ * The fix adds a trigger denominated in the quantity that actually matters, and measured rather than assumed:
+ * {@code maxDeltaScanRatio} bounds the buffer against how many nodes this index's graph walks are observed to
+ * visit. Because it is evaluated on the search path against a cost only searches produce, an ingest-only workload
+ * never reaches it and keeps the geometric amortization {@code rebuildGraphRatio} exists to provide - only a
+ * workload actually paying the scan pays for the rebuilds that remove it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("vector")
+class Issue6797DeltaScanScalingTest extends TestHelper {
+
+  private static final int EMBEDDING_DIM = 32;
+  // Must be >= LSMVectorIndex.ASYNC_REBUILD_MIN_GRAPH_SIZE (1000) so a rebuild goes through the async, threshold
+  // -gated path rather than the unconditional synchronous one small graphs take.
+  private static final int BASE_VECTORS   = 1100;
+
+  private static final Duration REBUILD_SETTLE_TIMEOUT =
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsLong() + 60_000L);
+
+  /**
+   * The defect itself, as a pure function of the four inputs the engine feeds it. The table is the one reported in
+   * the issue: the ratio-derived term is the right shape, but the ceiling on it is a constant, so past
+   * {@code maxPendingMutations / rebuildGraphRatio} vectors the threshold is the same on a million-vector index
+   * as on a ten-million-vector one.
+   */
+  @Test
+  void rebuildThresholdStopsScalingOnceTheFixedCeilingBinds() {
+    final int absolute = GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.getDefValue() instanceof Integer i ?
+        i : 100;
+    final float ratio = 0.2f;
+    final int maxPending = 50_000;
+
+    assertThat(LSMVectorIndex.computeRebuildThreshold(absolute, 10_000, ratio, maxPending))
+        .as("below the ceiling the threshold tracks the graph").isEqualTo(2_000);
+    assertThat(LSMVectorIndex.computeRebuildThreshold(absolute, 100_000, ratio, maxPending))
+        .isEqualTo(20_000);
+    assertThat(LSMVectorIndex.computeRebuildThreshold(absolute, 250_000, ratio, maxPending))
+        .as("the ceiling binds exactly here").isEqualTo(50_000);
+
+    // From here on the graph grows by 40x and the permitted buffer does not move at all.
+    assertThat(LSMVectorIndex.computeRebuildThreshold(absolute, 1_000_000, ratio, maxPending))
+        .isEqualTo(50_000);
+    assertThat(LSMVectorIndex.computeRebuildThreshold(absolute, 10_000_000, ratio, maxPending))
+        .as("issue #6797: 0.2 x 10M is 2,000,000, but the fixed ceiling pins it at the same 50,000 a 250,000"
+            + "-vector index gets").isEqualTo(50_000);
+
+    // The two escape hatches the arithmetic already had, pinned so the extraction cannot have changed them.
+    assertThat(LSMVectorIndex.computeRebuildThreshold(absolute, 10_000_000, 0f, maxPending))
+        .as("ratio 0 disables scaling and leaves the absolute floor").isEqualTo(absolute);
+    assertThat(LSMVectorIndex.computeRebuildThreshold(absolute, 10_000_000, ratio, 0))
+        .as("maxPending 0 removes the ceiling").isEqualTo(2_000_000);
+    assertThat(LSMVectorIndex.computeRebuildThreshold(120_000, 250_000, ratio, maxPending))
+        .as("the absolute floor is applied last, so an explicit value above the ceiling still wins")
+        .isEqualTo(120_000);
+  }
+
+  /**
+   * The damping term. A budget denominated in the cost of one query knows nothing about what draining the buffer
+   * costs, so on a large index under steady ingest it would be exceeded again seconds after a rebuild that took
+   * minutes, and would ask for another - a background thread turned permanently busy, which would be a worse
+   * problem than the one being fixed. The guard is the amortized argument in the currency both sides can be
+   * counted in, so it is asserted as arithmetic rather than as a latency.
+   */
+  @Test
+  void aRebuildIsOnlyWorthTriggeringOnceTheScansHavePaidForIt() {
+    final long rebuildWork = 1_000_000L;
+
+    assertThat(LSMVectorIndex.deltaScanPaysForARebuild(0L, rebuildWork))
+        .as("no query has scanned anything - nothing has been lost to the buffer yet").isFalse();
+    assertThat(LSMVectorIndex.deltaScanPaysForARebuild(rebuildWork - 1, rebuildWork))
+        .as("still cheaper to keep scanning than to rebuild").isFalse();
+    assertThat(LSMVectorIndex.deltaScanPaysForARebuild(rebuildWork, rebuildWork))
+        .as("the scans have now cost what the rebuild will, which is the 2-competitive bound this gives: the "
+            + "extra rebuild CPU the policy adds can never exceed the query CPU it removes").isTrue();
+    assertThat(LSMVectorIndex.deltaScanPaysForARebuild(rebuildWork * 100, rebuildWork)).isTrue();
+
+    // A graph that costs nothing to rebuild is always worth rebuilding; the caller keeps the "is there a graph
+    // at all" question to itself, because a rebuild that has no graph to walk is not this policy's decision.
+    assertThat(LSMVectorIndex.deltaScanPaysForARebuild(5L, 0L)).isTrue();
+  }
+
+  /**
+   * The fix, end to end: with every mutation-count trigger placed out of reach, a buffer that outgrows the
+   * measured graph-walk cost must still be drained.
+   */
+  @Test
+  void deltaScanOutgrowingTheGraphWalkTriggersARebuild() {
+    disableEveryCountBasedTrigger();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 1.0f);
+
+    final Random random = new Random(6797);
+    final LSMVectorIndex index = createSettledIndex(random);
+
+    // One query to measure the walk. Until a search has actually walked this graph there is no latency to protect
+    // and the policy deliberately does nothing.
+    index.findNeighborsFromVector(randomUnitVector(random), 10);
+
+    final long walkCost = index.getStats().get("graphWalkVisitedAvg");
+    assertThat(walkCost).as("a graph walk over %d vectors must have visited something", BASE_VECTORS)
+        .isGreaterThan(0L);
+
+    final long budget = index.getStats().get("deltaScanBudget");
+    assertThat(budget).as("the budget must be a real number, not the disabled sentinel")
+        .isLessThan(Long.MAX_VALUE);
+    assertThat(budget).as("at ratio 1.0 the budget IS the measured walk cost, not the absolute floor - if it were "
+            + "the floor, this test would be pinning mutationsBeforeRebuild rather than the new policy")
+        .isEqualTo(walkCost)
+        .isGreaterThan(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.getValueAsInteger());
+
+    // Fill the buffer past the budget. Nothing here can reach a mutation-count trigger: the effective count
+    // threshold is over a hundred thousand and the inactivity timer is off.
+    final int overBudget = (int) Math.min(budget + 50, 5_000);
+    insertVectors(random, overBudget);
+
+    assertThat(index.getStats().get("mutationsSinceRebuild"))
+        .as("well below the count threshold of %d - only the scan budget can fire here",
+            index.getStats().get("effectiveMutationsThreshold"))
+        .isLessThan(index.getStats().get("effectiveMutationsThreshold"));
+    assertThat(index.getStats().get("deltaVectorsCount"))
+        .as("the buffer is over the measured budget of %d", budget)
+        .isGreaterThanOrEqualTo(budget);
+
+    // ...but not yet enough scanning to have paid for the rebuild: the buffer being over budget is only half
+    // the trigger. This is what stops the policy asking for a rebuild the instant the buffer refills.
+    assertThat(index.getStats().get("deltaScanWorkSinceRebuild"))
+        .as("no query has scanned the new buffer yet")
+        .isLessThan(index.getStats().get("estimatedRebuildWork"));
+
+    // The trigger lives on the search path, so searches are what must notice - and enough of them that the scan
+    // they have collectively paid for exceeds what the rebuild will cost.
+    index.findNeighborsFromVector(randomUnitVector(random), 10);
+
+    Awaitility.await("a delta buffer that outgrew the graph walk is drained by a rebuild (issue #6797)")
+        .atMost(REBUILD_SETTLE_TIMEOUT)
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> {
+          index.findNeighborsFromVector(randomUnitVector(random), 10);
+          assertThat(index.getStats().get("deltaVectorsCount")).isZero();
+        });
+  }
+
+  /**
+   * The control, and the opt-out: with {@code maxDeltaScanRatio} at 0 the engine behaves exactly as it did before
+   * this issue - the count thresholds are the only trigger, and a buffer well past any measured walk cost is
+   * scanned query after query without anything draining it.
+   */
+  @Test
+  void ratioZeroLeavesTheCountThresholdsAsTheOnlyTrigger() throws Exception {
+    disableEveryCountBasedTrigger();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 0f);
+
+    final Random random = new Random(6797);
+    final LSMVectorIndex index = createSettledIndex(random);
+
+    index.findNeighborsFromVector(randomUnitVector(random), 10);
+    assertThat(index.getStats().get("deltaScanBudget"))
+        .as("ratio 0 reports the disabled sentinel").isEqualTo(Long.MAX_VALUE);
+
+    final int buffered = 600;
+    insertVectors(random, buffered);
+
+    for (int i = 0; i < 5; i++)
+      index.findNeighborsFromVector(randomUnitVector(random), 10);
+
+    // Long enough for an async rebuild to have started and drained the buffer had anything triggered one.
+    Thread.sleep(1_000);
+
+    assertThat(index.getStats().get("deltaVectorsCount"))
+        .as("with the policy off, nothing bounds the scan - which is precisely the behaviour issue #6797 reports")
+        .isEqualTo((long) buffered);
+  }
+
+  /**
+   * The scan's own answer must not have changed. Pruning against the k-th best distance before the duplicate and
+   * tombstone checks rather than after admits exactly the same rows - the heap only advances when a row is added,
+   * and neither check can make a row admissible - and this pins that against distances computed by hand.
+   */
+  @Test
+  void deltaScanStillRanksExactly() {
+    disableEveryCountBasedTrigger();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 0f);
+
+    final Random random = new Random(6797);
+    final LSMVectorIndex index = createSettledIndex(random);
+    index.findNeighborsFromVector(randomUnitVector(random), 10);
+
+    // Buffered vectors placed strictly nearer the query than anything the base corpus holds: the base vectors are
+    // random unit vectors, these sit on the first axis a hair away from the query. So the answer is decided
+    // entirely by the delta scan and can be checked against distances computed here.
+    final float[] query = new float[EMBEDDING_DIM];
+    query[0] = 1f;
+
+    final List<float[]> planted = new ArrayList<>();
+    for (int i = 0; i < 12; i++) {
+      final float[] vector = new float[EMBEDDING_DIM];
+      vector[0] = 1f;
+      vector[1] = 0.001f * (i + 1);
+      planted.add(vector);
+    }
+    database.transaction(() -> {
+      for (final float[] vector : planted)
+        database.command("sql", "INSERT INTO Embedding SET vector = ?", (Object) vector);
+    });
+
+    assertThat(index.getStats().get("deltaVectorsCount")).isEqualTo((long) planted.size());
+
+    final int k = 5;
+    final List<Pair<RID, Float>> results = index.findNeighborsFromVector(query, k);
+    assertThat(results).hasSize(k);
+
+    // Ascending by distance, and the k nearest planted vectors in the order their euclidean distances dictate.
+    for (int i = 1; i < results.size(); i++)
+      assertThat(results.get(i).getSecond()).isGreaterThanOrEqualTo(results.get(i - 1).getSecond());
+
+    for (int i = 0; i < k; i++) {
+      final float[] stored = (float[]) results.get(i).getFirst().asVertex().get("vector");
+      assertThat(stored[1]).as("row %d must be the %d-th nearest planted vector", i, i)
+          .isEqualTo(0.001f * (i + 1));
+    }
+  }
+
+  /**
+   * The one state in which the delta merge is offered a RID the graph walk already returned - a rebuild leaves a
+   * node unreachable and re-queues its vector into the buffer while the node itself survives in the graph. The
+   * duplicate check that catches it moved below the distance prune, so pin that it still catches it.
+   */
+  @Test
+  void aRidInBothTheGraphAndTheBufferIsReturnedOnce() {
+    disableEveryCountBasedTrigger();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 0f);
+
+    final Random random = new Random(6797);
+    final LSMVectorIndex index = createSettledIndex(random);
+    final float[] query = randomUnitVector(random);
+
+    final List<Pair<RID, Float>> before = index.findNeighborsFromVector(query, 10);
+    assertThat(before).isNotEmpty();
+
+    // Put the nearest row into the delta buffer as well, without removing its graph node.
+    final RID duplicated = before.getFirst().getFirst();
+    assertThat(index.requeueIntoDeltaBufferForTest(duplicated))
+        .as("the row must still carry a live graph node").isNotEqualTo(-1);
+
+    final List<Pair<RID, Float>> after = index.findNeighborsFromVector(query, 10);
+    final Set<RID> distinct = new HashSet<>();
+    for (final Pair<RID, Float> row : after)
+      assertThat(distinct.add(row.getFirst())).as("%s returned twice", row.getFirst()).isTrue();
+    assertThat(after).hasSameSizeAs(before);
+  }
+
+  /**
+   * Puts every mutation-count trigger out of reach so only the scan budget can fire. The count threshold is
+   * {@code max(absolute, min(ratio x graphSize, maxPending))}, so an enormous ratio with the ceiling removed
+   * leaves it at six figures on a 1100-vector graph, while the absolute floor - which is also the floor the scan
+   * budget is held to - stays at its default.
+   */
+  private void disableEveryCountBasedTrigger() {
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 100f);
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_PENDING_MUTATIONS, 0);
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 0);
+  }
+
+  private LSMVectorIndex createSettledIndex(final Random random) {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Embedding");
+      database.getSchema().getType("Embedding").createProperty("vector", Type.ARRAY_OF_FLOATS);
+      database.command("sql", """
+          CREATE INDEX ON Embedding (vector) LSM_VECTOR
+          METADATA {
+              "dimensions": %d,
+              "similarity": "EUCLIDEAN"
+          }""".formatted(EMBEDDING_DIM));
+    });
+
+    insertVectors(random, BASE_VECTORS);
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Embedding[vector]");
+    final LSMVectorIndex index = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    // The first search on an empty graph builds it synchronously whatever the thresholds say, which is what
+    // settles the buffer and gets the graph past ASYNC_REBUILD_MIN_GRAPH_SIZE.
+    assertThat(index.findNeighborsFromVector(randomUnitVector(random), 10)).isNotEmpty();
+    Awaitility.await("the initial synchronous build settles the buffer")
+        .atMost(REBUILD_SETTLE_TIMEOUT)
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> assertThat(index.getStats().get("deltaVectorsCount")).isZero());
+    assertThat(index.getStats().get("graphNodeCount")).isGreaterThanOrEqualTo(1000L);
+    return index;
+  }
+
+  private void insertVectors(final Random random, final int count) {
+    database.transaction(() -> {
+      for (int i = 0; i < count; i++)
+        database.command("sql", "INSERT INTO Embedding SET vector = ?", (Object) randomUnitVector(random));
+    });
+  }
+
+  private float[] randomUnitVector(final Random random) {
+    final float[] vector = new float[EMBEDDING_DIM];
+    float norm = 0;
+    for (int i = 0; i < EMBEDDING_DIM; i++) {
+      vector[i] = random.nextFloat() * 2 - 1;
+      norm += vector[i] * vector[i];
+    }
+    norm = (float) Math.sqrt(norm);
+    if (norm > 0)
+      for (int i = 0; i < EMBEDDING_DIM; i++)
+        vector[i] /= norm;
+    return vector;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
@@ -176,7 +176,7 @@ class Issue6797DeltaScanScalingTest extends TestHelper {
     // the trigger. This is what stops the policy asking for a rebuild the instant the buffer refills.
     assertThat(index.getStats().get("deltaScanWorkSinceRebuild"))
         .as("no query has scanned the new buffer yet")
-        .isLessThan(index.getStats().get("estimatedRebuildWork"));
+        .isLessThan(index.getStats().get("deltaScanWorkTarget"));
 
     // The trigger lives on the search path, so searches are what must notice - and enough of them that the scan
     // they have collectively paid for exceeds what the rebuild will cost.
@@ -212,9 +212,15 @@ class Issue6797DeltaScanScalingTest extends TestHelper {
     index.findNeighborsFromVector(randomUnitVector(random), 10);
 
     final long budget = index.getStats().get("deltaScanBudget");
-    final long rebuildWork = index.getStats().get("estimatedRebuildWork");
+    // deltaScanWorkTarget, not estimatedRebuildWork: the latter is the graph-only cost estimate, the former is
+    // that estimate scaled by the ratio and is what the trigger actually compares against.
+    final long rebuildWork = index.getStats().get("deltaScanWorkTarget");
     assertThat(budget).isLessThan(Long.MAX_VALUE);
     assertThat(rebuildWork).isPositive();
+    assertThat(index.getStats().get("estimatedRebuildWork"))
+        .as("the cost estimate must answer for the graph alone - at ratio 1.0 the target equals it, and it must "
+            + "not have been scaled twice")
+        .isEqualTo(rebuildWork);
 
     // Policy off while the state is arranged: the scan is charged to the amortization counter regardless of the
     // ratio, but with the ratio at 0 nothing - search path or timer - can act on what accumulates.
@@ -245,6 +251,43 @@ class Issue6797DeltaScanScalingTest extends TestHelper {
     assertThat(index.inactivityRebuildIsWorthIt())
         .as("policy on: the same buffer, on an idle machine, is worth the rebuild the search path would also "
             + "have asked for (issue #6797)").isTrue();
+  }
+
+  /**
+   * The approximate search path scans the delta buffer too - {@code mergeWithDeltaScanApproximate} delegates the
+   * scan itself to {@code mergeWithDeltaScan} - but it is the one search path that never called
+   * {@code rebuildGraphBeforeSearch()}, so no query on it has ever triggered a rebuild of any kind. Leaving it
+   * out would have made the mode sold on microsecond latency the one mode where the linear scan still grows
+   * without limit.
+   */
+  @Test
+  void theApproximateSearchPathIsBoundedToo() {
+    disableEveryCountBasedTrigger();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 1.0f);
+
+    final Random random = new Random(6797);
+    final LSMVectorIndex index = createSettledIndex(random, true);
+
+    // Every query below goes through the PQ path, never the exact one - if PQ were unavailable the method falls
+    // back to findNeighborsFromVector and this test would silently be re-testing the path already covered.
+    assertThat(index.isPQSearchAvailable())
+        .as("this fixture must exercise the approximate path, not fall back to the exact one").isTrue();
+
+    index.findNeighborsFromVectorApproximate(randomUnitVector(random), 10);
+    final long budget = index.getStats().get("deltaScanBudget");
+    assertThat(budget).as("the approximate path must feed the walk measurement as well")
+        .isLessThan(Long.MAX_VALUE);
+
+    insertVectors(random, (int) Math.min(budget + 50, 5_000));
+    assertThat(index.getStats().get("deltaVectorsCount")).isGreaterThanOrEqualTo(budget);
+
+    Awaitility.await("approximate queries alone must be able to drain a buffer they are paying to scan")
+        .atMost(REBUILD_SETTLE_TIMEOUT)
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> {
+          index.findNeighborsFromVectorApproximate(randomUnitVector(random), 10);
+          assertThat(index.getStats().get("deltaVectorsCount")).isZero();
+        });
   }
 
   /**
@@ -369,10 +412,21 @@ class Issue6797DeltaScanScalingTest extends TestHelper {
   }
 
   private LSMVectorIndex createSettledIndex(final Random random) {
+    return createSettledIndex(random, false);
+  }
+
+  private LSMVectorIndex createSettledIndex(final Random random, final boolean productQuantization) {
     database.transaction(() -> {
       database.getSchema().createVertexType("Embedding");
       database.getSchema().getType("Embedding").createProperty("vector", Type.ARRAY_OF_FLOATS);
-      database.command("sql", """
+      database.command("sql", productQuantization ? """
+          CREATE INDEX ON Embedding (vector) LSM_VECTOR
+          METADATA {
+              "dimensions": %d,
+              "similarity": "EUCLIDEAN",
+              "quantization": "PRODUCT",
+              "pqClusters": 32
+          }""".formatted(EMBEDDING_DIM) : """
           CREATE INDEX ON Embedding (vector) LSM_VECTOR
           METADATA {
               "dimensions": %d,

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6797DeltaScanScalingTest.java
@@ -307,6 +307,19 @@ class Issue6797DeltaScanScalingTest extends TestHelper {
     assertThat(index.getStats().get("deltaScanBudget"))
         .as("ratio 0 reports the disabled sentinel").isEqualTo(Long.MAX_VALUE);
 
+    // No rebuild may still be settling from the fixture before the negative assertion below starts: this test
+    // proves a buffer is NOT drained, so a stray rebuild finishing during the wait would fail it for a reason
+    // that has nothing to do with the policy. Bounded in seconds, deliberately, and NOT by
+    // REBUILD_SETTLE_TIMEOUT: this waits on an in-process flag that the fixture's synchronous build has already
+    // cleared, so ten seconds is generous. Sizing it to the rebuild-permit timeout instead would mean that on the
+    // one occasion the flag is genuinely stuck - another class in the same JVM still holding the semaphore - this
+    // test blocks the whole vector lane for ten minutes before saying so.
+    Awaitility.await("the fixture's rebuild has fully finished, not just published its buffer")
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+
+    final long generationBefore = index.getStats().get("rebuildSnapshotGeneration");
     final int buffered = 600;
     insertVectors(random, buffered);
 
@@ -319,6 +332,11 @@ class Issue6797DeltaScanScalingTest extends TestHelper {
     assertThat(index.getStats().get("deltaVectorsCount"))
         .as("with the policy off, nothing bounds the scan - which is precisely the behaviour issue #6797 reports")
         .isEqualTo((long) buffered);
+    // The buffer count alone would also read unchanged if a rebuild had run and been immediately refilled, which
+    // cannot happen here but would make this test pass for the wrong reason if it could. The generation counter
+    // says no rebuild ran at all.
+    assertThat(index.getStats().get("rebuildSnapshotGeneration"))
+        .as("no rebuild of any kind may have run").isEqualTo(generationBefore);
   }
 
   /**


### PR DESCRIPTION
Closes #6797.

## The defect

Every rebuild trigger an `LSM_VECTOR` index had was denominated in mutations, and no number of mutations bounds what a query pays for them.

Vectors ingested since the last rebuild are answered by a linear scan of the in-memory delta buffer, so that term of a query is `O(buffer)` while the HNSW walk it supplements is `O(log corpus)`. The two knobs that size the buffer are both the wrong shape for that:

- `rebuildGraphRatio` makes the buffer a fixed **fraction of the corpus**. A fifth of the corpus scanned linearly dominates a logarithmic walk at every scale, so this never bounds the scan - it only decides how large the corpus has to get before the scan wins.
- `maxPendingMutations` caps the ratio-derived term at a **fixed count**. At the defaults it binds from 250,000 vectors upward, from which point the threshold is the same on a 1M index as on a 10M one and the same absolute scan cost lands on both.

The reporter measured it at that cap on a 200,000-vector index with the rebuild disabled and the graph pinned at exactly 200,000 nodes throughout: p50 went from 0.399 ms at 100 buffered vectors to 1.866 ms at the 50,000 the cap permits - 4.7x, of which ~1.47 ms is scan against a ~0.40 ms graph walk, so roughly 79% of the query is brute force.

## Why this is not a tuning change

The two goals genuinely conflict and no single scalar serves both. A rebuild is `O(corpus)`, so bounding the buffer by a constant makes ingestion quadratic - which is exactly what `rebuildGraphRatio` exists to prevent. Lowering the cap trades that back. Raising it trades query latency. That is why the issue is filed as a design question rather than a patch.

What breaks the tie is that **only one of the two workloads is paying**. So the new trigger is evaluated on the search path, against a cost that only searches produce: an ingest-only workload never reaches it and keeps its geometric amortization untouched, while a query-heavy workload trades rebuild CPU it has to spare for the latency it is actually losing.

## The fix

A new `arcadedb.vectorIndex.maxDeltaScanRatio` (`Float`, default `1.0`, `0` disables) triggers a rebuild when **both** of these hold:

1. **The scan has outgrown the walk.** The buffer exceeds `ratio x` the nodes this index's graph walks are *observed* to visit. The denominator is JVector's own `visitedCount`, recorded as an EWMA on every search rather than derived from `efSearch`, `maxConnections` and the corpus size - the beam is chosen adaptively per query, a `Bits` filter can make a walk visit far more nodes than the beam suggests, and a degraded graph far fewer. Only the measurement knows.

2. **The scans have already paid for the rebuild.** The brute-force work performed since the last build has reached what the next build is estimated to cost, both counted in similarity computations.

The second condition is what keeps the first honest. A budget denominated in the cost of one query knows nothing about what draining the buffer costs, so on its own it would ask for a rebuild the moment the buffer refilled - seconds after a rebuild that took minutes on a large index, and again after that, turning a background thread into a permanently busy one. The amortized form bounds the extra rebuild CPU this policy can introduce by the query CPU it removes, at any index size and any ingest rate, and needs no clock and no arbitrary duty-cycle constant. It self-tunes in both directions at once: a bigger index makes the rebuild side larger, a busier query load makes the scan side fill faster.

The two are complementary, and each blocks a case the other admits: a 50-entry buffer scanned a million times satisfies the amortization and buys nothing, which the budget rejects; a buffer far over budget on an index nobody is querying satisfies the budget and is not worth a rebuild, which the amortization rejects.

The absolute `mutationsBeforeRebuild` floor still applies on top, so the new trigger can never rebuild more eagerly than that setting already permits, and the pre-existing count thresholds are untouched.

The same condition is added to the inactivity timer, because it would be odd for the search path to judge the scan too expensive and the timer, looking at the same buffer with the machine idle, to decline.

## Alternative considered, and why not

The issue lists three candidate answers: a smaller cap, a cap that scales with something, or a delta structure that is not a linear scan.

The third is the asymptotically correct one - an in-memory HNSW over the delta ("L0" of the LSM) makes query cost `log(N) + log(D)` and retires the whole threshold question. It is worth doing and is the natural follow-up, but it is a much larger change: it would make the delta side approximate on five distinct search paths (exact k-NN, PQ-approximate, grouped, grouped pre-filter, and the shortfall brute-force scan), each carrying its own exactness invariant from a prior issue, and it needs its own background build, cancellation and heap accounting. Landing the policy first bounds the damage now, is fully reversible with one setting, and leaves that work with a measured baseline (`graphWalkVisitedAvg`, `deltaScanBudget`, `deltaScanWorkSinceRebuild`, `estimatedRebuildWork` and `deltaScanWorkTarget` are all reported in the index statistics) to be judged against.

## The approximate search path

`findNeighborsFromVectorApproximate` is the one search path that has never called `rebuildGraphBeforeSearch()`, so no query on it has ever triggered a rebuild of any kind - while it does scan the delta buffer, since `mergeWithDeltaScanApproximate` delegates the scan itself to `mergeWithDeltaScan`. Left alone, the mode sold on microsecond latency would have been the one mode where the scan still grew without limit.

`boundDeltaScanBeforeApproximateSearch()` evaluates the new trigger there, and deliberately only that one rather than calling `rebuildGraphBeforeSearch()` outright: that method's small-graph arm rebuilds *synchronously, on the calling thread*, and putting a synchronous full rebuild into a path whose contract is zero disk I/O is a different kind of change. Whether the count thresholds should reach that path is a real question and a separate one.

The narrow-allow-list pre-filter plans (issues #6502 / #6514) remain outside the policy, and the javadoc says so: they answer without walking the graph at all, so there is no walk to measure the scan against, and deriving a denominator from `efSearch` and the corpus size instead is exactly the assumed-not-measured estimate this design rejects.

## Also in this change

The scan itself, unchanged in what it returns:

- The two per-entry hash lookups in `mergeWithDeltaScan` (the graph-result dedup and the tombstone check) moved **below** the distance prune. They are random memory accesses that only matter for a candidate that is going to be admitted, and the prune rejects all but a handful. The admitted set is identical either way - the heap only advances when an entry is added, and neither check can make an entry admissible.
- The k-th best distance is kept unboxed instead of read off the heap head per entry, which cost a pointer chase into a `Pair` plus a `Float` unbox on every one of tens of thousands of iterations.
- `vectorIndex()` (a volatile read behind a materialization check) is hoisted out of both delta loops, and an index carrying no tombstones now skips the per-entry `isDeleted` lookup outright instead of performing and discarding it. Hoisting is also strictly more correct: the tombstone question has to be asked of a single generation.

## Verification

New `Issue6797DeltaScanScalingTest` (9 tests, `@Tag("vector")`):

- `rebuildThresholdStopsScalingOnceTheFixedCeilingBinds` pins the defect as the reported table, via the threshold arithmetic extracted to a pure function so graph sizes no engine test can build (1M, 10M) can be asserted directly.
- `aRebuildIsOnlyWorthTriggeringOnceTheScansHavePaidForIt` pins the amortization bound as arithmetic rather than as a latency.
- `deltaScanOutgrowingTheGraphWalkTriggersARebuild` is the end-to-end fix, with every mutation-count trigger placed out of reach so only the new one can fire, and asserts the budget is the *measured* walk cost rather than the absolute floor - otherwise it would be pinning `mutationsBeforeRebuild` instead of the new policy.
- `ratioZeroLeavesTheCountThresholdsAsTheOnlyTrigger` is the control and the opt-out: identical setup, policy off, buffer stays put. It is what makes the previous test non-vacuous.
- `deltaScanStillRanksExactly` checks the reordered scan against distances computed by hand, on planted vectors that are strictly nearer the query than the corpus so the answer is decided entirely by the scan.
- `aRidInBothTheGraphAndTheBufferIsReturnedOnce` pins the dedup that moved below the prune, driven into the only state that produces it.
- `theInactivityTimerHonoursTheSameScanBudget` pins that the timer decides identically. It asks the predicate directly rather than driving a real timer: the search path evaluates the same condition on every query and would usually act first, so a timeout-based test races the thing it is isolating. Arranging the state under `maxDeltaScanRatio = 0` - where the scan work still accumulates but nothing can trigger on it - and only then turning the policy on removes the race.
- `theApproximateSearchPathIsBoundedToo` covers the PQ path, and asserts `isPQSearchAvailable()` first so it cannot silently fall back to the exact path and re-cover what is already covered.
- `theGroupedSearchPathIsBoundedToo` covers the third path that scans. It has its own scan (`scoreDeltaCandidates`, which scores the whole buffer rather than a top-k slice of it) so the claim "every search path pays for what it scans" is asserted for all three rather than two plus an assumption. It also documents a trap: grouping by something coarse means the cap can never fill, the walk resumes until it exhausts its candidate budget, and the measured cost climbs to most of the graph - after which the buffer never exceeds its own denominator and nothing triggers. That is the policy being right, not a gap, but it makes for a test that hangs rather than one that fails.

Each of the three end-to-end tests was checked against its own fix removed, and fails without it.

Locally, `mvn -o -pl engine test -Dtest='com.arcadedb.index.vector.*Test'`: 440 tests green, plus the adjacent SQL/Cypher/select vector suites (437 tests). That is a scoped run for iteration only - `-Dtest` replaces Surefire's default include patterns rather than narrowing them, so CI's own `vector-unit-tests` / `unit-tests` lanes are what actually gate this.

## Documentation

`maxDeltaScanRatio` is a new user-facing setting and `maxPendingMutations`' description now says why it stops scaling and points at it. Happy to open the matching PR on the docs repo on request.
