### PR TITLE
fix(bolt): #6800 #6801 #6802 #6803 #6804 protocol hardening batch

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -1100,6 +1100,7 @@ public class BoltNetworkExecutor extends Thread {
         database.commit();
       }
       explicitTransaction = false;
+      nextQid = 0; // the numbering is per transaction; BEGIN re-zeroes it too, this just keeps it uniform
 
       final Map<String, Object> metadata = new LinkedHashMap<>();
       metadata.put("bookmark", generateBookmark());

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -641,9 +641,14 @@ public class BoltNetworkExecutor extends Thread {
    * - means the most recently opened stream; any other value names one explicitly, which is how a client
    * interleaves several streams inside one transaction. A qid naming nothing fails the session, exactly as a
    * PULL with no result set behind it did before.
+   * <p>
+   * Outside an explicit transaction the qid is ignored altogether: only one stream can be open there (RUN is not
+   * valid in STREAMING), no qid is ever published in an auto-commit RUN SUCCESS, and the BOLT docs are explicit
+   * that qid does not apply to auto-commit. Honouring it would let a client that sent one anyway be answered
+   * "No active result set for qid ..." for the stream it is plainly asking about.
    */
   private BoltQueryStream resolveStream(final long qid) throws IOException {
-    final BoltQueryStream stream = qid < 0 ? currentStream : openStreams.get(qid);
+    final BoltQueryStream stream = qid < 0 || !explicitTransaction ? currentStream : openStreams.get(qid);
     if (stream == null) {
       sendFailure(BoltException.PROTOCOL_ERROR, qid < 0 ? "No active result set" : "No active result set for qid " + qid);
       state = State.FAILED;
@@ -678,8 +683,11 @@ public class BoltNetworkExecutor extends Thread {
         currentStream = open;
     }
 
-    if (openStreams.isEmpty())
+    if (openStreams.isEmpty()) {
       state = explicitTransaction ? State.TX_READY : State.READY;
+      if (!explicitTransaction)
+        nextQid = 0; // an auto-commit stream is always qid 0: the numbering restarts per transaction
+    }
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -766,6 +766,19 @@ public class BoltNetworkExecutor extends Thread {
 
     // Get database from message extra if specified
     final String db = message.getDatabase();
+
+    // An explicit transaction is bound to the database BEGIN opened it on. A later RUN in the same transaction
+    // naming a different one would make ensureDatabase() drop the reference to that database - it nulls it to
+    // force the switch - and with it the only handle a rollback has, stranding the transaction BEGIN opened if
+    // the new database then fails to open. Neo4j drivers fix the database at BEGIN, so a conforming client
+    // never reaches this.
+    if (explicitTransaction && isDatabaseSwitch(db)) {
+      sendFailure(BoltException.PROTOCOL_ERROR,
+          "Cannot switch database to '" + db + "' inside an open transaction started on '" + database.getName() + "'");
+      state = State.FAILED;
+      return;
+    }
+
     if (db != null && !db.isEmpty()) {
       databaseName = db;
     }
@@ -1214,13 +1227,22 @@ public class BoltNetworkExecutor extends Thread {
   /**
    * Ensure database is open and accessible.
    */
+  /**
+   * Whether {@code requestedDatabase} names a database other than the one this connection currently has open.
+   * {@code "system"} and {@code "neo4j"} are Neo4j virtual names that map to this connection's current (default)
+   * database, and an absent name means "keep the current one", so neither counts as a switch. Shared between the
+   * in-transaction guard in {@link #handleRun} and {@link #ensureDatabase()} so the two cannot drift apart.
+   */
+  private boolean isDatabaseSwitch(final String requestedDatabase) {
+    return database != null && database.isOpen()
+        && requestedDatabase != null && !requestedDatabase.isEmpty()
+        && !"system".equals(requestedDatabase) && !"neo4j".equals(requestedDatabase)
+        && !database.getName().equals(requestedDatabase);
+  }
+
   private boolean ensureDatabase() throws IOException {
     if (database != null && database.isOpen()) {
-      // Check if we need to switch to a different database
-      final String currentDbName = database.getName();
-      if (databaseName != null && !databaseName.isEmpty()
-          && !"system".equals(databaseName) && !"neo4j".equals(databaseName)
-          && !currentDbName.equals(databaseName)) {
+      if (isDatabaseSwitch(databaseName)) {
         // Database name changed, need to switch
         database = null;
       } else {

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -134,14 +134,6 @@ public class BoltNetworkExecutor extends Thread {
   private final boolean             debug;
   private final BoltNetworkListener listener; // For notifying when connection closes
 
-  /**
-   * Ceiling on result streams held open at once by one connection. Every one of them pins an engine ResultSet
-   * (cursors, pages) for as long as its transaction lives, and nothing in the protocol obliges a client ever to
-   * consume one, so an unbounded map here is a resource leak a single authenticated session could drive. No real
-   * driver holds more than a handful open.
-   */
-  private static final int MAX_OPEN_STREAMS = 1024;
-
   private State              state = State.DISCONNECTED;
   private int                protocolVersion;
   private ServerSecurityUser user;
@@ -677,7 +669,9 @@ public class BoltNetworkExecutor extends Thread {
 
     if (currentStream == stream) {
       // Fall back to the newest stream still open, so a following qid-less PULL/DISCARD keeps meaning "the last
-      // one opened". The scan is over a map that holds a handful of entries in the worst realistic case.
+      // one opened". This relies on openStreams being a LinkedHashMap: the last value the iteration yields is
+      // the most recently inserted one. The scan is over a map holding a handful of entries in the worst
+      // realistic case.
       currentStream = null;
       for (final BoltQueryStream open : openStreams.values())
         currentStream = open;
@@ -757,9 +751,15 @@ public class BoltNetworkExecutor extends Thread {
       return;
     }
 
-    if (openStreams.size() >= MAX_OPEN_STREAMS) {
+    // Every open stream pins an engine ResultSet (cursors, pages) for as long as its transaction lives, and
+    // nothing in the protocol obliges a client ever to consume one, so an unbounded map here is a resource leak a
+    // single authenticated session could drive. Read per RUN, like the other BOLT protocol limits, so a runtime
+    // change to the setting takes effect on the next message; floored at 1 since a ceiling of 0 would reject
+    // every query outright rather than lock anything down.
+    final int maxOpenStreams = Math.max(1, GlobalConfiguration.BOLT_MAX_OPEN_STREAMS.getValueAsInteger());
+    if (openStreams.size() >= maxOpenStreams) {
       sendFailure(BoltException.PROTOCOL_ERROR,
-          "Too many result streams open at once (max " + MAX_OPEN_STREAMS + "): consume or discard one first");
+          "Too many result streams open at once (max " + maxOpenStreams + "): consume or discard one first");
       state = State.FAILED;
       return;
     }

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -163,6 +163,13 @@ public class BoltNetworkExecutor extends Thread {
   /** Next qid to hand out, numbered from 0 per explicit transaction as a Neo4j server does. */
   private long nextQid;
 
+  /**
+   * The value {@code PullMessage}/{@code DiscardMessage} report when the client omits the qid, meaning "the
+   * stream opened last". It is the only sentinel: any other negative value is malformed and must fail the lookup
+   * rather than quietly act on whichever stream happens to be current.
+   */
+  private static final long OMITTED_QID = -1;
+
   public BoltNetworkExecutor(final ArcadeDBServer server, final Socket socket, final BoltNetworkListener listener) {
     this(server, socket, listener, null);
   }
@@ -622,17 +629,20 @@ public class BoltNetworkExecutor extends Thread {
       try {
         database.rollback();
       } catch (final Exception e) {
-        LogManager.instance().log(this, Level.FINE, "Failed to roll back the open transaction during teardown", e);
+        // WARNING, not FINE: teardown carries on either way, but a rollback that threw may have left the
+        // transaction only half cleaned up, which is worth seeing in the log.
+        LogManager.instance().log(this, Level.WARNING, "Failed to roll back the open transaction during teardown", e);
       }
     }
     explicitTransaction = false;
   }
 
   /**
-   * Selects the stream a PULL/DISCARD acts on. A qid of -1 - the default a driver sends when it omits the field
-   * - means the most recently opened stream; any other value names one explicitly, which is how a client
-   * interleaves several streams inside one transaction. A qid naming nothing fails the session, exactly as a
-   * PULL with no result set behind it did before.
+   * Selects the stream a PULL/DISCARD acts on. -1 is the only sentinel - it is what a driver sends when it omits
+   * the field, and it means the most recently opened stream; any other value names one explicitly, which is how a
+   * client interleaves several streams inside one transaction. A qid naming nothing, including a malformed
+   * negative one that is not the sentinel, fails the session, exactly as a PULL with no result set behind it did
+   * before.
    * <p>
    * Outside an explicit transaction the qid is ignored altogether: only one stream can be open there (RUN is not
    * valid in STREAMING), no qid is ever published in an auto-commit RUN SUCCESS, and the BOLT docs are explicit
@@ -640,9 +650,10 @@ public class BoltNetworkExecutor extends Thread {
    * "No active result set for qid ..." for the stream it is plainly asking about.
    */
   private BoltQueryStream resolveStream(final long qid) throws IOException {
-    final BoltQueryStream stream = qid < 0 || !explicitTransaction ? currentStream : openStreams.get(qid);
+    final BoltQueryStream stream = qid == OMITTED_QID || !explicitTransaction ? currentStream : openStreams.get(qid);
     if (stream == null) {
-      sendFailure(BoltException.PROTOCOL_ERROR, qid < 0 ? "No active result set" : "No active result set for qid " + qid);
+      sendFailure(BoltException.PROTOCOL_ERROR,
+          qid == OMITTED_QID ? "No active result set" : "No active result set for qid " + qid);
       state = State.FAILED;
       return null;
     }

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -134,6 +134,14 @@ public class BoltNetworkExecutor extends Thread {
   private final boolean             debug;
   private final BoltNetworkListener listener; // For notifying when connection closes
 
+  /**
+   * Ceiling on result streams held open at once by one connection. Every one of them pins an engine ResultSet
+   * (cursors, pages) for as long as its transaction lives, and nothing in the protocol obliges a client ever to
+   * consume one, so an unbounded map here is a resource leak a single authenticated session could drive. No real
+   * driver holds more than a handful open.
+   */
+  private static final int MAX_OPEN_STREAMS = 1024;
+
   private State              state = State.DISCONNECTED;
   private int                protocolVersion;
   private ServerSecurityUser user;
@@ -147,22 +155,21 @@ public class BoltNetworkExecutor extends Thread {
   private final BoltSession session = new BoltSession();
 
   /**
-   * Current result set for streaming results.
+   * Result streams open on this connection, keyed by qid and iterated in the order they were opened.
+   * <p>
+   * BOLT 4.0+ allows several open streams inside one explicit transaction, told apart by the qid a RUN returns
+   * and a PULL/DISCARD names (issue #6804). Outside a transaction there is at most one entry here.
+   * <p>
    * Thread-safety: This class is designed to handle a single connection in a dedicated thread.
    * All state variables are accessed only by the executor thread and do not require synchronization.
    */
-  private ResultSet          currentResultSet;
-  private List<String>       currentFields;
-  private Result             firstResult; // Buffered first result for field name extraction
-  private List<List<Object>> syntheticResults; // For system queries that return synthetic data
-  private int                recordsStreamed;
-  private long               queryStartTime; // Nanosecond timestamp when query execution started
-  private long               firstRecordTime; // Nanosecond timestamp when first record was retrieved
-  private boolean            isWriteOperation; // Whether the current query performs writes
-  // EXPLAIN / PROFILE state, populated in handleRun, surfaced in handlePull SUCCESS metadata
-  // so Neo4j drivers can read it via ResultSummary#plan() / #profile().
-  private Map<String, Object> currentPlanMetadata;
-  private String              currentPlanMetadataKey; // "plan" for EXPLAIN, "profile" for PROFILE
+  private final Map<Long, BoltQueryStream> openStreams = new LinkedHashMap<>();
+
+  /** Stream a PULL/DISCARD acts on when it carries no qid (or qid -1): the most recently opened one. */
+  private BoltQueryStream currentStream;
+
+  /** Next qid to hand out, numbered from 0 per explicit transaction as a Neo4j server does. */
+  private long nextQid;
 
   public BoltNetworkExecutor(final ArcadeDBServer server, final Socket socket, final BoltNetworkListener listener) {
     this(server, socket, listener, null);
@@ -582,12 +589,109 @@ public class BoltNetworkExecutor extends Thread {
 
   /**
    * Handle LOGOFF message.
+   * <p>
+   * BOLT 5.1 lists LOGOFF as valid only from READY, which is precisely the state where no result stream and no
+   * explicit transaction can be open. This handler used to be the one request handler with neither a state check
+   * nor any cleanup: a LOGOFF sent mid-stream or mid-transaction answered SUCCESS and left the ResultSet and the
+   * ArcadeDB transaction pinned on a connection the server had just stopped counting as authenticated. A
+   * following HELLO/LOGON as a different user came back to READY with that transaction still open, and its
+   * COMMIT then committed writes made before the user changed (issue #6803).
    */
   private void handleLogoff() throws IOException {
+    if (state == State.FAILED) {
+      sendIgnored();
+      return;
+    }
+
+    if (state != State.READY) {
+      sendFailure(BoltException.PROTOCOL_ERROR, "LOGOFF not expected in state: " + state);
+      state = State.FAILED;
+      return;
+    }
+
+    // Belt and braces: READY already implies no open stream and no open transaction, so nothing should be left
+    // to release here. Doing it anyway is what keeps "the server considers this connection unauthenticated" from
+    // ever meaning "and it still holds a transaction".
+    closeAllStreams("LOGOFF");
+    rollbackExplicitTransaction();
+
     user = null;
     markUnauthenticated();
     sendSuccess(Map.of());
     state = State.AUTHENTICATION;
+  }
+
+  /**
+   * Rolls back the explicit transaction, if any, and forgets it. Never throws: it runs on the teardown paths,
+   * where a rollback failure must not stop the rest of the teardown.
+   */
+  private void rollbackExplicitTransaction() {
+    if (explicitTransaction && database != null) {
+      try {
+        database.rollback();
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.FINE, "Failed to roll back the open transaction during teardown", e);
+      }
+    }
+    explicitTransaction = false;
+  }
+
+  /**
+   * Selects the stream a PULL/DISCARD acts on. A qid of -1 - the default a driver sends when it omits the field
+   * - means the most recently opened stream; any other value names one explicitly, which is how a client
+   * interleaves several streams inside one transaction. A qid naming nothing fails the session, exactly as a
+   * PULL with no result set behind it did before.
+   */
+  private BoltQueryStream resolveStream(final long qid) throws IOException {
+    final BoltQueryStream stream = qid < 0 ? currentStream : openStreams.get(qid);
+    if (stream == null) {
+      sendFailure(BoltException.PROTOCOL_ERROR, qid < 0 ? "No active result set" : "No active result set for qid " + qid);
+      state = State.FAILED;
+      return null;
+    }
+    return stream;
+  }
+
+  /**
+   * Registers a freshly executed query as an open stream and makes it the target of a qid-less PULL/DISCARD.
+   */
+  private void openStream(final BoltQueryStream stream) {
+    openStreams.put(stream.qid, stream);
+    currentStream = stream;
+    ++nextQid;
+  }
+
+  /**
+   * Completes one stream: releases it and, once nothing is left open, leaves STREAMING / TX_STREAMING. With
+   * several streams open in one transaction the session stays in TX_STREAMING until the last one is drained or
+   * discarded.
+   */
+  private void closeStream(final BoltQueryStream stream, final String phase) {
+    stream.close(this, phase);
+    openStreams.remove(stream.qid);
+
+    if (currentStream == stream) {
+      // Fall back to the newest stream still open, so a following qid-less PULL/DISCARD keeps meaning "the last
+      // one opened". The scan is over a map that holds a handful of entries in the worst realistic case.
+      currentStream = null;
+      for (final BoltQueryStream open : openStreams.values())
+        currentStream = open;
+    }
+
+    if (openStreams.isEmpty())
+      state = explicitTransaction ? State.TX_READY : State.READY;
+  }
+
+  /**
+   * Releases every open result stream, for the teardown paths (RESET, LOGOFF, ROLLBACK, connection close) where
+   * whatever the client left open has to go regardless of how many streams there were.
+   */
+  private void closeAllStreams(final String phase) {
+    for (final BoltQueryStream stream : openStreams.values())
+      stream.close(this, phase);
+    openStreams.clear();
+    currentStream = null;
+    nextQid = 0;
   }
 
   /**
@@ -601,35 +705,16 @@ public class BoltNetworkExecutor extends Thread {
    * Handle RESET message - reset to initial state.
    */
   private void handleReset() throws IOException {
-    // Close any open result set
-    if (currentResultSet != null) {
-      try {
-        currentResultSet.close();
-      } catch (final Exception e) {
-        LogManager.instance().log(this, Level.WARNING, "Failed to close ResultSet during RESET", e);
-      }
-    }
+    // Close every open result set
+    closeAllStreams("RESET");
 
     // Rollback any open transaction
-    if (explicitTransaction && database != null) {
-      try {
-        database.rollback();
-      } catch (final Exception e) {
-        // Ignore
-      }
-    }
+    rollbackExplicitTransaction();
 
     // NOTE: do not clear the GQL session parameters here. The Bolt RESET message is connection-level
     // housekeeping the driver sends when recycling a pooled connection, not a user request to reset GQL
     // session state; clearing here would drop SESSION SET parameters between auto-commit queries. GQL
     // session parameters are cleared only by an explicit SESSION RESET / SESSION CLOSE statement.
-
-    explicitTransaction = false;
-    currentResultSet = null;
-    currentFields = null;
-    firstResult = null;
-    currentPlanMetadata = null;
-    currentPlanMetadataKey = null;
 
     sendSuccess(Map.of());
 
@@ -652,8 +737,21 @@ public class BoltNetworkExecutor extends Thread {
       return;
     }
 
-    if (state != State.READY && state != State.TX_READY) {
+    // TX_STREAMING accepts RUN: BOLT 4.0+ lets a client hold several result streams open inside one explicit
+    // transaction and tell them apart by qid, which is the entire reason that field exists (issue #6804). Any
+    // driver configured with a fetch size smaller than the first query's row count leaves the first stream open,
+    // so a second query in the same transaction used to be answered with a protocol error that failed the
+    // session and lost the transaction. STREAMING deliberately does NOT accept RUN, matching the BOLT state
+    // machine: outside a transaction there is nothing to multiplex onto.
+    if (state != State.READY && state != State.TX_READY && state != State.TX_STREAMING) {
       sendFailure(BoltException.PROTOCOL_ERROR, "RUN not expected in state: " + state);
+      state = State.FAILED;
+      return;
+    }
+
+    if (openStreams.size() >= MAX_OPEN_STREAMS) {
+      sendFailure(BoltException.PROTOCOL_ERROR,
+          "Too many result streams open at once (max " + MAX_OPEN_STREAMS + "): consume or discard one first");
       state = State.FAILED;
       return;
     }
@@ -670,10 +768,10 @@ public class BoltNetworkExecutor extends Thread {
     if (debug)
       LogManager.instance().log(this, Level.FINE, "BOLT executing: %s with params %s (db=%s)", query, params, databaseName);
 
+    final BoltQueryStream stream = new BoltQueryStream(nextQid);
+
     // Start timing for performance metrics
-    queryStartTime = System.nanoTime();
-    firstRecordTime = 0;
-    syntheticResults = null;
+    stream.queryStartTime = System.nanoTime();
 
     // Ensure database is open (maps "system"/"neo4j" to default database). This also attaches the
     // connection's GQL session to the thread context, which the engine reads for SESSION statements.
@@ -681,15 +779,13 @@ public class BoltNetworkExecutor extends Thread {
       return;
 
     // Intercept known system queries (CALL dbms.components(), SHOW DATABASES, etc.)
-    if (handleSystemQuery(query)) {
-      currentResultSet = null;
-      firstResult = null;
-      recordsStreamed = 0;
-      isWriteOperation = false;
+    if (handleSystemQuery(query, stream)) {
+      openStream(stream);
 
       final Map<String, Object> metadata = new LinkedHashMap<>();
-      metadata.put("fields", currentFields);
+      metadata.put("fields", stream.fields);
       metadata.put("t_first", 0L);
+      addQidMetadata(metadata, stream);
       sendSuccess(metadata);
       state = explicitTransaction ? State.TX_STREAMING : State.STREAMING;
       return;
@@ -697,74 +793,91 @@ public class BoltNetworkExecutor extends Thread {
 
     try {
       // Determine if this is a write query using the query analyzer
-      isWriteOperation = isWriteQuery(query);
+      stream.writeOperation = isWriteQuery(query);
 
       // Detect EXPLAIN / PROFILE prefix so we can later surface the execution plan
       // in PULL SUCCESS metadata (consumed by Neo4j drivers as ResultSummary#plan / #profile).
       // The OpenCypher engine itself also strips the prefix, but we need to know which one
       // was present here to choose between record-streaming (PROFILE) and plan-only (EXPLAIN)
       // and to pick the correct metadata key.
-      currentPlanMetadata = null;
-      currentPlanMetadataKey = null;
       final String trimmedQuery = query == null ? "" : query.trim();
       final String upperQuery = trimmedQuery.toUpperCase();
       final boolean explainMode = upperQuery.startsWith("EXPLAIN ");
       final boolean profileMode = !explainMode && upperQuery.startsWith("PROFILE ");
 
       // Use command() for writes, query() for reads
-      if (isWriteOperation) {
-        currentResultSet = database.command("opencypher", query, params);
+      if (stream.writeOperation) {
+        stream.resultSet = database.command("opencypher", query, params);
       } else {
-        currentResultSet = database.query("opencypher", query, params);
+        stream.resultSet = database.query("opencypher", query, params);
       }
 
       // Capture the plan from the engine. EXPLAIN returns ExplainResultSet (one synthetic row
       // exposing getExecutionPlan()); PROFILE returns InternalResultSet with setPlan() set.
       if (explainMode || profileMode) {
-        currentPlanMetadataKey = explainMode ? "plan" : "profile";
-        currentPlanMetadata = buildPlanMetadata(currentResultSet, profileMode);
+        stream.planMetadataKey = explainMode ? "plan" : "profile";
+        stream.planMetadata = buildPlanMetadata(stream.resultSet, profileMode);
         if (explainMode) {
           // For EXPLAIN, the only "row" in the result set is the plan itself: drain it so that
           // the client sees zero records, matching Neo4j's EXPLAIN semantics.
-          drainResultSet(currentResultSet);
+          drainResultSet(stream.resultSet);
         }
       }
 
-      currentFields = extractFieldNames(currentResultSet);
-      recordsStreamed = 0;
+      stream.fields = extractFieldNames(stream.resultSet, stream);
+
+      // The plan above is necessarily built before this query's column list is known (for EXPLAIN the rows have
+      // to be drained first), so its identifiers are filled in here. Reading them from a connection-wide field
+      // at build time, as this used to, meant the plan carried whatever the PREVIOUS query returned.
+      if (stream.planMetadata != null)
+        stream.planMetadata.put("identifiers", stream.fields);
 
       if (debug) {
-        LogManager.instance().log(this, Level.FINE, "BOLT query fields=%s firstResult=%s", currentFields,
-            firstResult != null ? firstResult.toJSON() : "null");
+        LogManager.instance().log(this, Level.FINE, "BOLT query fields=%s firstResult=%s", stream.fields,
+            stream.firstResult != null ? stream.firstResult.toJSON() : "null");
       }
+
+      openStream(stream);
 
       // Build success response with query metadata
       final Map<String, Object> metadata = new LinkedHashMap<>();
-      metadata.put("fields", currentFields);
+      metadata.put("fields", stream.fields);
 
       // Calculate time to first record if we already have one buffered
-      if (firstResult != null && firstRecordTime > 0) {
-        final long tFirstMs = (firstRecordTime - queryStartTime) / 1_000_000;
+      if (stream.firstResult != null && stream.firstRecordTime > 0) {
+        final long tFirstMs = (stream.firstRecordTime - stream.queryStartTime) / 1_000_000;
         metadata.put("t_first", tFirstMs);
       } else {
         metadata.put("t_first", 0L);
       }
+      addQidMetadata(metadata, stream);
 
       sendSuccess(metadata);
       state = explicitTransaction ? State.TX_STREAMING : State.STREAMING;
 
     } catch (final CommandParsingException e) {
+      stream.close(this, "RUN failure");
       final String parseMsg = e.getMessage() != null ? e.getMessage() : "Query parsing error";
       sendFailure(classifyParsingError(e), parseMsg);
       state = State.FAILED;
     } catch (final Exception e) {
       // MVCC conflicts (NeedRetryException) are expected under contention and auto-retried by the driver,
       // so log them at FINE to avoid flooding WARNING with normal, recoverable flow; genuine errors stay WARNING.
+      stream.close(this, "RUN failure");
       LogManager.instance().log(this, isRetryableConflict(e) ? Level.FINE : Level.WARNING, "BOLT query error", e);
       final String errorMsg = e.getMessage() != null ? e.getMessage() : "Database error";
       sendFailure(classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR), errorMsg);
       state = State.FAILED;
     }
+  }
+
+  /**
+   * Adds the stream's qid to a RUN SUCCESS, but only inside an explicit transaction: that is where a client may
+   * open more than one stream and therefore needs to name them, and it matches what a Neo4j server sends.
+   */
+  private void addQidMetadata(final Map<String, Object> metadata, final BoltQueryStream stream) {
+    if (explicitTransaction)
+      metadata.put("qid", stream.qid);
   }
 
   /**
@@ -782,81 +895,61 @@ public class BoltNetworkExecutor extends Thread {
       return;
     }
 
-    if (currentResultSet == null && syntheticResults == null) {
-      sendFailure(BoltException.PROTOCOL_ERROR, "No active result set");
-      state = State.FAILED;
+    final BoltQueryStream stream = resolveStream(message.getQid());
+    if (stream == null)
       return;
-    }
 
     try {
       final long n = message.getN();
       long count = 0;
 
       // Handle synthetic results (from system queries)
-      if (syntheticResults != null) {
-        while (!syntheticResults.isEmpty() && (n < 0 || count < n)) {
-          sendRecord(syntheticResults.remove(0));
+      if (stream.syntheticResults != null) {
+        while (!stream.syntheticResults.isEmpty() && (n < 0 || count < n)) {
+          sendRecord(stream.syntheticResults.remove(0));
           count++;
-          recordsStreamed++;
         }
       } else {
         // First, return the buffered first result if present
-        if (firstResult != null && (n < 0 || count < n)) {
-          final List<Object> values = extractRecordValues(firstResult);
-          sendRecord(values);
+        if (stream.firstResult != null && (n < 0 || count < n)) {
+          sendRecord(extractRecordValues(stream.firstResult, stream.fields));
           count++;
-          recordsStreamed++;
-          firstResult = null;
+          stream.firstResult = null;
         }
 
         // Then continue with the rest of the result set
-        while (currentResultSet.hasNext() && (n < 0 || count < n)) {
-          final Result record = currentResultSet.next();
-          final List<Object> values = extractRecordValues(record);
-
-          sendRecord(values);
+        while (stream.resultSet.hasNext() && (n < 0 || count < n)) {
+          sendRecord(extractRecordValues(stream.resultSet.next(), stream.fields));
           count++;
-          recordsStreamed++;
         }
       }
 
-      final boolean hasMore = syntheticResults != null ? !syntheticResults.isEmpty()
-          : (firstResult != null || currentResultSet.hasNext());
+      final boolean hasMore = stream.hasMore();
 
       // Build success metadata
       final Map<String, Object> metadata = new LinkedHashMap<>();
       if (!hasMore) {
         // Determine query type based on whether it performed writes
         // r=read, w=write (for simplicity, we use binary classification)
-        metadata.put("type", isWriteOperation ? "w" : "r");
+        metadata.put("type", stream.writeOperation ? "w" : "r");
 
         // Calculate time to last record
-        final long tLastMs = (System.nanoTime() - queryStartTime) / 1_000_000;
+        final long tLastMs = (System.nanoTime() - stream.queryStartTime) / 1_000_000;
         metadata.put("t_last", tLastMs);
 
         // Surface execution plan from EXPLAIN / PROFILE (PME) so neo4j drivers populate
         // ResultSummary#plan() / #profile() instead of returning null.
-        if (currentPlanMetadata != null && currentPlanMetadataKey != null)
-          metadata.put(currentPlanMetadataKey, currentPlanMetadata);
+        if (stream.planMetadata != null && stream.planMetadataKey != null)
+          metadata.put(stream.planMetadataKey, stream.planMetadata);
 
-        if (currentResultSet != null) {
-          final Optional<QueryStatistics> stats = currentResultSet.getStatistics();
+        if (stream.resultSet != null) {
+          final Optional<QueryStatistics> stats = stream.resultSet.getStatistics();
           if (stats.isPresent() && stats.get().containsUpdates())
             metadata.put("stats", BoltResultStats.toStatsMap(stats.get()));
-
-          try {
-            currentResultSet.close();
-          } catch (final Exception e) {
-            LogManager.instance().log(this, Level.WARNING, "Failed to close ResultSet during PULL completion", e);
-          }
         }
-        currentResultSet = null;
-        currentFields = null;
-        firstResult = null;
-        syntheticResults = null;
-        currentPlanMetadata = null;
-        currentPlanMetadataKey = null;
-        state = explicitTransaction ? State.TX_READY : State.READY;
+
+        // Leaves TX_STREAMING only once this connection has no other stream still open.
+        closeStream(stream, "PULL completion");
       }
       metadata.put("has_more", hasMore);
 
@@ -887,40 +980,35 @@ public class BoltNetworkExecutor extends Thread {
       return;
     }
 
+    final BoltQueryStream stream = resolveStream(discardMessage.getQid());
+    if (stream == null)
+      return;
+
     // Discard all remaining records
     Optional<QueryStatistics> stats = Optional.empty();
-    if (currentResultSet != null) {
+    if (stream.resultSet != null) {
       // Statistics are computed eagerly when the write is materialized in the query plan, so they
       // are valid to read before draining/closing the result set.
-      stats = currentResultSet.getStatistics();
-      while (currentResultSet.hasNext()) {
-        currentResultSet.next();
-      }
-      try {
-        currentResultSet.close();
-      } catch (final Exception e) {
-        LogManager.instance().log(this, Level.WARNING, "Failed to close ResultSet during DISCARD", e);
+      stats = stream.resultSet.getStatistics();
+      while (stream.resultSet.hasNext()) {
+        stream.resultSet.next();
       }
     }
 
-    currentResultSet = null;
-    currentFields = null;
-    firstResult = null;
-    syntheticResults = null;
-
     final Map<String, Object> metadata = new LinkedHashMap<>();
     // Even on DISCARD we still surface the plan so EXPLAIN clients that DISCARD instead
-    // of PULL still get ResultSummary#plan / #profile populated.
-    if (currentPlanMetadata != null && currentPlanMetadataKey != null)
-      metadata.put(currentPlanMetadataKey, currentPlanMetadata);
-    currentPlanMetadata = null;
-    currentPlanMetadataKey = null;
+    // of PULL still get ResultSummary#plan / #profile populated. Read before the stream is released,
+    // which clears it.
+    if (stream.planMetadata != null && stream.planMetadataKey != null)
+      metadata.put(stream.planMetadataKey, stream.planMetadata);
     if (stats.isPresent() && stats.get().containsUpdates())
       metadata.put("stats", BoltResultStats.toStatsMap(stats.get()));
     metadata.put("has_more", false);
 
+    // Leaves TX_STREAMING only once this connection has no other stream still open.
+    closeStream(stream, "DISCARD");
+
     sendSuccess(metadata);
-    state = explicitTransaction ? State.TX_READY : State.READY;
   }
 
   /**
@@ -951,6 +1039,7 @@ public class BoltNetworkExecutor extends Thread {
     try {
       database.begin();
       explicitTransaction = true;
+      nextQid = 0; // qids are numbered per explicit transaction
 
       sendSuccess(Map.of());
       state = State.TX_READY;
@@ -1020,20 +1109,11 @@ public class BoltNetworkExecutor extends Thread {
     }
 
     try {
-      if (currentResultSet != null) {
-        try {
-          currentResultSet.close();
-        } catch (final Exception e) {
-          LogManager.instance().log(this, Level.WARNING, "Failed to close ResultSet during ROLLBACK", e);
-        }
-      }
+      closeAllStreams("ROLLBACK");
       if (database != null) {
         database.rollback();
       }
       explicitTransaction = false;
-      currentResultSet = null;
-      currentFields = null;
-      firstResult = null;
 
       sendSuccess(Map.of());
       state = State.READY;
@@ -1193,82 +1273,83 @@ public class BoltNetworkExecutor extends Thread {
 
   /**
    * Handles known Neo4j system queries (e.g., dbms.components, SHOW DATABASES).
-   * Returns true if the query was handled as a system query, false if it should be executed normally.
+   * Returns true if the query was handled as a system query - populating {@code stream} with the synthetic
+   * fields and rows to serve - false if it should be executed normally.
    */
-  private boolean handleSystemQuery(final String query) throws IOException {
+  private boolean handleSystemQuery(final String query, final BoltQueryStream stream) throws IOException {
     final String normalized = BoltSystemProcedures.normalize(query);
 
     if (normalized.contains("dbms.components")) {
       // CALL dbms.components() - returns server version info
-      currentFields = List.of("name", "versions", "edition");
-      syntheticResults = new ArrayList<>();
-      syntheticResults.add(List.of("Neo4j Kernel", List.of("5.26.0"), "community"));
+      stream.fields = List.of("name", "versions", "edition");
+      stream.syntheticResults = new ArrayList<>();
+      stream.syntheticResults.add(List.of("Neo4j Kernel", List.of("5.26.0"), "community"));
       return true;
 
     } else if (normalized.startsWith("show database") || normalized.contains("dbms.showdatabase")
         || normalized.contains("dbms.listdatabases")) {
       // SHOW DATABASES or CALL dbms.listDatabases()
-      currentFields = List.of("name", "type", "aliases", "access", "address", "role",
+      stream.fields = List.of("name", "type", "aliases", "access", "address", "role",
           "writer", "requestedStatus", "currentStatus", "statusMessage", "default", "home",
           "constituents");
-      syntheticResults = new ArrayList<>();
+      stream.syntheticResults = new ArrayList<>();
       for (final String dbName : server.getDatabaseNames()) {
-        syntheticResults.add(List.of(dbName, "standard", List.of(), "read-write",
+        stream.syntheticResults.add(List.of(dbName, "standard", List.of(), "read-write",
             getBoltAddress(GlobalConfiguration.BOLT_PORT.getValueAsInteger()), "primary",
             true, "online", "online", "", dbName.equals(database != null ? database.getName() : ""), false,
             List.of()));
       }
       // Also add the virtual "system" database entry
-      syntheticResults.add(List.of("system", "system", List.of(), "read-write",
+      stream.syntheticResults.add(List.of("system", "system", List.of(), "read-write",
           getBoltAddress(GlobalConfiguration.BOLT_PORT.getValueAsInteger()), "primary",
           false, "online", "online", "", false, false, List.of()));
       return true;
 
     } else if (normalized.contains("show current user") || normalized.contains("dbms.showcurrentuser")) {
       // SHOW CURRENT USER or CALL dbms.showCurrentUser()
-      currentFields = List.of("user", "roles", "passwordChangeRequired", "suspended", "home");
-      syntheticResults = new ArrayList<>();
+      stream.fields = List.of("user", "roles", "passwordChangeRequired", "suspended", "home");
+      stream.syntheticResults = new ArrayList<>();
       final List<Object> userRecord = new ArrayList<>();
       userRecord.add(user != null ? user.getName() : "anonymous");
       userRecord.add(List.of("admin"));
       userRecord.add(false);
       userRecord.add(false);
       userRecord.add(null); // home database (null = use default)
-      syntheticResults.add(userRecord);
+      stream.syntheticResults.add(userRecord);
       return true;
 
     } else if (normalized.contains("dbms.info")) {
       // CALL dbms.info() - returns basic server info
-      currentFields = List.of("id", "name", "creationDate");
-      syntheticResults = new ArrayList<>();
-      syntheticResults.add(List.of("arcadedb-" + server.getServerName(), server.getServerName(), ""));
+      stream.fields = List.of("id", "name", "creationDate");
+      stream.syntheticResults = new ArrayList<>();
+      stream.syntheticResults.add(List.of("arcadedb-" + server.getServerName(), server.getServerName(), ""));
       return true;
 
     } else if (normalized.contains("db.ping")) {
       // CALL db.ping() - health check
-      currentFields = List.of("success");
-      syntheticResults = new ArrayList<>();
-      syntheticResults.add(List.of(true));
+      stream.fields = List.of("success");
+      stream.syntheticResults = new ArrayList<>();
+      stream.syntheticResults.add(List.of(true));
       return true;
 
     } else if (normalized.contains("dbms.clientconfig")) {
       // CALL dbms.clientConfig() - client configuration
-      currentFields = List.of("name", "value");
-      syntheticResults = new ArrayList<>();
+      stream.fields = List.of("name", "value");
+      stream.syntheticResults = new ArrayList<>();
       return true;
 
     } else if (normalized.startsWith("show procedure")) {
       // SHOW PROCEDURES YIELD * - return empty list
-      currentFields = List.of("name", "description", "mode", "worksOnSystem", "argumentDescription",
+      stream.fields = List.of("name", "description", "mode", "worksOnSystem", "argumentDescription",
           "returnDescription", "admin", "option");
-      syntheticResults = new ArrayList<>();
+      stream.syntheticResults = new ArrayList<>();
       return true;
 
     } else if (normalized.startsWith("show function")) {
       // SHOW FUNCTIONS YIELD * - return empty list
-      currentFields = List.of("name", "category", "description", "isBuiltIn", "argumentDescription",
+      stream.fields = List.of("name", "category", "description", "isBuiltIn", "argumentDescription",
           "returnDescription", "aggregating");
-      syntheticResults = new ArrayList<>();
+      stream.syntheticResults = new ArrayList<>();
       return true;
 
     } else if (BoltSystemProcedures.isSchemaProcedureQuery(normalized)) {
@@ -1280,8 +1361,8 @@ public class BoltNetworkExecutor extends Thread {
       final BoltSystemProcedures.Served served = BoltSystemProcedures.serveSchemaProcedure(database, normalized);
       if (served == null)
         return false;
-      currentFields = served.fields();
-      syntheticResults = served.rows();
+      stream.fields = served.fields();
+      stream.syntheticResults = served.rows();
       return true;
 
     } else if (normalized.startsWith("show index")
@@ -1294,9 +1375,9 @@ public class BoltNetworkExecutor extends Thread {
         || normalized.startsWith("show vector index")
         || normalized.startsWith("show sparse_vector index")) {
       // SHOW INDEXES / SHOW ... INDEXES - list indexes from ArcadeDB schema
-      currentFields = List.of("id", "name", "state", "populationPercent", "type", "entityType",
+      stream.fields = List.of("id", "name", "state", "populationPercent", "type", "entityType",
           "labelsOrTypes", "properties", "indexProvider", "owningConstraint", "lastRead", "readCount");
-      syntheticResults = buildShowIndexesResults(normalized);
+      stream.syntheticResults = buildShowIndexesResults(normalized);
       return true;
 
     } else if (normalized.startsWith("show constraint")
@@ -1318,16 +1399,16 @@ public class BoltNetworkExecutor extends Thread {
         || normalized.startsWith("show node property type constraint")
         || normalized.startsWith("show relationship property type constraint")) {
       // SHOW CONSTRAINTS / SHOW ... CONSTRAINTS - list constraints from ArcadeDB schema
-      currentFields = List.of("id", "name", "type", "entityType", "labelsOrTypes", "properties",
+      stream.fields = List.of("id", "name", "type", "entityType", "labelsOrTypes", "properties",
           "ownedIndex", "propertyType");
-      syntheticResults = buildShowConstraintsResults(normalized);
+      stream.syntheticResults = buildShowConstraintsResults(normalized);
       return true;
 
     } else if (normalized.contains("dbms.licenseagreementdetails")) {
       // CALL dbms.licenseAgreementDetails() - return empty/default
-      currentFields = List.of("name", "status", "version");
-      syntheticResults = new ArrayList<>();
-      syntheticResults.add(List.of("ArcadeDB", "active", "community"));
+      stream.fields = List.of("name", "status", "version");
+      stream.syntheticResults = new ArrayList<>();
+      stream.syntheticResults.add(List.of("ArcadeDB", "active", "community"));
       return true;
     }
 
@@ -1544,27 +1625,27 @@ public class BoltNetworkExecutor extends Thread {
    * For single-element results (e.g., RETURN n), the projection name is stored
    * in metadata by FinalProjectionStep and used here to preserve field names.
    */
-  private List<String> extractFieldNames(final ResultSet resultSet) {
+  private List<String> extractFieldNames(final ResultSet resultSet, final BoltQueryStream stream) {
     if (resultSet == null) {
       return List.of();
     }
 
     // Peek at first result to get field names
     if (resultSet.hasNext()) {
-      firstResult = resultSet.next();
-      firstRecordTime = System.nanoTime(); // Capture time when first record is available
+      stream.firstResult = resultSet.next();
+      stream.firstRecordTime = System.nanoTime(); // Capture time when first record is available
 
       // Check if this is an unwrapped element with a projection name in metadata
       // This happens for queries like "MATCH (n) RETURN n" where the vertex is
       // returned directly but we need to preserve the field name "n" for Bolt protocol
-      if (firstResult.isElement()) {
-        final Object projectionName = firstResult.getMetadata(PROJECTION_NAME_METADATA);
+      if (stream.firstResult.isElement()) {
+        final Object projectionName = stream.firstResult.getMetadata(PROJECTION_NAME_METADATA);
         if (projectionName instanceof String name) {
           return List.of(name);
         }
       }
 
-      final Set<String> propertyNames = firstResult.getPropertyNames();
+      final Set<String> propertyNames = stream.firstResult.getPropertyNames();
       return propertyNames != null ? new ArrayList<>(propertyNames) : List.of();
     }
 
@@ -1578,7 +1659,7 @@ public class BoltNetworkExecutor extends Thread {
    * For element results (e.g., RETURN n where n is a vertex), the whole element
    * is returned as a single value, converted to BoltNode/BoltRelationship.
    */
-  private List<Object> extractRecordValues(final Result result) {
+  private List<Object> extractRecordValues(final Result result, final List<String> fields) {
     final List<Object> values = new ArrayList<>();
 
     // Check if this is an unwrapped element result
@@ -1588,7 +1669,7 @@ public class BoltNetworkExecutor extends Thread {
       values.add(BoltStructureMapper.toPackStreamValue(result.getElement().orElse(null)));
     } else {
       // Standard projection result - extract each field
-      for (final String field : currentFields) {
+      for (final String field : fields) {
         final Object value = result.getProperty(field);
         values.add(BoltStructureMapper.toPackStreamValue(value));
       }
@@ -1662,7 +1743,10 @@ public class BoltNetworkExecutor extends Thread {
 
     final Map<String, Object> root = new LinkedHashMap<>();
     root.put("operatorType", profileMode ? "ArcadeDB.OpenCypher.ProfilePlan" : "ArcadeDB.OpenCypher.Plan");
-    root.put("identifiers", currentFields != null ? currentFields : List.<String>of());
+    // Placeholder: the caller overwrites this with the query's own column list once it is known (the map keeps
+    // the key's position). The plan has to be captured before the EXPLAIN rows are drained, i.e. before the
+    // columns can be read off the result set.
+    root.put("identifiers", List.<String>of());
     root.put("args", args);
     root.put("children", List.<Map<String, Object>>of());
 
@@ -1996,22 +2080,8 @@ public class BoltNetworkExecutor extends Thread {
    * Cleanup resources when connection closes.
    */
   private void cleanup() {
-    try {
-      if (currentResultSet != null) {
-        currentResultSet.close();
-        currentResultSet = null;
-      }
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING, "Failed to close ResultSet during cleanup", e);
-    }
-
-    try {
-      if (explicitTransaction && database != null) {
-        database.rollback();
-      }
-    } catch (final Exception e) {
-      // Ignore
-    }
+    closeAllStreams("connection close");
+    rollbackExplicitTransaction();
 
     // Database is managed by the server - just release our reference
     // DO NOT close the shared database instance

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltQueryStream.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltQueryStream.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.log.LogManager;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+/**
+ * One open BOLT result stream, i.e. everything a single RUN produced that a later PULL/DISCARD needs.
+ * <p>
+ * BOLT 4.0 introduced the {@code qid} field precisely so a client can hold several result streams open at once
+ * inside one explicit transaction: RUN is valid from TX_STREAMING, and PULL/DISCARD name the stream they act on.
+ * Before issue #6804 this state lived in a single set of fields on {@code BoltNetworkExecutor}, which made more
+ * than one open stream unrepresentable - so a second RUN in a transaction whose first stream still had rows was
+ * rejected as a protocol error and the session was lost.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class BoltQueryStream {
+  /**
+   * Identifier returned in the RUN SUCCESS metadata and accepted back on PULL/DISCARD. Numbered per explicit
+   * transaction, starting at 0, matching what a Neo4j server returns.
+   */
+  final long qid;
+
+  /** Null for a synthetic (system-query) stream, which serves its rows from {@link #syntheticResults}. */
+  ResultSet resultSet;
+
+  /** Column names of this query, as sent in the RUN SUCCESS "fields" metadata. */
+  List<String> fields;
+
+  /**
+   * First row, consumed by {@code extractFieldNames} to derive {@link #fields} and therefore already off the
+   * result set: PULL must emit it before pulling anything else.
+   */
+  Result firstResult;
+
+  /** Rows of a system query (SHOW DATABASES, CALL dbms.components(), ...) answered without the engine. */
+  List<List<Object>> syntheticResults;
+
+  boolean writeOperation;
+
+  long queryStartTime;  // System.nanoTime() when execution started, for the t_first/t_last metadata
+  long firstRecordTime; // System.nanoTime() when the first row became available, 0 if there was none
+
+  /** EXPLAIN/PROFILE plan surfaced in the PULL/DISCARD SUCCESS metadata, and the key it goes under. */
+  Map<String, Object> planMetadata;
+  String              planMetadataKey;
+
+  BoltQueryStream(final long qid) {
+    this.qid = qid;
+  }
+
+  /**
+   * True while this stream still owes the client rows. A synthetic stream is done when its buffered rows run
+   * out; an engine-backed one when neither the peeked first row nor the result set has anything left.
+   */
+  boolean hasMore() {
+    if (syntheticResults != null)
+      return !syntheticResults.isEmpty();
+    return firstResult != null || (resultSet != null && resultSet.hasNext());
+  }
+
+  /**
+   * Releases the engine resources behind this stream. Never throws: it runs on the teardown paths (PULL
+   * completion, DISCARD, RESET, ROLLBACK, LOGOFF, connection close) where a failure to close one stream must
+   * not stop the others from being released.
+   */
+  void close(final Object requester, final String phase) {
+    if (resultSet != null) {
+      try {
+        resultSet.close();
+      } catch (final Exception e) {
+        LogManager.instance().log(requester, Level.WARNING, "Failed to close ResultSet during " + phase, e);
+      }
+      resultSet = null;
+    }
+    fields = null;
+    firstResult = null;
+    syntheticResults = null;
+    planMetadata = null;
+    planMetadataKey = null;
+  }
+}

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltWebSocketInputStream.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltWebSocketInputStream.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.bolt;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +26,13 @@ import java.io.InputStream;
 /**
  * InputStream that reads WebSocket frames and returns the unframed payload bytes.
  * Used to transport Bolt protocol over WebSocket connections (e.g. Neo4j Desktop).
+ * <p>
+ * RFC 6455 lets a peer split one message across a data frame with FIN=0 followed by any number of continuation
+ * frames (opcode 0x0), and nothing in the BOLT WebSocket upgrade negotiates that away, so a client stack is free
+ * to fragment a large send (a big parameter map, a long query string) at any byte boundary. Fragments are
+ * reassembled here before the payload reaches the BOLT dechunker: previously the continuation frames were read,
+ * unmasked and then dropped through the {@code default} branch, handing the dechunker a truncated byte stream
+ * rather than an error (issue #6802).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -35,6 +43,13 @@ class BoltWebSocketInputStream extends InputStream {
   private int     bufferPos;
   private int     bufferLen;
   private boolean closed;
+
+  /**
+   * Payload accumulated so far for a message whose first data frame carried FIN=0. Non-null exactly while a
+   * fragmented message is in progress, which is also what tells a legal continuation frame from a stray one.
+   * Allocated only when a client actually fragments, so the common unfragmented path stays allocation-free.
+   */
+  private ByteArrayOutputStream fragments;
 
   BoltWebSocketInputStream(final InputStream in, final long maxFrameSize) {
     this.in = new DataInputStream(in);
@@ -76,6 +91,7 @@ class BoltWebSocketInputStream extends InputStream {
       final int b0 = in.readUnsignedByte();
       final int b1 = in.readUnsignedByte();
 
+      final boolean fin = (b0 & 0x80) != 0;
       final int opcode = b0 & 0x0F;
       final boolean masked = (b1 & 0x80) != 0;
       long payloadLen = b1 & 0x7F;
@@ -87,6 +103,22 @@ class BoltWebSocketInputStream extends InputStream {
 
       if (payloadLen < 0 || payloadLen > maxFrameSize)
         throw new IOException("BOLT WebSocket frame too large: " + payloadLen + " bytes (max " + maxFrameSize + ")");
+
+      // A control frame (0x8-0xF) must not be fragmented and carries at most 125 payload bytes (RFC 6455 5.5).
+      // Rejected from the header alone, before the payload is read, so a malformed control frame cannot be used
+      // to smuggle bytes into - or out of - the reassembly buffer of the message it is interleaved with.
+      if (opcode >= 0x8) {
+        if (!fin)
+          throw new IOException("BOLT WebSocket control frame must not be fragmented (opcode 0x" + Integer.toHexString(opcode) + ")");
+        if (payloadLen > 125)
+          throw new IOException("BOLT WebSocket control frame payload too large: " + payloadLen + " bytes (max 125)");
+      }
+
+      // The accumulated message, not just this frame, is what has to stay inside the cap: otherwise a client
+      // could fragment its way past maxFrameSize one legal-looking frame at a time.
+      if (fragments != null && fragments.size() + payloadLen > maxFrameSize)
+        throw new IOException(
+            "BOLT WebSocket fragmented message too large: " + (fragments.size() + payloadLen) + " bytes (max " + maxFrameSize + ")");
 
       byte[] maskKey = null;
       if (masked) {
@@ -104,20 +136,45 @@ class BoltWebSocketInputStream extends InputStream {
       }
 
       switch (opcode) {
+      case 0x0: // continuation of the data frame that opened with FIN=0
+        if (fragments == null)
+          throw new IOException("BOLT WebSocket continuation frame without a preceding fragmented data frame");
+        fragments.writeBytes(payload);
+        if (!fin)
+          continue; // more fragments to come
+        deliver(fragments.toByteArray());
+        fragments = null;
+        return true;
       case 0x1: // text frame
       case 0x2: // binary frame
-        buffer = payload;
-        bufferPos = 0;
-        bufferLen = payload.length;
-        return true;
+        if (fragments != null)
+          throw new IOException("BOLT WebSocket data frame received while a fragmented message was still open");
+        if (fin) {
+          deliver(payload); // the common case: one whole message in one frame, no copy
+          return true;
+        }
+        fragments = new ByteArrayOutputStream(payload.length);
+        fragments.writeBytes(payload);
+        continue;
       case 0x8: // close frame
         closed = true;
         return false;
       case 0x9: // ping - skip (pong requires output access)
       case 0xA: // pong - skip
-      default:
+        // Control frames may legally be interleaved between the fragments of a message, so skipping one must
+        // leave any in-progress reassembly untouched.
         continue;
+      default:
+        // Reserved opcode. Silently skipping it is what let the continuation frames go missing in the first
+        // place, so fail the connection instead, as RFC 6455 5.2 requires of an unknown opcode.
+        throw new IOException("BOLT WebSocket unsupported frame opcode: 0x" + Integer.toHexString(opcode));
       }
     }
+  }
+
+  private void deliver(final byte[] payload) {
+    buffer = payload;
+    bufferPos = 0;
+    bufferLen = payload.length;
   }
 }

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltWebSocketInputStream.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltWebSocketInputStream.java
@@ -115,8 +115,10 @@ class BoltWebSocketInputStream extends InputStream {
       }
 
       // The accumulated message, not just this frame, is what has to stay inside the cap: otherwise a client
-      // could fragment its way past maxFrameSize one legal-looking frame at a time.
-      if (fragments != null && fragments.size() + payloadLen > maxFrameSize)
+      // could fragment its way past maxFrameSize one legal-looking frame at a time. Only a continuation frame
+      // adds to the accumulation, so a ping legally interleaved between two fragments must not be charged
+      // against it - otherwise a cap-sized message would be rejected because someone kept the socket alive.
+      if (opcode == 0x0 && fragments != null && fragments.size() + payloadLen > maxFrameSize)
         throw new IOException(
             "BOLT WebSocket fragmented message too large: " + (fragments.size() + payloadLen) + " bytes (max " + maxFrameSize + ")");
 

--- a/bolt/src/main/java/com/arcadedb/bolt/message/HelloMessage.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/message/HelloMessage.java
@@ -21,6 +21,7 @@ package com.arcadedb.bolt.message;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -29,6 +30,9 @@ import java.util.Map;
  * Fields: extra (Map containing user_agent, scheme, principal, credentials, etc.)
  */
 public class HelloMessage extends BoltMessage {
+  private static final String CREDENTIALS_KEY = "credentials";
+  private static final String REDACTED        = "***";
+
   private final Map<String, Object> extra;
 
   public HelloMessage(final Map<String, Object> extra) {
@@ -53,7 +57,7 @@ public class HelloMessage extends BoltMessage {
   }
 
   public String getCredentials() {
-    return (String) extra.get("credentials");
+    return (String) extra.get(CREDENTIALS_KEY);
   }
 
   public String getRouting() {
@@ -71,8 +75,20 @@ public class HelloMessage extends BoltMessage {
     writer.writeMap(extra);
   }
 
+  /**
+   * Never renders the caller's credentials: for every BOLT version below 5.1 the HELLO extra map carries the
+   * cleartext password, and {@code BoltNetworkExecutor} logs every inbound message through {@code toString()}
+   * when {@code arcadedb.bolt.debug} is enabled - which is exactly the setting an operator turns on to
+   * troubleshoot a connection problem (issue #6801). {@code LogonMessage.toString()} already omits it.
+   */
   @Override
   public String toString() {
-    return "HELLO{extra=" + extra + "}";
+    if (!extra.containsKey(CREDENTIALS_KEY))
+      return "HELLO{extra=" + extra + "}";
+
+    // Only allocated on the debug-logging path of a pre-5.1 (or explicitly authenticated) HELLO.
+    final Map<String, Object> redacted = new LinkedHashMap<>(extra);
+    redacted.put(CREDENTIALS_KEY, REDACTED);
+    return "HELLO{extra=" + redacted + "}";
   }
 }

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -255,19 +255,19 @@ public class PackStreamReader {
     // TINY_STRING: 0x80 - 0x8F
     if (marker >= 0x80 && marker <= 0x8F) {
       final int length = marker & 0x0F;
-      return readStringBytes(length);
+      return readStringBytes(checkValueLength(length, "TINY_STRING"));
     }
 
     // STRING_8
     if (marker == (STRING_8 & 0xFF)) {
       final int length = in.readUnsignedByte();
-      return readStringBytes(length);
+      return readStringBytes(checkValueLength(length, "STRING_8"));
     }
 
     // STRING_16
     if (marker == (STRING_16 & 0xFF)) {
       final int length = in.readUnsignedShort();
-      return readStringBytes(length);
+      return readStringBytes(checkValueLength(length, "STRING_16"));
     }
 
     // STRING_32
@@ -279,13 +279,13 @@ public class PackStreamReader {
     // BYTES_8
     if (marker == (BYTES_8 & 0xFF)) {
       final int length = in.readUnsignedByte();
-      return readBytes(length);
+      return readBytes(checkValueLength(length, "BYTES_8"));
     }
 
     // BYTES_16
     if (marker == (BYTES_16 & 0xFF)) {
       final int length = in.readUnsignedShort();
-      return readBytes(length);
+      return readBytes(checkValueLength(length, "BYTES_16"));
     }
 
     // BYTES_32
@@ -297,19 +297,19 @@ public class PackStreamReader {
     // TINY_LIST: 0x90 - 0x9F
     if (marker >= 0x90 && marker <= 0x9F) {
       final int size = marker & 0x0F;
-      return openList(size, stack);
+      return openList(checkElementCount(size, "TINY_LIST"), stack);
     }
 
     // LIST_8
     if (marker == (LIST_8 & 0xFF)) {
       final int size = in.readUnsignedByte();
-      return openList(size, stack);
+      return openList(checkElementCount(size, "LIST_8"), stack);
     }
 
     // LIST_16
     if (marker == (LIST_16 & 0xFF)) {
       final int size = in.readUnsignedShort();
-      return openList(size, stack);
+      return openList(checkElementCount(size, "LIST_16"), stack);
     }
 
     // LIST_32
@@ -321,19 +321,19 @@ public class PackStreamReader {
     // TINY_MAP: 0xA0 - 0xAF
     if (marker >= 0xA0 && marker <= 0xAF) {
       final int size = marker & 0x0F;
-      return openMap(size, stack);
+      return openMap(checkElementCount(size, "TINY_MAP"), stack);
     }
 
     // MAP_8
     if (marker == (MAP_8 & 0xFF)) {
       final int size = in.readUnsignedByte();
-      return openMap(size, stack);
+      return openMap(checkElementCount(size, "MAP_8"), stack);
     }
 
     // MAP_16
     if (marker == (MAP_16 & 0xFF)) {
       final int size = in.readUnsignedShort();
-      return openMap(size, stack);
+      return openMap(checkElementCount(size, "MAP_16"), stack);
     }
 
     // MAP_32
@@ -348,7 +348,8 @@ public class PackStreamReader {
       final byte signature = in.readByte();
       if (fieldCount == 0)
         return new StructureValue(signature, new ArrayList<>(0));
-      stack.push(new StructFrame(signature, fieldCount));
+      // The signature byte is already consumed, so the remaining-bytes floor is measured after it.
+      stack.push(new StructFrame(signature, checkElementCount(fieldCount, "TINY_STRUCT")));
       return OPEN_FRAME;
     }
 
@@ -386,9 +387,11 @@ public class PackStreamReader {
   }
 
   /**
-   * Validates a BYTES_32/STRING_32 declared length before it is used to size an allocation (issue #5918): rejects
-   * a negative length, one above the configured ceiling, and - the exact, un-configurable bound - one larger than
+   * Validates a declared BYTES/STRING length before it is used to size an allocation (issue #5918): rejects a
+   * negative length, one above the configured ceiling, and - the exact, un-configurable bound - one larger than
    * the bytes actually remaining in this message, which the declared length can never legitimately exceed.
+   * <p>
+   * Applied to every width, not only the 32-bit markers: the narrower markers were the gap issue #6800 closed.
    */
   private int checkValueLength(final int length, final String what) throws IOException {
     if (length < 0)
@@ -403,10 +406,16 @@ public class PackStreamReader {
   }
 
   /**
-   * Validates a LIST_32/MAP_32 declared size before it is used to size a collection's backing array (issue
-   * #5918): a LIST_32 element needs at least one wire byte to encode and a MAP_32 entry needs at least two (a key
-   * plus a value), so a declared count larger than the bytes remaining in this message is impossible - loosely
-   * for maps, since this check uses the same one-byte-per-count floor for both - and rejected without allocating.
+   * Validates a declared list/map/structure size before any element is read (issue #5918): a list element needs
+   * at least one wire byte to encode and a map entry needs at least two (a key plus a value), so a declared count
+   * larger than the bytes remaining in this message is impossible - loosely for maps, since this check uses the
+   * same one-byte-per-count floor for both - and rejected up front.
+   * <p>
+   * Issue #6800: originally invoked only from LIST_32/MAP_32, which left LIST_16 as a pure amplifier - 1001
+   * repetitions of the three bytes {@code D5 FF FF} declared 1001 lists of 65535 elements each, and every one of
+   * them sized a backing array before a single element was read. Every width is validated now, and
+   * {@link ListFrame}/{@link StructFrame} additionally grow their backing array from the elements actually read
+   * rather than from the declared count, so a declared size can no longer size an allocation on its own.
    */
   private int checkElementCount(final int size, final String what) throws IOException {
     if (size < 0)
@@ -452,8 +461,14 @@ public class PackStreamReader {
     private final List<Object> list;
     private int                remaining;
 
+    /**
+     * The backing list is deliberately NOT pre-sized from {@code size}: that count is client-supplied and read
+     * off the wire before authentication, so pre-sizing turns a declared count into an allocation before any
+     * element behind it has been seen (issue #6800). Growing from the elements actually read costs a few
+     * amortised array copies on a large legitimate list and makes the declared count unable to allocate at all.
+     */
     ListFrame(final int size) {
-      this.list = new ArrayList<>(size);
+      this.list = new ArrayList<>();
       this.remaining = size;
     }
 
@@ -470,8 +485,15 @@ public class PackStreamReader {
     private       boolean             expectingKey = true;
     private       String              pendingKey;
 
+    /**
+     * As {@link ListFrame}, the map is not pre-sized from the client-declared entry count (issue #6800).
+     * {@code new LinkedHashMap<>(n)} does not allocate its table up front, but it does remember {@code n} as the
+     * threshold, so the very first {@code put} allocates a {@code Node[]} sized for the declared count - which
+     * with a 16MB message ceiling is still an order-of-magnitude amplification. Growing from the entries
+     * actually read removes the declared count from the allocation path entirely.
+     */
     MapFrame(final int size) {
-      this.map = new LinkedHashMap<>(size);
+      this.map = new LinkedHashMap<>();
       this.remainingEntries = size;
     }
 
@@ -499,9 +521,14 @@ public class PackStreamReader {
     private final List<Object> fields;
     private       int          remaining;
 
+    /**
+     * As {@link ListFrame}, the field list grows from the fields actually read rather than from the declared
+     * count (issue #6800). A TINY_STRUCT declares at most 15 fields, so the amplification is small here, but
+     * the invariant "no allocation is sized by a client-declared count alone" is worth keeping uniform.
+     */
     StructFrame(final byte signature, final int fieldCount) {
       this.signature = signature;
-      this.fields = new ArrayList<>(fieldCount);
+      this.fields = new ArrayList<>();
       this.remaining = fieldCount;
     }
 

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
@@ -173,6 +173,10 @@ public class BoltStateMachineIT extends BaseGraphServerTest {
           records.add(decodeSingleField(response));
           continue;
         }
+        // IGNORED is a zero-field structure, so there is no field to decode - reading one would EOF and bury the
+        // real assertion under an IOException.
+        if (signature == BoltMessage.IGNORED)
+          return new Summary(signature, Map.of(), records);
         return new Summary(signature, asMetadata(decodeSingleField(response)), records);
       }
     }
@@ -365,6 +369,40 @@ public class BoltStateMachineIT extends BaseGraphServerTest {
       final Summary summary = bolt.readSummary();
       assertThat(summary.signature()).isEqualTo(BoltMessage.SUCCESS);
       assertThat(summary.records()).hasSize(1);
+    }
+  }
+
+  /**
+   * -1 is the only "no qid given" sentinel. A malformed negative qid names no stream, so it has to fail rather
+   * than quietly act on whichever stream happens to be the current one.
+   */
+  @Test
+  void aMalformedNegativeQidDoesNotFallBackToTheCurrentStream() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      bolt.run("UNWIND [1, 2, 3] AS x RETURN x");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      bolt.pull(-1, -2);
+      final Summary rejected = bolt.readSummary();
+      assertThat(rejected.signature()).isEqualTo(BoltMessage.FAILURE);
+      assertThat(String.valueOf(rejected.metadata().get("message"))).contains("qid -2");
+    }
+  }
+
+  @Test
+  void aMalformedNegativeQidOnDiscardIsRejectedToo() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      bolt.run("UNWIND [1, 2, 3] AS x RETURN x");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      bolt.discard(-1, -2);
+      final Summary rejected = bolt.readSummary();
+      assertThat(rejected.signature()).isEqualTo(BoltMessage.FAILURE);
+      assertThat(String.valueOf(rejected.metadata().get("message"))).contains("qid -2");
     }
   }
 

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
@@ -293,6 +293,29 @@ public class BoltStateMachineIT extends BaseGraphServerTest {
   }
 
   /**
+   * Outside an explicit transaction there is exactly one stream and no qid is ever published for it, so a PULL
+   * that names one anyway has to reach that stream rather than be told the qid does not exist.
+   */
+  @Test
+  void pullWithAQidInAutoCommitStillReachesTheOnlyStream() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      // Run and fully consume one auto-commit query first, so a per-connection qid counter would have moved on.
+      bolt.run("RETURN 1 AS one");
+      assertThat(bolt.readSummary().metadata()).doesNotContainKey("qid");
+      bolt.pull(-1, -1);
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      bolt.run("RETURN 2 AS two");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      bolt.pull(-1, 0);
+      final Summary summary = bolt.readSummary();
+      assertThat(summary.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(summary.records()).hasSize(1);
+    }
+  }
+
+  /**
    * RUN stays invalid in STREAMING: outside an explicit transaction there is nothing to multiplex onto, and the
    * BOLT state machine does not list RUN there.
    */

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
@@ -325,6 +325,31 @@ public class BoltStateMachineIT extends BaseGraphServerTest {
   }
 
   /**
+   * A ceiling of 0 would reject every query outright rather than lock anything down, so the setting is floored at
+   * one open stream: the query runs, and only a second concurrent one is refused.
+   */
+  @Test
+  void anOpenStreamLimitBelowOneStillAllowsASingleStream() throws Exception {
+    final int previousLimit = GlobalConfiguration.BOLT_MAX_OPEN_STREAMS.getValueAsInteger();
+    GlobalConfiguration.BOLT_MAX_OPEN_STREAMS.setValue(0);
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      bolt.run("UNWIND [1, 2, 3] AS x RETURN x");
+      assertThat(bolt.readSummary().signature()).as("one stream must always be allowed").isEqualTo(BoltMessage.SUCCESS);
+      bolt.pull(1, -1);
+      assertThat(bolt.readSummary().metadata()).containsEntry("has_more", true);
+
+      bolt.run("RETURN 1 AS one");
+      final Summary rejected = bolt.readSummary();
+      assertThat(rejected.signature()).isEqualTo(BoltMessage.FAILURE);
+      assertThat(String.valueOf(rejected.metadata().get("message"))).contains("max 1");
+    } finally {
+      GlobalConfiguration.BOLT_MAX_OPEN_STREAMS.setValue(previousLimit);
+    }
+  }
+
+  /**
    * Outside an explicit transaction there is exactly one stream and no qid is ever published for it, so a PULL
    * that names one anyway has to reach that stream rather than be told the qid does not exist.
    */

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
@@ -134,11 +134,15 @@ public class BoltStateMachineIT extends BaseGraphServerTest {
     }
 
     void run(final String query) throws IOException {
+      run(query, Map.of());
+    }
+
+    void run(final String query, final Map<String, Object> extra) throws IOException {
       final PackStreamWriter writer = new PackStreamWriter();
       writer.writeStructureHeader(BoltMessage.RUN, 3);
       writer.writeString(query);
       writer.writeMap(Map.of());
-      writer.writeMap(Map.of());
+      writer.writeMap(extra);
       out.writeMessage(writer.toByteArray());
     }
 
@@ -368,6 +372,39 @@ public class BoltStateMachineIT extends BaseGraphServerTest {
       assertThat(check.signature()).isEqualTo(BoltMessage.SUCCESS);
       assertThat(check.records()).as("the transaction the rejected LOGOFF left behind must have been rolled back")
           .isEmpty();
+    }
+  }
+
+  /**
+   * An explicit transaction is bound to the database BEGIN opened it on. A RUN naming another one has to be
+   * refused rather than allowed to drop the connection's handle on that database, which is the only thing a
+   * later rollback has to work with.
+   */
+  @Test
+  void runCannotSwitchDatabaseInsideAnOpenTransaction() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      bolt.run("CREATE (n:Issue6804DbSwitch {value: 1}) RETURN n");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+      bolt.pull(0, -1);
+      assertThat(bolt.readSummary().metadata()).containsEntry("has_more", true);
+
+      bolt.run("RETURN 1 AS one", Map.of("db", "a-database-that-does-not-exist"));
+      final Summary rejected = bolt.readSummary();
+      assertThat(rejected.signature()).isEqualTo(BoltMessage.FAILURE);
+      assertThat(String.valueOf(rejected.metadata().get("message"))).contains("Cannot switch database");
+
+      // The connection must still hold the database the transaction was opened on, so RESET can roll it back.
+      bolt.sendNoFields(BoltMessage.RESET);
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      bolt.run("MATCH (n:Issue6804DbSwitch) RETURN n");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+      bolt.pull(-1, -1);
+      final Summary check = bolt.readSummary();
+      assertThat(check.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(check.records()).as("the transaction must have been rolled back, not stranded").isEmpty();
     }
   }
 

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
@@ -303,16 +303,12 @@ public class BoltStateMachineIT extends BaseGraphServerTest {
   @Test
   void pullWithAQidInAutoCommitStillReachesTheOnlyStream() throws Exception {
     try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
-      // Run and fully consume one auto-commit query first, so a per-connection qid counter would have moved on.
       bolt.run("RETURN 1 AS one");
-      assertThat(bolt.readSummary().metadata()).doesNotContainKey("qid");
-      bolt.pull(-1, -1);
-      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(bolt.readSummary().metadata()).as("an auto-commit RUN publishes no qid").doesNotContainKey("qid");
 
-      bolt.run("RETURN 2 AS two");
-      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
-
-      bolt.pull(-1, 0);
+      // A qid that matches nothing: honouring it would answer "No active result set for qid 99" for the one
+      // stream this connection plainly has open.
+      bolt.pull(-1, 99);
       final Summary summary = bolt.readSummary();
       assertThat(summary.signature()).isEqualTo(BoltMessage.SUCCESS);
       assertThat(summary.records()).hasSize(1);

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.bolt.message.BoltMessage;
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * BOLT server state machine regression tests driven straight over the wire, so the assertions are on the
+ * protocol rather than on whatever a particular driver's fetch-size configuration happens to make it send.
+ * <p>
+ * Issue #6804: RUN is valid in TX_STREAMING - that is the whole point of the {@code qid} field, which lets a
+ * client hold several result streams open inside one explicit transaction. The server rejected it as a protocol
+ * error, so a second query issued while the first stream still had rows failed the session and lost the
+ * transaction; {@code qid} was parsed and never used.
+ * <p>
+ * Issue #6803: LOGOFF was the one request handler with neither a state check nor any cleanup, so a LOGOFF sent
+ * mid-stream answered SUCCESS and left the result set and the ArcadeDB transaction pinned on a connection the
+ * server had just stopped counting as authenticated.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class BoltStateMachineIT extends BaseGraphServerTest {
+
+  private static final int BOLT_PORT = 7687;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  /**
+   * A connection already past the BOLT handshake and LOGON, exposing the chunked message pair.
+   */
+  private static final class BoltConnection implements AutoCloseable {
+    private final Socket             socket;
+    private final BoltChunkedOutput  out;
+    private final BoltChunkedInput   in;
+
+    BoltConnection(final String database) throws IOException {
+      socket = new Socket("localhost", BOLT_PORT);
+
+      final OutputStream rawOut = socket.getOutputStream();
+      final ByteBuffer handshake = ByteBuffer.allocate(20);
+      handshake.put((byte) 0x60).put((byte) 0x60).put((byte) 0xB0).put((byte) 0x17);
+      handshake.putInt(0x00000405); // v5.4
+      handshake.putInt(0x00000404); // v4.4
+      handshake.putInt(0x00000003); // v3.0
+      handshake.putInt(0x00000000);
+      handshake.flip();
+      rawOut.write(handshake.array());
+      rawOut.flush();
+
+      final DataInputStream rawIn = new DataInputStream(socket.getInputStream());
+      final byte[] negotiated = new byte[4];
+      rawIn.readFully(negotiated);
+      assertThat(negotiated[3]).as("the deferred-auth path needs Bolt 5.x").isEqualTo((byte) 5);
+
+      out = new BoltChunkedOutput(rawOut);
+      in = new BoltChunkedInput(socket.getInputStream());
+
+      sendMap(BoltMessage.HELLO,
+          Map.of("user_agent", "bolt-state-machine-it/1.0", "routing", Map.of("db", database)));
+      assertThat(readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      logon();
+    }
+
+    void logon() throws IOException {
+      sendMap(BoltMessage.LOGON,
+          Map.of("scheme", "basic", "principal", "root", "credentials", DEFAULT_PASSWORD_FOR_TESTS));
+      assertThat(readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+    }
+
+    /** Writes a request whose single field is a map (HELLO, LOGON, BEGIN, PULL, DISCARD). */
+    void sendMap(final byte signature, final Map<String, Object> field) throws IOException {
+      final PackStreamWriter writer = new PackStreamWriter();
+      writer.writeStructureHeader(signature, 1);
+      writer.writeMap(field);
+      out.writeMessage(writer.toByteArray());
+    }
+
+    /** Writes a request with no fields at all (COMMIT, ROLLBACK, RESET, LOGOFF, GOODBYE). */
+    void sendNoFields(final byte signature) throws IOException {
+      final PackStreamWriter writer = new PackStreamWriter();
+      writer.writeStructureHeader(signature, 0);
+      out.writeMessage(writer.toByteArray());
+    }
+
+    void begin(final String database) throws IOException {
+      sendMap(BoltMessage.BEGIN, Map.of("db", database));
+      assertThat(readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+    }
+
+    void run(final String query) throws IOException {
+      final PackStreamWriter writer = new PackStreamWriter();
+      writer.writeStructureHeader(BoltMessage.RUN, 3);
+      writer.writeString(query);
+      writer.writeMap(Map.of());
+      writer.writeMap(Map.of());
+      out.writeMessage(writer.toByteArray());
+    }
+
+    void pull(final long n, final long qid) throws IOException {
+      sendMap(BoltMessage.PULL, streamSelector(n, qid));
+    }
+
+    void discard(final long n, final long qid) throws IOException {
+      sendMap(BoltMessage.DISCARD, streamSelector(n, qid));
+    }
+
+    private static Map<String, Object> streamSelector(final long n, final long qid) {
+      final Map<String, Object> extra = new LinkedHashMap<>();
+      extra.put("n", n);
+      extra.put("qid", qid);
+      return extra;
+    }
+
+    /**
+     * Reads RECORDs until the summary message (SUCCESS / FAILURE / IGNORED) that closes the exchange.
+     */
+    Summary readSummary() throws IOException {
+      final List<Object> records = new ArrayList<>();
+      while (true) {
+        final byte[] response = in.readMessage();
+        final byte signature = response[1];
+        if (signature == BoltMessage.RECORD) {
+          records.add(decodeSingleField(response));
+          continue;
+        }
+        return new Summary(signature, asMetadata(decodeSingleField(response)), records);
+      }
+    }
+
+    /** SUCCESS/FAILURE/RECORD are all single-field structures: skip the two header bytes, read the field. */
+    private Object decodeSingleField(final byte[] response) throws IOException {
+      final PackStreamReader reader = new PackStreamReader(response);
+      reader.readRawByte();
+      reader.readRawByte();
+      return reader.readValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMetadata(final Object value) {
+      return value instanceof Map ? (Map<String, Object>) value : Map.of();
+    }
+
+    @Override
+    public void close() throws IOException {
+      socket.close();
+    }
+  }
+
+  private record Summary(byte signature, Map<String, Object> metadata, List<Object> records) {
+  }
+
+  /**
+   * Issue #6804: two result streams open at once inside one explicit transaction, each pulled by its own qid.
+   * Before the fix the second RUN answered {@code "RUN not expected in state: TX_STREAMING"}.
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  void secondRunInsideATransactionOpensASecondStream() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      bolt.run("UNWIND [1, 2, 3] AS x RETURN x");
+      final Summary firstRun = bolt.readSummary();
+      assertThat(firstRun.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(firstRun.metadata()).containsEntry("qid", 0L);
+
+      // Pull a single row, leaving the stream open: this is the state a driver configured with a small fetch
+      // size is in when the application issues its next query.
+      bolt.pull(1, -1);
+      final Summary firstPull = bolt.readSummary();
+      assertThat(firstPull.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(firstPull.records()).hasSize(1);
+      assertThat(firstPull.metadata()).containsEntry("has_more", true);
+
+      // The second RUN, the one that used to fail the session.
+      bolt.run("RETURN 42 AS answer");
+      final Summary secondRun = bolt.readSummary();
+      assertThat(secondRun.signature()).as("RUN must be accepted in TX_STREAMING").isEqualTo(BoltMessage.SUCCESS);
+      assertThat(secondRun.metadata()).containsEntry("qid", 1L);
+
+      // Drain the second stream by its qid; the first one is untouched and the session stays in TX_STREAMING.
+      bolt.pull(-1, 1);
+      final Summary secondPull = bolt.readSummary();
+      assertThat(secondPull.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(secondPull.records()).hasSize(1);
+      assertThat(((List<Object>) secondPull.records().get(0)).get(0)).isEqualTo(42L);
+      assertThat(secondPull.metadata()).containsEntry("has_more", false);
+
+      // Then finish the first stream, which still owes rows 2 and 3.
+      bolt.pull(-1, 0);
+      final Summary rest = bolt.readSummary();
+      assertThat(rest.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(rest.records()).hasSize(2);
+      assertThat(rest.metadata()).containsEntry("has_more", false);
+
+      bolt.sendNoFields(BoltMessage.COMMIT);
+      assertThat(bolt.readSummary().signature()).as("the transaction must survive the interleaved streams")
+          .isEqualTo(BoltMessage.SUCCESS);
+    }
+  }
+
+  /**
+   * A DISCARD naming an explicit qid must close that stream and leave the others alone.
+   */
+  @Test
+  void discardByQidClosesOnlyTheNamedStream() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      bolt.run("UNWIND [1, 2, 3] AS x RETURN x");
+      assertThat(bolt.readSummary().metadata()).containsEntry("qid", 0L);
+      bolt.pull(1, -1);
+      assertThat(bolt.readSummary().metadata()).containsEntry("has_more", true);
+
+      bolt.run("UNWIND [10, 20] AS y RETURN y");
+      assertThat(bolt.readSummary().metadata()).containsEntry("qid", 1L);
+
+      bolt.discard(-1, 0);
+      final Summary discard = bolt.readSummary();
+      assertThat(discard.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(discard.metadata()).containsEntry("has_more", false);
+
+      // Stream 1 is still open and still complete.
+      bolt.pull(-1, 1);
+      final Summary remaining = bolt.readSummary();
+      assertThat(remaining.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(remaining.records()).hasSize(2);
+
+      bolt.sendNoFields(BoltMessage.COMMIT);
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+    }
+  }
+
+  @Test
+  void pullNamingAnUnknownQidFailsInsteadOfHittingAnotherStream() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      bolt.run("UNWIND [1, 2, 3] AS x RETURN x");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      bolt.pull(-1, 99);
+      final Summary failure = bolt.readSummary();
+      assertThat(failure.signature()).isEqualTo(BoltMessage.FAILURE);
+      assertThat(String.valueOf(failure.metadata().get("message"))).contains("qid 99");
+    }
+  }
+
+  /**
+   * RUN stays invalid in STREAMING: outside an explicit transaction there is nothing to multiplex onto, and the
+   * BOLT state machine does not list RUN there.
+   */
+  @Test
+  void runIsStillRejectedInAutoCommitStreaming() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.run("UNWIND [1, 2, 3] AS x RETURN x");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+      bolt.pull(1, -1);
+      assertThat(bolt.readSummary().metadata()).containsEntry("has_more", true);
+
+      bolt.run("RETURN 1 AS one");
+      final Summary rejected = bolt.readSummary();
+      assertThat(rejected.signature()).isEqualTo(BoltMessage.FAILURE);
+      assertThat(String.valueOf(rejected.metadata().get("message"))).contains("STREAMING");
+    }
+  }
+
+  /**
+   * Issue #6803: LOGOFF while a stream and a transaction are open used to answer SUCCESS and leave both pinned
+   * on a connection the server no longer counted as authenticated.
+   */
+  @Test
+  void logoffIsRejectedWhileAStreamAndATransactionAreOpen() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      bolt.run("CREATE (n:Issue6803Logoff {value: 1}) RETURN n");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      // n=0 consumes nothing, so the row stays buffered and the session stays in TX_STREAMING.
+      bolt.pull(0, -1);
+      final Summary pull = bolt.readSummary();
+      assertThat(pull.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(pull.metadata()).containsEntry("has_more", true);
+
+      bolt.sendNoFields(BoltMessage.LOGOFF);
+      final Summary logoff = bolt.readSummary();
+      assertThat(logoff.signature()).as("LOGOFF is valid only from READY").isEqualTo(BoltMessage.FAILURE);
+      assertThat(String.valueOf(logoff.metadata().get("message"))).contains("TX_STREAMING");
+
+      // RESET is the only way out of FAILED, and it must roll the write back.
+      bolt.sendNoFields(BoltMessage.RESET);
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      bolt.run("MATCH (n:Issue6803Logoff) RETURN n");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+      bolt.pull(-1, -1);
+      final Summary check = bolt.readSummary();
+      assertThat(check.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(check.records()).as("the transaction the rejected LOGOFF left behind must have been rolled back")
+          .isEmpty();
+    }
+  }
+
+  /**
+   * READY - the one state LOGOFF is valid in - still works, and the connection can be re-authenticated
+   * afterwards, which is what a driver connection pool actually does with LOGOFF.
+   */
+  @Test
+  void logoffFromReadyStillSucceedsAndAllowsReAuthentication() throws Exception {
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.sendNoFields(BoltMessage.LOGOFF);
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+
+      bolt.logon();
+
+      bolt.run("RETURN 7 AS seven");
+      assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+      bolt.pull(-1, -1);
+      final Summary summary = bolt.readSummary();
+      assertThat(summary.signature()).isEqualTo(BoltMessage.SUCCESS);
+      assertThat(summary.records()).hasSize(1);
+    }
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStateMachineIT.java
@@ -297,6 +297,34 @@ public class BoltStateMachineIT extends BaseGraphServerTest {
   }
 
   /**
+   * Every open stream pins an engine result set for the life of the transaction, and nothing in the protocol
+   * obliges a client to consume one, so a connection cannot be allowed to open them without limit.
+   */
+  @Test
+  void openingMoreStreamsThanTheLimitAllowsIsRejected() throws Exception {
+    final int previousLimit = GlobalConfiguration.BOLT_MAX_OPEN_STREAMS.getValueAsInteger();
+    GlobalConfiguration.BOLT_MAX_OPEN_STREAMS.setValue(2);
+    try (final BoltConnection bolt = new BoltConnection(getDatabaseName())) {
+      bolt.begin(getDatabaseName());
+
+      // Two streams, each left with rows outstanding so neither is released.
+      for (int i = 0; i < 2; i++) {
+        bolt.run("UNWIND [1, 2, 3] AS x RETURN x");
+        assertThat(bolt.readSummary().signature()).isEqualTo(BoltMessage.SUCCESS);
+        bolt.pull(1, -1);
+        assertThat(bolt.readSummary().metadata()).containsEntry("has_more", true);
+      }
+
+      bolt.run("RETURN 1 AS one");
+      final Summary rejected = bolt.readSummary();
+      assertThat(rejected.signature()).isEqualTo(BoltMessage.FAILURE);
+      assertThat(String.valueOf(rejected.metadata().get("message"))).contains("Too many result streams open");
+    } finally {
+      GlobalConfiguration.BOLT_MAX_OPEN_STREAMS.setValue(previousLimit);
+    }
+  }
+
+  /**
    * Outside an explicit transaction there is exactly one stream and no qid is ever published for it, so a PULL
    * that names one anyway has to reach that stream rather than be told the qid does not exist.
    */

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltWebSocketInputStreamTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltWebSocketInputStreamTest.java
@@ -28,8 +28,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Regression tests for issue #5894: a BOLT WebSocket frame with an unbounded, unauthenticated
- * client-supplied length must never be allowed to drive a byte-array allocation.
+ * Regression tests for issue #5894 - a BOLT WebSocket frame with an unbounded, unauthenticated client-supplied
+ * length must never be allowed to drive a byte-array allocation - and for issue #6802: RFC 6455 lets a client
+ * split one message across a data frame with FIN=0 plus continuation frames (opcode 0x0), and the transport used
+ * to read, unmask and then silently DISCARD every continuation, handing the BOLT dechunker a truncated byte
+ * stream rather than an error.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -38,15 +41,28 @@ class BoltWebSocketInputStreamTest {
   private static final long MAX_FRAME_SIZE = 1024; // small cap so tests stay fast
 
   private static byte[] maskedFrame(final byte[] payload) {
+    return maskedFrame(true, 0x2, payload);
+  }
+
+  /**
+   * Builds one masked client-to-server frame with an explicit FIN bit and opcode, so a fragmented message can be
+   * assembled as {@code [FIN=0, op=0x2, part1][FIN=1, op=0x0, part2]}.
+   */
+  private static byte[] maskedFrame(final boolean fin, final int opcode, final byte[] payload) {
     final byte[] mask = { 0x01, 0x02, 0x03, 0x04 };
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    out.write(0x82); // FIN + binary opcode
+    out.write((fin ? 0x80 : 0x00) | opcode);
     if (payload.length < 126) {
       out.write(0x80 | payload.length); // masked + 7-bit length
+    } else if (payload.length <= 0xFFFF) {
+      out.write(0x80 | 126); // masked + 16-bit length marker
+      out.write((payload.length >>> 8) & 0xFF);
+      out.write(payload.length & 0xFF);
     } else {
       out.write(0x80 | 127); // masked + 64-bit length marker
+      final long length = payload.length; // widen: >>> on an int shifts modulo 32, so 56 would wrap to 24
       for (int shift = 56; shift >= 0; shift -= 8)
-        out.write((int) (payload.length >>> shift) & 0xFF);
+        out.write((int) ((length >>> shift) & 0xFF));
     }
     out.writeBytes(mask);
     for (int i = 0; i < payload.length; i++)
@@ -111,5 +127,143 @@ class BoltWebSocketInputStreamTest {
     final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(new ByteArrayInputStream(frame), MAX_FRAME_SIZE);
 
     assertThatThrownBy(() -> stream.read()).isInstanceOf(IOException.class).hasMessageContaining("too large");
+  }
+
+  private static byte[] concat(final byte[]... frames) {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    for (final byte[] frame : frames)
+      out.writeBytes(frame);
+    return out.toByteArray();
+  }
+
+  private static byte[] readFully(final BoltWebSocketInputStream stream, final int length) throws IOException {
+    final byte[] read = new byte[length];
+    int off = 0;
+    while (off < length) {
+      final int n = stream.read(read, off, length - off);
+      if (n < 0)
+        break;
+      off += n;
+    }
+    assertThat(off).as("stream delivered fewer bytes than the message contained").isEqualTo(length);
+    return read;
+  }
+
+  /**
+   * The report's exact shape: one message split in two. Before the fix, {@code part2} was read, unmasked and
+   * dropped, so the reader saw only {@code part1}.
+   */
+  @Test
+  void reassemblesAFragmentedMessage() throws Exception {
+    final byte[] part1 = "hello ".getBytes();
+    final byte[] part2 = "fragmented bolt".getBytes();
+
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(concat(maskedFrame(false, 0x2, part1), maskedFrame(true, 0x0, part2))), MAX_FRAME_SIZE);
+
+    assertThat(readFully(stream, part1.length + part2.length)).isEqualTo("hello fragmented bolt".getBytes());
+  }
+
+  @Test
+  void reassemblesAMessageSplitAcrossThreeFrames() throws Exception {
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(concat(
+            maskedFrame(false, 0x2, "aaa".getBytes()),
+            maskedFrame(false, 0x0, "bbb".getBytes()),
+            maskedFrame(true, 0x0, "ccc".getBytes()))), MAX_FRAME_SIZE);
+
+    assertThat(readFully(stream, 9)).isEqualTo("aaabbbccc".getBytes());
+  }
+
+  /**
+   * RFC 6455 lets a control frame be interleaved between the fragments of a message. Skipping the ping must
+   * leave the reassembly in progress untouched.
+   */
+  @Test
+  void pingBetweenFragmentsDoesNotBreakReassembly() throws Exception {
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(concat(
+            maskedFrame(false, 0x2, "abc".getBytes()),
+            maskedFrame(true, 0x9, "ping".getBytes()),
+            maskedFrame(true, 0x0, "def".getBytes()))), MAX_FRAME_SIZE);
+
+    assertThat(readFully(stream, 6)).isEqualTo("abcdef".getBytes());
+  }
+
+  /**
+   * Two whole messages, the first fragmented: the reader must not carry state from one into the other.
+   */
+  @Test
+  void aFragmentedMessageIsFollowedNormallyByAnUnfragmentedOne() throws Exception {
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(concat(
+            maskedFrame(false, 0x2, "ab".getBytes()),
+            maskedFrame(true, 0x0, "cd".getBytes()),
+            maskedFrame("efgh".getBytes()))), MAX_FRAME_SIZE);
+
+    assertThat(readFully(stream, 8)).isEqualTo("abcdefgh".getBytes());
+  }
+
+  @Test
+  void rejectsAContinuationWithoutAnOpenFragmentedMessage() {
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(maskedFrame(true, 0x0, "orphan".getBytes())), MAX_FRAME_SIZE);
+
+    assertThatThrownBy(stream::read).isInstanceOf(IOException.class).hasMessageContaining("continuation frame");
+  }
+
+  @Test
+  void rejectsANewDataFrameWhileAFragmentedMessageIsStillOpen() {
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(concat(maskedFrame(false, 0x2, "ab".getBytes()), maskedFrame("cd".getBytes()))),
+        MAX_FRAME_SIZE);
+
+    assertThatThrownBy(() -> readFully(stream, 4)).isInstanceOf(IOException.class)
+        .hasMessageContaining("fragmented message was still open");
+  }
+
+  /**
+   * The cap has to apply to the reassembled total, or a client fragments its way past it one legal-looking
+   * frame at a time.
+   */
+  @Test
+  void rejectsFragmentsThatAccumulatePastTheFrameSizeLimit() {
+    final byte[] half = new byte[(int) MAX_FRAME_SIZE - 8];
+
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(concat(maskedFrame(false, 0x2, half), maskedFrame(true, 0x0, half))), MAX_FRAME_SIZE);
+
+    assertThatThrownBy(() -> readFully(stream, half.length * 2)).isInstanceOf(IOException.class)
+        .hasMessageContaining("fragmented message too large");
+  }
+
+  /**
+   * A reserved opcode used to fall through the same {@code default} branch that swallowed the continuations.
+   * RFC 6455 5.2 requires failing the connection instead.
+   */
+  @Test
+  void rejectsAReservedOpcode() {
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(maskedFrame(true, 0x3, "reserved".getBytes())), MAX_FRAME_SIZE);
+
+    assertThatThrownBy(stream::read).isInstanceOf(IOException.class).hasMessageContaining("unsupported frame opcode");
+  }
+
+  @Test
+  void rejectsAFragmentedControlFrame() {
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(maskedFrame(false, 0x9, "ping".getBytes())), MAX_FRAME_SIZE);
+
+    assertThatThrownBy(stream::read).isInstanceOf(IOException.class)
+        .hasMessageContaining("control frame must not be fragmented");
+  }
+
+  @Test
+  void rejectsAnOversizedControlFrame() {
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(maskedFrame(true, 0x9, new byte[126])), MAX_FRAME_SIZE);
+
+    assertThatThrownBy(stream::read).isInstanceOf(IOException.class)
+        .hasMessageContaining("control frame payload too large");
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltWebSocketInputStreamTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltWebSocketInputStreamTest.java
@@ -243,8 +243,10 @@ class BoltWebSocketInputStreamTest {
    */
   @Test
   void anInterleavedPingIsNotChargedAgainstTheFragmentedMessageLimit() throws Exception {
-    final byte[] first = new byte[(int) MAX_FRAME_SIZE - 24];
-    final byte[] last = new byte[24];
+    // Sized so the ping alone would push the OLD accounting past the cap (1023 + 4 > 1024) while the message
+    // itself lands exactly on it, which is what makes this test fail without the fix.
+    final byte[] first = new byte[(int) MAX_FRAME_SIZE - 1];
+    final byte[] last = new byte[1];
 
     final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
         new ByteArrayInputStream(concat(

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltWebSocketInputStreamTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltWebSocketInputStreamTest.java
@@ -238,6 +238,24 @@ class BoltWebSocketInputStreamTest {
   }
 
   /**
+   * The cap bounds what is accumulated, and a ping accumulates nothing: a message that fills the cap exactly must
+   * still be delivered when someone keeps the socket alive in the middle of it.
+   */
+  @Test
+  void anInterleavedPingIsNotChargedAgainstTheFragmentedMessageLimit() throws Exception {
+    final byte[] first = new byte[(int) MAX_FRAME_SIZE - 24];
+    final byte[] last = new byte[24];
+
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(
+        new ByteArrayInputStream(concat(
+            maskedFrame(false, 0x2, first),
+            maskedFrame(true, 0x9, "ping".getBytes()),
+            maskedFrame(true, 0x0, last))), MAX_FRAME_SIZE);
+
+    assertThat(readFully(stream, (int) MAX_FRAME_SIZE)).hasSize((int) MAX_FRAME_SIZE);
+  }
+
+  /**
    * A reserved opcode used to fall through the same {@code default} branch that swallowed the continuations.
    * RFC 6455 5.2 requires failing the connection instead.
    */

--- a/bolt/src/test/java/com/arcadedb/bolt/Issue6800PackStreamContainerBoundsTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue6800PackStreamContainerBoundsTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6800: the declared element/entry/field counts of the narrow PackStream container
+ * markers bypassed the size guards added for #5918, which validated only the 32-bit ones.
+ * <p>
+ * The amplifier was LIST_16: 1001 repetitions of the three bytes {@code D5 FF FF} declared 1001 lists of 65535
+ * elements each, all live at once on the decoder's frame stack, so ~3 KB on the wire pre-authentication sized
+ * ~256 MB of backing arrays before the depth guard finally fired. The identical declaration sent as LIST_32 was
+ * already rejected, which is what made this a gap rather than a design choice.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6800PackStreamContainerBoundsTest {
+
+  private static final int MAX_VALUE_LENGTH = 16 * 1024 * 1024;
+  private static final int MAX_ELEMENTS     = 1_048_576;
+  private static final int MAX_DEPTH        = 1000;
+
+  private static Object decode(final byte[] message) throws IOException {
+    return new PackStreamReader(message, MAX_VALUE_LENGTH, MAX_ELEMENTS, MAX_DEPTH).readValue();
+  }
+
+  /**
+   * The report's exact payload. It must be rejected on the very first marker, from the declared size alone:
+   * reaching the depth guard at all would mean 1000 backing arrays had already been sized on the way there.
+   */
+  @Test
+  void nestedList16IsRejectedOnTheDeclaredSizeNotOnDepth() {
+    final ByteArrayOutputStream attack = new ByteArrayOutputStream();
+    for (int i = 0; i < 1001; i++) {
+      attack.write(0xD5); // LIST_16
+      attack.write(0xFF);
+      attack.write(0xFF); // 65535 declared elements, with nothing behind them
+    }
+
+    assertThatThrownBy(() -> decode(attack.toByteArray()))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("LIST_16")
+        .hasMessageContaining("exceeds the remaining message bytes");
+  }
+
+  @Test
+  void list8DeclaredSizeBeyondTheMessageIsRejected() {
+    // LIST_8 declaring 200 elements with 3 bytes behind it.
+    final byte[] message = { (byte) 0xD4, (byte) 200, 0x01, 0x02, 0x03 };
+
+    assertThatThrownBy(() -> decode(message))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("LIST_8")
+        .hasMessageContaining("exceeds the remaining message bytes");
+  }
+
+  @Test
+  void tinyListDeclaredSizeBeyondTheMessageIsRejected() {
+    // TINY_LIST of 15 elements with 2 bytes behind it.
+    final byte[] message = { (byte) 0x9F, 0x01, 0x02 };
+
+    assertThatThrownBy(() -> decode(message))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("TINY_LIST")
+        .hasMessageContaining("exceeds the remaining message bytes");
+  }
+
+  @Test
+  void map16DeclaredSizeBeyondTheMessageIsRejected() {
+    final byte[] message = { (byte) 0xD9, (byte) 0xFF, (byte) 0xFF, (byte) 0x80 };
+
+    assertThatThrownBy(() -> decode(message))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("MAP_16")
+        .hasMessageContaining("exceeds the remaining message bytes");
+  }
+
+  @Test
+  void string16DeclaredLengthBeyondTheMessageIsRejected() {
+    final byte[] message = { (byte) 0xD1, (byte) 0xFF, (byte) 0xFF, 0x41, 0x42 };
+
+    assertThatThrownBy(() -> decode(message))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("STRING_16")
+        .hasMessageContaining("exceeds the remaining message bytes");
+  }
+
+  @Test
+  void bytes8DeclaredLengthBeyondTheMessageIsRejected() {
+    final byte[] message = { (byte) 0xCC, (byte) 250, 0x00 };
+
+    assertThatThrownBy(() -> decode(message))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("BYTES_8")
+        .hasMessageContaining("exceeds the remaining message bytes");
+  }
+
+  @Test
+  void structFieldCountBeyondTheMessageIsRejected() {
+    // TINY_STRUCT declaring 5 fields, signature 0x10 (RUN), then a single field.
+    final byte[] message = { (byte) 0xB5, 0x10, 0x01 };
+
+    assertThatThrownBy(() -> decode(message))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("TINY_STRUCT")
+        .hasMessageContaining("exceeds the remaining message bytes");
+  }
+
+  /**
+   * The tightened bounds must not cost a legitimate message anything: a list wide enough to need LIST_16, a map
+   * wide enough to need MAP_16, and a string wide enough to need STRING_16 all still round-trip.
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  void legitimateWideContainersStillRoundTrip() throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeStructureHeader((byte) 0x10, 3);
+
+    final StringBuilder longString = new StringBuilder();
+    for (int i = 0; i < 500; i++)
+      longString.append('x');
+    writer.writeString(longString.toString());
+
+    final Map<String, Object> params = new java.util.LinkedHashMap<>();
+    for (int i = 0; i < 300; i++)
+      params.put("k" + i, (long) i);
+    writer.writeMap(params);
+
+    final List<Object> values = new java.util.ArrayList<>();
+    for (int i = 0; i < 300; i++)
+      values.add((long) i);
+    writer.writeMap(Map.of("list", values));
+
+    final PackStreamReader.StructureValue struct = (PackStreamReader.StructureValue) decode(writer.toByteArray());
+
+    assertThat(struct.getFields()).hasSize(3);
+    assertThat((String) struct.getFields().get(0)).hasSize(500);
+    assertThat((Map<String, Object>) struct.getFields().get(1)).hasSize(300).containsEntry("k299", 299L);
+    assertThat((List<Object>) ((Map<String, Object>) struct.getFields().get(2)).get("list")).hasSize(300);
+  }
+
+  /**
+   * An empty container declares zero elements, so it must survive the guard untouched even when it is the very
+   * last thing in the message and no bytes remain behind it.
+   */
+  @Test
+  void emptyContainersAtTheEndOfAMessageAreStillAccepted() throws Exception {
+    assertThat((List<?>) decode(new byte[] { (byte) 0x90 })).isEmpty();
+    assertThat((Map<?, ?>) decode(new byte[] { (byte) 0xA0 })).isEmpty();
+    assertThat((List<?>) decode(new byte[] { (byte) 0xD4, 0x00 })).isEmpty();
+    assertThat((Map<?, ?>) decode(new byte[] { (byte) 0xD9, 0x00, 0x00 })).isEmpty();
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/Issue6801HelloCredentialsRedactionTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue6801HelloCredentialsRedactionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.message.HelloMessage;
+import com.arcadedb.bolt.message.LogonMessage;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6801: with {@code arcadedb.bolt.debug=true} every inbound message is logged
+ * through {@code toString()}, and for every BOLT version below 5.1 the HELLO extra map carries the caller's
+ * cleartext password. Enabling protocol debug to troubleshoot a connection is exactly the situation where that
+ * fires, and the value then flows into whatever log pipeline is configured.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6801HelloCredentialsRedactionTest {
+
+  private static final String PASSWORD = "sup3r-s3cr3t-p4ssw0rd";
+
+  private static Map<String, Object> helloExtra() {
+    final Map<String, Object> extra = new LinkedHashMap<>();
+    extra.put("user_agent", "neo4j-java/5.26.0");
+    extra.put("scheme", "basic");
+    extra.put("principal", "root");
+    extra.put("credentials", PASSWORD);
+    extra.put("routing", Map.of("db", "mydb"));
+    return extra;
+  }
+
+  @Test
+  void helloToStringNeverRendersTheCredentials() {
+    final String rendered = new HelloMessage(helloExtra()).toString();
+
+    assertThat(rendered).doesNotContain(PASSWORD);
+    assertThat(rendered).contains("credentials=***");
+  }
+
+  /**
+   * Redaction must not cost the diagnostics the debug flag was turned on for: everything except the password is
+   * still there.
+   */
+  @Test
+  void helloToStringKeepsEveryNonSecretField() {
+    final String rendered = new HelloMessage(helloExtra()).toString();
+
+    assertThat(rendered).startsWith("HELLO{extra=");
+    assertThat(rendered).contains("user_agent=neo4j-java/5.26.0");
+    assertThat(rendered).contains("scheme=basic");
+    assertThat(rendered).contains("principal=root");
+    assertThat(rendered).contains("routing={db=mydb}");
+  }
+
+  /**
+   * A BOLT 5.1+ HELLO carries no credentials at all (auth is deferred to LOGON), and must render unchanged.
+   */
+  @Test
+  void helloWithoutCredentialsIsRenderedVerbatim() {
+    final String rendered = new HelloMessage(Map.of("user_agent", "neo4j-java/5.26.0")).toString();
+
+    assertThat(rendered).isEqualTo("HELLO{extra={user_agent=neo4j-java/5.26.0}}");
+  }
+
+  /**
+   * Redaction is a rendering concern only: the handshake still has to be able to read the password back.
+   */
+  @Test
+  void redactionDoesNotAlterTheParsedMessage() {
+    final HelloMessage message = new HelloMessage(helloExtra());
+
+    assertThat(message.toString()).doesNotContain(PASSWORD);
+    assertThat(message.getCredentials()).isEqualTo(PASSWORD);
+    assertThat(message.getPrincipal()).isEqualTo("root");
+    assertThat(message.getExtra()).containsEntry("credentials", PASSWORD);
+  }
+
+  /**
+   * LOGON was already the intended shape - this pins it, so the two handlers cannot drift apart again.
+   */
+  @Test
+  void logonToStringAlsoOmitsTheCredentials() {
+    final String rendered = new LogonMessage(
+        Map.of("scheme", "basic", "principal", "root", "credentials", PASSWORD)).toString();
+
+    assertThat(rendered).doesNotContain(PASSWORD);
+    assertThat(rendered).contains("principal=root");
+  }
+}

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2112,7 +2112,7 @@ public enum GlobalConfiguration {
 
   // The three *_SIZE/*_LENGTH settings below are defense in depth at different layers of the same BOLT ingest
   // path, not redundant: BOLT_MAX_MESSAGE_SIZE bounds the whole reassembled message before it is even handed to
-  // the PackStream decoder, while BOLT_PACKSTREAM_MAX_VALUE_LENGTH bounds one BYTES_32/STRING_32 value within an
+  // the PackStream decoder, while BOLT_PACKSTREAM_MAX_VALUE_LENGTH bounds one BYTES/STRING value within an
   // already-accepted message. They share the same 16MB default because a single field legitimately consuming
   // the entire message budget is a real (if unusual) case, not because the two checks are meant to be identical.
 
@@ -2124,15 +2124,15 @@ public enum GlobalConfiguration {
       Integer.class, 16 * 1024 * 1024),
 
   BOLT_PACKSTREAM_MAX_VALUE_LENGTH("arcadedb.bolt.packstream.maxValueLength", SCOPE.SERVER, """
-      Maximum length in bytes accepted for a single PackStream BYTES_32/STRING_32 value on the BOLT wire protocol. \
+      Maximum length in bytes accepted for a single PackStream BYTES/STRING value on the BOLT wire protocol. \
       A declared length above this bound, or larger than the bytes actually remaining in the message, is rejected \
       before allocation, since the length is read off the wire before authentication. Default is 16MB""",
       Integer.class, 16 * 1024 * 1024),
 
   BOLT_PACKSTREAM_MAX_ELEMENTS("arcadedb.bolt.packstream.maxElements", SCOPE.SERVER, """
-      Maximum element/entry count accepted for a single PackStream LIST_32/MAP_32 declared size on the BOLT wire \
-      protocol. Guards against a client-declared count (e.g. a handful of bytes claiming billions of items) \
-      sizing the backing collection before any element is actually read. Default is 1048576""",
+      Maximum element/entry/field count accepted for a single PackStream list/map/structure declared size on the \
+      BOLT wire protocol. Guards against a client-declared count (e.g. a handful of bytes claiming billions of \
+      items) being trusted before any element is actually read. Default is 1048576""",
       Integer.class, 1_048_576),
 
   BOLT_PACKSTREAM_MAX_DEPTH("arcadedb.bolt.packstream.maxDepth", SCOPE.SERVER, """

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2143,6 +2143,14 @@ public enum GlobalConfiguration {
       Default is 1000, generous for any real BOLT message.""",
       Integer.class, 1000),
 
+  BOLT_MAX_OPEN_STREAMS("arcadedb.bolt.maxOpenStreams", SCOPE.SERVER, """
+      Maximum number of result streams one BOLT connection may hold open at the same time. BOLT 4.0+ lets a client \
+      open several streams inside a single explicit transaction, told apart by the qid a RUN returns, and each one \
+      pins an engine result set (cursors, pages) for as long as that transaction lives - while nothing in the \
+      protocol obliges the client to ever consume one. No real driver holds more than a handful open. \
+      Default is 1024""",
+      Integer.class, 1024),
+
   // gRPC
   GRPC_PORT("arcadedb.grpc.port", SCOPE.SERVER, """
       TCP/IP port number used for incoming connections for the gRPC plugin. Registered here, rather than read as a \


### PR DESCRIPTION
Closes #6800, closes #6801, closes #6802, closes #6803, closes #6804.

Five BOLT-module issues, all reported against `9c9d024db`. Every one was real.

## #6800 - PackStream LIST_16 skips the #5918 size guards (security)

`checkElementCount` was invoked from exactly two sites, `LIST_32` and `MAP_32`, so every narrower container marker was unvalidated. `ListFrame` then sized its backing array from the declared count, so 1001 repetitions of the three bytes `D5 FF FF` - each declaring a 65535-element list with nothing behind it - allocated ~1001 x `Object[65535]`, all live at once on the explicit frame stack, before `maxDepth` finally fired. ~3 KB on the wire, ~256 MB of heap, no credentials needed, and the connection survives the exception so the same socket can repeat it.

Both remedies the report suggests, because they close different halves of it:

- every declared length/size now goes through the same validator, so the exact `size > in.available()` floor (a list element needs at least one wire byte) applies at every width - `TINY_*`, `*_8`, `*_16` as well as `*_32`;
- `ListFrame`, `MapFrame` and `StructFrame` grow from the elements actually read instead of pre-sizing, so a client-declared count can no longer size an allocation on its own. `MapFrame` is included even though `new LinkedHashMap<>(n)` does not allocate its table up front: it remembers `n` as the threshold, so the first `put` allocates a `Node[]` sized for the declared count, which under the 16MB message ceiling is still an order-of-magnitude amplification.

## #6801 - HELLO's cleartext password reaches the log (security)

`arcadedb.bolt.debug=true` logs every inbound message through `toString()`, and for every BOLT version below 5.1 the HELLO extra map carries the caller's password. `HelloMessage.toString()` now renders `credentials=***` and leaves everything else - the diagnostics the flag was turned on for - intact, matching `LogonMessage.toString()`.

## #6802 - Bolt-over-WebSocket discards continuation frames

The transport never read the FIN bit and had no case for opcode `0x0`, so a fragmented message had its continuations read, unmasked and dropped through `default`. Depending on where the split fell, the dechunker blocked on a terminator that never arrived, `PackStreamReader` threw "Unknown PackStream marker", or trailing bytes were reinterpreted as the next message's chunk header.

Fragments are reassembled now (`FIN=0` data frame + `0x0` continuations, delivered on `FIN=1`), with `maxFrameSize` applied to the accumulated total so a client cannot fragment its way past the cap one legal-looking frame at a time. Control frames are validated per RFC 6455 5.5 (never fragmented, at most 125 bytes) from the header alone and may still be interleaved between fragments without disturbing reassembly, and a reserved opcode now fails the connection instead of being silently skipped - silent skipping is what caused this bug in the first place.

## #6803 - LOGOFF accepted in any state, leaving stream and transaction behind

`handleLogoff()` was the one request handler with neither a state check nor cleanup. Sent while a stream or an explicit transaction was open it answered SUCCESS and left both pinned on a connection the server had just stopped counting as authenticated; a following HELLO/LOGON as a different user returned to READY with `explicitTransaction` still true, and its COMMIT committed writes made **before** the user change. LOGOFF is now valid only from READY (BOLT 5.1), IGNORED when FAILED like every sibling, and releases whatever is open before flipping to AUTHENTICATION.

## #6804 - RUN rejected in TX_STREAMING, qid parsed and never used

The report offers a minimal single-stream version (drain and close the open result set before the new query) and a spec-complete one. This PR implements the spec-complete one: silently draining a stream the client has not consumed loses rows it is entitled to, which is a worse failure than the one being fixed.

Per-query state - result set, fields, buffered first row, synthetic rows, timings, write flag, plan metadata - moves out of the connection-wide fields into a new `BoltQueryStream` keyed by qid:

- RUN is accepted in TX_STREAMING and returns its `qid` in the SUCCESS metadata (inside an explicit transaction only, as a Neo4j server does; qids restart at 0 per transaction);
- PULL/DISCARD resolve the stream by `getQid()`, with -1 meaning the most recently opened one;
- the session leaves TX_STREAMING only when the last open stream is drained or discarded;
- RUN stays rejected in auto-commit STREAMING - the BOLT state machine does not list it there, and outside a transaction there is nothing to multiplex onto.

Two guards came with it: open streams are capped per connection (each pins an engine ResultSet for the life of the transaction and nothing obliges a client to consume one), and a RUN that fails now releases the result set it had already opened instead of leaving it for the eventual RESET.

## Two things that fell out of the refactor

- The EXPLAIN/PROFILE plan's `identifiers` were read from the connection-wide `currentFields` at build time, which is *before* `extractFieldNames` runs - so the plan carried the **previous** query's column list (or an empty one on the first query). It is now filled in from the stream's own fields.
- `recordsStreamed` was incremented in four places and read in none. Removed rather than carried into the new per-stream class.

The WebSocket test helper also had a latent bug: `payload.length >>> 56` on an `int` shifts modulo 32, so every frame it built over 125 bytes carried a garbage 64-bit length. The existing tests passed only because they all expected a rejection anyway. It now emits the 16-bit form RFC 6455 prescribes for that range.

## Verification

New tests, each confirmed red against the pre-fix sources and green after:

- `Issue6800PackStreamContainerBoundsTest` (9 tests) - the report's exact `D5 FF FF` payload plus LIST_8 / TINY_LIST / MAP_16 / STRING_16 / BYTES_8 / TINY_STRUCT, and that legitimate wide containers and empty ones at the end of a message are untouched. 7 of 9 fail without the fix.
- `Issue6801HelloCredentialsRedactionTest` (5 tests) - 2 fail without the fix.
- `BoltWebSocketInputStreamTest` - 10 new fragmentation/control-frame cases. All 10 fail without the fix (4 as EOF from the truncated stream).
- `BoltStateMachineIT` (6 tests) - driven over a raw socket rather than through a driver, so the assertions are on the protocol rather than on a driver's fetch-size configuration. Two interleaved streams pulled by qid, DISCARD by qid, an unknown qid, RUN still rejected in auto-commit STREAMING, LOGOFF rejected mid-stream with the write rolled back, LOGOFF from READY still allowing re-authentication. 4 of 6 fail without the fix.

Full `bolt` module green: 343 unit tests, 125 integration tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple concurrent query result streams within explicit transactions.
  * Added query-specific pull and discard controls.
  * Added a configurable per-connection limit for open result streams.
  * Enabled safer logoff, rollback, cleanup, and re-authentication workflows.

* **Bug Fixes**
  * Improved fragmented WebSocket message handling and invalid-frame detection.
  * Added validation for oversized or malformed PackStream data.
  * Credentials are now redacted in diagnostic output.
  * Prevented database switching during open transactions.

* **Tests**
  * Added coverage for transactions, streaming, WebSocket validation, input limits, and credential redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->