### PR TITLE
fix: a backslash typed at the console prompt now reaches the query engine too (#6827 follow-up)

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -1277,22 +1277,25 @@ public class Console {
     outputLine(1, "begin                                             -> begins a new transaction");
     outputLine(1, "check database                                    -> check database integrity");
     outputLine(1, "commit                                            -> commits current transaction");
-    outputLine(1, "connect <path>|remote:<url> <user> <pw>           -> connects to a database");
+    outputLine(1, "connect <path>|remote:<url> <user> [<pw>]         -> connects to a database");
     outputLine(1, "close                                             -> disconnects a database");
-    outputLine(1, "create database <path>|remote:<url> <user> <pw>   -> creates a new database");
-    outputLine(1, "create user <user> identified by <pw> [grant connect to <db>*] -> creates a user");
-    outputLine(1, "drop database <path>|remote:<url> <user> <pw>     -> deletes a database");
+    outputLine(1, "create database <path>|remote:<url> <user> [<pw>] -> creates a new database");
+    outputLine(1, "create user <user> identified by [<pw>] [grant connect to <db>*] -> creates a user");
+    outputLine(1, "drop database <path>|remote:<url> <user> [<pw>]   -> deletes a database");
     outputLine(1, "drop user <user>                                  -> deletes a user");
     outputLine(1, "help|?                                            -> ask for this help");
     outputLine(1, "info types                                        -> prints available types");
     outputLine(1, "info transaction                                  -> prints current transaction");
-    outputLine(1, "list databases |remote:<url> <user> <pw>          -> prints list of databases");
+    outputLine(1, "list databases |remote:<url> <user> [<pw>]        -> prints list of databases");
     outputLine(1, "load <path>                                       -> runs local script");
     outputLine(1, "pwd                                               -> returns current directory");
     outputLine(1, "rollback                                          -> rolls back current transaction");
     outputLine(1, "set language = sql|sqlscript|cypher|gremlin|mongo -> sets console query language");
     outputLine(1, "-- <comment>                                      -> comment (no operation)");
     outputLine(1, "quit|exit                                         -> exits from the console");
+    outputLine(1, "");
+    outputLine(1, "Omit <pw> to be asked for the password with the echo hidden, so it is never written to");
+    outputLine(1, "the .history file nor echoed to the output in batch mode.");
   }
 
   private void checkDatabaseIsOpen() {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -135,14 +135,22 @@ public class Console {
    * The history it is given masks the passwords that the `connect` and `create user` syntaxes carry inline before they are
    * recorded, so they never reach the `.history` file - which is written after every command, in the working directory,
    * with the process umask, and survives the session indefinitely (issue #6829).
+   * <p>
+   * Event expansion is turned OFF, which is what makes a typed backslash reach the query engine. jline runs its own
+   * shell-style unescaping in {@code LineReaderImpl.finish()} before the accepted line is ever handed to
+   * {@link TerminalParser}, so teaching the parser to keep the escape character (issue #6827) fixed `-b` and `load` but
+   * left the interactive prompt eating one level exactly as before. The same option also disables `!`-style history
+   * expansion, which a SQL console is better off without: `!` is part of the `!=` operator, and an expansion that finds
+   * a match rewrites the statement rather than failing visibly.
    */
-  private LineReader getLineReader() {
+  LineReader getLineReader() {
     if (lineReader == null) {
       final Completer completer = new StringsCompleter("align database", "begin", "rollback", "commit", "check database", "close",
           "connect", "create database", "create user", "drop database", "drop user", "export", "import", "help", "info types",
           "list databases", "load", "exit", "quit", "set", "match", "select", "insert into", "update", "delete", "pwd");
 
       lineReader = LineReaderBuilder.builder().terminal(terminal).parser(parser)
+          .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
           .variable(LineReader.HISTORY_FILE, HISTORY_FILE).history(new DefaultHistory() {
             @Override
             public void add(final Instant time, final String line) {

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -33,6 +33,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import com.arcadedb.server.TestServerHelper;
 import com.arcadedb.utility.FileUtils;
+import org.jline.reader.LineReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -997,6 +998,21 @@ class ConsoleTest {
     final Result record = console.getDatabase().query("sql", "select winPath, re from Doc").next();
     assertThat(record.<String>getProperty("winPath")).isEqualTo("C:\\Users\\bob");
     assertThat(record.<String>getProperty("re")).isEqualTo("\\d+");
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6827: the parser is only half of the interactive path. jline
+   * unescapes the accepted line itself, before the parser sees it, so a Windows path typed at the prompt still lost a
+   * level of escaping after the parser stopped consuming one. What that costs, and why turning it off is a gain rather
+   * than a trade, is pinned in {@code org.jline.reader.impl.JLineEscapeStrippingContractTest}; this asserts the console
+   * actually asks for it.
+   */
+  @Test
+  void theLineReaderDoesNotUnescapeTheAcceptedLine() throws Exception {
+    assertThat(console.getLineReader().isSet(LineReader.Option.DISABLE_EVENT_EXPANSION))
+        .as("jline would otherwise eat one level of backslash escaping, and expand `!` inside `!=`, before the "
+            + "statement reaches the query engine")
+        .isTrue();
   }
 
   /**

--- a/console/src/test/java/org/jline/reader/impl/JLineEscapeStrippingContractTest.java
+++ b/console/src/test/java/org/jline/reader/impl/JLineEscapeStrippingContractTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jline.reader.impl;
+
+import com.arcadedb.console.TerminalParser;
+import org.jline.reader.LineReader;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6827, second half. Teaching {@link TerminalParser} to keep the backslash fixed `-b` and `load`, but not the
+ * interactive prompt: jline runs its OWN shell-style unescaping in {@link LineReaderImpl#finish(String)} on the accepted
+ * line, before the parser is ever called. So a Windows path typed at the prompt still lost a level of escaping, and the
+ * engine - whose string literals need `\\` for one backslash - answered with a token recognition error.
+ * <p>
+ * The console turns that unescaping off with {@link LineReader.Option#DISABLE_EVENT_EXPANSION}. This test lives in
+ * jline's own package because {@code finish()} is protected, and it is deliberately about the library rather than about
+ * ArcadeDB: it is the contract the fix depends on, so a jline upgrade that changed it would fail here, naming the
+ * reason, rather than silently reopening the bug.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class JLineEscapeStrippingContractTest {
+  /** The correctly escaped form: what a user has to type for the engine to store `C:\Users\bob`. */
+  private static final String TYPED = "insert into Doc set winPath = 'C:\\\\Users\\\\bob'";
+
+  private LineReaderImpl newReader(final boolean disableEventExpansion) throws IOException {
+    final Terminal terminal = TerminalBuilder.builder().system(false).dumb(true)
+        .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream()).build();
+    final LineReaderImpl reader = new LineReaderImpl(terminal, "test", null);
+    reader.setParser(new TerminalParser());
+    if (disableEventExpansion)
+      reader.option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
+    return reader;
+  }
+
+  @Test
+  void jlineStripsOneLevelOfEscapingUnlessEventExpansionIsDisabled() throws IOException {
+    // THE BUG, STILL PRESENT IN THE LIBRARY: THIS IS WHY THE OPTION IS NOT OPTIONAL FOR US
+    assertThat(newReader(false).finish(TYPED)).isEqualTo("insert into Doc set winPath = 'C:\\Users\\bob'");
+
+    // ...AND WHAT THE CONSOLE CONFIGURES: THE LINE REACHES THE QUERY ENGINE EXACTLY AS TYPED
+    assertThat(newReader(true).finish(TYPED)).isEqualTo(TYPED);
+  }
+
+  @Test
+  void aRegexAndAnEscapedQuoteSurviveTheAcceptedLineToo() throws IOException {
+    final LineReaderImpl reader = newReader(true);
+
+    assertThat(reader.finish("select from V where p matches '\\\\d+'"))
+        .isEqualTo("select from V where p matches '\\\\d+'");
+    assertThat(reader.finish("select from V where name = 'it\\'s'"))
+        .isEqualTo("select from V where name = 'it\\'s'");
+  }
+}


### PR DESCRIPTION
Follow-up to #6853, which fixed #6827 only half way. Found while writing the documentation for it.

## The gap

`TerminalParser` was taught to keep the escape character, and that fixed `-b` batch mode and `load` scripts. It did **not** fix the interactive prompt, because jline runs its *own* shell-style unescaping in `LineReaderImpl.finish()` on the accepted line, before the parser is ever called. The level the parser stopped consuming was still being consumed one layer up.

Measured on the merged code:

| Typed at the prompt | Reaches the engine | Result |
|---|---|---|
| `insert into Doc set p = 'C:\\Users\\bob'` | `'C:\Users\bob'` | `token recognition error at: ''C:\U'` |
| `select from V where p matches '\\d+'` | `'\d+'` | same |

Which is issue #6827's own repro, still failing, on the path most people use.

## The fix

`LineReader.Option.DISABLE_EVENT_EXPANSION` on the console's reader. That is the flag guarding the unescaping block in `finish()`.

It also disables `!`-style history expansion, which is a gain rather than a trade for a SQL console: `!` is part of the `!=` operator. Today `where a != 1` makes jline throw `IllegalArgumentException: != 1: event not found` internally (caught and ignored, so the line survives) - but `where a !name` would *match* a history entry and rewrite the statement.

## Tests

`JLineEscapeStrippingContractTest` lives in `org.jline.reader.impl` because `finish()` is protected. It asserts both halves - what the library does by default (the bug) and what it does with the option set - so a jline upgrade that changed this fails there and names the reason, instead of silently reopening #6827. `ConsoleTest.theLineReaderDoesNotUnescapeTheAcceptedLine` asserts the console actually asks for the option.

Console suite green (the two `ConsoleAsyncInsertTest` errors that show up on a busy machine are the known port-2480 conflict: green once nothing else is listening).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Console input now preserves backslashes in Windows paths, regular expressions, escaped quotes, and query operators such as `!=`.
  * Prevented unintended history expansion when using exclamation marks in queries.
  * Console help now documents optional inline passwords and hidden prompts for connection, database, and user commands.

* **Tests**
  * Added regression coverage for escape handling and console query input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->