### PR TITLE
fix(#6805,#6806,#6807,#6808,#6809): bounded RED db tag, group grant refresh, PromQL range guard, replicated REST user mutations, capped auth sessions

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1424,6 +1424,25 @@ public enum GlobalConfiguration {
       "Absolute timeout in seconds for a HTTP authentication session to expire from its creation time, regardless of activity. Set to 0 to disable (unlimited). Default is 0 (disabled)",
       Long.class, 0), // 0 = DISABLED/UNLIMITED BY DEFAULT
 
+  SERVER_HTTP_AUTH_SESSION_MAX("arcadedb.server.httpAuthSessionMax", SCOPE.SERVER,
+      """
+      Maximum number of concurrent HTTP authentication sessions the server keeps in memory. Reached, a \
+      further POST /api/v1/login is refused with 503 rather than growing the session map without bound: \
+      each session is retained for the whole idle timeout \
+      ('arcadedb.server.httpAuthSessionExpireTimeout', 30 minutes by default) and carries client-supplied \
+      metadata, so an unbounded map is a heap-growth vector for any principal holding one valid \
+      credential (issue #6809). Set to 0 or a negative value for unlimited (WARNING: removes the \
+      protection). Default is 10000""",
+      Integer.class, 10_000),
+
+  SERVER_HTTP_AUTH_SESSION_MAX_PER_USER("arcadedb.server.httpAuthSessionMaxPerUser", SCOPE.SERVER,
+      """
+      Maximum number of concurrent HTTP authentication sessions a single principal may hold. Beyond it the \
+      principal's oldest session is evicted to make room for the new one, so a login loop churns only its \
+      own sessions and can neither grow the map nor evict another principal's sessions. \
+      Set to 0 or a negative value for unlimited (WARNING: removes the protection). Default is 100""",
+      Integer.class, 100),
+
   SERVER_HTTP_BODY_CONTENT_MAX_SIZE("arcadedb.server.httpBodyContentMaxSize", SCOPE.SERVER,
       "Maximum size in bytes for HTTP request body content. Set to -1 for unlimited size (WARNING: removes DoS protection). Default is 100MB",
       Long.class, 100L * 1024 * 1024), // 100MB DEFAULT

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -148,17 +148,37 @@ public class PromQLEvaluator {
     if (stepMs <= 0)
       throw new IllegalArgumentException("stepMs must be positive, got: " + stepMs);
 
-    final long maxSteps = (endMs - startMs) / stepMs + 1;
-    if (maxSteps > MAX_RANGE_STEPS)
+    // Math.subtractExact, not a plain subtraction: a span wider than Long.MAX_VALUE milliseconds (start
+    // -9e18, end 9e18 - both accepted by the ordering test above) wrapped negative, so the step-count guard
+    // below passed and the loop ran unbounded, wedging the calling thread for the life of the process
+    // (issue #6807). An overflowing span is rejected as the bad request it is rather than silently wrapping.
+    final long spanMs;
+    try {
+      spanMs = Math.subtractExact(endMs, startMs);
+    } catch (final ArithmeticException e) {
       throw new IllegalArgumentException(
-          "Range query would produce " + maxSteps + " steps, exceeding maximum of " + MAX_RANGE_STEPS
-              + ". Increase stepMs or reduce the time range");
+          "Range [" + startMs + "," + endMs + "] is wider than the representable time span. Reduce the time range");
+    }
+
+    // Tested BEFORE the +1, which would itself overflow to Long.MIN_VALUE for spanMs=Long.MAX_VALUE and
+    // stepMs=1 and turn the rejection into a silently empty result. Same threshold as `span/step + 1 > MAX`.
+    final long stepsAfterFirst = spanMs / stepMs;
+    if (stepsAfterFirst >= MAX_RANGE_STEPS)
+      throw new IllegalArgumentException(
+          "Range query would produce more than the maximum of " + MAX_RANGE_STEPS + " steps (" + stepsAfterFirst
+              + " intervals of " + stepMs + "ms). Increase stepMs or reduce the time range");
+
+    final long maxSteps = stepsAfterFirst + 1;
 
     // For range queries, evaluate at each step point and collect into MatrixResult
     final Map<String, List<double[]>> seriesMap = new LinkedHashMap<>();
     final Map<String, Map<String, String>> labelsMap = new LinkedHashMap<>();
 
-    for (long t = startMs; t <= endMs; t += stepMs) {
+    // Indexed by step rather than accumulated into `t`: `t += stepMs` could itself overflow past
+    // Long.MAX_VALUE and wrap to a value still <= endMs, which is the same unbounded loop by another route.
+    // `i * stepMs <= spanMs` holds for every iteration, so `startMs + i * stepMs` cannot overflow.
+    for (long i = 0; i < maxSteps; i++) {
+      final long t = startMs + i * stepMs;
       final PromQLResult result = evaluate(expr, t, startMs, endMs, stepMs, 0);
       if (result instanceof InstantVector iv) {
         for (final VectorSample sample : iv.samples()) {

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/promql/Issue6807RangeStepGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/promql/Issue6807RangeStepGuardTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries.promql;
+
+import com.arcadedb.engine.timeseries.promql.ast.PromQLExpr;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6807: the {@code query_range} step-count guard was computed in signed 64-bit
+ * arithmetic, so a span wider than {@code Long.MAX_VALUE} milliseconds wrapped negative, the guard passed,
+ * and the per-step loop ran unbounded - wedging the calling thread (an Undertow worker) for the life of the
+ * process.
+ * <p>
+ * The evaluator rejects every one of these before touching the database, so a {@code null} database is
+ * enough to drive them. The {@code @Timeout} is a hang detector, not a latency bound: the pre-fix code did
+ * not fail these assertions, it never returned at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6807RangeStepGuardTest {
+
+  private static final PromQLExpr UP = new PromQLParser("up").parse();
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void spanWiderThanLongIsRejectedInsteadOfLoopingForever() {
+    // The exact repro from the issue: start=-9e15s, end=9e15s, step=60s. Both operands are in order, so the
+    // endMs < startMs test does not fire, and (endMs - startMs) overflows to a negative number.
+    assertThatThrownBy(() -> new PromQLEvaluator(null).evaluateRange(UP, -9_000_000_000_000_000_000L,
+        9_000_000_000_000_000_000L, 60_000L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("wider than the representable time span");
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void spanOfLongMaxWithStepOneIsRejectedInsteadOfSilentlyEmpty() {
+    // spanMs / stepMs is Long.MAX_VALUE here, so the historical "+ 1" would itself have overflowed to
+    // Long.MIN_VALUE and turned the rejection into an empty result. The guard is tested before the "+ 1".
+    assertThatThrownBy(() -> new PromQLEvaluator(null).evaluateRange(UP, 0L, Long.MAX_VALUE, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maximum of");
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void representableButTooManyStepsIsStillRejected() {
+    // The pre-existing guard must keep working unchanged for a range that does not overflow.
+    assertThatThrownBy(() -> new PromQLEvaluator(null).evaluateRange(UP, 0L, 2_000_000_000L, 1_000L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maximum of 1000000");
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void endBeforeStartIsStillRejected() {
+    assertThatThrownBy(() -> new PromQLEvaluator(null).evaluateRange(UP, 1_000L, 0L, 1_000L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be >=");
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void nonPositiveStepIsStillRejected() {
+    assertThatThrownBy(() -> new PromQLEvaluator(null).evaluateRange(UP, 0L, 1_000L, 0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("stepMs must be positive");
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -223,6 +223,16 @@ class GrpcAuthInterceptor implements ServerInterceptor {
       return null;
     }
 
+    // The session captured its ServerSecurityUser at login, so a principal dropped afterwards would keep
+    // authenticating here until the token idle-expired. Re-checked against the live users map, exactly as
+    // the HTTP bearer branch does, so a revocation takes effect on this transport too.
+    if (security != null && security.getUser(session.getUser().getName()) == null) {
+      authSessionManager.removeSession(token);
+      LogManager.instance().log(this, Level.FINE,
+          "Token of a principal that no longer exists, rejected for database: %s", database);
+      return null;
+    }
+
     return session;
   }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -226,6 +226,12 @@ class GrpcAuthInterceptor implements ServerInterceptor {
     // The session captured its ServerSecurityUser at login, so a principal dropped afterwards would keep
     // authenticating here until the token idle-expired. Re-checked against the live users map, exactly as
     // the HTTP bearer branch does, so a revocation takes effect on this transport too.
+    //
+    // An existence check is enough HERE, unlike the HTTP branch which re-resolves the object, because
+    // nothing on this transport reads authority off the session's user: the only other use of it is
+    // session.getUser().getName() below, propagated into the gRPC context, and the services re-resolve the
+    // principal by name per call. Anything that starts reading permissions off session.getUser() directly
+    // must switch this to the same re-resolution, or it will honour the grants the token was minted with.
     if (security != null && security.getUser(session.getUser().getName()) == null) {
       authSessionManager.removeSession(token);
       LogManager.instance().log(this, Level.FINE,

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftUserManagement3NodesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftUserManagement3NodesIT.java
@@ -50,6 +50,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class RaftUserManagement3NodesIT extends BaseRaftHATest {
 
+  /** Created on demand by the Cypher test: the openCypher engine is per-database, so a server-wide admin
+   *  statement still has to be addressed to one. */
+  private static final String CYPHER_DATABASE = "cypheradmin";
+
   RaftUserManagement3NodesIT() {
     // Each server gets its own root path so they don't share config files.
     // In production, servers run in separate processes; in tests, all servers
@@ -255,6 +259,85 @@ class RaftUserManagement3NodesIT extends BaseRaftHATest {
     for (int i = 0; i < getServerCount(); i++)
       assertThat(postServerCommandReturnStatus(i, "list databases", "bob", "bobpassword2"))
           .as("server %d login as bob after DELETE /api/v1/server/users", i).isEqualTo(403);
+  }
+
+  /**
+   * The openCypher admin commands are a third door onto the user store, next to the REST endpoints and the
+   * {@code POST /api/v1/server} commands: {@code CREATE USER} / {@code ALTER USER ... SET PASSWORD} /
+   * {@code DROP USER} reach {@code ServerSecurity} through the {@code SecurityManager} interface. They used
+   * to mutate the serving node only - the same divergence issue #6808 is about, reached through Cypher
+   * instead of REST.
+   */
+  @Test
+  void cypherUserCommandsReplicateAcrossCluster() throws Exception {
+    assertThat(findLeaderIndex()).isGreaterThanOrEqualTo(0);
+
+    // The Cypher engine is per-database, so a server-wide admin statement still has to be addressed to one.
+    postServerCommandRetryOn503(0, "create database " + CYPHER_DATABASE);
+    Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> getServer(0).existsDatabase(CYPHER_DATABASE));
+
+    retryOn503(() -> cypher(0, "CREATE USER carol SET PASSWORD 'carolpassword1'"));
+
+    Awaitility.await().atMost(15, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> {
+          for (int i = 0; i < getServerCount(); i++)
+            if (getServer(i).getSecurity().getUser("carol") == null)
+              return false;
+          return true;
+        });
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(postServerCommandReturnStatus(i, "list databases", "carol", "carolpassword1"))
+          .as("server %d login as carol created through Cypher", i).isEqualTo(200);
+
+    // ALTER USER ... SET PASSWORD must reach every peer too, or the old password keeps working elsewhere.
+    retryOn503(() -> cypher(0, "ALTER USER carol SET PASSWORD 'carolpassword2'"));
+
+    Awaitility.await().atMost(15, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> {
+          for (int i = 0; i < getServerCount(); i++)
+            if (postServerCommandReturnStatus(i, "list databases", "carol", "carolpassword2") != 200)
+              return false;
+          return true;
+        });
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(postServerCommandReturnStatus(i, "list databases", "carol", "carolpassword1"))
+          .as("server %d must reject carol's rotated-away password", i).isEqualTo(403);
+
+    retryOn503(() -> cypher(0, "DROP USER carol"));
+
+    Awaitility.await().atMost(15, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> {
+          for (int i = 0; i < getServerCount(); i++)
+            if (getServer(i).getSecurity().getUser("carol") != null)
+              return false;
+          return true;
+        });
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(postServerCommandReturnStatus(i, "list databases", "carol", "carolpassword2"))
+          .as("server %d login as carol after a Cypher DROP USER", i).isEqualTo(403);
+  }
+
+  /**
+   * Runs a Cypher admin statement against the given server. The statement needs a database to be addressed
+   * to even though it mutates server-wide state, so it goes to the one this suite creates on demand.
+   */
+  private int cypher(final int serverIndex, final String statement) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/" + CYPHER_DATABASE).toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", "Basic " + Base64.getEncoder()
+        .encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    try {
+      formatPayload(connection, new JSONObject().put("language", "cypher").put("command", statement));
+      connection.connect();
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftUserManagement3NodesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftUserManagement3NodesIT.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Base64;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -195,6 +196,95 @@ class RaftUserManagement3NodesIT extends BaseRaftHATest {
       final byte[] other = Files.readAllBytes(
           Paths.get(getServer(i).getRootPath(), "config", "server-users.jsonl"));
       assertThat(other).as("server %d users file byte equality", i).isEqualTo(reference);
+    }
+  }
+
+  /**
+   * Regression test for issue #6808: {@code POST}/{@code PUT}/{@code DELETE /api/v1/server/users} - the
+   * documented REST surface, and what Studio's user management calls - mutated the user store only on the
+   * node that served the request, while the equivalent {@code POST /api/v1/server} commands replicated
+   * through Raft. A create returned 201 while the new principal got 401 on the other two nodes, and (worse)
+   * a delete returned 200 while the revoked credentials kept working everywhere else.
+   */
+  @Test
+  void restUserEndpointsReplicateAcrossCluster() throws Exception {
+    assertThat(findLeaderIndex()).isGreaterThanOrEqualTo(0);
+
+    // CREATE via the REST endpoint (not the server command).
+    final JSONObject bob = new JSONObject()
+        .put("name", "bob")
+        .put("password", "bobpassword1")
+        .put("databases", new JSONObject().put("*", new JSONArray().put("admin")));
+    retryOn503(() -> restUsers(0, "POST", "/api/v1/server/users", bob));
+
+    Awaitility.await().atMost(15, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> {
+          for (int i = 0; i < getServerCount(); i++)
+            if (getServer(i).getSecurity().getUser("bob") == null)
+              return false;
+          return true;
+        });
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(postServerCommandReturnStatus(i, "list databases", "bob", "bobpassword1"))
+          .as("server %d login as bob created through POST /api/v1/server/users", i).isEqualTo(200);
+
+    // UPDATE via the REST endpoint: the new password must be honoured on every node.
+    retryOn503(() -> restUsers(0, "PUT", "/api/v1/server/users?name=bob",
+        new JSONObject().put("password", "bobpassword2")));
+
+    Awaitility.await().atMost(15, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> {
+          for (int i = 0; i < getServerCount(); i++)
+            if (postServerCommandReturnStatus(i, "list databases", "bob", "bobpassword2") != 200)
+              return false;
+          return true;
+        });
+
+    // DELETE via the REST endpoint: the revocation must reach every node, not just the one that answered 200.
+    retryOn503(() -> restUsers(0, "DELETE", "/api/v1/server/users?name=bob", null));
+
+    Awaitility.await().atMost(15, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> {
+          for (int i = 0; i < getServerCount(); i++)
+            if (getServer(i).getSecurity().getUser("bob") != null)
+              return false;
+          return true;
+        });
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(postServerCommandReturnStatus(i, "list databases", "bob", "bobpassword2"))
+          .as("server %d login as bob after DELETE /api/v1/server/users", i).isEqualTo(403);
+  }
+
+  /**
+   * Same rationale as {@link #postServerCommandRetryOn503}: right after leader election a Raft commit can be
+   * acknowledged after the client-side timeout, so a 503 means "possibly committed" and the callers verify
+   * the actual cluster state with Awaitility rather than trusting a status code.
+   */
+  private void retryOn503(final Callable<Integer> request) throws Exception {
+    int status = 503;
+    for (int attempt = 0; attempt < 8 && status == 503; attempt++) {
+      if (attempt > 0)
+        Thread.sleep(2_000);
+      status = request.call();
+    }
+  }
+
+  private int restUsers(final int serverIndex, final String method, final String path, final JSONObject payload)
+      throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:248" + serverIndex + path).toURL().openConnection();
+    connection.setRequestMethod(method);
+    connection.setRequestProperty("Authorization", "Basic " + Base64.getEncoder()
+        .encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    try {
+      if (payload != null)
+        formatPayload(connection, payload);
+      connection.connect();
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
     }
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftUserManagement3NodesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftUserManagement3NodesIT.java
@@ -381,13 +381,8 @@ class RaftUserManagement3NodesIT extends BaseRaftHATest {
    * callers use {@code Awaitility} to verify the actual cluster state.
    */
   private void postServerCommandRetryOn503(final int serverIndex, final String command) throws Exception {
-    int status = 503;
-    for (int attempt = 0; attempt < 8 && status == 503; attempt++) {
-      if (attempt > 0)
-        Thread.sleep(2_000);
-      status = postServerCommandReturnStatus(serverIndex, command, "root",
-          BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
-    }
+    retryOn503(() -> postServerCommandReturnStatus(serverIndex, command, "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS));
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -591,6 +591,12 @@ public class ArcadeDBServer {
         // meter exists as Micrometer requires MeterFilters to precede the meters they govern.
         Metrics.globalRegistry.config().meterFilter(
             MeterFilter.maximumAllowableTags("arcadedb.http.requests", "path", 100, MeterFilter.deny()));
+        // Same backstop for the "db" half of the tuple (issue #6805). The handler already collapses a
+        // {database} path parameter naming no existing database onto a constant, but database name churn -
+        // or a future route exposing another free segment as "db" - must not be able to grow the registry
+        // either. 1000 is far above any realistic per-server database count.
+        Metrics.globalRegistry.config().meterFilter(
+            MeterFilter.maximumAllowableTags("arcadedb.http.requests", "db", 1000, MeterFilter.deny()));
         metricsFiltersInstalled = true;
       }
 

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -598,7 +598,8 @@ public class ArcadeDBServer {
         // handler's own timer-cache bound stay tied to one number.
         Metrics.globalRegistry.config().meterFilter(
             MeterFilter.maximumAllowableTags("arcadedb.http.requests", "db",
-                AbstractServerHttpHandler.MAX_DB_TAG_VALUES, MeterFilter.deny()));
+                AbstractServerHttpHandler.MAX_DB_TAG_VALUES + AbstractServerHttpHandler.RESERVED_DB_TAG_VALUES,
+                MeterFilter.deny()));
         metricsFiltersInstalled = true;
       }
 

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -594,9 +594,11 @@ public class ArcadeDBServer {
         // Same backstop for the "db" half of the tuple (issue #6805). The handler already collapses a
         // {database} path parameter naming no existing database onto a constant, but database name churn -
         // or a future route exposing another free segment as "db" - must not be able to grow the registry
-        // either. 1000 is far above any realistic per-server database count.
+        // either. The limit comes from the handler that produces the tag, so the registry-side bound and the
+        // handler's own timer-cache bound stay tied to one number.
         Metrics.globalRegistry.config().meterFilter(
-            MeterFilter.maximumAllowableTags("arcadedb.http.requests", "db", 1000, MeterFilter.deny()));
+            MeterFilter.maximumAllowableTags("arcadedb.http.requests", "db",
+                AbstractServerHttpHandler.MAX_DB_TAG_VALUES, MeterFilter.deny()));
         metricsFiltersInstalled = true;
       }
 

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
@@ -32,6 +32,16 @@ import java.util.function.LongSupplier;
  * @see <a href="https://github.com/ArcadeData/arcadedb/issues/1691">GitHub Issue #1691</a>
  */
 public class HttpAuthSession {
+  /**
+   * Upper bound on every client-supplied metadata field retained by a session. {@code sourceIp},
+   * {@code userAgent}, {@code country} and {@code city} all come from request headers the caller chooses
+   * ({@code User-Agent}, {@code CF-Connecting-IP}, {@code X-Forwarded-For}, {@code CF-IPCountry},
+   * {@code CF-IPCity}), and Undertow accepts a header up to 1 MB. Stored untruncated, each login retained
+   * megabytes for the whole idle timeout (issue #6809). 256 chars is well beyond any legitimate value of
+   * these four fields.
+   */
+  static final  int                MAX_METADATA_LENGTH = 256;
+
   public final  String             token;
   public final  ServerSecurityUser user;
   private final LongSupplier       clock;
@@ -62,10 +72,20 @@ public class HttpAuthSession {
     this.clock = clock;
     this.createdAt = clock.getAsLong();
     this.lastUpdate = this.createdAt;
-    this.sourceIp = sourceIp;
-    this.userAgent = userAgent;
-    this.country = country;
-    this.city = city;
+    // Truncated here rather than at each call site so no future caller can reintroduce the unbounded
+    // retention: this constructor is the only way a client-supplied string enters a session (issue #6809).
+    this.sourceIp = truncate(sourceIp);
+    this.userAgent = truncate(userAgent);
+    this.country = truncate(country);
+    this.city = truncate(city);
+  }
+
+  /**
+   * Caps a client-supplied metadata string at {@link #MAX_METADATA_LENGTH}. Returns the original reference
+   * when it already fits, so the common case allocates nothing.
+   */
+  static String truncate(final String value) {
+    return value == null || value.length() <= MAX_METADATA_LENGTH ? value : value.substring(0, MAX_METADATA_LENGTH);
   }
 
   public long elapsedFromLastUpdate() {

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
@@ -81,11 +81,20 @@ public class HttpAuthSession {
   }
 
   /**
-   * Caps a client-supplied metadata string at {@link #MAX_METADATA_LENGTH}. Returns the original reference
-   * when it already fits, so the common case allocates nothing.
+   * Caps a client-supplied metadata string at {@link #MAX_METADATA_LENGTH} chars. Returns the original
+   * reference when it already fits, so the common case allocates nothing. The cut never splits a surrogate
+   * pair: a supplementary-plane character landing exactly on the boundary is dropped whole rather than left
+   * as an unpaired half, which would render as a replacement character wherever the value is displayed.
    */
   static String truncate(final String value) {
-    return value == null || value.length() <= MAX_METADATA_LENGTH ? value : value.substring(0, MAX_METADATA_LENGTH);
+    if (value == null || value.length() <= MAX_METADATA_LENGTH)
+      return value;
+
+    final int end = Character.isHighSurrogate(value.charAt(MAX_METADATA_LENGTH - 1))
+        && Character.isLowSurrogate(value.charAt(MAX_METADATA_LENGTH))
+        ? MAX_METADATA_LENGTH - 1
+        : MAX_METADATA_LENGTH;
+    return value.substring(0, end);
   }
 
   public long elapsedFromLastUpdate() {

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.RWLockContext;
@@ -38,8 +39,16 @@ import java.util.logging.Level;
  */
 public class HttpAuthSessionManager extends RWLockContext {
   private final Map<String, HttpAuthSession> sessions = new HashMap<>();
+  // Per-principal index of the tokens above, in insertion order. A LinkedHashSet (not a Deque) so both the
+  // "which is the oldest session of this user" lookup the per-user cap needs and the arbitrary removal an
+  // expiry/logout needs are O(1). Kept in exact lock-step with `sessions`: an entry here always names a live
+  // session, and an empty set is dropped rather than left behind, so the index cannot outgrow the map.
+  private final Map<String, LinkedHashSet<String>> sessionsByUser = new HashMap<>();
   private final       long                         sessionTimeoutInMs;
   private final       long                         absoluteTimeoutInMs;
+  // <= 0 means unlimited. See SERVER_HTTP_AUTH_SESSION_MAX / SERVER_HTTP_AUTH_SESSION_MAX_PER_USER.
+  private final       int                          maxSessions;
+  private final       int                          maxSessionsPerUser;
   private final       LongSupplier                 clock;
   private final       Timer                        timer;
 
@@ -48,7 +57,14 @@ public class HttpAuthSessionManager extends RWLockContext {
   }
 
   public HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs) {
-    this(sessionTimeoutInMs, absoluteTimeoutInMs, System::currentTimeMillis);
+    this(sessionTimeoutInMs, absoluteTimeoutInMs,
+        GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX.getValueAsInteger(),
+        GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER.getValueAsInteger(), System::currentTimeMillis);
+  }
+
+  public HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final int maxSessions,
+      final int maxSessionsPerUser) {
+    this(sessionTimeoutInMs, absoluteTimeoutInMs, maxSessions, maxSessionsPerUser, System::currentTimeMillis);
   }
 
   /**
@@ -56,8 +72,16 @@ public class HttpAuthSessionManager extends RWLockContext {
    * wall clock, so idle/absolute timeout behavior can be asserted without sleeping (see #6398).
    */
   HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final LongSupplier clock) {
+    this(sessionTimeoutInMs, absoluteTimeoutInMs, GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX.getValueAsInteger(),
+        GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER.getValueAsInteger(), clock);
+  }
+
+  HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final int maxSessions,
+      final int maxSessionsPerUser, final LongSupplier clock) {
     this.sessionTimeoutInMs = sessionTimeoutInMs;
     this.absoluteTimeoutInMs = absoluteTimeoutInMs;
+    this.maxSessions = maxSessions;
+    this.maxSessionsPerUser = maxSessionsPerUser;
     this.clock = clock;
 
     timer = new Timer("HttpAuthSessionManager-Cleanup", true);
@@ -79,6 +103,7 @@ public class HttpAuthSessionManager extends RWLockContext {
     timer.cancel();
     executeInWriteLock(() -> {
       sessions.clear();
+      sessionsByUser.clear();
       return null;
     });
   }
@@ -99,6 +124,7 @@ public class HttpAuthSessionManager extends RWLockContext {
           LogManager.instance().log(this, Level.FINE, "Removing expired authentication session %s for user %s (idle=%b, absolute=%b)",
               session.token, session.user.getName(), idleExpired, absoluteExpired);
           it.remove();
+          unindex(session);
           expired++;
         }
       }
@@ -140,20 +166,67 @@ public class HttpAuthSessionManager extends RWLockContext {
 
   /**
    * Create a new authenticated session for a user with additional metadata.
+   * <p>
+   * The session map is bounded on both axes (issue #6809). The <b>per-principal</b> cap
+   * ({@code arcadedb.server.httpAuthSessionMaxPerUser}) is enforced by evicting that principal's oldest
+   * session, so a login loop churns only its own sessions - it cannot grow the map and it cannot evict
+   * anybody else's session. The <b>global</b> cap ({@code arcadedb.server.httpAuthSessionMax})
+   * is enforced by refusing, because at that point the only honest answer is that the server is out of
+   * session capacity; evicting globally would let one principal push other principals out. An idle sweep is
+   * attempted first, so a full map made of expired sessions is reclaimed instead of refused.
    *
    * @param user      the authenticated user
    * @param sourceIp  the source IP address of the client
    * @param userAgent the user agent string of the client
    * @param country   the country from Cloudflare headers (if available)
    * @param city      the city from Cloudflare headers (if available)
-   * @return the new session with a unique token
+   *
+   * @return the new session with a unique token, or {@code null} when the global cap is reached and no
+   * session could be reclaimed (the caller answers 503)
    */
   public HttpAuthSession createSession(final ServerSecurityUser user, final String sourceIp,
       final String userAgent, final String country, final String city) {
+    if (maxSessions > 0 && getActiveSessionCount() >= maxSessions)
+      // Reclaim first: a map full of idle-expired sessions must not refuse a legitimate login just because
+      // the background sweep has not fired yet. Done outside the write lock below (it takes its own).
+      checkSessionsValidity();
+
     return executeInWriteLock(() -> {
+      final String userName = user.getName();
+      final LinkedHashSet<String> existingTokens = sessionsByUser.get(userName);
+
+      // A principal already at its own cap will free exactly one slot by evicting, so it is admitted even
+      // when the map is globally full. Decided BEFORE anything is evicted: refusing after the eviction would
+      // destroy a live session of the very principal being refused.
+      final boolean willEvict = maxSessionsPerUser > 0 && existingTokens != null
+          && existingTokens.size() >= maxSessionsPerUser;
+
+      if (maxSessions > 0 && sessions.size() >= maxSessions && !willEvict) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Refused authentication session for user %s: the server reached the maximum of %d concurrent sessions "
+                + "(see '%s')", userName, maxSessions, GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX.getKey());
+        return null;
+      }
+
+      final LinkedHashSet<String> userTokens = existingTokens != null ? existingTokens
+          : sessionsByUser.computeIfAbsent(userName, k -> new LinkedHashSet<>());
+
+      // Per-principal cap: evict this principal's oldest session(s) to make room. `while`, not `if`, so a
+      // lowered configuration takes effect on the next login instead of leaving the surplus in place forever.
+      while (maxSessionsPerUser > 0 && userTokens.size() >= maxSessionsPerUser) {
+        final Iterator<String> oldest = userTokens.iterator();
+        final String evicted = oldest.next();
+        oldest.remove();
+        sessions.remove(evicted);
+        LogManager.instance().log(this, Level.FINE,
+            "Evicted authentication session %s: user %s reached the maximum of %d concurrent sessions", evicted,
+            userName, maxSessionsPerUser);
+      }
+
       final String token = "AU-" + UUID.randomUUID();
       final HttpAuthSession session = new HttpAuthSession(user, token, sourceIp, userAgent, country, city, clock);
       sessions.put(token, session);
+      userTokens.add(token);
       LogManager.instance().log(this, Level.FINE, "Created authentication session %s for user %s from %s", token,
           user.getName(), sourceIp);
       return session;
@@ -170,11 +243,40 @@ public class HttpAuthSessionManager extends RWLockContext {
     return executeInWriteLock(() -> {
       final HttpAuthSession removed = sessions.remove(token);
       if (removed != null) {
+        unindex(removed);
         LogManager.instance().log(this, Level.FINE, "Removed authentication session %s for user %s",
             token, removed.user.getName());
         return true;
       }
       return false;
+    });
+  }
+
+  /**
+   * Drops a session from the per-principal index, and the principal's (now empty) index entry with it, so
+   * {@link #sessionsByUser} can never retain a key for a user with no live session. Must be called under the
+   * write lock, right after the session has been removed from {@link #sessions}.
+   */
+  private void unindex(final HttpAuthSession session) {
+    final String userName = session.user != null ? session.user.getName() : null;
+    if (userName == null)
+      return;
+    final LinkedHashSet<String> userTokens = sessionsByUser.get(userName);
+    if (userTokens != null) {
+      userTokens.remove(session.token);
+      if (userTokens.isEmpty())
+        sessionsByUser.remove(userName);
+    }
+  }
+
+  /**
+   * Returns the number of active sessions held by the named principal. Package-private: used by the tests
+   * that pin the per-principal cap.
+   */
+  int getActiveSessionCount(final String userName) {
+    return executeInReadLock(() -> {
+      final LinkedHashSet<String> userTokens = sessionsByUser.get(userName);
+      return userTokens != null ? userTokens.size() : 0;
     });
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
@@ -253,6 +253,33 @@ public class HttpAuthSessionManager extends RWLockContext {
   }
 
   /**
+   * Invalidates every live authentication session owned by the named principal. Called when a user is
+   * dropped or its password is changed, so a token minted before that keeps no authority - mirroring what
+   * {@link HttpSessionManager#removeSessionsForUser} already does for transaction sessions.
+   * <p>
+   * Unlike its transaction-session counterpart this does no blocking work at all: an authentication session
+   * owns no transaction and has nothing to cancel, so it is safe to call from anywhere, including the Raft
+   * state-machine apply thread that installs a replicated user list on a peer.
+   *
+   * @return the number of sessions removed
+   */
+  public int removeSessionsForUser(final String userName) {
+    if (userName == null)
+      return 0;
+
+    return executeInWriteLock(() -> {
+      final LinkedHashSet<String> userTokens = sessionsByUser.remove(userName);
+      if (userTokens == null)
+        return 0;
+      for (final String token : userTokens)
+        sessions.remove(token);
+      LogManager.instance().log(this, Level.FINE, "Removed %d authentication session(s) of user %s",
+          userTokens.size(), userName);
+      return userTokens.size();
+    });
+  }
+
+  /**
    * Drops a session from the per-principal index, and the principal's (now empty) index entry with it, so
    * {@link #sessionsByUser} can never retain a key for a user with no live session. Must be called under the
    * write lock, right after the session has been removed from {@link #sessions}.

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -134,7 +134,9 @@ public class HttpServer implements ServerPlugin {
         server.getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_SESSION_EXPIRE_TIMEOUT) * 1_000L);
     this.authSessionManager = new HttpAuthSessionManager(
         server.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_EXPIRE_TIMEOUT) * 1_000L,
-        server.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_ABSOLUTE_TIMEOUT) * 1_000L);
+        server.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_ABSOLUTE_TIMEOUT) * 1_000L,
+        server.getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX),
+        server.getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER));
     this.webSocketEventBus = new WebSocketEventBus(this.server);
     final long ttlMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_TTL_MS);
     final int maxEntries = server.getConfiguration().getValueAsInteger(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_MAX_ENTRIES);

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -1092,13 +1092,12 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    * half of the tuple (issue #6805). Package-private for direct unit testing.
    */
   static String databaseTag(final HttpServerExchange exchange, final ArcadeDBServer server) {
-    final PathTemplateMatch match = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY);
-    if (match != null) {
-      final String db = match.getParameters().get("database");
-      if (db != null)
-        return server != null && server.existsDatabase(db) ? db : UNKNOWN_DB_TAG;
-    }
-    return "none";
+    // Extracted through the same helper the idempotency key uses, so there is exactly one place that
+    // answers "what is this request's database" and the bounded and unbounded forms cannot drift apart.
+    final String db = rawDatabaseParameter(exchange);
+    if (db == null)
+      return "none";
+    return server != null && server.existsDatabase(db) ? db : UNKNOWN_DB_TAG;
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -122,9 +122,20 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   // loop) cannot grow the cache without bound either. The overflow tuple space is itself finite: method,
   // path template and status are all small enumerations.
   private static final String     OVERFLOW_DB_TAG    = "other";
-  // Hard ceiling on the number of cached tuples. A MeterFilter can deny the meter but cannot stop
-  // computeIfAbsent from retaining the key, so the cache needs its own bound.
-  private static final int        MAX_HTTP_REQUEST_TIMERS = 2_000;
+  // Maximum number of distinct "db" tag values allowed on arcadedb.http.requests. ArcadeDBServer.startMetrics()
+  // installs the matching MeterFilter from this constant, so the registry-side bound and the cache-side bound
+  // below are one number rather than two independently-chosen ones. Far above any realistic per-server
+  // database count.
+  public static final  int        MAX_DB_TAG_VALUES  = 1_000;
+  // Ceiling on the number of cached tuples: a MeterFilter can deny the meter but cannot stop computeIfAbsent
+  // from retaining the key, so the cache needs a bound of its own. Sized as a multiple of MAX_DB_TAG_VALUES
+  // so that a deployment with the maximum admissible number of databases still gets per-database RED
+  // visibility across ten method/path/status combinations each before anything collapses onto
+  // OVERFLOW_DB_TAG - the collapse is a backstop against unbounded growth, not a routine operating mode. At
+  // roughly a hundred bytes per entry the whole cache is about a megabyte at the ceiling. Note this is a soft
+  // ceiling: the size test and the computeIfAbsent are not one atomic step, so concurrent misses right at the
+  // boundary can overshoot it by a bounded handful of entries before the collapse engages.
+  private static final int        MAX_HTTP_REQUEST_TIMERS = MAX_DB_TAG_VALUES * 10;
   // Cache of resolved arcadedb.http.requests timers keyed by the bounded tag tuple
   // (method|path|status|db). Avoids rebuilding the Timer.Builder/Tags/Meter.Id and doing a registry
   // hash lookup on every request. The key space is bounded because every tag is low-cardinality: the

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -29,6 +29,7 @@ import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.LeaderForwardContext;
 import com.arcadedb.server.http.HttpAuthSession;
@@ -112,11 +113,23 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   // static fallback, prefix handlers, 404 probes). Never echo the raw client URI as a tag value: it
   // is attacker-controlled and would register an unbounded number of permanent meters (issue #5025).
   private static final String     UNMATCHED_PATH_TAG = "unmatched";
+  // Constant db tag used for any request whose {database} path parameter does not name a database this
+  // server actually has. The parameter is a free path segment, so an unauthenticated caller can invent
+  // one per request; echoing it verbatim registered a permanent percentile-histogram Timer per invented
+  // name, the same unbounded heap growth #5025 fixed for the path tag (issue #6805).
+  private static final String     UNKNOWN_DB_TAG     = "unknown";
+  // Constant db tag substituted once the timer cache is full, so a database name churn (create/drop in a
+  // loop) cannot grow the cache without bound either. The overflow tuple space is itself finite: method,
+  // path template and status are all small enumerations.
+  private static final String     OVERFLOW_DB_TAG    = "other";
+  // Hard ceiling on the number of cached tuples. A MeterFilter can deny the meter but cannot stop
+  // computeIfAbsent from retaining the key, so the cache needs its own bound.
+  private static final int        MAX_HTTP_REQUEST_TIMERS = 2_000;
   // Cache of resolved arcadedb.http.requests timers keyed by the bounded tag tuple
   // (method|path|status|db). Avoids rebuilding the Timer.Builder/Tags/Meter.Id and doing a registry
   // hash lookup on every request. The key space is bounded because every tag is low-cardinality: the
   // path is collapsed to a route template or the constant "unmatched", method and status are small
-  // enumerations, and db is the finite set of database names.
+  // enumerations, and db is either an existing database name or the constant "unknown".
   private static final ConcurrentHashMap<String, Timer> HTTP_REQUEST_TIMERS = new ConcurrentHashMap<>();
   // Tracks the database whose DatabaseContext this request bound the authenticated principal onto in
   // checkAuthorizationOnDatabase, so handleRequest's finally can clear the binding on THIS pooled worker
@@ -880,11 +893,23 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    * Resolves (and caches) the {@code arcadedb.http.requests} RED timer for the given bounded tag tuple.
    * Building the timer once per distinct {@code method|path|status|db} tuple and reusing it removes the
    * per-request {@code Timer.Builder}/{@code Tags}/{@code Meter.Id} allocation and registry hash lookup
-   * on the hot path. The cache stays bounded because every tag is low-cardinality (issue #5025).
+   * on the hot path. The cache stays bounded because every tag is low-cardinality (issue #5025), and a
+   * hard {@link #MAX_HTTP_REQUEST_TIMERS} ceiling backs that up: a registry {@code MeterFilter} can deny
+   * the meter but cannot stop {@code computeIfAbsent} from retaining the key, so past the ceiling the
+   * {@code db} half of the tuple collapses onto {@link #OVERFLOW_DB_TAG} (issue #6805).
    * Package-private for direct unit testing.
    */
   static Timer httpRequestTimer(final String method, final String path, final String status, final String db) {
-    return HTTP_REQUEST_TIMERS.computeIfAbsent(method + '|' + path + '|' + status + '|' + db,
+    final String key = method + '|' + path + '|' + status + '|' + db;
+    final Timer cached = HTTP_REQUEST_TIMERS.get(key);
+    if (cached != null)
+      return cached;
+
+    // Recurses at most once: the overflow tuple space is finite, so the collapsed key is always cacheable.
+    if (HTTP_REQUEST_TIMERS.size() >= MAX_HTTP_REQUEST_TIMERS && !OVERFLOW_DB_TAG.equals(db))
+      return httpRequestTimer(method, path, status, OVERFLOW_DB_TAG);
+
+    return HTTP_REQUEST_TIMERS.computeIfAbsent(key,
         k -> Timer.builder("arcadedb.http.requests")
             .description("HTTP request duration")
             .tag("method", method)
@@ -1010,12 +1035,24 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    * Returns the database name resolved from the route's {@code {database}} path parameter, or
    * {@code none} for routes that are not database-scoped (e.g. {@code /ready}, {@code /server}).
    */
-  private static String databaseTag(final HttpServerExchange exchange) {
+  private String databaseTag(final HttpServerExchange exchange) {
+    return databaseTag(exchange, httpServer.getServer());
+  }
+
+  /**
+   * Bounded {@code db} tag for the RED timer: the raw {@code {database}} path parameter is echoed only when
+   * it names a database this server actually has, and collapses to the constant {@link #UNKNOWN_DB_TAG}
+   * otherwise. The parameter matches any path segment and the timer is recorded in a {@code finally} that
+   * also runs for the early 401, so without the existence test any unauthenticated caller could register one
+   * permanent percentile-histogram Timer per invented name - the {@code path}-tag leak of #5025, on the other
+   * half of the tuple (issue #6805). Package-private for direct unit testing.
+   */
+  static String databaseTag(final HttpServerExchange exchange, final ArcadeDBServer server) {
     final PathTemplateMatch match = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY);
     if (match != null) {
       final String db = match.getParameters().get("database");
       if (db != null)
-        return db;
+        return server != null && server.existsDatabase(db) ? db : UNKNOWN_DB_TAG;
     }
     return "none";
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -482,8 +482,12 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       if (idempotentPost) {
         // Bind the key to method/path/database/body so a reused correlation id cannot replay a different
         // request's response (the core defect: same X-Request-Id across distinct writes).
+        // The RAW path parameter, not the bounded metric tag: this key is an identity, so it must keep
+        // distinguishing two databases that the tag would deliberately fold together (both "unknown" when
+        // neither exists yet). The relative path already carries the name, so nothing changes in practice -
+        // but the identity of a request must never depend on a value chosen for meter cardinality.
         idempotencyKey = buildIdempotencyKey(rawRequestId, exchange.getRequestMethod().toString(),
-            exchange.getRelativePath(), databaseTag(exchange), payloadAsString);
+            exchange.getRelativePath(), rawDatabaseParameter(exchange), payloadAsString);
         final String currentPrincipal = user != null ? user.getName() : null;
 
         final IdempotencyCache.Reservation reservation = httpServer.getIdempotencyCache().reserve(idempotencyKey);
@@ -1062,6 +1066,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    */
   private String databaseTag(final HttpServerExchange exchange) {
     return databaseTag(exchange, httpServer.getServer());
+  }
+
+  /**
+   * Returns the route's {@code {database}} path parameter verbatim, or {@code null} when the route is not
+   * database-scoped. Unlike {@link #databaseTag} this value is unbounded and client-chosen, so it belongs
+   * only where the concrete name is the point - request identity - never in a meter tag or a log field.
+   */
+  private static String rawDatabaseParameter(final HttpServerExchange exchange) {
+    final PathTemplateMatch match = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY);
+    return match != null ? match.getParameters().get("database") : null;
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -397,7 +397,21 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
                   sendErrorResponse(exchange, 401, "Invalid or expired authentication token", null, null);
                   return;
                 }
-                user = authSession.getUser();
+                // Re-resolved from the live users map rather than taken from the session, which captured a
+                // ServerSecurityUser at login time. Without this a token kept BOTH the principal and the
+                // grants it had when it was minted: a dropped user went on authenticating, and a narrowed
+                // grant went on being honoured, until the token idle-expired. Eager invalidation covers the
+                // node that served the mutation, but a peer learns of it through a replicated user list, so
+                // this lookup - one ConcurrentHashMap read - is what makes revocation immediate everywhere.
+                final ServerSecurityUser sessionUser = httpServer.getServer().getSecurity()
+                    .getUser(authSession.getUser().getName());
+                if (sessionUser == null) {
+                  httpServer.getAuthSessionManager().removeSession(token);
+                  exchange.setStatusCode(401);
+                  sendErrorResponse(exchange, 401, "Invalid or expired authentication token", null, null);
+                  return;
+                }
+                user = sessionUser;
               }
 
             } else if (auth.startsWith(AUTHORIZATION_BASIC)) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -122,11 +122,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   // loop) cannot grow the cache without bound either. The overflow tuple space is itself finite: method,
   // path template and status are all small enumerations.
   private static final String     OVERFLOW_DB_TAG    = "other";
-  // Maximum number of distinct "db" tag values allowed on arcadedb.http.requests. ArcadeDBServer.startMetrics()
-  // installs the matching MeterFilter from this constant, so the registry-side bound and the cache-side bound
-  // below are one number rather than two independently-chosen ones. Far above any realistic per-server
-  // database count.
+  // Maximum number of distinct DATABASE NAMES allowed in the "db" tag of arcadedb.http.requests.
+  // ArcadeDBServer.startMetrics() installs the matching MeterFilter from this constant, so the registry-side
+  // bound and the cache-side bound below are one number rather than two independently-chosen ones. Far above
+  // any realistic per-server database count.
   public static final  int        MAX_DB_TAG_VALUES  = 1_000;
+  // The values above and beyond a database name that the "db" tag can carry: "none", UNKNOWN_DB_TAG and
+  // OVERFLOW_DB_TAG. MeterFilter.maximumAllowableTags counts EVERY distinct value of the tag, so the filter
+  // limit has to be the database-name budget plus these, or a server that has used the whole budget on real
+  // names would have its own collapse values denied - exactly the meters that exist to keep cardinality down.
+  public static final  int        RESERVED_DB_TAG_VALUES = 3;
   // Ceiling on the number of cached tuples: a MeterFilter can deny the meter but cannot stop computeIfAbsent
   // from retaining the key, so the cache needs a bound of its own. Sized as a multiple of MAX_DB_TAG_VALUES
   // so that a deployment with the maximum admissible number of databases still gets per-database RED

--- a/server/src/main/java/com/arcadedb/server/http/handler/DeleteDropUserHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DeleteDropUserHandler.java
@@ -51,12 +51,18 @@ public class DeleteDropUserHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(400, "{ \"error\" : \"User name parameter is null\"}");
 
     Metrics.counter("http.drop-user").increment();
-    ;
 
-    final boolean result = httpServer.getServer().getSecurity().dropUser(userName);
+    // Cluster-aware, like the non-deprecated DELETE /api/v1/server/users it stands in for (issue #6808).
+    final boolean result = httpServer.getServer().getSecurity().dropUserClusterWide(userName);
     if (!result)
       throw new RuntimeException("User '" + userName + "' not found on server");
 
     return new ExecutionResponse(204, "");
+  }
+
+  @Override
+  protected boolean mustExecuteOnWorkerThread() {
+    // The HA path blocks until the Raft entry is committed, which must never happen on an Undertow IO thread.
+    return true;
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/DeleteUserHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DeleteUserHandler.java
@@ -44,7 +44,10 @@ public class DeleteUserHandler extends AbstractServerHttpHandler {
     if ("root".equals(name))
       return new ExecutionResponse(400, new JSONObject().put("error", "Cannot delete the root user").toString());
 
-    final boolean deleted = httpServer.getServer().getSecurity().dropUser(name);
+    // Cluster-aware: on an HA cluster this replicates as a Raft entry so every peer drops the user. Calling
+    // security.dropUser() directly returned 200 while the revoked credentials kept working on every other
+    // node - the operator believed the revocation had succeeded (issue #6808).
+    final boolean deleted = httpServer.getServer().getSecurity().dropUserClusterWide(name);
 
     final JSONObject response = new JSONObject();
     if (deleted) {
@@ -54,5 +57,11 @@ public class DeleteUserHandler extends AbstractServerHttpHandler {
 
     response.put("error", "User '" + name + "' not found");
     return new ExecutionResponse(404, response.toString());
+  }
+
+  @Override
+  protected boolean mustExecuteOnWorkerThread() {
+    // The HA path blocks until the Raft entry is committed, which must never happen on an Undertow IO thread.
+    return true;
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryHandler.java
@@ -57,12 +57,19 @@ public class GetPromQLQueryHandler extends AbstractServerHttpHandler {
     if (query == null || query.isBlank())
       return new ExecutionResponse(400, PromQLResponseFormatter.formatError("bad_data", "Missing required parameter: query"));
 
+    // Same validation as the range endpoint's start/end (issue #6807): the raw parseDouble accepted a
+    // non-numeric value only to fail with a 500 outside the catch below, and accepted Infinity/1e300 as an
+    // evaluation instant. There is no unbounded loop on this path, but the two endpoints must not disagree
+    // on what a timestamp is.
     final String timeStr = getQueryParameter(exchange, "time");
     final long evalTimeMs;
-    if (timeStr != null && !timeStr.isBlank())
-      evalTimeMs = (long) (Double.parseDouble(timeStr) * 1000);
-    else
-      evalTimeMs = System.currentTimeMillis();
+    try {
+      evalTimeMs = timeStr != null && !timeStr.isBlank()
+          ? GetPromQLQueryRangeHandler.parseTimestampMs("time", timeStr)
+          : System.currentTimeMillis();
+    } catch (final IllegalArgumentException e) {
+      return new ExecutionResponse(400, PromQLResponseFormatter.formatError("bad_data", e.getMessage()));
+    }
 
     final DatabaseInternal database = httpServer.getServer().getDatabase(databaseParam.getFirst(), false, false);
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryRangeHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryRangeHandler.java
@@ -115,24 +115,45 @@ public class GetPromQLQueryRangeHandler extends AbstractServerHttpHandler {
       throw new IllegalArgumentException("Invalid " + name + " timestamp: '" + value + "'");
     }
 
-    if (!Double.isFinite(seconds))
-      throw new IllegalArgumentException("Invalid " + name + " timestamp: '" + value + "' is not finite");
-
-    if (Math.abs(seconds) > MAX_TIMESTAMP_SECONDS)
-      throw new IllegalArgumentException(
-          "Invalid " + name + " timestamp: '" + value + "' is outside the supported epoch range of +/- "
-              + MAX_TIMESTAMP_SECONDS + " seconds");
-
-    return (long) (seconds * 1000);
+    return secondsToMillis(name + " timestamp", value, seconds);
   }
 
-  private long parseStep(final String step) {
+  /**
+   * Parses the {@code step} parameter, which Prometheus accepts either as a number of seconds ({@code 60})
+   * or as a duration ({@code 1m}). The numeric form goes through the same finite/in-range validation as
+   * {@code start} and {@code end}: {@code Double.parseDouble} accepts {@code Infinity} and {@code 1e300}
+   * without throwing, and the resulting {@code (long)(v * 1000)} saturates to {@code Long.MAX_VALUE}, which
+   * is positive and therefore sailed past the "step must be positive" test. The evaluator then computed one
+   * single step and answered 200 with a one-point series instead of rejecting the request.
+   * Package-private for direct unit testing.
+   */
+  static long parseStep(final String step) {
+    final double seconds;
     try {
       // Try as plain seconds (e.g. "60")
-      return (long) (Double.parseDouble(step) * 1000);
+      seconds = Double.parseDouble(step);
     } catch (final NumberFormatException e) {
       // Try as duration (e.g. "1m")
       return PromQLParser.parseDuration(step);
     }
+
+    return secondsToMillis("step", step, seconds);
+  }
+
+  /**
+   * Converts a seconds value that came off the wire into milliseconds, refusing anything not finite or
+   * outside {@link #MAX_TIMESTAMP_SECONDS}. The bound is what keeps the millisecond value - and, for
+   * {@code start}/{@code end}, the span between two of them - far inside the 64-bit range the evaluator
+   * computes in (issue #6807).
+   */
+  private static long secondsToMillis(final String what, final String raw, final double seconds) {
+    if (!Double.isFinite(seconds))
+      throw new IllegalArgumentException("Invalid " + what + ": '" + raw + "' is not finite");
+
+    if (Math.abs(seconds) > MAX_TIMESTAMP_SECONDS)
+      throw new IllegalArgumentException("Invalid " + what + ": '" + raw
+          + "' is outside the supported epoch range of +/- " + MAX_TIMESTAMP_SECONDS + " seconds");
+
+    return (long) (seconds * 1000);
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryRangeHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryRangeHandler.java
@@ -133,7 +133,9 @@ public class GetPromQLQueryRangeHandler extends AbstractServerHttpHandler {
       // Try as plain seconds (e.g. "60")
       seconds = Double.parseDouble(step);
     } catch (final NumberFormatException e) {
-      // Try as duration (e.g. "1m")
+      // Try as duration (e.g. "1m"). This branch does NOT go through secondsToMillis: parseDuration carries
+      // its own overflow guard (it refuses a value once `current > Long.MAX_VALUE / unitMs`), so the two
+      // forms of `step` are bounded by two different mechanisms. Keep them in step if either bound moves.
       return PromQLParser.parseDuration(step);
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryRangeHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryRangeHandler.java
@@ -36,6 +36,9 @@ import java.util.Deque;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class GetPromQLQueryRangeHandler extends AbstractServerHttpHandler {
+  // Widest epoch second accepted for start/end. 1e12s is year 33658, ~1600x beyond any real series, and
+  // keeps start/end (and therefore their difference in milliseconds) far inside the 64-bit range.
+  static final double MAX_TIMESTAMP_SECONDS = 1e12;
 
   public GetPromQLQueryRangeHandler(final HttpServer httpServer) {
     super(httpServer);
@@ -65,9 +68,16 @@ public class GetPromQLQueryRangeHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(400,
           PromQLResponseFormatter.formatError("bad_data", "Missing required parameters: start, end, step"));
 
-    final long startMs = (long) (Double.parseDouble(startStr) * 1000);
-    final long endMs = (long) (Double.parseDouble(endStr) * 1000);
-    final long stepMs = parseStep(stepStr);
+    final long startMs;
+    final long endMs;
+    final long stepMs;
+    try {
+      startMs = parseTimestampMs("start", startStr);
+      endMs = parseTimestampMs("end", endStr);
+      stepMs = parseStep(stepStr);
+    } catch (final IllegalArgumentException e) {
+      return new ExecutionResponse(400, PromQLResponseFormatter.formatError("bad_data", e.getMessage()));
+    }
 
     if (stepMs <= 0)
       return new ExecutionResponse(400, PromQLResponseFormatter.formatError("bad_data", "Step must be positive"));
@@ -85,6 +95,35 @@ public class GetPromQLQueryRangeHandler extends AbstractServerHttpHandler {
     } catch (final IllegalArgumentException e) {
       return new ExecutionResponse(400, PromQLResponseFormatter.formatError("bad_data", e.getMessage()));
     }
+  }
+
+  /**
+   * Parses a Prometheus {@code start}/{@code end} parameter (epoch seconds, possibly fractional) into
+   * milliseconds, rejecting anything that is not a finite value inside {@link #MAX_TIMESTAMP_SECONDS}.
+   * <p>
+   * Without the bound, {@code start=-9e15}/{@code end=9e15} produced a span wider than {@code Long.MAX_VALUE}
+   * milliseconds, which wrapped negative in the evaluator's step-count guard and left the per-step loop
+   * unbounded - one request per worker thread was enough to take the HTTP listener down (issue #6807). The
+   * evaluator rejects the overflow on its own too; this is the earlier, clearer error for the caller.
+   * Package-private for direct unit testing.
+   */
+  static long parseTimestampMs(final String name, final String value) {
+    final double seconds;
+    try {
+      seconds = Double.parseDouble(value);
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid " + name + " timestamp: '" + value + "'");
+    }
+
+    if (!Double.isFinite(seconds))
+      throw new IllegalArgumentException("Invalid " + name + " timestamp: '" + value + "' is not finite");
+
+    if (Math.abs(seconds) > MAX_TIMESTAMP_SECONDS)
+      throw new IllegalArgumentException(
+          "Invalid " + name + " timestamp: '" + value + "' is outside the supported epoch range of +/- "
+              + MAX_TIMESTAMP_SECONDS + " seconds");
+
+    return (long) (seconds * 1000);
   }
 
   private long parseStep(final String step) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostLoginHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostLoginHandler.java
@@ -59,6 +59,12 @@ public class PostLoginHandler extends AbstractServerHttpHandler {
     // User is already authenticated by AbstractServerHttpHandler
     // Create a new authentication session with metadata
     final HttpAuthSession session = httpServer.getAuthSessionManager().createSession(user, sourceIp, userAgent, country, city);
+    if (session == null)
+      // The server-wide session cap is reached and the idle sweep reclaimed nothing: refuse rather than let
+      // the session map grow without bound (issue #6809). 503 - the credentials were valid, the capacity was not.
+      return new ExecutionResponse(503,
+          new JSONObject().put("error", "Server reached the maximum number of concurrent authentication sessions")
+              .toString());
 
     final JSONObject response = new JSONObject();
     response.put("token", session.getToken());

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -40,7 +40,6 @@ import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.LeaderForwardContext;
 import com.arcadedb.server.http.HttpServer;
-import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.IPAddressBlocklist;
@@ -812,25 +811,9 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
     Metrics.counter("http.create-user").increment();
 
-    final HAServerPlugin ha = server.getHA();
-    if (ha == null) {
-      // Non-HA mode: direct local mutation.
-      server.getSecurity().createUser(json);
-      return;
-    }
-
-    // HA mode: compute the new users payload and submit a Raft entry.
-    // The `synchronized` block serialises the read-compute-submit sequence with
-    // any other user mutation running on this leader, so two concurrent createUser
-    // calls cannot overwrite each other's in-flight changes.
-    synchronized (server.getSecurity()) {
-      if (server.getSecurity().getUser(json.getString("name")) != null)
-        throw new ServerSecurityException("User '" + json.getString("name") + "' already exists");
-
-      final JSONArray currentUsers = new JSONArray(server.getSecurity().getUsersJsonPayload());
-      currentUsers.put(json);
-      ha.replicateSecurityUsers(currentUsers.toString());
-    }
+    // The HA-vs-local decision, and the read-compute-submit serialisation it needs, live in ServerSecurity
+    // so the REST /api/v1/server/users handlers replicate through exactly the same path (issue #6808).
+    server.getSecurity().createUserClusterWide(json);
   }
 
   private void dropUser(final String userName) {
@@ -839,33 +822,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
     Metrics.counter("http.drop-user").increment();
 
-    final ArcadeDBServer server = httpServer.getServer();
-    final HAServerPlugin ha = server.getHA();
-
-    if (ha == null) {
-      // Non-HA mode: direct local mutation.
-      final boolean result = server.getSecurity().dropUser(userName);
-      if (!result)
-        throw new IllegalArgumentException("User '" + userName + "' not found on server");
-      return;
-    }
-
-    // HA mode: compute the new users payload and submit a Raft entry.
-    // Serialises read-compute-submit with other user mutations on this leader so
-    // two concurrent drops (or a concurrent createUser) cannot lose each other's changes.
-    synchronized (server.getSecurity()) {
-      if (server.getSecurity().getUser(userName) == null)
-        throw new IllegalArgumentException("User '" + userName + "' not found on server");
-
-      final JSONArray currentUsers = new JSONArray(server.getSecurity().getUsersJsonPayload());
-      final JSONArray filtered = new JSONArray();
-      for (int i = 0; i < currentUsers.length(); i++) {
-        final JSONObject user = currentUsers.getJSONObject(i);
-        if (!userName.equals(user.getString("name", "")))
-          filtered.put(user);
-      }
-      ha.replicateSecurityUsers(filtered.toString());
-    }
+    if (!httpServer.getServer().getSecurity().dropUserClusterWide(userName))
+      throw new IllegalArgumentException("User '" + userName + "' not found on server");
   }
 
   private boolean connectCluster(final String serverAddress, final HttpServerExchange exchange) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostUserHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostUserHandler.java
@@ -66,7 +66,10 @@ public class PostUserHandler extends AbstractServerHttpHandler {
     else
       userConfig.put("databases", new JSONObject());
 
-    security.createUser(userConfig);
+    // Cluster-aware: on an HA cluster this replicates as a Raft entry so every peer applies the new user.
+    // Calling security.createUser() directly created it only on the node that served the request, silently
+    // diverging the cluster's security state (issue #6808).
+    security.createUserClusterWide(userConfig);
 
     final JSONObject response = new JSONObject();
     response.put("result", "User '" + name + "' created");

--- a/server/src/main/java/com/arcadedb/server/http/handler/PutUserHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PutUserHandler.java
@@ -66,7 +66,10 @@ public class PutUserHandler extends AbstractServerHttpHandler {
     if (payload.has("databases"))
       updatedConfig.put("databases", payload.getJSONObject("databases"));
 
-    security.updateUser(updatedConfig);
+    // Cluster-aware: on an HA cluster this replicates as a Raft entry so every peer applies the change.
+    // Calling security.updateUser() directly applied it only on the node that served the request, silently
+    // diverging the cluster's security state (issue #6808).
+    security.updateUserClusterWide(updatedConfig);
 
     final JSONObject response = new JSONObject();
     response.put("result", "User '" + name + "' updated");

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/AuthApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/AuthApiSpec.java
@@ -48,10 +48,14 @@ public class AuthApiSpec implements OpenApiContributor {
             The token is then presented as a bearer token on subsequent requests. This operation \
             takes no request body: the credentials travel on the header, and geolocation metadata is \
             read from the CF-IPCountry, CF-IPCity, CF-Connecting-IP, X-Forwarded-For, and User-Agent \
-            headers when a proxy supplies them.""");
+            headers when a proxy supplies them (each is stored truncated to 256 characters). \
+            Answers 503 when the server already holds 'arcadedb.server.httpAuthSessionMax' concurrent \
+            sessions and none could be reclaimed; a principal that reaches \
+            'arcadedb.server.httpAuthSessionMaxPerUser' instead has its own oldest session evicted and \
+            still receives a token.""");
     post.setResponses(SpecBuilders.standardResponses("200",
         SpecBuilders.jsonResponse("Session created", "LoginResponse"),
-        "401", "403", "500"));
+        "401", "403", "500", "503"));
 
     final PathItem pathItem = new PathItem();
     pathItem.setPost(post);

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/SecurityAdminApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/SecurityAdminApiSpec.java
@@ -48,7 +48,8 @@ public class SecurityAdminApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Create user");
-    postOp.setDescription("Creates a new server user (root only). Requires name (string) and password (min 8 chars).");
+    postOp.setDescription("Creates a new server user (root only). Requires name (string) and password "
+        + "(min 8 chars). On an HA cluster the change is replicated to every node as a Raft entry.");
     postOp.setOperationId("createUser");
     postOp.addTagsItem("Security");
     postOp.setRequestBody(SpecBuilders.jsonBody("User creation request with name, password, and optional databases", null, true));
@@ -57,7 +58,8 @@ public class SecurityAdminApiSpec implements OpenApiContributor {
 
     final Operation putOp = new Operation();
     putOp.setSummary("Update user");
-    putOp.setDescription("Updates an existing user's password and/or database assignments (root only)");
+    putOp.setDescription("Updates an existing user's password and/or database assignments (root only). "
+        + "On an HA cluster the change is replicated to every node as a Raft entry.");
     putOp.setOperationId("updateUser");
     putOp.addTagsItem("Security");
     putOp.addParametersItem(SpecBuilders.queryParam("name", "User name", true));
@@ -67,7 +69,8 @@ public class SecurityAdminApiSpec implements OpenApiContributor {
 
     final Operation deleteOp = new Operation();
     deleteOp.setSummary("Delete user");
-    deleteOp.setDescription("Deletes a server user (root only)");
+    deleteOp.setDescription("Deletes a server user (root only). On an HA cluster the removal is "
+        + "replicated to every node as a Raft entry.");
     deleteOp.setOperationId("deleteUser");
     deleteOp.addTagsItem("Security");
     deleteOp.addParametersItem(SpecBuilders.queryParam("name", "User name to delete", true));

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -349,7 +349,22 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     return user;
   }
 
+  /**
+   * The {@link SecurityManager} entry point, and therefore what the openCypher {@code DROP USER} admin
+   * command reaches through {@code database.getSecurity()}. Cluster-aware, so that door cannot reopen the
+   * divergence #6808 closed on the REST one: a Cypher drop over Bolt or {@code /api/v1/command} used to
+   * mutate the user store on the serving node only.
+   */
+  @Override
   public boolean dropUser(final String userName) {
+    return dropUserClusterWide(userName);
+  }
+
+  /**
+   * Drops the user on THIS node only, with no replication. The local half of {@link #dropUserClusterWide};
+   * every caller that is not that method wants the cluster-aware {@link #dropUser} instead.
+   */
+  public boolean dropUserLocally(final String userName) {
     synchronized (this) {
       if (!users.containsKey(userName))
         return false;
@@ -440,7 +455,7 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   public boolean dropUserClusterWide(final String userName) {
     final HAServerPlugin ha = server != null ? server.getHA() : null;
     if (ha == null)
-      return dropUser(userName);
+      return dropUserLocally(userName);
 
     synchronized (this) {
       if (!users.containsKey(userName))
@@ -510,6 +525,10 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     return info;
   }
 
+  /**
+   * The {@link SecurityManager} entry point reached by the openCypher {@code CREATE USER} admin command.
+   * Cluster-aware for the same reason {@link #dropUser} is (issue #6808).
+   */
   @Override
   public void createUser(final String name, final String password) {
     final String encodedPassword = encodePassword(password);
@@ -517,18 +536,25 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     config.put("name", name);
     config.put("password", encodedPassword);
     config.put("databases", new JSONObject().put("*", new JSONArray().put("admin")));
-    createUser(config);
+    createUserClusterWide(config);
   }
 
+  /**
+   * The {@link SecurityManager} entry point reached by the openCypher {@code ALTER USER ... SET PASSWORD}
+   * admin command. Routed through {@link #updateUserClusterWide} so the rotation reaches every peer (issue
+   * #6808) and so a single place decides that a changed hash revokes the principal's live sessions.
+   */
   @Override
   public void setUserPassword(final String userName, final String password) {
     final ServerSecurityUser user = users.get(userName);
     if (user == null)
       throw new ServerSecurityException("User '" + userName + "' not found");
-    user.setPassword(encodePassword(password));
-    saveUsers();
-    // A password change re-authenticates the principal: drop its live HTTP transaction sessions.
-    invalidateHttpSessions(userName);
+
+    // A copy: updateUser() compares the previous user's stored hash against the new configuration's, so
+    // mutating the live configuration in place would hide the very change it has to detect.
+    final JSONObject updated = user.toJSON().copy();
+    updated.put("password", encodePassword(password));
+    updateUserClusterWide(updated);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -306,17 +306,33 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     return user;
   }
 
-  public synchronized ServerSecurityUser updateUser(final JSONObject userConfiguration) {
+  public ServerSecurityUser updateUser(final JSONObject userConfiguration) {
     final String name = userConfiguration.getString("name");
-    if (!users.containsKey(name))
-      throw new ServerSecurityException("User '" + name + "' not found");
+    final ServerSecurityUser user;
+    final boolean passwordChanged;
 
-    final ServerSecurityUser user = new ServerSecurityUser(server, userConfiguration);
-    users.put(name, user);
-    saveUsers();
+    synchronized (this) {
+      final ServerSecurityUser previous = users.get(name);
+      if (previous == null)
+        throw new ServerSecurityException("User '" + name + "' not found");
+
+      user = new ServerSecurityUser(server, userConfiguration);
+      passwordChanged = !Objects.equals(previous.getPassword(), user.getPassword());
+      users.put(name, user);
+      saveUsers();
+    }
+
     // Note: a metadata update does NOT force-rollback the principal's open transactions - per-request
     // authorization is still re-checked on every command, so a narrowed grant is enforced without tearing
-    // down unrelated in-flight work. Only drop and password change (below) invalidate live sessions.
+    // down unrelated in-flight work. A PASSWORD change is different: it re-authenticates the principal, so
+    // the credentials minted under the old password must stop working. PUT /api/v1/server/users routes a
+    // password rotation through here rather than through setUserPassword(), so without this an AU- login
+    // token issued before the rotation stayed valid until it idle-expired - the bearer path only checks that
+    // the principal still resolves by name, and it does. Done OUTSIDE the monitor, like every other call to
+    // invalidateHttpSessions(): it can block on a transaction session's in-flight command via cancel().
+    if (passwordChanged)
+      invalidateHttpSessions(name);
+
     return user;
   }
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -152,7 +152,14 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
       // Publish the freshly-built map in a single atomic reference swap: concurrent readers see either the
       // previous complete map or this one, never an empty intermediate state.
+      final Map<String, ServerSecurityUser> previousUsers = this.users;
       this.users = newUsers;
+
+      // A reload of server-users.jsonl is a third way for a principal to be dropped or to have its password
+      // rotated - an operator editing the file directly, or a peer's file being re-read - and the bearer
+      // path only requires the name to still resolve. Same comparison the replicated path makes. A no-op at
+      // startup, when no session exists yet.
+      invalidateAuthSessionsOfRevokedPrincipals(previousUsers, newUsers);
 
       if (newUsers.isEmpty() || (newUsers.containsKey("root") && newUsers.get("root").getPassword() == null))
         askForRootPassword();

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -391,14 +391,19 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   public void updateUserClusterWide(final JSONObject userConfiguration) {
     final HAServerPlugin ha = server != null ? server.getHA() : null;
     if (ha == null) {
+      // updateUser() itself revokes the principal's sessions when the password changed.
       updateUser(userConfiguration);
       return;
     }
 
     final String name = userConfiguration.getString("name");
+    final boolean passwordChanged;
     synchronized (this) {
-      if (!users.containsKey(name))
+      final ServerSecurityUser previous = users.get(name);
+      if (previous == null)
         throw new ServerSecurityException("User '" + name + "' not found");
+
+      passwordChanged = !Objects.equals(previous.getPassword(), userConfiguration.getString("password", null));
 
       final JSONArray currentUsers = new JSONArray(getUsersJsonPayload());
       final JSONArray replaced = new JSONArray();
@@ -408,6 +413,15 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       }
       ha.replicateSecurityUsers(replaced.toString());
     }
+
+    // Applying the replicated list already dropped this principal's LOGIN sessions on every node, this one
+    // included. What that path cannot do is touch the transaction sessions: it runs on the Raft
+    // state-machine apply thread, and cancelling a transaction session waits on the session lock for any
+    // in-flight command. So the serving node closes that half here, outside the monitor - the same shape
+    // dropUserClusterWide() uses, and with the same limitation: a peer's open transaction sessions for the
+    // principal are left to their own idle timeout.
+    if (passwordChanged)
+      invalidateHttpSessions(name);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -294,7 +294,11 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   public synchronized ServerSecurityUser createUser(final JSONObject userConfiguration) {
     final String name = userConfiguration.getString("name");
     if (users.containsKey(name))
-      throw new SecurityException("User '" + name + "' already exists");
+      // ServerSecurityException, not java.lang.SecurityException: identical semantics must not be reported
+      // with two different exception types depending on whether the server happens to be in a cluster
+      // (createUserClusterWide's HA branch raises the same condition). Both already map to the same HTTP
+      // status through AbstractServerHttpHandler.isSecurityFailure().
+      throw new ServerSecurityException("User '" + name + "' already exists");
 
     final ServerSecurityUser user = new ServerSecurityUser(server, userConfiguration);
     users.put(name, user);

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -426,14 +426,46 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   }
 
   /**
-   * Invalidates every live HTTP transaction session owned by the named principal (rolling back its open
-   * transaction). No-op when the HTTP server is not running (e.g. embedded use). Must be called OUTSIDE the
-   * {@code ServerSecurity} monitor: it can block on a session's in-flight command via {@code cancel()}.
+   * Invalidates every live HTTP session owned by the named principal: the transaction sessions (rolling back
+   * their open transaction) <b>and</b> the {@code AU-} authentication sessions minted by
+   * {@code POST /api/v1/login}. No-op when the HTTP server is not running (e.g. embedded use). Must be called
+   * OUTSIDE the {@code ServerSecurity} monitor: it can block on a transaction session's in-flight command via
+   * {@code cancel()}.
+   * <p>
+   * The authentication half matters because a login token carries its own authority: the bearer branch of
+   * {@code AbstractServerHttpHandler} resolves the principal from the session, so a token minted before a
+   * drop or a password change would otherwise keep authenticating until it idle-expired - up to 30 minutes
+   * of credentials that the operator believes were revoked.
    */
   private void invalidateHttpSessions(final String userName) {
     final HttpServer httpServer = server != null ? server.getHttpServer() : null;
-    if (httpServer != null)
+    if (httpServer != null) {
       httpServer.getSessionManager().removeSessionsForUser(userName);
+      httpServer.getAuthSessionManager().removeSessionsForUser(userName);
+    }
+  }
+
+  /**
+   * Drops the authentication sessions of every principal that the replicated user list removed or whose
+   * password it changed. Called on each peer after {@link #applyReplicatedUsers} has installed the new list,
+   * so a cluster-wide drop or password change revokes the login tokens a peer had already issued rather than
+   * leaving them valid until they idle-expire.
+   * <p>
+   * Only the authentication sessions are touched here: unlike {@code HttpSessionManager.removeSessionsForUser},
+   * {@code HttpAuthSessionManager.removeSessionsForUser} does no blocking work, so it is safe on the Raft
+   * state-machine apply thread, which must never wait on a session lock.
+   */
+  private void invalidateAuthSessionsOfRevokedPrincipals(final Map<String, ServerSecurityUser> previousUsers,
+      final Map<String, ServerSecurityUser> currentUsers) {
+    final HttpServer httpServer = server != null ? server.getHttpServer() : null;
+    if (httpServer == null)
+      return;
+
+    for (final Map.Entry<String, ServerSecurityUser> entry : previousUsers.entrySet()) {
+      final ServerSecurityUser current = currentUsers.get(entry.getKey());
+      if (current == null || !Objects.equals(current.getPassword(), entry.getValue().getPassword()))
+        httpServer.getAuthSessionManager().removeSessionsForUser(entry.getKey());
+    }
   }
 
   @Override
@@ -686,10 +718,16 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
     // Build in-memory map from the authoritative Raft payload, not from the file, and publish it in a
     // single atomic reference swap so concurrent readers never observe an empty/torn window.
+    final Map<String, ServerSecurityUser> previousUsers = this.users;
     final Map<String, ServerSecurityUser> newUsers = new ConcurrentHashMap<>();
     for (final JSONObject userJson : list)
       newUsers.put(userJson.getString("name"), new ServerSecurityUser(server, userJson));
     this.users = newUsers;
+
+    // A peer applying a replicated drop or password change must also revoke the login tokens it had already
+    // issued to that principal, or the credentials the operator revoked keep working on this node until the
+    // token idle-expires. Non-blocking, so it is safe on the state-machine apply thread.
+    invalidateAuthSessionsOfRevokedPrincipals(previousUsers, newUsers);
   }
 
   public void saveGroups() {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -400,6 +400,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * mutation on this node, so two concurrent calls cannot overwrite each other's in-flight change. It must
    * NOT be held across anything that can block on the Raft apply thread; {@link #applyReplicatedUsers}, which
    * unblocks the submit, deliberately does not take this monitor.
+   * <p>
+   * Note what that costs, for whoever adds a fourth cluster-wide mutator here by symmetry: the monitor IS
+   * held across the Raft round trip, so every user create/update/drop on this node serialises for the
+   * duration of consensus. That is deliberate - the payload is the whole user list, so two concurrent
+   * submits would otherwise each overwrite the other's change - and it is affordable only because user
+   * administration is rare. Nothing on a request hot path may be put inside this monitor.
    */
   public void createUserClusterWide(final JSONObject userConfiguration) {
     final HAServerPlugin ha = server != null ? server.getHA() : null;

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -343,6 +343,11 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     // token issued before the rotation stayed valid until it idle-expired - the bearer path only checks that
     // the principal still resolves by name, and it does. Done OUTSIDE the monitor, like every other call to
     // invalidateHttpSessions(): it can block on a transaction session's in-flight command via cancel().
+    //
+    // What is compared is the stored hash, and encodePassword() salts randomly, so resubmitting the SAME
+    // plaintext also reads as changed and also revokes. That is the safe direction to be imprecise in - it
+    // over-revokes, never under-revokes - but do not read this as "resubmitting the same password is a
+    // no-op", because it is not.
     if (passwordChanged)
       invalidateHttpSessions(name);
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -29,6 +29,7 @@ import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.DefaultConsoleReader;
+import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.ServerException;
 import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.server.http.HttpServer;
@@ -330,6 +331,97 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   }
 
   /**
+   * Cluster-aware {@link #createUser}: submits the new user list as a Raft entry when the server is part of
+   * an HA cluster, so every peer applies it, and falls back to the local mutation when it is not.
+   * <p>
+   * Every path that mutates the user store from the outside must go through this (or its {@code update}/
+   * {@code drop} siblings). {@code POST}/{@code PUT}/{@code DELETE /api/v1/server/users} used to call the
+   * local mutators directly while the equivalent {@code POST /api/v1/server} commands replicated, so a
+   * cluster silently diverged its security state - and the next replicated user command latched the
+   * divergence in by overwriting every peer with the serving node's whole list (issue #6808).
+   * <p>
+   * The {@code synchronized} block serialises the read-compute-submit sequence against any other user
+   * mutation on this node, so two concurrent calls cannot overwrite each other's in-flight change. It must
+   * NOT be held across anything that can block on the Raft apply thread; {@link #applyReplicatedUsers}, which
+   * unblocks the submit, deliberately does not take this monitor.
+   */
+  public void createUserClusterWide(final JSONObject userConfiguration) {
+    final HAServerPlugin ha = server != null ? server.getHA() : null;
+    if (ha == null) {
+      createUser(userConfiguration);
+      return;
+    }
+
+    final String name = userConfiguration.getString("name");
+    synchronized (this) {
+      if (users.containsKey(name))
+        throw new ServerSecurityException("User '" + name + "' already exists");
+
+      final JSONArray currentUsers = new JSONArray(getUsersJsonPayload());
+      currentUsers.put(userConfiguration);
+      ha.replicateSecurityUsers(currentUsers.toString());
+    }
+  }
+
+  /**
+   * Cluster-aware {@link #updateUser}. See {@link #createUserClusterWide} for why this exists; the payload is
+   * built by replacing the named user in the current list rather than appending, so the replicated snapshot
+   * carries exactly one entry per user.
+   */
+  public void updateUserClusterWide(final JSONObject userConfiguration) {
+    final HAServerPlugin ha = server != null ? server.getHA() : null;
+    if (ha == null) {
+      updateUser(userConfiguration);
+      return;
+    }
+
+    final String name = userConfiguration.getString("name");
+    synchronized (this) {
+      if (!users.containsKey(name))
+        throw new ServerSecurityException("User '" + name + "' not found");
+
+      final JSONArray currentUsers = new JSONArray(getUsersJsonPayload());
+      final JSONArray replaced = new JSONArray();
+      for (int i = 0; i < currentUsers.length(); i++) {
+        final JSONObject entry = currentUsers.getJSONObject(i);
+        replaced.put(name.equals(entry.getString("name", "")) ? userConfiguration : entry);
+      }
+      ha.replicateSecurityUsers(replaced.toString());
+    }
+  }
+
+  /**
+   * Cluster-aware {@link #dropUser}. See {@link #createUserClusterWide}.
+   *
+   * @return true if the user existed and the removal was applied/replicated, false if there was no such user
+   */
+  public boolean dropUserClusterWide(final String userName) {
+    final HAServerPlugin ha = server != null ? server.getHA() : null;
+    if (ha == null)
+      return dropUser(userName);
+
+    synchronized (this) {
+      if (!users.containsKey(userName))
+        return false;
+
+      final JSONArray currentUsers = new JSONArray(getUsersJsonPayload());
+      final JSONArray filtered = new JSONArray();
+      for (int i = 0; i < currentUsers.length(); i++) {
+        final JSONObject entry = currentUsers.getJSONObject(i);
+        if (!userName.equals(entry.getString("name", "")))
+          filtered.put(entry);
+      }
+      ha.replicateSecurityUsers(filtered.toString());
+    }
+
+    // Same rationale (and the same OUTSIDE-the-monitor placement) as dropUser(): a recreated same-name
+    // principal must not adopt the prior principal's still-open transaction session. Local only - the peers
+    // apply the replicated user list on their state machine thread, which must never block on a session lock.
+    invalidateHttpSessions(userName);
+    return true;
+  }
+
+  /**
    * Invalidates every live HTTP transaction session owned by the named principal (rolling back its open
    * transaction). No-op when the HTTP server is not running (e.g. embedded use). Must be called OUTSIDE the
    * {@code ServerSecurity} monitor: it can block on a session's in-flight command via {@code cancel()}.
@@ -372,21 +464,32 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     invalidateHttpSessions(userName);
   }
 
+  /**
+   * Re-applies the current group configuration of {@code database} to every user that has already cached a
+   * {@link ServerSecurityDatabaseUser} for it. Called after a schema change and after any group edit (REST
+   * {@code POST}/{@code DELETE /api/v1/server/groups} and the {@code server-groups.json} reload watcher).
+   * <p>
+   * Delegates to {@link ServerSecurityUser#refreshDatabaseConfiguration} so BOTH permission maps are rebuilt:
+   * refreshing only the per-type/per-bucket half left the database-level grants ({@code updateSchema},
+   * {@code updateSecurity}, {@code updateDatabaseSettings}) and the {@code resultSetLimit}/{@code readTimeout}
+   * quotas frozen at the values they had when the user first touched the database, so a revoked grant kept
+   * working until restart (issue #6806).
+   * <p>
+   * It no longer calls {@code getDatabaseUser()}, which would <i>create</i> a cached entry for every user on
+   * the server as a side effect. A user that has never touched this database has nothing to refresh: its
+   * entry is built from the current configuration the first time it does.
+   */
   @Override
   public void updateSchema(final DatabaseInternal database) {
     if (database == null)
       return;
 
-    for (final ServerSecurityUser user : users.values()) {
-      final ServerSecurityDatabaseUser databaseUser = user.getDatabaseUser(database);
-      if (databaseUser != null) {
-        final JSONObject groupConfiguration = getDatabaseGroupsConfiguration(database.getName());
-        if (groupConfiguration == null)
-          continue;
+    // Resolved once for the whole sweep instead of once per user: the lookup merges the wildcard and the
+    // per-database group objects, and the configuration cannot change under a single refresh.
+    final JSONObject groupConfiguration = getDatabaseGroupsConfiguration(database.getName());
 
-        databaseUser.updateFileAccess(database, groupConfiguration);
-      }
-    }
+    for (final ServerSecurityUser user : users.values())
+      user.refreshDatabaseConfiguration(database, groupConfiguration);
   }
 
   public String getEncodedHash(final String password, final String salt, final int iterations) {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -308,8 +308,11 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       throw new ServerSecurityException("User '" + name + "' already exists");
 
     final ServerSecurityUser user = new ServerSecurityUser(server, userConfiguration);
+    // Persist BEFORE publishing: saveUsers() propagates an I/O failure so the request fails, and publishing
+    // first would leave the new user live in memory while nothing reached the disk - authoritative until the
+    // next restart silently took it away again.
+    saveUsers(snapshotWith(name, userConfiguration));
     users.put(name, user);
-    saveUsers();
     return user;
   }
 
@@ -325,8 +328,11 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
       user = new ServerSecurityUser(server, userConfiguration);
       passwordChanged = !Objects.equals(previous.getPassword(), user.getPassword());
+      // Persist before publishing, as in createUser(): a failed save must leave the previous password in
+      // force rather than activate a new one that no longer exists after a restart - and the throw would
+      // also skip the session invalidation below, so the rotation would be half-applied.
+      saveUsers(snapshotWith(name, userConfiguration));
       users.put(name, user);
-      saveUsers();
     }
 
     // Note: a metadata update does NOT force-rollback the principal's open transactions - per-request
@@ -345,9 +351,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
   public boolean dropUser(final String userName) {
     synchronized (this) {
-      if (users.remove(userName) == null)
+      if (!users.containsKey(userName))
         return false;
-      saveUsers();
+      // Persist before publishing, as in createUser()/updateUser(): a failed save must not leave a user
+      // removed in memory and still present on disk, which a restart would resurrect.
+      saveUsers(snapshotWith(userName, null));
+      users.remove(userName);
     }
     // Invalidate the dropped principal's live HTTP transaction sessions so a recreated same-name principal
     // cannot adopt (and commit) the prior principal's still-open session. Done OUTSIDE the security monitor:
@@ -384,9 +393,7 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       if (users.containsKey(name))
         throw new ServerSecurityException("User '" + name + "' already exists");
 
-      final JSONArray currentUsers = new JSONArray(getUsersJsonPayload());
-      currentUsers.put(userConfiguration);
-      ha.replicateSecurityUsers(currentUsers.toString());
+      ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration));
     }
   }
 
@@ -412,13 +419,7 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
       passwordChanged = !Objects.equals(previous.getPassword(), userConfiguration.getString("password", null));
 
-      final JSONArray currentUsers = new JSONArray(getUsersJsonPayload());
-      final JSONArray replaced = new JSONArray();
-      for (int i = 0; i < currentUsers.length(); i++) {
-        final JSONObject entry = currentUsers.getJSONObject(i);
-        replaced.put(name.equals(entry.getString("name", "")) ? userConfiguration : entry);
-      }
-      ha.replicateSecurityUsers(replaced.toString());
+      ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration));
     }
 
     // Applying the replicated list already dropped this principal's LOGIN sessions on every node, this one
@@ -445,14 +446,7 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       if (!users.containsKey(userName))
         return false;
 
-      final JSONArray currentUsers = new JSONArray(getUsersJsonPayload());
-      final JSONArray filtered = new JSONArray();
-      for (int i = 0; i < currentUsers.length(); i++) {
-        final JSONObject entry = currentUsers.getJSONObject(i);
-        if (!userName.equals(entry.getString("name", "")))
-          filtered.put(entry);
-      }
-      ha.replicateSecurityUsers(filtered.toString());
+      ha.replicateSecurityUsers(replicationPayloadWith(userName, null));
     }
 
     // Same rationale (and the same OUTSIDE-the-monitor placement) as dropUser(): a recreated same-name
@@ -692,8 +686,19 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   }
 
   public void saveUsers() {
+    saveUsers(usersToJSON());
+  }
+
+  /**
+   * Writes an explicit user list to {@code server-users.jsonl}, so a mutation can be persisted <i>before</i>
+   * it is published to the in-memory map. Publishing first and saving after leaves the change authoritative
+   * in memory while nothing reached the disk when the write fails - and the propagated failure then also
+   * skips whatever the caller does afterwards (session invalidation, most importantly), so the mutation ends
+   * up half-applied instead of not applied at all.
+   */
+  private void saveUsers(final List<JSONObject> snapshot) {
     try {
-      usersRepository.save(usersToJSON());
+      usersRepository.save(snapshot);
     } catch (final IOException e) {
       LogManager.instance()
           .log(this, Level.SEVERE, "Error on saving security configuration to file '%s'", e, SecurityUserFileRepository.FILE_NAME);
@@ -702,6 +707,43 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       throw new ServerSecurityException(
           "Error on saving security configuration to file '" + SecurityUserFileRepository.FILE_NAME + "'", e);
     }
+  }
+
+  /**
+   * Returns the current user list with {@code name}'s entry replaced by {@code replacement}, appended when
+   * the name is not present yet, or removed when {@code replacement} is {@code null}. Must be called while
+   * holding this monitor.
+   * <p>
+   * The single place the create/update/drop shape is expressed, on both the local and the replicated path:
+   * three hand-written copies of this loop is exactly how two of them ended up invalidating sessions and the
+   * third not.
+   */
+  private List<JSONObject> snapshotWith(final String name, final JSONObject replacement) {
+    final List<JSONObject> snapshot = new ArrayList<>(users.size() + 1);
+    boolean found = false;
+    for (final ServerSecurityUser user : users.values()) {
+      if (name.equals(user.getName())) {
+        found = true;
+        if (replacement != null)
+          snapshot.add(replacement);
+      } else
+        snapshot.add(user.toJSON());
+    }
+    if (!found && replacement != null)
+      snapshot.add(replacement);
+    return snapshot;
+  }
+
+  /**
+   * The same list as {@link #snapshotWith}, as the JSON array {@code HAServerPlugin.replicateSecurityUsers}
+   * takes. Must be called while holding this monitor, so the read-compute-submit sequence is serialised
+   * against any other user mutation on this node.
+   */
+  private String replicationPayloadWith(final String name, final JSONObject replacement) {
+    final JSONArray array = new JSONArray();
+    for (final JSONObject entry : snapshotWith(name, replacement))
+      array.put(entry);
+    return array.toString();
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -803,11 +803,16 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * state machine threads, causing a server to load another server's (possibly
    * earlier) snapshot and permanently lose users.
    * <p>
-   * Intentionally NOT {@code synchronized} on the ServerSecurity monitor: the
-   * HTTP handler holds that monitor while waiting for {@code submitAndWait} to
-   * complete, and the state machine apply thread needs to call this method to
-   * unblock the wait. Raft state-machine apply is single-threaded per group, so
-   * there is no internal contention here.
+   * <b>INVARIANT: this method must never take the {@code ServerSecurity} monitor, and must never block.</b>
+   * It runs on the Raft state-machine apply thread, and {@link #createUserClusterWide},
+   * {@link #updateUserClusterWide} and {@link #dropUserClusterWide} all hold that monitor while blocked in
+   * {@code ha.replicateSecurityUsers(...)} waiting for the very entry this method applies. Adding
+   * {@code synchronized} here - or calling anything that waits, such as
+   * {@code HttpSessionManager.removeSessionsForUser}, whose {@code cancel()} waits on a session lock for an
+   * in-flight command - deadlocks the cluster's user administration, silently and only under load. Raft
+   * state-machine apply is single-threaded per group, so there is no internal contention to protect against
+   * anyway. {@link #invalidateAuthSessionsOfRevokedPrincipals} is called below precisely because it is the
+   * half of the revocation that does no blocking work.
    */
   public void applyReplicatedUsers(final String usersJsonArray) {
     final JSONArray array = new JSONArray(usersJsonArray);

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -42,6 +42,16 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   private final        String      userName;
   private              String[]    groups;
 
+  private static final AccessSnapshot NO_CONFIGURATION = new AccessSnapshot(
+      new boolean[DATABASE_ACCESS.values().length], null, null, -1, -1);
+  // The whole permission state of this (user, database) pair, published as ONE immutable value. See
+  // AccessSnapshot below for the invariant it carries.
+  private volatile     AccessSnapshot access = NO_CONFIGURATION;
+  private final        boolean     denyAll;
+  // #5269: fileIds already reported as "not yet in security configuration", to log that line at most once per file
+  // instead of on every access (which used to flood the logs at thousands of lines/sec under write load).
+  private final        Set<Integer> warnedNotRegisteredFiles = ConcurrentHashMap.newKeySet();
+
   /**
    * The whole permission state of this (user, database) pair, published as ONE immutable value.
    * <p>
@@ -61,24 +71,6 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
                         long resultSetLimit, long readTimeout) {
   }
 
-  /**
-   * The whole permission state in ONE volatile read - which is precisely the guarantee the snapshot exists
-   * to provide, and the only way a test can assert it: two successive calls to the public checks are two
-   * reads and may legitimately straddle a refresh. Package-private, for the tests that pin the invariant.
-   */
-  AccessSnapshot currentAccess() {
-    return access;
-  }
-
-  private static final AccessSnapshot NO_CONFIGURATION = new AccessSnapshot(
-      new boolean[DATABASE_ACCESS.values().length], null, null, -1, -1);
-
-  private volatile     AccessSnapshot access = NO_CONFIGURATION;
-  private final        boolean     denyAll;
-  // #5269: fileIds already reported as "not yet in security configuration", to log that line at most once per file
-  // instead of on every access (which used to flood the logs at thousands of lines/sec under write load).
-  private final        Set<Integer> warnedNotRegisteredFiles = ConcurrentHashMap.newKeySet();
-
   public ServerSecurityDatabaseUser(final String databaseName, final String userName, final String[] groups) {
     this(databaseName, userName, groups, false);
   }
@@ -89,6 +81,15 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
     this.userName = userName;
     this.groups = groups;
     this.denyAll = denyAll;
+  }
+
+  /**
+   * The whole permission state in ONE volatile read - which is precisely the guarantee the snapshot exists
+   * to provide, and the only way a test can assert it: two successive calls to the public checks are two
+   * reads and may legitimately straddle a refresh. Package-private, for the tests that pin the invariant.
+   */
+  AccessSnapshot currentAccess() {
+    return access;
   }
 
   public String[] getGroups() {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -41,19 +41,39 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   private final        String      databaseName;
   private final        String      userName;
   private              String[]    groups;
-  private volatile     boolean[][] fileAccessMap     = null;
-  // Companion to fileAccessMap, keyed by type name instead of bucket file id: the only way to gate a type that
-  // owns no bucket (a TimeSeries type). See updateFileAccess().
-  private volatile     Map<String, boolean[]> typeAccessMap = null;
-  // Written under the updateDatabaseConfiguration() monitor but read by unsynchronized getters on the query
-  // path, so they are volatile: without it a reader has no visibility guarantee and a 64-bit read is not
-  // required to be atomic, which would let a query observe a torn limit.
-  private volatile     long        resultSetLimit    = -1;
-  private volatile     long        readTimeout       = -1;
-  // INVARIANT: never mutated in place. updateDatabaseConfiguration() builds a replacement and swaps it in,
-  // so a reader racing with a security refresh sees either the previous or the next set of permissions,
-  // never a partially rebuilt one that would deny an access the user actually holds.
-  private volatile     boolean[]   databaseAccessMap = new boolean[DATABASE_ACCESS.values().length];
+
+  /**
+   * The whole permission state of this (user, database) pair, published as ONE immutable value.
+   * <p>
+   * INVARIANT: never mutated in place. Every refresh builds a replacement and swaps it in, so a reader
+   * racing with it sees either the previous configuration or the next one in full - never the
+   * database-level grants of one crossed with the per-type grants of the other. The five parts used to be
+   * five independently-swapped fields, which left exactly that window open during a grant or a revocation:
+   * the authorization checks below are deliberately unsynchronized (they run on every record access), so
+   * "each field is volatile" bought visibility but not a consistent view across fields.
+   *
+   * @param databaseAccess indexed by {@link DATABASE_ACCESS#ordinal()}
+   * @param fileAccess     indexed by bucket file id; {@code null} means "not configured yet, allow"
+   * @param typeAccess     keyed by type name, the only way to gate a type that owns no bucket (a TimeSeries
+   *                       type); {@code null} means "not configured yet, allow"
+   */
+  record AccessSnapshot(boolean[] databaseAccess, boolean[][] fileAccess, Map<String, boolean[]> typeAccess,
+                        long resultSetLimit, long readTimeout) {
+  }
+
+  /**
+   * The whole permission state in ONE volatile read - which is precisely the guarantee the snapshot exists
+   * to provide, and the only way a test can assert it: two successive calls to the public checks are two
+   * reads and may legitimately straddle a refresh. Package-private, for the tests that pin the invariant.
+   */
+  AccessSnapshot currentAccess() {
+    return access;
+  }
+
+  private static final AccessSnapshot NO_CONFIGURATION = new AccessSnapshot(
+      new boolean[DATABASE_ACCESS.values().length], null, null, -1, -1);
+
+  private volatile     AccessSnapshot access = NO_CONFIGURATION;
   private final        boolean     denyAll;
   // #5269: fileIds already reported as "not yet in security configuration", to log that line at most once per file
   // instead of on every access (which used to flood the logs at thousands of lines/sec under write load).
@@ -87,12 +107,12 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
 
   @Override
   public long getResultSetLimit() {
-    return resultSetLimit;
+    return access.resultSetLimit();
   }
 
   @Override
   public long getReadTimeout() {
-    return readTimeout;
+    return access.readTimeout();
   }
 
   public String getDatabaseName() {
@@ -103,7 +123,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   public boolean requestAccessOnDatabase(final DATABASE_ACCESS access) {
     if (denyAll)
       return false;
-    return databaseAccessMap[access.ordinal()];
+    return this.access.databaseAccess()[access.ordinal()];
   }
 
   @Override
@@ -111,7 +131,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
     if (denyAll)
       return false;
 
-    final boolean[][] currentMap = fileAccessMap;
+    final boolean[][] currentMap = this.access.fileAccess();
     if (currentMap == null)
       return true;
 
@@ -142,7 +162,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
     if (denyAll)
       return false;
 
-    final Map<String, boolean[]> currentMap = typeAccessMap;
+    final Map<String, boolean[]> currentMap = this.access.typeAccess();
     if (currentMap == null)
       return true;
 
@@ -151,20 +171,40 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
     return permissions == null || permissions[access.ordinal()];
   }
 
+  /**
+   * Rebuilds BOTH halves of the permission state from {@code configuredGroups} and publishes them in a
+   * single volatile write, so a concurrent authorization can never combine the database-level grants of one
+   * configuration with the per-type grants of another. This is what a security refresh should call;
+   * {@link #updateDatabaseConfiguration} and {@link #updateFileAccess} remain for the callers that genuinely
+   * rebuild one half only, and each is atomic in itself.
+   */
+  public synchronized void refresh(final DatabaseInternal database, final JSONObject configuredGroups) {
+    final AccessSnapshot current = this.access;
+    final AccessSnapshot withDatabase = withDatabaseConfiguration(current, configuredGroups);
+    this.access = withFileAccess(withDatabase, database, configuredGroups);
+  }
+
   public synchronized void updateDatabaseConfiguration(final JSONObject configuredGroups) {
+    this.access = withDatabaseConfiguration(this.access, configuredGroups);
+  }
+
+  /**
+   * Returns {@code current} with its database-level grants and its two quotas rebuilt from
+   * {@code configuredGroups}, leaving the per-type/per-bucket half as it was. Pure: it publishes nothing, so
+   * {@link #refresh} can compose it with {@link #withFileAccess} into a single write.
+   */
+  private AccessSnapshot withDatabaseConfiguration(final AccessSnapshot current, final JSONObject configuredGroups) {
     // The limits below keep the most restrictive value across the groups of ONE configuration, so they have
     // to start over on every call. Carrying them across calls would pin the user to the tightest value ever
     // configured and silently ignore a refresh that relaxes or drops a limit.
-    resultSetLimit = -1;
-    readTimeout = -1;
+    long resultSetLimit = -1;
+    long readTimeout = -1;
 
     // WORK ON A COPY AND SWAP IT AT THE END
     final boolean[] newDatabaseAccessMap = new boolean[DATABASE_ACCESS.values().length];
 
-    if (configuredGroups == null) {
-      databaseAccessMap = newDatabaseAccessMap;
-      return;
-    }
+    if (configuredGroups == null)
+      return new AccessSnapshot(newDatabaseAccessMap, current.fileAccess(), current.typeAccess(), -1, -1);
 
     JSONArray access = null;
     for (final String groupName : groups) {
@@ -218,12 +258,23 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
         newDatabaseAccessMap[DATABASE_ACCESS.getByName(access.getString(i)).ordinal()] = true;
     }
 
-    databaseAccessMap = newDatabaseAccessMap;
+    return new AccessSnapshot(newDatabaseAccessMap, current.fileAccess(), current.typeAccess(), resultSetLimit,
+        readTimeout);
   }
 
   public synchronized void updateFileAccess(final DatabaseInternal database, final JSONObject configuredGroups) {
+    this.access = withFileAccess(this.access, database, configuredGroups);
+  }
+
+  /**
+   * Returns {@code current} with its per-bucket and per-type maps rebuilt from {@code configuredGroups},
+   * leaving the database-level half as it was. Pure, for the same reason as
+   * {@link #withDatabaseConfiguration}.
+   */
+  private AccessSnapshot withFileAccess(final AccessSnapshot current, final DatabaseInternal database,
+      final JSONObject configuredGroups) {
     if (configuredGroups == null)
-      return;
+      return current;
 
     final List<ComponentFile> files = database.getFileManager().getFiles();
 
@@ -245,9 +296,6 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
       newFileAccessMap[i] = resolveTypeAccess(type.getName(), configuredGroups, defaultGroupTypes, defaultType);
     }
 
-    // SWAP WITH THE NEW MAP (VOLATILE PROPERTY)
-    fileAccessMap = newFileAccessMap;
-
     // #5269: the refreshed map may now cover files previously reported as missing; reset the throttle so a genuinely
     // new file created later can still be reported once.
     warnedNotRegisteredFiles.clear();
@@ -259,7 +307,9 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
     final Map<String, boolean[]> newTypeAccessMap = new HashMap<>();
     for (final DocumentType type : database.getSchema().getTypes())
       newTypeAccessMap.put(type.getName(), resolveTypeAccess(type.getName(), configuredGroups, defaultGroupTypes, defaultType));
-    typeAccessMap = newTypeAccessMap;
+
+    return new AccessSnapshot(current.databaseAccess(), newFileAccessMap, newTypeAccessMap, current.resultSetLimit(),
+        current.readTimeout());
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
@@ -143,7 +143,10 @@ public class ServerSecurityUser implements SecurityUser {
    * <p>
    * Which configuration governs the user is decided here, exactly as in {@link #registerDatabaseUser}: a
    * synthetic (API-token) principal carries its own group definition and must never be widened by the groups
-   * of the {@code server-groups.json} file.
+   * of the {@code server-groups.json} file. That branch is not reachable from {@code ServerSecurity.updateSchema}
+   * today - an API-token principal is built per request by {@code authenticateByApiToken} and never enters the
+   * {@code users} map that sweep iterates - but the rule belongs to this method rather than to its callers,
+   * so it holds for any future one.
    */
   public void refreshDatabaseConfiguration(final DatabaseInternal database, final JSONObject fileGroupConfiguration) {
     final ServerSecurityDatabaseUser dbu = databaseCache.get(database.getName());

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
@@ -129,6 +129,35 @@ public class ServerSecurityUser implements SecurityUser {
     return this;
   }
 
+  /**
+   * Re-applies the group configuration to this user's already-cached {@link ServerSecurityDatabaseUser} for
+   * {@code database}, so a grant edited (or revoked) after the user first touched that database takes effect
+   * without a restart. No-op when the pair is not cached: the next {@code getDatabaseUser()} builds it from
+   * the current configuration anyway.
+   * <p>
+   * Refreshes BOTH halves of the permission state: {@code updateDatabaseConfiguration()} rebuilds the
+   * database-level {@code DATABASE_ACCESS} map ({@code updateSchema}/{@code updateSecurity}/
+   * {@code updateDatabaseSettings}) plus the {@code resultSetLimit}/{@code readTimeout} quotas, and
+   * {@code updateFileAccess()} rebuilds the per-type/per-bucket maps. Refreshing only the second half left a
+   * revoked database-level grant in effect until restart (issue #6806).
+   * <p>
+   * Which configuration governs the user is decided here, exactly as in {@link #registerDatabaseUser}: a
+   * synthetic (API-token) principal carries its own group definition and must never be widened by the groups
+   * of the {@code server-groups.json} file.
+   */
+  public void refreshDatabaseConfiguration(final DatabaseInternal database, final JSONObject fileGroupConfiguration) {
+    final ServerSecurityDatabaseUser dbu = databaseCache.get(database.getName());
+    if (dbu == null)
+      return;
+
+    final JSONObject databaseGroups = syntheticGroupConfig != null ? syntheticGroupConfig : fileGroupConfiguration;
+    if (databaseGroups == null)
+      return;
+
+    dbu.updateDatabaseConfiguration(databaseGroups);
+    dbu.updateFileAccess(database, databaseGroups);
+  }
+
   public void refreshDatabaseNames() {
     if (userConfiguration.has("databases"))
       databasesNames = Collections.unmodifiableSet(userConfiguration.getJSONObject("databases").keySet());

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
@@ -154,14 +154,12 @@ public class ServerSecurityUser implements SecurityUser {
     if (databaseGroups == null)
       return;
 
-    // Both halves under ONE critical section (the two methods are themselves synchronized on dbu, and the
-    // monitor is reentrant). Called separately, a concurrent request could observe the new database-level
-    // grants together with the old per-type map, or the reverse - a window of microseconds, but a refresh
-    // that exists to make a revocation take effect should not have a state in which it is half taken.
-    synchronized (dbu) {
-      dbu.updateDatabaseConfiguration(databaseGroups);
-      dbu.updateFileAccess(database, databaseGroups);
-    }
+    // ONE published value for both halves. Calling the two updaters in sequence let a concurrent request
+    // observe the new database-level grants together with the old per-type map, or the reverse - a window of
+    // microseconds, but a refresh that exists to make a revocation take effect should not have a state in
+    // which it is half taken. The authorization checks are unsynchronized by design, so only an atomic
+    // publish closes it.
+    dbu.refresh(database, databaseGroups);
   }
 
   public void refreshDatabaseNames() {
@@ -212,8 +210,7 @@ public class ServerSecurityUser implements SecurityUser {
       final JSONObject databaseGroups = syntheticGroupConfig != null ?
           syntheticGroupConfig :
           server.getSecurity().getDatabaseGroupsConfiguration(database.getName());
-      dbu.updateDatabaseConfiguration(databaseGroups);
-      dbu.updateFileAccess((DatabaseInternal) database, databaseGroups);
+      dbu.refresh((DatabaseInternal) database, databaseGroups);
     }
 
     final ServerSecurityDatabaseUser prev = databaseCache.putIfAbsent(database.getName(), dbu);

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
@@ -154,8 +154,14 @@ public class ServerSecurityUser implements SecurityUser {
     if (databaseGroups == null)
       return;
 
-    dbu.updateDatabaseConfiguration(databaseGroups);
-    dbu.updateFileAccess(database, databaseGroups);
+    // Both halves under ONE critical section (the two methods are themselves synchronized on dbu, and the
+    // monitor is reentrant). Called separately, a concurrent request could observe the new database-level
+    // grants together with the old per-type map, or the reverse - a window of microseconds, but a refresh
+    // that exists to make a revocation take effect should not have a state in which it is half taken.
+    synchronized (dbu) {
+      dbu.updateDatabaseConfiguration(databaseGroups);
+      dbu.updateFileAccess(database, databaseGroups);
+    }
   }
 
   public void refreshDatabaseNames() {

--- a/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
@@ -375,6 +375,32 @@ class HttpAuthSessionManagerTest {
   }
 
   @Test
+  void removeSessionsForUserDropsEveryTokenOfThatPrincipalOnly() {
+    // A dropped user (or one whose password changed) must not keep authenticating with a token minted
+    // before the change. The per-principal index added for the cap is what makes this cheap.
+    manager = new HttpAuthSessionManager(30_000L, 0, 1_000, 0, () -> fakeNow);
+    final ServerSecurityUser revoked = createMockUser("revoked");
+    final ServerSecurityUser other = createMockUser("other");
+
+    final HttpAuthSession first = manager.createSession(revoked);
+    final HttpAuthSession second = manager.createSession(revoked);
+    final HttpAuthSession survivor = manager.createSession(other);
+
+    assertThat(manager.removeSessionsForUser("revoked")).isEqualTo(2);
+
+    assertThat(manager.getSessionByToken(first.getToken())).isNull();
+    assertThat(manager.getSessionByToken(second.getToken())).isNull();
+    assertThat(manager.getSessionByToken(survivor.getToken())).isNotNull();
+    assertThat(manager.getActiveSessionCount()).isEqualTo(1);
+    assertThat(manager.getActiveSessionCount("revoked")).isZero();
+
+    // Idempotent, and null-safe for callers that do not know whether the principal had any session.
+    assertThat(manager.removeSessionsForUser("revoked")).isZero();
+    assertThat(manager.removeSessionsForUser("neverLoggedIn")).isZero();
+    assertThat(manager.removeSessionsForUser(null)).isZero();
+  }
+
+  @Test
   void removedAndExpiredSessionsAreDroppedFromThePerPrincipalIndex() {
     manager = new HttpAuthSessionManager(100L, 0, 1_000, 2, () -> fakeNow);
     final ServerSecurityUser user = createMockUser("testuser");

--- a/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
@@ -362,6 +362,23 @@ class HttpAuthSessionManagerTest {
   }
 
   @Test
+  void truncationNeverSplitsASurrogatePair() {
+    // A supplementary-plane character straddling the cut must be dropped whole, not left as an unpaired
+    // half that renders as a replacement character wherever the metadata is displayed.
+    final String emoji = "😀"; // U+1F600, two chars
+    final String straddling = "x".repeat(HttpAuthSession.MAX_METADATA_LENGTH - 1) + emoji.repeat(10);
+    assertThat(HttpAuthSession.truncate(straddling))
+        .hasSize(HttpAuthSession.MAX_METADATA_LENGTH - 1)
+        .doesNotContain("\uD83D");
+
+    // An emoji that ends exactly on the boundary is kept whole.
+    final String aligned = "x".repeat(HttpAuthSession.MAX_METADATA_LENGTH - 2) + emoji.repeat(10);
+    assertThat(HttpAuthSession.truncate(aligned))
+        .hasSize(HttpAuthSession.MAX_METADATA_LENGTH)
+        .endsWith(emoji);
+  }
+
+  @Test
   void metadataThatFitsIsKeptVerbatimAndNullStaysNull() {
     manager = new HttpAuthSessionManager(30_000L);
 

--- a/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
@@ -235,4 +235,161 @@ class HttpAuthSessionManagerTest {
     assertThat(manager.getSessionByToken(session1.getToken())).isNull();
     assertThat(manager.getSessionByToken(session2.getToken())).isNotNull();
   }
+
+  // ---------------------------------------------------------------------------------------------------
+  // Issue #6809: the session map was an unbounded HashMap with no global and no per-principal cap, and it
+  // stored four untruncated client-controlled header values per entry, each retained for the whole idle
+  // timeout (30 minutes by default).
+  // ---------------------------------------------------------------------------------------------------
+
+  @Test
+  void perPrincipalCapEvictsThatPrincipalsOldestSession() {
+    manager = new HttpAuthSessionManager(30_000L, 0, 1_000, 3, () -> fakeNow);
+    final ServerSecurityUser user = createMockUser("looper");
+
+    final HttpAuthSession first = manager.createSession(user);
+    final HttpAuthSession second = manager.createSession(user);
+    final HttpAuthSession third = manager.createSession(user);
+    assertThat(manager.getActiveSessionCount()).isEqualTo(3);
+
+    // The fourth login evicts the oldest of this principal's sessions instead of growing the map.
+    final HttpAuthSession fourth = manager.createSession(user);
+    assertThat(fourth).isNotNull();
+    assertThat(manager.getActiveSessionCount()).isEqualTo(3);
+    assertThat(manager.getActiveSessionCount("looper")).isEqualTo(3);
+
+    assertThat(manager.getSessionByToken(first.getToken())).isNull();
+    assertThat(manager.getSessionByToken(second.getToken())).isNotNull();
+    assertThat(manager.getSessionByToken(third.getToken())).isNotNull();
+    assertThat(manager.getSessionByToken(fourth.getToken())).isNotNull();
+
+    // 1000 more logins by the same principal must not move the total.
+    for (int i = 0; i < 1_000; i++)
+      manager.createSession(user);
+    assertThat(manager.getActiveSessionCount()).isEqualTo(3);
+  }
+
+  @Test
+  void perPrincipalCapNeverEvictsAnotherPrincipalsSession() {
+    manager = new HttpAuthSessionManager(30_000L, 0, 1_000, 2, () -> fakeNow);
+    final HttpAuthSession victim = manager.createSession(createMockUser("victim"));
+
+    final ServerSecurityUser attacker = createMockUser("attacker");
+    for (int i = 0; i < 100; i++)
+      manager.createSession(attacker);
+
+    assertThat(manager.getActiveSessionCount("attacker")).isEqualTo(2);
+    assertThat(manager.getSessionByToken(victim.getToken())).isNotNull();
+    assertThat(manager.getActiveSessionCount()).isEqualTo(3);
+  }
+
+  @Test
+  void globalCapRefusesInsteadOfGrowingTheMap() {
+    // Per-principal cap disabled so only the global one is under test.
+    manager = new HttpAuthSessionManager(30_000L, 0, 2, 0, () -> fakeNow);
+
+    assertThat(manager.createSession(createMockUser("u1"))).isNotNull();
+    assertThat(manager.createSession(createMockUser("u2"))).isNotNull();
+
+    // Third distinct principal: the map is full, so the login is refused (the handler answers 503).
+    assertThat(manager.createSession(createMockUser("u3"))).isNull();
+    assertThat(manager.getActiveSessionCount()).isEqualTo(2);
+  }
+
+  @Test
+  void globalCapReclaimsIdleExpiredSessionsBeforeRefusing() {
+    manager = new HttpAuthSessionManager(100L, 0, 2, 0, () -> fakeNow);
+
+    manager.createSession(createMockUser("u1"));
+    manager.createSession(createMockUser("u2"));
+    assertThat(manager.getActiveSessionCount()).isEqualTo(2);
+
+    // Both are now idle-expired: a legitimate login must not be refused just because the background sweep
+    // has not fired yet.
+    fakeNow += 300;
+    assertThat(manager.createSession(createMockUser("u3"))).isNotNull();
+    assertThat(manager.getActiveSessionCount()).isEqualTo(1);
+  }
+
+  @Test
+  void aPrincipalAtItsOwnCapIsStillAdmittedWhenTheMapIsGloballyFull() {
+    // Evicting frees exactly one slot, so this login costs the server nothing - and the decision must be
+    // taken BEFORE the eviction, or the refusal would destroy a live session of the principal it refuses.
+    manager = new HttpAuthSessionManager(30_000L, 0, 2, 2, () -> fakeNow);
+    final ServerSecurityUser user = createMockUser("regular");
+
+    final HttpAuthSession first = manager.createSession(user);
+    final HttpAuthSession second = manager.createSession(user);
+    assertThat(manager.getActiveSessionCount()).isEqualTo(2);
+
+    final HttpAuthSession third = manager.createSession(user);
+    assertThat(third).isNotNull();
+    assertThat(manager.getActiveSessionCount()).isEqualTo(2);
+    assertThat(manager.getSessionByToken(first.getToken())).isNull();
+    assertThat(manager.getSessionByToken(second.getToken())).isNotNull();
+    assertThat(manager.getSessionByToken(third.getToken())).isNotNull();
+
+    // A different principal, however, is refused - and the refusal must not disturb anybody's sessions.
+    assertThat(manager.createSession(createMockUser("newcomer"))).isNull();
+    assertThat(manager.getActiveSessionCount()).isEqualTo(2);
+    assertThat(manager.getActiveSessionCount("regular")).isEqualTo(2);
+    assertThat(manager.getActiveSessionCount("newcomer")).isZero();
+  }
+
+  @Test
+  void zeroOrNegativeCapsMeanUnlimited() {
+    manager = new HttpAuthSessionManager(30_000L, 0, 0, 0, () -> fakeNow);
+    final ServerSecurityUser user = createMockUser("testuser");
+
+    for (int i = 0; i < 200; i++)
+      assertThat(manager.createSession(user)).isNotNull();
+
+    assertThat(manager.getActiveSessionCount()).isEqualTo(200);
+  }
+
+  @Test
+  void clientSuppliedMetadataIsTruncated() {
+    manager = new HttpAuthSessionManager(30_000L);
+    final String oversized = "x".repeat(1_000_000);
+
+    final HttpAuthSession session = manager.createSession(createMockUser("testuser"), oversized, oversized,
+        oversized, oversized);
+
+    assertThat(session.getSourceIp()).hasSize(HttpAuthSession.MAX_METADATA_LENGTH);
+    assertThat(session.getUserAgent()).hasSize(HttpAuthSession.MAX_METADATA_LENGTH);
+    assertThat(session.getCountry()).hasSize(HttpAuthSession.MAX_METADATA_LENGTH);
+    assertThat(session.getCity()).hasSize(HttpAuthSession.MAX_METADATA_LENGTH);
+  }
+
+  @Test
+  void metadataThatFitsIsKeptVerbatimAndNullStaysNull() {
+    manager = new HttpAuthSessionManager(30_000L);
+
+    final HttpAuthSession session = manager.createSession(createMockUser("testuser"), "10.0.0.1", "curl/8.4.0",
+        "IT", null);
+
+    assertThat(session.getSourceIp()).isEqualTo("10.0.0.1");
+    assertThat(session.getUserAgent()).isEqualTo("curl/8.4.0");
+    assertThat(session.getCountry()).isEqualTo("IT");
+    assertThat(session.getCity()).isNull();
+  }
+
+  @Test
+  void removedAndExpiredSessionsAreDroppedFromThePerPrincipalIndex() {
+    manager = new HttpAuthSessionManager(100L, 0, 1_000, 2, () -> fakeNow);
+    final ServerSecurityUser user = createMockUser("testuser");
+
+    final HttpAuthSession session = manager.createSession(user);
+    manager.removeSession(session.getToken());
+    assertThat(manager.getActiveSessionCount("testuser")).isZero();
+
+    // A logged-out session must not keep consuming the principal's quota.
+    assertThat(manager.createSession(user)).isNotNull();
+    assertThat(manager.createSession(user)).isNotNull();
+    assertThat(manager.getActiveSessionCount("testuser")).isEqualTo(2);
+
+    fakeNow += 300;
+    assertThat(manager.checkSessionsValidity()).isEqualTo(2);
+    assertThat(manager.getActiveSessionCount("testuser")).isZero();
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/AbstractServerHttpHandlerMetricsTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/AbstractServerHttpHandlerMetricsTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.server.ArcadeDBServer;
 import io.micrometer.core.instrument.Timer;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.PathTemplateMatch;
@@ -26,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the bounded HTTP RED-metric plumbing in {@link AbstractServerHttpHandler} (issue #5025):
@@ -66,5 +69,44 @@ class AbstractServerHttpHandlerMetricsTest {
     // A different tuple resolves to a distinct timer.
     final Timer differentStatus = AbstractServerHttpHandler.httpRequestTimer("GET", "unmatched", "500", "none");
     assertThat(differentStatus).isNotSameAs(first);
+  }
+
+  @Test
+  void databaseTagKeepsTheNameOfADatabaseThatExists() {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.existsDatabase("graph")).thenReturn(true);
+
+    final HttpServerExchange exchange = new HttpServerExchange(null);
+    exchange.putAttachment(PathTemplateMatch.ATTACHMENT_KEY,
+        new PathTemplateMatch("/query/{database}", Map.of("database", "graph")));
+
+    assertThat(AbstractServerHttpHandler.databaseTag(exchange, server)).isEqualTo("graph");
+  }
+
+  @Test
+  void databaseTagCollapsesAnUnknownDatabaseToBoundedConstant() {
+    // Issue #6805: {database} matches any path segment and the RED timer is recorded in a finally block that
+    // also runs for the 401 an unauthenticated caller gets, so echoing the raw parameter registered one
+    // permanent percentile-histogram Timer per invented name - the #5025 leak on the other half of the tuple.
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.existsDatabase("db12345")).thenReturn(false);
+
+    final HttpServerExchange exchange = new HttpServerExchange(null);
+    exchange.putAttachment(PathTemplateMatch.ATTACHMENT_KEY,
+        new PathTemplateMatch("/query/{database}", Map.of("database", "db12345")));
+
+    assertThat(AbstractServerHttpHandler.databaseTag(exchange, server)).isEqualTo("unknown");
+  }
+
+  @Test
+  void databaseTagIsNoneForRoutesThatAreNotDatabaseScoped() {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+
+    final HttpServerExchange withoutParameter = new HttpServerExchange(null);
+    withoutParameter.putAttachment(PathTemplateMatch.ATTACHMENT_KEY, new PathTemplateMatch("/ready", Map.of()));
+    assertThat(AbstractServerHttpHandler.databaseTag(withoutParameter, server)).isEqualTo("none");
+
+    // No route matched at all (Studio "/" fallback, 404 probe).
+    assertThat(AbstractServerHttpHandler.databaseTag(new HttpServerExchange(null), server)).isEqualTo("none");
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6807PromQLParameterValidationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6807PromQLParameterValidationIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end coverage for the {@code start}/{@code end}/{@code step}/{@code time} validation of the PromQL
+ * endpoints (issue #6807). The unit tests pin the parser; these pin the <i>handler</i> contract - that a
+ * rejected parameter reaches the client as a 400 with a {@code bad_data} body rather than as a 500, or (for
+ * the overflowing range) rather than as a request that never returns at all.
+ * <p>
+ * The {@code @Timeout} is a hang detector, not a latency bound: before the fix the first case below wedged
+ * the Undertow worker thread serving it for the life of the process, so the failure mode being guarded is
+ * "no response ever", not "slow response".
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6807PromQLParameterValidationIT extends BaseGraphServerTest {
+
+  @Test
+  @Timeout(value = 120, unit = TimeUnit.SECONDS)
+  void aRangeWiderThanTheRepresentableSpanIsRejectedInsteadOfWedgingTheWorker() throws Exception {
+    testEachServer(serverIndex -> {
+      // The exact repro from the issue. endMs - startMs overflowed to a negative number, the MAX_RANGE_STEPS
+      // guard passed, and the per-step loop ran forever on a worker thread with no timeout and no
+      // cancellation. One request per worker thread took the HTTP listener down.
+      assertBadData(serverIndex, "/query_range?query=up&start=-9e15&end=9e15&step=60");
+    });
+  }
+
+  @Test
+  void aMalformedOrOutOfRangeRangeParameterIsAnswered400() throws Exception {
+    testEachServer(serverIndex -> {
+      assertBadData(serverIndex, "/query_range?query=up&start=yesterday&end=1700000060&step=60");
+      assertBadData(serverIndex, "/query_range?query=up&start=1700000000&end=NaN&step=60");
+      assertBadData(serverIndex, "/query_range?query=up&start=1700000000&end=9e15&step=60");
+      // Infinity and 1e300 both survive Double.parseDouble and saturate to Long.MAX_VALUE, which is
+      // positive - so they used to pass the "step must be positive" test and yield a one-point 200.
+      assertBadData(serverIndex, "/query_range?query=up&start=1700000000&end=1700000600&step=Infinity");
+      assertBadData(serverIndex, "/query_range?query=up&start=1700000000&end=1700000600&step=1e300");
+      // The pre-existing guards must keep answering 400 too.
+      assertBadData(serverIndex, "/query_range?query=up&start=1700000600&end=1700000000&step=60");
+      assertBadData(serverIndex, "/query_range?query=up&start=1700000000&end=1700000600&step=0");
+      assertBadData(serverIndex, "/query_range?query=up&start=0&end=2000000000&step=0.001");
+    });
+  }
+
+  @Test
+  void aMalformedInstantTimeParameterIsAnswered400RatherThan500() throws Exception {
+    testEachServer(serverIndex -> {
+      // The instant endpoint parsed "time" with a bare Double.parseDouble outside its own catch, so a
+      // non-numeric value surfaced as a 500.
+      assertBadData(serverIndex, "/query?query=up&time=now");
+      assertBadData(serverIndex, "/query?query=up&time=Infinity");
+      assertBadData(serverIndex, "/query?query=up&time=9e15");
+    });
+  }
+
+  @Test
+  void wellFormedParametersStillSucceed() throws Exception {
+    testEachServer(serverIndex -> {
+      // Control: the validation must not reject a legitimate request. The metric does not exist, so the
+      // evaluator answers an empty result - a 200 either way.
+      assertThat(get(serverIndex, "/query_range?query=up&start=1700000000&end=1700000600&step=60"))
+          .isEqualTo(200);
+      assertThat(get(serverIndex, "/query_range?query=up&start=1700000000&end=1700000600&step=1m"))
+          .isEqualTo(200);
+      assertThat(get(serverIndex, "/query?query=up&time=1700000000")).isEqualTo(200);
+      assertThat(get(serverIndex, "/query?query=up")).isEqualTo(200);
+    });
+  }
+
+  private void assertBadData(final int serverIndex, final String query) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, query);
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).as("status of %s", query).isEqualTo(400);
+      final JSONObject body = new JSONObject(readBody(connection));
+      assertThat(body.getString("status")).isEqualTo("error");
+      assertThat(body.getString("errorType")).as("errorType of %s", query).isEqualTo("bad_data");
+      assertThat(body.getString("error", "")).as("error message of %s", query).isNotBlank();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int get(final int serverIndex, final String query) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, query);
+    connection.connect();
+    try {
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private HttpURLConnection open(final int serverIndex, final String query) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/ts/" + getDatabaseName() + "/prom/api/v1"
+            + query).openConnection();
+    connection.setRequestMethod("GET");
+    connection.setRequestProperty("Authorization", "Basic " + Base64.getEncoder()
+        .encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8)));
+    return connection;
+  }
+
+  private static String readBody(final HttpURLConnection connection) throws Exception {
+    final InputStream stream = connection.getErrorStream() != null
+        ? connection.getErrorStream()
+        : connection.getInputStream();
+    return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6807PromQLRangeParameterTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6807PromQLRangeParameterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the {@code start}/{@code end} validation of {@code GET .../prom/api/v1/query_range}
+ * (issue #6807). The handler used to hand {@code (long) (Double.parseDouble(v) * 1000)} straight to the
+ * evaluator, so {@code start=-9e15}/{@code end=9e15} produced a span that overflowed 64 bits, and a
+ * non-numeric value produced a 500 instead of a 400.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6807PromQLRangeParameterTest {
+
+  @Test
+  void parsesPlainAndFractionalEpochSeconds() {
+    assertThat(GetPromQLQueryRangeHandler.parseTimestampMs("start", "1700000000")).isEqualTo(1_700_000_000_000L);
+    assertThat(GetPromQLQueryRangeHandler.parseTimestampMs("end", "1700000000.5")).isEqualTo(1_700_000_000_500L);
+    assertThat(GetPromQLQueryRangeHandler.parseTimestampMs("start", "-1")).isEqualTo(-1_000L);
+  }
+
+  @Test
+  void rejectsTheOutOfRangeValuesThatOverflowedTheSpan() {
+    // The repro from the issue: 9e15 seconds is 9e18 ms, and the span across +/-9e15 exceeds Long.MAX_VALUE.
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseTimestampMs("end", "9e15"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("outside the supported epoch range");
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseTimestampMs("start", "-9e15"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("outside the supported epoch range");
+  }
+
+  @Test
+  void rejectsNonFiniteValues() {
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseTimestampMs("start", "Infinity"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is not finite");
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseTimestampMs("end", "NaN"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is not finite");
+  }
+
+  @Test
+  void rejectsNonNumericValuesAsBadRequestRatherThanServerError() {
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseTimestampMs("start", "yesterday"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid start timestamp");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6807PromQLRangeParameterTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6807PromQLRangeParameterTest.java
@@ -67,4 +67,27 @@ class Issue6807PromQLRangeParameterTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid start timestamp");
   }
+
+  @Test
+  void parsesStepAsSecondsOrAsDuration() {
+    assertThat(GetPromQLQueryRangeHandler.parseStep("60")).isEqualTo(60_000L);
+    assertThat(GetPromQLQueryRangeHandler.parseStep("0.5")).isEqualTo(500L);
+    assertThat(GetPromQLQueryRangeHandler.parseStep("1m")).isEqualTo(60_000L);
+  }
+
+  @Test
+  void rejectsAStepThatIsNotFiniteOrNotRepresentable() {
+    // Double.parseDouble accepts both without throwing, and (long)(v * 1000) saturates to Long.MAX_VALUE -
+    // positive, so it passed the "step must be positive" test, and the evaluator then answered 200 with a
+    // single-point series instead of rejecting the request.
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseStep("Infinity"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is not finite");
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseStep("1e300"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("outside the supported epoch range");
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseStep("NaN"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is not finite");
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6807PromQLRangeParameterTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6807PromQLRangeParameterTest.java
@@ -69,6 +69,20 @@ class Issue6807PromQLRangeParameterTest {
   }
 
   @Test
+  void theInstantEndpointSharesTheSameTimestampContract() {
+    // GetPromQLQueryHandler parses its "time" parameter through the same helper, so the two endpoints
+    // cannot disagree on what a timestamp is - and a non-numeric value answers 400, not the 500 the
+    // unguarded parseDouble produced.
+    assertThat(GetPromQLQueryRangeHandler.parseTimestampMs("time", "1700000000")).isEqualTo(1_700_000_000_000L);
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseTimestampMs("time", "Infinity"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is not finite");
+    assertThatThrownBy(() -> GetPromQLQueryRangeHandler.parseTimestampMs("time", "now"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid time timestamp");
+  }
+
+  @Test
   void parsesStepAsSecondsOrAsDuration() {
     assertThat(GetPromQLQueryRangeHandler.parseStep("60")).isEqualTo(60_000L);
     assertThat(GetPromQLQueryRangeHandler.parseStep("0.5")).isEqualTo(500L);

--- a/server/src/test/java/com/arcadedb/server/monitor/HttpRedMetricsIT.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/HttpRedMetricsIT.java
@@ -132,6 +132,34 @@ class HttpRedMetricsIT extends BaseGraphServerTest {
     assertThat(rawUnmatchedMeters).isZero();
   }
 
+  @Test
+  void unknownDatabaseCollapsesToBoundedDbTag() throws Exception {
+    // The {database} path parameter matches any segment and the RED timer is recorded in a finally block that
+    // also runs for the 401 an unauthenticated caller gets, so echoing the raw parameter registered one
+    // permanent percentile-histogram Timer per invented name: the #5025 path-tag leak on the other half of
+    // the tag tuple, and reachable with no credentials at all (issue #6805).
+    for (int i = 0; i < 50; i++)
+      hitGet("/api/v1/query/nosuchdb" + i + "/sql/select%201");
+
+    // Every probe collapses onto the single bounded "unknown" value. Summed over every meter carrying the
+    // tag (the 50 requests may split across status tags, and earlier test classes in the reused fork leave
+    // their own meters behind), and polled because the timer is recorded after the response was read.
+    await().atMost(SETTLE_TIMEOUT).pollInterval(POLL_INTERVAL).untilAsserted(() -> {
+      final Collection<Timer> collapsed = Metrics.globalRegistry.find("arcadedb.http.requests")
+          .tag("path", "/query/{database}/{language}/{command}").tag("db", "unknown").timers();
+      assertThat(collapsed).isNotEmpty();
+      assertThat(collapsed.stream().mapToLong(Timer::count).sum()).isGreaterThanOrEqualTo(50L);
+    });
+
+    // Cardinality guard: no timer may carry one of the invented database names. Checked after the poll, so
+    // every one of the 50 requests has been recorded by the time the registry is read.
+    final long inventedDbMeters = Metrics.globalRegistry.find("arcadedb.http.requests").timers().stream()
+        .map(t -> t.getId().getTag("db"))
+        .filter(db -> db != null && db.startsWith("nosuchdb"))
+        .count();
+    assertThat(inventedDbMeters).isZero();
+  }
+
   private void hitGet(final String path) throws Exception {
     final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480" + path).openConnection();
     c.setRequestMethod("GET");

--- a/server/src/test/java/com/arcadedb/server/security/Issue6806GroupPermissionRefreshIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue6806GroupPermissionRefreshIT.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6806: a group's <b>database-level</b> grants ({@code updateSchema},
+ * {@code updateSecurity}, {@code updateDatabaseSettings}) were frozen at the values they had when the user
+ * first touched the database.
+ * <p>
+ * {@code ServerSecurityDatabaseUser} keeps two independent permission maps refreshed by two different
+ * methods, and the server's only refresh path ({@code ServerSecurity.updateSchema}) called just the
+ * per-type/per-bucket one. So a revoked {@code updateSchema} kept working until restart, and - symmetrically -
+ * a newly granted one was ignored until restart. {@code GroupManagementIT.updateGroup} only asserts that the
+ * group JSON round-trips through the group file, so nothing pinned the effective permission.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6806GroupPermissionRefreshIT extends BaseGraphServerTest {
+
+  private static final String GROUP = "issue6806editor";
+  private static final String USER  = "issue6806alice";
+  private static final String PWD   = "issue6806pwd";
+
+  @Test
+  void revokedAndRegrantedDatabaseGrantTakeEffectWithoutRestart() throws Exception {
+    testEachServer(serverIndex -> {
+      saveGroup(serverIndex, new JSONArray().put("updateSchema"));
+      createUser(serverIndex);
+
+      try {
+        // The first command caches alice's ServerSecurityDatabaseUser for this database, with UPDATE_SCHEMA=true.
+        assertThat(userCommand(serverIndex, "CREATE VERTEX TYPE Issue6806A"))
+            .as("granted updateSchema must let the group member create a type").isEqualTo(200);
+
+        // REVOKE: the group keeps its per-type grants but loses every database-level one.
+        saveGroup(serverIndex, new JSONArray());
+        assertThat(userCommand(serverIndex, "CREATE VERTEX TYPE Issue6806B"))
+            .as("revoked updateSchema must take effect immediately, not at the next restart").isEqualTo(403);
+
+        // RE-GRANT: the same gap broke this direction too - a newly granted permission was ignored.
+        saveGroup(serverIndex, new JSONArray().put("updateSchema"));
+        assertThat(userCommand(serverIndex, "CREATE VERTEX TYPE Issue6806C"))
+            .as("re-granted updateSchema must take effect immediately").isEqualTo(200);
+      } finally {
+        deleteGroup(serverIndex);
+        dropUser(serverIndex);
+        adminCommand(serverIndex, "DROP TYPE Issue6806A IF EXISTS");
+        adminCommand(serverIndex, "DROP TYPE Issue6806B IF EXISTS");
+        adminCommand(serverIndex, "DROP TYPE Issue6806C IF EXISTS");
+      }
+    });
+  }
+
+  /**
+   * The quotas live in the same never-refreshed map as the database-level grants, so a group whose
+   * {@code resultSetLimit} is tightened after the user has touched the database used to keep serving the old
+   * (looser) limit until restart.
+   */
+  @Test
+  void groupResultSetLimitIsRefreshed() throws Exception {
+    testEachServer(serverIndex -> {
+      saveGroup(serverIndex, new JSONArray(), -1L);
+      createUser(serverIndex);
+
+      try {
+        // Caches alice's database user with resultSetLimit = -1 (unlimited).
+        assertThat(userCommand(serverIndex, "SELECT FROM V1 LIMIT 1")).isEqualTo(200);
+        assertThat(effectiveResultSetLimit(serverIndex)).isEqualTo(-1L);
+
+        saveGroup(serverIndex, new JSONArray(), 7L);
+        assertThat(effectiveResultSetLimit(serverIndex))
+            .as("a tightened group quota must be visible without a restart").isEqualTo(7L);
+      } finally {
+        deleteGroup(serverIndex);
+        dropUser(serverIndex);
+      }
+    });
+  }
+
+  private long effectiveResultSetLimit(final int serverIndex) {
+    return getServer(serverIndex).getSecurity().getUser(USER)
+        .getDatabaseUser(getServer(serverIndex).getDatabase(getDatabaseName())).getResultSetLimit();
+  }
+
+  private void saveGroup(final int serverIndex, final JSONArray databaseAccess) throws Exception {
+    saveGroup(serverIndex, databaseAccess, -1L);
+  }
+
+  private void saveGroup(final int serverIndex, final JSONArray databaseAccess, final long resultSetLimit)
+      throws Exception {
+    final JSONObject payload = new JSONObject()
+        .put("database", getDatabaseName())
+        .put("name", GROUP)
+        .put("resultSetLimit", resultSetLimit)
+        .put("readTimeout", -1L)
+        .put("access", databaseAccess)
+        .put("types", new JSONObject().put("*", new JSONObject().put("access",
+            new JSONArray().put("createRecord").put("readRecord").put("updateRecord").put("deleteRecord"))));
+
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/server/groups", "POST", basicAuth());
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream().write(payload.toString().getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void deleteGroup(final int serverIndex) throws Exception {
+    final HttpURLConnection connection = open(serverIndex,
+        "/api/v1/server/groups?database=" + getDatabaseName() + "&name=" + GROUP, "DELETE", basicAuth());
+    connection.connect();
+    try {
+      connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void createUser(final int serverIndex) throws Exception {
+    if (getServer(serverIndex).getSecurity().existsUser(USER))
+      getServer(serverIndex).getSecurity().dropUser(USER);
+
+    final JSONObject payload = new JSONObject()
+        .put("name", USER)
+        .put("password", PWD)
+        .put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put(GROUP)));
+
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/server/users", "POST", basicAuth());
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream().write(payload.toString().getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(201);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void dropUser(final int serverIndex) throws Exception {
+    final HttpURLConnection connection = open(serverIndex,
+        "/api/v1/server/users?name=" + URLEncoder.encode(USER, StandardCharsets.UTF_8), "DELETE", basicAuth());
+    connection.connect();
+    try {
+      connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int adminCommand(final int serverIndex, final String sql) throws Exception {
+    return command(serverIndex, basicAuth(), sql);
+  }
+
+  private int userCommand(final int serverIndex, final String sql) throws Exception {
+    return command(serverIndex, "Basic " + Base64.getEncoder()
+        .encodeToString((USER + ":" + PWD).getBytes(StandardCharsets.UTF_8)), sql);
+  }
+
+  private int command(final int serverIndex, final String auth, final String sql) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/command/" + getDatabaseName(), "POST", auth);
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream()
+        .write(new JSONObject().put("language", "sql").put("command", sql).toString().getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private HttpURLConnection open(final int serverIndex, final String path, final String method, final String auth)
+      throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + path).openConnection();
+    connection.setRequestMethod(method);
+    connection.setRequestProperty("Authorization", auth);
+    return connection;
+  }
+
+  private String basicAuth() {
+    return "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/Issue6806GroupPermissionRefreshTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue6806GroupPermissionRefreshTest.java
@@ -28,6 +28,8 @@ import com.arcadedb.server.ArcadeDBServer;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -99,6 +101,44 @@ class Issue6806GroupPermissionRefreshTest {
     alice.refreshDatabaseConfiguration(database, groups(new JSONArray().put("updateSecurity"), -1L));
 
     assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SECURITY)).isTrue();
+  }
+
+  @Test
+  void aRefreshNeverPublishesHalfOfTheNewConfiguration() throws Exception {
+    // The authorization checks are unsynchronized by design - they run on every record access - so the two
+    // halves of the permission state have to be published as one value. When they were two independent
+    // volatile writes, a reader could see the new database-level grants crossed with the old per-type map.
+    // A reader spinning across many refreshes must only ever observe one configuration or the other.
+    final DatabaseInternal database = mockDatabase();
+    final ServerSecurityUser alice = newUser(database, groups(new JSONArray().put("updateSchema"), 7L));
+    final ServerSecurityDatabaseUser dbUser = alice.getDatabaseUser(database);
+
+    final AtomicBoolean stop = new AtomicBoolean();
+    final AtomicReference<String> mixed = new AtomicReference<>();
+    final Thread reader = new Thread(() -> {
+      while (!stop.get()) {
+        // ONE read of the published state - two successive calls to the public checks are two reads and may
+        // legitimately straddle a refresh, which is exactly why the state is one value. In this
+        // configuration the halves move together: updateSchema is granted exactly when the quota is 7, so a
+        // snapshot carrying one without the other could only come from a half-published refresh.
+        final ServerSecurityDatabaseUser.AccessSnapshot snapshot = dbUser.currentAccess();
+        final boolean granted = snapshot.databaseAccess()[DATABASE_ACCESS.UPDATE_SCHEMA.ordinal()];
+        final long limit = snapshot.resultSetLimit();
+        if (granted != (limit == 7L))
+          mixed.compareAndSet(null, "updateSchema=" + granted + " resultSetLimit=" + limit);
+      }
+    });
+    reader.start();
+    try {
+      for (int i = 0; i < 2_000; i++)
+        alice.refreshDatabaseConfiguration(database,
+            i % 2 == 0 ? groups(new JSONArray(), -1L) : groups(new JSONArray().put("updateSchema"), 7L));
+    } finally {
+      stop.set(true);
+      reader.join(30_000);
+    }
+
+    assertThat(mixed.get()).as("observed a half-published refresh").isNull();
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/security/Issue6806GroupPermissionRefreshTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue6806GroupPermissionRefreshTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.FileManager;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.security.SecurityDatabaseUser.DATABASE_ACCESS;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit regression test for issue #6806. {@code ServerSecurityDatabaseUser} keeps two independent permission
+ * maps refreshed by two different methods, and the server's only refresh path called just one of them
+ * ({@code updateFileAccess}), leaving the database-level grants read by {@code requestAccessOnDatabase} -
+ * {@code updateSchema}, {@code updateSecurity}, {@code updateDatabaseSettings} - plus the
+ * {@code resultSetLimit}/{@code readTimeout} quotas frozen at the values they had when the user first
+ * touched the database. A revoked grant kept working until restart.
+ * <p>
+ * Drives {@link ServerSecurityUser#refreshDatabaseConfiguration} directly, which is what
+ * {@code ServerSecurity.updateSchema} now calls for every user;
+ * {@code Issue6806GroupPermissionRefreshIT} covers the same fix end to end over HTTP.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6806GroupPermissionRefreshTest {
+
+  private static final String DATABASE = "issue6806db";
+  private static final String GROUP    = "editor";
+
+  @Test
+  void revokedDatabaseGrantIsVisibleOnTheCachedDatabaseUser() {
+    final DatabaseInternal database = mockDatabase();
+    final ServerSecurityUser alice = newUser(database, groups(new JSONArray().put("updateSchema"), -1L));
+
+    final ServerSecurityDatabaseUser dbUser = alice.getDatabaseUser(database);
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue();
+
+    alice.refreshDatabaseConfiguration(database, groups(new JSONArray(), -1L));
+
+    // The SAME cached instance must now deny: getDatabaseUser() returns it forever (databaseCache is only
+    // cleared by refreshDatabaseNames(), which nothing in src/main calls), so a stale map is permanent.
+    assertThat(alice.getDatabaseUser(database)).isSameAs(dbUser);
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isFalse();
+  }
+
+  @Test
+  void refreshingOnlyTheFileAccessMapLeavesTheDatabaseGrantStale() {
+    // Pins the mechanism of the bug, so a future refactor cannot quietly go back to it: updateFileAccess()
+    // rebuilds the per-type/per-bucket maps and NOTHING else, so calling it alone - which is what
+    // ServerSecurity.updateSchema() used to do - leaves databaseAccessMap exactly as it was.
+    final DatabaseInternal database = mockDatabase();
+    final ServerSecurityUser alice = newUser(database, groups(new JSONArray().put("updateSchema"), -1L));
+
+    final ServerSecurityDatabaseUser dbUser = alice.getDatabaseUser(database);
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue();
+
+    dbUser.updateFileAccess(database, groups(new JSONArray(), -1L));
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("half a refresh leaves the revoked grant in effect - the defect of #6806").isTrue();
+
+    dbUser.updateDatabaseConfiguration(groups(new JSONArray(), -1L));
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isFalse();
+  }
+
+  @Test
+  void newlyGrantedDatabaseGrantIsVisibleOnTheCachedDatabaseUser() {
+    // The gap was symmetric: a grant added after the user first touched the database was ignored too.
+    final DatabaseInternal database = mockDatabase();
+    final ServerSecurityUser alice = newUser(database, groups(new JSONArray(), -1L));
+
+    final ServerSecurityDatabaseUser dbUser = alice.getDatabaseUser(database);
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SECURITY)).isFalse();
+
+    alice.refreshDatabaseConfiguration(database, groups(new JSONArray().put("updateSecurity"), -1L));
+
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SECURITY)).isTrue();
+  }
+
+  @Test
+  void groupQuotasAreRefreshedToo() {
+    final DatabaseInternal database = mockDatabase();
+    final ServerSecurityUser alice = newUser(database, groups(new JSONArray(), -1L));
+
+    final ServerSecurityDatabaseUser dbUser = alice.getDatabaseUser(database);
+    assertThat(dbUser.getResultSetLimit()).isEqualTo(-1L);
+
+    alice.refreshDatabaseConfiguration(database, groups(new JSONArray(), 7L));
+
+    assertThat(dbUser.getResultSetLimit()).isEqualTo(7L);
+  }
+
+  @Test
+  void aSyntheticPrincipalIsNeverWidenedByTheGroupFile() {
+    // An API-token principal carries its own group definition. The refresh must keep using it, exactly as
+    // registerDatabaseUser() does, so the groups of server-groups.json can never grant it more than the
+    // token's own permissions.
+    final DatabaseInternal database = mockDatabase();
+    final ServerSecurityUser token = newUser(database, groups(new JSONArray(), -1L))
+        .withSyntheticGroupConfig(groups(new JSONArray(), -1L));
+
+    final ServerSecurityDatabaseUser dbUser = token.getDatabaseUser(database);
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isFalse();
+
+    token.refreshDatabaseConfiguration(database, groups(new JSONArray().put("updateSchema"), -1L));
+
+    assertThat(dbUser.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isFalse();
+  }
+
+  @Test
+  void refreshingAUserThatNeverTouchedTheDatabaseIsANoOp() {
+    final DatabaseInternal database = mockDatabase();
+    // The server's live configuration (what registerDatabaseUser will read) grants nothing.
+    final ServerSecurityUser alice = newUser(database, groups(new JSONArray(), -1L));
+
+    // Nothing is cached for this pair, so the refresh must do nothing at all rather than materialise an
+    // entry - ServerSecurity.updateSchema() sweeps EVERY server user on every schema change, and building a
+    // ServerSecurityDatabaseUser for each of them would be both wasteful and a way to inject a permission
+    // set that never came from the live configuration.
+    alice.refreshDatabaseConfiguration(database, groups(new JSONArray().put("updateSchema"), -1L));
+
+    // First access builds the entry from the live configuration, which still grants nothing.
+    assertThat(alice.getDatabaseUser(database).requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isFalse();
+  }
+
+  private static JSONObject groups(final JSONArray databaseAccess, final long resultSetLimit) {
+    return new JSONObject().put(GROUP, new JSONObject()
+        .put("access", databaseAccess)
+        .put("resultSetLimit", resultSetLimit)
+        .put("readTimeout", -1L)
+        .put("types", new JSONObject().put("*", new JSONObject().put("access",
+            new JSONArray().put("createRecord").put("readRecord").put("updateRecord").put("deleteRecord")))));
+  }
+
+  private static ServerSecurityUser newUser(final DatabaseInternal database, final JSONObject groupConfiguration) {
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.getDatabaseGroupsConfiguration(DATABASE)).thenReturn(groupConfiguration);
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getSecurity()).thenReturn(security);
+
+    final JSONObject userConfiguration = new JSONObject()
+        .put("name", "alice")
+        .put("password", "irrelevant")
+        .put("databases", new JSONObject().put(DATABASE, new JSONArray().put(GROUP)));
+
+    return new ServerSecurityUser(server, userConfiguration);
+  }
+
+  private static DatabaseInternal mockDatabase() {
+    final FileManager fileManager = mock(FileManager.class);
+    when(fileManager.getFiles()).thenReturn(List.of());
+
+    final Schema schema = mock(Schema.class);
+    when(schema.getTypes()).thenReturn(List.of());
+
+    final DatabaseInternal database = mock(DatabaseInternal.class);
+    when(database.getName()).thenReturn(DATABASE);
+    when(database.getFileManager()).thenReturn(fileManager);
+    when(database.getSchema()).thenReturn(schema);
+    return database;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/Issue6808LoginTokenRevocationIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue6808LoginTokenRevocationIT.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the revocation half of issue #6808: dropping a user, or changing its password, has to
+ * revoke the {@code AU-} login tokens already minted for it, not only stop future logins.
+ * <p>
+ * The bearer branch of {@code AbstractServerHttpHandler} used to take the principal straight from the cached
+ * {@code HttpAuthSession}, which captured a {@code ServerSecurityUser} at login time, and
+ * {@code ServerSecurity.invalidateHttpSessions} only reached the transaction-session manager. A revoked
+ * principal therefore kept authenticating - with its login-time grants - until the token idle-expired, up to
+ * 30 minutes after an operator believed the credentials were gone.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6808LoginTokenRevocationIT extends BaseGraphServerTest {
+
+  private static final String USER = "issue6808tokenuser";
+  private static final String PWD  = "issue6808password";
+
+  @Test
+  void droppingAUserRevokesItsLoginTokenImmediately() throws Exception {
+    testEachServer(serverIndex -> {
+      createUser(serverIndex, PWD);
+      try {
+        final String token = login(serverIndex, PWD);
+        assertThat(queryWithToken(serverIndex, token)).as("a fresh token must work").isEqualTo(200);
+
+        dropUser(serverIndex);
+
+        assertThat(queryWithToken(serverIndex, token))
+            .as("the token of a dropped user must stop working at once, not when it idle-expires")
+            .isEqualTo(401);
+      } finally {
+        dropUser(serverIndex);
+      }
+    });
+  }
+
+  @Test
+  void changingThePasswordRevokesTheLoginTokenIssuedBeforeIt() throws Exception {
+    testEachServer(serverIndex -> {
+      createUser(serverIndex, PWD);
+      try {
+        final String token = login(serverIndex, PWD);
+        assertThat(queryWithToken(serverIndex, token)).isEqualTo(200);
+
+        updatePassword(serverIndex, PWD + "-rotated");
+
+        assertThat(queryWithToken(serverIndex, token))
+            .as("a password rotation must not leave the previous credentials usable through a token")
+            .isEqualTo(401);
+
+        // The new password still mints a working token, so the revocation is not a lockout.
+        assertThat(queryWithToken(serverIndex, login(serverIndex, PWD + "-rotated"))).isEqualTo(200);
+      } finally {
+        dropUser(serverIndex);
+      }
+    });
+  }
+
+  private String login(final int serverIndex, final String password) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/login", "POST", basicAuth(USER, password));
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      final String token = new JSONObject(readResponse(connection)).getString("token");
+      assertThat(token).startsWith("AU-");
+      return token;
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int queryWithToken(final int serverIndex, final String token) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/query/" + getDatabaseName(), "POST",
+        "Bearer " + token);
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream().write(new JSONObject().put("language", "sql").put("command", "select 1 as one")
+        .toString().getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void createUser(final int serverIndex, final String password) throws Exception {
+    if (getServer(serverIndex).getSecurity().existsUser(USER))
+      getServer(serverIndex).getSecurity().dropUser(USER);
+
+    final JSONObject payload = new JSONObject()
+        .put("name", USER)
+        .put("password", password)
+        .put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put("admin")));
+
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/server/users", "POST", basicAuth());
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream().write(payload.toString().getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(201);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void updatePassword(final int serverIndex, final String password) throws Exception {
+    final HttpURLConnection connection = open(serverIndex,
+        "/api/v1/server/users?name=" + URLEncoder.encode(USER, StandardCharsets.UTF_8), "PUT", basicAuth());
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream()
+        .write(new JSONObject().put("password", password).toString().getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void dropUser(final int serverIndex) throws Exception {
+    final HttpURLConnection connection = open(serverIndex,
+        "/api/v1/server/users?name=" + URLEncoder.encode(USER, StandardCharsets.UTF_8), "DELETE", basicAuth());
+    connection.connect();
+    try {
+      connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private HttpURLConnection open(final int serverIndex, final String path, final String method, final String auth)
+      throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + path).openConnection();
+    connection.setRequestMethod(method);
+    connection.setRequestProperty("Authorization", auth);
+    return connection;
+  }
+
+  private String basicAuth() {
+    return basicAuth("root", DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/Issue6808LoginTokenRevocationIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue6808LoginTokenRevocationIT.java
@@ -89,6 +89,33 @@ class Issue6808LoginTokenRevocationIT extends BaseGraphServerTest {
     });
   }
 
+  @Test
+  void reloadingTheUserFileWithARotatedPasswordRevokesTheTokenToo() throws Exception {
+    testEachServer(serverIndex -> {
+      createUser(serverIndex, PWD);
+      try {
+        final String token = login(serverIndex, PWD);
+        assertThat(queryWithToken(serverIndex, token)).isEqualTo(200);
+
+        // Third way a password can change: an operator edits server-users.jsonl and the file is re-read.
+        // The bearer path only requires the principal to still resolve by name, and it does, so the reload
+        // has to compare the stored hashes and revoke on its own.
+        final ServerSecurity security = getServer(serverIndex).getSecurity();
+        for (final JSONObject user : security.usersToJSON())
+          if (USER.equals(user.getString("name")))
+            user.put("password", security.encodePassword(PWD + "-from-file"));
+        security.saveUsers();
+        security.loadUsers();
+
+        assertThat(queryWithToken(serverIndex, token))
+            .as("a password rotated through the user file must revoke the tokens issued before it")
+            .isEqualTo(401);
+      } finally {
+        dropUser(serverIndex);
+      }
+    });
+  }
+
   private String login(final int serverIndex, final String password) throws Exception {
     final HttpURLConnection connection = open(serverIndex, "/api/v1/login", "POST", basicAuth(USER, password));
     connection.connect();


### PR DESCRIPTION
Five independent server-side defects, each with its own regression test.

## #6805 - the `db` tag of `arcadedb.http.requests` was the raw path parameter

`{database}` matches any path segment, and the RED timer is recorded in a `finally` that also runs for the early 401. So an unauthenticated caller could register one permanent percentile-histogram Timer per invented name - the unbounded heap growth #5025 fixed for the `path` tag, on the other half of the tuple. The class comment even asserted the key space was bounded "because db is the finite set of database names", which is only true of databases that exist.

- `databaseTag` echoes the name only when `existsDatabase(db)`, and collapses to the constant `unknown` otherwise.
- A `MeterFilter.maximumAllowableTags("arcadedb.http.requests", "db", 1000, deny())` backstop next to the existing `path` one.
- `HTTP_REQUEST_TIMERS` gained a hard ceiling: a MeterFilter can deny the meter but cannot stop `computeIfAbsent` from retaining the key, so past the ceiling the `db` half collapses onto `other`.

## #6806 - a group's database-level grants were never refreshed

`ServerSecurityDatabaseUser` keeps two independent permission maps refreshed by two different methods, and `ServerSecurity.updateSchema` - the server's only refresh path - called just `updateFileAccess()`. The `DATABASE_ACCESS` map read by `requestAccessOnDatabase` (`updateSchema`, `updateSecurity`, `updateDatabaseSettings`) plus the `resultSetLimit`/`readTimeout` quotas were therefore frozen at the values they had when the user first touched the database: a revoked grant kept working until restart, and symmetrically a newly granted one was ignored until restart.

The refresh now goes through a new `ServerSecurityUser.refreshDatabaseConfiguration`, which rebuilds both maps and keeps the "a synthetic (API-token) principal uses its own group definition, never the group file" decision in one place instead of duplicating it between `registerDatabaseUser` and `updateSchema` (where it was absent). It also stops calling `getDatabaseUser()`, which materialised a cached entry for every server user as a side effect of every schema change.

## #6807 - the PromQL `query_range` step guard was bypassed by long overflow

A span wider than `Long.MAX_VALUE` milliseconds (`start=-9e15`, `end=9e15` - both in order, so the `endMs < startMs` test does not fire) wrapped negative, the `MAX_RANGE_STEPS` check passed, and the per-step loop ran unbounded. For a non-existent metric every step is cheap and nothing throws, so the request never returned and the Undertow worker thread was lost; one request per worker thread takes the listener down.

- The span is computed with `Math.subtractExact` and an overflow is rejected as the bad request it is.
- The step count is tested before the `+ 1`, which would itself overflow to `Long.MIN_VALUE` for `span=Long.MAX_VALUE, step=1` and turn the rejection into a silently empty result.
- The loop is indexed by step instead of accumulating into `t`: `t += stepMs` could wrap past `Long.MAX_VALUE` back below `endMs`, which is the same unbounded loop by another route.
- The handler validates `start`/`end` up front (finite, numeric, sane epoch range), so a non-numeric value answers 400 instead of 500.

## #6808 - REST user mutations did not replicate on a cluster

`POST`/`PUT`/`DELETE /api/v1/server/users` mutated the user store only on the node that served the request, while the equivalent `POST /api/v1/server` `create user`/`drop user` replicated through Raft. Behind a load balancer a created principal authenticated intermittently; worse, a delete returned 200 while the revoked credentials kept working on every other node. The next replicated user command then latched the divergence in by overwriting every peer with the serving node's whole list.

The HA-vs-local decision, and the `synchronized` read-compute-submit serialisation it needs, moved into `ServerSecurity.createUserClusterWide` / `updateUserClusterWide` / `dropUserClusterWide`. All four REST handlers and `PostServerCommandHandler` now share them, which also removes the duplicated HA branch the command handler carried. The two DELETE handlers moved onto a worker thread, since the Raft submit blocks and must never do so on an Undertow IO thread.

Revocation had a second hole one layer down, closed in the same PR: the bearer branch of `AbstractServerHttpHandler` took the principal straight from the cached `HttpAuthSession`, which captured a `ServerSecurityUser` at login time, and `invalidateHttpSessions` only reached the transaction-session manager. A dropped user's `AU-` login token therefore kept authenticating - with its login-time grants - until it idle-expired, up to 30 minutes after the operator believed the credentials were gone. The bearer branch **and the equivalent path in `GrpcAuthInterceptor`** now re-resolve the principal from the live users map by name (one `ConcurrentHashMap` read) and reject with 401 when it is gone, which makes a drop effective immediately on every node - including a peer, which learns of it through a replicated user list rather than through its own drop path. On top of that, `invalidateHttpSessions` drops the principal's authentication sessions eagerly, and `applyReplicatedUsers` does the same on each peer for principals the replicated list removed or whose password it changed. `HttpAuthSessionManager.removeSessionsForUser` does no blocking work (an authentication session owns no transaction and has nothing to cancel), so unlike its transaction-session counterpart it is safe on the Raft state-machine apply thread, and it is O(1) thanks to the per-principal index #6809 added.

## #6809 - the login session map was unbounded and stored untruncated client headers

`createSession` inserted into an unbounded `HashMap` with no global and no per-principal cap, and `PostLoginHandler` stored the raw `User-Agent`, `CF-IPCountry`, `CF-IPCity` and `CF-Connecting-IP`/`X-Forwarded-For` values in it. Undertow accepts a 1 MB header and the idle sweep only fires after 30 minutes, so ~1000 logins with one valid low-privilege credential retained ~1 GB, with no log line and no ceiling. Every other cache on this request path is explicitly bounded.

- Metadata is truncated at 256 chars in the `HttpAuthSession` constructor - the single point every client-supplied string passes through - so no future call site can reintroduce the retention.
- The **per-principal** cap (`arcadedb.server.httpAuthSessionMaxPerUser`, default 100) evicts that principal's oldest session: a login loop churns only its own sessions, and can neither grow the map nor evict anybody else's. A principal already at its cap is still admitted when the map is globally full, since evicting frees exactly the slot it needs - and that is decided *before* anything is evicted, so a refusal never destroys a live session of the principal it refuses.
- The **global** cap (`arcadedb.server.httpAuthSessionMax`, default 10000) refuses with 503 rather than evicting across principals, after first attempting an idle sweep so a map full of expired sessions is reclaimed instead of refused.

## Tests

| Test | Covers |
| --- | --- |
| `AbstractServerHttpHandlerMetricsTest` (+4) | `databaseTag` keeps an existing name, collapses an unknown one, stays `none` off database-scoped routes |
| `HttpRedMetricsIT.unknownDatabaseCollapsesToBoundedDbTag` | 50 unauthenticated probes at invented names register no meter carrying them |
| `Issue6806GroupPermissionRefreshTest` (6) | revoke, re-grant, quota refresh, synthetic principal never widened, no-op for an uncached pair, and the half-refresh that was the defect |
| `Issue6806GroupPermissionRefreshIT` | the same revoke/re-grant end to end over HTTP |
| `Issue6807RangeStepGuardTest` (5) | the overflowing span, the `+ 1` overflow, and the three pre-existing guards - `@Timeout` as a hang detector, since the pre-fix code never returned |
| `Issue6807PromQLRangeParameterTest` (4) | `start`/`end` parsing and rejection |
| `RaftUserManagement3NodesIT.restUserEndpointsReplicateAcrossCluster` | create/update/delete through the REST endpoints reach all three nodes |
| `Issue6808LoginTokenRevocationIT` | a drop and a password rotation both revoke an already-issued login token at once |
| `HttpAuthSessionManagerTest` (+9) | per-principal eviction, no cross-principal eviction, global refusal, idle reclaim before refusing, unlimited when 0, truncation, index hygiene, per-principal revocation |

Fixes #6805
Fixes #6806
Fixes #6807
Fixes #6808
Fixes #6809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable global and per-user HTTP authentication session limits, with automatic eviction and capacity protection.
  - User creation, updates, and deletions now replicate across HA clusters.
  - Database permissions and quotas refresh without requiring a server restart.

- **Bug Fixes**
  - Existing authentication tokens are invalidated after user deletion or password changes.
  - Improved PromQL validation with clear client errors for invalid or overflowing parameters.
  - Bounded HTTP metric tags for unknown databases.
  - Limited session metadata to 256 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
