### PR TITLE
fix(schema): carry the whole index definition over at every rebuild site (#5742)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -376,9 +376,10 @@ public class RebuildIndexStatement extends DDLStatement {
         // answers the current page size unless it is not legal to create with, in which case it repairs it.
         final int pageSize = ((IndexInternal) idx).getPageSizeForNewFile();
         final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
-        // Get index metadata (includes vector-specific settings like dimensions, similarity, etc.), reconstructing
-        // FULL_TEXT/GEOSPATIAL from the index's persisted JSON so the rebuild preserves their type-specific
-        // settings (issue #4732/#5478) instead of the generic IndexMetadata getMetadata() would otherwise return.
+        // Get index metadata (includes vector-specific settings like dimensions, similarity, etc.) through the
+        // accessor that answers with the type-specific configuration a WRAPPER index keeps outside the underlying
+        // LSM-Tree, so the rebuild preserves the analyzers, the geohash resolution and the sparse dimensionality
+        // (issues #4732/#5478/#5742) instead of the generic IndexMetadata getMetadata() would otherwise return.
         // Shared with DatabaseChecker's auto-fix rebuild path (issue #5934).
         final IndexMetadata rebuildMetadata = IndexMetadata.reconstructForRebuild((IndexInternal) idx, typeName,
             propertyNames.toArray(new String[0]));

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateTypeStatement.java
@@ -31,10 +31,8 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.IndexMetadata;
-import com.arcadedb.schema.LSMVectorIndexMetadata;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.TypeIndexBuilder;
-import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
 
 import java.util.*;
 
@@ -233,14 +231,17 @@ public class TruncateTypeStatement extends DDLStatement {
     builder.withPageSize(def.pageSize);
     builder.withNullStrategy(def.nullStrategy);
 
-    // Type-specific metadata (e.g. LSM_VECTOR dimensions/similarity) must be carried over,
-    // otherwise the recreated index loses its configuration and inserts fail with "index
-    // dimension 0" (issue #4359). The type-specific builder's withMetadata(IndexMetadata)
-    // override reinstates the vector-specific fields.
-    if (def.indexType == Schema.INDEX_TYPE.LSM_VECTOR && def.metadata instanceof LSMVectorIndexMetadata vectorMeta)
-      // A copy - rather than the original reference - keeps the dropped index's per-index runtime state (notably
-      // buildState) off the rebuilt one and resets associatedBucketId so the per-bucket builder sets it during create().
-      ((TypeLSMVectorIndexBuilder) builder).withMetadata(vectorMeta.copy(def.typeName, def.propertyNames, -1));
+    // Type-specific metadata must be carried over, otherwise the recreated index loses its configuration: a vector
+    // index comes back with dimensions 0 and rejects every insert (issue #4359), a full-text one with a different
+    // analyzer and a different ranking, a geospatial one with a different cell size (issue #5742). withType() above
+    // has already swapped in the builder subclass that owns those settings, so the polymorphic withMetadata() call
+    // lands on the override that reinstates them - no per-index-type branch here to forget one.
+    //
+    // A copy - rather than the original reference - keeps the dropped index's per-index runtime state (notably the
+    // vector index's buildState and the full-text corpus counters, which describe records that are about to be gone)
+    // off the rebuilt one, and resets associatedBucketId so the per-bucket builder sets it during create().
+    if (def.metadata != null)
+      builder.withMetadata(def.metadata.copy(def.typeName, def.propertyNames, -1));
 
     builder.create();
   }
@@ -284,10 +285,13 @@ public class TruncateTypeStatement extends DDLStatement {
 
     static IndexDefinition from(final TypeIndex index) {
       final List<String> props = index.getPropertyNames();
-      // getPageSizeForNewFile(), not getPageSize(): this definition is replayed through the creation path after the
-      // index has been dropped, so a page size creation refuses would leave the type without the index it had (#5713).
+      // getPageSizeForNewFile()/getMetadataForNewFile(), not getPageSize()/getMetadata(): this definition is replayed
+      // through the creation path after the index has been dropped, so the page size carried over has to be one that
+      // path accepts (#5713), and the configuration has to be the one the WRAPPER index types keep outside the
+      // underlying LSM-Tree - analyzers, geohash resolution, sparse dimensionality (#5742).
       return new IndexDefinition(index.getName(), index.getTypeName(), props.toArray(new String[0]),
-          index.getType(), index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), index.getMetadata());
+          index.getType(), index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(),
+          index.getMetadataForNewFile());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/IndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexMetadata.java
@@ -87,6 +87,28 @@ public class IndexMetadata {
     return copy;
   }
 
+  /**
+   * The in-place form of {@link #copyCommonTo}: takes the base-class settings from the definition of the index this one
+   * sits on top of.
+   * <p>
+   * A WRAPPER index type - full-text, geospatial, sparse-vector - splits its definition in two: the base settings
+   * (collations, the user-supplied {@code TypeIndex} name) belong to the underlying LSM-Tree's plain
+   * {@link IndexMetadata}, while the type-specific ones live in a subclass instance the wrapper holds. Creation
+   * populates a single instance carrying both halves, but a schema RELOAD builds the subclass instance from the
+   * bucket-level index JSON, which carries no {@code typeName} key and therefore skips {@link #fromJSON}'s base-field
+   * read entirely. Without this hop, {@link com.arcadedb.index.IndexInternal#getMetadataForNewFile()} would answer with
+   * the type-specific settings and NO collations and NO manual index name after a restart, and every carry-over site
+   * reading it would trade one silent loss for another (issue #5742).
+   *
+   * @param source the underlying index's definition, or {@code null} when there is none to inherit from
+   */
+  public final void inheritCommonSettingsFrom(final IndexMetadata source) {
+    if (source == null || source == this)
+      return;
+    collations = source.collations;
+    typeIndexName = source.typeIndexName;
+  }
+
   public void fromJSON(final JSONObject metadata) {
     typeName = metadata.getString("typeName");
     propertyNames = metadata.getJSONArray("properties").toListOfStrings();
@@ -331,15 +353,21 @@ public class IndexMetadata {
   }
 
   /**
-   * Reconstructs the metadata an index rebuild should carry over, for the two index types whose configuration
-   * {@link com.arcadedb.index.IndexInternal#getMetadata()} does not capture. {@code FULL_TEXT} and {@code GEOSPATIAL}
-   * keep their type-specific settings (analyzer, BM25 parameters, GeoHash precision) in a subtype the generic
-   * {@code IndexMetadata} does not carry, so a rebuild that passed {@code getMetadata()} straight through silently
-   * reset them to defaults (issue #4732). Reconstructing from the index's persisted JSON recovers them. FULL_TEXT's
-   * BM25 corpus counters are reset to zero so the re-index pass recomputes them from scratch instead of doubling the
-   * persisted totals; GEOSPATIAL's tokenization is reset to {@link GeoIndexMetadata#DEFAULT_TOKENIZATION}, which is
-   * also the one safe moment (a full re-read of every record) to publish the compact FRONTIER layout on an index
-   * created before 26.8.1 (#5478).
+   * The metadata an index rebuild has to carry over into the new index file: everything
+   * {@link com.arcadedb.index.IndexInternal#getMetadataForNewFile()} answers, retargeted to the type and properties the
+   * rebuilt index is created against, with the two adjustments a rebuild - and only a rebuild - is entitled to make.
+   * <p>
+   * FULL_TEXT's BM25 corpus counters are left behind (which {@link FullTextIndexMetadata#copy} already does) so the
+   * re-index pass recomputes them from scratch instead of doubling the persisted totals. GEOSPATIAL's tokenization is
+   * reset to {@link GeoIndexMetadata#DEFAULT_TOKENIZATION}: a rebuild is a full re-read of every record, which is the
+   * one safe moment to publish the compact FRONTIER layout on an index created before 26.8.1 (#5478).
+   * <p>
+   * Reads through the accessor rather than round-tripping the index's persisted JSON, which is what it used to do for
+   * FULL_TEXT and GEOSPATIAL and could not do at all for LSM_SPARSE_VECTOR: falling through to {@code getMetadata()}
+   * there answered with the underlying LSM-Tree's plain metadata, and the sparse builder refuses it outright, so
+   * {@code REBUILD INDEX} and {@code CHECK DATABASE FIX} on a sparse-vector index failed with "requires
+   * LSMSparseVectorIndexMetadata but got IndexMetadata" (issue #5742). One accessor answers for every index type, so an
+   * index type added later cannot be forgotten here.
    * <p>
    * Shared by {@code RebuildIndexStatement.buildIndex()} and {@code DatabaseChecker}'s auto-fix rebuild path, which
    * both drop and recreate a corrupted or explicitly-rebuilt index the same way (issue #5934).
@@ -350,18 +378,14 @@ public class IndexMetadata {
    */
   public static IndexMetadata reconstructForRebuild(final IndexInternal idx, final String typeName,
       final String[] propertyNames) {
-    final Schema.INDEX_TYPE type = idx.getType();
-    if (type == Schema.INDEX_TYPE.FULL_TEXT) {
-      final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, propertyNames, -1);
-      ftMeta.fromJSON(idx.toJSON());
-      ftMeta.setCounters(0L, 0L);
-      return ftMeta;
-    } else if (type == Schema.INDEX_TYPE.GEOSPATIAL) {
-      final GeoIndexMetadata geoMeta = new GeoIndexMetadata(typeName, propertyNames, -1);
-      geoMeta.fromJSON(idx.toJSON());
-      geoMeta.setTokenization(GeoIndexMetadata.DEFAULT_TOKENIZATION);
-      return geoMeta;
-    }
-    return idx.getMetadata();
+    final IndexMetadata source = idx.getMetadataForNewFile();
+    if (source == null)
+      return null;
+
+    // bucketId -1: the per-bucket builder binds each sub-index during create().
+    final IndexMetadata metadata = source.copy(typeName, propertyNames, -1);
+    if (metadata instanceof GeoIndexMetadata geoMetadata)
+      geoMetadata.setTokenization(GeoIndexMetadata.DEFAULT_TOKENIZATION);
+    return metadata;
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1554,11 +1554,19 @@ public class LocalDocumentType implements DocumentType {
           // getPageSizeForNewFile(), not getPageSize(): this creates a NEW index file, so the page size carried over has
           // to be one the creation path accepts. A HASH index predating #5713 can hold an unaddressable one, and
           // adding a bucket to its type must not fail because of it (#5713).
+          //
+          // getMetadataForNewFile(), not getMetadata(), for the same reason applied to the configuration: on a WRAPPER
+          // index type the latter answers with the underlying LSM-Tree's plain metadata, so the sub-index minted here
+          // for the new bucket came up with the DEFAULT analyzer, the DEFAULT geohash resolution or - for a sparse
+          // vector index, which refuses a plain IndexMetadata outright - not at all (issue #5742). The instance is
+          // handed over as-is rather than copied: this is one more bucket of the SAME logical index, which is exactly
+          // what index creation does when it passes one metadata instance to every bucket sub-index, and what keeps
+          // the full-text corpus counters type-wide instead of restarting them at zero for the new bucket.
           schema.createBucketIndex(this, idx.getKeyTypes(), bucket, name, idx.getType(), idx.isUnique(),
               idx.getPageSizeForNewFile(),
               idx.getNullStrategy(), null, idx.getPropertyNames().toArray(new String[idx.getPropertyNames().size()]), idx,
               IndexBuilder.BUILD_BATCH_SIZE,
-              idx.getMetadata());
+              idx.getMetadataForNewFile());
         }
       });
     }
@@ -2262,11 +2270,13 @@ public class LocalDocumentType implements DocumentType {
 
       // Inherit the page size of the index being propagated, like the createBucket() path above does. Hardcoding the
       // LSM default here gave a HASH index a page size it cannot address (#5713), and getPageSizeForNewFile() is the
-      // accessor that guarantees the value is legal to create with.
+      // accessor that guarantees the value is legal to create with. getMetadataForNewFile() is its counterpart for
+      // everything that is not the page size, and is handed over as-is, for the reasons spelled out in
+      // addBucketInternal(): the sub-index created here belongs to the SAME logical index being propagated (#5742).
       final Index subIndex = schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(),
           index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), null,
           index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
-          IndexBuilder.BUILD_BATCH_SIZE, index.getMetadata(), !sharesCallerTransaction);
+          IndexBuilder.BUILD_BATCH_SIZE, index.getMetadataForNewFile(), !sharesCallerTransaction);
 
       created.add(subIndex);
       if (sharesCallerTransaction)

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -677,6 +677,15 @@ public class LocalSchema implements Schema {
    * either side of it is the {@code catch} below: it drops {@code newTypeName}, and with it the buckets and records
    * already committed, so a failed copy leaves the schema as it found it rather than a half-built type. The SOURCE type
    * is only ever read, so it is unaffected either way.
+   * <p>
+   * What the safety net cannot cover is a hard CRASH inside that same window - after the records commit, before or
+   * during the index build - because nothing runs to drop the copy. What survives is a populated type whose indexes are
+   * empty or partial, which reads as a working type that silently answers nothing to an indexed query, and
+   * {@code CHECK DATABASE} does not report it: index checking here is STRUCTURAL ({@code IndexInternal.checkIntegrity}
+   * walks the key order of the index's own pages), so an index that is merely missing entries looks healthy. The repair
+   * is {@code REBUILD INDEX <name>} on the copy's indexes, or simply dropping the copy and running {@code copyType()}
+   * again; both are cheap next to making the operation atomic, which would mean holding every copied record in one
+   * transaction (issue #5742).
    *
    * @param typeName             type to copy from, left untouched
    * @param newTypeName          type to create, which must not exist yet
@@ -2030,6 +2039,12 @@ public class LocalSchema implements Schema {
                     // its getAssociatedBucketId(); this metadata only carries the full-text/BM25 configuration, not the binding.
                     final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, properties, -1);
                     ftMeta.fromJSON(indexJSON);
+                    // The bucket-level index JSON carries no "typeName" key, so fromJSON() above skipped the base-field
+                    // read: take the collations and the manual TypeIndex name from the underlying definition, which
+                    // setMetadata(indexJSON) has just populated. Without this the full-text metadata comes back from a
+                    // restart missing both, and every site that carries the definition into a new index file through
+                    // getMetadataForNewFile() loses them (issue #5742).
+                    ftMeta.inheritCommonSettingsFrom(index.getMetadata());
                     // Same reserved-name guard as the creation path, in case a hand-edited/restored schema reintroduced a property
                     // colliding with the query parser's default-field sentinel.
                     LSMTreeFullTextIndex.checkReservedPropertyNames(ftMeta.propertyNames);
@@ -2044,6 +2059,8 @@ public class LocalSchema implements Schema {
                   } else if (configuredIndexType.equalsIgnoreCase(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR.toString())) {
                     final LSMSparseVectorIndexMetadata sparseMeta = new LSMSparseVectorIndexMetadata(typeName, properties, -1);
                     sparseMeta.fromJSON(indexJSON);
+                    // Same reason as the full-text branch above (issue #5742).
+                    sparseMeta.inheritCommonSettingsFrom(index.getMetadata());
                     index = new LSMSparseVectorIndex((LSMTreeIndex) index, sparseMeta);
                     indexMap.put(indexName, index);
                   } else {

--- a/engine/src/test/java/com/arcadedb/schema/Issue5723CopyTypeIndexConfigurationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue5723CopyTypeIndexConfigurationTest.java
@@ -269,7 +269,9 @@ class Issue5723CopyTypeIndexConfigurationTest extends TestHelper {
 
     assertThat(database.getSchema().existsIndex("myVectorIndex")).isTrue();
 
-    database.transaction(() -> database.command("sql", "TRUNCATE TYPE Doc"));
+    // NOT inside a transaction: with one active TRUNCATE TYPE joins it and deletes record by record, which never
+    // drops the index at all - so the carry-over this test is about would not run (issue #6220).
+    database.command("sql", "TRUNCATE TYPE Doc UNSAFE").close();
 
     assertThat(database.getSchema().existsIndex("myVectorIndex")).as("the truncated index must keep its manual name")//
         .isTrue();

--- a/engine/src/test/java/com/arcadedb/schema/Issue5742IndexConfigurationCarryOverTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue5742IndexConfigurationCarryOverTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.fulltext.LSMTreeFullTextIndex;
+import com.arcadedb.index.geospatial.LSMTreeGeoIndex;
+import com.arcadedb.index.sparsevector.SegmentFormat;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5742: an index rebuilt from its own definition lost the configuration the WRAPPER index
+ * types - full-text, geospatial, sparse-vector - keep outside the underlying LSM-Tree, because every carry-over site
+ * read it with {@code IndexInternal.getMetadata()}, which on those types answers with the underlying index's plain
+ * {@link IndexMetadata}. Four sites did it: {@code TRUNCATE TYPE}, {@code REBUILD INDEX} / {@code CHECK DATABASE FIX}
+ * (for the sparse-vector type, where it did not merely lose the settings but failed outright), {@code ALTER TYPE ...
+ * BUCKET +...} and {@code ALTER TYPE ... SUPERTYPE +...}. Each is a distinct user-visible operation, so each gets its
+ * own case here.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5742IndexConfigurationCarryOverTest extends TestHelper {
+
+  private static final String ENGLISH_ANALYZER = "org.apache.lucene.analysis.en.EnglishAnalyzer";
+
+  @Test
+  void truncateTypeKeepsTheFullTextConfiguration() {
+    createFullTextFixture("Doc");
+    database.transaction(() -> database.newDocument("Doc").set("text", "the quick brown foxes").save());
+
+    database.command("sql", "TRUNCATE TYPE Doc UNSAFE").close();
+
+    assertThat(fullTextMetadataOf("Doc").getAnalyzerClass()).isEqualTo(ENGLISH_ANALYZER);
+    assertThat(fullTextMetadataOf("Doc").getBm25K1()).isEqualTo(1.5f);
+
+    database.transaction(() -> database.newDocument("Doc").set("text", "the quick brown foxes").save());
+    assertThat(indexOf("Doc").get(new Object[] { "fox" }).hasNext())
+        .as("the English stem must still match after the truncate").isTrue();
+  }
+
+  @Test
+  void truncateTypeKeepsTheGeospatialPrecision() {
+    createGeoFixture("Doc", 7);
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET name = 'Rome', coords = 'POINT (12.5 41.9)'").close());
+
+    database.command("sql", "TRUNCATE TYPE Doc UNSAFE").close();
+
+    assertThat(((LSMTreeGeoIndex) subIndexOf("Doc")).getPrecision()).isEqualTo(7);
+  }
+
+  @Test
+  void truncateTypeKeepsTheVectorConfiguration() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("embedding", Type.ARRAY_OF_FLOATS);
+      database.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA {dimensions: 4, similarity: 'EUCLIDEAN'}").close();
+    });
+    database.transaction(() -> database.newDocument("Doc").set("embedding", new float[] { 1f, 2f, 3f, 4f }).save());
+
+    database.command("sql", "TRUNCATE TYPE Doc UNSAFE").close();
+
+    final LSMVectorIndexMetadata metadata = (LSMVectorIndexMetadata) indexOf("Doc").getMetadataForNewFile();
+    assertThat(metadata.dimensions).isEqualTo(4);
+  }
+
+  @Test
+  void addingABucketKeepsTheFullTextConfiguration() {
+    createFullTextFixture("Doc");
+
+    database.command("sql", "ALTER TYPE Doc BUCKET +Doc_extra").close();
+
+    for (final IndexInternal sub : ((TypeIndex) indexOf("Doc")).getSubIndexes())
+      assertThat(((FullTextIndexMetadata) sub.getMetadataForNewFile()).getAnalyzerClass())
+          .as("every bucket sub-index must carry the analyzer").isEqualTo(ENGLISH_ANALYZER);
+  }
+
+  @Test
+  void addingASuperTypeKeepsTheFullTextConfiguration() {
+    createFullTextFixture("Super");
+    database.transaction(() -> database.getSchema().createDocumentType("Sub").createProperty("text", Type.STRING));
+
+    database.command("sql", "ALTER TYPE Sub SUPERTYPE +Super").close();
+
+    final TypeIndex index = (TypeIndex) indexOf("Super");
+    assertThat(index.getSubIndexes().size()).as("the index must have been propagated onto Sub's buckets")
+        .isGreaterThan(1);
+    for (final IndexInternal sub : index.getSubIndexes())
+      assertThat(((FullTextIndexMetadata) sub.getMetadataForNewFile()).getAnalyzerClass())
+          .as("every propagated sub-index must carry the analyzer").isEqualTo(ENGLISH_ANALYZER);
+  }
+
+  @Test
+  void rebuildIndexKeepsTheSparseVectorConfiguration() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("Doc");
+      type.createProperty("dims", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+      database.command("sql", "CREATE INDEX ON Doc (dims, weights) LSM_SPARSE_VECTOR"
+          + " METADATA {dimensions: 128, modifier: 'IDF', weightQuantization: 'FP16'}").close();
+    });
+
+    database.command("sql", "REBUILD INDEX `Doc[dims,weights]`").close();
+
+    final LSMSparseVectorIndexMetadata metadata = (LSMSparseVectorIndexMetadata) indexOf("Doc").getMetadataForNewFile();
+    assertThat(metadata.dimensions).isEqualTo(128);
+    assertThat(metadata.modifier).isEqualTo(LSMSparseVectorIndexMetadata.MODIFIER_IDF);
+    assertThat(metadata.weightQuantization).isEqualTo(SegmentFormat.WeightQuantization.FP16);
+  }
+
+  /**
+   * The sparse-vector wrapper keeps its dimensionality, scoring modifier and weight quantization in a metadata of its
+   * own, and its builder REFUSES a plain {@link IndexMetadata}: the shared rebuild path did not merely lose those
+   * settings, it could not rebuild the index at all ("An LSM_SPARSE_VECTOR index requires
+   * LSMSparseVectorIndexMetadata but got com.arcadedb.schema.IndexMetadata").
+   */
+  @Test
+  void checkDatabaseFixKeepsTheSparseVectorConfiguration() {
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc").close();
+      database.command("sql", "CREATE PROPERTY Doc.dims ARRAY_OF_INTEGERS").close();
+      database.command("sql", "CREATE PROPERTY Doc.weights ARRAY_OF_FLOATS").close();
+      final Result inserted = database.command("sql", "INSERT INTO Doc SET dims = [1,5], weights = [0.5,0.25]").next();
+      database.command("sql", "CREATE INDEX sparseDoc ON Doc (dims, weights) LSM_SPARSE_VECTOR"
+          + " METADATA {dimensions: 128, modifier: 'IDF', weightQuantization: 'FP16'}").close();
+      victim.set(inserted.toElement().getIdentity());
+    });
+
+    corruptRecordTypeByte((DatabaseInternal) database, victim.get());
+
+    try (final ResultSet result = database.command("sql", "CHECK DATABASE FIX")) {
+      assertThat(result.next().<Long>getProperty("autoFix")).isGreaterThan(0L);
+    }
+
+    assertThat(database.getSchema().existsIndex("sparseDoc")).as("the repaired index must keep its manual name").isTrue();
+    final IndexMetadata repaired = ((IndexInternal) database.getSchema().getIndexByName("sparseDoc")).getMetadataForNewFile();
+    assertThat(repaired).as("the repaired index must still be a sparse-vector index, not a plain one")
+        .isInstanceOf(LSMSparseVectorIndexMetadata.class);
+    final LSMSparseVectorIndexMetadata metadata = (LSMSparseVectorIndexMetadata) repaired;
+    assertThat(metadata.dimensions).isEqualTo(128);
+    assertThat(metadata.modifier).isEqualTo(LSMSparseVectorIndexMetadata.MODIFIER_IDF);
+    assertThat(metadata.weightQuantization).isEqualTo(SegmentFormat.WeightQuantization.FP16);
+  }
+
+  /**
+   * The two halves of a wrapper index's definition are joined again on schema RELOAD, and the bucket-level index JSON
+   * the type-specific half is read from carries no {@code typeName} key - so the base-field read is skipped and the
+   * collations and the user-supplied index name are only on the underlying definition. A carry-over site that reads
+   * the type-specific half would then trade one silent loss for another: right analyzer, lost index name.
+   */
+  @Test
+  void truncateAfterAReopenKeepsBothHalvesOfTheDefinition() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("text", Type.STRING);
+      database.command("sql", "CREATE INDEX myFullText ON Doc (text) FULL_TEXT"
+          + " METADATA {\"analyzer\": \"" + ENGLISH_ANALYZER + "\"}").close();
+    });
+    database.transaction(() -> database.newDocument("Doc").set("text", "the quick brown foxes").save());
+
+    reopenDatabase();
+
+    database.command("sql", "TRUNCATE TYPE Doc UNSAFE").close();
+
+    assertThat(database.getSchema().existsIndex("myFullText")).as("the truncated index must keep its manual name").isTrue();
+    assertThat(((FullTextIndexMetadata) ((IndexInternal) database.getSchema().getIndexByName("myFullText"))
+        .getMetadataForNewFile()).getAnalyzerClass())
+        .as("and its analyzer").isEqualTo(ENGLISH_ANALYZER);
+  }
+
+  private void createFullTextFixture(final String typeName) {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(typeName).createProperty("text", Type.STRING);
+      final TypeFullTextIndexBuilder builder = (TypeFullTextIndexBuilder) database.getSchema()//
+          .buildTypeIndex(typeName, new String[] { "text" }).withType(Schema.INDEX_TYPE.FULL_TEXT);
+      builder.withAnalyzer(ENGLISH_ANALYZER).withBM25(1.5f, 0.5f);
+      builder.create();
+    });
+  }
+
+  private void createGeoFixture(final String typeName, final int precision) {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(typeName);
+      type.createProperty("name", Type.STRING);
+      type.createProperty("coords", Type.STRING);
+      final TypeIndexBuilder builder = database.getSchema().buildTypeIndex(typeName, new String[] { "coords" })//
+          .withType(Schema.INDEX_TYPE.GEOSPATIAL);
+      final GeoIndexMetadata metadata = new GeoIndexMetadata(typeName, new String[] { "coords" }, -1);
+      metadata.setPrecision(precision);
+      builder.withMetadata(metadata);
+      builder.create();
+    });
+  }
+
+  private IndexInternal indexOf(final String typeName) {
+    return (IndexInternal) database.getSchema().getType(typeName).getAllIndexes(false).iterator().next();
+  }
+
+  private IndexInternal subIndexOf(final String typeName) {
+    return ((TypeIndex) indexOf(typeName)).getSubIndexes().getFirst();
+  }
+
+  private FullTextIndexMetadata fullTextMetadataOf(final String typeName) {
+    return (FullTextIndexMetadata) ((LSMTreeFullTextIndex) subIndexOf(typeName)).getMetadataForNewFile();
+  }
+}


### PR DESCRIPTION
Fixes #5742.

## The defect

Any site that rebuilds an index **from its own configuration** has to read that configuration back and feed it through the creation path. They read it with `IndexInternal.getMetadata()`, which for the WRAPPER index types answers with the *underlying LSM-Tree's* plain `IndexMetadata`:

- `LSMTreeFullTextIndex` keeps its analyzers, query-parser options and BM25 parameters in its own `FullTextIndexMetadata`
- `LSMTreeGeoIndex` keeps its geohash resolution and storage layout as plain fields
- `LSMSparseVectorIndex` keeps its dimensionality, scoring modifier and weight quantization in its own `LSMSparseVectorIndexMetadata`

None of that is reachable through the underlying index, so each site silently recreated the index with the DEFAULT configuration - a different analyzer and a different ranking for a full-text index, a different cell size for a geospatial one. Nothing logged, and the index kept working.

## What changed

Every site now reads `getMetadataForNewFile()`, the accessor #5734 added for exactly this.

| Site | Was | Now |
|---|---|---|
| `TRUNCATE TYPE` | `getMetadata()`, carried over only for `LSM_VECTOR`, behind an explicit per-index-type branch | `getMetadataForNewFile().copy(...)`, one polymorphic `withMetadata()` for every index type |
| `REBUILD INDEX` / `CHECK DATABASE FIX` (`IndexMetadata.reconstructForRebuild`) | `FULL_TEXT`/`GEOSPATIAL` reconstructed from the index's persisted JSON, everything else `getMetadata()` | one accessor + `copy()`, keeping the two adjustments only a rebuild may make |
| `ALTER TYPE ... BUCKET +...` | `getMetadata()` | `getMetadataForNewFile()` |
| `ALTER TYPE ... SUPERTYPE +...` | `getMetadata()` | `getMetadataForNewFile()` |

`TRUNCATE TYPE` loses its per-index-type branch entirely: `withType()` has already swapped in the builder subclass that owns those settings, so the polymorphic call lands on the override that reinstates them and there is no list to forget an index type from.

**LSM_SPARSE_VECTOR was worse than a silent loss.** Falling through to `getMetadata()` handed the sparse builder a plain `IndexMetadata`, which it refuses outright, so `REBUILD INDEX` and `CHECK DATABASE FIX` on a sparse-vector index *failed*:

```
Error on rebuilding index 'Doc[dims,weights]'
  (error=An LSM_SPARSE_VECTOR index requires LSMSparseVectorIndexMetadata but got com.arcadedb.schema.IndexMetadata)
```

### The half of the definition the accessor did not carry

A wrapper index's definition is split in two: the base settings (collations, the user-supplied index name) belong to the underlying LSM-Tree's metadata, the type-specific ones to the wrapper's own. Creation populates one instance carrying both halves, but a schema RELOAD rebuilds the type-specific half from the bucket-level index JSON, which carries no `typeName` key - so `fromJSON()` skips the base-field read and those settings stay only on the underlying half. Switching the carry-over sites to the accessor without fixing that would have traded one silent loss for another: right analyzer, lost index name. The two halves are joined back at load through the new `IndexMetadata.inheritCommonSettingsFrom()`, and `truncateAfterAReopenKeepsBothHalvesOfTheDefinition` fails without it.

### Bucket/super-type propagation hands the instance over as-is

Not copied, unlike the other two sites: the sub-index minted there belongs to the SAME logical index. That is what index creation itself does when it passes one metadata instance to every bucket sub-index, and it is what keeps the full-text corpus counters type-wide instead of restarting them at zero for the new bucket.

## `copyType()`'s crash window

The issue also asks for a story on `copyType()`'s deliberate non-atomicity. The existing `catch` covers a *failure* on either side of the commit boundary by dropping the copy; a hard **crash** in the same window leaves a populated type with empty or partial indexes, and `CHECK DATABASE` does not report it because its index check is STRUCTURAL (`checkIntegrity()` walks the key order of the index's own pages, so an index merely missing entries looks healthy). Rather than pay for atomicity - which would mean holding every copied record in one transaction - the javadoc now names the window explicitly and names `REBUILD INDEX <name>` as the repair.

## Tests

New `Issue5742IndexConfigurationCarryOverTest`, one case per user-visible operation - all five fail on `main`:

- `truncateTypeKeepsTheFullTextConfiguration` - asserts behaviourally, on the English stem still matching after the truncate, not only on the attribute
- `truncateTypeKeepsTheGeospatialPrecision`
- `addingABucketKeepsTheFullTextConfiguration`
- `addingASuperTypeKeepsTheFullTextConfiguration`
- `rebuildIndexKeepsTheSparseVectorConfiguration`
- `checkDatabaseFixKeepsTheSparseVectorConfiguration`
- `truncateAfterAReopenKeepsBothHalvesOfTheDefinition`

Also fixed a vacuous existing test: `Issue5723CopyTypeIndexConfigurationTest.truncatingAManuallyNamedVectorIndexKeepsItsName` ran its `TRUNCATE TYPE` inside a transaction, which takes the record-by-record path and never drops the index at all (#6220), so it asserted on a carry-over that had not happened.

Full `engine` module suite green (13745 tests, 0 failures); vector lane green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved index configuration—including analyzers, collations, geospatial settings, sparse-vector dimensions, and manual names—when indexes are rebuilt, truncated, repaired, or recreated.
  * Improved index metadata preservation when adding buckets or propagating indexes across related types.
  * Documented recovery guidance for copied schemas whose indexes may be incomplete after a crash.

* **Tests**
  * Added regression coverage across index rebuild, truncation, repair, schema reopening, and bucket operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->