### PR TITLE
fix(#6799): DROP PROPERTY leaves a stale default-property cache and breaks record creation

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/DocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/DocumentType.java
@@ -82,7 +82,15 @@ public interface DocumentType {
   default void applyDefaultValues(final MutableDocument document) {
     for (final String propertyName : getPolymorphicPropertiesWithDefaultDefined()) {
       if (document.get(propertyName) == null) {
-        final Object defaultValue = getPolymorphicProperty(propertyName).getDefaultValue();
+        // Issue #6799: the name set is read lock-free and the lookup that follows is a separate step, so a DROP
+        // PROPERTY committing in between leaves a name here with nothing behind it. getPolymorphicProperty() would
+        // raise "Cannot find property" and fail the record create over a property the schema no longer has - which is
+        // exactly the outcome the drop asked us to avoid - so a name that has already gone is skipped instead.
+        final Property property = getPolymorphicPropertyIfExists(propertyName);
+        if (property == null)
+          continue;
+
+        final Object defaultValue = property.getDefaultValue();
         if (defaultValue != null)
           document.set(propertyName, defaultValue);
       }

--- a/engine/src/main/java/com/arcadedb/schema/DocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/DocumentType.java
@@ -82,10 +82,11 @@ public interface DocumentType {
   default void applyDefaultValues(final MutableDocument document) {
     for (final String propertyName : getPolymorphicPropertiesWithDefaultDefined()) {
       if (document.get(propertyName) == null) {
-        // Issue #6799: the name set is read lock-free and the lookup that follows is a separate step, so a DROP
-        // PROPERTY committing in between leaves a name here with nothing behind it. getPolymorphicProperty() would
-        // raise "Cannot find property" and fail the record create over a property the schema no longer has - which is
-        // exactly the outcome the drop asked us to avoid - so a name that has already gone is skipped instead.
+        // Issue #6799: on the plan-step path (ApplyDefaultsStep), which holds no database lock, the name set is read
+        // and the lookup that follows is a separate step, so a DROP PROPERTY committing in between leaves a name here
+        // with nothing behind it. getPolymorphicProperty() would raise "Cannot find property" and fail the record
+        // create over a property the schema no longer has - exactly the outcome the drop asked us to avoid - so a
+        // name that has already gone is skipped instead.
         final Property property = getPolymorphicPropertyIfExists(propertyName);
         if (property == null)
           continue;

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 public class LocalDocumentType implements DocumentType {
@@ -75,11 +76,15 @@ public class LocalDocumentType implements DocumentType {
   protected       BucketSelectionStrategy           bucketSelectionStrategy      = new RoundRobinBucketSelectionStrategy();
   // Names of the OWN properties that declare a DEFAULT. A cache: the authority is the per-property default value, but
   // record creation would otherwise pay an O(properties) scan to find the (usually empty) subset that has one.
-  // Copy-on-write reassigned under schema mutation and read lock-free by every record create through
-  // getPolymorphicPropertiesWithDefaultDefined(): volatile so a creating thread cannot observe a partially built
-  // replacement set, same publication pattern as cachedPolymorphicBuckets above. Maintained in exactly one place,
-  // {@link #setPropertyHasDefault}, so it cannot drift from the properties map again (issue #6799).
-  protected volatile Set<String>                    propertiesWithDefaultDefined = Collections.emptySet();
+  // Copy-on-write and read lock-free by every record create through getPolymorphicPropertiesWithDefaultDefined(), so
+  // the replacement has to be published atomically or a creating thread could observe a half-built set - the same
+  // publication requirement documented on cachedPolymorphicBuckets above. An AtomicReference rather than a volatile
+  // field because the update is a read-copy-write: two ALTER PROPERTY ... DEFAULT statements on two properties of the
+  // same type would otherwise copy the same snapshot and the second publication would drop the first one's name.
+  // Maintained in exactly one place, {@link #setPropertyHasDefault}, so it cannot drift from the properties map
+  // again (issue #6799).
+  private final AtomicReference<Set<String>>        propertiesWithDefaultDefined = new AtomicReference<>(
+      Collections.emptySet());
   // Map: primary bucket id -> external bucket id. Populated lazily when the first EXTERNAL property is
   // set on the type, and persisted in schema.json under the per-type "externalBuckets" key.
   protected final Map<Integer, Integer>             externalBucketIdByPrimaryBucketId = new ConcurrentHashMap<>();
@@ -134,10 +139,11 @@ public class LocalDocumentType implements DocumentType {
 
   @Override
   public Set<String> getPolymorphicPropertiesWithDefaultDefined() {
+    final Set<String> own = propertiesWithDefaultDefined.get();
     if (superTypes.isEmpty())
-      return propertiesWithDefaultDefined;
+      return own;
 
-    final HashSet<String> set = new HashSet<>(propertiesWithDefaultDefined);
+    final HashSet<String> set = new HashSet<>(own);
     for (final LocalDocumentType superType : superTypes)
       set.addAll(superType.getPolymorphicPropertiesWithDefaultDefined());
     return set;
@@ -655,16 +661,23 @@ public class LocalDocumentType implements DocumentType {
    * case (a type with no defaults at all, or a re-set that does not change membership) allocation-free.
    */
   void setPropertyHasDefault(final String propertyName, final boolean hasDefault) {
-    if (hasDefault == propertiesWithDefaultDefined.contains(propertyName))
+    // The common case - a re-set that does not change membership, or a type with no defaults at all - reads the
+    // reference once and neither allocates nor writes.
+    if (hasDefault == propertiesWithDefaultDefined.get().contains(propertyName))
       return;
 
-    final Set<String> updated = new HashSet<>(propertiesWithDefaultDefined);
-    if (hasDefault)
-      updated.add(propertyName);
-    else
-      updated.remove(propertyName);
+    propertiesWithDefaultDefined.updateAndGet(current -> {
+      if (hasDefault == current.contains(propertyName))
+        return current;
 
-    propertiesWithDefaultDefined = updated.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(updated);
+      final Set<String> updated = new HashSet<>(current);
+      if (hasDefault)
+        updated.add(propertyName);
+      else
+        updated.remove(propertyName);
+
+      return updated.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(updated);
+    });
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -61,11 +61,11 @@ public class LocalDocumentType implements DocumentType {
   protected final List<LocalDocumentType>           superTypes                   = new ArrayList<>();
   protected final List<LocalDocumentType>           subTypes                     = new ArrayList<>();
   private         Set<String>                       aliases                      = Collections.emptySet();
-  // Mutated by CREATE/DROP PROPERTY under the schema write lock, but read without it: by every record create
-  // (applyDefaultValues, getPolymorphicProperty), by query planning, and by toJSON() - which
-  // LocalSchema.recordFileChanges calls to save schema.json AFTER the write lock is released, so a save running
-  // alongside another thread's DDL threw ConcurrentModificationException out of a plain HashMap. Concurrent, so a
-  // reader crossing an in-flight mutation sees a weakly consistent view of it rather than a corrupt one (#6799).
+  // Mutated by CREATE/DROP PROPERTY under the schema write lock. Record creation reads it under the read lock and is
+  // therefore excluded, but two readers are not: query planning, and toJSON() - which LocalSchema.recordFileChanges
+  // calls to save schema.json AFTER the write lock is released, so a save running alongside another thread's DDL threw
+  // ConcurrentModificationException straight out of a plain HashMap. Concurrent, so a reader crossing an in-flight
+  // mutation sees a weakly consistent view of it rather than a corrupt one (#6799).
   protected final Map<String, Property>             properties                   = new ConcurrentHashMap<>();
   protected final Map<Integer, List<IndexInternal>> bucketIndexesByBucket        = new HashMap<>();
   protected final Map<List<String>, TypeIndex>      indexesByProperties          = new HashMap<>();
@@ -81,11 +81,16 @@ public class LocalDocumentType implements DocumentType {
   protected       BucketSelectionStrategy           bucketSelectionStrategy      = new RoundRobinBucketSelectionStrategy();
   // Names of the OWN properties that declare a DEFAULT. A cache: the authority is the per-property default value, but
   // record creation would otherwise pay an O(properties) scan to find the (usually empty) subset that has one.
-  // Copy-on-write and read lock-free by every record create through getPolymorphicPropertiesWithDefaultDefined(), so
-  // the replacement has to be published atomically or a creating thread could observe a half-built set - the same
-  // publication requirement documented on cachedPolymorphicBuckets above. An AtomicReference rather than a volatile
-  // field because the update is a read-copy-write: two ALTER PROPERTY ... DEFAULT statements on two properties of the
-  // same type would otherwise copy the same snapshot and the second publication would drop the first one's name.
+  // Copy-on-write, and read through getPolymorphicPropertiesWithDefaultDefined() by ApplyDefaultsStep (the SQL insert
+  // and UPDATE ... APPLY DEFAULTS plans), which holds no database lock - LocalDatabase.createRecord does take the read
+  // lock, so that path is already excluded against DDL. The replacement therefore has to be published atomically or a
+  // lock-free reader could observe a half-built set, the same publication requirement documented on
+  // cachedPolymorphicBuckets above.
+  // An AtomicReference rather than a plain volatile field, unlike those siblings, because the update is a
+  // read-copy-write and it must stay correct where its writers are NOT serialized: setDefaultValue publishes inside
+  // recordFileChanges, but that bypasses the write lock entirely while the schema is being read from file, and the
+  // CAS is what makes setPropertyHasDefault safe on its own terms rather than only as long as every future caller
+  // remembers to hold the lock. Without it, two writers copying the same snapshot would lose one of the two names.
   // Maintained in exactly one place, {@link #setPropertyHasDefault}, so it cannot drift from the properties map
   // again (issue #6799).
   private final AtomicReference<Set<String>>        propertiesWithDefaultDefined = new AtomicReference<>(

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -672,7 +672,9 @@ public class LocalDocumentType implements DocumentType {
    */
   void setPropertyHasDefault(final String propertyName, final boolean hasDefault) {
     // The common case - a re-set that does not change membership, or a type with no defaults at all - reads the
-    // reference once and neither allocates nor writes.
+    // reference once and neither allocates nor writes. Deliberately a duplicate of the check inside updateAndGet
+    // below, not a substitute for it: this one skips the closure and the copy, that one re-decides against whatever
+    // the CAS actually saw. Removing either is a regression - one in allocation, the other in correctness.
     if (hasDefault == propertiesWithDefaultDefined.get().contains(propertyName))
       return;
 

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -73,7 +73,13 @@ public class LocalDocumentType implements DocumentType {
   protected       List<Integer>                     bucketIds                    = new ArrayList<>();
   protected volatile List<Integer>                  cachedPolymorphicBucketIds   = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
   protected       BucketSelectionStrategy           bucketSelectionStrategy      = new RoundRobinBucketSelectionStrategy();
-  protected       Set<String>                       propertiesWithDefaultDefined = Collections.emptySet();
+  // Names of the OWN properties that declare a DEFAULT. A cache: the authority is the per-property default value, but
+  // record creation would otherwise pay an O(properties) scan to find the (usually empty) subset that has one.
+  // Copy-on-write reassigned under schema mutation and read lock-free by every record create through
+  // getPolymorphicPropertiesWithDefaultDefined(): volatile so a creating thread cannot observe a partially built
+  // replacement set, same publication pattern as cachedPolymorphicBuckets above. Maintained in exactly one place,
+  // {@link #setPropertyHasDefault}, so it cannot drift from the properties map again (issue #6799).
+  protected volatile Set<String>                    propertiesWithDefaultDefined = Collections.emptySet();
   // Map: primary bucket id -> external bucket id. Populated lazily when the first EXTERNAL property is
   // set on the type, and persisted in schema.json under the per-type "externalBuckets" key.
   protected final Map<Integer, Integer>             externalBucketIdByPrimaryBucketId = new ConcurrentHashMap<>();
@@ -624,11 +630,41 @@ public class LocalDocumentType implements DocumentType {
 
     return recordFileChanges(() -> {
       final Property removed = properties.remove(propertyName);
-      // Keep the EXTERNAL counter consistent so hasExternalProperties() stays O(1).
-      if (removed != null && removed.isExternal())
-        ownExternalPropertyCount.decrementAndGet();
+      if (removed != null) {
+        // Keep the EXTERNAL counter consistent so hasExternalProperties() stays O(1).
+        if (removed.isExternal())
+          ownExternalPropertyCount.decrementAndGet();
+        // Issue #6799: and the same for the default-property cache. A dropped property must stop participating in
+        // default-value processing at once, or the next record create looks the name up with getPolymorphicProperty()
+        // and fails with "Cannot find property '<name>' in type '<type>'". Only the in-memory view was ever wrong -
+        // schema.json holds the default on the property itself, so a reload rebuilt the set correctly - which is why
+        // the failure looked like it healed on restart.
+        setPropertyHasDefault(propertyName, false);
+      }
       return removed;
     });
+  }
+
+  /**
+   * The single point of maintenance for {@link #propertiesWithDefaultDefined}. Every mutation that can change whether
+   * an own property declares a DEFAULT routes here: {@link LocalProperty#setDefaultValue} when one is set, changed or
+   * cleared, and {@link #dropProperty} when the property itself goes away.
+   * <p>
+   * Copy-on-write: the set is published as an immutable snapshot, never mutated in place, so the lock-free readers on
+   * the record-create path always see one consistent version of it. The membership check up front keeps the common
+   * case (a type with no defaults at all, or a re-set that does not change membership) allocation-free.
+   */
+  void setPropertyHasDefault(final String propertyName, final boolean hasDefault) {
+    if (hasDefault == propertiesWithDefaultDefined.contains(propertyName))
+      return;
+
+    final Set<String> updated = new HashSet<>(propertiesWithDefaultDefined);
+    if (hasDefault)
+      updated.add(propertyName);
+    else
+      updated.remove(propertyName);
+
+    propertiesWithDefaultDefined = updated.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(updated);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -61,7 +61,12 @@ public class LocalDocumentType implements DocumentType {
   protected final List<LocalDocumentType>           superTypes                   = new ArrayList<>();
   protected final List<LocalDocumentType>           subTypes                     = new ArrayList<>();
   private         Set<String>                       aliases                      = Collections.emptySet();
-  protected final Map<String, Property>             properties                   = new HashMap<>();
+  // Mutated by CREATE/DROP PROPERTY under the schema write lock, but read without it: by every record create
+  // (applyDefaultValues, getPolymorphicProperty), by query planning, and by toJSON() - which
+  // LocalSchema.recordFileChanges calls to save schema.json AFTER the write lock is released, so a save running
+  // alongside another thread's DDL threw ConcurrentModificationException out of a plain HashMap. Concurrent, so a
+  // reader crossing an in-flight mutation sees a weakly consistent view of it rather than a corrupt one (#6799).
+  protected final Map<String, Property>             properties                   = new ConcurrentHashMap<>();
   protected final Map<Integer, List<IndexInternal>> bucketIndexesByBucket        = new HashMap<>();
   protected final Map<List<String>, TypeIndex>      indexesByProperties          = new HashMap<>();
   protected final RecordEventsRegistry              events                       = new RecordEventsRegistry();

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -57,7 +57,8 @@ public class LocalProperty extends AbstractProperty {
     final Expression compiled = compileDefaultValue(convertedValue, database);
 
     if (!Objects.equals(this.defaultValue.value(), convertedValue)) {
-      final LocalDocumentType type = (LocalDocumentType) owner;
+      // Not named `type`: that is this property's own Type (STRING, INTEGER, ...) everywhere else in the class.
+      final LocalDocumentType ownerType = (LocalDocumentType) owner;
 
       // The property's own default and the owner type's default-property cache are two views of one fact, and the
       // other statement that changes them, DROP PROPERTY, mutates both under the schema write lock (recordFileChanges).
@@ -65,19 +66,19 @@ public class LocalProperty extends AbstractProperty {
       // and leave the cache naming a property that no longer exists - the very state issue #6799 is about. Only the
       // publication is serialized: conversion and validation stay outside, so a rejected default touches no state and
       // its SchemaException reaches the caller unwrapped, and the write lock is held for two field assignments.
-      type.recordFileChanges(() -> {
+      ownerType.recordFileChanges(() -> {
         // Holding the same lock as dropProperty() also settles the order of the two: whoever arrives second sees the
         // other's result. A handle to a property that has since been dropped (or dropped and recreated) is detached,
         // and writing its default through would leave a name in the cache that resolves to nothing - #6799 reached
         // from the other side. Identity and not mere presence, so a recreated namesake cannot be written through the
         // stale handle either.
-        if (type.getPropertyIfExists(name) != this)
-          throw new SchemaException("Cannot set the default value of property '" + type.getName() + "." + name
+        if (ownerType.getPropertyIfExists(name) != this)
+          throw new SchemaException("Cannot set the default value of property '" + ownerType.getName() + "." + name
               + "' because the property is no longer declared in the type");
 
         // One publication, so no reader can see the new value with the old (or no) compiled expression.
         this.defaultValue = new DefaultValue(convertedValue, compiled);
-        type.setPropertyHasDefault(name, convertedValue != DEFAULT_NOT_SET);
+        ownerType.setPropertyHasDefault(name, convertedValue != DEFAULT_NOT_SET);
         return null;
       });
     }

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -57,12 +57,20 @@ public class LocalProperty extends AbstractProperty {
     final Expression compiled = compileDefaultValue(convertedValue, database);
 
     if (!Objects.equals(this.defaultValue.value(), convertedValue)) {
-      // One publication, so no reader can see the new value with the old (or no) compiled expression.
-      this.defaultValue = new DefaultValue(convertedValue, compiled);
+      final LocalDocumentType type = (LocalDocumentType) owner;
 
-      ((LocalDocumentType) owner).setPropertyHasDefault(name, convertedValue != DEFAULT_NOT_SET);
-
-      owner.getSchema().getEmbedded().saveConfiguration();
+      // The property's own default and the owner type's default-property cache are two views of one fact, and the
+      // other statement that changes them, DROP PROPERTY, mutates both under the schema write lock (recordFileChanges).
+      // Publishing them outside that lock let a concurrent DROP PROPERTY on the same type interleave between the two
+      // and leave the cache naming a property that no longer exists - the very state issue #6799 is about. Only the
+      // publication is serialized: conversion and validation stay outside, so a rejected default touches no state and
+      // its SchemaException reaches the caller unwrapped, and the write lock is held for two field assignments.
+      type.recordFileChanges(() -> {
+        // One publication, so no reader can see the new value with the old (or no) compiled expression.
+        this.defaultValue = new DefaultValue(convertedValue, compiled);
+        type.setPropertyHasDefault(name, convertedValue != DEFAULT_NOT_SET);
+        return null;
+      });
     }
     return this;
   }

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -41,9 +41,29 @@ public class LocalProperty extends AbstractProperty {
         .checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
   }
 
+  /**
+   * A {@link Property} object outlives the DROP PROPERTY that removed it, so a caller can hold one that the type no
+   * longer declares. Writing a default through such a handle would put the dropped name back into the type's
+   * default-property cache and break the next record create - issue #6799 reached from the other side. Identity and
+   * not mere presence, so a namesake recreated in between is not written through the stale handle either.
+   */
+  private void checkStillDeclaredIn(final LocalDocumentType ownerType) {
+    if (ownerType.getPropertyIfExists(name) != this)
+      throw new SchemaException("Cannot set the default value of property '" + ownerType.getName() + "." + name
+          + "' because the property is no longer declared in the type");
+  }
+
   @Override
   public Property setDefaultValue(final Object defaultValue) {
     checkForSchemaMutation();
+    final LocalDocumentType ownerType = (LocalDocumentType) owner;
+
+    // Whether the requested default happens to match the current one is not part of the caller's contract, so the
+    // refusal cannot live only on the path that publishes something: a detached handle is refused first, whatever it
+    // carries. This read is outside the schema write lock, which is all a request that writes nothing needs - the
+    // authoritative check is the one inside the publication below.
+    checkStillDeclaredIn(ownerType);
+
     final Database database = owner.getSchema().getEmbedded().getDatabase();
 
     final Object convertedValue = defaultValue instanceof String ?
@@ -57,9 +77,6 @@ public class LocalProperty extends AbstractProperty {
     final Expression compiled = compileDefaultValue(convertedValue, database);
 
     if (!Objects.equals(this.defaultValue.value(), convertedValue)) {
-      // Not named `type`: that is this property's own Type (STRING, INTEGER, ...) everywhere else in the class.
-      final LocalDocumentType ownerType = (LocalDocumentType) owner;
-
       // The property's own default and the owner type's default-property cache are two views of one fact, and the
       // other statement that changes them, DROP PROPERTY, mutates both under the schema write lock (recordFileChanges).
       // Publishing them outside that lock let a concurrent DROP PROPERTY on the same type interleave between the two
@@ -67,14 +84,9 @@ public class LocalProperty extends AbstractProperty {
       // publication is serialized: conversion and validation stay outside, so a rejected default touches no state and
       // its SchemaException reaches the caller unwrapped, and the write lock is held for two field assignments.
       ownerType.recordFileChanges(() -> {
-        // Holding the same lock as dropProperty() also settles the order of the two: whoever arrives second sees the
-        // other's result. A handle to a property that has since been dropped (or dropped and recreated) is detached,
-        // and writing its default through would leave a name in the cache that resolves to nothing - #6799 reached
-        // from the other side. Identity and not mere presence, so a recreated namesake cannot be written through the
-        // stale handle either.
-        if (ownerType.getPropertyIfExists(name) != this)
-          throw new SchemaException("Cannot set the default value of property '" + ownerType.getName() + "." + name
-              + "' because the property is no longer declared in the type");
+        // Re-checked here because this is the check that counts: holding the same lock as dropProperty() settles the
+        // order of the two, so whoever arrives second sees the other's result rather than a snapshot taken before it.
+        checkStillDeclaredIn(ownerType);
 
         // One publication, so no reader can see the new value with the old (or no) compiled expression.
         this.defaultValue = new DefaultValue(convertedValue, compiled);

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -83,6 +83,9 @@ public class LocalProperty extends AbstractProperty {
       // and leave the cache naming a property that no longer exists - the very state issue #6799 is about. Only the
       // publication is serialized: conversion and validation stay outside, so a rejected default touches no state and
       // its SchemaException reaches the caller unwrapped, and the write lock is held for two field assignments.
+      // This is why this setter takes the heavier path while setReadonly, setMandatory, setNotNull and the rest of
+      // them below just assign and save: a default is the only property attribute with a second reader-visible home,
+      // the per-type cache, and the two have to move together. Do not "harmonise" it back to a bare assignment.
       ownerType.recordFileChanges(() -> {
         // Re-checked here because this is the check that counts: holding the same lock as dropProperty() settles the
         // order of the two, so whoever arrives second sees the other's result rather than a snapshot taken before it.

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -60,13 +60,7 @@ public class LocalProperty extends AbstractProperty {
       // One publication, so no reader can see the new value with the old (or no) compiled expression.
       this.defaultValue = new DefaultValue(convertedValue, compiled);
 
-      // REPLACE THE SET OF PROPERTIES WITH DEFAULT VALUES DEFINED
-      final Set<String> propertiesWithDefaultDefined = new HashSet<>(((LocalDocumentType) owner).propertiesWithDefaultDefined);
-      if (convertedValue == DEFAULT_NOT_SET)
-        propertiesWithDefaultDefined.remove(name);
-      else
-        propertiesWithDefaultDefined.add(name);
-      ((LocalDocumentType) owner).propertiesWithDefaultDefined = Collections.unmodifiableSet(propertiesWithDefaultDefined);
+      ((LocalDocumentType) owner).setPropertyHasDefault(name, convertedValue != DEFAULT_NOT_SET);
 
       owner.getSchema().getEmbedded().saveConfiguration();
     }

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -66,6 +66,15 @@ public class LocalProperty extends AbstractProperty {
       // publication is serialized: conversion and validation stay outside, so a rejected default touches no state and
       // its SchemaException reaches the caller unwrapped, and the write lock is held for two field assignments.
       type.recordFileChanges(() -> {
+        // Holding the same lock as dropProperty() also settles the order of the two: whoever arrives second sees the
+        // other's result. A handle to a property that has since been dropped (or dropped and recreated) is detached,
+        // and writing its default through would leave a name in the cache that resolves to nothing - #6799 reached
+        // from the other side. Identity and not mere presence, so a recreated namesake cannot be written through the
+        // stale handle either.
+        if (type.getPropertyIfExists(name) != this)
+          throw new SchemaException("Cannot set the default value of property '" + type.getName() + "." + name
+              + "' because the property is no longer declared in the type");
+
         // One publication, so no reader can see the new value with the old (or no) compiled expression.
         this.defaultValue = new DefaultValue(convertedValue, compiled);
         type.setPropertyHasDefault(name, convertedValue != DEFAULT_NOT_SET);

--- a/engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java
@@ -426,6 +426,90 @@ class PropertyDefaultValueTest extends TestHelper {
   }
 
   /**
+   * Issue #6799. The exact reproduction from the report: an edge property that had a DEFAULT, dropped, then an edge
+   * created. The name used to stay behind in the type's default-property set, so the next record create looked it up
+   * with {@code getPolymorphicProperty()} and blew up with "Cannot find property 'obsolete' in type 'TestEdge'".
+   */
+  @Test
+  void droppingAPropertyWithADefaultDoesNotBreakTheNextRecordCreate() {
+    database.command("sql", "CREATE VERTEX TYPE TestVertex");
+    database.command("sql", "CREATE PROPERTY TestVertex.id STRING");
+    database.command("sql", "CREATE INDEX ON TestVertex (id) UNIQUE");
+
+    database.command("sql", "CREATE EDGE TYPE TestEdge");
+    database.command("sql", "CREATE PROPERTY TestEdge.obsolete STRING");
+    database.command("sql", "ALTER PROPERTY TestEdge.obsolete DEFAULT 'legacy'");
+    database.command("sql", "DROP PROPERTY TestEdge.obsolete");
+
+    assertThat(database.getSchema().getType("TestEdge").getPolymorphicPropertiesWithDefaultDefined()).doesNotContain(
+        "obsolete");
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TestVertex SET id = 'source'");
+      database.command("sql", "CREATE VERTEX TestVertex SET id = 'target'");
+
+      final ResultSet rs = database.command("sql", "CREATE EDGE TestEdge FROM (SELECT FROM TestVertex WHERE id = 'source') "
+          + "TO (SELECT FROM TestVertex WHERE id = 'target')");
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().getElement().get().asEdge().has("obsolete")).isFalse();
+    });
+  }
+
+  /**
+   * The same invariant through the engine API, on a document type, and with a second defaulted property left in place:
+   * dropping one must not disturb the other.
+   */
+  @Test
+  void aDroppedDefaultLeavesTheSurvivingDefaultsAlone() {
+    final DocumentType type = database.getSchema().createDocumentType("Probe");
+    type.createProperty("gone", Type.STRING).setDefaultValue("'legacy'");
+    type.createProperty("kept", Type.STRING).setDefaultValue("'ok'");
+
+    type.dropProperty("gone");
+
+    assertThat(type.getPolymorphicPropertiesWithDefaultDefined()).containsExactly("kept");
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Probe").save();
+      assertThat(doc.has("gone")).isFalse();
+      assertThat(doc.getString("kept")).isEqualTo("ok");
+    });
+  }
+
+  /**
+   * The set is per-declaring-type and read polymorphically, so dropping a defaulted property on a supertype has to
+   * clear it for every subtype too.
+   */
+  @Test
+  void droppingADefaultOnASupertypeClearsItForTheSubtypes() {
+    database.command("sql", "CREATE DOCUMENT TYPE Base");
+    database.command("sql", "CREATE PROPERTY Base.status STRING (DEFAULT 'first')");
+    database.command("sql", "CREATE DOCUMENT TYPE Derived EXTENDS Base");
+
+    final DocumentType derived = database.getSchema().getType("Derived");
+    assertThat(derived.getPolymorphicPropertiesWithDefaultDefined()).contains("status");
+
+    database.command("sql", "DROP PROPERTY Base.status");
+
+    assertThat(derived.getPolymorphicPropertiesWithDefaultDefined()).doesNotContain("status");
+    database.transaction(() -> assertThat(database.newDocument("Derived").save().has("status")).isFalse());
+  }
+
+  /**
+   * {@code getOrCreateProperty()} with a different type drops and recreates the property internally. The recreated one
+   * has no default, so the name must not survive from the dropped one.
+   */
+  @Test
+  void retypingAPropertyWithGetOrCreateDropsItsDefault() {
+    final DocumentType type = database.getSchema().createDocumentType("Probe");
+    type.createProperty("counter", Type.STRING).setDefaultValue("'legacy'");
+
+    type.getOrCreateProperty("counter", Type.INTEGER);
+
+    assertThat(type.getPolymorphicPropertiesWithDefaultDefined()).doesNotContain("counter");
+    database.transaction(() -> assertThat(database.newDocument("Probe").save().has("counter")).isFalse());
+  }
+
+  /**
    * Closes the database, rewrites one property's persisted default in schema.json to something this release would
    * reject at DDL time, and reopens - standing in for a database created by an earlier release.
    */

--- a/engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java
@@ -510,6 +510,115 @@ class PropertyDefaultValueTest extends TestHelper {
   }
 
   /**
+   * The default-property cache is updated read-copy-write. Setting a default on N properties of the same type
+   * concurrently used to let two threads copy the same snapshot and publish sets that each held only their own name,
+   * silently losing the other defaults - a record created afterwards would come out missing them. The update is a CAS
+   * now, so every name survives whatever the interleaving was.
+   */
+  @Test
+  void concurrentDefaultUpdatesOnTheSameTypeDoNotLoseEachOther() throws Exception {
+    final int properties = 16;
+
+    final DocumentType type = database.getSchema().createDocumentType("Probe");
+    for (int i = 0; i < properties; i++)
+      type.createProperty("p" + i, Type.STRING);
+
+    final CountDownLatch start = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(properties);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final List<Thread> threads = new ArrayList<>(properties);
+
+    for (int i = 0; i < properties; i++) {
+      final int index = i;
+      final Thread t = new Thread(() -> {
+        try {
+          start.await();
+          type.getProperty("p" + index).setDefaultValue("'v" + index + "'");
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        } finally {
+          done.countDown();
+        }
+      });
+      threads.add(t);
+      t.start();
+    }
+
+    start.countDown();
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    for (final Thread t : threads)
+      t.join();
+    assertThat(failure.get()).isNull();
+
+    final List<String> expected = new ArrayList<>();
+    for (int i = 0; i < properties; i++)
+      expected.add("p" + i);
+    assertThat(type.getPolymorphicPropertiesWithDefaultDefined()).containsExactlyInAnyOrderElementsOf(expected);
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Probe").save();
+      for (int i = 0; i < properties; i++)
+        assertThat(doc.getString("p" + i)).isEqualTo("v" + i);
+    });
+  }
+
+  /**
+   * The other half of the same race: a DROP PROPERTY landing while other properties of the type are having their
+   * defaults set. The dropped name must be gone and none of the others may have been dropped with it.
+   */
+  @Test
+  void aConcurrentDropDoesNotResurrectOrLoseOtherDefaults() throws Exception {
+    final int properties = 12;
+
+    final DocumentType type = database.getSchema().createDocumentType("Probe");
+    type.createProperty("doomed", Type.STRING).setDefaultValue("'legacy'");
+    for (int i = 0; i < properties; i++)
+      type.createProperty("p" + i, Type.STRING);
+
+    final CountDownLatch start = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(properties + 1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final List<Thread> threads = new ArrayList<>(properties + 1);
+
+    for (int i = 0; i <= properties; i++) {
+      final int index = i;
+      final Thread t = new Thread(() -> {
+        try {
+          start.await();
+          if (index == properties)
+            type.dropProperty("doomed");
+          else
+            type.getProperty("p" + index).setDefaultValue("'v" + index + "'");
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        } finally {
+          done.countDown();
+        }
+      });
+      threads.add(t);
+      t.start();
+    }
+
+    start.countDown();
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    for (final Thread t : threads)
+      t.join();
+    assertThat(failure.get()).isNull();
+
+    final List<String> expected = new ArrayList<>();
+    for (int i = 0; i < properties; i++)
+      expected.add("p" + i);
+    assertThat(type.getPolymorphicPropertiesWithDefaultDefined()).containsExactlyInAnyOrderElementsOf(expected);
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Probe").save();
+      assertThat(doc.has("doomed")).isFalse();
+      for (int i = 0; i < properties; i++)
+        assertThat(doc.getString("p" + i)).isEqualTo("v" + i);
+    });
+  }
+
+  /**
    * Closes the database, rewrites one property's persisted default in schema.json to something this release would
    * reject at DDL time, and reopens - standing in for a database created by an earlier release.
    */

--- a/engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java
@@ -639,6 +639,11 @@ class PropertyDefaultValueTest extends TestHelper {
         .hasMessageContaining("Probe.obsolete");
     assertThat(type.getPolymorphicPropertiesWithDefaultDefined()).doesNotContain("obsolete");
 
+    // Including the request that happens to carry the value the property already had: whether the write would have
+    // changed anything is not what makes the handle detached.
+    assertThatThrownBy(() -> stale.setDefaultValue("'legacy'")).isInstanceOf(SchemaException.class)
+        .hasMessageContaining("Probe.obsolete");
+
     // And the same for a namesake recreated in the meantime: the stale handle must not write through to it.
     type.createProperty("obsolete", Type.INTEGER);
     assertThatThrownBy(() -> stale.setDefaultValue("'resurrected'")).isInstanceOf(SchemaException.class);

--- a/engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java
@@ -27,6 +27,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -516,6 +517,7 @@ class PropertyDefaultValueTest extends TestHelper {
    * now, so every name survives whatever the interleaving was.
    */
   @Test
+  @Timeout(60)
   void concurrentDefaultUpdatesOnTheSameTypeDoNotLoseEachOther() throws Exception {
     final int properties = 16;
 
@@ -545,7 +547,7 @@ class PropertyDefaultValueTest extends TestHelper {
     }
 
     start.countDown();
-    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    done.await();
     for (final Thread t : threads)
       t.join();
     assertThat(failure.get()).isNull();
@@ -567,6 +569,7 @@ class PropertyDefaultValueTest extends TestHelper {
    * defaults set. The dropped name must be gone and none of the others may have been dropped with it.
    */
   @Test
+  @Timeout(60)
   void aConcurrentDropDoesNotResurrectOrLoseOtherDefaults() throws Exception {
     final int properties = 12;
 
@@ -600,7 +603,7 @@ class PropertyDefaultValueTest extends TestHelper {
     }
 
     start.countDown();
-    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    done.await();
     for (final Thread t : threads)
       t.join();
     assertThat(failure.get()).isNull();
@@ -616,6 +619,32 @@ class PropertyDefaultValueTest extends TestHelper {
       for (int i = 0; i < properties; i++)
         assertThat(doc.getString("p" + i)).isEqualTo("v" + i);
     });
+  }
+
+  /**
+   * #6799 reached from the other side: the property object outlives the DROP, so a caller holding one can still call
+   * {@code setDefaultValue()} on it. Writing that default through would put the dropped name back into the cache and
+   * break the next record create all over again, so the publication rejects a detached handle instead - identity
+   * against the type's own declaration, which also covers a name that was dropped and recreated in between.
+   */
+  @Test
+  void aDroppedPropertyHandleCannotWriteItsDefaultBack() {
+    final DocumentType type = database.getSchema().createDocumentType("Probe");
+    final Property stale = type.createProperty("obsolete", Type.STRING);
+    stale.setDefaultValue("'legacy'");
+
+    type.dropProperty("obsolete");
+
+    assertThatThrownBy(() -> stale.setDefaultValue("'resurrected'")).isInstanceOf(SchemaException.class)
+        .hasMessageContaining("Probe.obsolete");
+    assertThat(type.getPolymorphicPropertiesWithDefaultDefined()).doesNotContain("obsolete");
+
+    // And the same for a namesake recreated in the meantime: the stale handle must not write through to it.
+    type.createProperty("obsolete", Type.INTEGER);
+    assertThatThrownBy(() -> stale.setDefaultValue("'resurrected'")).isInstanceOf(SchemaException.class);
+    assertThat(type.getPolymorphicPropertiesWithDefaultDefined()).doesNotContain("obsolete");
+
+    database.transaction(() -> assertThat(database.newDocument("Probe").save().has("obsolete")).isFalse());
   }
 
   /**


### PR DESCRIPTION
Closes #6799.

## Problem

`LocalDocumentType.propertiesWithDefaultDefined` is the cache of which own properties declare a `DEFAULT`, consulted whenever a record is created. It had two writers that had to agree with the properties map: `LocalProperty.setDefaultValue()` maintained it, `dropProperty()` did not.

So after

```sql
CREATE PROPERTY TestEdge.obsolete STRING;
ALTER PROPERTY TestEdge.obsolete DEFAULT 'legacy';
DROP PROPERTY TestEdge.obsolete;
```

the name stayed in the set, and the next create of that type resolved it with `getPolymorphicProperty()` and failed the commit:

```
com.arcadedb.exception.SchemaException: Cannot find property 'obsolete' in type 'TestEdge'
  at com.arcadedb.schema.DocumentType.getPolymorphicProperty(DocumentType.java:237)
  at com.arcadedb.database.LocalDatabase.setDefaultValues(LocalDatabase.java:2653)
```

The type stayed unwritable for the life of the process. Only the in-memory view was ever wrong - `schema.json` stores the default on the property itself, so a reload rebuilt the set correctly, which is why a restart looked like it fixed it.

## Fix

Rather than adding a third place that removes the name (the reporter's suggestion, and the shape that produced the bug), the maintenance is collapsed into a single method, `LocalDocumentType.setPropertyHasDefault(name, hasDefault)`. `setDefaultValue()` and `dropProperty()` both route through it, so the cache cannot drift from the properties map again. `dropProperty()` calls it next to the `ownExternalPropertyCount` bookkeeping it already does, inside the same `recordFileChanges` block, and only when a property was actually removed.

Review rounds then closed four further holes around the same invariant:

- **The cache update is a CAS.** `propertiesWithDefaultDefined` is an `AtomicReference<Set<String>>` updated with `updateAndGet`, not a plain volatile field like its sibling caches. Both of today's writers do run serialized under the database write lock, so nothing contends in practice; the CAS is what keeps `setPropertyHasDefault` correct on its own terms - the publication path bypasses that lock entirely while the schema is being read from file, and a future caller that forgets the lock cannot silently lose a name. A membership check ahead of it keeps the common case (no defaults, or a re-set that changes nothing) allocation-free, and an emptied set collapses back to `Collections.emptySet()`.
- **The publication is serialized.** `setDefaultValue()` publishes the property's own default and the cache entry inside `recordFileChanges()`, the same write lock `dropProperty()` takes, which also replaces the hand-rolled `saveConfiguration()` it used to call. Conversion and validation deliberately stay outside it: a rejected default must touch no state and its `SchemaException` must reach the caller unwrapped.
- **A detached handle is refused.** A `Property` object outlives the DROP that removed it, so a retained one could write its default straight back into the cache. `setDefaultValue()` now checks `getPropertyIfExists(name) == this` - first, unconditionally, so the refusal does not depend on whether the value happens to be unchanged, and again inside the locked publication where it is authoritative. Identity rather than presence, so a namesake recreated in between is not written through the stale handle either.
- **A property that vanishes mid-create is skipped, not fatal.** `applyDefaultValues()` reads the name set and then looks each name up as a separate step, and on the plan-step path (`ApplyDefaultsStep`) holds no database lock, so a `DROP PROPERTY` committing in between could still raise "Cannot find property". It uses `getPolymorphicPropertyIfExists()` and skips a name that has already gone, which is what the drop asked for.

## A separate defect the new concurrency tests caught

`LocalDocumentType.toJSON()` threw `ConcurrentModificationException` walking the type's property map. That map was a plain `HashMap`, mutated by CREATE/DROP PROPERTY under the schema write lock but read without it - by query planning, and by the schema save, which `LocalSchema.recordFileChanges` runs *after* releasing that lock. Any `DROP PROPERTY` concurrent with a save could hit it. It is a `ConcurrentHashMap` now, matching `externalBucketIdByPrimaryBucketId` in the same class, so a reader crossing an in-flight mutation sees a weakly consistent view rather than a corrupt one. Record creation was never exposed: it reads under the read lock and is excluded against DDL. No dedicated regression test - the failure is a race with no deterministic trigger; the two concurrency tests below are what surfaced it.

## Behaviour change

`setDefaultValue()` on a `Property` handle whose property has since been dropped now throws a `SchemaException` where it used to succeed (and corrupt the cache). Only reachable through the Java embedded API - SQL resolves the property fresh on every statement - and only for a caller that holds a `Property` reference across a `DROP PROPERTY` of that same property. Worth a line in the release notes.

## Tests

Seven regression tests in `PropertyDefaultValueTest`, each failing before the change it covers:

- `droppingAPropertyWithADefaultDoesNotBreakTheNextRecordCreate` - the reported edge-type reproduction end to end through SQL
- `aDroppedDefaultLeavesTheSurvivingDefaultsAlone` - the drop must not disturb another defaulted property on the same type
- `droppingADefaultOnASupertypeClearsItForTheSubtypes` - the set is per-declaring-type and read polymorphically
- `retypingAPropertyWithGetOrCreateDropsItsDefault` - `getOrCreateProperty()` with a different type drops and recreates internally; the recreated property has no default
- `concurrentDefaultUpdatesOnTheSameTypeDoNotLoseEachOther` - N threads, one property each; every name survives
- `aConcurrentDropDoesNotResurrectOrLoseOtherDefaults` - the same with a `DROP PROPERTY` racing them
- `aDroppedPropertyHandleCannotWriteItsDefaultBack` - the stale handle, including the request carrying the value the property already had, and a recreated namesake

The two concurrency tests use `@Timeout` purely as a hang detector rather than asserting a latch against wall-clock elapsed time. Both were verified non-vacuous: they fail against a non-atomic publication. Neither is tagged `slow`: they spin 12-16 threads but measure 0.013s and 0.015s respectively (surefire), so they belong in the default lane.

Full `engine` unit suite green (13669 tests, 0 failures), and `PropertyDefaultValueTest` run five times over for the concurrency cases. The `server` module was not run: another process holds port 2480 on this machine, and the change is engine-only schema code.

## Files

- `engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java`
- `engine/src/main/java/com/arcadedb/schema/LocalProperty.java`
- `engine/src/main/java/com/arcadedb/schema/DocumentType.java`
- `engine/src/test/java/com/arcadedb/schema/PropertyDefaultValueTest.java`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of default values during concurrent schema changes.
  * Prevented stale property references from restoring defaults after properties are removed or recreated.
  * Preserved default settings for unaffected properties and inherited document types.
  * Ensured newly created records and edges receive the correct default values.

* **Tests**
  * Added regression coverage for concurrent default assignments, property removal and recreation, inheritance, stale references, and subsequent record or edge creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
