### PR TITLE
fix(check): a dangling edge endpoint that is absent is reported, not flagged corrupted (#5777)

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1878,10 +1878,12 @@ public class GraphDatabaseChecker {
    */
   private static VertexInternal loadEndpointVertex(final Edge edge, final RID edgeRID, final Vertex.DIRECTION direction,
       final CheckReport report, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors) {
+    // Every constant spelled out and NO default: the switch is visibly exhaustive, and a constant added to
+    // DIRECTION one day fails to compile here instead of being swallowed into a catch-all arm.
     final boolean incoming = switch (direction) {
       case IN -> true;
       case OUT -> false;
-      default -> throw new IllegalArgumentException(
+      case BOTH -> throw new IllegalArgumentException(
           "Cannot load a single endpoint of edge " + edgeRID + " for direction " + direction);
     };
     final RID endpoint = incoming ? edge.getIn() : edge.getOut();

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1913,6 +1913,13 @@ public class GraphDatabaseChecker {
    * count instead of emitting one line per dangling edge. A single missing supernode can be referenced by millions of
    * edges; this collapses that fan-out into "vertex X could not be loaded, referenced by N edge(s)". The distinct-target
    * set is bounded by {@code maxTracked} to keep memory in check (counts for already-tracked targets keep incrementing).
+   * <p>
+   * "MISSING" IS THE COMMON CASE, NOT THE ONLY ONE. {@link #loadEndpointVertex} calls this for BOTH of its failure
+   * arms, so an entry can also be a target that is right there and could not be DECODED. The distinction is not lost -
+   * {@code missingReferenceErrors} carries the exception text per target, and only the absent ones leave the target
+   * unflagged - but a consumer reading {@code missingReferences} alone must not take the key to mean "this record no
+   * longer exists". Longstanding behaviour, spelled out here rather than changed: the map is the operator's
+   * "which far records did edges fail to reach", and both shapes belong in it.
    */
   private static void trackMissingReference(final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors,
       final int maxTracked, final RID target, final String error) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1867,8 +1867,10 @@ public class GraphDatabaseChecker {
    * vertex bucket that does not materialise as one is a load failure, and letting the {@link ClassCastException}
    * out to be caught further away as something else would describe it worse.
    *
-   * @param direction {@link Vertex.DIRECTION#IN} for the edge's incoming endpoint, anything else for its outgoing
-   *                  one
+   * @param direction {@link Vertex.DIRECTION#IN} or {@link Vertex.DIRECTION#OUT}, naming which endpoint to load.
+   *                  {@link Vertex.DIRECTION#BOTH} is rejected rather than folded into one of them: an edge has one
+   *                  endpoint per direction, so "both" names no single record to return and a caller that passes it
+   *                  has a bug that silently reading the OUT side would hide
    *
    * @return the endpoint vertex, or {@code null} when it could not be loaded - the caller decides what that means
    * for the adjacency entry it is walking, which is the only thing that legitimately differs between the two
@@ -1876,7 +1878,12 @@ public class GraphDatabaseChecker {
    */
   private static VertexInternal loadEndpointVertex(final Edge edge, final RID edgeRID, final Vertex.DIRECTION direction,
       final CheckReport report, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors) {
-    final boolean incoming = direction == Vertex.DIRECTION.IN;
+    final boolean incoming = switch (direction) {
+      case IN -> true;
+      case OUT -> false;
+      default -> throw new IllegalArgumentException(
+          "Cannot load a single endpoint of edge " + edgeRID + " for direction " + direction);
+    };
     final RID endpoint = incoming ? edge.getIn() : edge.getOut();
     final String side = incoming ? "incoming" : "outgoing";
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -694,9 +694,9 @@ public class GraphDatabaseChecker {
             deleteCorruptedRecord(rid);
             // Counted AFTER the delete returns, not before it is attempted (issue #6128). autoFix is what an
             // operator reads to decide whether a run did anything, so it must not include a repair that failed -
-            // and the failure here is routine rather than exotic: checkEdges flags both ends of a dangling edge,
-            // and the far end is flagged precisely because it is not there, so its delete always raises
-            // RecordNotFoundException. One dangling edge used to report two repairs.
+            // and the failure here is routine rather than exotic: an adjacency list still naming an EDGE record
+            // that is gone flags that RID (the "edge not found" arm of the walk above), and its delete therefore
+            // always raises RecordNotFoundException. One such entry used to report a repair that never happened.
             autoFix.incrementAndGet();
             // Reported, not only counted: an operator reads deletedRecordsAfterFix to learn WHICH records a repair
             // removed, and until this arm populated it the answer depended on which pass happened to do the delete -
@@ -1052,24 +1052,13 @@ public class GraphDatabaseChecker {
                   removeEntry = true;
                   ++report.invalidLinks;
                 } else {
-                  try {
-                    inVertex = (VertexInternal) edge.getOutVertex().asVertex(true);
-                  } catch (final RecordNotFoundException e) {
-                    report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
-                    trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
-                    report.corrupt(edgeRID);
+                  // #5777: one shared arm for all four endpoint loads in this class - see loadEndpointVertex.
+                  inVertex = loadEndpointVertex(edge, edgeRID, Vertex.DIRECTION.OUT, report, missingReferences,
+                      missingReferenceErrors);
+                  if (inVertex == null)
+                    // An adjacency entry naming an edge whose far endpoint is unusable is pruned, exactly as both
+                    // catch arms this replaces did.
                     removeEntry = true;
-                    report.corrupt(edge.getOut());
-                    ++report.invalidLinks;
-                  } catch (final Exception e) {
-                    // UNKNOWN ERROR ON LOADING
-                    report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
-                            + describe(e) + ")");
-                    trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
-                    report.corrupt(edgeRID);
-                    removeEntry = true;
-                    report.corrupt(edge.getOut());
-                  }
                 }
 
                 if (!edge.getIn().equals(vertexIdentity)) {
@@ -1312,24 +1301,11 @@ public class GraphDatabaseChecker {
                   removeEntry = true;
                   ++report.invalidLinks;
                 } else {
-                  try {
-                    outVertex = (VertexInternal) edge.getInVertex().asVertex(true);
-                  } catch (final RecordNotFoundException e) {
-                    report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
-                    trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
-                    report.corrupt(edgeRID);
+                  // #5777: the twin of the checkIncomingEdges arm, now the same code rather than a copy of it.
+                  outVertex = loadEndpointVertex(edge, edgeRID, Vertex.DIRECTION.IN, report, missingReferences,
+                      missingReferenceErrors);
+                  if (outVertex == null)
                     removeEntry = true;
-                    report.corrupt(edge.getIn());
-                    ++report.invalidLinks;
-                  } catch (final Exception e) {
-                    // UNKNOWN ERROR ON LOADING
-                    report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
-                            + describe(e) + ")");
-                    trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
-                    report.corrupt(edgeRID);
-                    removeEntry = true;
-                    report.corrupt(edge.getIn());
-                  }
                 }
 
                 if (!edge.getOut().equals(vertexIdentity)) {
@@ -1612,30 +1588,17 @@ public class GraphDatabaseChecker {
             boolean inProbed = false;
             boolean inUnreferenced = false;
 
-            Vertex inVertex = null;
-            try {
-              inVertex = edge.getInVertex().asVertex(true);
-            } catch (final RecordNotFoundException e) {
-              report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
-              trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
-              report.corrupt(edgeRID);
-              report.corrupt(edge.getIn());
-              ++report.invalidLinks;
-            } catch (final Exception e) {
-              // UNKNOWN ERROR ON LOADING
-              report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
-                      + describe(e) + ")");
-              trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
-              report.corrupt(edgeRID);
-              report.corrupt(edge.getIn());
-            }
+            // #5777: BOTH endpoints go through the same arm, so the two sides cannot report the same finding
+            // differently again. This one used to flag the missing IN vertex corrupted where the OUT arm below
+            // flagged only the edge - see loadEndpointVertex for which of the two was right and why.
+            final VertexInternal inVertex = loadEndpointVertex(edge, edgeRID, Vertex.DIRECTION.IN, report,
+                missingReferences, missingReferenceErrors);
 
             if (inVertex != null)
               try {
                 // Memoised per list (#6062). A vertex with no IN list at all answers false, exactly as the
                 // inEdges == null arm this replaces did, and an unreadable one still throws into the guard below.
-                final boolean referenced = probeCache.containsEdge((VertexInternal) inVertex, Vertex.DIRECTION.IN,
-                    edgeRID);
+                final boolean referenced = probeCache.containsEdge(inVertex, Vertex.DIRECTION.IN, edgeRID);
                 inProbed = true;
                 if (!referenced) {
                   // LEGITIMATE FOR A UNIDIRECTIONAL EDGE TYPE, a defect for a bidirectional one - which is why the
@@ -1655,28 +1618,13 @@ public class GraphDatabaseChecker {
                           + "), left to the vertex check to rebuild");
               }
 
-            Vertex outVertex = null;
-            try {
-              outVertex = edge.getOutVertex().asVertex(true);
-            } catch (final RecordNotFoundException e) {
-              report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
-              trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
-              report.corrupt(edgeRID);
-              ++report.invalidLinks;
-            } catch (final Exception e) {
-              // UNKNOWN ERROR ON LOADING
-              report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
-                      + describe(e) + ")");
-              trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
-              report.corrupt(edgeRID);
-              report.corrupt(edge.getOut());
-            }
+            final VertexInternal outVertex = loadEndpointVertex(edge, edgeRID, Vertex.DIRECTION.OUT, report,
+                missingReferences, missingReferenceErrors);
 
             if (outVertex != null)
               try {
                 // See the incoming side: memoised per list rather than re-walked per edge (#6062).
-                final boolean referenced = probeCache.containsEdge((VertexInternal) outVertex, Vertex.DIRECTION.OUT,
-                    edgeRID);
+                final boolean referenced = probeCache.containsEdge(outVertex, Vertex.DIRECTION.OUT, edgeRID);
                 outProbed = true;
                 if (!referenced) {
                   // ALWAYS A DEFECT, for every edge type: no outgoing traversal can reach the record. Same
@@ -1790,9 +1738,11 @@ public class GraphDatabaseChecker {
             deleteCorruptedRecord(rid);
             // Counted AFTER the delete returns, not before it is attempted (issue #6128). autoFix is what an
             // operator reads to decide whether a run did anything, so it must not include a repair that failed -
-            // and the failure here is routine rather than exotic: checkEdges flags both ends of a dangling edge,
-            // and the far end is flagged precisely because it is not there, so its delete always raises
-            // RecordNotFoundException. One dangling edge used to report two repairs.
+            // and the failure here is routine rather than exotic. It used to be so by construction: a dangling
+            // edge flagged its ABSENT endpoint alongside itself, whose delete could never succeed, so one
+            // dangling edge reported two repairs. #5777 stopped flagging an endpoint that is merely not there,
+            // and what remains is the ordinary race - the record this pass read and flagged is gone by the time
+            // the repair loop reaches it.
             autoFix.incrementAndGet();
             // Reported, not only counted: an operator reads deletedRecordsAfterFix to learn WHICH records a repair
             // removed, and until this arm populated it the answer depended on which pass happened to do the delete -
@@ -1818,7 +1768,7 @@ public class GraphDatabaseChecker {
       // Same sum as the vertex arm, and prunedDanglingEntries is structurally ZERO here: pruning happens in
       // checkIncomingEdges/checkOutgoingEdges, which only checkVertices calls. Kept rather than simplified to
       // autoFix.get() so the two arms report autoFix identically, and so an edge arm that one day does prune -
-      // #5777 is about exactly this arm's handling of endpoints - cannot silently stop counting it. Do not read
+      // #5777 changed exactly this arm's handling of endpoints - cannot silently stop counting it. Do not read
       // it as evidence that this arm prunes today. reconnectedEdges is structurally zero here for the same reason:
       // this arm plans no re-links.
       putRepairCounters(stats, autoFix.get(), report.prunedDanglingEntries, 0L);
@@ -1876,6 +1826,76 @@ public class GraphDatabaseChecker {
    */
   private static boolean isBidirectional(final Edge edge) {
     return !(edge.getType() instanceof EdgeType edgeType) || edgeType.isBidirectional();
+  }
+
+  /**
+   * Loads ONE endpoint vertex of {@code edge} and reports what happened. The single arm every endpoint probe in
+   * this class goes through - the two in {@code checkEdges}, and the far-endpoint probe of
+   * {@code checkIncomingEdges}/{@code checkOutgoingEdges} (issue #5777).
+   * <p>
+   * IT EXISTS BECAUSE THE FOUR COPIES DIVERGED. They were the same fifteen lines with the direction swapped, and
+   * one of them - {@code checkEdges}' incoming side - additionally flagged the MISSING VERTEX corrupted where its
+   * outgoing twin flagged only the edge. Nothing distinguished the two cases: an edge dangling on its IN side and
+   * an edge dangling on its OUT side are the same finding and the same repair, and the unknown-error arms beside
+   * them were symmetric in the opposite direction, which is what a copy-paste divergence looks like rather than a
+   * decision. One arm cannot drift from itself.
+   * <p>
+   * THE POLICY IT SETTLES, and why the outgoing side was the right one:
+   * <ul>
+   *   <li>NOT FOUND ({@link RecordNotFoundException}) - the edge is flagged, the endpoint is NOT. A RID that
+   *   simply is not there is not corruption, and the difference is expensive: a record flagged corrupted puts its
+   *   BUCKET into {@code affectedBuckets}, and {@code CHECK DATABASE ... FIX} then drops and rebuilds every index
+   *   on that bucket - a full bucket scan per index. Flagging the absent endpoint therefore had a dangling-edge
+   *   sweep after a bulk delete rebuild the indexes of every vertex bucket the deleted vertices lived in, and
+   *   bought nothing for it: the repair loop's {@code deleteRecord} on a RID that is not there raises
+   *   {@link RecordNotFoundException} and is ignored, so no repair was ever performed on the strength of the
+   *   flag. It is the same rule the {@code RECORD} scope already applies to a hand-typed RID that does not
+   *   resolve, and the same rule #5680/#5764 settled. Nothing else consumes {@code corruptedRecords}: it becomes
+   *   {@code affectedBuckets} in {@code DatabaseChecker.check()} and the delete list here, and neither wants a
+   *   phantom. The operator still learns about the missing vertex through {@code trackMissingReference}, which is
+   *   the mechanism built for it and which collapses "one missing supernode" into a single line naming the
+   *   reference count instead of one line per incident edge.</li>
+   *   <li>UNLOADABLE (anything else) - BOTH are flagged. Here the record IS there and could not be read, which is
+   *   corruption by the same definition, and rebuilding the indexes on its bucket is exactly what a corrupt record
+   *   in that bucket calls for.</li>
+   * </ul>
+   * {@code invalidLinks} keeps the split it already had - counted for a not-found endpoint, not for an unloadable
+   * one - because that number is published and this change is about what gets REPAIRED, not about renumbering
+   * what gets reported.
+   * <p>
+   * The {@link VertexInternal} cast sits INSIDE the guard, as two of the four copies already had it: a record in a
+   * vertex bucket that does not materialise as one is a load failure, and letting the {@link ClassCastException}
+   * out to be caught further away as something else would describe it worse.
+   *
+   * @param direction {@link Vertex.DIRECTION#IN} for the edge's incoming endpoint, anything else for its outgoing
+   *                  one
+   *
+   * @return the endpoint vertex, or {@code null} when it could not be loaded - the caller decides what that means
+   * for the adjacency entry it is walking, which is the only thing that legitimately differs between the two
+   * families of caller (the list walkers prune the entry, the edge scan has no entry to prune)
+   */
+  private static VertexInternal loadEndpointVertex(final Edge edge, final RID edgeRID, final Vertex.DIRECTION direction,
+      final CheckReport report, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors) {
+    final boolean incoming = direction == Vertex.DIRECTION.IN;
+    final RID endpoint = incoming ? edge.getIn() : edge.getOut();
+    final String side = incoming ? "incoming" : "outgoing";
+
+    try {
+      return (VertexInternal) (incoming ? edge.getInVertex() : edge.getOutVertex()).asVertex(true);
+    } catch (final RecordNotFoundException e) {
+      report.warn("edge " + edgeRID + " points to the " + side + " vertex " + endpoint + " that is not found (deleted?)");
+      trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, endpoint, describe(e));
+      report.corrupt(edgeRID);
+      ++report.invalidLinks;
+    } catch (final Exception e) {
+      // UNKNOWN ERROR ON LOADING
+      report.warn("edge " + edgeRID + " points to the " + side + " vertex " + endpoint + " which cannot be loaded (error: "
+              + describe(e) + ")");
+      trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, endpoint, describe(e));
+      report.corrupt(edgeRID);
+      report.corrupt(endpoint);
+    }
+    return null;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
@@ -216,7 +216,10 @@ class CheckDatabaseTest extends TestHelper {
       assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
       assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(TOTAL - 1);
       assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(1);
-      assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(TOTAL); // ALL THE EDGES + ROOT VERTEX
+      // ALL THE EDGES. The root vertex is NOT among them: it was deleted at low level, and #5777 stopped calling a
+      // RID that is simply absent corrupt - it is reported through missingReferences instead, which is what keeps
+      // FIX from dropping and rebuilding every index on the vertex bucket over a record that is not there.
+      assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(TOTAL - 1);
       assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0);
       assertThat((Long) row.getProperty("invalidLinks")).isEqualTo((TOTAL - 1) * 2);
       assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo(TOTAL - 1);

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseAutoFixAccountingTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseAutoFixAccountingTest.java
@@ -36,10 +36,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * then failed to remove was still reported as fixed. That is not a cosmetic miscount: {@code autoFix} is the number
  * an operator reads to decide whether a run did anything, and one that includes failed deletes cannot answer that.
  * <p>
- * The case reached here is the ordinary one rather than a contrived failure. {@code checkEdges} flags BOTH ends of a
- * dangling edge - the edge record itself and the RID it points at - and that second RID is flagged precisely because
- * the record is NOT there, so its delete raises {@code RecordNotFoundException} every time. A database with one
- * dangling edge therefore reported two repairs while performing one.
+ * The case reached here is the ordinary one rather than a contrived failure: an adjacency list still naming an EDGE
+ * record that is gone. {@code checkIncomingEdges}/{@code checkOutgoingEdges} flag that RID corrupted - it is what
+ * the damaged list points at - and it is flagged precisely because the record is NOT there, so its delete raises
+ * {@code RecordNotFoundException} every time.
+ * <p>
+ * #5777 moved this test off its original fixture. It used to reach the same shape through {@code checkEdges}, which
+ * flagged BOTH ends of a dangling edge - the edge record and the ABSENT vertex it pointed at. That second flag is
+ * gone: an endpoint that is merely not there is reported, never called corrupt, because flagging it had
+ * {@code FIX} drop and rebuild every index on the vanished vertex's bucket for nothing. The accounting rule this
+ * test pins is unchanged, so it is pinned through the arm that still produces the shape.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -56,7 +62,6 @@ class CheckDatabaseAutoFixAccountingTest extends TestHelper {
   @Test
   void autoFixCountsOnlyTheRecordsItActuallyRemoved() {
     final RID[] edge = new RID[1];
-    final RID[] target = new RID[1];
 
     database.transaction(() -> {
       database.getSchema().createVertexType(VERTEX_TYPE);
@@ -66,30 +71,38 @@ class CheckDatabaseAutoFixAccountingTest extends TestHelper {
     database.transaction(() -> {
       final MutableVertex from = database.newVertex(VERTEX_TYPE).set("name", "from").save();
       final MutableVertex to = database.newVertex(VERTEX_TYPE).set("name", "to").save();
-      target[0] = to.getIdentity();
       edge[0] = from.newEdge(EDGE_TYPE, to).getIdentity();
     });
 
-    // Remove the target vertex underneath the edge, leaving the edge pointing at a RID that is not there. Both the
-    // edge and the missing target end up in corruptedRecords; only the edge can actually be deleted.
+    // Remove the EDGE record through its bucket, leaving both vertices' adjacency lists naming a RID that is not
+    // there. The walk flags that RID corrupted, and the repair loop can never delete it.
     database.transaction(
-        () -> database.getSchema().getBucketById(target[0].getBucketId()).deleteRecord(target[0]));
+        () -> database.getSchema().getBucketById(edge[0].getBucketId()).deleteRecord(edge[0]));
 
     final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
-        .checkEdges(EDGE_TYPE, true, 0);
+        .checkVertices(VERTEX_TYPE, true, 0);
 
-    // PRECONDITION: the run really did flag both RIDs, otherwise the miscount could not arise and this test would
-    // be asserting nothing.
+    // PRECONDITION: the run really did flag a RID it cannot delete, otherwise the miscount could not arise and this
+    // test would be asserting nothing.
     assertThat((Collection<RID>) stats.get("corruptedRecords"))
-        .as("both the dangling edge and the RID it points at must be flagged: %s", stats)
-        .contains(edge[0], target[0]);
+        .as("the RID the damaged list points at must be flagged: %s", stats)
+        .contains(edge[0]);
 
     assertThat((Collection<RID>) stats.get("deletedRecordsAfterFix"))
-        .as("only the edge exists to be removed: %s", stats)
-        .containsExactly(edge[0]);
+        .as("there is nothing left to remove: %s", stats)
+        .isEmpty();
 
+    // The per-kind counter is where a failed delete would show up. autoFix itself is NOT zero here - it also folds
+    // in the dangling list entries this run pruned, which are repairs that did happen (#6128) - so asserting on it
+    // alone could not tell the two apart.
+    assertThat((Long) stats.get("removedRecords"))
+        .as("a delete that raised must not be counted as a repair: %s", stats)
+        .isEqualTo(0L);
+    assertThat((Long) stats.get("prunedDanglingEntries"))
+        .as("precondition: the repairs autoFix DOES count here are the pruned entries: %s", stats)
+        .isGreaterThan(0L);
     assertThat((Long) stats.get("autoFix"))
-        .as("autoFix must count the repair it performed, not the one it attempted: %s", stats)
-        .isEqualTo(1L);
+        .as("autoFix must count the repairs it performed, not the one it attempted: %s", stats)
+        .isEqualTo((Long) stats.get("prunedDanglingEntries"));
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseSinglePassTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseSinglePassTest.java
@@ -215,7 +215,13 @@ class CheckDatabaseSinglePassTest extends TestHelper {
    * <p>
    * Reached through the one caller that flags the same RID twice in one visit: an edge whose IN and OUT vertices
    * are both gone flags the edge on each side. With a cap of 1 the edge is the only retained RID, so the second
-   * flag on it is exactly the case the {@code contains} check answers.
+   * flag on it is exactly the case the {@code contains} check answers - {@code addBounded} is already past the cap
+   * by then and can only recognise the repeat because the set still holds it.
+   * <p>
+   * #5777 sharpened this: the two flags used to be the edge and the MISSING IN VERTEX, and the edge's second flag
+   * only came from the OUT side flagging it again. An absent endpoint is no longer flagged at all, so the edge is
+   * now the only RID this visit produces - and the arithmetic below is purely the de-duplication being measured,
+   * with no second finding riding along.
    */
   @Test
   void theCorruptedTotalDoesNotDoubleCountARetainedRecordPastTheCap() {
@@ -236,16 +242,20 @@ class CheckDatabaseSinglePassTest extends TestHelper {
     final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
         .checkEdges("WorksAt", false, 0, 100, 1);
 
-    // The retained slot holds the EDGE because checkEndpoints flags it before the missing endpoint it found: the
-    // IN branch calls corrupt(edgeRID) first, then corrupt(edge.getIn()). Asserted rather than assumed, so a
-    // future reorder of that branch fails here instead of quietly changing what this test is measuring.
+    // The retained slot holds the EDGE, which is the only record either side flags. Asserted rather than assumed,
+    // so a future change to what the endpoint arms flag fails here instead of quietly changing what this test is
+    // measuring.
     final Collection<RID> corrupted = (Collection<RID>) stats.get("corruptedRecords");
-    assertThat(corrupted).as("precondition: the cap must bite, and the edge must be what it retained")
+    assertThat(corrupted).as("precondition: the edge, and only the edge, must be what the cap retained")
         .hasSize(1).containsExactly(edge);
-    // Flagged: the edge (twice - once per missing endpoint) and the missing IN vertex. The edge's second flag is
-    // the one that must not count, because the set still answers "already seen" for it.
+    // Flagged twice - once per missing endpoint. The second flag arrives with the set already at its cap, so it is
+    // the contains() branch that has to answer "already seen"; counting it would be the #5773 defect.
     assertThat((Long) stats.get("totalCorruptedRecords"))
-        .as("a retained RID flagged twice is one corrupted record: %s", stats).isEqualTo(2L);
+        .as("a retained RID flagged twice is one corrupted record: %s", stats).isEqualTo(1L);
+    // The absent endpoints are still REPORTED, through the channel that scales to a missing supernode (#5777).
+    assertThat((Map<RID, Long>) stats.get("missingReferences"))
+        .as("both absent endpoints must still reach the operator: %s", stats)
+        .containsOnlyKeys(endpoints[0], endpoints[1]);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/graph/Issue5777DanglingEndpointScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5777DanglingEndpointScopeTest.java
@@ -236,6 +236,7 @@ class Issue5777DanglingEndpointScopeTest extends TestHelper {
         .map(Index::getName).collect(Collectors.toSet());
   }
 
+  /** The fixture's RIDs, named so an assertion says which vertex or edge it means rather than which array slot. */
   private record Graph(RID person1, RID person2, RID company1, RID company2, RID edge1, RID edge2) {
   }
 
@@ -306,10 +307,12 @@ class Issue5777DanglingEndpointScopeTest extends TestHelper {
     });
   }
 
+  /** The {@code missingReferences} entry for a vertex exactly one edge pointed at. */
   private static Map.Entry<RID, Long> entryOf(final RID rid) {
     return Map.entry(rid, 1L);
   }
 
+  /** Runs a CHECK DATABASE statement and returns its single result row. */
   private Result check(final String command) {
     try (final ResultSet rs = database.command("sql", command)) {
       assertThat(rs.hasNext()).isTrue();
@@ -317,6 +320,7 @@ class Issue5777DanglingEndpointScopeTest extends TestHelper {
     }
   }
 
+  /** Reads a numeric check-database property, failing loudly when the field does not exist. */
   private static long longProperty(final Result row, final String name) {
     final Object value = row.getProperty(name);
     assertThat(value).as("check database must report '%s': %s", name, row.toJSON()).isNotNull();

--- a/engine/src/test/java/com/arcadedb/graph/Issue5777DanglingEndpointScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5777DanglingEndpointScopeTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.index.Index;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5777: what {@code CHECK DATABASE} does with an edge endpoint that IS NOT THERE.
+ * <p>
+ * Two defects, one cause. {@code GraphDatabaseChecker} carried FOUR copies of the same fifteen-line endpoint
+ * probe - both sides of {@code checkEdges}, plus the far-endpoint load in {@code checkIncomingEdges} and
+ * {@code checkOutgoingEdges} - and one of them had drifted: {@code checkEdges}' incoming side flagged the MISSING
+ * VERTEX corrupted alongside the edge, where its outgoing twin flagged only the edge. So the same damage reported
+ * differently depending on which end of the edge had lost its vertex.
+ * <p>
+ * The drift also picked the wrong side. A RID that raised {@code RecordNotFoundException} is not corruption, it is
+ * absence, and the distinction is expensive rather than cosmetic: every RID in {@code corruptedRecords} puts its
+ * BUCKET into {@code affectedBuckets}, and {@code FIX} drops and rebuilds every index on it. Flagging the absent
+ * vertex therefore had a dangling-edge sweep after a bulk delete rebuild the indexes of every vertex bucket the
+ * deleted vertices lived in - and bought nothing, because the repair loop's delete of a RID that is not there
+ * raises {@code RecordNotFoundException} and is ignored. That is the same rule #5680/#5764 settled for a
+ * hand-typed RID in the {@code RECORD} scope.
+ * <p>
+ * These tests pin the resulting contract from both ends: an ABSENT endpoint is reported and never flagged, an
+ * UNREADABLE one still is, and the two directions answer identically.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5777DanglingEndpointScopeTest extends TestHelper {
+  /** These tests deliberately delete records underneath live edges, so the blanket end-of-test check would fire. */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  /**
+   * THE ASYMMETRY. An edge whose IN vertex is gone and an edge whose OUT vertex is gone are the same finding, so
+   * the pass must flag the same thing for both: the edge, and only the edge.
+   * <p>
+   * Before the fix the incoming side additionally flagged {@code edge.getIn()}, so this run reported three
+   * corrupted records for two dangling edges - and which three depended on which end had been deleted.
+   */
+  @Test
+  void bothDirectionsFlagTheEdgeAndNothingElse() {
+    final Graph graph = createGraph();
+
+    // One edge loses its IN endpoint (the company), the other its OUT endpoint (the person).
+    rawDelete(graph.company1);
+    rawDelete(graph.person2);
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkEdges("WorksAt", false, 0, 100, 100);
+
+    assertThat((Collection<RID>) stats.get("corruptedRecords"))
+        .as("only the two dangling EDGES are corrupt, neither absent vertex: %s", stats)
+        .containsExactlyInAnyOrder(graph.edge1, graph.edge2);
+    assertThat((Long) stats.get("totalCorruptedRecords"))
+        .as("and the total must not count the phantoms either: %s", stats).isEqualTo(2L);
+    // Both sides still count the dangling link, which is the number that DOES describe this damage.
+    assertThat((Long) stats.get("invalidLinks")).as("%s", stats).isEqualTo(2L);
+  }
+
+  /**
+   * The finding is not lost by not being flagged: {@code trackMissingReference} is the channel built for it, and it
+   * names both absent endpoints with the count of edges that referenced them.
+   */
+  @Test
+  void theAbsentEndpointsAreStillReportedToTheOperator() {
+    final Graph graph = createGraph();
+
+    rawDelete(graph.company1);
+    rawDelete(graph.person2);
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkEdges("WorksAt", false, 0, 100, 100);
+
+    assertThat((Map<RID, Long>) stats.get("missingReferences"))
+        .as("each absent vertex is named once, with its reference count: %s", stats)
+        .containsOnly(entryOf(graph.company1), entryOf(graph.person2));
+
+    final Collection<String> warnings = (Collection<String>) stats.get("warnings");
+    assertThat(warnings).as("%s", stats).anyMatch(w -> w.equals(
+        "edge " + graph.edge1 + " points to the incoming vertex " + graph.company1 + " that is not found (deleted?)"));
+    assertThat(warnings).as("%s", stats).anyMatch(w -> w.equals(
+        "edge " + graph.edge2 + " points to the outgoing vertex " + graph.person2 + " that is not found (deleted?)"));
+  }
+
+  /**
+   * THE COST, measured where an operator pays it. {@code rebuiltIndexes} is the set {@code FIX} drops and rebuilds,
+   * derived from the buckets of the corrupted records, and a vertex that is not there must not put its bucket in
+   * it - a full scan per index on that bucket, bought with a phantom.
+   * <p>
+   * Run through the full {@code CHECK DATABASE} rather than the graph checker alone, because the derivation from
+   * {@code corruptedRecords} to {@code affectedBuckets} to {@code rebuiltIndexes} lives in {@code DatabaseChecker}
+   * and is the whole point of the distinction.
+   */
+  @Test
+  void anAbsentEndpointDoesNotDragItsBucketIntoTheIndexRebuild() {
+    final Graph graph = createGraph();
+
+    rawDelete(graph.person2);
+
+    // The BUCKET-level names, which is what rebuiltIndexes reports - not the "Person[name]" TypeIndex wrapper the
+    // schema is asked for by name. Asserting the wrapper's name would never have matched and would have passed
+    // whatever the checker did.
+    final Set<String> personIndexes = indexNamesOnBucketOf(graph.person2);
+    assertThat(personIndexes).as("precondition: the Person bucket must carry an index there is a cost to rebuild")
+        .isNotEmpty();
+
+    final Result row = check("CHECK DATABASE");
+
+    assertThat((Collection<String>) row.getProperty("rebuiltIndexes"))
+        .as("no index on the Person bucket may be rebuilt over a Person that is not there: %s", row.toJSON())
+        .doesNotContainAnyElementsOf(personIndexes);
+    assertThat((Collection<RID>) row.getProperty("corruptedRecords"))
+        .as("the dangling edge is the finding, the absent vertex is not: %s", row.toJSON())
+        .contains(graph.edge2).doesNotContain(graph.person2);
+  }
+
+  /**
+   * The other half of the contract: an endpoint whose record IS there and cannot be READ is corruption, and stays
+   * flagged - together with the edge. Rebuilding the indexes on ITS bucket is exactly what a corrupt record in that
+   * bucket calls for, so the expensive path is still taken where it is earned.
+   */
+  @Test
+  void anUnreadableEndpointIsStillFlaggedCorrupted() {
+    final Graph graph = createGraph();
+
+    // Present in its slot, decodable by nobody: the endpoint load fails with something that is NOT
+    // RecordNotFoundException, which is the arm that must keep flagging the vertex.
+    //
+    // TRUNCATION rather than a bogus record-type byte, which does NOT work here: an endpoint is resolved by
+    // getOutVertex() as lookupByRID(rid, false), which types the record from its BUCKET, and the deferred
+    // asVertex(true) then reads the buffer without ever re-reading the type byte. A record shorter than the fixed
+    // vertex prefix is the shape that fails in that deferred read.
+    shrinkRecordBuffer(graph.person2);
+    // The endpoint load resolves through lookupByRID, which answers from the record cache, and person2 is in it
+    // from the fixture. Reopening is what makes the check read the bytes this test just wrote.
+    reopenDatabase();
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkEdges("WorksAt", false, 0, 100, 100);
+
+    assertThat((Collection<RID>) stats.get("corruptedRecords"))
+        .as("a record that is there but unreadable is corrupt, and so is the edge that points at it: %s", stats)
+        .contains(graph.edge2, graph.person2);
+    assertThat((Collection<String>) stats.get("warnings")).as("%s", stats).anyMatch(w -> w.startsWith(
+        "edge " + graph.edge2 + " points to the outgoing vertex " + graph.person2 + " which cannot be loaded (error:"));
+  }
+
+  /**
+   * The same rule in the OTHER family of caller. {@code checkVertices} walks each vertex's adjacency lists and loads
+   * the FAR endpoint of every entry; those two copies flagged the absent far vertex too. The dangling entry is still
+   * pruned - that repair is unaffected - but the RID that is not there is no longer called corrupt.
+   */
+  @Test
+  void theAdjacencyWalkAlsoStopsFlaggingAnAbsentFarEndpoint() {
+    final Graph graph = createGraph();
+
+    // company1 is edge1's IN endpoint, so walking person1's OUT list loads a vertex that is gone.
+    rawDelete(graph.company1);
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkVertices("Person", null, false, 0, 100, 100);
+
+    assertThat((Collection<RID>) stats.get("corruptedRecords"))
+        .as("the walk flags the edge it cannot follow, not the vertex that is not there: %s", stats)
+        .contains(graph.edge1).doesNotContain(graph.company1);
+    assertThat((Map<RID, Long>) stats.get("missingReferences"))
+        .as("still reported, through the channel meant for it: %s", stats).containsKey(graph.company1);
+  }
+
+  /**
+   * FIX still repairs what there is to repair, and reports one repair per record it actually removed. The absent
+   * vertex contributes nothing to {@code autoFix} - it never did, because the count happens after the delete
+   * returns (#6128) and a delete of a RID that is not there raises - which is precisely why flagging it was pure
+   * cost.
+   */
+  @Test
+  void fixStillRemovesTheDanglingEdgeAndCountsItOnce() {
+    final Graph graph = createGraph();
+
+    rawDelete(graph.person2);
+
+    final Result row = check("CHECK DATABASE TYPE WorksAt FIX");
+
+    assertThat(longProperty(row, "autoFix")).as("one record removed: %s", row.toJSON()).isEqualTo(1L);
+    assertThat((Collection<RID>) row.getProperty("deletedRecordsAfterFix"))
+        .as("%s", row.toJSON()).containsExactly(graph.edge2);
+    database.transaction(() -> assertThat(database.existsRecord(graph.edge2))
+        .as("the dangling edge must be gone").isFalse());
+  }
+
+  /** The names {@code rebuiltIndexes} would use for the indexes attached to {@code rid}'s bucket. */
+  private Set<String> indexNamesOnBucketOf(final RID rid) {
+    return Arrays.stream(database.getSchema().getIndexes())
+        .filter(index -> index.getAssociatedBucketId() == rid.getBucketId())
+        .map(Index::getName).collect(Collectors.toSet());
+  }
+
+  private record Graph(RID person1, RID person2, RID company1, RID company2, RID edge1, RID edge2) {
+  }
+
+  /**
+   * Two disjoint person-to-company edges, so one can lose its IN endpoint and the other its OUT endpoint in the
+   * same run without the two findings overlapping. The unique index on {@code Person.name} is what makes
+   * {@code rebuiltIndexes} observable.
+   */
+  private Graph createGraph() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Person", 1).createProperty("name", Type.STRING)
+          .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+      database.getSchema().createVertexType("Company", 1);
+      database.getSchema().createEdgeType("WorksAt", 1);
+    });
+
+    final RID[] rids = new RID[6];
+    database.transaction(() -> {
+      final MutableVertex person1 = database.newVertex("Person").set("name", "p1").save();
+      final MutableVertex person2 = database.newVertex("Person").set("name", "p2").save();
+      final MutableVertex company1 = database.newVertex("Company").set("name", "c1").save();
+      final MutableVertex company2 = database.newVertex("Company").set("name", "c2").save();
+
+      rids[0] = person1.getIdentity();
+      rids[1] = person2.getIdentity();
+      rids[2] = company1.getIdentity();
+      rids[3] = company2.getIdentity();
+      rids[4] = person1.newEdge("WorksAt", company1).getIdentity();
+      rids[5] = person2.newEdge("WorksAt", company2).getIdentity();
+    });
+
+    return new Graph(rids[0], rids[1], rids[2], rids[3], rids[4], rids[5]);
+  }
+
+  /**
+   * Removes the record through the BUCKET, leaving every reference to it - the adjacency entries and the index
+   * entries - behind. That is the shape a check meets after a crash or a raw repair, and the only way to produce a
+   * RID that resolves to nothing while an edge still names it.
+   */
+  private void rawDelete(final RID rid) {
+    database.transaction(() -> database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid));
+  }
+
+  /**
+   * Replaces the record-size varint with a single-byte varint encoding a size far below the fixed vertex prefix:
+   * the record still occupies its slot and still resolves, but cannot be DECODED. zigzag(8) == 16.
+   */
+  private void shrinkRecordBuffer(final RID rid) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = rid.getBucketId();
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
+
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
+        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
+        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
+        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
+        page.writeByte(recordOffset, (byte) 16);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private static Map.Entry<RID, Long> entryOf(final RID rid) {
+    return Map.entry(rid, 1L);
+  }
+
+  private Result check(final String command) {
+    try (final ResultSet rs = database.command("sql", command)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next();
+    }
+  }
+
+  private static long longProperty(final Result row, final String name) {
+    final Object value = row.getProperty(name);
+    assertThat(value).as("check database must report '%s': %s", name, row.toJSON()).isNotNull();
+    return ((Number) value).longValue();
+  }
+}


### PR DESCRIPTION
Fixes #5777.

## The two defects, one cause

`GraphDatabaseChecker` carried **four** copies of the same fifteen-line endpoint probe - both sides of `checkEdges`, plus the far-endpoint load in `checkIncomingEdges` and `checkOutgoingEdges` - and one had drifted. `checkEdges`' incoming side flagged the **missing vertex** corrupted alongside the edge:

```java
// incoming endpoint not found
report.corrupt(edgeRID);
report.corrupt(edge.getIn());   // <-- the missing VERTEX too

// outgoing endpoint not found
report.corrupt(edgeRID);        // <-- edge only
```

The unknown-error arms beside them were asymmetric in the opposite direction (both add the vertex), so the divergence is only in the `RecordNotFoundException` arms - a copy-paste divergence rather than a decision. The same drift was present in the two adjacency-walk copies, which the issue did not name but which flag the absent far endpoint for the same reason.

The drift also picked the wrong side. Every RID in `corruptedRecords` puts its **bucket** into `affectedBuckets`, and `CHECK DATABASE ... FIX` then drops and rebuilds every index on it - a full bucket scan per index. Flagging the absent endpoint therefore had a dangling-edge sweep after a bulk delete rebuild the indexes of every vertex bucket the deleted vertices lived in, and bought nothing for it: the repair loop's `deleteRecord` on a RID that is not there raises `RecordNotFoundException` and is ignored, so no repair was ever performed on the strength of the flag. That is the rule #5680/#5764 already settled for a hand-typed RID in the `RECORD` scope, quoted verbatim in both scoped arms.

Settled as the issue asked: nothing else consumes `corruptedRecords`. It becomes `affectedBuckets` in `DatabaseChecker.check()` and the delete list in each repair loop, and neither wants a phantom.

## Better than the proposed one-line deletion

The issue proposes dropping the one `addCorrupted(edge.getIn())`. That fixes the symptom and leaves four copies of the code that produced it - including two the issue had not spotted. Instead, all four are replaced by a single `loadEndpointVertex(edge, edgeRID, direction, ...)` arm, so the two directions cannot report the same finding differently again, and the policy lives in exactly one place:

| endpoint load | edge | endpoint |
|---|---|---|
| `RecordNotFoundException` - not there | flagged | **not** flagged, reported via `trackMissingReference` |
| anything else - there, unreadable | flagged | flagged (this IS corruption) |

The list walkers keep pruning the dangling adjacency entry - the only thing that legitimately differs between the two families of caller - by acting on the `null` return. `invalidLinks` keeps the split it already had, so no published number is renumbered beyond `corruptedRecords`/`totalCorruptedRecords` themselves.

## Verification

New `Issue5777DanglingEndpointScopeTest` (6 cases): both directions flag the edge and nothing else; both absent endpoints still reach the operator through `missingReferences` and the warnings; **no index on the absent vertex's bucket appears in `rebuiltIndexes`** - the cost, measured where an operator pays it; an unreadable endpoint is still flagged; the adjacency walk stops flagging the absent far endpoint; `FIX` still removes the dangling edge and counts it once.

Three of the six fail against the previous behaviour, including the `rebuiltIndexes` one, which reported `Person_0_...` before the change.

Updated for the new counts:
- `CheckDatabaseSinglePassTest.theCorruptedTotalDoesNotDoubleCountARetainedRecordPastTheCap` - 2 to 1, exactly as the issue predicted. It gets sharper: the edge is now the only RID the visit produces, so the arithmetic is purely the de-duplication being measured.
- `CheckDatabaseTest.checkBrokenDeletedVertex` - `TOTAL` to `TOTAL - 1`: all the edges, no longer the low-level-deleted root vertex.
- `CheckDatabaseAutoFixAccountingTest` - its precondition (a flagged RID that cannot be deleted) is no longer reachable through a dangling endpoint, so it is re-based onto the arm that still produces the shape: an adjacency list naming an edge record that is gone. The #6128 accounting rule it pins is unchanged, and is now asserted on `removedRecords` rather than `autoFix`, which also folds in the prunes.

`mvn -o -pl engine test` over `com/arcadedb/graph/**` + `com/arcadedb/database/**`: 904 tests, 0 failures.

## Docs

`CHECK DATABASE`'s reported `corruptedRecords`/`totalCorruptedRecords` no longer include RIDs that do not exist. Worth a line in the docs repo if the counters are described there - happy to prepare it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database checks for graph records with missing or unreadable endpoints.
  * Missing endpoints are now reported as references, while unreadable endpoints and dangling edges are identified as corrupted.
  * Database repair now accurately reports successfully removed records and excludes failed deletions.
  * Graph index rebuilding excludes entries for missing endpoints.
  * Repair operations consistently remove and count dangling edges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->