### PR TITLE
fix(schema): one copy point for the index builder swap (#5606)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -355,8 +355,9 @@ public class CreateIndexStatement extends DDLStatement {
       resultingIndex = ftBuilder.create();
 
     } else if (indexType == Schema.INDEX_TYPE.LSM_SPARSE_VECTOR) {
-      final TypeLSMSparseVectorIndexBuilder sparseBuilder = builder.withType(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR)
-          .withSparseVectorType();
+      // Builder is already a TypeLSMSparseVectorIndexBuilder after the withType() above, exactly like the three
+      // branches around this one: re-selecting the index type here would be a no-op.
+      final TypeLSMSparseVectorIndexBuilder sparseBuilder = builder.withSparseVectorType();
       if (metadata != null) {
         final Map<String, Object> metadataMap = metadata.toMap((Result) null, context);
         final JSONObject jsonMetadata = new JSONObject(metadataMap);

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -48,6 +48,36 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
     this.propertyNames = propertyNames;
   }
 
+  /**
+   * The copy constructor of the bucket-level swap, the mirror of
+   * {@link TypeIndexBuilder#TypeIndexBuilder(TypeIndexBuilder, Schema.INDEX_TYPE, IndexMetadata)}: {@link #withType}
+   * hands back a specialised subclass once the index type is known, and everything configured before that call has to
+   * survive being carried onto it.
+   * <p>
+   * {@link BucketLSMVectorIndexBuilder} used to copy the common state itself, field by field, which is the same
+   * footgun issue #5606 removed from the type-level hierarchy - and it was already missing the same two fields,
+   * {@code replaceIfIncompatible} (#5675) and {@code userMetadata} (#5723). One hierarchy fixed and the other left
+   * exposed is not a fix: the next field added to {@link IndexBuilder} would simply go missing here instead.
+   *
+   * @param copyFrom  the builder being replaced, whose configuration must survive the swap
+   * @param indexType the index type this specialised builder stands for
+   * @param metadata  a freshly built metadata of the subclass the specialised builder writes its settings into
+   */
+  protected BucketIndexBuilder(final BucketIndexBuilder copyFrom, final Schema.INDEX_TYPE indexType,
+      final IndexMetadata metadata) {
+    super(copyFrom.database, Index.class);
+    this.typeName = copyFrom.typeName;
+    this.bucketName = copyFrom.bucketName;
+    this.propertyNames = copyFrom.propertyNames;
+
+    // Null-guarded, unlike the type-level twin: a plain BucketIndexBuilder does not necessarily carry a metadata at
+    // all - only a specialised subclass installs one - so there may be no common definition to carry over.
+    this.metadata = copyFrom.metadata == null ? metadata : copyFrom.metadata.copyCommonTo(metadata);
+    this.indexType = indexType;
+
+    copyBaseFieldsFrom(copyFrom);
+  }
+
   @Override
   public IndexBuilder<Index> withType(Schema.INDEX_TYPE indexType) {
     if (indexType == Schema.INDEX_TYPE.LSM_VECTOR && !(this instanceof BucketLSMVectorIndexBuilder))

--- a/engine/src/main/java/com/arcadedb/schema/BucketLSMVectorIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketLSMVectorIndexBuilder.java
@@ -43,20 +43,10 @@ public class BucketLSMVectorIndexBuilder extends BucketIndexBuilder {
   }
 
   protected BucketLSMVectorIndexBuilder(final BucketIndexBuilder copyFrom) {
-    super(copyFrom.database, copyFrom.typeName, copyFrom.bucketName, copyFrom.propertyNames);
-
-    this.indexType = Schema.INDEX_TYPE.LSM_VECTOR;
-    this.unique = copyFrom.unique;
-    this.pageSize = copyFrom.pageSize;
-    this.nullStrategy = copyFrom.nullStrategy;
-    this.callback = copyFrom.callback;
-    this.ignoreIfExists = copyFrom.ignoreIfExists;
-    this.indexName = copyFrom.indexName;
-    this.filePath = copyFrom.filePath;
-    this.keyTypes = copyFrom.keyTypes;
-    this.batchSize = copyFrom.batchSize;
-    this.maxAttempts = copyFrom.maxAttempts;
-    this.metadata = new LSMVectorIndexMetadata(copyFrom.typeName, copyFrom.propertyNames, -1);
+    // Every common setting is carried over by the shared copy constructor, which is the ONE place a new builder field
+    // has to be added - see BucketIndexBuilder(BucketIndexBuilder, INDEX_TYPE, IndexMetadata) and issue #5606.
+    super(copyFrom, Schema.INDEX_TYPE.LSM_VECTOR,
+        new LSMVectorIndexMetadata(copyFrom.typeName, copyFrom.propertyNames, -1));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -89,6 +89,42 @@ public abstract class IndexBuilder<T extends Index> {
   }
 
   /**
+   * Carries every setting THIS class declares over to a builder that replaces {@code this} mid-configuration - the
+   * builder swap of {@link TypeIndexBuilder#withType}, which hands back a specialised subclass once the index type is
+   * known and leaves everything configured so far behind unless it is copied across.
+   * <p>
+   * The point of it being one method is that it is the ONE place a new field of this class has to be added. The four
+   * specialised builders used to hand-copy the same eleven fields each, which is a copy that cannot fail to compile
+   * and cannot be missed by review: {@code replaceIfIncompatible} (#5675) and {@code userMetadata} (#5723) were both
+   * added to this class, wired through a {@code withX()} setter, and silently dropped by every one of them - working
+   * perfectly for {@code LSM_TREE} and {@code HASH}, which never swap builders, and evaporating for FULL_TEXT,
+   * GEOSPATIAL and the two vector types (issue #5606). The shadowed {@code metadata} field of #5478 was the same class
+   * of bug one level down.
+   * <p>
+   * {@link #indexType}, {@link #metadata}, {@link #database} and {@link #indexImplementation} are deliberately NOT
+   * here: they are what the swap is FOR - the target builder is constructed around the new index type and its own
+   * metadata subclass, and gets the database from the source. See
+   * {@link TypeIndexBuilder#TypeIndexBuilder(TypeIndexBuilder, Schema.INDEX_TYPE, IndexMetadata)}, which sets those
+   * three and then calls this.
+   */
+  protected void copyBaseFieldsFrom(final IndexBuilder<?> source) {
+    this.unique = source.unique;
+    this.pageSize = source.pageSize;
+    this.nullStrategy = source.nullStrategy;
+    this.callback = source.callback;
+    this.ignoreIfExists = source.ignoreIfExists;
+    this.replaceIfIncompatible = source.replaceIfIncompatible;
+    this.indexName = source.indexName;
+    this.filePath = source.filePath;
+    this.keyTypes = source.keyTypes;
+    this.batchSize = source.batchSize;
+    this.maxAttempts = source.maxAttempts;
+    // The clause as written: shared rather than re-copied, because withUserMetadata() already deep-copied it on the
+    // way in and neither builder mutates it afterwards.
+    this.userMetadata = source.userMetadata;
+  }
+
+  /**
    * Answers whether {@code existing} already provides everything the caller asked for, which is the only thing that
    * makes an {@code IF NOT EXISTS} / {@link #withIgnoreIfExists(boolean)} request a legitimate no-op.
    * <p>

--- a/engine/src/main/java/com/arcadedb/schema/TypeFullTextIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeFullTextIndexBuilder.java
@@ -29,24 +29,11 @@ import com.arcadedb.serializer.json.JSONObject;
 public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
 
   protected TypeFullTextIndexBuilder(final TypeIndexBuilder copyFrom) {
-    super(copyFrom.database, copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]));
-
-    this.metadata = new FullTextIndexMetadata(
-        copyFrom.metadata.typeName,
-        copyFrom.metadata.propertyNames.toArray(new String[0]),
-        copyFrom.metadata.associatedBucketId);
-
-    this.indexType = Schema.INDEX_TYPE.FULL_TEXT;
-    this.unique = copyFrom.unique;
-    this.pageSize = copyFrom.pageSize;
-    this.nullStrategy = copyFrom.nullStrategy;
-    this.callback = copyFrom.callback;
-    this.ignoreIfExists = copyFrom.ignoreIfExists;
-    this.indexName = copyFrom.indexName;
-    this.filePath = copyFrom.filePath;
-    this.keyTypes = copyFrom.keyTypes;
-    this.batchSize = copyFrom.batchSize;
-    this.maxAttempts = copyFrom.maxAttempts;
+    // Every common setting is carried over by the shared copy constructor, which is the ONE place a new builder field
+    // has to be added - see TypeIndexBuilder(TypeIndexBuilder, INDEX_TYPE, IndexMetadata) and issue #5606.
+    super(copyFrom, Schema.INDEX_TYPE.FULL_TEXT,
+        new FullTextIndexMetadata(copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]),
+            copyFrom.metadata.associatedBucketId));
   }
 
   protected TypeFullTextIndexBuilder(final DatabaseInternal database, final String typeName, final String[] propertyNames) {

--- a/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
@@ -31,26 +31,11 @@ import com.arcadedb.serializer.json.JSONObject;
  */
 public class TypeGeoIndexBuilder extends TypeIndexBuilder {
   protected TypeGeoIndexBuilder(final TypeIndexBuilder copyFrom) {
-    super(copyFrom.database, copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]));
-
-    this.metadata = new GeoIndexMetadata(
-        copyFrom.metadata.typeName,
-        copyFrom.metadata.propertyNames.toArray(new String[0]),
-        copyFrom.metadata.associatedBucketId);
-    this.metadata.collations = copyFrom.metadata.collations;
-    this.metadata.typeIndexName = copyFrom.metadata.typeIndexName;
-
-    this.indexType = Schema.INDEX_TYPE.GEOSPATIAL;
-    this.unique = copyFrom.unique;
-    this.pageSize = copyFrom.pageSize;
-    this.nullStrategy = copyFrom.nullStrategy;
-    this.callback = copyFrom.callback;
-    this.ignoreIfExists = copyFrom.ignoreIfExists;
-    this.indexName = copyFrom.indexName;
-    this.filePath = copyFrom.filePath;
-    this.keyTypes = copyFrom.keyTypes;
-    this.batchSize = copyFrom.batchSize;
-    this.maxAttempts = copyFrom.maxAttempts;
+    // Every common setting is carried over by the shared copy constructor, which is the ONE place a new builder field
+    // has to be added - see TypeIndexBuilder(TypeIndexBuilder, INDEX_TYPE, IndexMetadata) and issue #5606.
+    super(copyFrom, Schema.INDEX_TYPE.GEOSPATIAL,
+        new GeoIndexMetadata(copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]),
+            copyFrom.metadata.associatedBucketId));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -73,6 +73,47 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   }
 
   /**
+   * The one copy constructor of the whole builder hierarchy: the specialised builders {@link #withType} swaps in -
+   * {@link TypeFullTextIndexBuilder}, {@link TypeLSMVectorIndexBuilder}, {@link TypeLSMSparseVectorIndexBuilder} and
+   * {@link TypeGeoIndexBuilder} - all delegate here, each supplying only the two things that make it different: the
+   * index type it stands for and the {@link IndexMetadata} subclass its own settings live in.
+   * <p>
+   * Each of the four used to copy the common state itself, field by field, so a field added to {@link IndexBuilder} or
+   * to this class kept working for {@code LSM_TREE} and {@code HASH} - which never swap builders - and was dropped on
+   * the floor for all four specialised types, with no compile error and nothing to notice it (issue #5606). Now a new
+   * field has exactly one place to be added: here if it is declared by this class, {@link #copyBaseFieldsFrom} if it
+   * is declared by the base one.
+   *
+   * @param copyFrom  the builder being replaced, whose configuration must survive the swap
+   * @param indexType the index type this specialised builder stands for
+   * @param metadata  a freshly built metadata of the subclass the specialised builder writes its settings into; the
+   *                  common definition ({@code collations}, {@code typeIndexName}) is carried onto it from
+   *                  {@code copyFrom}
+   */
+  protected TypeIndexBuilder(final TypeIndexBuilder copyFrom, final Schema.INDEX_TYPE indexType,
+      final IndexMetadata metadata) {
+    super(copyFrom.database, TypeIndex.class);
+
+    // The type/properties/bucket identity comes from the metadata the subclass just built out of copyFrom's; what is
+    // left is the rest of the DEFINITION, which used to survive the swap only for GEOSPATIAL.
+    this.metadata = copyFrom.metadata.copyCommonTo(metadata);
+    this.indexType = indexType;
+
+    copyBaseFieldsFrom(copyFrom);
+
+    this.defaultKeyTypesForUndeclaredProperties = copyFrom.defaultKeyTypesForUndeclaredProperties;
+    // Sorted build cannot actually reach a specialised builder today - withType() refuses it for anything but
+    // LSM_TREE - so these five ride along for correctness rather than because something depends on them. That guard is
+    // circumstantial, not a design: the day a second index family learns to build sorted, the settings must already be
+    // here rather than being remembered as a sixth thing to add.
+    this.buildMode = copyFrom.buildMode;
+    this.buildMemoryBudgetBytes = copyFrom.buildMemoryBudgetBytes;
+    this.buildSpillDirectory = copyFrom.buildSpillDirectory;
+    this.buildMergeFanIn = copyFrom.buildMergeFanIn;
+    this.buildParallelism = copyFrom.buildParallelism;
+  }
+
+  /**
    * Tells the builder to fall back to {@code defaultKeyType} (one entry per property) when a
    * property is not yet declared on the document type, instead of throwing
    * {@link SchemaException}. The property remains undeclared on the schema: this avoids the

--- a/engine/src/main/java/com/arcadedb/schema/TypeLSMSparseVectorIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeLSMSparseVectorIndexBuilder.java
@@ -31,24 +31,11 @@ import com.arcadedb.serializer.json.JSONObject;
 public class TypeLSMSparseVectorIndexBuilder extends TypeIndexBuilder {
 
   protected TypeLSMSparseVectorIndexBuilder(final TypeIndexBuilder copyFrom) {
-    super(copyFrom.database, copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]));
-
-    this.metadata = new LSMSparseVectorIndexMetadata(
-        copyFrom.metadata.typeName,
-        copyFrom.metadata.propertyNames.toArray(new String[0]),
-        copyFrom.metadata.associatedBucketId);
-
-    this.indexType = Schema.INDEX_TYPE.LSM_SPARSE_VECTOR;
-    this.unique = copyFrom.unique;
-    this.pageSize = copyFrom.pageSize;
-    this.nullStrategy = copyFrom.nullStrategy;
-    this.callback = copyFrom.callback;
-    this.ignoreIfExists = copyFrom.ignoreIfExists;
-    this.indexName = copyFrom.indexName;
-    this.filePath = copyFrom.filePath;
-    this.keyTypes = copyFrom.keyTypes;
-    this.batchSize = copyFrom.batchSize;
-    this.maxAttempts = copyFrom.maxAttempts;
+    // Every common setting is carried over by the shared copy constructor, which is the ONE place a new builder field
+    // has to be added - see TypeIndexBuilder(TypeIndexBuilder, INDEX_TYPE, IndexMetadata) and issue #5606.
+    super(copyFrom, Schema.INDEX_TYPE.LSM_SPARSE_VECTOR,
+        new LSMSparseVectorIndexMetadata(copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]),
+            copyFrom.metadata.associatedBucketId));
   }
 
   protected TypeLSMSparseVectorIndexBuilder(final DatabaseInternal database, final String typeName,

--- a/engine/src/main/java/com/arcadedb/schema/TypeLSMVectorIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeLSMVectorIndexBuilder.java
@@ -31,24 +31,11 @@ import com.arcadedb.serializer.json.JSONObject;
  */
 public class TypeLSMVectorIndexBuilder extends TypeIndexBuilder {
   protected TypeLSMVectorIndexBuilder(final TypeIndexBuilder copyFrom) {
-    super(copyFrom.database, copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]));
-
-    this.metadata = new LSMVectorIndexMetadata(
-        copyFrom.metadata.typeName,
-        copyFrom.metadata.propertyNames.toArray(new String[0]),
-        copyFrom.metadata.associatedBucketId);
-
-    this.indexType = Schema.INDEX_TYPE.LSM_VECTOR;
-    this.unique = copyFrom.unique;
-    this.pageSize = copyFrom.pageSize;
-    this.nullStrategy = copyFrom.nullStrategy;
-    this.callback = copyFrom.callback;
-    this.ignoreIfExists = copyFrom.ignoreIfExists;
-    this.indexName = copyFrom.indexName;
-    this.filePath = copyFrom.filePath;
-    this.keyTypes = copyFrom.keyTypes;
-    this.batchSize = copyFrom.batchSize;
-    this.maxAttempts = copyFrom.maxAttempts;
+    // Every common setting is carried over by the shared copy constructor, which is the ONE place a new builder field
+    // has to be added - see TypeIndexBuilder(TypeIndexBuilder, INDEX_TYPE, IndexMetadata) and issue #5606.
+    super(copyFrom, Schema.INDEX_TYPE.LSM_VECTOR,
+        new LSMVectorIndexMetadata(copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]),
+            copyFrom.metadata.associatedBucketId));
   }
 
   protected TypeLSMVectorIndexBuilder(final DatabaseInternal database, final String typeName, final String[] propertyNames) {

--- a/engine/src/test/java/com/arcadedb/schema/Issue5606BuilderStateCarryOverTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue5606BuilderStateCarryOverTest.java
@@ -54,6 +54,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class Issue5606BuilderStateCarryOverTest extends TestHelper {
   private static final String   TYPE_NAME     = "Issue5606";
+  private static final String   BUCKET_NAME   = "Issue5606_bucket";
   private static final String[] PROPERTY_NAME = { "name" };
 
   /**
@@ -94,6 +95,9 @@ class Issue5606BuilderStateCarryOverTest extends TestHelper {
    * from a pristine builder's: both are structural and final, handed to the specialised builder from the source.
    */
   private static final Set<String> NOT_CONFIGURABLE = Set.of("database", "indexImplementation");
+
+  /** The bucket-level identity, handed to the specialised builder rather than configured through a setter. */
+  private static final Set<String> BUCKET_IDENTITY = Set.of("typeName", "bucketName", "propertyNames");
 
   @ParameterizedTest
   @EnumSource(SpecialisedBuilder.class)
@@ -183,6 +187,78 @@ class Issue5606BuilderStateCarryOverTest extends TestHelper {
   }
 
   /**
+   * The SAME swap one hierarchy over: {@link BucketIndexBuilder#withType} hands back a
+   * {@link BucketLSMVectorIndexBuilder} for {@code LSM_VECTOR}, and that copy constructor carried the identical
+   * hand-written field list - already missing {@code replaceIfIncompatible} and {@code userMetadata}, the exact two
+   * this issue is about. Fixing one hierarchy and leaving the other is not a fix, so it is asserted the same way.
+   */
+  @Test
+  void everySettingSurvivesTheBucketBuilderSwap() {
+    final BucketIndexBuilder source = configureEveryBaseSetting(
+        database.getSchema().buildBucketIndex(TYPE_NAME, BUCKET_NAME, PROPERTY_NAME));
+
+    final IndexBuilder<?> swapped = source.withType(Schema.INDEX_TYPE.LSM_VECTOR);
+
+    assertThat(swapped).isInstanceOf(BucketLSMVectorIndexBuilder.class);
+    assertThat(swapped.metadata).isInstanceOf(LSMVectorIndexMetadata.class);
+    assertThat(swapped.getIndexType()).isEqualTo(Schema.INDEX_TYPE.LSM_VECTOR);
+
+    for (final Field field : declaredFieldsOf(IndexBuilder.class, BucketIndexBuilder.class)) {
+      if (NOT_CARRIED_OVER.contains(field.getName()))
+        continue;
+      assertThat(Objects.deepEquals(read(field, swapped), read(field, source)))
+          .withFailMessage("'%s' did not survive BucketIndexBuilder.withType(LSM_VECTOR): the specialised builder has"
+                  + " <%s> but the caller had configured <%s>. Carry it over in BucketIndexBuilder's copy constructor"
+                  + " (or in IndexBuilder.copyBaseFieldsFrom when the field is declared there) - see issue #5606.",
+              field.getName(), describe(read(field, swapped)), describe(read(field, source)))
+          .isTrue();
+    }
+  }
+
+  /** The bucket-level half of {@link #everySettingIsActuallyConfiguredByThisTest}. */
+  @Test
+  void everyBaseSettingIsActuallyConfiguredByThisTest() {
+    final BucketIndexBuilder pristine = database.getSchema().buildBucketIndex(TYPE_NAME, BUCKET_NAME, PROPERTY_NAME);
+    final BucketIndexBuilder configured = configureEveryBaseSetting(
+        database.getSchema().buildBucketIndex(TYPE_NAME, BUCKET_NAME, PROPERTY_NAME));
+
+    final List<String> leftAtDefault = new ArrayList<>();
+    for (final Field field : declaredFieldsOf(IndexBuilder.class, BucketIndexBuilder.class)) {
+      if (NOT_CARRIED_OVER.contains(field.getName()) || NOT_CONFIGURABLE.contains(field.getName())
+          || BUCKET_IDENTITY.contains(field.getName()))
+        continue;
+      if (Objects.deepEquals(read(field, configured), read(field, pristine)))
+        leftAtDefault.add(field.getName());
+    }
+
+    assertThat(leftAtDefault)
+        .withFailMessage("configureEveryBaseSetting() leaves %s at its default value, so the bucket-level carry-over"
+            + " test does not actually check it. See issue #5606.", leftAtDefault)
+        .isEmpty();
+  }
+
+  /**
+   * The {@link IndexBuilder} half of {@link #configureEverySetting}, for the bucket-level builder, which declares no
+   * settings of its own - only the type/bucket/properties identity.
+   */
+  private BucketIndexBuilder configureEveryBaseSetting(final BucketIndexBuilder builder) {
+    builder.withUnique(true);
+    builder.withPageSize(8192);
+    builder.withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR);
+    builder.withCallback((document, totalIndexed) -> {
+    });
+    builder.withIgnoreIfExists(true);
+    builder.withReplaceIfIncompatible(true);
+    builder.withIndexName("Issue5606ManualName");
+    builder.withFilePath("target/issue5606.idx");
+    builder.withKeyTypes(new Type[] { Type.STRING });
+    builder.withBatchSize(37);
+    builder.withMaxAttempts(11);
+    builder.withUserMetadata(new JSONObject().put("issue", 5606));
+    return builder;
+  }
+
+  /**
    * Sets every field of {@link IndexBuilder} and {@link TypeIndexBuilder} to something distinguishable from the
    * default, through the public API rather than reflection: an option that cannot be reached from outside the class
    * is not one the carry-over has to protect.
@@ -213,10 +289,15 @@ class Issue5606BuilderStateCarryOverTest extends TestHelper {
     return builder;
   }
 
-  /** Every instance field the two builder classes declare, in a stable order. */
+  /** Every instance field the two type-level builder classes declare, in a stable order. */
   private static List<Field> declaredBuilderFields() {
+    return declaredFieldsOf(IndexBuilder.class, TypeIndexBuilder.class);
+  }
+
+  /** Every instance field the given classes declare, in a stable order. */
+  private static List<Field> declaredFieldsOf(final Class<?>... classes) {
     final List<Field> fields = new ArrayList<>();
-    for (final Class<?> clazz : new Class<?>[] { IndexBuilder.class, TypeIndexBuilder.class })
+    for (final Class<?> clazz : classes)
       for (final Field field : clazz.getDeclaredFields())
         if (!Modifier.isStatic(field.getModifiers()) && !field.isSynthetic()) {
           field.setAccessible(true);

--- a/engine/src/test/java/com/arcadedb/schema/Issue5606BuilderStateCarryOverTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue5606BuilderStateCarryOverTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #5606: {@link TypeIndexBuilder#withType} hands back a SPECIALISED builder for the index types that carry
+ * settings of their own, so every setting configured before that call has to survive being copied onto the new
+ * instance. The four specialised builders used to hand-copy the same eleven fields each, which made a field added to
+ * {@link IndexBuilder} work for {@code LSM_TREE} and {@code HASH} - which never swap builders - and evaporate for
+ * FULL_TEXT, GEOSPATIAL and the two vector types, with no compile error and nothing to notice it.
+ * <p>
+ * The test is deliberately reflective rather than a list of hand-written assertions, for exactly the reason the defect
+ * existed: a hand-written list is a second field list to keep in sync, and the first one already went stale.
+ * {@link #everySettingSurvivesTheBuilderSwap} compares EVERY declared field, and
+ * {@link #everySettingIsActuallyConfiguredByThisTest} is what stops that comparison from going vacuous - it fails when
+ * a field is left at its default by the setup, which is what a newly added field looks like.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5606BuilderStateCarryOverTest extends TestHelper {
+  private static final String   TYPE_NAME     = "Issue5606";
+  private static final String[] PROPERTY_NAME = { "name" };
+
+  /**
+   * The index types {@link TypeIndexBuilder#withType} answers with a builder OTHER than itself. Kept as an enum rather
+   * than read off {@code Schema.INDEX_TYPE} so that adding an index type without a specialised builder does not
+   * silently widen the test into asserting nothing.
+   */
+  enum SpecialisedBuilder {
+    FULL_TEXT(Schema.INDEX_TYPE.FULL_TEXT, TypeFullTextIndexBuilder.class, FullTextIndexMetadata.class),
+    LSM_VECTOR(Schema.INDEX_TYPE.LSM_VECTOR, TypeLSMVectorIndexBuilder.class, LSMVectorIndexMetadata.class),
+    LSM_SPARSE_VECTOR(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR, TypeLSMSparseVectorIndexBuilder.class,
+        LSMSparseVectorIndexMetadata.class),
+    GEOSPATIAL(Schema.INDEX_TYPE.GEOSPATIAL, TypeGeoIndexBuilder.class, GeoIndexMetadata.class);
+
+    final Schema.INDEX_TYPE                     indexType;
+    final Class<? extends TypeIndexBuilder>     builderClass;
+    final Class<? extends IndexMetadata>        metadataClass;
+
+    SpecialisedBuilder(final Schema.INDEX_TYPE indexType, final Class<? extends TypeIndexBuilder> builderClass,
+        final Class<? extends IndexMetadata> metadataClass) {
+      this.indexType = indexType;
+      this.builderClass = builderClass;
+      this.metadataClass = metadataClass;
+    }
+  }
+
+  /**
+   * Fields the swap is FOR, so they are expected to differ on the new builder rather than to be carried over:
+   * {@code indexType} is the index type being selected, {@code metadata} is replaced by the subclass the specialised
+   * settings live in (its common definition is asserted separately), and {@code buildMode} cannot reach a specialised
+   * builder at all - {@code withType()} refuses a sorted build for anything but {@code LSM_TREE}, which
+   * {@link #sortedBuildIsRefusedBySpecialisedTypes} pins down.
+   */
+  private static final Set<String> NOT_CARRIED_OVER = Set.of("indexType", "metadata", "buildMode");
+
+  /**
+   * Additionally not settable, so {@link #everySettingIsActuallyConfiguredByThisTest} cannot expect them to differ
+   * from a pristine builder's: both are structural and final, handed to the specialised builder from the source.
+   */
+  private static final Set<String> NOT_CONFIGURABLE = Set.of("database", "indexImplementation");
+
+  @ParameterizedTest
+  @EnumSource(SpecialisedBuilder.class)
+  void everySettingSurvivesTheBuilderSwap(final SpecialisedBuilder specialised) {
+    final TypeIndexBuilder source = configureEverySetting(database.getSchema().buildTypeIndex(TYPE_NAME, PROPERTY_NAME));
+
+    final TypeIndexBuilder swapped = source.withType(specialised.indexType);
+
+    assertThat(swapped).isInstanceOf(specialised.builderClass);
+    assertThat(swapped.metadata).isInstanceOf(specialised.metadataClass);
+    assertThat(swapped.getIndexType()).isEqualTo(specialised.indexType);
+
+    for (final Field field : declaredBuilderFields()) {
+      if (NOT_CARRIED_OVER.contains(field.getName()))
+        continue;
+      assertThat(Objects.deepEquals(read(field, swapped), read(field, source)))
+          .withFailMessage("'%s' did not survive withType(%s): the specialised builder has <%s> but the caller had"
+                  + " configured <%s>. Carry it over in TypeIndexBuilder's copy constructor (or in"
+                  + " IndexBuilder.copyBaseFieldsFrom when the field is declared there) - see issue #5606.",
+              field.getName(), specialised.indexType, describe(read(field, swapped)), describe(read(field, source)))
+          .isTrue();
+    }
+
+    // The identity and the common part of the definition, which live on the metadata the subclass replaces. Only
+    // TypeGeoIndexBuilder used to carry collations and typeIndexName across; the other three dropped both.
+    assertThat(swapped.metadata.typeName).isEqualTo(source.metadata.typeName);
+    assertThat(swapped.metadata.propertyNames).isEqualTo(source.metadata.propertyNames);
+    assertThat(swapped.metadata.associatedBucketId).isEqualTo(source.metadata.associatedBucketId);
+    assertThat(swapped.metadata.collations).isEqualTo(source.metadata.collations);
+    assertThat(swapped.metadata.typeIndexName).isEqualTo(source.metadata.typeIndexName);
+  }
+
+  /**
+   * The anti-vacuity half: every field the carry-over test compares must have been moved OFF its default by
+   * {@link #configureEverySetting}, or comparing it proves nothing. A field added to the builder and not wired in here
+   * fails this, which is the whole point - it is the reminder the four hand-written copies never gave anyone.
+   */
+  @Test
+  void everySettingIsActuallyConfiguredByThisTest() {
+    final TypeIndexBuilder pristine = database.getSchema().buildTypeIndex(TYPE_NAME, PROPERTY_NAME);
+    final TypeIndexBuilder configured = configureEverySetting(
+        database.getSchema().buildTypeIndex(TYPE_NAME, PROPERTY_NAME));
+
+    final List<String> leftAtDefault = new ArrayList<>();
+    for (final Field field : declaredBuilderFields()) {
+      if (NOT_CARRIED_OVER.contains(field.getName()) || NOT_CONFIGURABLE.contains(field.getName()))
+        continue;
+      if (Objects.deepEquals(read(field, configured), read(field, pristine)))
+        leftAtDefault.add(field.getName());
+    }
+
+    assertThat(leftAtDefault)
+        .withFailMessage("configureEverySetting() leaves %s at its default value, so the carry-over test does not"
+            + " actually check it. Give it a distinct value there - and make sure the builder copy constructor carries"
+            + " it over. See issue #5606.", leftAtDefault)
+        .isEmpty();
+  }
+
+  /**
+   * The reason {@code buildMode} is exempt above, asserted rather than assumed: a sorted build is refused for every
+   * index type that swaps builders, so the setting cannot be observed on the other side of the swap. It is still
+   * copied by the constructor, because that guard is circumstantial rather than a design.
+   */
+  @ParameterizedTest
+  @EnumSource(SpecialisedBuilder.class)
+  void sortedBuildIsRefusedBySpecialisedTypes(final SpecialisedBuilder specialised) {
+    final TypeIndexBuilder builder = database.getSchema().buildTypeIndex(TYPE_NAME, PROPERTY_NAME)
+        .withBuildMode(IndexBuildMode.SORTED);
+
+    assertThatThrownBy(() -> builder.withType(specialised.indexType))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Sorted build");
+  }
+
+  /**
+   * A builder that is ALREADY the specialised one must be handed back untouched: {@code withType()} is called twice on
+   * the SQL path ({@code CreateIndexStatement} calls it, then {@code withGeoType()}/{@code withFullTextType()}), and a
+   * second swap there would throw away everything configured in between.
+   */
+  @ParameterizedTest
+  @EnumSource(SpecialisedBuilder.class)
+  void secondWithTypeKeepsTheSameBuilder(final SpecialisedBuilder specialised) {
+    final TypeIndexBuilder first = database.getSchema().buildTypeIndex(TYPE_NAME, PROPERTY_NAME)
+        .withType(specialised.indexType);
+
+    assertThat(first.withType(specialised.indexType)).isSameAs(first);
+  }
+
+  /**
+   * Sets every field of {@link IndexBuilder} and {@link TypeIndexBuilder} to something distinguishable from the
+   * default, through the public API rather than reflection: an option that cannot be reached from outside the class
+   * is not one the carry-over has to protect.
+   */
+  private TypeIndexBuilder configureEverySetting(final TypeIndexBuilder builder) {
+    builder.withUnique(true);
+    builder.withPageSize(8192);
+    builder.withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR);
+    builder.withCallback((document, totalIndexed) -> {
+    });
+    builder.withIgnoreIfExists(true);
+    builder.withReplaceIfIncompatible(true);
+    builder.withIndexName("Issue5606ManualName");
+    builder.withFilePath("target/issue5606.idx");
+    builder.withKeyTypes(new Type[] { Type.STRING });
+    builder.withBatchSize(37);
+    builder.withMaxAttempts(11);
+    builder.withUserMetadata(new JSONObject().put("issue", 5606));
+    builder.withCollations(List.of(IndexMetadata.COLLATION_CI));
+    builder.withDefaultKeyTypesForUndeclaredProperties(new Type[] { Type.LONG });
+    builder.withBuildMemoryBudget(4L * 1024 * 1024);
+    builder.withBuildSpillDirectory(Path.of("target"));
+    builder.withBuildMergeFanIn(4);
+    builder.withBuildParallelism(3);
+    // Not a with*() setter: typeIndexName is written straight onto the metadata by addIndexInternal, and is one of the
+    // two definition fields only the geospatial builder used to carry over.
+    builder.metadata.typeIndexName = "Issue5606TypeIndex";
+    return builder;
+  }
+
+  /** Every instance field the two builder classes declare, in a stable order. */
+  private static List<Field> declaredBuilderFields() {
+    final List<Field> fields = new ArrayList<>();
+    for (final Class<?> clazz : new Class<?>[] { IndexBuilder.class, TypeIndexBuilder.class })
+      for (final Field field : clazz.getDeclaredFields())
+        if (!Modifier.isStatic(field.getModifiers()) && !field.isSynthetic()) {
+          field.setAccessible(true);
+          fields.add(field);
+        }
+    fields.sort((a, b) -> a.getName().compareTo(b.getName()));
+    return fields;
+  }
+
+  private static Object read(final Field field, final Object target) {
+    try {
+      return field.get(target);
+    } catch (final IllegalAccessException e) {
+      throw new IllegalStateException("Cannot read field '" + field.getName() + "'", e);
+    }
+  }
+
+  private static String describe(final Object value) {
+    return value instanceof Object[] array ? Arrays.toString(array) : String.valueOf(value);
+  }
+}


### PR DESCRIPTION
Closes #5606.

## The defect

`TypeIndexBuilder.withType()` does not configure the builder it is called on: for the four index types that carry settings of their own it constructs a **different** builder and hands that back. Every one of those four copy constructors then hand-copied the same eleven fields of `IndexBuilder`:

- `TypeFullTextIndexBuilder(TypeIndexBuilder)`
- `TypeLSMVectorIndexBuilder(TypeIndexBuilder)`
- `TypeLSMSparseVectorIndexBuilder(TypeIndexBuilder)`
- `TypeGeoIndexBuilder(TypeIndexBuilder)`

So adding a field to `IndexBuilder` and wiring it through a `withX()` setter works perfectly for `LSM_TREE` and `HASH` - which never swap builders - and is silently dropped for FULL_TEXT, GEOSPATIAL and the two vector types. There is no compile error, and no existing test notices unless it happens to cover that setting on one of those four types specifically.

## What was actually being lost

Beyond the five sorted-build fields the issue named:

| field | declared in | carried over before |
|---|---|---|
| `replaceIfIncompatible` (#5675) | `IndexBuilder` | by nobody |
| `userMetadata` (#5723) | `IndexBuilder` | by nobody |
| `defaultKeyTypesForUndeclaredProperties` | `TypeIndexBuilder` (private) | by nobody |
| `buildMode`, `buildMemoryBudgetBytes`, `buildSpillDirectory`, `buildMergeFanIn`, `buildParallelism` | `TypeIndexBuilder` (private) | by nobody |
| `collations` | `IndexMetadata` | geospatial only |
| `typeIndexName` | `IndexMetadata` | geospatial only |

Nothing is broken for a user today, and this PR is not claimed to fix a reachable bug: every caller in the tree happens to call `withType()` before the setters that would be dropped, `withType()` refuses a sorted build for anything but `LSM_TREE`, and `defaultKeyTypesForUndeclaredProperties` is only set by the OpenCypher and MongoDB paths, which create `LSM_TREE` indexes. Those are circumstantial guards rather than a design, which is exactly what makes the footgun worth removing rather than documenting.

## The fix, and why not the one the issue proposed

The issue suggested a `copyCommonFrom(TypeIndexBuilder)` the four constructors call. That leaves the failure mode intact one step further out: a fifth specialised builder can still forget to call it, and it cannot reach the six fields that are private to `TypeIndexBuilder`.

Instead the four constructors now **delegate to a single copy constructor** on `TypeIndexBuilder`, each supplying only the two things that make it different - the index type it stands for and the `IndexMetadata` subclass its own settings live in:

```java
protected TypeGeoIndexBuilder(final TypeIndexBuilder copyFrom) {
  super(copyFrom, Schema.INDEX_TYPE.GEOSPATIAL,
      new GeoIndexMetadata(copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]),
          copyFrom.metadata.associatedBucketId));
}
```

Constructor chaining, not a method to remember: a subclass cannot exist without going through it. Each class then owns exactly one place where its own fields are copied - `IndexBuilder.copyBaseFieldsFrom` for the base ones, the copy constructor itself for `TypeIndexBuilder`'s - and the common part of the definition rides along through the `IndexMetadata.copyCommonTo` that already existed for `copyType()`, so `collations` and `typeIndexName` stop being a geospatial-only privilege. Net -74/+97 lines with the doc comments, and 44 lines of hand-copying gone.

## Test

`Issue5606BuilderStateCarryOverTest` is deliberately reflective, for the same reason the defect existed: a hand-written list of assertions is a second field list to keep in sync, and the first one already went stale.

- `everySettingSurvivesTheBuilderSwap` configures every option, calls `withType()` for each of the four specialised types, and compares **every declared instance field** of `IndexBuilder` and `TypeIndexBuilder`, naming the field and both values when one does not survive.
- `everySettingIsActuallyConfiguredByThisTest` is the anti-vacuity half: it fails when the setup leaves a field at its default, which is what a newly added field looks like. Without it the comparison above would quietly start proving nothing.
- `sortedBuildIsRefusedBySpecialisedTypes` pins down the one documented exemption - `buildMode` cannot be observed across the swap because `withType()` rejects `SORTED` for anything but `LSM_TREE` - so the exemption is asserted rather than assumed.
- `secondWithTypeKeepsTheSameBuilder` covers the SQL path, which calls `withType()` and then `withGeoType()`/`withFullTextType()`: a second swap there would discard everything configured in between.

Verified the test catches a real drop by removing one carried-over field: 4 failures, each naming `buildParallelism` and the index type.

## Verification

`mvn -o -pl engine -am test` over the schema, index, LSM and SQL index test packages: **1060 tests, 0 failures**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved index configuration when converting between specialized index types.
  - Maintained metadata, naming, key settings, callbacks, batching, retry limits, and other builder options during index updates.
  - Prevented configuration loss across repeated type conversions.
  - Ensured sparse-vector index creation uses the selected specialized index type consistently.

- **Tests**
  - Added coverage verifying configuration retention when converting bucket indexes to vector indexes.
  - Verified specialized builder and metadata types are preserved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->