### PR TITLE
fix(importer): ZIP silently empty, clobbered delimiter, skipped-record resurrection, XML sibling carryover, long-text typed LONG (#6810 #6811 #6812 #6813 #6814)

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/AnalyzedProperty.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/AnalyzedProperty.java
@@ -61,44 +61,48 @@ public class AnalyzedProperty {
     return index;
   }
 
+  /**
+   * Feeds one source value into the analysis. Type refutation (is this column still a candidate for {@code LONG} /
+   * {@code DOUBLE}?) runs on <b>every</b> value, independently of sample collection: stopping the collection of
+   * distinct values - because the value is too long to be worth indexing in the dictionary, or because
+   * {@code maxValueSampling} distinct values were already seen - used to return before the numeric probes, so a
+   * column whose first value happened to look numeric stayed a {@code LONG} candidate forever and was declared
+   * {@code LONG}. The import then died converting the very value that should have disproved it (issue #6814).
+   */
   public void setLastContent(final String lastContent) {
-    if (!collectingSamples)
+    if (lastContent == null)
       return;
 
-    if (lastContent != null) {
-      if (lastContent.length() > 100) {
-        collectingSamples = false;
-        contents.clear();
-        return;
-      }
+    this.lastContent = lastContent;
 
-      this.lastContent = lastContent;
-      if (contents.size() > maxValueSampling) {
-        collectingSamples = false;
-        contents.clear();
-        return;
-      }
-
-      contents.add(lastContent);
-
-      if (!lastContent.isEmpty()) {
-        if (candidateForInteger) {
-          try {
-            Long.parseLong(lastContent);
-          } catch (final NumberFormatException e) {
-            candidateForInteger = false;
-          }
+    if (!lastContent.isEmpty()) {
+      if (candidateForInteger) {
+        try {
+          Long.parseLong(lastContent);
+        } catch (final NumberFormatException e) {
+          candidateForInteger = false;
         }
+      }
 
-        if (candidateForDecimal) {
-          try {
-            Double.parseDouble(lastContent);
-          } catch (final NumberFormatException e) {
-            candidateForDecimal = false;
-          }
+      if (candidateForDecimal) {
+        try {
+          Double.parseDouble(lastContent);
+        } catch (final NumberFormatException e) {
+          candidateForDecimal = false;
         }
       }
     }
+
+    if (!collectingSamples)
+      return;
+
+    if (lastContent.length() > 100 || contents.size() > maxValueSampling) {
+      collectingSamples = false;
+      contents.clear();
+      return;
+    }
+
+    contents.add(lastContent);
   }
 
   public Set<String> getContents() {

--- a/integration/src/main/java/com/arcadedb/integration/importer/Source.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Source.java
@@ -43,12 +43,24 @@ public class Source {
     this.closeCallback = closeCallback;
   }
 
+  /**
+   * Re-opens the underlying stream from the beginning. A failure here leaves the source unreadable, so it is
+   * propagated rather than only logged: swallowing it turned a broken re-open into an empty stream, and the import
+   * then reported a successful run with zero records instead of an error (issue #6810).
+   */
   public void reset() throws IOException {
     if (resetCallback != null)
       try {
         resetCallback.call(this);
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE, "Error on resetting source %s", e, this);
+
+        if (e instanceof IOException ioException)
+          throw ioException;
+        if (e instanceof RuntimeException runtimeException)
+          throw runtimeException;
+
+        throw new IOException("Error on resetting source " + this, e);
       }
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/Source.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Source.java
@@ -49,19 +49,18 @@ public class Source {
    * then reported a successful run with zero records instead of an error (issue #6810).
    */
   public void reset() throws IOException {
-    if (resetCallback != null)
-      try {
-        resetCallback.call(this);
-      } catch (final Exception e) {
-        LogManager.instance().log(this, Level.SEVERE, "Error on resetting source %s", e, this);
+    if (resetCallback == null)
+      return;
 
-        if (e instanceof IOException ioException)
-          throw ioException;
-        if (e instanceof RuntimeException runtimeException)
-          throw runtimeException;
-
-        throw new IOException("Error on resetting source " + this, e);
-      }
+    try {
+      resetCallback.call(this);
+    } catch (final RuntimeException e) {
+      // com.arcadedb.utility.Callable.call() declares no checked exception, so both reset callbacks in
+      // SourceDiscovery already wrap their IOException into an ImportException: a RuntimeException is the only thing
+      // that can arrive here
+      LogManager.instance().log(this, Level.SEVERE, "Error on resetting source %s", e, this);
+      throw e;
+    }
   }
 
   public void close() {

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -141,15 +141,17 @@ public class SourceDiscovery {
     return getSourceFromContent(new BufferedInputStream(connection.getInputStream()), connection.getContentLengthLong(), resource,
         source -> {
           try {
+            source.inputStream.close();
             connection.disconnect();
 
             final HttpURLConnection connection1 = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
 
             if (source.inputStream instanceof GZIPInputStream)
               source.inputStream = new GZIPInputStream(connection1.getInputStream(), 2048);
-            else if (source.inputStream instanceof ZipInputStream stream) {
-              source.inputStream = new ZipInputStream(connection1.getInputStream());
-              stream.getNextEntry();
+            else if (source.inputStream instanceof ZipInputStream) {
+              final ZipInputStream zip = new ZipInputStream(connection1.getInputStream());
+              positionZipStream(zip, resource);
+              source.inputStream = zip;
             } else
               source.inputStream = new BufferedInputStream(connection1.getInputStream());
           } catch (final Exception e) {
@@ -174,27 +176,22 @@ public class SourceDiscovery {
       filePath = getClass().getClassLoader().getResource(filePath).getFile();
     }
 
-    final File file = new File(filePath);
+    final String resolvedPath = filePath;
+    final File file = new File(resolvedPath);
 
-    final InputStream fis;
-    if (file.exists())
-      fis = new BufferedInputStream(new FileInputStream(file));
-    else {
-      fis = getClass().getClassLoader().getResourceAsStream(filePath);
-      if (fis == null)
-        throw new FileNotFoundException(filePath);
-    }
+    final InputStream fis = openLocalStream(file, resolvedPath);
 
     return getSourceFromContent(fis, file.length(), resource, source -> {
       try {
         source.inputStream.close();
         if (source.inputStream instanceof GZIPInputStream)
-          source.inputStream = new GZIPInputStream(new FileInputStream(file), 2048);
-        else if (source.inputStream instanceof ZipInputStream stream) {
-          source.inputStream = new ZipInputStream(new FileInputStream(file));
-          stream.getNextEntry();
+          source.inputStream = new GZIPInputStream(openLocalStream(file, resolvedPath), 2048);
+        else if (source.inputStream instanceof ZipInputStream) {
+          final ZipInputStream zip = new ZipInputStream(openLocalStream(file, resolvedPath));
+          positionZipStream(zip, resource);
+          source.inputStream = zip;
         } else
-          source.inputStream = new BufferedInputStream(new FileInputStream(file));
+          source.inputStream = openLocalStream(file, resolvedPath);
       } catch (final IOException e) {
         throw new ImportException("Error on reset local resource", e);
       }
@@ -203,6 +200,22 @@ public class SourceDiscovery {
       fis.close();
       return null;
     });
+  }
+
+  /**
+   * Opens the local source the same way for the initial read and for every {@link Source#reset()}: as a file when one
+   * exists at that path, otherwise as a classpath resource. Reset used to unconditionally re-open a
+   * {@link FileInputStream}, which cannot work for the classpath fallback.
+   */
+  private InputStream openLocalStream(final File file, final String filePath) throws IOException {
+    if (file.exists())
+      return new BufferedInputStream(new FileInputStream(file));
+
+    final InputStream stream = getClass().getClassLoader().getResourceAsStream(filePath);
+    if (stream == null)
+      throw new FileNotFoundException(filePath);
+
+    return stream;
   }
 
   private FormatImporter analyzeSourceContent(final Parser parser, final AnalyzedEntity.EntityType entityType,
@@ -233,8 +246,12 @@ public class SourceDiscovery {
       break;
 
     case DATABASE:
-      // NO SPECIAL SETTINGS
+      // NO PER-ENTITY SETTINGS: THE GENERIC `delimiter` OPTION IS THE ONE THE USER CAN SET ON THIS FORM
+      // (-delimiter / IMPORT DATABASE ... WITH delimiter = ';'), SO READ IT BACK FROM THE OPTIONS AND FALL BACK TO
+      // -documentsDelimiter WHEN IT IS ABSENT (ISSUE #6811)
       knownFileType = getFileTypeByExtension(settings.url);
+      final Object genericDelimiter = settings.options.get("delimiter");
+      knownDelimiter = genericDelimiter != null ? genericDelimiter.toString() : settings.documentsDelimiter;
       break;
 
     default:
@@ -243,7 +260,10 @@ public class SourceDiscovery {
 
     if (knownFileType != null) {
       if ("csv".equalsIgnoreCase(knownFileType)) {
-        settings.options.put("delimiter", knownDelimiter);
+        // NEVER OVERWRITE THE USER'S `delimiter` OPTION WITH NULL: THE PER-ENTITY DELIMITER IS AN OVERRIDE, NOT A
+        // MANDATORY VALUE, AND CLOBBERING IT MADE EVERY NON-COMMA CSV UNIMPORTABLE (ISSUE #6811)
+        if (knownDelimiter != null)
+          settings.options.put("delimiter", knownDelimiter);
         return new CSVImporterFormat();
       } else if ("json".equalsIgnoreCase(knownFileType)) {
         return new JSONImporterFormat();
@@ -369,7 +389,10 @@ public class SourceDiscovery {
   }
 
   private boolean isSeparator(final char c) {
-    return c == ' ' || c == '\t' || c == ',' || c == '|' || c == '-' || c == '_';
+    // ';' IS THE OTHER MAINSTREAM CSV DELIMITER (LOCALES WHERE ',' IS THE DECIMAL SEPARATOR). WITHOUT IT, A
+    // SEMICOLON-SEPARATED FILE WHOSE EXTENSION ISN'T ".csv" PRODUCED NO CANDIDATE AT ALL AND THE IMPORT DIED WITH
+    // "Cannot determine the file type" (ISSUE #6811)
+    return c == ' ' || c == '\t' || c == ',' || c == ';' || c == '|' || c == '-' || c == '_';
   }
 
   private String getFileTypeByExtension(final String fileName) {
@@ -480,21 +503,12 @@ public class SourceDiscovery {
     in.mark(0);
 
     final ZipInputStream zip = new ZipInputStream(in);
-    ZipEntry entry = zip.getNextEntry();
+    final ZipEntry entry = zip.getNextEntry();
     if (entry != null) {
       // ZIPPED FILE
-      if (resource != null) {
+      if (resource != null)
         // SEARCH FOR THE RIGHT ENTRY
-        while (entry != null) {
-          if (resource.equals(entry.getName()))
-            return new Source(url, zip, totalSize, true, resetCallback, closeCallback);
-
-          zip.closeEntry();
-          entry = zip.getNextEntry();
-        }
-
-        throw new IllegalArgumentException("Resource '" + resource + "' not found");
-      }
+        seekZipEntry(zip, entry, resource);
 
       return new Source(url, zip, totalSize, true, resetCallback, closeCallback);
     }
@@ -513,6 +527,34 @@ public class SourceDiscovery {
 
     // ANALYZE THE INPUT AS TEXT
     return new Source(url, in, totalSize, false, resetCallback, closeCallback);
+  }
+
+  /**
+   * Positions a freshly opened {@link ZipInputStream} exactly the way {@link #getSourceFromContent} positioned the
+   * original one: on the entry named {@code resource}, or on the first entry when no resource was requested. The
+   * reset callbacks used to call {@code getNextEntry()} on the <b>old</b>, already closed stream instead, so the new
+   * one was left with no current entry - and a {@link ZipInputStream} with no current entry reads as an empty file
+   * rather than failing, which turned every ZIP import into a silent "0 records imported, completed" (issue #6810).
+   */
+  private static void positionZipStream(final ZipInputStream zip, final String resource) throws IOException {
+    final ZipEntry entry = zip.getNextEntry();
+    if (resource != null)
+      seekZipEntry(zip, entry, resource);
+  }
+
+  /**
+   * Advances {@code zip} from {@code entry} until the entry named {@code resource} is the current one.
+   */
+  private static void seekZipEntry(final ZipInputStream zip, ZipEntry entry, final String resource) throws IOException {
+    while (entry != null) {
+      if (resource.equals(entry.getName()))
+        return;
+
+      zip.closeEntry();
+      entry = zip.getNextEntry();
+    }
+
+    throw new IllegalArgumentException("Resource '" + resource + "' not found");
   }
 
   private String getFormatFromExtension(String fileName) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
@@ -217,7 +217,11 @@ public class JSONImporterFormat implements FormatImporter {
         if (recordFailed.get())
           throw new ImportException("A nested object/array failed to import, skipping the whole record", null);
 
-        if (record instanceof Map)
+        // ONLY A RECORD WITH NO MAPPING AT ALL IS AN ANONYMOUS DOCUMENT. WITH A MAPPING OBJECT, a Map COMING BACK
+        // MEANS createRecord() REFUSED THE RECORD (MISSING @cat/@type, UNRESOLVABLE @type, OR AN EDGE DEFERRED TO
+        // THE MAPPING PHASE) - MATERIALIZING IT INTO settings.documentTypeName SAVED EXACTLY WHAT THE IMPORTER HAD
+        // JUST LOGGED AS SKIPPED (ISSUE #6812)
+        if (record instanceof Map && mappingObject == null)
           saveAnonymousRecord(database, settings, (Map<String, Object>) record);
 
         database.commit();
@@ -350,6 +354,11 @@ public class JSONImporterFormat implements FormatImporter {
       document.save();
       return record;
     }
+
+    if (record != null)
+      // A DUPLICATE @id WITHOUT "@strategy": "merge": createRecord() RETURNED THE EXISTING, IMMUTABLE RECORD.
+      // HAND IT BACK SO THE CALLER LINKS TO IT INSTEAD OF RE-MATERIALIZING THE SKIPPED ATTRIBUTES (ISSUE #6812)
+      return record;
 
     return attributes.map;
   }
@@ -669,17 +678,20 @@ public class JSONImporterFormat implements FormatImporter {
         }
 
         final MutableVertex destVertex;
-        if (destVertexItem instanceof Document)
-          destVertex = (MutableVertex) destVertexItem;
+        // modify() IS A NO-OP ON A MutableVertex AND THE ONLY WAY TO GET ONE OUT OF AN EXISTING (IMMUTABLE) RECORD,
+        // WHICH IS WHAT createRecord() HANDS BACK FOR A DEDUPLICATED @id
+        if (destVertexItem instanceof Vertex vertex)
+          destVertex = vertex.modify();
         else if (destVertexItem instanceof Map) {
-          destVertex = (MutableVertex) createRecord(record.getDatabase(), context,
+          final Document destRecord = createRecord(record.getDatabase(), context,
               new CascadingProperties(attributes, (Map<String, Object>) destVertexItem),
               destVertexMappingObject, settings);
-          if (destVertex == null) {
+          if (!(destRecord instanceof Vertex destVertexRecord)) {
             LogManager.instance().log(this, Level.WARNING, "Cannot convert inner map into destination vertex: %s", destVertexItem);
             context.errors.incrementAndGet();
             return null;
           }
+          destVertex = destVertexRecord.modify();
         } else {
           LogManager.instance().log(this, Level.WARNING, "Cannot convert object " + destVertexItem + " into a record");
           context.errors.incrementAndGet();

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -95,17 +95,28 @@ public class XMLImporterFormat implements FormatImporter {
           } else if (nestLevel == objectNestLevel + 1) {
             // GET ELEMENT'S SUB-NODES AS PROPERTIES
             if (lastName != null)
-              object.put(lastName, lastContent);
+              object.put(lastName, emptyWhenNoContent(lastContent));
 
             lastName = getQualifiedName(xmlReader.getName());
+            // A NEW SUB-ELEMENT STARTS WITH NO TEXT OF ITS OWN: WITHOUT THIS, AN EMPTY OR SELF-CLOSING ELEMENT
+            // INHERITED THE PREVIOUS SIBLING'S VALUE (ISSUE #6813)
+            lastContent = null;
           }
 
           ++nestLevel;
           break;
 
         case XMLStreamReader.END_ELEMENT:
-          if (lastName != null)
-            object.put(lastName, lastContent);
+          if (lastName != null) {
+            object.put(lastName, emptyWhenNoContent(lastContent));
+            if (nestLevel == objectNestLevel + 2) {
+              // THE PROPERTY ELEMENT ITSELF IS CLOSING (DEEPER ENDS ARE ITS OWN DESCENDANTS, WHOSE TEXT STILL FEEDS
+              // THE PROPERTY, SO LEAVE THE STATE ALONE THERE): THE NEXT SIBLING MUST START FROM SCRATCH RATHER THAN
+              // INHERIT THIS VALUE (ISSUE #6813)
+              lastName = null;
+              lastContent = null;
+            }
+          }
 
           LogManager.instance().log(this, Level.FINE, "</%s> (nestLevel=%d)", null, xmlReader.getName(), nestLevel);
 
@@ -241,26 +252,36 @@ public class XMLImporterFormat implements FormatImporter {
               entityName = "v_" + qualifiedName;  // v_ prefix for vertices (including DATABASE for backward compatibility)
             }
 
+            // CLEAR THE PER-RECORD STATE, THE SAME WAY load() DOES
+            lastName = null;
+            lastContent = null;
+
             // GET ELEMENT'S ATTRIBUTES AS PROPERTIES (with namespace prefix if present)
-            for (int i = 0; i < xmlReader.getAttributeCount(); ++i) {
+            for (int i = 0; i < xmlReader.getAttributeCount(); ++i)
               analyzedSchema.getOrCreateEntity(entityName, entityType)
                   .getOrCreateProperty(getQualifiedName(xmlReader.getAttributeName(i)), xmlReader.getAttributeValue(i));
-              lastName = null;
-            }
           } else if (nestLevel == objectNestLevel + 1) {
             // GET ELEMENT'S SUB-NODES AS PROPERTIES
             if (lastName != null)
-              analyzedSchema.getOrCreateEntity(entityName, entityType).getOrCreateProperty(lastName, lastContent);
+              analyzedSchema.getOrCreateEntity(entityName, entityType).getOrCreateProperty(lastName, emptyWhenNoContent(lastContent));
 
             lastName = getQualifiedName(xmlReader.getName());
+            // SEE THE SAME COMMENT IN load(): THE SCHEMA ANALYSIS INHERITED THE SIBLING'S VALUE TOO (ISSUE #6813)
+            lastContent = null;
           }
 
           ++nestLevel;
           break;
 
         case XMLStreamReader.END_ELEMENT:
-          if (lastName != null)
-            analyzedSchema.getOrCreateEntity(entityName, entityType).getOrCreateProperty(lastName, lastContent);
+          if (lastName != null) {
+            analyzedSchema.getOrCreateEntity(entityName, entityType).getOrCreateProperty(lastName, emptyWhenNoContent(lastContent));
+            if (nestLevel == objectNestLevel + 2) {
+              // SEE THE SAME COMMENT IN load() (ISSUE #6813)
+              lastName = null;
+              lastContent = null;
+            }
+          }
 
           LogManager.instance().log(this, Level.FINE, "</%s> (nestLevel=%d)", null, xmlReader.getName(), nestLevel);
 
@@ -330,6 +351,15 @@ public class XMLImporterFormat implements FormatImporter {
   @Override
   public String getFormat() {
     return "XML";
+  }
+
+  /**
+   * An element that was opened and closed without any character content has the empty string as its text content, not
+   * the previous sibling's value (issue #6813) and not {@code null}: {@code <b></b>} and {@code <b/>} both become an
+   * empty property rather than a missing or {@code null} one.
+   */
+  private static String emptyWhenNoContent(final String lastContent) {
+    return lastContent != null ? lastContent : "";
   }
 
   /**

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6810ZipSourceTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6810ZipSourceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.integration.TestHelper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6810: {@code SourceDiscovery}'s reset callbacks called {@code getNextEntry()} on the <b>old</b>, already
+ * closed {@code ZipInputStream} instead of the freshly created one. The reset path runs on every import, so any ZIP
+ * source imported as 0 records - and {@code Source.reset()} swallowed the underlying {@code IOException}, so the
+ * import reported success.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6810ZipSourceTest {
+
+  private static final String NODES = """
+      id,name
+      1,Alice
+      2,Bob
+      3,Carol
+      """;
+
+  private static final String OTHER = """
+      id,city
+      1,Rome
+      """;
+
+  @Test
+  void aSingleEntryZipImportsItsRecords() throws Exception {
+    final String databasePath = "target/databases/test-import-6810-single-entry";
+    final File zipFile = writeZip("importer-6810-single.csv.zip", Map.of("nodes.csv", NODES));
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + zipFile.getAbsolutePath());
+
+      assertThat(db.countType("Document", true)).isEqualTo(3);
+    } finally {
+      db.drop();
+      zipFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * The rebuilt stream must be seeked to the {@code :::<resource>} entry the user asked for, not merely to the first
+   * entry in the archive.
+   */
+  @Test
+  void aMultiEntryZipImportsTheRequestedEntry() throws Exception {
+    final String databasePath = "target/databases/test-import-6810-multi-entry";
+
+    final Map<String, String> entries = new LinkedHashMap<>();
+    entries.put("other.csv", OTHER);
+    entries.put("nodes.csv", NODES);
+    final File zipFile = writeZip("importer-6810-multi.zip", entries);
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + zipFile.getAbsolutePath() + ":::nodes.csv");
+
+      assertThat(db.countType("Document", true)).isEqualTo(3);
+
+      final Document first = db.iterateType("Document", true).next().asDocument(true);
+      assertThat(first.getPropertyNames()).contains("name");
+      assertThat(first.getPropertyNames()).doesNotContain("city");
+    } finally {
+      db.drop();
+      zipFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  private static File writeZip(final String fileName, final Map<String, String> entries) throws IOException {
+    final File file = new File("target/" + fileName);
+    file.getParentFile().mkdirs();
+    try (final ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(file))) {
+      for (final Map.Entry<String, String> entry : entries.entrySet()) {
+        zip.putNextEntry(new ZipEntry(entry.getKey()));
+        zip.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+      }
+    }
+    return file;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6811CsvDelimiterOptionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6811CsvDelimiterOptionTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.integration.TestHelper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6811: {@code SourceDiscovery.analyzeSourceContent()} unconditionally wrote {@code knownDelimiter} into
+ * {@code settings.options}, but left it {@code null} for {@code EntityType.DATABASE}. Since the user's
+ * {@code -delimiter} / {@code WITH delimiter = ';'} lands in that same map, it was destroyed for every CSV source,
+ * and the whole line ended up parsed as a single column.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6811CsvDelimiterOptionTest {
+
+  @Test
+  void importDatabaseHonoursTheDelimiterSetWithSql() throws IOException {
+    final String databasePath = "target/databases/test-import-6811-sql";
+    final File csvFile = writeSemicolonCsv("importer-6811-sql.csv");
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + csvFile.getAbsolutePath() + " WITH delimiter = ';'");
+      assertImportedColumns(db);
+    } finally {
+      db.drop();
+      csvFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  @Test
+  void importDatabaseHonoursTheDelimiterSetOnTheCommandLine() throws Exception {
+    final String databasePath = "target/databases/test-import-6811-cli";
+    final File csvFile = writeSemicolonCsv("importer-6811-cli.csv");
+
+    try {
+      new Importer(new String[] { "-url", "file://" + csvFile.getAbsolutePath(), "-database", databasePath,
+          "-forceDatabaseCreate", "true", "-delimiter", ";" }).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertImportedColumns(db);
+      }
+    } finally {
+      final DatabaseFactory factory = new DatabaseFactory(databasePath);
+      if (factory.exists())
+        factory.open().drop();
+      csvFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * The per-entity delimiter is an override, not a mandatory value: leaving it unset must not clear whatever the
+   * user asked for, and a plain comma-separated file must keep working with no delimiter set at all.
+   */
+  @Test
+  void aCommaSeparatedFileStillImportsWithNoDelimiterSet() {
+    final String databasePath = "target/databases/test-import-6811-default";
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://src/test/resources/importer-vertices.csv");
+      assertThat(db.countType("Document", true)).isEqualTo(6);
+    } finally {
+      db.drop();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * With no ".csv" extension to short-circuit on, the delimiter is auto-detected from the first line - and ';' was
+   * missing from the candidate set, so a semicolon-separated file produced no candidate at all and the import died
+   * with "Cannot determine the file type".
+   */
+  @Test
+  void aSemicolonSeparatedFileWithoutACsvExtensionIsAutoDetected() throws IOException {
+    final String databasePath = "target/databases/test-import-6811-autodetect";
+    final File csvFile = writeSemicolonCsv("importer-6811-autodetect.txt");
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + csvFile.getAbsolutePath());
+      assertImportedColumns(db);
+    } finally {
+      db.drop();
+      csvFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  private static void assertImportedColumns(final Database db) {
+    assertThat(db.countType("Document", true)).isEqualTo(2);
+
+    final Document first = db.iterateType("Document", true).next().asDocument(true);
+    assertThat(first.getPropertyNames()).contains("id", "name", "age");
+    // BEFORE THE FIX THE WHOLE LINE WAS ONE COLUMN LITERALLY NAMED "id;name;age"
+    assertThat(first.getPropertyNames()).doesNotContain("id;name;age");
+  }
+
+  private static File writeSemicolonCsv(final String fileName) throws IOException {
+    final File file = new File("target/" + fileName);
+    file.getParentFile().mkdirs();
+    try (final FileWriter writer = new FileWriter(file)) {
+      writer.write("id;name;age\n");
+      writer.write("1;Alice;30\n");
+      writer.write("2;Bob;25\n");
+    }
+    return file;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6812JsonSkippedRecordTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6812JsonSkippedRecordTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.integration.TestHelper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6812: {@code JSONImporterFormat.createRecord()} used the same return signal for two opposite outcomes -
+ * "there is no mapping, save this as an anonymous document" and "this record is rejected or deduplicated, drop it" -
+ * so a record the importer had just logged as skipped was saved as an anonymous {@code Document} instead.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6812JsonSkippedRecordTest {
+
+  @Test
+  void aDuplicateIdIsSkippedInsteadOfBeingSavedAsAnAnonymousDocument() throws Exception {
+    final String databasePath = "target/databases/test-import-6812-duplicate-id";
+    final File jsonFile = writeJsonFile("importer-6812-duplicate-id.json",
+        "{\"Users\":[{\"id\":\"1\",\"name\":\"a\"},{\"id\":\"1\",\"name\":\"b\"}]}");
+
+    final String mapping = "{\"Users\":[{\"@cat\":\"v\",\"@type\":\"User\",\"@id\":\"id\",\"@idType\":\"string\"}]}";
+
+    try {
+      new Importer(new String[] { "-url", "file://" + jsonFile.getAbsolutePath(), "-database", databasePath,
+          "-forceDatabaseCreate", "true", "-mapping", mapping }).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.countType("User", true)).isEqualTo(1);
+
+        final Document user = db.iterateType("User", true).next().asDocument(true);
+        // THE SECOND ENTRY IS SKIPPED, NOT MERGED: "@strategy" IS NOT "merge" HERE
+        assertThat(user.getString("name")).isEqualTo("a");
+
+        // THE SKIPPED DUPLICATE MUST NOT RESURFACE AS AN ANONYMOUS DOCUMENT
+        assertThat(db.getSchema().existsType("Document")).isFalse();
+      }
+    } finally {
+      dropDatabase(databasePath);
+      jsonFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  @Test
+  void aMappingObjectWithoutCatIsSkippedInsteadOfBeingSavedAsAnAnonymousDocument() throws Exception {
+    final String databasePath = "target/databases/test-import-6812-no-cat";
+    final File jsonFile = writeJsonFile("importer-6812-no-cat.json", "{\"Users\":[{\"id\":\"1\",\"name\":\"a\"}]}");
+
+    final String mapping = "{\"Users\":[{\"@type\":\"User\",\"@id\":\"id\"}]}";
+
+    try {
+      new Importer(new String[] { "-url", "file://" + jsonFile.getAbsolutePath(), "-database", databasePath,
+          "-forceDatabaseCreate", "true", "-mapping", mapping }).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.getSchema().existsType("Document")).isFalse();
+        assertThat(db.getSchema().existsType("User")).isFalse();
+      }
+    } finally {
+      dropDatabase(databasePath);
+      jsonFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * The anonymous-document path is intentional when there is no mapping object at all - which is exactly why the two
+   * cases had to be told apart. This pins it so the fix cannot be "tightened" into dropping legitimate records.
+   */
+  @Test
+  void withoutAMappingObjectTheRecordIsStillSavedAsAnAnonymousDocument() throws Exception {
+    final String databasePath = "target/databases/test-import-6812-anonymous";
+    final File jsonFile = writeJsonFile("importer-6812-anonymous.json", "{\"Users\":[{\"id\":\"1\"},{\"id\":\"2\"}]}");
+
+    try {
+      new Importer(new String[] { "-url", "file://" + jsonFile.getAbsolutePath(), "-database", databasePath,
+          "-forceDatabaseCreate", "true", "-mapping", "{'Users':[]}" }).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.countType("Document", true)).isEqualTo(2);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      jsonFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  private static void dropDatabase(final String databasePath) {
+    final DatabaseFactory factory = new DatabaseFactory(databasePath);
+    if (factory.exists())
+      factory.open().drop();
+  }
+
+  private static File writeJsonFile(final String fileName, final String content) throws IOException {
+    final File file = new File("target/" + fileName);
+    file.getParentFile().mkdirs();
+    try (final FileWriter writer = new FileWriter(file)) {
+      writer.write(content);
+    }
+    return file;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6813XmlEmptySubElementTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6813XmlEmptySubElementTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6813: in the XML importer {@code lastContent} was cleared only when a new record started, never when a new
+ * sub-element started, so an empty or self-closing sub-element inherited the previous sibling's text. This is the
+ * sub-element twin of #2759, which {@code XMLImporterFormatTest.noPropertyCarryoverBetweenRecords} fixed for
+ * attributes only.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6813XmlEmptySubElementTest {
+
+  @Test
+  void emptyAndSelfClosingSubElementsDoNotInheritThePreviousSiblingValue() throws IOException {
+    final String databasePath = "target/databases/test-import-6813-empty-subelement";
+    final File xmlFile = writeXmlFile("importer-6813-empty-subelement.xml", """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rows>
+          <row>
+            <a>1</a>
+            <b></b>
+            <c/>
+          </row>
+          <row>
+            <a>2</a>
+            <b>two</b>
+            <c/>
+          </row>
+        </rows>""");
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + xmlFile.getAbsolutePath() + " WITH objectNestLevel=1, entityType='VERTEX'");
+
+      assertThat(db.countType("v_row", true)).isEqualTo(2);
+
+      final Result first = selectByA(db, "1");
+      assertThat(first.<String>getProperty("a")).isEqualTo("1");
+      assertThat(first.<String>getProperty("b")).isEmpty();
+      assertThat(first.<String>getProperty("c")).isEmpty();
+
+      // ...AND NOT FROM THE PREVIOUS RECORD'S LAST SUB-ELEMENT EITHER
+      final Result second = selectByA(db, "2");
+      assertThat(second.<String>getProperty("b")).isEqualTo("two");
+      assertThat(second.<String>getProperty("c")).isEmpty();
+    } finally {
+      db.drop();
+      xmlFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * The flat property model keeps the last text found under a sub-element, including text carried by its own
+   * descendants: clearing the state on the sub-element boundary must not change that.
+   */
+  @Test
+  void nestedSubElementsStillContributeTheirTextToTheProperty() throws IOException {
+    final String databasePath = "target/databases/test-import-6813-nested-subelement";
+    final File xmlFile = writeXmlFile("importer-6813-nested-subelement.xml", """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rows>
+          <row>
+            <a><x>1</x><y>2</y></a>
+            <b/>
+          </row>
+        </rows>""");
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + xmlFile.getAbsolutePath() + " WITH objectNestLevel=1, entityType='VERTEX'");
+
+      assertThat(db.countType("v_row", true)).isEqualTo(1);
+
+      final ResultSet rs = db.query("sql", "SELECT FROM v_row");
+      final Result row = rs.next();
+      rs.close();
+
+      assertThat(row.<String>getProperty("a")).isEqualTo("2");
+      assertThat(row.<String>getProperty("b")).isEmpty();
+    } finally {
+      db.drop();
+      xmlFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  private static Result selectByA(final Database db, final String a) {
+    try (final ResultSet rs = db.query("sql", "SELECT FROM v_row WHERE a = ?", a)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next();
+    }
+  }
+
+  private static File writeXmlFile(final String fileName, final String content) throws IOException {
+    final File file = new File("target/" + fileName);
+    file.getParentFile().mkdirs();
+    try (final FileWriter writer = new FileWriter(file)) {
+      writer.write(content);
+    }
+    return file;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6814AnalyzedPropertyLongTextTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6814AnalyzedPropertyLongTextTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6814: {@code AnalyzedProperty.setLastContent()} treated a value longer than 100 characters as "stop sampling"
+ * <b>and</b> as "no evidence about the type", returning before the numeric probes and permanently disabling any
+ * further analysis of that column. A column whose first value looked numeric was therefore declared {@code LONG}, and
+ * the import then died converting the very value that should have disproved it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6814AnalyzedPropertyLongTextTest {
+
+  /** 150 characters, well past the 100-character sampling cut-off. */
+  private static final String LONG_TEXT = "a".repeat(150);
+
+  @Test
+  void longValueDisprovesTheNumericCandidates() {
+    final AnalyzedProperty property = new AnalyzedProperty("description", Type.STRING, 100, 0);
+
+    property.setLastContent("42");
+    property.setLastContent(LONG_TEXT);
+    property.endParsing();
+
+    assertThat(property.getType()).isEqualTo(Type.STRING);
+  }
+
+  @Test
+  void valuesAfterTheSamplingCutOffAreStillAnalyzed() {
+    final AnalyzedProperty property = new AnalyzedProperty("description", Type.STRING, 100, 0);
+
+    property.setLastContent("42");
+    // STOPS SAMPLE COLLECTION: EVERY VALUE AFTER IT USED TO BE A NO-OP
+    property.setLastContent(LONG_TEXT);
+    property.setLastContent("not a number");
+    property.endParsing();
+
+    assertThat(property.getType()).isEqualTo(Type.STRING);
+    assertThat(property.isCollectingSamples()).isFalse();
+    assertThat(property.getContents()).isEmpty();
+  }
+
+  @Test
+  void aGenuinelyNumericColumnIsStillTypedLong() {
+    final AnalyzedProperty property = new AnalyzedProperty("age", Type.STRING, 100, 0);
+
+    property.setLastContent("42");
+    property.setLastContent("43");
+    property.endParsing();
+
+    assertThat(property.getType()).isEqualTo(Type.LONG);
+  }
+
+  @Test
+  void aGenuinelyDecimalColumnIsStillTypedDouble() {
+    final AnalyzedProperty property = new AnalyzedProperty("price", Type.STRING, 100, 0);
+
+    property.setLastContent("10.90");
+    property.setLastContent("1985");
+    property.endParsing();
+
+    assertThat(property.getType()).isEqualTo(Type.DOUBLE);
+  }
+
+  /**
+   * End to end: the analyzed type is what {@code AbstractImporter.updateDatabaseSchema()} creates the property with,
+   * so the wrong analysis aborted the whole import on the long row with
+   * "Cannot convert type 'java.lang.String' to 'LONG'".
+   */
+  @Test
+  void csvWithALongTextColumnWhoseFirstValueLooksNumericImportsAsString() throws IOException {
+    final String databasePath = "target/databases/test-import-6814";
+    final File csvFile = new File("target/importer-6814-long-text.csv");
+    csvFile.getParentFile().mkdirs();
+    try (final FileWriter writer = new FileWriter(csvFile)) {
+      writer.write("id,description\n");
+      writer.write("1,42\n");
+      writer.write("2,\"" + LONG_TEXT + "\"\n");
+      writer.write("3,not a number\n");
+    }
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + csvFile.getAbsolutePath());
+
+      assertThat(db.getSchema().getType("Document").getProperty("description").getType()).isEqualTo(Type.STRING);
+      assertThat(db.countType("Document", true)).isEqualTo(3);
+    } finally {
+      db.drop();
+      csvFile.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+}


### PR DESCRIPTION
Fixes #6810, fixes #6811, fixes #6812, fixes #6813, fixes #6814.

Five independent defects in the importer module, all of which either drop or corrupt imported data without the import ever reporting a failure. Each one has a regression test that was verified to fail against `main` before the fix.

## #6810 - any ZIP source imports as 0 records, reported as success

Both reset callbacks in `SourceDiscovery` called `getNextEntry()` on the **old**, already closed `ZipInputStream` instead of the freshly created one, so the new stream was left with no current entry. A `ZipInputStream` with no current entry reads as an empty file rather than throwing, and the reset path runs on every import (`Importer.loadFromSource`, `SourceDiscovery.getSchema`, `CSVImporterFormat.analyze`). `Source.reset()` only logged the resulting `Stream closed` at SEVERE, so the run finished with `Total documents: 0` and no error.

Beyond the suggested fix in the issue:

- the new stream is positioned through the **same** seek the initial open uses, extracted as `seekZipEntry`/`positionZipStream`, so the `:::<resource>` entry is honoured on reset too (it never was - reset landed on the first entry of the archive regardless of what the user asked for);
- `Source.reset()` propagates instead of swallowing, so a broken re-open can never again be mistaken for an empty input;
- the remote reset callback closes the old stream before disconnecting the connection it belongs to. The local callback already did; the URL one leaked it, and on a ZIP source it then went on to advance that leaked stream instead of the new one, which is the defect itself;
- the local reset now re-opens through the same file-then-classpath resolution the first open used. It previously hard-coded `new FileInputStream(file)`, which cannot work for the classpath fallback - a latent second way for reset to fail, and one that the newly propagating `reset()` would have turned into a hard error.

## #6811 - the user's delimiter is overwritten with null for every CSV source

`analyzeSourceContent()` unconditionally wrote `knownDelimiter` into `settings.options`, but left it `null` for `EntityType.DATABASE`. Since `-delimiter` / `WITH delimiter = ';'` lands in that same map (`ImporterSettings.parseParameter`), it was destroyed for every CSV source, and `IMPORT DATABASE file://data.csv WITH delimiter = ';'` parsed the whole line as one column - producing a property literally named `id;name;age`, and reporting success.

The put is now guarded, and `case DATABASE` reads the generic option back from `settings.options` (falling back to `-documentsDelimiter`). The guard also means a generic `-delimiter` now survives for the `-documents`/`-vertices`/`-edges` forms when no per-entity delimiter is set, instead of being cleared.

One addition beyond the issue: `;` joins the `isSeparator()` candidate set. Without it a semicolon-separated file whose extension is not `.csv` produced no candidate at all and the import died with `Cannot determine the file type`; `;` is no more ambiguous than the `-` and `_` already in that set, and the best-candidate-by-frequency logic is unchanged.

## #6812 - a record logged as skipped is saved as an anonymous Document

`createRecord()` used the same return signal for two opposite outcomes: *no mapping, save this anonymously* and *this record is rejected or deduplicated, drop it*. `parseRecord()` collapsed both into `attributes.map`, and `parseRecordsArray()` then materialized it into `settings.documentTypeName`. A duplicate `@id` without `"@strategy": "merge"`, or a mapping object missing `@cat`/`@type` - both of which log `will be skipped` and increment `context.errors` - ended up saved anyway.

Rather than a sentinel return value, the two cases are separated where the information already exists:

- `parseRecordsArray()` anonymously saves only when `mappingObject == null`. That is the one case the anonymous path is meant for, and it deliberately keeps working for the **nested** `"@cat":"e"` object, which returns its attribute map on purpose so `convertMap()` can turn it into an edge during the mapping phase. Returning a sentinel from `createRecord()` would have broken exactly that path.
- a deduplicated `@id` now hands the existing record back, so a caller links to it instead of re-materializing the skipped attributes.

That second change also fixes a latent `ClassCastException` on the same code path: `convertMap()` cast the destination vertex to `MutableVertex`, which an existing (immutable) record from the dedup branch could never satisfy. It now goes through `modify()`, a no-op on a `MutableVertex`.

## #6813 - an empty or self-closing XML sub-element inherits the previous sibling's value

`lastContent` was cleared only when a new **record** started, never when a new sub-element started, so `<rows><row><a>1</a><b></b></row></rows>` imported as `{a: "1", b: "1"}`, in both `load()` and `analyze()`. This is the sub-element twin of #2759, whose regression test uses attributes exclusively.

State is cleared on the sub-element boundary, but only there: the clear at `END_ELEMENT` is conditioned on closing the property element itself (`nestLevel == objectNestLevel + 2`), so a deeper descendant's text still feeds the property and `<a><x>1</x><y>2</y></a>` keeps its existing last-wins result. The `#2759` whitespace fix is untouched - whitespace *between* elements still cannot erase the content of the element currently being read. An element opened and closed with no character content becomes an empty property, which is its XML text content, rather than a missing or `null` one.

## #6814 - a long text value is treated as no evidence, so the column is typed LONG

`AnalyzedProperty.setLastContent()` treated a value longer than 100 chars as *stop sampling* **and** as *no evidence about the type*, returning before the numeric probes and - because `collectingSamples` was now permanently `false` - making every subsequent value for that column a no-op too. A column whose first value looked numeric was declared `LONG` and created as such in the schema, and the import then died on the long value it never examined with `Cannot convert type 'java.lang.String' to 'LONG'` (or, under `-onRowError skip`, silently dropped every long-text row).

Type refutation now runs on **every** value, independently of sample collection, which covers the `maxValueSampling` short-circuit the issue also flagged. Sample collection still stops exactly where it did.

## Tests

- `Issue6810ZipSourceTest` - single-entry and multi-entry (`:::nodes.csv`) archives.
- `Issue6811CsvDelimiterOptionTest` - SQL `WITH delimiter`, CLI `-delimiter`, `;` auto-detection, plus a guard that a plain comma file still imports with no delimiter set.
- `Issue6812JsonSkippedRecordTest` - duplicate `@id`, missing `@cat`, plus a guard that the legitimate anonymous path still saves.
- `Issue6813XmlEmptySubElementTest` - empty and self-closing siblings, plus a guard for nested sub-elements.
- `Issue6814AnalyzedPropertyLongTextTest` - unit-level refutation, values after the cut-off, end-to-end CSV import, plus guards that genuinely numeric columns are still typed `LONG`/`DOUBLE`.

Full `integration` module green: 181 unit + 118 integration tests, including `CSVImporterIT`, `JSONImporterIT`, `XMLImporterIT`, `JsonLImporterIT`, `Neo4jImporterIT`, `OrientDBImporterIT` and `XMLImporterFormatTest` (the #2759 regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QF6LJaiD6ZRr6oA9WZxVBK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP, local, and remote source reopening, including reliable archive-entry selection.
  * CSV imports now honor configured delimiters and detect semicolon-separated files.
  * Fixed JSON handling for skipped, duplicate, and mapped records.
  * Corrected XML imports so empty or self-closing elements do not inherit previous values.
  * Improved type detection for long text and numeric-looking data.
  * Source reset failures are now reported correctly.

* **Tests**
  * Added coverage for ZIP, CSV, JSON, XML, and long-text import scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
