### PR TITLE
fix(#6831,#6832): one implementation of the openCypher SET clause

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherValues.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherValues.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor;
+
+/**
+ * Comparisons between a value stored on a record and a value a query supplies.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class CypherValues {
+  private CypherValues() {
+  }
+
+  /**
+   * Numeric-tolerant equality: a stored {@code Integer} 1 equals a supplied {@code Long} 1, which is what makes a
+   * MERGE pattern match a record written with a different integral width. A {@code Float} and a {@code Double} may
+   * still report unequal after widening (0.1f != 0.1d); that is conservative on purpose, since every caller pays for
+   * a false negative with a redundant write or an extra probe, never with a wrong answer.
+   */
+  public static boolean equalValues(final Object a, final Object b) {
+    if (a == null)
+      return b == null;
+    if (a.equals(b))
+      return true;
+    if (a instanceof Number numberA && b instanceof Number numberB)
+      return numberA.longValue() == numberB.longValue()
+          && Double.compare(numberA.doubleValue(), numberB.doubleValue()) == 0;
+    return false;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1338,8 +1338,10 @@ public class MergeStep extends AbstractExecutionStep {
       final LabelReplacements labelReplacements) {
     if (setClause == null || setClause.isEmpty())
       return;
-    // Each MERGE row runs in its own transaction, so read-your-writes state cannot outlive it: a fresh map per row
-    // is both correct and cheaper than clearing a shared one.
+    // A fresh map per call, so read-your-writes reaches across the items of this clause and no further. That is the
+    // pre-existing behaviour - the MERGE copy had no such cache at all - and it is narrower than the transaction:
+    // a path pattern matching several existing rows fans out inside ONE executeMerge(), and those rows do not see
+    // each other's writes. They target different records, which is why it has never mattered.
     setApplier.apply(setClause, result, new HashMap<>(), labelReplacements);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -71,7 +71,9 @@ import java.util.concurrent.atomic.AtomicReference;
  * - MERGE (a)-[r:KNOWS]->(b) - finds or creates relationship
  * <p>
  * MERGE is an "upsert" operation (update or insert).
- * TODO: Support ON CREATE SET and ON MATCH SET sub-clauses
+ * <p>
+ * The ON CREATE SET / ON MATCH SET sub-clauses are applied by {@link SetClauseApplier}, the same implementation the
+ * stand-alone SET step uses.
  */
 public class MergeStep extends AbstractExecutionStep {
   private final MergeClause        mergeClause;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -40,6 +40,7 @@ import com.arcadedb.query.opencypher.ast.RelationshipPattern;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
+import com.arcadedb.query.opencypher.executor.CypherValues;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
 import com.arcadedb.query.opencypher.executor.LabelReplacements;
 import com.arcadedb.query.opencypher.parser.CypherASTBuilder;
@@ -55,12 +56,10 @@ import com.arcadedb.schema.DocumentType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -75,14 +74,16 @@ import java.util.concurrent.atomic.AtomicReference;
  * TODO: Support ON CREATE SET and ON MATCH SET sub-clauses
  */
 public class MergeStep extends AbstractExecutionStep {
-  private final MergeClause mergeClause;
+  private final MergeClause        mergeClause;
   private final ExpressionEvaluator evaluator;
+  private final SetClauseApplier    setApplier;
 
   public MergeStep(final MergeClause mergeClause, final CommandContext context,
                    final CypherFunctionFactory functionFactory) {
     super(context);
     this.mergeClause = mergeClause;
     this.evaluator = new ExpressionEvaluator(functionFactory);
+    this.setApplier = SetClauseApplier.forMergeAction(context, this.evaluator);
   }
 
   @Override
@@ -1159,23 +1160,10 @@ public class MergeStep extends AbstractExecutionStep {
       if (actualValue == null)
         return false;
       // Use numeric-safe comparison (Integer vs Long, etc.)
-      if (!valuesEqual(actualValue, expectedValue))
+      if (!CypherValues.equalValues(actualValue, expectedValue))
         return false;
     }
     return true;
-  }
-
-  private static boolean valuesEqual(final Object a, final Object b) {
-    if (a == null)
-      return b == null;
-    if (a.equals(b))
-      return true;
-    // Numeric type-safe comparison: Integer(1) equals Long(1). Float vs Double may report unequal
-    // after widening (0.1f != 0.1d): conservative on purpose, the only cost is a redundant write.
-    if (a instanceof Number && b instanceof Number)
-      return ((Number) a).longValue() == ((Number) b).longValue()
-          && Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue()) == 0;
-    return false;
   }
 
   /**
@@ -1332,148 +1320,25 @@ public class MergeStep extends AbstractExecutionStep {
 
   /**
    * Applies a SET clause to the result (used for ON CREATE SET / ON MATCH SET).
+   * <p>
+   * The clause is served by the same {@link SetClauseApplier} the stand-alone SET step uses, so every shape the
+   * shared parser production emits - the dynamic-key form, the expression-target forms, the property-value type
+   * check and the simultaneous-assignment rule - behaves here exactly as it does outside a MERGE (issue #6831).
+   * The applier is configured for a merge action, which is what keeps an unchanged value from being re-written
+   * (issue #4474).
    *
    * @param setClause          the SET clause to apply
    * @param result             the result containing variables to update
    * @param labelReplacements  the vertices a label write earlier in this step replaced, and the machinery to
    *                           perform the next one
    */
-  @SuppressWarnings("unchecked")
   private void applySetClause(final SetClause setClause, final Result result,
       final LabelReplacements labelReplacements) {
     if (setClause == null || setClause.isEmpty())
       return;
-
-    // A node an earlier row of this MERGE relabelled reaches this row as the deleted original: point every alias
-    // of it - the MERGE's own variable and anything the input row bound to the same node - at the replacement.
-    labelReplacements.redirect(result);
-
-    for (final SetClause.SetItem item : setClause.getItems()) {
-      final String variable = item.getVariable();
-      final Object obj = result.getProperty(variable);
-      if (obj == null)
-        continue;
-
-      switch (item.getType()) {
-        case PROPERTY: {
-          if (!(obj instanceof Document doc))
-            break;
-          final String property = item.getProperty();
-          final Object value = evaluator.evaluate(item.getValueExpression(), result, context);
-          if (value == null) {
-            // Removing an absent property is a no-op: skip to avoid bumping the MVCC version.
-            if (doc.has(property)) {
-              final MutableDocument mutableDoc = doc.modify();
-              mutableDoc.remove(property);
-              mutableDoc.save();
-              context.getStatistics().addPropertiesSet(1);
-              ((ResultInternal) result).setProperty(variable, mutableDoc);
-            }
-          } else {
-            final Object coerced = TemporalUtil.toCoreJavaType(value);
-            // Neo4j counts a non-null assignment whether or not the value actually changed.
-            context.getStatistics().addPropertiesSet(1);
-            // Skip the write when the value is unchanged to avoid a needless MVCC version bump
-            // (concurrent readers of this record would otherwise fail with ConcurrentModificationException).
-            if (!valuesEqual(doc.get(property), coerced)) {
-              final MutableDocument mutableDoc = doc.modify();
-              mutableDoc.set(property, coerced);
-              mutableDoc.save();
-              ((ResultInternal) result).setProperty(variable, mutableDoc);
-            }
-          }
-          break;
-        }
-        case REPLACE_MAP: {
-          if (!(obj instanceof Document doc))
-            break;
-          final Object mapValue = evaluator.evaluate(item.getValueExpression(), result, context);
-          final Map<String, Object> map;
-          if (mapValue instanceof Map)
-            map = (Map<String, Object>) mapValue;
-          else if (mapValue instanceof Document srcDoc)
-            map = srcDoc.propertiesAsMap();
-          else
-            break;
-          final MutableDocument mutableDoc = doc.modify();
-          final Set<String> existingProps = new HashSet<>(mutableDoc.getPropertyNames());
-          for (final String prop : existingProps)
-            if (!prop.startsWith("@"))
-              mutableDoc.remove(prop);
-          int propertiesSet = 0;
-          for (final Map.Entry<String, Object> entry : map.entrySet())
-            if (entry.getValue() != null) {
-              mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
-              propertiesSet++;
-            }
-          // Neo4j counts both the properties written and the pre-existing properties removed by
-          // the replace (i.e. not re-set with a non-null value), matching the PROPERTY/MERGE_MAP
-          // branches above.
-          propertiesSet += CypherStatisticsHelper.countRemovedProperties(existingProps, map);
-          mutableDoc.save();
-          context.getStatistics().addPropertiesSet(propertiesSet);
-          ((ResultInternal) result).setProperty(variable, mutableDoc);
-          break;
-        }
-        case MERGE_MAP: {
-          if (!(obj instanceof Document doc))
-            break;
-          final Object mapValue = evaluator.evaluate(item.getValueExpression(), result, context);
-          final Map<String, Object> map;
-          if (mapValue instanceof Map)
-            map = (Map<String, Object>) mapValue;
-          else if (mapValue instanceof Document srcDoc)
-            map = srcDoc.propertiesAsMap();
-          else
-            break;
-          final MutableDocument mutableDoc = doc.modify();
-          int mergedPropertiesSet = 0;
-          for (final Map.Entry<String, Object> entry : map.entrySet())
-            if (entry.getValue() == null) {
-              if (mutableDoc.has(entry.getKey())) {
-                mutableDoc.remove(entry.getKey());
-                mergedPropertiesSet++;
-              }
-            } else {
-              mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
-              mergedPropertiesSet++;
-            }
-          mutableDoc.save();
-          // A null value removes a property; removing an absent property is a no-op and is not counted.
-          context.getStatistics().addPropertiesSet(mergedPropertiesSet);
-          ((ResultInternal) result).setProperty(variable, mutableDoc);
-          break;
-        }
-        case LABELS: {
-          if (!(obj instanceof Vertex vertex))
-            break;
-          vertex = labelReplacements.resolve(vertex);
-          // Same rule as SET: the new type is built from the vertex's OWN labels, so an inherited label is not
-          // re-listed in place of the subtype that carries it, and a label the vertex already answers to adds
-          // nothing (issue #6363).
-          final DocumentType currentType = vertex.getType();
-          final List<String> allLabels = new ArrayList<>(Labels.getOwnLabels(vertex));
-          int newLabelsCount = 0;
-          for (final String label : item.getLabels())
-            if (!currentType.instanceOf(label) && !allLabels.contains(label)) {
-              allLabels.add(label);
-              newLabelsCount++;
-            }
-          final String newTypeName = Labels.ensureCompositeType(
-              context.getDatabase().getSchema(), allLabels);
-          if (!vertex.getTypeName().equals(newTypeName)) {
-            // The record moves, so the same shared rewrite SET and REMOVE use: it carries the edges over with
-            // their properties, migrates a self-loop once and onto the replacement rather than onto the record
-            // about to be deleted, and records what moved so every alias can follow it.
-            labelReplacements.replace(vertex, newTypeName);
-            if (newLabelsCount > 0)
-              context.getStatistics().addLabelsAdded(newLabelsCount);
-            labelReplacements.redirect(result);
-          }
-          break;
-        }
-      }
-    }
+    // Each MERGE row runs in its own transaction, so read-your-writes state cannot outlive it: a fresh map per row
+    // is both correct and cheaper than clearing a shared one.
+    setApplier.apply(setClause, result, new HashMap<>(), labelReplacements);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
@@ -132,6 +132,7 @@ public final class SetClauseApplier {
     // lands AFTER this point fail the MVCC version check at commit, surfacing a retryable conflict the auto-retry
     // loop re-runs cleanly.
     final Object[] values = new Object[items.size()];
+    final Object[] targets = new Object[items.size()];
     final String[] keys = new String[items.size()];
     final boolean[] keyIsNull = new boolean[items.size()];
     for (int i = 0; i < items.size(); i++) {
@@ -139,9 +140,20 @@ public final class SetClauseApplier {
       switch (item.getType()) {
       case PROPERTY:
         // Resolve the latest doc first so self-referential reads across row fanout (e.g. via UNWIND) observe
-        // prior-row writes, then snapshot key + value.
+        // prior-row writes, then snapshot target + key + value.
         if (item.getVariable() != null)
           reloadLatestDoc(item.getVariable(), result, writtenDocs);
+        if (item.getTargetExpression() != null) {
+          // WHICH record an expression target names is a read of the graph too, so it is answered from the
+          // pre-clause state like every other read: "SET n.enabled = false, (CASE WHEN n.enabled THEN n END).flag = 1"
+          // writes the flag, because n.enabled was true when the clause began. Phase 2 re-resolves the captured
+          // record through labelReplacements, so a label write earlier in the clause still moves the write with it.
+          targets[i] = evaluator.evaluate(item.getTargetExpression(), result, context);
+          // #5795: the CASE branch (or bracket-syntax base) can itself resolve to a variable that was deleted
+          // earlier in the same query, e.g. SET (CASE WHEN true THEN t END).v = 99 after DELETE t. Unlike the
+          // plain-variable branch, this path never goes through resolveLatestDoc(), so the check happens here.
+          DeletedEntityMarker.checkNotDeleted(targets[i]);
+        }
         if (item.getKeyExpression() != null) {
           final Object keyValue = evaluator.evaluate(item.getKeyExpression(), result, context);
           if (keyValue == null)
@@ -154,7 +166,12 @@ public final class SetClauseApplier {
       case REPLACE_MAP:
       case MERGE_MAP:
         reloadLatestDoc(item.getVariable(), result, writtenDocs);
-        values[i] = evaluator.evaluate(item.getValueExpression(), result, context);
+        // Materialise the properties HERE, not at write time: an entity right-hand side evaluates to the live record,
+        // so deferring the copy to phase 2 would let an earlier item of this same clause be read back through it
+        // ("SET b.name = 'new', a = b" must copy b's PRE-clause name). Resolving the shape now also means a
+        // right-hand side that is neither an entity nor a map fails the clause before any of it has been written.
+        values[i] = toPropertyMap(evaluator.evaluate(item.getValueExpression(), result, context),
+            item.getType() == SetClause.SetType.REPLACE_MAP ? "=" : "+=");
         break;
       case LABELS:
         break;
@@ -166,13 +183,13 @@ public final class SetClauseApplier {
       final SetClause.SetItem item = items.get(i);
       switch (item.getType()) {
       case PROPERTY:
-        applyPropertySet(item, result, writtenDocs, values[i], keys[i], keyIsNull[i]);
+        applyPropertySet(item, result, writtenDocs, labelReplacements, values[i], targets[i], keys[i], keyIsNull[i]);
         break;
       case REPLACE_MAP:
-        applyReplaceMap(item, result, writtenDocs, values[i]);
+        applyReplaceMap(item, result, writtenDocs, asPropertyMap(values[i]));
         break;
       case MERGE_MAP:
-        applyMergeMap(item, result, writtenDocs, values[i]);
+        applyMergeMap(item, result, writtenDocs, asPropertyMap(values[i]));
         break;
       case LABELS:
         applyLabels(item, result, writtenDocs, labelReplacements);
@@ -182,20 +199,17 @@ public final class SetClauseApplier {
   }
 
   private void applyPropertySet(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue, final String precomputedKey,
+      final Map<RID, MutableDocument> writtenDocs, final LabelReplacements labelReplacements,
+      final Object precomputedValue, final Object precomputedTarget, final String precomputedKey,
       final boolean keyIsNull) {
     final Object obj;
     final String variableToUpdate;
 
     if (item.getTargetExpression() != null) {
-      // Expression target: SET (CASE WHEN ... THEN t END).prop = value
-      // Evaluate the target expression to get the document
-      obj = evaluator.evaluate(item.getTargetExpression(), result, context);
-      // #5795: the CASE branch (or bracket-syntax base) can itself resolve to a variable that was deleted earlier in
-      // the same query, e.g. SET (CASE WHEN true THEN t END).v = 99 after DELETE t. Unlike the plain-variable branch
-      // below, this path never goes through resolveLatestDoc(), so the DeletedEntityMarker check has to be applied
-      // here too.
-      DeletedEntityMarker.checkNotDeleted(obj);
+      // Expression target: SET (CASE WHEN ... THEN t END).prop = value, resolved in phase 1 against the pre-clause
+      // state. A label write earlier in this clause replaced the record it named, so follow that move: the captured
+      // vertex is the one the rewrite deleted.
+      obj = precomputedTarget instanceof Vertex vertex ? labelReplacements.resolve(vertex) : precomputedTarget;
       if (obj == null)
         return; // CASE returned null, no-op (conditional SET pattern)
       variableToUpdate = null;
@@ -270,13 +284,12 @@ public final class SetClauseApplier {
   }
 
   private void applyReplaceMap(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue) {
-    final Document doc = resolveLatestDoc(item.getVariable(), result, writtenDocs);
-    if (doc == null)
+      final Map<RID, MutableDocument> writtenDocs, final Map<String, Object> map) {
+    if (map == null)
       return;
 
-    final Map<String, Object> map = toPropertyMap(precomputedValue, "=");
-    if (map == null)
+    final Document doc = resolveLatestDoc(item.getVariable(), result, writtenDocs);
+    if (doc == null)
       return;
 
     final MutableDocument mutableDoc = doc.modify();
@@ -314,13 +327,12 @@ public final class SetClauseApplier {
   }
 
   private void applyMergeMap(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue) {
-    final Document doc = resolveLatestDoc(item.getVariable(), result, writtenDocs);
-    if (doc == null)
+      final Map<RID, MutableDocument> writtenDocs, final Map<String, Object> map) {
+    if (map == null)
       return;
 
-    final Map<String, Object> map = toPropertyMap(precomputedValue, "+=");
-    if (map == null)
+    final Document doc = resolveLatestDoc(item.getVariable(), result, writtenDocs);
+    if (doc == null)
       return;
 
     final MutableDocument mutableDoc = doc.modify();
@@ -350,6 +362,11 @@ public final class SetClauseApplier {
     RowAliases.propagateUpdate(result, doc, mutableDoc);
     if (doc.getIdentity() == null)
       ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asPropertyMap(final Object phase1Value) {
+    return (Map<String, Object>) phase1Value;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
@@ -161,7 +161,10 @@ public final class SetClauseApplier {
           else
             keys[i] = keyValue.toString();
         }
-        values[i] = evaluator.evaluate(item.getValueExpression(), result, context);
+        // Coerce and validate HERE so an invalid value rejects the clause before any of it has been written: the
+        // step rolls back only a transaction it opened itself, so a value refused halfway through would otherwise
+        // leave the earlier items behind in the caller's transaction.
+        values[i] = coerceAndValidate(evaluator.evaluate(item.getValueExpression(), result, context));
         break;
       case REPLACE_MAP:
       case MERGE_MAP:
@@ -233,7 +236,7 @@ public final class SetClauseApplier {
     } else
       propertyName = item.getProperty();
 
-    final Object value = precomputedValue != null ? coerceAndValidate(precomputedValue) : null;
+    final Object value = precomputedValue;
 
     // Issue #4474: a MERGE action never re-asserts a value the record already holds, because the write would bump
     // the MVCC version and invalidate the record for every concurrent reader that had matched it. The statistic is
@@ -307,7 +310,7 @@ public final class SetClauseApplier {
     int propertiesSet = 0;
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
       if (entry.getValue() != null) {
-        mutableDoc.set(entry.getKey(), coerceAndValidate(entry.getValue()));
+        mutableDoc.set(entry.getKey(), entry.getValue());
         propertiesSet++;
       }
     }
@@ -349,7 +352,7 @@ public final class SetClauseApplier {
           propertiesSet++;
         }
       } else {
-        mutableDoc.set(entry.getKey(), coerceAndValidate(entry.getValue()));
+        mutableDoc.set(entry.getKey(), entry.getValue());
         propertiesSet++;
       }
     }
@@ -380,15 +383,24 @@ public final class SetClauseApplier {
   private static Map<String, Object> toPropertyMap(final Object value, final String operator) {
     if (value == null)
       return null;
+
+    final Map<String, Object> source;
     if (value instanceof Map)
-      return (Map<String, Object>) value;
-    if (value instanceof Document sourceDoc)
-      // A MutableDocument hands out a live view of its own property map, so the copy is not optional: the replace
-      // form clears the target's properties before reading this map, and "SET a = a" would otherwise read a map it
-      // has just emptied.
-      return new LinkedHashMap<>(sourceDoc.propertiesAsMap());
-    throw new IllegalArgumentException("TypeError: InvalidArgumentType - the right-hand side of '" + operator
-        + "' must be a map, a node or a relationship, but was " + value.getClass().getSimpleName());
+      source = (Map<String, Object>) value;
+    else if (value instanceof Document sourceDoc)
+      source = sourceDoc.propertiesAsMap();
+    else
+      throw new IllegalArgumentException("TypeError: InvalidArgumentType - the right-hand side of '" + operator
+          + "' must be a map, a node or a relationship, but was " + value.getClass().getSimpleName());
+
+    // Always a copy, never the map itself. A MutableDocument hands out a live view of its own properties, and the
+    // replace form clears the target before reading this map, so "SET a = a" would otherwise read a map it has just
+    // emptied. Coercing and validating the entries here rather than at write time is what lets an invalid one reject
+    // the clause before any earlier item has been written.
+    final Map<String, Object> materialised = new LinkedHashMap<>(source.size());
+    for (final Map.Entry<String, Object> entry : source.entrySet())
+      materialised.put(entry.getKey(), coerceAndValidate(entry.getValue()));
+    return materialised;
   }
 
   private Document resolveLatestDoc(final String variable, final Result result,
@@ -493,9 +505,12 @@ public final class SetClauseApplier {
    * Coerces a right-hand-side value to its stored Java type and rejects the ones a property cannot hold. Every write
    * goes through here, so {@code SET n = {x: {y: 1}}} is refused exactly like the {@code SET n.x = {y: 1}} that Neo4j
    * refuses with "Property values can only be of primitive types or arrays thereof" - the map forms used to be the
-   * way around the check.
+   * way around the check. Every call is made in phase 1, so the clause is refused as a whole rather than halfway
+   * through.
    */
   private static Object coerceAndValidate(final Object value) {
+    if (value == null)
+      return null; // a null value is a removal, not a stored value
     final Object coerced = TemporalUtil.toCoreJavaType(value);
     validatePropertyValue(coerced);
     return coerced;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
@@ -196,7 +196,7 @@ public final class SetClauseApplier {
       // here too.
       DeletedEntityMarker.checkNotDeleted(obj);
       if (obj == null)
-        return; // CASE returned null — no-op (conditional SET pattern)
+        return; // CASE returned null, no-op (conditional SET pattern)
       variableToUpdate = null;
     } else {
       variableToUpdate = item.getVariable();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
@@ -103,8 +103,9 @@ public final class SetClauseApplier {
    *
    * @param setClause         the clause to apply; a null or empty clause is a no-op
    * @param result            the row carrying the variables the clause writes to
-   * @param writtenDocs       the latest written state per RID, so that a later row of the same result set reads
-   *                          through this row's writes (self-referential SET across a row fanout)
+   * @param writtenDocs       the latest written state per RID, so that a later write reads through an earlier one:
+   *                          across the items of this clause, and - for a caller that keeps the map across rows, as
+   *                          the stand-alone SET step does - across a row fanout onto the same record
    * @param labelReplacements the vertices a label write already replaced, and the machinery to perform the next one
    */
   public void apply(final SetClause setClause, final Result result, final Map<RID, MutableDocument> writtenDocs,
@@ -218,11 +219,7 @@ public final class SetClauseApplier {
     } else
       propertyName = item.getProperty();
 
-    Object value = precomputedValue;
-    if (value != null) {
-      value = TemporalUtil.toCoreJavaType(value);
-      validatePropertyValue(value);
-    }
+    final Object value = precomputedValue != null ? coerceAndValidate(precomputedValue) : null;
 
     // Issue #4474: a MERGE action never re-asserts a value the record already holds, because the write would bump
     // the MVCC version and invalidate the record for every concurrent reader that had matched it. The statistic is
@@ -297,7 +294,7 @@ public final class SetClauseApplier {
     int propertiesSet = 0;
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
       if (entry.getValue() != null) {
-        mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
+        mutableDoc.set(entry.getKey(), coerceAndValidate(entry.getValue()));
         propertiesSet++;
       }
     }
@@ -340,7 +337,7 @@ public final class SetClauseApplier {
           propertiesSet++;
         }
       } else {
-        mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
+        mutableDoc.set(entry.getKey(), coerceAndValidate(entry.getValue()));
         propertiesSet++;
       }
     }
@@ -473,6 +470,18 @@ public final class SetClauseApplier {
     // Combined SET n.prop+n:Label across fanout still has ordering-dependent behaviour, but this prevents outright
     // stale reads.
     writtenDocs.remove(originalRid);
+  }
+
+  /**
+   * Coerces a right-hand-side value to its stored Java type and rejects the ones a property cannot hold. Every write
+   * goes through here, so {@code SET n = {x: {y: 1}}} is refused exactly like the {@code SET n.x = {y: 1}} that Neo4j
+   * refuses with "Property values can only be of primitive types or arrays thereof" - the map forms used to be the
+   * way around the check.
+   */
+  private static Object coerceAndValidate(final Object value) {
+    final Object coerced = TemporalUtil.toCoreJavaType(value);
+    validatePropertyValue(coerced);
+    return coerced;
   }
 
   private static void validatePropertyValue(final Object value) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.database.Document;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.Labels;
+import com.arcadedb.query.opencypher.ast.SetClause;
+import com.arcadedb.query.opencypher.executor.CypherValues;
+import com.arcadedb.query.opencypher.executor.DeletedEntityMarker;
+import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
+import com.arcadedb.query.opencypher.executor.LabelReplacements;
+import com.arcadedb.query.opencypher.executor.RowAliases;
+import com.arcadedb.query.opencypher.temporal.TemporalUtil;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.QueryStatistics;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.schema.DocumentType;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The single implementation of the openCypher SET clause: {@code SET n.prop = value}, {@code SET n[key] = value},
+ * {@code SET n = <map|node|relationship>}, {@code SET n += <map|node|relationship>} and {@code SET n:Label}.
+ * <p>
+ * It is shared by {@link SetStep} (the stand-alone clause) and by {@link MergeStep} ({@code ON CREATE SET} /
+ * {@code ON MATCH SET}). Both are fed by the same parser production ({@code visitSetClause}), so both see every SET
+ * shape, and a second hand-maintained copy of the switch drifted from this one in both directions: the MERGE copy
+ * dropped the dynamic-key and expression-target items and skipped the property-value type check (issue #6831), while
+ * this one refused a node or relationship right-hand side that the MERGE copy handled (issue #6832).
+ * <p>
+ * The two call sites still differ on two deliberate points, hence the two factory methods:
+ * <ul>
+ *   <li><b>reloading the write target</b> ({@link #forSetClause}): a stand-alone SET reloads each target to its
+ *       latest committed version before evaluating the right-hand side, so a concurrent commit is observed instead of
+ *       being silently overwritten (issue #5227). A MERGE action already runs inside the retrying transaction that
+ *       matched or created the record, and reloading would pin the page and reintroduce exactly the write-conflict
+ *       storm the next point exists to prevent;</li>
+ *   <li><b>skipping a no-op property write</b> ({@link #forMergeAction}): re-asserting an unchanged value bumps the
+ *       record's MVCC version and invalidates it for every concurrent reader. A high-throughput MERGE that re-writes
+ *       constant attributes on a shared vertex turns read-only matches into a conflict storm, so the write (not the
+ *       statistic, which Neo4j still counts) is skipped when the value is unchanged (issue #4474).</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class SetClauseApplier {
+  private final CommandContext      context;
+  private final ExpressionEvaluator evaluator;
+  private final boolean             reloadLatestTarget;
+  private final boolean             skipUnchangedPropertyWrites;
+
+  private SetClauseApplier(final CommandContext context, final ExpressionEvaluator evaluator,
+      final boolean reloadLatestTarget, final boolean skipUnchangedPropertyWrites) {
+    this.context = context;
+    this.evaluator = evaluator;
+    this.reloadLatestTarget = reloadLatestTarget;
+    this.skipUnchangedPropertyWrites = skipUnchangedPropertyWrites;
+  }
+
+  /**
+   * The stand-alone {@code SET} clause: reloads the write target to its latest committed version, and writes every
+   * item unconditionally.
+   */
+  public static SetClauseApplier forSetClause(final CommandContext context, final ExpressionEvaluator evaluator) {
+    return new SetClauseApplier(context, evaluator, true, false);
+  }
+
+  /**
+   * A {@code MERGE} action ({@code ON CREATE SET} / {@code ON MATCH SET}): the record is already the one this
+   * transaction matched or created, and an unchanged property value is not re-written.
+   */
+  public static SetClauseApplier forMergeAction(final CommandContext context, final ExpressionEvaluator evaluator) {
+    return new SetClauseApplier(context, evaluator, false, true);
+  }
+
+  /**
+   * Applies every item of {@code setClause} to {@code result}.
+   *
+   * @param setClause         the clause to apply; a null or empty clause is a no-op
+   * @param result            the row carrying the variables the clause writes to
+   * @param writtenDocs       the latest written state per RID, so that a later row of the same result set reads
+   *                          through this row's writes (self-referential SET across a row fanout)
+   * @param labelReplacements the vertices a label write already replaced, and the machinery to perform the next one
+   */
+  public void apply(final SetClause setClause, final Result result, final Map<RID, MutableDocument> writtenDocs,
+      final LabelReplacements labelReplacements) {
+    if (setClause == null || setClause.isEmpty())
+      return;
+
+    // Pre-resolve any vertex aliases that were replaced by a label change on a prior row so that property-SET
+    // operations (which go through resolveLatestDoc) observe the live vertex rather than the deleted original.
+    labelReplacements.redirect(result);
+
+    final List<SetClause.SetItem> items = setClause.getItems();
+
+    // Phase 1: evaluate all right-hand-side expressions against the graph state *before* the SET clause runs.
+    // openCypher / Neo4j SET is a simultaneous assignment: every read must observe the pre-clause value, never a
+    // value written by an earlier item in the same clause (issue #5190). E.g. "SET a.x = a.y, a.y = a.x" must swap
+    // rather than copy.
+    //
+    // #5227: for a stand-alone SET the pre-clause snapshot must be the LATEST COMMITTED state (what a locked read
+    // would observe), NOT the possibly-stale record snapshot the MATCH loaded. reloadLatestDoc() below reloads each
+    // variable target to its current committed version before its right-hand side is evaluated, so a concurrent
+    // transaction that committed between the MATCH read and this write is observed here instead of being silently
+    // overwritten (a lost update on e.g. "SET a.c = a.c + 1"). The page pinned by the reload makes any commit that
+    // lands AFTER this point fail the MVCC version check at commit, surfacing a retryable conflict the auto-retry
+    // loop re-runs cleanly.
+    final Object[] values = new Object[items.size()];
+    final String[] keys = new String[items.size()];
+    final boolean[] keyIsNull = new boolean[items.size()];
+    for (int i = 0; i < items.size(); i++) {
+      final SetClause.SetItem item = items.get(i);
+      switch (item.getType()) {
+      case PROPERTY:
+        // Resolve the latest doc first so self-referential reads across row fanout (e.g. via UNWIND) observe
+        // prior-row writes, then snapshot key + value.
+        if (item.getVariable() != null)
+          reloadLatestDoc(item.getVariable(), result, writtenDocs);
+        if (item.getKeyExpression() != null) {
+          final Object keyValue = evaluator.evaluate(item.getKeyExpression(), result, context);
+          if (keyValue == null)
+            keyIsNull[i] = true;
+          else
+            keys[i] = keyValue.toString();
+        }
+        values[i] = evaluator.evaluate(item.getValueExpression(), result, context);
+        break;
+      case REPLACE_MAP:
+      case MERGE_MAP:
+        reloadLatestDoc(item.getVariable(), result, writtenDocs);
+        values[i] = evaluator.evaluate(item.getValueExpression(), result, context);
+        break;
+      case LABELS:
+        break;
+      }
+    }
+
+    // Phase 2: apply the writes using the pre-computed snapshot values.
+    for (int i = 0; i < items.size(); i++) {
+      final SetClause.SetItem item = items.get(i);
+      switch (item.getType()) {
+      case PROPERTY:
+        applyPropertySet(item, result, writtenDocs, values[i], keys[i], keyIsNull[i]);
+        break;
+      case REPLACE_MAP:
+        applyReplaceMap(item, result, writtenDocs, values[i]);
+        break;
+      case MERGE_MAP:
+        applyMergeMap(item, result, writtenDocs, values[i]);
+        break;
+      case LABELS:
+        applyLabels(item, result, writtenDocs, labelReplacements);
+        break;
+      }
+    }
+  }
+
+  private void applyPropertySet(final SetClause.SetItem item, final Result result,
+      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue, final String precomputedKey,
+      final boolean keyIsNull) {
+    final Object obj;
+    final String variableToUpdate;
+
+    if (item.getTargetExpression() != null) {
+      // Expression target: SET (CASE WHEN ... THEN t END).prop = value
+      // Evaluate the target expression to get the document
+      obj = evaluator.evaluate(item.getTargetExpression(), result, context);
+      // #5795: the CASE branch (or bracket-syntax base) can itself resolve to a variable that was deleted earlier in
+      // the same query, e.g. SET (CASE WHEN true THEN t END).v = 99 after DELETE t. Unlike the plain-variable branch
+      // below, this path never goes through resolveLatestDoc(), so the DeletedEntityMarker check has to be applied
+      // here too.
+      DeletedEntityMarker.checkNotDeleted(obj);
+      if (obj == null)
+        return; // CASE returned null — no-op (conditional SET pattern)
+      variableToUpdate = null;
+    } else {
+      variableToUpdate = item.getVariable();
+      obj = resolveLatestDoc(variableToUpdate, result, writtenDocs);
+      if (obj == null)
+        return;
+    }
+
+    if (!(obj instanceof Document doc))
+      return;
+
+    // Resolve the property name. For dynamic bracket syntax (SET n[keyExpr] = value) the name is computed at runtime
+    // (snapshotted in phase 1); otherwise it is the static dot-syntax name.
+    final String propertyName;
+    if (item.getKeyExpression() != null) {
+      if (keyIsNull)
+        return; // null key is a no-op
+      propertyName = precomputedKey;
+    } else
+      propertyName = item.getProperty();
+
+    Object value = precomputedValue;
+    if (value != null) {
+      value = TemporalUtil.toCoreJavaType(value);
+      validatePropertyValue(value);
+    }
+
+    // Issue #4474: a MERGE action never re-asserts a value the record already holds, because the write would bump
+    // the MVCC version and invalidate the record for every concurrent reader that had matched it. The statistic is
+    // still reported for an assignment, which is what Neo4j counts.
+    if (skipUnchangedPropertyWrites) {
+      if (value == null) {
+        if (!doc.has(propertyName))
+          return; // removing an absent property: no write, and nothing to count
+      } else if (CypherValues.equalValues(doc.get(propertyName), value)) {
+        context.getStatistics().addPropertiesSet(1);
+        return;
+      }
+    }
+
+    final MutableDocument mutableDoc = doc.modify();
+    // When doc.modify() returns a fresher MutableDocument (e.g. from the tx cache in an outer transaction), update
+    // the result row so that later reads see the latest state, not the original snapshot.
+    if (mutableDoc != doc && variableToUpdate != null)
+      ((ResultInternal) result).setProperty(variableToUpdate, mutableDoc);
+
+    final boolean propertyExisted;
+    if (value == null) {
+      // Removing an absent property is a no-op for Neo4j-compatible statistics: only count it when the property
+      // actually existed before the removal.
+      propertyExisted = mutableDoc.has(propertyName);
+      mutableDoc.remove(propertyName);
+    } else {
+      mutableDoc.set(propertyName, value);
+      propertyExisted = true;
+    }
+    mutableDoc.save();
+
+    // Neo4j counts both a property assignment and a genuine (existing-property) null-valued removal under
+    // "properties set".
+    final QueryStatistics stats = context.getStatistics();
+    if (propertyExisted)
+      stats.addPropertiesSet(1);
+
+    // Record the latest written state so subsequent rows can read through it.
+    final RID savedRid = mutableDoc.getIdentity();
+    if (savedRid != null)
+      writtenDocs.put(savedRid, mutableDoc);
+
+    RowAliases.propagateUpdate(result, doc, mutableDoc);
+    // Fallback: ensure the named variable is updated even when doc has no identity yet
+    if (variableToUpdate != null && doc.getIdentity() == null)
+      ((ResultInternal) result).setProperty(variableToUpdate, mutableDoc);
+  }
+
+  private void applyReplaceMap(final SetClause.SetItem item, final Result result,
+      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue) {
+    final Document doc = resolveLatestDoc(item.getVariable(), result, writtenDocs);
+    if (doc == null)
+      return;
+
+    final Map<String, Object> map = toPropertyMap(precomputedValue, "=");
+    if (map == null)
+      return;
+
+    final MutableDocument mutableDoc = doc.modify();
+    if (mutableDoc != doc)
+      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
+
+    // Remove all existing properties except internal ones
+    final Set<String> existingProps = new HashSet<>(mutableDoc.getPropertyNames());
+    for (final String prop : existingProps) {
+      if (!prop.startsWith("@"))
+        mutableDoc.remove(prop);
+    }
+
+    // Set new properties from map (skip null values - they mean "remove")
+    int propertiesSet = 0;
+    for (final Map.Entry<String, Object> entry : map.entrySet()) {
+      if (entry.getValue() != null) {
+        mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
+        propertiesSet++;
+      }
+    }
+
+    // Neo4j counts both the properties written and the pre-existing properties removed by the replace (i.e. not
+    // re-set with a non-null value), matching applyPropertySet/applyMergeMap.
+    propertiesSet += CypherStatisticsHelper.countRemovedProperties(existingProps, map);
+
+    mutableDoc.save();
+    context.getStatistics().addPropertiesSet(propertiesSet);
+    final RID savedRid = mutableDoc.getIdentity();
+    if (savedRid != null)
+      writtenDocs.put(savedRid, mutableDoc);
+    RowAliases.propagateUpdate(result, doc, mutableDoc);
+    if (doc.getIdentity() == null)
+      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
+  }
+
+  private void applyMergeMap(final SetClause.SetItem item, final Result result,
+      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue) {
+    final Document doc = resolveLatestDoc(item.getVariable(), result, writtenDocs);
+    if (doc == null)
+      return;
+
+    final Map<String, Object> map = toPropertyMap(precomputedValue, "+=");
+    if (map == null)
+      return;
+
+    final MutableDocument mutableDoc = doc.modify();
+    if (mutableDoc != doc)
+      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
+
+    // Merge: non-null values set the property, a null value removes it. Removing a property that does not exist is a
+    // no-op and is not counted (Neo4j reports properties-set only for changes).
+    int propertiesSet = 0;
+    for (final Map.Entry<String, Object> entry : map.entrySet()) {
+      if (entry.getValue() == null) {
+        if (mutableDoc.has(entry.getKey())) {
+          mutableDoc.remove(entry.getKey());
+          propertiesSet++;
+        }
+      } else {
+        mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
+        propertiesSet++;
+      }
+    }
+
+    mutableDoc.save();
+    context.getStatistics().addPropertiesSet(propertiesSet);
+    final RID savedRid = mutableDoc.getIdentity();
+    if (savedRid != null)
+      writtenDocs.put(savedRid, mutableDoc);
+    RowAliases.propagateUpdate(result, doc, mutableDoc);
+    if (doc.getIdentity() == null)
+      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
+  }
+
+  /**
+   * Resolves the right-hand side of {@code SET x = y} / {@code SET x += y} to the properties it contributes.
+   * <p>
+   * Cypher accepts a map literal, a node or a relationship there - copying every property off another entity is the
+   * documented way to clone one - so anything else is a type error rather than a discarded write (issue #6832). A
+   * null right-hand side stays a no-op, which is what the two callers get back as a null map.
+   */
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> toPropertyMap(final Object value, final String operator) {
+    if (value == null)
+      return null;
+    if (value instanceof Map)
+      return (Map<String, Object>) value;
+    if (value instanceof Document sourceDoc)
+      // A MutableDocument hands out a live view of its own property map, so the copy is not optional: the replace
+      // form clears the target's properties before reading this map, and "SET a = a" would otherwise read a map it
+      // has just emptied.
+      return new LinkedHashMap<>(sourceDoc.propertiesAsMap());
+    throw new IllegalArgumentException("TypeError: InvalidArgumentType - the right-hand side of '" + operator
+        + "' must be a map, a node or a relationship, but was " + value.getClass().getSimpleName());
+  }
+
+  private Document resolveLatestDoc(final String variable, final Result result,
+      final Map<RID, MutableDocument> writtenDocs) {
+    final Object raw = result.getProperty(variable);
+    // #5795: a node deleted earlier in the same query is replaced in the result row with a DeletedEntityMarker (see
+    // DeleteStep). Using it as a SET write target must fail the same way reading a property from it already does,
+    // instead of silently no-op'ing (which let the preceding DELETE commit while the SET vanished).
+    DeletedEntityMarker.checkNotDeleted(raw);
+    if (!(raw instanceof Document rawDoc))
+      return null;
+    final RID rid = rawDoc.getIdentity();
+    if (rid != null) {
+      final MutableDocument latest = writtenDocs.get(rid);
+      if (latest != null && latest != raw) {
+        ((ResultInternal) result).setProperty(variable, latest);
+        return latest;
+      }
+    }
+    return rawDoc;
+  }
+
+  /**
+   * #5227: resolves the target variable and replaces it in the result row with its mutable, latest-committed
+   * version so a SET right-hand side is evaluated against the current state of the record, not the snapshot the
+   * MATCH loaded. {@link com.arcadedb.database.ImmutableDocument#modify()} force-reloads a record that was read
+   * outside the write path to its latest committed version and pins its page in the transaction; evaluating the
+   * right-hand side against that (instead of a stale MATCH buffer) prevents concurrent read-modify-write updates
+   * from being silently lost, while the pinned page makes any later concurrent commit fail the commit-time MVCC
+   * version check as a retryable conflict. A record already written earlier in this transaction (in
+   * {@code writtenDocs}) is a {@link MutableDocument} whose {@code modify()} returns itself, so cross-row
+   * read-your-writes semantics are preserved.
+   * <p>
+   * A MERGE action does not do this: see the class Javadoc.
+   */
+  private void reloadLatestDoc(final String variable, final Result result, final Map<RID, MutableDocument> writtenDocs) {
+    if (variable == null || !reloadLatestTarget)
+      return;
+    final Document doc = resolveLatestDoc(variable, result, writtenDocs);
+    if (doc == null)
+      return;
+    final MutableDocument mutable = doc.modify();
+    if (mutable != doc)
+      ((ResultInternal) result).setProperty(variable, mutable);
+  }
+
+  private void applyLabels(final SetClause.SetItem item, final Result result,
+      final Map<RID, MutableDocument> writtenDocs, final LabelReplacements labelReplacements) {
+    final Object obj = result.getProperty(item.getVariable());
+    // #5795: reject a label write targeting a node deleted earlier in the same query instead of silently no-op'ing.
+    DeletedEntityMarker.checkNotDeleted(obj);
+    if (!(obj instanceof Vertex vertex))
+      return;
+
+    // If this vertex was already replaced on a prior row (row fanout hitting the same node), redirect to the
+    // replacement so the idempotency check below reads the current type. The per-row redirect() at the top of
+    // apply() reaches this alias too, so today this only re-confirms it; it stays because it makes the method
+    // correct on its own terms - the write target is resolved here, not assumed to have been resolved by the
+    // caller - and it costs one map lookup that is skipped entirely until a label write actually happens.
+    final Vertex prior = labelReplacements.resolve(vertex);
+    if (prior != vertex) {
+      RowAliases.propagateUpdate(result, vertex, prior);
+      vertex = prior;
+    }
+    // The RID the write is about to displace: the live one, not the one the row happened to carry.
+    final RID originalRid = vertex.getIdentity();
+
+    // The labels the new type has to be built from are the vertex's OWN labels, not every label it answers to: an
+    // inherited one comes back through the hierarchy, and naming it in the composite instead of the subtype that
+    // carries it would move the vertex out of that subtype (issue #6363). A label the vertex already answers to -
+    // its own, or one it inherits - is already present and adds nothing.
+    final DocumentType currentType = vertex.getType();
+    final List<String> allLabels = new ArrayList<>(Labels.getOwnLabels(vertex));
+    int newLabelsCount = 0;
+    for (final String label : item.getLabels())
+      if (!currentType.instanceOf(label) && !allLabels.contains(label)) {
+        allLabels.add(label);
+        newLabelsCount++;
+      }
+
+    // Create the composite type for the combined labels
+    final String newTypeName = Labels.ensureCompositeType(context.getDatabase().getSchema(), allLabels);
+
+    // If the type hasn't changed, nothing to do (all labels already present)
+    if (vertex.getTypeName().equals(newTypeName))
+      return;
+
+    // Rewrite the vertex under the composite type: the record moves, and the replacement is recorded so this row and
+    // every later one follow it.
+    labelReplacements.replace(vertex, newTypeName);
+    if (newLabelsCount > 0)
+      context.getStatistics().addLabelsAdded(newLabelsCount);
+
+    labelReplacements.redirect(result);
+    // Invalidate any property-SET state for the old RID so subsequent rows don't read stale MutableDocument entries.
+    // Combined SET n.prop+n:Label across fanout still has ordering-dependent behaviour, but this prevents outright
+    // stale reads.
+    writtenDocs.remove(originalRid);
+  }
+
+  private static void validatePropertyValue(final Object value) {
+    if (value instanceof List) {
+      for (final Object element : (List<?>) value) {
+        if (element instanceof Map)
+          throw new IllegalArgumentException("TypeError: InvalidPropertyType - Property values can not contain map values");
+        if (element instanceof List)
+          validatePropertyValue(element);
+      }
+    } else if (value instanceof Map)
+      throw new IllegalArgumentException("TypeError: InvalidPropertyType - Property values can not be maps");
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -18,48 +18,40 @@
  */
 package com.arcadedb.query.opencypher.executor.steps;
 
-import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.TimeoutException;
-import com.arcadedb.graph.Vertex;
-import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.SetClause;
-import com.arcadedb.query.opencypher.temporal.TemporalUtil;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
-import com.arcadedb.query.opencypher.executor.DeletedEntityMarker;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
 import com.arcadedb.query.opencypher.executor.LabelReplacements;
-import com.arcadedb.query.opencypher.executor.RowAliases;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
-import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
-import com.arcadedb.schema.DocumentType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 /**
  * Execution step for SET clause.
- * Supports: SET n.prop = value, SET n = {map}, SET n += {map}, SET n:Label
+ * Supports: SET n.prop = value, SET n[key] = value, SET n = {map}, SET n += {map}, SET n:Label
+ * <p>
+ * The clause semantics live in {@link SetClauseApplier}, which {@link MergeStep} shares for ON CREATE SET /
+ * ON MATCH SET; this step only owns the row loop and the implicit transaction around it.
  */
 public class SetStep extends AbstractExecutionStep {
-  private final SetClause setClause;
-  private final ExpressionEvaluator evaluator;
+  private final SetClause         setClause;
+  private final SetClauseApplier  applier;
 
   public SetStep(final SetClause setClause, final CommandContext context,
                  final CypherFunctionFactory functionFactory) {
     super(context);
     this.setClause = setClause;
-    this.evaluator = new ExpressionEvaluator(functionFactory);
+    this.applier = SetClauseApplier.forSetClause(context, new ExpressionEvaluator(functionFactory));
   }
 
   @Override
@@ -135,79 +127,13 @@ public class SetStep extends AbstractExecutionStep {
     if (setClause == null || setClause.isEmpty())
       return;
 
-    // Pre-resolve any vertex aliases that were replaced by a label change on a prior row so
-    // that property-SET operations (which go through resolveLatestDoc) observe the live vertex
-    // rather than the deleted original.
-    labelReplacements.redirect(result);
-
     final boolean wasInTransaction = context.getDatabase().isTransactionActive();
 
     try {
       if (!wasInTransaction)
         context.getDatabase().begin();
 
-      final List<SetClause.SetItem> items = setClause.getItems();
-
-      // Phase 1: evaluate all right-hand-side expressions against the graph state *before* the SET
-      // clause runs. openCypher / Neo4j SET is a simultaneous assignment: every read must observe
-      // the pre-clause value, never a value written by an earlier item in the same clause
-      // (issue #5190). E.g. "SET a.x = a.y, a.y = a.x" must swap rather than copy.
-      //
-      // #5227: the pre-clause snapshot must be the LATEST COMMITTED state (what a locked read would
-      // observe), NOT the possibly-stale record snapshot the MATCH loaded. reloadLatestDoc() below
-      // reloads each variable target to its current committed version before its right-hand side is
-      // evaluated, so a concurrent transaction that committed between the MATCH read and this write is
-      // observed here instead of being silently overwritten (a lost update on e.g. "SET a.c = a.c + 1").
-      // The page pinned by the reload makes any commit that lands AFTER this point fail the MVCC
-      // version check at commit, surfacing a retryable conflict the auto-retry loop re-runs cleanly.
-      final Object[] values = new Object[items.size()];
-      final String[] keys = new String[items.size()];
-      final boolean[] keyIsNull = new boolean[items.size()];
-      for (int i = 0; i < items.size(); i++) {
-        final SetClause.SetItem item = items.get(i);
-        switch (item.getType()) {
-          case PROPERTY:
-            // Resolve the latest doc first so self-referential reads across row fanout (e.g. via
-            // UNWIND) observe prior-row writes, then snapshot key + value.
-            if (item.getVariable() != null)
-              reloadLatestDoc(item.getVariable(), result, writtenDocs);
-            if (item.getKeyExpression() != null) {
-              final Object keyValue = evaluator.evaluate(item.getKeyExpression(), result, context);
-              if (keyValue == null)
-                keyIsNull[i] = true;
-              else
-                keys[i] = keyValue.toString();
-            }
-            values[i] = evaluator.evaluate(item.getValueExpression(), result, context);
-            break;
-          case REPLACE_MAP:
-          case MERGE_MAP:
-            reloadLatestDoc(item.getVariable(), result, writtenDocs);
-            values[i] = evaluator.evaluate(item.getValueExpression(), result, context);
-            break;
-          case LABELS:
-            break;
-        }
-      }
-
-      // Phase 2: apply the writes using the pre-computed snapshot values.
-      for (int i = 0; i < items.size(); i++) {
-        final SetClause.SetItem item = items.get(i);
-        switch (item.getType()) {
-          case PROPERTY:
-            applyPropertySet(item, result, writtenDocs, values[i], keys[i], keyIsNull[i]);
-            break;
-          case REPLACE_MAP:
-            applyReplaceMap(item, result, writtenDocs, values[i]);
-            break;
-          case MERGE_MAP:
-            applyMergeMap(item, result, writtenDocs, values[i]);
-            break;
-          case LABELS:
-            applyLabels(item, result, writtenDocs, labelReplacements);
-            break;
-        }
-      }
+      applier.apply(setClause, result, writtenDocs, labelReplacements);
 
       if (!wasInTransaction)
         context.getDatabase().commit();
@@ -216,282 +142,6 @@ public class SetStep extends AbstractExecutionStep {
         context.getDatabase().rollback();
       throw e;
     }
-  }
-
-  private void applyPropertySet(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue, final String precomputedKey,
-      final boolean keyIsNull) {
-    final Object obj;
-    final String variableToUpdate;
-
-    if (item.getTargetExpression() != null) {
-      // Expression target: SET (CASE WHEN ... THEN t END).prop = value
-      // Evaluate the target expression to get the document
-      obj = evaluator.evaluate(item.getTargetExpression(), result, context);
-      // #5795: the CASE branch (or bracket-syntax base) can itself resolve to a variable that
-      // was deleted earlier in the same query, e.g. SET (CASE WHEN true THEN t END).v = 99 after
-      // DELETE t. Unlike the plain-variable branch below, this path never goes through
-      // resolveLatestDoc(), so the DeletedEntityMarker check has to be applied here too.
-      DeletedEntityMarker.checkNotDeleted(obj);
-      if (obj == null)
-        return; // CASE returned null — no-op (conditional SET pattern)
-      variableToUpdate = null;
-    } else {
-      variableToUpdate = item.getVariable();
-      obj = resolveLatestDoc(variableToUpdate, result, writtenDocs);
-      if (obj == null)
-        return;
-    }
-
-    if (!(obj instanceof Document doc))
-      return;
-
-    final MutableDocument mutableDoc = doc.modify();
-    // When doc.modify() returns a fresher MutableDocument (e.g. from the tx cache in an
-    // outer transaction), update the result row before evaluating the RHS so that
-    // self-referential expressions read the latest state, not the original snapshot.
-    if (mutableDoc != doc && variableToUpdate != null)
-      ((ResultInternal) result).setProperty(variableToUpdate, mutableDoc);
-
-    // Resolve the property name. For dynamic bracket syntax (SET n[keyExpr] = value) the name is
-    // computed at runtime (snapshotted in phase 1); otherwise it is the static dot-syntax name.
-    final String propertyName;
-    if (item.getKeyExpression() != null) {
-      if (keyIsNull)
-        return; // null key is a no-op
-      propertyName = precomputedKey;
-    } else
-      propertyName = item.getProperty();
-
-    Object value = precomputedValue;
-    final boolean propertyExisted;
-    if (value == null) {
-      // Removing an absent property is a no-op for Neo4j-compatible statistics: only count it
-      // when the property actually existed before the removal.
-      propertyExisted = mutableDoc.has(propertyName);
-      mutableDoc.remove(propertyName);
-    } else {
-      value = TemporalUtil.toCoreJavaType(value);
-      validatePropertyValue(value);
-      mutableDoc.set(propertyName, value);
-      propertyExisted = true;
-    }
-    mutableDoc.save();
-    // Neo4j counts both a property assignment and a genuine (existing-property) null-valued
-    // removal under "properties set".
-    final QueryStatistics stats = context.getStatistics();
-    if (propertyExisted)
-      stats.addPropertiesSet(1);
-
-    // Record the latest written state so subsequent rows can read through it.
-    final RID savedRid = mutableDoc.getIdentity();
-    if (savedRid != null)
-      writtenDocs.put(savedRid, mutableDoc);
-
-    RowAliases.propagateUpdate(result, doc, mutableDoc);
-    // Fallback: ensure the named variable is updated even when doc has no identity yet
-    if (variableToUpdate != null && doc.getIdentity() == null)
-      ((ResultInternal) result).setProperty(variableToUpdate, mutableDoc);
-  }
-
-  @SuppressWarnings("unchecked")
-  private void applyReplaceMap(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue) {
-    final Document doc = resolveLatestDoc(item.getVariable(), result, writtenDocs);
-    if (doc == null)
-      return;
-
-    final Object mapValue = precomputedValue;
-    if (!(mapValue instanceof Map))
-      return;
-
-    final Map<String, Object> map = (Map<String, Object>) mapValue;
-    final MutableDocument mutableDoc = doc.modify();
-    if (mutableDoc != doc)
-      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
-
-    // Remove all existing properties except internal ones
-    final Set<String> existingProps = new HashSet<>(mutableDoc.getPropertyNames());
-    for (final String prop : existingProps) {
-      if (!prop.startsWith("@"))
-        mutableDoc.remove(prop);
-    }
-
-    // Set new properties from map (skip null values - they mean "remove")
-    int propertiesSet = 0;
-    for (final Map.Entry<String, Object> entry : map.entrySet()) {
-      if (entry.getValue() != null) {
-        mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
-        propertiesSet++;
-      }
-    }
-
-    // Neo4j counts both the properties written and the pre-existing properties removed by the
-    // replace (i.e. not re-set with a non-null value), matching applyPropertySet/applyMergeMap.
-    propertiesSet += CypherStatisticsHelper.countRemovedProperties(existingProps, map);
-
-    mutableDoc.save();
-    final QueryStatistics stats = context.getStatistics();
-    stats.addPropertiesSet(propertiesSet);
-    final RID savedRid = mutableDoc.getIdentity();
-    if (savedRid != null)
-      writtenDocs.put(savedRid, mutableDoc);
-    RowAliases.propagateUpdate(result, doc, mutableDoc);
-    if (doc.getIdentity() == null)
-      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
-  }
-
-  @SuppressWarnings("unchecked")
-  private void applyMergeMap(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final Object precomputedValue) {
-    final Document doc = resolveLatestDoc(item.getVariable(), result, writtenDocs);
-    if (doc == null)
-      return;
-
-    final Object mapValue = precomputedValue;
-    if (!(mapValue instanceof Map))
-      return;
-
-    final Map<String, Object> map = (Map<String, Object>) mapValue;
-    final MutableDocument mutableDoc = doc.modify();
-    if (mutableDoc != doc)
-      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
-
-    // Merge: non-null values set the property, a null value removes it. Removing a property that
-    // does not exist is a no-op and is not counted (Neo4j reports properties-set only for changes).
-    int propertiesSet = 0;
-    for (final Map.Entry<String, Object> entry : map.entrySet()) {
-      if (entry.getValue() == null) {
-        if (mutableDoc.has(entry.getKey())) {
-          mutableDoc.remove(entry.getKey());
-          propertiesSet++;
-        }
-      } else {
-        mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
-        propertiesSet++;
-      }
-    }
-
-    mutableDoc.save();
-    final QueryStatistics stats = context.getStatistics();
-    stats.addPropertiesSet(propertiesSet);
-    final RID savedRid = mutableDoc.getIdentity();
-    if (savedRid != null)
-      writtenDocs.put(savedRid, mutableDoc);
-    RowAliases.propagateUpdate(result, doc, mutableDoc);
-    if (doc.getIdentity() == null)
-      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
-  }
-
-  private Document resolveLatestDoc(final String variable, final Result result,
-      final Map<RID, MutableDocument> writtenDocs) {
-    final Object raw = result.getProperty(variable);
-    // #5795: a node deleted earlier in the same query is replaced in the result row with a
-    // DeletedEntityMarker (see DeleteStep). Using it as a SET write target must fail the same
-    // way reading a property from it already does, instead of silently no-op'ing (which let the
-    // preceding DELETE commit while the SET vanished).
-    DeletedEntityMarker.checkNotDeleted(raw);
-    if (!(raw instanceof Document rawDoc))
-      return null;
-    final RID rid = rawDoc.getIdentity();
-    if (rid != null) {
-      final MutableDocument latest = writtenDocs.get(rid);
-      if (latest != null && latest != raw) {
-        ((ResultInternal) result).setProperty(variable, latest);
-        return latest;
-      }
-    }
-    return rawDoc;
-  }
-
-  /**
-   * #5227: resolves the target variable and replaces it in the result row with its mutable, latest-committed
-   * version so a SET right-hand side is evaluated against the current state of the record, not the snapshot the
-   * MATCH loaded. {@link com.arcadedb.database.ImmutableDocument#modify()} force-reloads a record that was read
-   * outside the write path to its latest committed version and pins its page in the transaction; evaluating the
-   * right-hand side against that (instead of a stale MATCH buffer) prevents concurrent read-modify-write updates
-   * from being silently lost, while the pinned page makes any later concurrent commit fail the commit-time MVCC
-   * version check as a retryable conflict. A record already written earlier in this transaction (in
-   * {@code writtenDocs}) is a {@link MutableDocument} whose {@code modify()} returns itself, so cross-row
-   * read-your-writes semantics are preserved.
-   */
-  private void reloadLatestDoc(final String variable, final Result result, final Map<RID, MutableDocument> writtenDocs) {
-    if (variable == null)
-      return;
-    final Document doc = resolveLatestDoc(variable, result, writtenDocs);
-    if (doc == null)
-      return;
-    final MutableDocument mutable = doc.modify();
-    if (mutable != doc)
-      ((ResultInternal) result).setProperty(variable, mutable);
-  }
-
-  private void applyLabels(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final LabelReplacements labelReplacements) {
-    final Object obj = result.getProperty(item.getVariable());
-    // #5795: reject a label write targeting a node deleted earlier in the same query instead of
-    // silently no-op'ing.
-    DeletedEntityMarker.checkNotDeleted(obj);
-    if (!(obj instanceof Vertex vertex))
-      return;
-
-    // If this vertex was already replaced on a prior row (row fanout hitting the same node), redirect to the
-    // replacement so the idempotency check below reads the current type. The per-row redirect() at the top of
-    // applySetOperations reaches this alias too, so today this only re-confirms it; it stays because it makes the
-    // method correct on its own terms - the write target is resolved here, not assumed to have been resolved by
-    // the caller - and it costs one map lookup that is skipped entirely until a label write actually happens.
-    final Vertex prior = labelReplacements.resolve(vertex);
-    if (prior != vertex) {
-      RowAliases.propagateUpdate(result, vertex, prior);
-      vertex = prior;
-    }
-    // The RID the write is about to displace: the live one, not the one the row happened to carry.
-    final RID originalRid = vertex.getIdentity();
-
-    // The labels the new type has to be built from are the vertex's OWN labels, not every label it answers to: an
-    // inherited one comes back through the hierarchy, and naming it in the composite instead of the subtype that
-    // carries it would move the vertex out of that subtype (issue #6363). A label the vertex already answers to -
-    // its own, or one it inherits - is already present and adds nothing.
-    final DocumentType currentType = vertex.getType();
-    final List<String> allLabels = new ArrayList<>(Labels.getOwnLabels(vertex));
-    int newLabelsCount = 0;
-    for (final String label : item.getLabels())
-      if (!currentType.instanceOf(label) && !allLabels.contains(label)) {
-        allLabels.add(label);
-        newLabelsCount++;
-      }
-
-    // Create the composite type for the combined labels
-    final String newTypeName = Labels.ensureCompositeType(
-        context.getDatabase().getSchema(), allLabels);
-
-    // If the type hasn't changed, nothing to do (all labels already present)
-    if (vertex.getTypeName().equals(newTypeName))
-      return;
-
-    // Rewrite the vertex under the composite type: the record moves, and the replacement is recorded so
-    // this row and every later one follow it.
-    labelReplacements.replace(vertex, newTypeName);
-    if (newLabelsCount > 0)
-      context.getStatistics().addLabelsAdded(newLabelsCount);
-
-    labelReplacements.redirect(result);
-    // Invalidate any property-SET state for the old RID so subsequent rows don't read
-    // stale MutableDocument entries. Combined SET n.prop+n:Label across fanout still has
-    // ordering-dependent behaviour, but this prevents outright stale reads.
-    writtenDocs.remove(originalRid);
-  }
-
-  private void validatePropertyValue(final Object value) {
-    if (value instanceof List) {
-      for (final Object element : (List<?>) value) {
-        if (element instanceof Map)
-          throw new IllegalArgumentException("TypeError: InvalidPropertyType - Property values can not contain map values");
-        if (element instanceof List)
-          validatePropertyValue(element);
-      }
-    } else if (value instanceof Map)
-      throw new IllegalArgumentException("TypeError: InvalidPropertyType - Property values can not be maps");
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6831: {@code MERGE ... ON CREATE SET} / {@code ON MATCH SET} used to be served by a
+ * second, hand-maintained copy of the SET clause that understood only the {@code variable.property} shape. The
+ * dynamic-key form, the expression-target form, the property-value type check and the simultaneous-assignment rule
+ * were all missing from that copy, so a MERGE action behaved differently from the identical stand-alone SET.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherMergeSetClauseParityIssue6831Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testcypher-6831").create();
+    database.getSchema().createVertexType("P");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void onMatchSetWritesDynamicKey() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1})"));
+
+    database.transaction(() -> database.command("opencypher", "MERGE (n:P {id: 1}) ON MATCH SET n[$k] = 5",
+        Map.of("k", "score")));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.score AS score");
+    assertThat(rs.next().<Number>getProperty("score").intValue()).isEqualTo(5);
+  }
+
+  @Test
+  void onCreateSetWritesDynamicKey() {
+    database.transaction(() -> database.command("opencypher", "MERGE (n:P {id: 7}) ON CREATE SET n[$k] = 'new'",
+        Map.of("k", "origin")));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P {id: 7}) RETURN n.origin AS origin");
+    assertThat(rs.next().<String>getProperty("origin")).isEqualTo("new");
+  }
+
+  @Test
+  void onMatchSetWritesThroughExpressionTarget() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MERGE (n:P {id: 1}) ON MATCH SET (CASE WHEN true THEN n END).x = 1"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.x AS x");
+    assertThat(rs.next().<Number>getProperty("x").intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void onMatchSetWithFalseExpressionTargetIsANoOp() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MERGE (n:P {id: 1}) ON MATCH SET (CASE WHEN false THEN n END).x = 1"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.x AS x");
+    assertThat(rs.next().<Object>getProperty("x")).isNull();
+  }
+
+  @Test
+  void onCreateSetRejectsAMapPropertyValue() {
+    // The identical stand-alone SET already raises this; the MERGE action must not be the lenient one.
+    assertThatThrownBy(() -> database.transaction(
+        () -> database.command("opencypher", "MERGE (n:P {id: 2}) ON CREATE SET n.p = {a: 1}")))
+        .rootCause()
+        .hasMessageContaining("TypeError: InvalidPropertyType");
+  }
+
+  @Test
+  void onMatchSetIsASimultaneousAssignment() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1, x: 'left', y: 'right'})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MERGE (n:P {id: 1}) ON MATCH SET n.x = n.y, n.y = n.x"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.x AS x, n.y AS y");
+    final var row = rs.next();
+    assertThat(row.<String>getProperty("x")).isEqualTo("right");
+    assertThat(row.<String>getProperty("y")).isEqualTo("left");
+  }
+
+  @Test
+  void onMatchSetStillCopiesFromAnotherEntity() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1}), (:P {id: 2, tag: 'src'})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (src:P {id: 2}) MERGE (n:P {id: 1}) ON MATCH SET n += src"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P {tag: 'src'}) RETURN count(n) AS c");
+    assertThat(rs.next().<Number>getProperty("c").intValue()).isEqualTo(2);
+  }
+
+  @Test
+  void onMatchSetStillAddsLabels() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1})"));
+
+    database.transaction(() -> database.command("opencypher", "MERGE (n:P {id: 1}) ON MATCH SET n:Extra"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Extra) RETURN n.id AS id");
+    assertThat(rs.next().<Number>getProperty("id").intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void onMatchSetRemovesPropertyWithNullValue() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1, gone: 'x'})"));
+
+    database.transaction(() -> database.command("opencypher", "MERGE (n:P {id: 1}) ON MATCH SET n.gone = null"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.gone AS gone");
+    assertThat(rs.next().<Object>getProperty("gone")).isNull();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
@@ -244,4 +244,36 @@ class CypherMergeSetClauseParityIssue6831Test {
     assertThat(row.<Number>getProperty("a").intValue()).isEqualTo(1);
     assertThat(row.<Number>getProperty("b").intValue()).isEqualTo(2);
   }
+
+  /**
+   * The map-replace and map-merge forms reach the type check through the shared applier, but this PR's whole thesis
+   * is that the MERGE path cannot be assumed to behave like the stand-alone one: assert it here rather than infer it.
+   */
+  @Test
+  void onMatchSetRejectsAScalarReplaceSource() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1})"));
+
+    assertThatThrownBy(() -> database.transaction(
+        () -> database.command("opencypher", "MERGE (n:P {id: 1}) ON MATCH SET n = 5")))
+        .rootCause()
+        .hasMessageContaining("TypeError");
+  }
+
+  @Test
+  void onCreateSetRejectsAScalarMergeSource() {
+    assertThatThrownBy(() -> database.transaction(
+        () -> database.command("opencypher", "MERGE (n:P {id: 9}) ON CREATE SET n += 'nope'")))
+        .rootCause()
+        .hasMessageContaining("TypeError");
+  }
+
+  @Test
+  void onMatchSetRejectsANestedMapInsideAMergeSource() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1})"));
+
+    assertThatThrownBy(() -> database.transaction(
+        () -> database.command("opencypher", "MERGE (n:P {id: 1}) ON MATCH SET n += {bad: {nested: 1}}")))
+        .rootCause()
+        .hasMessageContaining("TypeError: InvalidPropertyType");
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
@@ -194,4 +194,50 @@ class CypherMergeSetClauseParityIssue6831Test {
     assertThat(row.<String>getProperty("bank")).isEqualTo("ACME");
     assertThat(row.<String>getProperty("branch")).isEqualTo("WEST");
   }
+
+  /**
+   * WHICH record an expression target names is a read of the graph like any other, so it is answered from the
+   * pre-clause state: n.enabled was true when the clause began, so the CASE selects n and the flag is written.
+   */
+  @Test
+  void expressionTargetResolvesAgainstThePreClauseState() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1, enabled: true})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (n:P) SET n.enabled = false, (CASE WHEN n.enabled THEN n END).flag = true"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.flag AS flag, n.enabled AS enabled");
+    final var row = rs.next();
+    assertThat(row.<Boolean>getProperty("flag")).isTrue();
+    assertThat(row.<Boolean>getProperty("enabled")).isFalse();
+  }
+
+  /**
+   * Resolving the target in phase 1 must not outrun a label write in the same clause: the rewrite deletes the record
+   * the target names, so the captured vertex has to follow the move rather than be written to after its death.
+   */
+  @Test
+  void expressionTargetFollowsALabelWriteFromTheSameClause() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (n:P) SET n:Extra, (CASE WHEN true THEN n END).x = 1"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Extra) RETURN n.x AS x");
+    assertThat(rs.next().<Number>getProperty("x").intValue()).isEqualTo(1);
+  }
+
+  /** Two expression-target writes to the same record accumulate rather than the second losing the first. */
+  @Test
+  void twoExpressionTargetWritesToTheSameRecordAccumulate() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (n:P) SET (CASE WHEN true THEN n END).a = 1, (CASE WHEN true THEN n END).b = 2"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.a AS a, n.b AS b");
+    final var row = rs.next();
+    assertThat(row.<Number>getProperty("a").intValue()).isEqualTo(1);
+    assertThat(row.<Number>getProperty("b").intValue()).isEqualTo(2);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
@@ -52,6 +52,10 @@ class CypherMergeSetClauseParityIssue6831Test {
   @AfterEach
   void tearDown() {
     if (database != null) {
+      // A test that fails inside a caller-managed transaction leaves it open, and drop() refuses a database still in
+      // use: without this the failure would be reported as the next test's setUp() error instead of its own.
+      if (database.isTransactionActive())
+        database.rollback();
       database.drop();
       database = null;
     }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeSetClauseParityIssue6831Test.java
@@ -20,12 +20,14 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.event.AfterRecordUpdateListener;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -148,5 +150,48 @@ class CypherMergeSetClauseParityIssue6831Test {
 
     final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.gone AS gone");
     assertThat(rs.next().<Object>getProperty("gone")).isNull();
+  }
+
+  /**
+   * #4474 travels with the shared applier: re-asserting a value the record already holds must still not write, because
+   * the write would bump the record's MVCC version and invalidate it for every concurrent reader that had matched it.
+   * The pre-existing regression test for this asserts the absence of a ConcurrentModificationException between two
+   * racing threads, which no longer fails when the optimization is removed; counting the update events the write would
+   * have raised pins the behaviour directly and deterministically.
+   */
+  @Test
+  void onMatchSetDoesNotRewriteAnUnchangedValue() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1, bank: 'ACME'})"));
+
+    final AtomicInteger updates = new AtomicInteger();
+    final AfterRecordUpdateListener listener = record -> updates.incrementAndGet();
+    database.getSchema().getType("P").getEvents().registerListener(listener);
+    try {
+      database.transaction(() -> database.command("opencypher", "MERGE (n:P {id: 1}) ON MATCH SET n.bank = 'ACME'"));
+      assertThat(updates.get()).isZero();
+
+      // The guard has to be about the value, not about SET being inert: a different value does write.
+      database.transaction(() -> database.command("opencypher", "MERGE (n:P {id: 1}) ON MATCH SET n.bank = 'OTHER'"));
+      assertThat(updates.get()).isEqualTo(1);
+    } finally {
+      database.getSchema().getType("P").getEvents().unregisterListener(listener);
+    }
+  }
+
+  /**
+   * The same guard must not swallow a genuine removal: an unchanged-value skip is decided per item, and a null value
+   * on a property that exists is a change.
+   */
+  @Test
+  void onMatchSetStillWritesWhenOnlyOneOfTwoItemsChanges() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:P {id: 1, bank: 'ACME', branch: 'HQ'})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MERGE (n:P {id: 1}) ON MATCH SET n.bank = 'ACME', n.branch = 'WEST'"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:P) RETURN n.bank AS bank, n.branch AS branch");
+    final var row = rs.next();
+    assertThat(row.<String>getProperty("bank")).isEqualTo("ACME");
+    assertThat(row.<String>getProperty("branch")).isEqualTo("WEST");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
@@ -185,4 +185,33 @@ class CypherSetFromEntityIssue6832Test {
     assertThat(row.<Number>getProperty("id").intValue()).isEqualTo(1);
     assertThat(row.<String>getProperty("name")).isEqualTo("keep");
   }
+
+  /**
+   * SET is a simultaneous assignment: every read observes the pre-clause state (#5190). The entity right-hand side is
+   * a read like any other, so an earlier item of the same clause must not be visible to it.
+   */
+  @Test
+  void replaceFromNodeReadsThePreClauseStateOfTheSource() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1}), (:B {id: 2, name: 'old'})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (a:A), (b:B) SET b.name = 'new', a = b"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.name AS name");
+    assertThat(rs.next().<String>getProperty("name")).isEqualTo("old");
+
+    final ResultSet source = database.query("opencypher", "MATCH (b:B) RETURN b.name AS name");
+    assertThat(source.next().<String>getProperty("name")).isEqualTo("new");
+  }
+
+  @Test
+  void mergeFromNodeReadsThePreClauseStateOfTheSource() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1}), (:B {id: 2, name: 'old'})"));
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (a:A), (b:B) SET b.name = 'new', a += b"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.name AS name");
+    assertThat(rs.next().<String>getProperty("name")).isEqualTo("old");
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
@@ -52,6 +52,10 @@ class CypherSetFromEntityIssue6832Test {
   @AfterEach
   void tearDown() {
     if (database != null) {
+      // A test that fails inside a caller-managed transaction leaves it open, and drop() refuses a database still in
+      // use: without this the failure would be reported as the next test's setUp() error instead of its own.
+      if (database.isTransactionActive())
+        database.rollback();
       database.drop();
       database = null;
     }
@@ -239,5 +243,45 @@ class CypherSetFromEntityIssue6832Test {
     final var row = rs.next();
     assertThat(row.<Number>getProperty("id").intValue()).isEqualTo(1);
     assertThat(row.<String>getProperty("name")).isEqualTo("keep");
+  }
+
+  /**
+   * A SET clause is rejected as a whole or not at all: an invalid value in a later item must not leave an earlier
+   * item's write behind. The caller's transaction is the one that makes this observable, since the step rolls back
+   * only a transaction it opened itself.
+   */
+  @Test
+  void anInvalidMapEntryRejectsTheClauseBeforeAnyOfItIsWritten() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1})"));
+
+    database.begin();
+    assertThatThrownBy(() -> database.command("opencypher", "MATCH (a:A) SET a.ok = 1, a += {bad: {nested: 1}}"))
+        .rootCause()
+        .hasMessageContaining("TypeError: InvalidPropertyType");
+
+    final ResultSet inTx = database.query("opencypher", "MATCH (a:A) RETURN a.ok AS ok");
+    assertThat(inTx.next().<Object>getProperty("ok")).isNull();
+    database.commit();
+
+    final ResultSet afterCommit = database.query("opencypher", "MATCH (a:A) RETURN a.ok AS ok");
+    assertThat(afterCommit.next().<Object>getProperty("ok")).isNull();
+  }
+
+  /** The same guarantee when the invalid value is on a plain property item rather than inside a map. */
+  @Test
+  void anInvalidPropertyValueRejectsTheClauseBeforeAnyOfItIsWritten() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1})"));
+
+    database.begin();
+    assertThatThrownBy(() -> database.command("opencypher", "MATCH (a:A) SET a.ok = 1, a.bad = {nested: 1}"))
+        .rootCause()
+        .hasMessageContaining("TypeError: InvalidPropertyType");
+
+    final ResultSet inTx = database.query("opencypher", "MATCH (a:A) RETURN a.ok AS ok");
+    assertThat(inTx.next().<Object>getProperty("ok")).isNull();
+    database.commit();
+
+    final ResultSet afterCommit = database.query("opencypher", "MATCH (a:A) RETURN a.ok AS ok");
+    assertThat(afterCommit.next().<Object>getProperty("ok")).isNull();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.QueryStatistics;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6832: {@code SET a = b} and {@code SET a += b}, where the right-hand side is a node or
+ * a relationship rather than a literal map, were silent no-ops. Neo4j copies the source entity's properties onto the
+ * target, and a right-hand side that is neither an entity nor a map is a type error rather than a discarded write.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherSetFromEntityIssue6832Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testcypher-6832").create();
+    database.getSchema().createVertexType("A");
+    database.getSchema().createVertexType("B");
+    database.getSchema().createEdgeType("REL");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void replaceFromNodeCopiesEveryProperty() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1, own: 'gone'}), (:B {id: 2, name: 'x', age: 7})"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (a:A {id: 1}), (b:B {id: 2}) SET a = b"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.name AS name, a.age AS age, a.id AS id, a.own AS own");
+    final var row = rs.next();
+    assertThat(row.<String>getProperty("name")).isEqualTo("x");
+    assertThat(row.<Number>getProperty("age").intValue()).isEqualTo(7);
+    // "=" replaces: the source's id wins and the target's own properties are dropped.
+    assertThat(row.<Number>getProperty("id").intValue()).isEqualTo(2);
+    assertThat(row.<Object>getProperty("own")).isNull();
+  }
+
+  @Test
+  void replaceFromNodeCountsPropertiesSet() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1, own: 'gone'}), (:B {id: 2, name: 'x', age: 7})"));
+
+    database.transaction(() -> {
+      final ResultSet rs = database.command("opencypher", "MATCH (a:A {id: 1}), (b:B {id: 2}) SET a = b");
+      while (rs.hasNext())
+        rs.next();
+      final QueryStatistics stats = rs.getStatistics().orElseThrow();
+      // 3 written (id, name, age) + 1 removed (own)
+      assertThat(stats.getPropertiesSet()).isEqualTo(4);
+    });
+  }
+
+  @Test
+  void mergeFromNodeKeepsTargetOwnProperties() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1, own: 'kept'}), (:B {id: 2, name: 'x'})"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (a:A {id: 1}), (b:B {id: 2}) SET a += b"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.name AS name, a.id AS id, a.own AS own");
+    final var row = rs.next();
+    assertThat(row.<String>getProperty("name")).isEqualTo("x");
+    assertThat(row.<Number>getProperty("id").intValue()).isEqualTo(2);
+    assertThat(row.<String>getProperty("own")).isEqualTo("kept");
+  }
+
+  @Test
+  void mergeFromRelationshipCopiesRelationshipProperties() {
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:A {id: 1})-[:REL {since: 1999, kind: 'friend'}]->(b:B {id: 2})"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (a:A)-[r:REL]->(b:B) SET a += r"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.since AS since, a.kind AS kind");
+    final var row = rs.next();
+    assertThat(row.<Number>getProperty("since").intValue()).isEqualTo(1999);
+    assertThat(row.<String>getProperty("kind")).isEqualTo("friend");
+  }
+
+  @Test
+  void replaceFromScalarIsATypeError() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1})"));
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a = 5")))
+        .rootCause()
+        .hasMessageContaining("TypeError");
+  }
+
+  @Test
+  void mergeFromScalarIsATypeError() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1})"));
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a += 'nope'")))
+        .rootCause()
+        .hasMessageContaining("TypeError");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
@@ -214,4 +214,30 @@ class CypherSetFromEntityIssue6832Test {
     final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.name AS name");
     assertThat(rs.next().<String>getProperty("name")).isEqualTo("old");
   }
+
+  /** The same protection on the merge form: "+=" reads a copy of the source, so self-merge cannot lose anything. */
+  @Test
+  void mergeFromItselfKeepsEveryProperty() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1, name: 'keep'})"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a += a"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.id AS id, a.name AS name");
+    final var row = rs.next();
+    assertThat(row.<Number>getProperty("id").intValue()).isEqualTo(1);
+    assertThat(row.<String>getProperty("name")).isEqualTo("keep");
+  }
+
+  /** And on the MERGE side, which reaches the same copy through the shared applier. */
+  @Test
+  void mergeActionFromItselfKeepsEveryProperty() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1, name: 'keep'})"));
+
+    database.transaction(() -> database.command("opencypher", "MERGE (a:A {id: 1}) ON MATCH SET a += a"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.id AS id, a.name AS name");
+    final var row = rs.next();
+    assertThat(row.<Number>getProperty("id").intValue()).isEqualTo(1);
+    assertThat(row.<String>getProperty("name")).isEqualTo("keep");
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSetFromEntityIssue6832Test.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -126,5 +128,61 @@ class CypherSetFromEntityIssue6832Test {
     assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a += 'nope'")))
         .rootCause()
         .hasMessageContaining("TypeError");
+  }
+
+  /**
+   * The map forms used to be the way around the property-value type check that the dot form applies: only
+   * applyPropertySet validated, so SET n = {x: {y: 1}} stored a map where SET n.x = {y: 1} raised. Neo4j refuses both
+   * with "Property values can only be of primitive types or arrays thereof".
+   */
+  @Test
+  void replaceMapRejectsANestedMapValue() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1})"));
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a = {x: {y: 1}}")))
+        .rootCause()
+        .hasMessageContaining("TypeError: InvalidPropertyType");
+  }
+
+  @Test
+  void mergeMapRejectsANestedMapValue() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1})"));
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a += {x: {y: 1}}")))
+        .rootCause()
+        .hasMessageContaining("TypeError: InvalidPropertyType");
+  }
+
+  @Test
+  void mergeMapRejectsAListOfMapsValue() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1})"));
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a += {x: [{y: 1}]}")))
+        .rootCause()
+        .hasMessageContaining("TypeError: InvalidPropertyType");
+  }
+
+  @Test
+  void mergeMapStillAcceptsAListOfScalars() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1})"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a += {tags: ['x', 'y']}"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.tags AS tags");
+    assertThat(rs.next().<List<Object>>getProperty("tags")).containsExactly("x", "y");
+  }
+
+  /** Copying from an entity onto itself must be a no-op, not a self-inflicted wipe: the replace form clears the
+   *  target before reading the source, and a MutableDocument hands out a live view of its own property map. */
+  @Test
+  void replaceFromItselfKeepsEveryProperty() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 1, name: 'keep'})"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (a:A) SET a = a"));
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:A) RETURN a.id AS id, a.name AS name");
+    final var row = rs.next();
+    assertThat(row.<Number>getProperty("id").intValue()).isEqualTo(1);
+    assertThat(row.<String>getProperty("name")).isEqualTo("keep");
   }
 }


### PR DESCRIPTION
Fixes #6831
Fixes #6832

## The shared root cause

`MERGE ... ON CREATE SET` / `ON MATCH SET` was served by `MergeStep.applySetClause`, a private second implementation of the SET clause. Both it and `SetStep` are fed by the **same** parser production (`CypherASTBuilder.visitSetClause`), so both see every SET shape - and the two copies had drifted in opposite directions. Each issue is one direction of that drift.

### #6831 - what the MERGE copy dropped

It read only `item.getVariable()` and `item.getProperty()`, never `getKeyExpression()` or `getTargetExpression()`:

| Query | Before |
|---|---|
| `MERGE (n:P {id:1}) ON MATCH SET n[$k] = 5` | `NullPointerException` deep in `MutableDocument.set(null, …)` |
| `MERGE (n:P {id:1}) ON MATCH SET (CASE WHEN true THEN n END).x = 1` | silent no-op (`variable == null` → `getProperty(null)` → `continue`) |
| `MERGE (n:P {id:2}) ON CREATE SET n.p = {a:1}` | stores a map, where the identical stand-alone SET raises `TypeError: InvalidPropertyType` |
| `MERGE (n:P {id:1}) ON MATCH SET n.x = n.y, n.y = n.x` | copies instead of swapping (items evaluated one by one, no pre-clause snapshot) |

### #6832 - what the stand-alone copy dropped

`applyReplaceMap`/`applyMergeMap` bailed out unless the right-hand side was a `java.util.Map`. A variable bound to a node evaluates to the `Vertex` record itself, so `SET a = b` and `SET a += b` - the documented way to clone an entity, and what the MERGE copy already handled - were silent no-ops: no write, no error, and `propertiesSet` reported 0. Data-loss-shaped, because a clone/ETL query appeared to succeed. Neo4j copies `b`'s properties onto `a`.

## The fix

Both issues suggest keeping two implementations in sync; the better alternative, and what this PR does, is to have only one. `SetClauseApplier` is now the single implementation, used by `SetStep` and `MergeStep` alike, so a SET item behaves the same inside and outside a MERGE and neither can drift again.

On top of the unification:
- a node or relationship right-hand side contributes its properties. The copy is defensive on purpose: `MutableDocument.propertiesAsMap()` hands out a live view of its own map, and the replace form clears the target before reading the source, so `SET a = a` would otherwise read a map it had just emptied;
- a right-hand side that is neither an entity nor a map is now a `TypeError` instead of a discarded write. `null` stays a no-op.

### The two differences that were deliberate

They survive as the two factory methods, named rather than buried in a divergent copy of the switch:

- `forSetClause()` reloads each write target to its latest committed version before evaluating the right-hand side, so a concurrent commit is observed instead of silently overwritten (#5227);
- `forMergeAction()` does not re-assert a value the record already holds (#4474). This is also why the MERGE path deliberately does **not** reload: reloading pins the page, which would reintroduce exactly the write-conflict storm #4474 fixed.

The numeric-tolerant value comparison both steps needed moves to `CypherValues.equalValues()` rather than being copied a third time.

## Verification

- `CypherMergeSetClauseParityIssue6831Test` (9 tests) and `CypherSetFromEntityIssue6832Test` (6 tests) - written first, 11 of the 15 red on `main`, all green now. They cover both dynamic-key forms, both expression-target outcomes, the map-value type check, simultaneous assignment, node and relationship right-hand sides for `=` and `+=`, the `propertiesSet` count, the scalar type errors, and the MERGE behaviours that had to keep working (entity copy, label add, null-valued removal).
- `mvn -o -pl engine test -Dtest='com.arcadedb.query.opencypher.**'`: **9039 tests, 0 failures**.
- openCypher TCK suite (`-Dsurefire.includes=**/*Suite.java`): **3897 tests, 0 failures**.

Net: 507 lines deleted, 22 added in the two steps, plus the shared applier.

## Documentation

`SET n = <node>` / `SET n += <node>` now work, and a non-entity, non-map right-hand side now errors. Worth a note in the Cypher compatibility page - happy to prepare that separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved openCypher `SET` and `MERGE` support for dynamic properties, map updates, entity-property copying, expression targets, labels, and null-based property removal.
  * Added consistent numeric and null-safe value comparisons.

* **Bug Fixes**
  * Corrected property updates, statistics, and behavior for `ON CREATE SET` and `ON MATCH SET`.
  * Added validation for invalid scalar and deleted-entity assignments.

* **Tests**
  * Added regression coverage for `SET` and `MERGE` edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->