### PR TITLE
fix(engine): name a broken chunk chain on the delete path, and keep the snapshot barrier's page count out of the filesystem

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -551,10 +551,11 @@ public enum GlobalConfiguration {
       loudly, so the consumer can fall back to the suspend-and-freeze path - never a silently truncated or torn \
       snapshot. The default -1 sizes the cap AUTOMATICALLY when the window opens (issue #6125), as the smaller of \
       the ceiling the shadow provably cannot exceed - one pre-image per page that existed at t0, so the t0 size of \
-      the page files - and half the space still usable on the volume holding the spill file. A flat number cannot \
-      do that: measurements on a 128 MB database show the shadow reaching 100% of the database under a flat-out \
-      writer, so any fixed default is simply the database size above which backups silently start falling back to \
-      throttling the writers. Set a positive value to pin an absolute cap in MB, or 0 for no cap at all; any \
+      the page files - and half the space still usable on the volume holding the spill file, but never less than \
+      PAGE_SNAPSHOT_MAX_RAM, because that half of the budget never touches the disk (issue #6132). A flat number \
+      cannot do that: measurements on a 128 MB database show the shadow reaching 100% of the database under a \
+      flat-out writer, so any fixed default is simply the database size above which backups silently start falling \
+      back to throttling the writers. Set a positive value to pin an absolute cap in MB, or 0 for no cap at all; any \
       negative value means automatic, so -1 is the spelling to use rather than the only one accepted.""",
       Long.class, -1),
 

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -380,6 +380,11 @@ public class Profiler {
     json.put("snapshotBarrierTime", new JSONObject().put("count", pStats.snapshotBarrierMillis));
     json.put("snapshotBarrierMaxTime", new JSONObject().put("value", pStats.snapshotBarrierMaxMillis));
     json.put("snapshotBarriersInexact", new JSONObject().put("count", pStats.snapshotBarriersInexact));
+    // #6132: a barrier that gave up before publishing a window leaves no other trace - every other snapshot counter
+    // needs a window to exist, and the consumer's fallback still completes the backup, just by throttling the writers
+    json.put("snapshotBarriersFailed", new JSONObject().put("count", pStats.snapshotBarriersFailed));
+    json.put("snapshotBarriersFailedSuspend", new JSONObject().put("count", pStats.snapshotBarriersFailedSuspend));
+    json.put("snapshotBarriersFailedFlush", new JSONObject().put("count", pStats.snapshotBarriersFailedFlush));
     json.put("deferredRAM", new JSONObject().put("space", pStats.deferredRAMBytes));
     json.put("pageFlushQueueWaits", new JSONObject().put("count", pStats.flushQueueWaits));
 
@@ -583,11 +588,13 @@ public class Profiler {
       // #6125: the t0 barrier on its own line. The average is what an operator compares against their write-latency
       // budget; the max is what a single unlucky backup actually cost, and averaging it away hides exactly the
       // outlier worth chasing.
-      buffer.append("%n    barriers=%d avg=%,dms max=%,dms inexact=%d overflowed=%d failed=%d".formatted(
+      buffer.append(
+        "%n    barriers=%d avg=%,dms max=%,dms inexact=%d windowsOverflowed=%d windowsFailed=%d barriersFailed=%d (suspend=%d flush=%d)".formatted(
           pStats.snapshotBarriers,
           pStats.snapshotBarriers > 0 ? pStats.snapshotBarrierMillis / pStats.snapshotBarriers : 0L,
           pStats.snapshotBarrierMaxMillis, pStats.snapshotBarriersInexact, pStats.snapshotWindowsOverflowed,
-          pStats.snapshotWindowsFailed));
+          pStats.snapshotWindowsFailed, pStats.snapshotBarriersFailed, pStats.snapshotBarriersFailedSuspend,
+          pStats.snapshotBarriersFailedFlush));
 
       buffer.append(
         "%n WAL totalFiles=%d pagesWritten=%d bytesWritten=%s".formatted(walTotalFiles, walPagesWritten,

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1537,20 +1537,16 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
             throw e;
           forceBrokenChainDelete = true;
           logBrokenChainForceDelete(record.getIdentity(), e);
-        } catch (final ConcurrentModificationException e) {
-          // The record body could not be assembled for a consistent read, so its indexed keys and EXTERNAL pointers could
-          // not be read for cleanup. loadMultiPageRecord throws this after exhausting TX_RETRIES, but exhausted retries do
-          // NOT prove corruption: its page-version validation also fails when concurrent writes touch OTHER records
-          // sharing the chain's pages, so under a busy bucket this can be pure contention. Deleting anyway in that case
-          // would leak index entries for a healthy record. Disambiguate with a version-blind STRUCTURAL walk of the chunk
-          // chain: only a genuinely broken chain (a bad continuation pointer - the case that would otherwise make the
-          // record undeletable forever) takes the tolerant path below; transient contention rethrows, preserving the
-          // NeedRetryException semantics so the retry machinery re-runs the DELETE with intact index cleanup.
-          if (!tolerateBrokenChain || !bucket.isChunkChainBroken(record.getIdentity()))
-            throw e;
-          forceBrokenChainDelete = true;
-          logBrokenChainForceDelete(record.getIdentity(), e);
         }
+        // NO ConcurrentModificationException ARM, AND ITS REMOVAL IS THE POINT (#6282). It used to re-walk the chain
+        // with isChunkChainBroken and force the delete through when that walk agreed. That probe asks a STRICTLY
+        // WEAKER question than the one the loader has already answered above: it walks the newest committed image
+        // and stops there, where loadMultiPageRecord walks the same image AND proves the chunks this read consumed
+        // are still byte-for-byte the ones it holds - which is what rules out a chain caught half-published. So a
+        // CME arriving here is the loader saying "I could not confirm it", and overruling that with the weaker
+        // walk is how a HEALTHY record whose commit was mid-publication gets force-deleted with its index cleanup
+        // skipped. Propagate instead: the retry machinery re-runs the DELETE, and a record that really is corrupt
+        // comes back as BrokenChunkChainException on an attempt that is not racing a publication.
       }
 
       if (record instanceof Edge edge) {
@@ -1566,15 +1562,10 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
             throw e;
           logBrokenChainForcePhysicalDelete(record.getIdentity(), e);
           graphEngine.deleteVertex((VertexInternal) record, true);
-        } catch (final ConcurrentModificationException e) {
-          // The physical removal can raise the #4932 retry signal even when index cleanup did not (e.g. the type has no
-          // index left to read, so the broken chain is only discovered here). Fall back to force ONLY when the chain is
-          // confirmed structurally broken; a genuine transient conflict (or an already-forced delete) rethrows to retry.
-          if (!tolerateBrokenChain || forceBrokenChainDelete || !bucket.isChunkChainBroken(record.getIdentity()))
-            throw e;
-          logBrokenChainForcePhysicalDelete(record.getIdentity(), e);
-          graphEngine.deleteVertex((VertexInternal) record, true);
         }
+        // NO ConcurrentModificationException ARM: see the index-cleanup branch above (#6282). Both sources of a CME
+        // here have already asked the stronger question and declined to confirm - the loader for the read of the
+        // edge lists, deleteRecordInternal for the physical free - so the answer is a retry, not a force.
       } else {
         try {
           bucket.deleteRecord(record.getIdentity(), forceBrokenChainDelete);
@@ -1587,17 +1578,11 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
             throw e;
           logBrokenChainForcePhysicalDelete(record.getIdentity(), e);
           bucket.deleteRecord(record.getIdentity(), true);
-        } catch (final ConcurrentModificationException e) {
-          // STILL REACHABLE, and not redundant with the arm above: the delete's own walk raises this for a break it
-          // could NOT confirm - a chain caught mid-publication, or one that broke somewhere else in the committed
-          // image - and for the ordinary page conflicts of a busy bucket. The probe is what tells a chain that is
-          // genuinely broken (the case that would otherwise make the record undeletable forever) from contention,
-          // and since #6282 it asks the newest committed image rather than this transaction's pinned view.
-          if (!tolerateBrokenChain || forceBrokenChainDelete || !bucket.isChunkChainBroken(record.getIdentity()))
-            throw e;
-          logBrokenChainForcePhysicalDelete(record.getIdentity(), e);
-          bucket.deleteRecord(record.getIdentity(), true);
         }
+        // NO ConcurrentModificationException ARM: see the index-cleanup branch above (#6282). deleteRecordInternal
+        // raises this only for a break its own confirmation could NOT prove - a chain caught mid-publication, or one
+        // that broke somewhere else in the committed image - and for the ordinary page conflicts of a busy bucket.
+        // Every one of those is answered by retrying, none of them by deleting.
       }
 
       success = true;

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1578,13 +1578,21 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       } else {
         try {
           bucket.deleteRecord(record.getIdentity(), forceBrokenChainDelete);
+        } catch (final BrokenChunkChainException e) {
+          // THE ARM #6258 LEFT OUT AS DEAD CODE, LIVE SINCE #6282: deleteRecordInternal walks the chunk chain itself
+          // and never loads the record, so it used to report a break as the #4932 retry signal and this branch had
+          // to walk the chain a second time to find out which of the two it was holding. It now confirms the break
+          // against the newest committed image and says so, exactly as the loader does for the vertex branch above.
+          if (!tolerateBrokenChain || forceBrokenChainDelete)
+            throw e;
+          logBrokenChainForcePhysicalDelete(record.getIdentity(), e);
+          bucket.deleteRecord(record.getIdentity(), true);
         } catch (final ConcurrentModificationException e) {
-          // NO BrokenChunkChainException ARM HERE, unlike the vertex branch above, and the asymmetry is real rather
-          // than an omission (code review on #6258): deleteRecordInternal walks the chunk chain itself and never
-          // loads the record, so it reports a break as the #4932 retry signal and the structural probe below is
-          // still what tells the two apart. The vertex branch differs because reaching a vertex's edge lists means
-          // READING it, which is where the loader's own verdict comes from. Add the arm here the day
-          // deleteRecordInternal learns to name a broken chain as one.
+          // STILL REACHABLE, and not redundant with the arm above: the delete's own walk raises this for a break it
+          // could NOT confirm - a chain caught mid-publication, or one that broke somewhere else in the committed
+          // image - and for the ordinary page conflicts of a busy bucket. The probe is what tells a chain that is
+          // genuinely broken (the case that would otherwise make the record undeletable forever) from contention,
+          // and since #6282 it asks the newest committed image rather than this transaction's pinned view.
           if (!tolerateBrokenChain || forceBrokenChainDelete || !bucket.isChunkChainBroken(record.getIdentity()))
             throw e;
           logBrokenChainForcePhysicalDelete(record.getIdentity(), e);

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -91,12 +91,13 @@ public class BucketIterator implements Iterator<Record> {
   /**
    * Number of records skipped so far for a known, tolerated corruption reason - a corrupted on-disk record
    * ({@link SerializationException}), page-layer corruption in a raw slot/pointer read, or a multi-page record
-   * whose chunk chain {@link LocalBucket#isChunkChainBroken} confirms is structurally broken - all via
+   * whose chunk chain the loader itself confirms is structurally broken ({@link BrokenChunkChainException}) - all via
    * {@link #logSkippedRecord(Exception)} in {@link #fetchNext()}. A correctness-sensitive caller (e.g. an exact
    * {@code COUNT}) can check this after exhausting the iterator to detect a truncated result; it is not
    * incremented for the benign concurrent-delete race handled by {@link RecordNotFoundException}, nor for a
-   * {@link ConcurrentModificationException} not confirmed as a broken chain (transient contention propagates
-   * instead so a retry can resolve it), nor for any other exception, which likewise propagates (#6015). It is
+   * {@link ConcurrentModificationException}, which the loader raises for a break it could NOT confirm and which
+   * therefore propagates so a retry can resolve it (#6282), nor for any other exception, which likewise
+   * propagates (#6015). It is
    * also, deliberately, not incremented for a slot whose position resolves to 0: since 24.1.1 that is a plain
    * deleted record (the delete zeroes the slot), not corruption, so it is skipped the same way
    * {@link RecordNotFoundException} is - this counter tracks skipped-due-to-corruption, not every reason a scan
@@ -110,8 +111,7 @@ public class BucketIterator implements Iterator<Record> {
    * Counts and logs a record slot skipped for a known, tolerated reason: a corrupted on-disk record
    * ({@link SerializationException}), page-layer corruption in a raw slot/pointer read (an unchecked exception
    * from a {@code BasePage.read*}/{@code Binary} accessor), or a confirmed structurally-broken multi-page chunk
-   * chain ({@link ConcurrentModificationException} where {@link LocalBucket#isChunkChainBroken} returns
-   * {@code true}) - see the call sites in {@link #fetchNext()}.
+   * chain ({@link BrokenChunkChainException}) - see the call sites in {@link #fetchNext()}.
    */
   private void logSkippedRecord(final Exception e) {
     skippedRecords++;
@@ -210,25 +210,23 @@ public class BucketIterator implements Iterator<Record> {
               } catch (final BrokenChunkChainException e) {
                 // THE LOADER ITSELF SAYS SO (#6258): a chain the read could not parse, confirmed broken against the
                 // newest committed image with the read's own chunks proven current. No second walk needed here.
-                // UNDO THE RESERVED SLOT: see the JLS note on the ConcurrentModificationException arm below.
-                writeIndex--;
-                logSkippedRecord(e);
-              } catch (final ConcurrentModificationException e) {
-                if (!bucket.isChunkChainBroken(rid))
-                  // TRANSIENT CONTENTION, NOT PROVEN CORRUPTION: loadMultiPageRecord() throws this after
-                  // exhausting TX_RETRIES, but exhausted retries alone do not prove the chain is broken - its
-                  // page-version validation also fails under ordinary concurrent writes to OTHER records sharing
-                  // the chain's pages. Propagate so the caller's retry machinery (if any) re-runs, the same
-                  // disambiguation LocalDatabase.deleteRecordInternal() already applies to this exception.
-                  throw e;
-                // CONFIRMED STRUCTURALLY BROKEN CHAIN: a version-blind walk (isChunkChainBroken) found a genuinely
-                // bad continuation pointer, not just a version mismatch - this is corruption, not contention.
                 // UNDO THE RESERVED SLOT: per JLS 15.26.1, `nextBatch[writeIndex++] = ...` evaluates the array
                 // index (incrementing writeIndex) BEFORE the right-hand side, so the increment already happened
                 // even though lookupByRID() threw before ever writing into that slot. Do not "simplify" this away.
                 writeIndex--;
                 logSkippedRecord(e);
               }
+              // NO ConcurrentModificationException ARM, AND ITS REMOVAL IS THE POINT (#6282). Until #6258 this
+              // exception was the only thing the loader could say about a chain it could not parse, so the scan
+              // re-walked the chain with isChunkChainBroken to tell corruption from contention and skipped the
+              // record when the walk agreed. The loader now answers that question ITSELF, and it asks a strictly
+              // STRONGER version of it: the committed image must fail to walk AND the chunks this read consumed
+              // must still be current, which is what rules out a chain caught mid-publication. So a CME reaching
+              // here means the break could NOT be confirmed - the record moved under the read - and a probe saying
+              // "broken" about it is answering a weaker question about a chain that is no longer the one this read
+              // followed. Skipping on that evidence silently drops a HEALTHY record from a scan; propagating lets
+              // the caller's retry machinery re-read it, which is what getSkippedRecordCount's contract has said
+              // all along.
 
             } else if (recordSize[0] == LocalBucket.RECORD_PLACEHOLDER_POINTER) {
               // PLACEHOLDER
@@ -253,14 +251,9 @@ public class BucketIterator implements Iterator<Record> {
                 // See the identical arm on the NOT-DELETED branch above (#6258).
                 logSkippedRecord(e);
                 continue;
-              } catch (final ConcurrentModificationException e) {
-                if (!bucket.isChunkChainBroken(placeholderTargetRid))
-                  // TRANSIENT CONTENTION, NOT PROVEN CORRUPTION: see the identical disambiguation on the
-                  // NOT-DELETED branch above.
-                  throw e;
-                logSkippedRecord(e);
-                continue;
               }
+              // NO ConcurrentModificationException ARM: see the NOT-DELETED branch above for why the probe that
+              // used to be here is now answering the wrong question (#6282).
 
               if (view == null)
                 continue;
@@ -276,8 +269,8 @@ public class BucketIterator implements Iterator<Record> {
           } catch (final SerializationException e) {
             // KNOWN-CORRUPT ON-DISK RECORD: log and skip so one bad record does not abort an otherwise healthy
             // full scan (the CHECK DATABASE-shaped case). Every OTHER exception - including one from a
-            // user-supplied AfterRecordReadListener/trigger, and a ConcurrentModificationException not confirmed
-            // as a broken chunk chain by the two dedicated catches above - is deliberately NOT caught here and
+            // user-supplied AfterRecordReadListener/trigger, and a ConcurrentModificationException, which the
+            // loader raises only for a break it could NOT confirm - is deliberately NOT caught here and
             // propagates instead, so a real bug (or genuine contention needing a real retry) surfaces where it
             // can be diagnosed or retried instead of silently looking like "this bucket has fewer records"
             // (#6015; see #5976 for a listener bug this used to hide).

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -359,6 +359,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
      * delete path meets a break in the transaction's view and asks the newest committed image whether the same hop,
      * to the same target, still fails. A committed image that breaks somewhere else is a record that MOVED under the
      * delete, which is contention and must keep its retry - not the permanent corruption verdict.
+     * <p>
+     * Set exactly when {@link #findBrokenChunkChain} returns a reason, and back to {@code -1}/{@code 0} on every exit
+     * that proves nothing - the clean walk included.
      */
     private int  brokenAtChunk = -1;
     private long brokenAtPointer;
@@ -640,6 +643,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     } catch (final BrokenChunkChainException e) {
       // NO PROBE NEEDED: the delete's own walk confirmed the break against the newest committed image before saying
       // so (#6282). This is the case force exists for, and the one this method escalates for.
+      LogManager.instance().log(this, Level.FINE, "Force-deleting record %s: %s", e, rid, e.getMessage());
       deleteRecord(rid, true);
     } catch (final ConcurrentModificationException e) {
       // CONTENTION, or a break the confirmation could not prove. The probe is what tells them apart, and since #6282
@@ -3561,9 +3565,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       for (int chunkId = 0; ; ++chunkId) {
         final long nextChunkPointer = chunkPage.readLong(
                 (int) (chunkPositionInPage + chunkHeader[1] + INT_SERIALIZED_SIZE));
-        if (nextChunkPointer == 0)
-          // REACHED THE LAST CHUNK CLEANLY
+        if (nextChunkPointer == 0) {
+          // REACHED THE LAST CHUNK CLEANLY. The break location is cleared rather than left pointing at the last
+          // SUCCESSFUL hop: both current consumers read it only after a reason came back, but a documented invariant
+          // that the code does not keep is a trap for the next one (PR review).
+          walk.brokenAtChunk = -1;
+          walk.brokenAtPointer = 0;
           return null;
+        }
 
         // FROM HERE UNTIL THE NEXT LAP, ANY FAILURE - RETURNED OR THROWN - HAPPENED FOLLOWING THIS HOP. Recorded up
         // front rather than at each exit because a corrupt slot offset leaves through an exception, and the catch

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -619,14 +619,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * Deletes a record an integrity check has already judged beyond repair, escalating to {@link #deleteRecord(RID,
    * boolean) force} only for the one failure that force exists to clear: a structurally broken chunk chain.
    * <p>
-   * The escalation is GATED, not unconditional, and that is the whole point of this method. Since #6282 the delete
-   * itself names a break it has confirmed against the newest committed image, so the common case needs no second
-   * question at all. What is left under {@link ConcurrentModificationException} does: it does not prove corruption -
-   * the same page-version validation fails when concurrent writes touch OTHER records sharing the chain's pages, so
-   * on a busy bucket it is ordinary contention, and forcing through it would orphan chunks and skip index cleanup
-   * for a healthy record. The version-blind structural probe is what tells the two apart; it is the same
-   * discriminator {@code LocalDatabase.deleteRecord} uses for the tolerant path, and a transient conflict still
-   * propagates as the retry signal it is.
+   * The escalation is GATED, not unconditional, and that is the whole point of this method. Since #6282 the gate is
+   * the delete's OWN verdict: {@link #deleteRecordInternal} confirms a break against the newest committed image, at
+   * the same hop and to the same target, before naming it - and only that earns the force. A
+   * {@link ConcurrentModificationException} is the other answer, and it does not prove corruption: the same
+   * page-version validation fails when concurrent writes touch OTHER records sharing the chain's pages, so on a busy
+   * bucket it is ordinary contention, and forcing through it would orphan chunks and skip index cleanup for a
+   * healthy record. It propagates as the retry signal it is.
    * <p>
    * Deliberately does NOT consult {@code DELETE_TOLERATE_BROKEN_CHAIN}: that setting governs whether an ORDINARY
    * delete may force through, and its own documentation states that CHECK DATABASE FIX is unaffected by it either
@@ -645,15 +644,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // so (#6282). This is the case force exists for, and the one this method escalates for.
       LogManager.instance().log(this, Level.FINE, "Force-deleting record %s: %s", e, rid, e.getMessage());
       deleteRecord(rid, true);
-    } catch (final ConcurrentModificationException e) {
-      // CONTENTION, or a break the confirmation could not prove. The probe is what tells them apart, and since #6282
-      // it too reads the newest committed image rather than this transaction's pinned view - which matters here more
-      // than anywhere, because a false positive escalates to a FORCE delete of a healthy record.
-      if (!isChunkChainBroken(rid))
-        // CONTENTION, not corruption: preserve the NeedRetryException semantics so the caller can retry.
-        throw e;
-      deleteRecord(rid, true);
     }
+    // NO ConcurrentModificationException ARM, AND ITS REMOVAL IS THE POINT (#6282). It used to re-walk the chain
+    // with isChunkChainBroken and force through when that walk agreed - but the delete has ALREADY asked a stronger
+    // question and declined to answer it: a CME from deleteRecordInternal means the newest committed image either
+    // walks cleanly or breaks somewhere else, i.e. the record moved under the delete. Forcing on the weaker walk is
+    // how a healthy record caught mid-publication gets deleted, and this method's answer is not a message but a
+    // removal. Let it propagate as the retry signal it is; the next attempt either succeeds or comes back as the
+    // BrokenChunkChainException the arm above handles.
   }
 
   @Override
@@ -3563,8 +3561,26 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       final LongHashSet visitedPointers = walk.chunks;
 
       for (int chunkId = 0; ; ++chunkId) {
-        final long nextChunkPointer = chunkPage.readLong(
-                (int) (chunkPositionInPage + chunkHeader[1] + INT_SERIALIZED_SIZE));
+        // The chunk has to describe itself legally before its continuation pointer means anything (PR review). A
+        // size that runs past the end of the page's content area - or a negative one - is the same provable
+        // corruption the reader meets as an exception out of getImmutableView, and without this the walk followed
+        // the pointer, reached the end of a chain of nonsense and reported it CLEAN: loadMultiPageRecord could then
+        // never confirm the break, so a record with a corrupt chunk size spent its whole retry budget and was
+        // reported as contention. Same bound, in the same words, as offPageContentFingerprint and chunkFootprint.
+        final int chunkHeaderPosition = (int) (chunkPositionInPage + chunkHeader[1]);
+        final int chunkSize = chunkPage.readInt(chunkHeaderPosition);
+        if (chunkSize < 0
+                || chunkHeaderPosition + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE + chunkSize
+                > chunkPage.getMaxContentSize()) {
+          // NOT A FAILED HOP: the chunk this walk is STANDING on is malformed, so there is no pointer to name. The
+          // delete path does not read sizes at all, so its confirmation can never match this and falls back to the
+          // retry - which is the conservative answer for a shape it did not itself observe.
+          walk.brokenAtChunk = chunkId;
+          walk.brokenAtPointer = 0;
+          return "invalid chunk size at chunk " + chunkId;
+        }
+
+        final long nextChunkPointer = chunkPage.readLong(chunkHeaderPosition + INT_SERIALIZED_SIZE);
         if (nextChunkPointer == 0) {
           // REACHED THE LAST CHUNK CLEANLY. The break location is cleared rather than left pointing at the last
           // SUCCESSFUL hop: both current consumers read it only after a reason came back, but a documented invariant
@@ -3651,17 +3667,24 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   }
 
   /**
-   * Structural probe for the tolerant delete path: tells whether the record at {@code rid} is a multi-page record
-   * whose chunk chain is structurally broken. Unlike {@link #loadMultiPageRecord} this walk ignores page versions,
-   * so a version race on a chain that still walks is not reported as a break. Any failure to probe (including a
-   * record that is not multi-page, or is already gone) conservatively returns {@code false}, keeping the caller on
-   * the strict retry behaviour.
+   * DIAGNOSTIC structural probe: does the chunk chain of {@code rid} walk cleanly against the NEWEST COMMITTED image
+   * of its pages? Unlike {@link #loadMultiPageRecord} this walk ignores page versions, so a version race on a chain
+   * that still walks is not reported as a break. Any failure to probe (including a record that is not multi-page, or
+   * is already gone) conservatively returns {@code false}.
    * <p>
-   * It is the WEAKER of the two questions #6258 asks. {@link #confirmBrokenChunkChain} follows a broken walk of the
-   * committed image with a second one - are the chunks the read consumed still, byte for byte, the ones the
-   * committed image holds - which is what rules out a chain caught half-published. This has no read to compare
-   * against, so it cannot; callers that DO hold the loader's verdict must take that instead, and since #6282 the
-   * read path no longer consults this at all.
+   * <b>Never use this as the verdict that force-deletes a record</b>, which is what it was written for and what
+   * every caller of it did until #6282. It is the WEAKER of the two questions #6258 asks: a commit publishes its
+   * pages one at a time and readers take no lock, so an independently loaded set of newest images can be a chain
+   * caught HALF-PUBLISHED, and this walk reports it broken. {@link #confirmBrokenChunkChain} rules that out by
+   * following the broken walk with a second question - are the chunks the read consumed still, byte for byte, the
+   * ones the committed image holds - and {@link #confirmBrokenChunkChainOnDelete} rules it out by requiring the
+   * committed image to fail at the SAME hop, to the SAME target, the delete itself failed at. This has neither a
+   * read nor a hop to compare against, so it can rule out nothing; a caller that force-deletes on it deletes a
+   * healthy record, skips its index cleanup and orphans its continuation chunks.
+   * <p>
+   * The callers that used to consult it now take the loader's or the delete's own confirmed verdict
+   * ({@link BrokenChunkChainException}) and retry on anything weaker. What is left for this is what its name says:
+   * answering the question, for {@code CHECK DATABASE}-shaped diagnostics and for tests.
    * <p>
    * It judges from the NEWEST COMMITTED image of every page and not from the caller's transaction (#6282, item 2).
    * The distinction is invisible under {@code READ_COMMITTED}, which pins nothing, and load-bearing under

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -953,7 +953,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       final int headerPos = (int) (chunkPositionInPageOffset + chunkMarker[1]);
       final int chunkSize = chunkPage.readInt(headerPos);
-      if (chunkSize < 0 || headerPos + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE + chunkSize > chunkPage.getMaxContentSize())
+      if (!chunkImageFitsPage(chunkPage, headerPos, chunkSize))
         return NO_OFF_PAGE_FINGERPRINT;
 
       // The chunk's own identity goes in too: a chain relocated onto other slots is a different tail even when every
@@ -2875,9 +2875,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    */
   private static byte[] readChunkImage(final BasePage page, final int chunkHeaderPos) throws IOException {
     final int chunkSize = page.readInt(chunkHeaderPos);
-    final int imageSize = INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE + chunkSize;
-    if (chunkSize < 0 || chunkHeaderPos + imageSize > page.getMaxContentSize())
+    if (!chunkImageFitsPage(page, chunkHeaderPos, chunkSize))
       return null;
+    final int imageSize = INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE + chunkSize;
     final byte[] image = new byte[imageSize];
     page.readByteArray(chunkHeaderPos, image, 0, imageSize);
     return image;
@@ -3568,10 +3568,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // never confirm the break, so a record with a corrupt chunk size spent its whole retry budget and was
         // reported as contention. Same bound, in the same words, as offPageContentFingerprint and chunkFootprint.
         final int chunkHeaderPosition = (int) (chunkPositionInPage + chunkHeader[1]);
-        final int chunkSize = chunkPage.readInt(chunkHeaderPosition);
-        if (chunkSize < 0
-                || chunkHeaderPosition + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE + chunkSize
-                > chunkPage.getMaxContentSize()) {
+        if (!chunkImageFitsPage(chunkPage, chunkHeaderPosition, chunkPage.readInt(chunkHeaderPosition))) {
           // NOT A FAILED HOP: the chunk this walk is STANDING on is malformed, so there is no pointer to name. The
           // delete path does not read sizes at all, so its confirmation can never match this and falls back to the
           // retry - which is the conservative answer for a shape it did not itself observe.
@@ -4865,6 +4862,23 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    *                                 chunk-chain walk an {@code IOException} means the exact opposite - the disk
    *                                 failed, so nothing at all is proved about the record (#6282).
    */
+  /**
+   * Whether the chunk whose size field sits at {@code chunkHeaderPos} describes itself legally: a non-negative size
+   * whose {@code [int size][long nextChunk][content]} image fits inside the page's content area.
+   * <p>
+   * <b>LONG arithmetic, and that is the whole reason this is a method rather than three copies of an expression</b>
+   * (PR review on #6282): {@code chunkHeaderPos + 12 + Integer.MAX_VALUE} overflows an int to a NEGATIVE number,
+   * which passes any {@code > getMaxContentSize()} test - so the largest corrupt size representable walked straight
+   * through the guard written to stop it, while smaller ones were caught. The {@code chunkSize < 0} half only ever
+   * covered a size STORED as negative, not one that wraps the sum.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private static boolean chunkImageFitsPage(final BasePage page, final int chunkHeaderPos, final int chunkSize) {
+    return chunkSize >= 0
+            && (long) chunkHeaderPos + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE + chunkSize <= page.getMaxContentSize();
+  }
+
   private int getRecordPositionInPage(final BasePage page, final int positionInPage) throws IOException {
     final int recordPositionInPage = (int) page.readUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE);
     if (recordPositionInPage != 0 && recordPositionInPage < contentHeaderSize)

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -4856,13 +4856,6 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   }
 
   /**
-   * @throws PageCorruptionException when the slot-table entry points inside the page header, which no writer can
-   *                                 produce: the page was READ fine, its CONTENTS are nonsense. A distinct type
-   *                                 rather than a plain {@link IOException} because a few lines away in the same
-   *                                 chunk-chain walk an {@code IOException} means the exact opposite - the disk
-   *                                 failed, so nothing at all is proved about the record (#6282).
-   */
-  /**
    * Whether the chunk whose size field sits at {@code chunkHeaderPos} describes itself legally: a non-negative size
    * whose {@code [int size][long nextChunk][content]} image fits inside the page's content area.
    * <p>
@@ -4879,6 +4872,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             && (long) chunkHeaderPos + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE + chunkSize <= page.getMaxContentSize();
   }
 
+  /**
+   * @throws PageCorruptionException when the slot-table entry points inside the page header, which no writer can
+   *                                 produce: the page was READ fine, its CONTENTS are nonsense. A distinct type
+   *                                 rather than a plain {@link IOException} because a few lines away in the same
+   *                                 chunk-chain walk an {@code IOException} means the exact opposite - the disk
+   *                                 failed, so nothing at all is proved about the record (#6282).
+   */
   private int getRecordPositionInPage(final BasePage page, final int positionInPage) throws IOException {
     final int recordPositionInPage = (int) page.readUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE);
     if (recordPositionInPage != 0 && recordPositionInPage < contentHeaderSize)

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -3569,9 +3569,19 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // reported as contention. Same bound, in the same words, as offPageContentFingerprint and chunkFootprint.
         final int chunkHeaderPosition = (int) (chunkPositionInPage + chunkHeader[1]);
         if (!chunkImageFitsPage(chunkPage, chunkHeaderPosition, chunkPage.readInt(chunkHeaderPosition))) {
-          // NOT A FAILED HOP: the chunk this walk is STANDING on is malformed, so there is no pointer to name. The
-          // delete path does not read sizes at all, so its confirmation can never match this and falls back to the
-          // retry - which is the conservative answer for a shape it did not itself observe.
+          // NOT A FAILED HOP: the chunk this walk is STANDING on is malformed, so there is no pointer to name.
+          //
+          // The delete path never reads sizes, and deliberately so rather than by omission (PR review round 4 asked
+          // for this scope to be stated rather than left implicit): the size field sits BESIDE the continuation
+          // pointer, not in front of it, so a chain whose only fault is a declared size still walks perfectly - the
+          // delete finds every chunk, frees every slot and simply succeeds. There is nothing there to name and
+          // nothing to retry, which is what Issue6282BrokenChainDeleteAndProbeTest pins from the other side.
+          //
+          // The one shape where the two walks disagree is a bad size AND a bad pointer: this walk stops at the size,
+          // the delete stops at the pointer, the hops do not match and the confirmation declines. That fails SAFE -
+          // the delete keeps its retryable exception, and CHECK DATABASE FIX force-deletes on its own detection,
+          // which does read sizes. Aligning the two indices would buy that shape a permanent verdict at the cost of
+          // more index bookkeeping in the code that has already been the source of most of this issue's mistakes.
           walk.brokenAtChunk = chunkId;
           walk.brokenAtPointer = 0;
           return "invalid chunk size at chunk " + chunkId;

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -32,6 +32,7 @@ import com.arcadedb.exception.BrokenChunkChainException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DatabaseIsReadOnlyException;
 import com.arcadedb.exception.DatabaseOperationException;
+import com.arcadedb.exception.PageCorruptionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.EdgeSegment;
 import com.arcadedb.log.LogManager;
@@ -350,10 +351,23 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
      * unreachable, so a caller reasoning about reachability has to fail closed on it.
      */
     private boolean incomplete;
+    /**
+     * Where the walk broke: the index of the chunk whose continuation pointer could not be resolved, and the value
+     * of that pointer. {@code -1}/{@code 0} while the walk has proved nothing.
+     * <p>
+     * This is what lets a SECOND walk be compared against a first one rather than merely agreed with (#6282): the
+     * delete path meets a break in the transaction's view and asks the newest committed image whether the same hop,
+     * to the same target, still fails. A committed image that breaks somewhere else is a record that MOVED under the
+     * delete, which is contention and must keep its retry - not the permanent corruption verdict.
+     */
+    private int  brokenAtChunk = -1;
+    private long brokenAtPointer;
 
     private void reset() {
       chunks.clear();
       incomplete = false;
+      brokenAtChunk = -1;
+      brokenAtPointer = 0;
     }
   }
 
@@ -602,13 +616,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * Deletes a record an integrity check has already judged beyond repair, escalating to {@link #deleteRecord(RID,
    * boolean) force} only for the one failure that force exists to clear: a structurally broken chunk chain.
    * <p>
-   * The escalation is GATED on {@link #isChunkChainBroken}, not unconditional, and that is the whole point of this
-   * method. A {@link ConcurrentModificationException} from a plain delete does not prove corruption - the same
-   * page-version validation fails when concurrent writes touch OTHER records sharing the chain's pages, so on a
-   * busy bucket it is ordinary contention, and forcing through it would orphan chunks and skip index cleanup for a
-   * healthy record. The version-blind structural probe is what tells the two apart; it is the same discriminator
-   * {@code LocalDatabase.deleteRecord} uses for the tolerant path, and a transient conflict still propagates as
-   * the retry signal it is.
+   * The escalation is GATED, not unconditional, and that is the whole point of this method. Since #6282 the delete
+   * itself names a break it has confirmed against the newest committed image, so the common case needs no second
+   * question at all. What is left under {@link ConcurrentModificationException} does: it does not prove corruption -
+   * the same page-version validation fails when concurrent writes touch OTHER records sharing the chain's pages, so
+   * on a busy bucket it is ordinary contention, and forcing through it would orphan chunks and skip index cleanup
+   * for a healthy record. The version-blind structural probe is what tells the two apart; it is the same
+   * discriminator {@code LocalDatabase.deleteRecord} uses for the tolerant path, and a transient conflict still
+   * propagates as the retry signal it is.
    * <p>
    * Deliberately does NOT consult {@code DELETE_TOLERATE_BROKEN_CHAIN}: that setting governs whether an ORDINARY
    * delete may force through, and its own documentation states that CHECK DATABASE FIX is unaffected by it either
@@ -622,7 +637,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   public void deleteCorruptedRecord(final RID rid) {
     try {
       deleteRecord(rid);
+    } catch (final BrokenChunkChainException e) {
+      // NO PROBE NEEDED: the delete's own walk confirmed the break against the newest committed image before saying
+      // so (#6282). This is the case force exists for, and the one this method escalates for.
+      deleteRecord(rid, true);
     } catch (final ConcurrentModificationException e) {
+      // CONTENTION, or a break the confirmation could not prove. The probe is what tells them apart, and since #6282
+      // it too reads the newest committed image rather than this transaction's pinned view - which matters here more
+      // than anywhere, because a false positive escalates to a FORCE delete of a healthy record.
       if (!isChunkChainBroken(rid))
         // CONTENTION, not corruption: preserve the NeedRetryException semantics so the caller can retry.
         throw e;
@@ -3494,10 +3516,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * on-page size and would never notice a broken chain. Never throws.
    * <p>
    * Returns a short human-readable reason when the chain is broken, and {@code null} when it could not be PROVED
-   * broken - which covers both a chain that walks cleanly and one whose walk could not load a page at all. Every
-   * caller reads the two the same way (leave the record alone), and conflating them is deliberate: an I/O fault is
-   * not evidence of anything about the record, and since #6258 a confirmed break costs the record its retries and
-   * sends the operator to {@code CHECK DATABASE FIX}, which deletes it.
+   * broken - which covers both a chain that walks cleanly and one whose walk hit an I/O fault. Every caller reads
+   * the two the same way (leave the record alone), and conflating them is deliberate: an I/O fault is not evidence
+   * of anything about the record, and since #6258 a confirmed break costs the record its retries and sends the
+   * operator to {@code CHECK DATABASE FIX}, which deletes it.
+   * <p>
+   * The line between the two is drawn by TYPE and not by where a {@code try} sits (#6282): a page that cannot be
+   * loaded, or any other {@link IOException}, proves nothing; a {@link PageCorruptionException} - a page that read
+   * fine and whose bytes are nonsense - is a break, exactly like the marker and range checks in the walk itself.
    *
    * @param fromNewestCommitted reads the continuation pages straight from the {@link PageManager} instead of through
    *                            the transaction, so the walk sees the newest committed image rather than whatever this
@@ -3539,6 +3565,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           // REACHED THE LAST CHUNK CLEANLY
           return null;
 
+        // FROM HERE UNTIL THE NEXT LAP, ANY FAILURE - RETURNED OR THROWN - HAPPENED FOLLOWING THIS HOP. Recorded up
+        // front rather than at each exit because a corrupt slot offset leaves through an exception, and the catch
+        // that answers for it is outside the loop and cannot see these (#6282).
+        walk.brokenAtChunk = chunkId;
+        walk.brokenAtPointer = nextChunkPointer;
+
         if (!visitedPointers.add(nextChunkPointer))
           return "chain loop detected at chunk " + chunkId;
 
@@ -3562,6 +3594,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           LogManager.instance().log(this, Level.FINE,
                   "Unable to load page %s while walking the chunk chain of %s", e, nextPageIdentity, rid);
           walk.incomplete = true;
+          walk.brokenAtChunk = -1;
           return null;
         }
 
@@ -3569,6 +3602,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           // Defensive: neither page source answers null while it is allowed to materialise a missing page. A null
           // here would still not be proof of a broken chain, so it must not be reported as one.
           walk.incomplete = true;
+          walk.brokenAtChunk = -1;
           return null;
         }
 
@@ -3580,13 +3614,28 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         if (chunkHeader[0] != NEXT_CHUNK)
           return "unexpected marker at chunk " + chunkId;
       }
+    } catch (final PageCorruptionException e) {
+      // THE PAGE WAS READ, ITS CONTENTS ARE NONSENSE: a proven break, and the only shape of IOException that is one.
+      // Caught BEFORE the IOException arm below - and the compiler enforces that ordering, which is precisely the
+      // point of giving this condition a type of its own (#6282, item 3).
+      walk.incomplete = true;
+      return "corrupt page content walking the chain: " + e.getMessage();
+    } catch (final IOException e) {
+      // THE OPPOSITE MEANING, a few lines from the one above: the disk failed, so nothing whatsoever is proved about
+      // the record. Answering a break here is what #6258's third review round caught at the page LOAD, and until the
+      // corrupt-offset case above got its own type this arm could not be written without swallowing it too.
+      LogManager.instance().log(this, Level.FINE, "I/O error while walking the chunk chain of %s", e, rid);
+      walk.incomplete = true;
+      walk.brokenAtChunk = -1;
+      return null;
     } catch (final Exception e) {
-      // Reported as a break, which is what this has always answered and what {@code check(fix)} deletes the record on.
-      // But NOT as a walk that reached a conclusion: unlike the marker and range checks above, which prove a break
-      // from the bytes, an exception here is only as trustworthy as its cause - a corrupt offset says the chain is
-      // broken, anything else says the walk failed. The caller that reasons about REACHABILITY must not be made to
-      // choose, so it is told the walk is incomplete and fails closed; the chunks past this point are not proof of
-      // an orphan, and freeing them on this evidence would be unrecoverable (PR review).
+      // What is left is the unchecked family the page accessors raise for an offset that leaves the page
+      // (IndexOutOfBounds / IllegalArgument / BufferUnderflow, depending on which one caught it first), which is the
+      // same "provably bad bytes" signal BucketIterator reads them as. Reported as a break, which is what this has
+      // always answered and what {@code check(fix)} deletes the record on. But NOT as a walk that reached a
+      // conclusion: the caller that reasons about REACHABILITY is told the walk is incomplete and fails closed - the
+      // chunks past this point are not proof of an orphan, and freeing them on this evidence would be unrecoverable
+      // (PR review). The two shapes that are NOT bad bytes now leave through their own arms above.
       walk.incomplete = true;
       return "error walking chain: " + e.getMessage();
     }
@@ -3595,32 +3644,33 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   /**
    * Structural probe for the tolerant delete path: tells whether the record at {@code rid} is a multi-page record
    * whose chunk chain is structurally broken. Unlike {@link #loadMultiPageRecord} this walk ignores page versions,
-   * so a transient concurrent modification never reports {@code true} - only a genuinely broken chain does. Any
-   * failure to probe (including a record that is not multi-page, or is already gone) conservatively returns
-   * {@code false}, keeping the caller on the strict retry behaviour.
+   * so a version race on a chain that still walks is not reported as a break. Any failure to probe (including a
+   * record that is not multi-page, or is already gone) conservatively returns {@code false}, keeping the caller on
+   * the strict retry behaviour.
+   * <p>
+   * It is the WEAKER of the two questions #6258 asks. {@link #confirmBrokenChunkChain} follows a broken walk of the
+   * committed image with a second one - are the chunks the read consumed still, byte for byte, the ones the
+   * committed image holds - which is what rules out a chain caught half-published. This has no read to compare
+   * against, so it cannot; callers that DO hold the loader's verdict must take that instead, and since #6282 the
+   * read path no longer consults this at all.
+   * <p>
+   * It judges from the NEWEST COMMITTED image of every page and not from the caller's transaction (#6282, item 2).
+   * The distinction is invisible under {@code READ_COMMITTED}, which pins nothing, and load-bearing under
+   * {@code REPEATABLE_READ}: a transaction that has already walked these pages holds them pinned, so a chain a
+   * concurrent commit has since REWRITTEN still presents as broken in the pinned image while walking cleanly in the
+   * committed one. What the answer is used for is what makes that unacceptable rather than merely imprecise - every
+   * caller escalates a {@code true} to a FORCE delete, and {@code check(fix)} deletes the record it flags, so a
+   * false positive here removes a healthy record. The walk it delegates to is the one #6258 already built to confirm
+   * a break authoritatively on the read path.
    *
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
   public boolean isChunkChainBroken(final RID rid) {
     try {
-      final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
-      final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
-      if (pageId >= getTotalPages())
-        return false;
-
-      final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
-      final int recordPositionInPage = getRecordPositionInPage(page, positionInPage);
-      if (recordPositionInPage == 0)
-        // DELETED
-        return false;
-
-      final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
-      if (!isChunkHead(recordSize[0]))
-        // NOT A MULTI-PAGE RECORD: A CME ON IT CANNOT COME FROM A BROKEN CHAIN
-        return false;
-
-      return findBrokenChunkChain(rid, page, recordPositionInPage, false) != null;
+      return findBrokenChunkChainInNewestCommitted(rid) != null;
     } catch (final Exception e) {
+      // CANNOT PROVE ANYTHING - INCLUDING AN I/O FAULT, WHICH MUST NEVER BECOME A LICENCE TO FORCE-DELETE
+      LogManager.instance().log(this, Level.FINE, "Unable to probe the chunk chain of %s", e, rid);
       return false;
     }
   }
@@ -3718,12 +3768,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             final int chunkPositionInPage = (int) (nextChunkPointer % maxRecordsInPage);
 
             // Resolve the next chunk. A broken link (out-of-range pointer, a slot that was cleaned, or a marker that
-            // is no longer NEXT_CHUNK) means the chain cannot be walked. Without force this is treated as a concurrent
-            // modification and rethrown as the #4932 retry signal, so a half-freed chain is never left behind. With
-            // force (admin repair) the walk stops here instead: the head slot is still freed below, and the chunks
-            // past this break are orphaned - a bounded space leak that the orphaned-chunk sweep of check(fix)
-            // reclaims (#6294), which is the only thing that does: compaction re-flows LIVE slots, and an orphaned
-            // chunk still has one.
+            // is no longer NEXT_CHUNK) means the chain cannot be walked. Without force the record is left alone, so a
+            // half-freed chain is never left behind - as WHICH exception, see the confirmation below. With force
+            // (admin repair) the walk stops here instead: the head slot is still freed below, and the chunks past
+            // this break are orphaned - a bounded space leak that the orphaned-chunk sweep of check(fix) reclaims
+            // (#6294), which is the only thing that does: compaction re-flows LIVE slots, and an orphaned chunk
+            // still has one.
             String chainProblem = null;
             try {
               if (chunkPageId >= getTotalPages())
@@ -3740,6 +3790,11 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                     chainProblem = "chunk marker is not NEXT_CHUNK";
                 }
               }
+            } catch (final PageCorruptionException e) {
+              // The page read fine and its bytes are nonsense: a STRUCTURAL problem exactly like the three above,
+              // and one no retry can resolve. It used to leave here as a plain IOException, which the arm below
+              // rethrew to a caller with no way to tell it from a disk that had just failed (#6282, item 3).
+              chainProblem = "corrupt chunk slot: " + e.getMessage();
             } catch (final IOException e) {
               if (!force)
                 throw e;
@@ -3747,10 +3802,26 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             }
 
             if (chainProblem != null) {
-              if (!force)
-                // Chunk was modified/removed by a concurrent operation — signal retry (#4932)
+              if (!force) {
+                // CORRUPTION IS NOT CONTENTION (#6258), and until #6282 this path said otherwise: it raised the
+                // #4932 retry signal for a chain it had just positively identified as structurally broken, costing
+                // the caller a full round of transactions before it gave up and forcing five call sites to walk the
+                // chain a SECOND time just to find out which of the two they were holding.
+                final String confirmed = confirmBrokenChunkChainOnDelete(rid, chunkId, nextChunkPointer);
+                if (confirmed != null)
+                  throw new BrokenChunkChainException(
+                          "Multi-page record " + rid + " has a broken chunk chain at chunk " + chunkId + " ("
+                                  + chainProblem + (confirmed.equals(chainProblem) ?
+                                  "" :
+                                  "; the committed image reports: " + confirmed)
+                                  + "): the record is corrupted and cannot be deleted. Run CHECK DATABASE FIX to "
+                                  + "repair it, or enable " + GlobalConfiguration.DELETE_TOLERATE_BROKEN_CHAIN.getKey()
+                                  + " to force the delete through");
+
+                // Chunk was modified/removed by a concurrent operation - signal retry (#4932)
                 throw new ConcurrentModificationException(
                         "Multi-page record " + rid + " chunk " + chunkId + " was modified concurrently. Please retry");
+              }
 
               LogManager.instance().log(this, Level.WARNING,
                       "Force-deleting multi-page record %s with a broken chunk chain at chunk %d (%s); orphaned chunks (if "
@@ -3855,6 +3926,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
               .log(this, Level.FINE, "Deleted record %s (%s threadId=%d)", null, rid, page, Thread.currentThread().threadId());
 
     } catch (final RecordNotFoundException e) {
+      throw e;
+    } catch (final BrokenChunkChainException e) {
+      // #6282: the corruption verdict thrown above, and it needs this arm for exactly the reason the #4932 one below
+      // does - the generic catch would swallow it, zero the slot pointer and report success, orphaning every chunk
+      // past the break and telling the caller a corrupted record had been deleted cleanly. Rethrow so the operator
+      // hears it, and so the tolerant path can decide whether to force the delete through.
       throw e;
     } catch (final ConcurrentModificationException e) {
       // #4932: this is the retry signal deliberately thrown above when a multi-page chunk chain was modified
@@ -4619,6 +4696,53 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   }
 
   /**
+   * The delete path's counterpart of {@link #confirmBrokenChunkChain}: confirms that a chunk chain
+   * {@link #deleteRecordInternal} could not walk is genuinely broken rather than a record that MOVED under the
+   * delete, and returns the reason it is broken, or {@code null} when the break cannot be told apart from
+   * contention - in which case the caller keeps the retryable {@link ConcurrentModificationException} it always
+   * raised (#6282, item 1).
+   * <p>
+   * The read path answers its second question with the bytes it consumed; a delete consumes none, so it asks a
+   * sharper one instead: does the newest committed image fail at the SAME HOP, to the SAME TARGET? Two facts make
+   * that the right question. A commit publishes its pages one at a time and readers take no lock, so a chain caught
+   * mid-publication can look broken while being sound at both ends of it - and a clean walk here rules that out. And
+   * a chain that is broken in the committed image but broken SOMEWHERE ELSE is not the chain this delete walked at
+   * all: the record was rewritten under it, which is contention and must keep its retry rather than earn the
+   * permanent verdict.
+   * <p>
+   * Only when both agree does the delete stop calling corruption contention. Everything else - an I/O fault while
+   * confirming, a record that has since been deleted or rewritten as a single-page one - falls back to the retry
+   * rather than condemn a record, because the verdict is not merely a message: it is non-retryable, and it points
+   * the operator at {@code CHECK DATABASE FIX}, which DELETES the record.
+   *
+   * @param chunkId          index of the chunk whose continuation pointer the delete could not follow
+   * @param nextChunkPointer the pointer it could not follow
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private String confirmBrokenChunkChainOnDelete(final RID rid, final int chunkId, final long nextChunkPointer) {
+    try {
+      final ChunkChainWalk walk = new ChunkChainWalk();
+      final String reason = findBrokenChunkChainInNewestCommitted(rid, walk);
+      if (reason == null)
+        // THE COMMITTED CHAIN WALKS CLEANLY (or the record is no longer a chunked one): contention, which is what
+        // the retry is for.
+        return null;
+
+      if (walk.brokenAtChunk != chunkId || walk.brokenAtPointer != nextChunkPointer)
+        // BROKEN, BUT NOT WHERE THIS DELETE BROKE: a different chain, so a record that moved rather than a corrupt one.
+        return null;
+
+      return reason;
+    } catch (final Exception e) {
+      // Could not prove corruption (an I/O fault, most likely): fall back to the retry rather than condemn a record.
+      LogManager.instance()
+              .log(this, Level.FINE, "Unable to confirm whether the chunk chain of %s is broken", e, rid);
+      return null;
+    }
+  }
+
+  /**
    * {@link #findBrokenChunkChain} against the newest committed image of every page, transaction snapshot and all
    * page versions ignored. Returns {@code null} when the chain walks cleanly, and also when the record is no longer
    * there to walk (deleted, or no longer a chunked record): that is a record that changed, not a broken chain.
@@ -4626,6 +4750,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
   private String findBrokenChunkChainInNewestCommitted(final RID rid) throws IOException {
+    return findBrokenChunkChainInNewestCommitted(rid, new ChunkChainWalk());
+  }
+
+  /**
+   * @param walk collects the chunks the confirmation walk went through and WHERE it broke, so a caller can compare
+   *             the committed image's break against the one it met itself rather than merely agree with it (#6282).
+   */
+  private String findBrokenChunkChainInNewestCommitted(final RID rid, final ChunkChainWalk walk) throws IOException {
     final int pageNumber = (int) (rid.getPosition() / maxRecordsInPage);
     final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
     if (pageNumber >= getTotalPages())
@@ -4648,7 +4780,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // NO LONGER A MULTI-PAGE RECORD: the record was rewritten under the read.
       return null;
 
-    return findBrokenChunkChain(rid, head, recordPositionInPage, true);
+    return findBrokenChunkChain(rid, head, recordPositionInPage, true, walk);
   }
 
   /**
@@ -4694,10 +4826,17 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     }
   }
 
+  /**
+   * @throws PageCorruptionException when the slot-table entry points inside the page header, which no writer can
+   *                                 produce: the page was READ fine, its CONTENTS are nonsense. A distinct type
+   *                                 rather than a plain {@link IOException} because a few lines away in the same
+   *                                 chunk-chain walk an {@code IOException} means the exact opposite - the disk
+   *                                 failed, so nothing at all is proved about the record (#6282).
+   */
   private int getRecordPositionInPage(final BasePage page, final int positionInPage) throws IOException {
     final int recordPositionInPage = (int) page.readUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE);
     if (recordPositionInPage != 0 && recordPositionInPage < contentHeaderSize)
-      throw new IOException(
+      throw new PageCorruptionException(
           "Invalid record #" + fileId + ":" + recordPosition(page.pageId.getPageNumber(), maxRecordsInPage, positionInPage));
     return recordPositionInPage;
   }

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -116,6 +116,14 @@ public class PageManager extends LockContext {
   private final    AtomicLong                        totalSnapshotBarrierMillis            = new AtomicLong();
   private final    AtomicLong                        maxSnapshotBarrierMillis              = new AtomicLong();
   private final    AtomicLong                        totalSnapshotBarriersInexact          = new AtomicLong();
+  // #6132, item 2: a barrier that gives up before publishing a window was counted only as a barrier, indistinguishable
+  // from one that succeeded. The two invalidation counters above require a window to EXIST, so they cannot see it.
+  // Split by the step that gave up, because the answer differs: SUSPEND_TIMEOUT is a busy process (another suspender
+  // resuming), FLUSH_TIMEOUT is a sick disk, and the rest is everything else - and the consumer's fallback to
+  // suspend-and-freeze hides all three behind a backup that still completes, just by throttling every writer.
+  private final    AtomicLong                        totalSnapshotBarriersFailed           = new AtomicLong();
+  private final    AtomicLong                        totalSnapshotBarriersFailedSuspend    = new AtomicLong();
+  private final    AtomicLong                        totalSnapshotBarriersFailedFlush      = new AtomicLong();
   private volatile long                              lastCheckForRAM                       = 0;
   // LIFECYCLE INVARIANT (#5070): flushThread and readCache are written only under LIFECYCLE_LOCK
   // during the 0->1 startup / 1->0 shutdown transitions, and read lock-free on the hot paths. That is safe
@@ -174,6 +182,49 @@ public class PageManager extends LockContext {
    * archive the backup is writing and the ordinary growth of the database while the window is open.
    */
   private static final int SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR = 2;
+
+  /**
+   * TEST-ONLY fault injection on the logical page-read funnel (#6282, item 4).
+   * <p>
+   * There was no way to make a specific page read fail on demand, and the paths whose WRONG ANSWER is the most
+   * expensive in the engine are exactly the I/O-failure paths: {@code LocalBucket.findBrokenChunkChain} answering
+   * "the chain is broken" for a page it merely could not read condemns a HEALTHY record permanently and points the
+   * operator at {@code CHECK DATABASE FIX}, which deletes it. That defect was found by reading rather than by a
+   * test, in the third review round of #6258, and it could not have been found by a test.
+   * <p>
+   * It hooks {@link #getCachedPage}, the funnel {@link #getImmutablePage} and {@link #getMutablePage} both go
+   * through, rather than the physical read in {@link #loadPage}: a test that wants a read to fail has no way to keep
+   * the page out of the read cache, so a hook on the physical read would simply never fire for a page the engine has
+   * just written.
+   * <p>
+   * <b>Cost when nothing is installed</b>: one read of a {@code static volatile} reference that is always null and a
+   * branch the predictor always gets right - the same shape, and the same reasoning, as {@link #activeSnapshots} on
+   * the write path. Nothing is allocated and nothing is looked up.
+   * <p>
+   * Static because a test installs it before it has a {@link PageManager} reference to hand, and JVM-wide because
+   * this class is. Tests MUST clear it in a {@code finally}.
+   */
+  @ExcludeFromJacocoGeneratedReport
+  @FunctionalInterface
+  public interface PageReadFaultInjector {
+    /**
+     * @throws IOException to make this logical page read fail, as a disk that could not serve the page would. Return
+     *                     normally to let it proceed.
+     */
+    void onPageRead(PageId pageId) throws IOException;
+  }
+
+  private static volatile PageReadFaultInjector pageReadFaultInjector = null;
+
+  /** Installs (or, with {@code null}, removes) the test-only page-read fault injector. See {@link PageReadFaultInjector}. */
+  public static void setPageReadFaultInjector(final PageReadFaultInjector injector) {
+    pageReadFaultInjector = injector;
+  }
+
+  /** The installed test-only page-read fault injector, {@code null} when there is none - which is the steady state. */
+  public static PageReadFaultInjector getPageReadFaultInjector() {
+    return pageReadFaultInjector;
+  }
 
   @ExcludeFromJacocoGeneratedReport
   public interface ConcurrentPageAccessCallback {
@@ -258,6 +309,17 @@ public class PageManager extends LockContext {
      * publication locks held - so a non-zero value means index compaction was feeding the pipeline throughout.
      */
     public long   snapshotBarriersInexact;
+    /**
+     * #6132: barriers that gave up before publishing a window at all, and the split of the two steps that can. A
+     * failed barrier leaves NO other trace an operator can alert on - {@link #snapshotWindowsInvalidated} and its two
+     * halves are incremented from a window that exists, and the consumer falls back to suspend-and-freeze and still
+     * completes - so without these a backup that has quietly gone back to throttling every writer on the server looks
+     * exactly like one that has not. {@code snapshotBarriersFailedSuspend} is transient and expected under load;
+     * {@code snapshotBarriersFailedFlush} is a write that never landed, which points at the disk.
+     */
+    public long   snapshotBarriersFailed;
+    public long   snapshotBarriersFailedSuspend;
+    public long   snapshotBarriersFailedFlush;
     /** See {@link PageManager#getDeferredRAMBytes()} (#6087): dirty pages held in RAM by a flush suspension. */
     public long   deferredRAMBytes;
     /** See {@link PageManager#getFlushQueueWaits()} (#6259): commits held waiting for room in the flush queue. */
@@ -539,6 +601,20 @@ public class PageManager extends LockContext {
     maxSnapshotBarrierMillis.accumulateAndGet(elapsedMillis, Math::max);
   }
 
+  /**
+   * Counts a barrier that gave up before publishing a window (#6132, item 2). Always bumps the total, and the split
+   * counter for the step that gave up when there is one - the total is what an operator alerts on, the split is what
+   * tells them where to look. Paired with {@link #recordSnapshotBarrier}, which times this barrier whether it
+   * succeeded or not.
+   */
+  private void recordSnapshotBarrierFailure(final PageSnapshotException.Reason reason) {
+    totalSnapshotBarriersFailed.incrementAndGet();
+    if (reason == PageSnapshotException.Reason.SUSPEND_TIMEOUT)
+      totalSnapshotBarriersFailedSuspend.incrementAndGet();
+    else if (reason == PageSnapshotException.Reason.FLUSH_TIMEOUT)
+      totalSnapshotBarriersFailedFlush.incrementAndGet();
+  }
+
   private PageSnapshot openSnapshotInternal(final DatabaseInternal database) throws IOException, InterruptedException {
     final PageManagerFlushThread thread = flushThread;
     if (thread == null)
@@ -633,6 +709,16 @@ public class PageManager extends LockContext {
         } finally {
           applyLock.writeLock().unlock();
         }
+      } catch (final PageSnapshotException e) {
+        // #6132: A BARRIER THAT NEVER PUBLISHES A WINDOW IS INVISIBLE TO EVERY OTHER SNAPSHOT COUNTER - THEY ALL
+        // REQUIRE A WINDOW TO EXIST - AND ITS CONSUMER FALLS BACK TO SUSPEND-AND-FREEZE AND STILL COMPLETES, SO THE
+        // BACKUP THAT NOW THROTTLES EVERY WRITER ON THE SERVER REPORTS SUCCESS. COUNTED HERE, SPLIT BY THE STEP THAT
+        // GAVE UP
+        recordSnapshotBarrierFailure(e.getReason());
+        throw e;
+      } catch (final IOException | InterruptedException | RuntimeException e) {
+        recordSnapshotBarrierFailure(PageSnapshotException.Reason.OTHER);
+        throw e;
       } finally {
         if (suspended)
           thread.setSuspended(database, false);
@@ -742,10 +828,15 @@ public class PageManager extends LockContext {
         continue;
       }
 
-      // getTotalPages() is a channel.size() syscall, and unlike SnapshotFile.lastModified() it CANNOT be made lazy:
-      // the page count at t0 is what defines which pages the snapshot covers, and reading it later would let a page
-      // appended after t0 into the snapshot un-shadowed. An fstat per file is orders of magnitude cheaper than the
-      // flush-queue drain this same barrier already performed.
+      // The page count at t0 is what defines which pages the snapshot covers, so unlike SnapshotFile.lastModified()
+      // it CANNOT be made lazy: reading it later would let a page appended after t0 into the snapshot un-shadowed.
+      // It is no longer a channel.size() SYSCALL, though, which is a different question and the one #6132 asked:
+      // #6126 waved the fstat through as "definitionally part of t0", true about WHEN it must be read and not about
+      // what it has to cost. Dozens to hundreds of them - one per bucket, index and compacted sub-index, each with a
+      // channelLock acquisition - ran under the JVM-wide lock the rest of this barrier works to keep short, and on a
+      // stalled filesystem not one of them was bounded by SNAPSHOT_BARRIER_MAX_MILLIS the way every other step is.
+      // PaginatedComponentFile now keeps the count itself; see its `totalPages` field for why it is exact, and
+      // Issue6132SnapshotBarrierFollowupsTest for the assertion that it agrees with the filesystem at t0.
       files.add(new PageSnapshot.SnapshotFile(paginated.getFileId(), paginated, paginated.getPageSize(),
           (int) paginated.getTotalPages(), paginated.getFileName()));
     }
@@ -796,7 +887,10 @@ public class PageManager extends LockContext {
    * <ul>
    * <li>the t0 size of the page files, which the shadow provably cannot exceed - it holds ONE pre-image per page that
    * existed at t0, and pages appended after t0 need none (challenge C7);</li>
-   * <li>half the space still usable on the spill volume, so a window can never be the reason the disk fills.</li>
+   * <li>half the space still usable on the spill volume, so a window can never be the reason the disk fills - but
+   * never LESS than {@code arcadedb.pageSnapshotMaxRAM}, because that half of the budget never touches the disk at
+   * all (#6132). Below it, a shadow that would have lived entirely in RAM was refused over free space it was never
+   * going to use.</li>
    * </ul>
    * The flat 1 GB default this replaces was measured to be undersized for what it protects: on a 128 MB database
    * under a flat-out writer the shadow reached 100% of the database size, so ANY fixed number is simply the database
@@ -834,11 +928,22 @@ public class PageManager extends LockContext {
     if (spillVolumeUsableSpace <= 0)
       return databaseSize;
 
+    // THE RAM BUDGET NEEDS NO DISK, SO IT IS NOT BOUNDED BY DISK (#6132, item 3). The cap covers RAM PLUS spill, and
+    // sizing it from the free space alone put it BELOW arcadedb.pageSnapshotMaxRAM whenever the spill volume had less
+    // than twice the RAM budget free - 20 MB against a 64 MB default on a volume with 40 MB free. A shadow that would
+    // have lived entirely in RAM and never written a byte to that volume was then invalidated at 20 MB, and its
+    // backup fell back to throttling every writer because of space it was never going to use, in exactly the case
+    // pageSnapshotSpillPath exists for: an operator who pointed it at a small volume.
+    final long ramBudget = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM) * 1024 * 1024;
+
     // CLAMPED TO AT LEAST ONE BYTE: THE DIVISION IS INTEGER, SO A VOLUME DOWN TO ITS LAST BYTE COMPUTES 1/2 == 0 AND
     // WOULD HAND THE SHADOW THE SAME "UNCAPPED" SENTINEL THE BRANCH ABOVE EXISTS TO AVOID - INVERTING THIS CAP
     // PRECISELY IN THE DISK-ALMOST-FULL CASE IT IS FOR. A ONE-BYTE CAP INSTEAD BREACHES ON THE FIRST CAPTURE, WHICH
-    // IS THE CORRECT ANSWER: THE WINDOW IS ABANDONED AND ITS CONSUMER FALLS BACK
-    return Math.max(1L, Math.min(databaseSize, spillVolumeUsableSpace / SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR));
+    // IS THE CORRECT ANSWER: THE WINDOW IS ABANDONED AND ITS CONSUMER FALLS BACK.
+    // The outer min() is unchanged and still the provable ceiling: whichever of the two budgets wins, no shadow can
+    // ever need more than one pre-image per page that existed at t0.
+    return Math.max(1L,
+        Math.min(databaseSize, Math.max(ramBudget, spillVolumeUsableSpace / SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR)));
   }
 
   private PageSnapshot registerSnapshot(final PageSnapshot snapshot) {
@@ -1396,6 +1501,9 @@ public class PageManager extends LockContext {
     stats.snapshotBarrierMillis = totalSnapshotBarrierMillis.get();
     stats.snapshotBarrierMaxMillis = maxSnapshotBarrierMillis.get();
     stats.snapshotBarriersInexact = totalSnapshotBarriersInexact.get();
+    stats.snapshotBarriersFailed = totalSnapshotBarriersFailed.get();
+    stats.snapshotBarriersFailedSuspend = totalSnapshotBarriersFailedSuspend.get();
+    stats.snapshotBarriersFailedFlush = totalSnapshotBarriersFailedFlush.get();
     stats.deferredRAMBytes = getDeferredRAMBytes();
     stats.flushQueueWaits = getFlushQueueWaits();
     collectSnapshotGauges(stats);
@@ -1808,6 +1916,12 @@ public class PageManager extends LockContext {
    */
   private CachedPage getCachedPage(final PageId pageId, final int pageSize, final boolean isNew, final boolean createIfNotExists)
       throws IOException {
+    // #6282, item 4: the ONE place a logical page read can be made to fail on demand. See PageReadFaultInjector for
+    // why it is here and not at the physical read, and for what it costs when nothing is installed (a null field).
+    final PageReadFaultInjector faultInjector = pageReadFaultInjector;
+    if (faultInjector != null)
+      faultInjector.onPageRead(pageId);
+
     checkForPageDisposal();
 
     CachedPage page = readCache.get(pageId);

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -210,7 +210,9 @@ public class PageManager extends LockContext {
    * the write path. Nothing is allocated and nothing is looked up.
    * <p>
    * Static because a test installs it before it has a {@link PageManager} reference to hand, and JVM-wide because
-   * this class is. Tests MUST clear it in a {@code finally}.
+   * this class is. Tests MUST clear it in a {@code finally}. That also makes it the one piece of state here that
+   * would not survive PARALLEL test execution: the engine module runs its tests sequentially today, and a move to
+   * parallel execution needs this scoped per-test (or those tests kept off the parallel lane) before it happens.
    */
   @ExcludeFromJacocoGeneratedReport
   @FunctionalInterface

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -184,6 +184,14 @@ public class PageManager extends LockContext {
   private static final int SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR = 2;
 
   /**
+   * The installed test-only page-read fault injector, {@code null} when there is none - which is the steady state.
+   * Declared here with the other fields, ahead of the interface that types it: a field after a nested type is a PMD
+   * FieldDeclarationsShouldBeAtStartOfClass violation, and a forward reference to a type declared later in the same
+   * file is perfectly ordinary Java. See {@link PageReadFaultInjector} for what it is for.
+   */
+  private static volatile PageReadFaultInjector pageReadFaultInjector = null;
+
+  /**
    * TEST-ONLY fault injection on the logical page-read funnel (#6282, item 4).
    * <p>
    * There was no way to make a specific page read fail on demand, and the paths whose WRONG ANSWER is the most
@@ -213,8 +221,6 @@ public class PageManager extends LockContext {
      */
     void onPageRead(PageId pageId) throws IOException;
   }
-
-  private static volatile PageReadFaultInjector pageReadFaultInjector = null;
 
   /** Installs (or, with {@code null}, removes) the test-only page-read fault injector. See {@link PageReadFaultInjector}. */
   public static void setPageReadFaultInjector(final PageReadFaultInjector injector) {

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
@@ -34,6 +34,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.spi.AbstractInterruptibleChannel;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.zip.CRC32;
@@ -52,6 +53,35 @@ public class PaginatedComponentFile extends ComponentFile {
    * channel can never be closed or replaced from under an in-flight operation.
    */
   private final ReentrantReadWriteLock channelLock = new ReentrantReadWriteLock();
+
+  /**
+   * How many whole pages this file holds, maintained in memory instead of asked of the filesystem (#6132, item 1).
+   * <p>
+   * It is EXACT rather than an estimate, and the argument is short: a paginated component file is extended by
+   * exactly one operation, {@link #write(MutablePage)}, which always writes one whole page at
+   * {@code pageNumber * pageSize}; nothing truncates it, and nothing else writes to the channel. Seeded from the
+   * real length at {@link #open}, advanced past every successful write, and re-seeded whenever the channel is
+   * reopened or renamed, it therefore says exactly what {@code channel.size() / pageSize} says. The monotonic
+   * {@code max} is not an approximation either: the value it maxes against is the file's own length, which only
+   * grows.
+   * <p>
+   * Why it is worth having: {@link PageManager}'s t0 snapshot barrier reads it once per page file while holding the
+   * JVM-wide page-manager lock, behind which every committer of every database in the process queues. On a database
+   * with many buckets, indexes and compacted sub-indexes that was dozens to hundreds of {@code fstat} calls plus a
+   * {@code channelLock} acquisition each, none of them bounded by the barrier's deadline on a stalled filesystem -
+   * the last unbounded filesystem I/O left under those locks. The second reader is {@link PageManager}'s
+   * new-page test on every read-cache miss, which is as hot as the engine gets.
+   */
+  private volatile int totalPages;
+
+  /**
+   * Updates {@link #totalPages} atomically WITHOUT an {@code AtomicInteger}: {@link #open} runs from the superclass
+   * constructor, before this class's field initializers, so an object field would still be null when it has to be
+   * seeded. A {@code volatile int} declared without an initializer keeps the value {@code open()} writes, and the
+   * updater - a static, created once at class initialization - gives the same compare-and-set the counter was for.
+   */
+  private static final AtomicIntegerFieldUpdater<PaginatedComponentFile> TOTAL_PAGES_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(PaginatedComponentFile.class, "totalPages");
 
   public static class InterruptibleInvocationHandler implements InvocationHandler {
     @Override
@@ -209,7 +239,20 @@ public class PaginatedComponentFile extends ComponentFile {
     }
   }
 
-  public long getTotalPages() throws IOException {
+  /**
+   * Whole pages this file holds. A field read, not a syscall - see {@link #totalPages} for why the two are the same
+   * number and why the difference matters (#6132).
+   */
+  public long getTotalPages() {
+    return totalPages;
+  }
+
+  /**
+   * The same number, read from the filesystem. Nothing in the engine calls this: it exists so a test can assert that
+   * the in-memory counter and the file agree, which is the whole warrant for {@link #getTotalPages()} not being a
+   * syscall.
+   */
+  public long getTotalPagesFromChannel() throws IOException {
     channelLock.readLock().lock();
     try {
       return channel.size() / pageSize;
@@ -288,6 +331,14 @@ public class PaginatedComponentFile extends ComponentFile {
             Thread.currentThread().interrupt();
         }
       }
+
+      // AFTER THE WRITE RETURNED, NOT BEFORE: the counter then never claims a page the file does not hold yet, which
+      // is the direction that matters - a reader told a page exists goes on to read it. The write above is the ONLY
+      // operation that extends this file, so this is where the length changes and the only place the counter has to
+      // follow it (#6132).
+      final int pagesAfterThisWrite = pageNumber + 1;
+      if (pagesAfterThisWrite > totalPages)
+        TOTAL_PAGES_UPDATER.accumulateAndGet(this, pagesAfterThisWrite, Math::max);
     } finally {
       channelLock.readLock().unlock();
     }
@@ -463,6 +514,11 @@ public class PaginatedComponentFile extends ComponentFile {
     this.file = new RandomAccessFile(osFile, mode == MODE.READ_WRITE ? "rw" : "r");
     this.channel = this.file.getChannel();
     doNotCloseOnInterrupt(this.channel);
+    // (RE)SEED THE IN-MEMORY PAGE COUNT FROM THE REAL LENGTH: this is the only place the file's size can change
+    // without this class having written it - a fresh open, a reopen after an interrupt closed the channel, or a
+    // rename. set() and not max(), so a file whose content was replaced under a rename cannot leave a stale higher
+    // count behind. A partial tail left by a kill is floored away exactly as PaginatedComponent does it.
+    this.totalPages = (int) (osFile.length() / pageSize);
     this.open = true;
   }
 

--- a/engine/src/main/java/com/arcadedb/exception/PageCorruptionException.java
+++ b/engine/src/main/java/com/arcadedb/exception/PageCorruptionException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.exception;
+
+import java.io.IOException;
+
+/**
+ * The bytes read out of a page do not make sense: a slot-table entry pointing inside the page header, a record
+ * marker where none can be, an offset past the end of the content. The page was READ successfully - this says
+ * nothing about the disk, and everything about what is on it.
+ * <p>
+ * It exists to separate the two opposite meanings {@link IOException} used to carry inside one chunk-chain walk
+ * (issue #6282, item 3). {@code LocalBucket.findBrokenChunkChain} answers "cannot prove a break" for a page it could
+ * not LOAD - an I/O fault is not evidence about a record - and "the chain is broken" for a page whose CONTENTS are
+ * nonsense; before this type the only thing keeping the two apart was where the {@code try}/{@code catch} sat, a
+ * positional invariant that the next restructuring of that walk had no type-level signal to preserve. The
+ * consequence of getting it backwards is not academic: since #6258 a confirmed break is permanent and non-retryable,
+ * and sends the operator to {@code CHECK DATABASE FIX}, which DELETES the record.
+ * <p>
+ * It extends {@link IOException} deliberately rather than being an unchecked {@link ArcadeDBException}: every page
+ * accessor on this path already declares {@code throws IOException}, and every caller that today treats a corrupt
+ * offset as an I/O failure keeps compiling and keeps behaving as it did. Only the callers that WANT the distinction
+ * catch this type first - which, because a subclass must be caught before its supertype, the compiler enforces.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PageCorruptionException extends IOException {
+  public PageCorruptionException(final String message) {
+    super(message);
+  }
+
+  public PageCorruptionException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/BrokenMultiPageRecordDeleteTest.java
+++ b/engine/src/test/java/com/arcadedb/BrokenMultiPageRecordDeleteTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
 import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.exception.BrokenChunkChainException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -136,14 +137,16 @@ class BrokenMultiPageRecordDeleteTest extends TestHelper {
       assertThat(bucket.isChunkChainBroken(intact)).isFalse();
     });
 
-    // The default (non-force) physical delete must still raise the #4932 retry signal on the broken chunk chain, so
-    // transient conflicts keep retrying instead of silently orphaning chunks.
+    // The default (non-force) physical delete must refuse. Since #6282 it refuses by NAME: the walk confirms the
+    // break against the newest committed image and raises BrokenChunkChainException, which is deliberately not a
+    // NeedRetryException - where it used to raise the #4932 retry signal, sending the caller round a retry loop that
+    // could not possibly succeed. Either way nothing is silently orphaned.
     database.begin();
     try {
       bucket.deleteRecord(broken);
-      fail("Expected ConcurrentModificationException on deleting a record with a broken chunk chain");
-    } catch (final ConcurrentModificationException expected) {
-      // EXPECTED: broken chain surfaces as the retry signal without force.
+      fail("Expected BrokenChunkChainException on deleting a record with a broken chunk chain");
+    } catch (final BrokenChunkChainException expected) {
+      // EXPECTED: a confirmed broken chain is corruption, not contention.
     } finally {
       database.rollback();
     }

--- a/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
@@ -113,6 +113,11 @@ class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
     final List<PageSnapshot.SnapshotFile> files = List.of(
         new PageSnapshot.SnapshotFile(0, null, 65_536, 1, "one.bucket"));
 
+    // NO RAM BUDGET AT ALL, SO THE FREE-SPACE TERM IS THE ONLY ONE LEFT AND THE SENTINEL EDGE IS REACHABLE. With the
+    // default 64 MB budget the shadow would live entirely in RAM here and the cap would never consult the disk at
+    // all (#6132), which is a different property, asserted in Issue6132SnapshotBarrierFollowupsTest
+    configuration.setValue(GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM, 0);
+
     for (final long usable : new long[] { 1L, 2L, 3L })
       assertThat(PageManager.snapshotMaxShadowSize(configuration, files, usable))
           .as("a nearly-full spill volume (%d usable bytes) must still cap the shadow", usable).isPositive();
@@ -121,7 +126,8 @@ class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
     assertThat(PageManager.snapshotMaxShadowSize(configuration, files, Long.MAX_VALUE))
         .as("with room to spare the cap is the provable ceiling").isEqualTo(65_536L);
     assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 40_000L))
-        .as("with less room than the database the cap is half the free space").isEqualTo(20_000L);
+        .as("with less room than the database, and no RAM budget to claim, the cap is half the free space")
+        .isEqualTo(20_000L);
     assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 0L))
         .as("an unreadable free-space figure is not 'no room': fall back to the provable ceiling")
         .isEqualTo(65_536L);

--- a/engine/src/test/java/com/arcadedb/engine/Issue6132SnapshotBarrierFollowupsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6132SnapshotBarrierFollowupsTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.PageSnapshotException;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6132, the three gaps left by #6125 - none a correctness bug, all three places where that PR's own stated
+ * invariant is not quite met.
+ * <ol>
+ * <li><b>The last unbounded filesystem I/O under the barrier's locks.</b> {@code buildSnapshot} ran one
+ * {@code channel.size()} syscall per page file - dozens to hundreds on a real database, each with a lock acquisition
+ * of its own - while holding the JVM-wide page-manager lock every committer of every database queues behind, and none
+ * of them bounded by the barrier's deadline on a stalled filesystem. It is now a field read, and the test that keeps
+ * it honest is the one below: the counter and the filesystem must agree, at t0, across appends, compaction and a
+ * reopen.</li>
+ * <li><b>A barrier that fails is invisible except in the log.</b> Every other snapshot counter is incremented from a
+ * window that EXISTS, so a barrier that gave up before publishing one left no trace an operator could alert on -
+ * while its consumer fell back to suspend-and-freeze and completed the backup by throttling every writer.</li>
+ * <li><b>The automatic cap could fall below the RAM budget</b> and refuse a shadow that would never have touched the
+ * disk at all, in exactly the case {@code pageSnapshotSpillPath} exists for.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6132SnapshotBarrierFollowupsTest extends TestHelper {
+
+  private static final String TYPE = "Doc";
+
+  @Override
+  protected void beginTest() {
+    final DocumentType type = database.getSchema().createDocumentType(TYPE);
+    type.createProperty("id", Integer.class);
+    type.createProperty("payload", String.class);
+    type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+
+    database.transaction(() -> {
+      for (int i = 0; i < 4_000; i++)
+        database.newDocument(TYPE).set("id", i).set("payload", "initial-" + "x".repeat(200)).save();
+    });
+    ((DatabaseInternal) database).getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+  }
+
+  /**
+   * Item 1, and the whole warrant for the syscall being gone: the in-memory count is not an estimate that is usually
+   * right, it is the same number the filesystem holds.
+   * <p>
+   * The argument it pins is short - a paginated component file is extended by exactly one operation, a whole-page
+   * write at a known page number, and nothing truncates it - but "should agree" is precisely what needed proving
+   * before the syscall could be removed, because being wrong here is SILENT: a count too low truncates the archive,
+   * one too high reads past the end of the file. Asserted at t0, which is when the snapshot reads it, and after each
+   * of the three events that could plausibly break it.
+   */
+  @Test
+  void theInMemoryPageCountAgreesWithTheFilesystemAtT0() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    assertEveryPageCountAgreesAtT0("straight after the fixture");
+
+    // A FRESHLY APPENDED PAGE: the counter has to follow the write that extended the file, not the next reopen
+    database.transaction(() -> {
+      for (int i = 0; i < 20_000; i++)
+        database.newDocument(TYPE).set("id", 100_000 + i).set("payload", "grown-" + "y".repeat(400)).save();
+    });
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+    assertEveryPageCountAgreesAtT0("after appending pages");
+
+    // COMPACTION: the case the issue was most worried about, because PaginatedComponent's own counter is monotonic
+    // and would over-report a file that shrank. The file-level counter cannot: compaction builds a NEW file and
+    // drops the old one, and a new file is seeded from its real length when it is opened
+    final Index[] indexes = db.getSchema().getIndexes();
+    assertThat(indexes).as("the fixture has to have an index for the compaction step to mean anything").isNotEmpty();
+    for (final Index index : indexes)
+      ((IndexInternal) index).compact();
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+    assertEveryPageCountAgreesAtT0("after compacting the index");
+
+    // AND A REOPEN, WHICH IS THE ONE MOMENT THE COUNTER IS SEEDED FROM THE FILESYSTEM RATHER THAN MAINTAINED
+    reopenDatabase();
+    assertEveryPageCountAgreesAtT0("after reopening the database");
+  }
+
+  /**
+   * Item 2. A barrier that gives up before publishing a window is the one snapshot outcome nothing could see: the
+   * invalidation counters all require a window to exist, and the consumer falls back to suspend-and-freeze and still
+   * completes, so a backup that has quietly gone back to throttling every writer on the server reported success.
+   * <p>
+   * The wedged in-flight batch is fabricated exactly as {@code Issue6125SnapshotBarrierAndCapTest} does it. Which of
+   * the two failing steps wins is NOT asserted - a full-suite run has other databases actively resuming, so
+   * {@code trySuspendUntil} can genuinely lose its own race first (#6394) - so the reason the exception reports is
+   * read out and the matching split counter is the one checked. The total is checked either way, which is the
+   * reading an operator alerts on.
+   */
+  @Test
+  void aBarrierThatGivesUpBeforePublishingAWindowIsCounted() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+    final PageManagerFlushThread flushThread = pageManager.getFlushThread();
+    assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+
+    final int fileId = db.getSchema().getType(TYPE).getBuckets(false).getFirst().getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final MutablePage page = pageManager.getImmutablePage(new PageId(db, fileId, 0), file.getPageSize(), false, true)
+        .modify();
+
+    final PageManager.PPageManagerStats before = pageManager.getStats();
+
+    // AN IN-FLIGHT BATCH OF THIS DATABASE THAT NEVER FINISHES: THE SHAPE A WEDGED DISK PRESENTS
+    flushThread.nextPagesToFlush.set(new PageManagerFlushThread.PagesToFlush(new ArrayList<>(List.of(page))));
+    final AtomicReference<PageSnapshotException.Reason> reason = new AtomicReference<>();
+    try {
+      try {
+        pageManager.openSnapshot(db).close();
+        assertThat(false).as("the fabricated never-completing flush must fail the barrier").isTrue();
+      } catch (final PageSnapshotException e) {
+        reason.set(e.getReason());
+      }
+    } finally {
+      flushThread.nextPagesToFlush.set(null);
+    }
+
+    final PageManager.PPageManagerStats after = pageManager.getStats();
+
+    assertThat(after.snapshotBarriersFailed)
+        .as("a barrier that never published a window must be counted, or nothing an operator can alert on records it")
+        .isEqualTo(before.snapshotBarriersFailed + 1);
+    assertThat(after.snapshotBarriers)
+        .as("and it is still a barrier: the timer already covered it, which is what made a failure indistinguishable")
+        .isEqualTo(before.snapshotBarriers + 1);
+
+    if (reason.get() == PageSnapshotException.Reason.FLUSH_TIMEOUT) {
+      assertThat(after.snapshotBarriersFailedFlush).isEqualTo(before.snapshotBarriersFailedFlush + 1);
+      assertThat(after.snapshotBarriersFailedSuspend).isEqualTo(before.snapshotBarriersFailedSuspend);
+    } else if (reason.get() == PageSnapshotException.Reason.SUSPEND_TIMEOUT) {
+      assertThat(after.snapshotBarriersFailedSuspend).isEqualTo(before.snapshotBarriersFailedSuspend + 1);
+      assertThat(after.snapshotBarriersFailedFlush).isEqualTo(before.snapshotBarriersFailedFlush);
+    }
+
+    // THE PAIRED ASSERTION: WITH THE FABRICATED BATCH GONE THE VERY SAME CALL SUCCEEDS AND COUNTS NOTHING AS FAILED,
+    // SO THE COUNTER ABOVE MOVED FOR THE FAILURE AND NOT FOR EVERY BARRIER
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.ACTIVE);
+    }
+    assertThat(pageManager.getStats().snapshotBarriersFailed).isEqualTo(after.snapshotBarriersFailed);
+  }
+
+  /**
+   * Item 3. The cap covers RAM plus spill, and sizing it from the free space alone put it BELOW
+   * {@code arcadedb.pageSnapshotMaxRAM} on any spill volume with less than twice the RAM budget free - so a shadow
+   * that would have lived entirely in memory and never written a byte to that volume was invalidated anyway, and its
+   * backup fell back to throttling every writer over space it was never going to use.
+   * <p>
+   * Pure arithmetic, like the sentinel edge it sits next to: no test can fill a disk, and the method is
+   * package-private precisely so these cases are reachable directly.
+   */
+  @Test
+  void theAutomaticCapNeverFallsBelowTheRamBudget() {
+    final ContextConfiguration configuration = database.getConfiguration();
+    final long oneMegabyte = 1024L * 1024L;
+
+    // A 256 MB DATABASE AT t0 AND A 64 MB RAM BUDGET, THE DEFAULT
+    final List<PageSnapshot.SnapshotFile> files = List.of(
+        new PageSnapshot.SnapshotFile(0, null, 64 * 1024, 4 * 1024, "one.bucket"));  // 4096 pages of 64 KB = 256 MB
+    configuration.setValue(GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM, 64);
+
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 40 * oneMegabyte))
+        .as("40 MB free on the spill volume used to cap the shadow at 20 MB - below a RAM budget that needs no disk")
+        .isEqualTo(64 * oneMegabyte);
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 0L))
+        .as("an unreadable free-space figure still falls back to the provable ceiling")
+        .isEqualTo(256 * oneMegabyte);
+
+    // THE DISK STILL WINS WHEN IT HAS MORE TO OFFER THAN THE RAM BUDGET: THIS RAISES THE FLOOR, IT DOES NOT REPLACE
+    // THE FREE-SPACE TERM
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 300 * oneMegabyte))
+        .as("half of 300 MB is more than the RAM budget, so it is what the cap uses").isEqualTo(150 * oneMegabyte);
+
+    // AND THE PROVABLE CEILING IS STILL THE OUTER BOUND: A RAM BUDGET LARGER THAN THE WHOLE DATABASE CANNOT RAISE
+    // THE CAP ABOVE ONE PRE-IMAGE PER PAGE THAT EXISTED AT t0
+    configuration.setValue(GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM, 4_096);
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 40 * oneMegabyte))
+        .as("the RAM budget raises the floor, it does not invent pre-images that cannot exist")
+        .isEqualTo(256 * oneMegabyte);
+
+    // AN EXPLICIT CAP IS UNTOUCHED BY ALL OF THIS
+    configuration.setValue(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE, 7);
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 40 * oneMegabyte))
+        .as("a number set by hand still means exactly what it says").isEqualTo(7 * oneMegabyte);
+  }
+
+  // ------------------------------------------------------------------------------------------------------ HELPERS
+
+  /**
+   * Opens a real snapshot window - so the counts are read at the very moment {@code buildSnapshot} reads them, with
+   * the pipeline drained and the flush thread suspended - and checks every page file against its own channel.
+   */
+  private void assertEveryPageCountAgreesAtT0(final String when) throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    int checked = 0;
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles()) {
+        final PaginatedComponentFile paginated = file.file();
+        assertThat((long) file.pageCount())
+            .as("%s: the t0 page count of '%s' must be what the file holds", when, file.fileName())
+            .isEqualTo(paginated.getTotalPagesFromChannel());
+        assertThat(paginated.getTotalPages())
+            .as("%s: the in-memory counter of '%s' must be what the file holds", when, file.fileName())
+            .isEqualTo(paginated.getTotalPagesFromChannel());
+        checked++;
+      }
+    }
+
+    // A SNAPSHOT OVER NO FILES WOULD MAKE EVERY ASSERTION ABOVE VACUOUS
+    assertThat(checked).as("%s: the snapshot must cover the database's page files", when).isGreaterThan(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6132SnapshotBarrierFollowupsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6132SnapshotBarrierFollowupsTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Issue #6132, the three gaps left by #6125 - none a correctness bug, all three places where that PR's own stated
@@ -143,7 +144,7 @@ class Issue6132SnapshotBarrierFollowupsTest extends TestHelper {
     try {
       try {
         pageManager.openSnapshot(db).close();
-        assertThat(false).as("the fabricated never-completing flush must fail the barrier").isTrue();
+        fail("the fabricated never-completing flush must fail the barrier");
       } catch (final PageSnapshotException e) {
         reason.set(e.getReason());
       }

--- a/engine/src/test/java/com/arcadedb/engine/Issue6282BrokenChainDeleteAndProbeTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6282BrokenChainDeleteAndProbeTest.java
@@ -289,6 +289,37 @@ class Issue6282BrokenChainDeleteAndProbeTest extends TestHelper {
         .isNotInstanceOf(NeedRetryException.class));
   }
 
+  /**
+   * The delete-side counterpart of the test above, and the reason the size check lives only on the walk that needs
+   * it (PR review round 4 asked for the scope to be explicit rather than implicit).
+   * <p>
+   * {@code deleteRecordInternal} walks the chain by POINTERS and MARKERS and never reads a chunk's declared size -
+   * and it does not need to, because the size field sits beside the continuation pointer rather than in front of it.
+   * A chain whose only corruption is a bad size therefore still walks perfectly: every chunk is found, every slot is
+   * freed, and the delete simply succeeds. There is nothing here to name and nothing to retry.
+   * <p>
+   * The combined shape - a bad size AND a bad pointer - is the one where the two walks disagree about which hop
+   * failed, and there the confirmation deliberately declines to match and the delete keeps its retryable exception.
+   * That fails SAFE: {@code CHECK DATABASE FIX} force-deletes on its own detection (which does read sizes), so no
+   * record is ever left permanently stuck.
+   */
+  @Test
+  void aBadChunkSizeAloneStillDeletesBecauseTheChainItselfIsIntact() {
+    final RID rid = createMultiPageVertex();
+    corruptFirstChunkSize(rid.getBucketId(), Integer.MAX_VALUE);
+
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
+    assertThat(bucket.isChunkChainBroken(rid))
+        .as("precondition: the READ path does see this as corruption").isTrue();
+
+    // NO force, NO opt-in: the pointers are all sound, so the physical free walks the whole chain and completes
+    database.transaction(() -> bucket.deleteRecord(rid));
+
+    assertThat(bucket.existsRecord(rid))
+        .as("a chain whose only fault is a declared size is still fully walkable, so it deletes like any other")
+        .isFalse();
+  }
+
   /** The hook is absent unless a test installs it, which is what makes it free in production. */
   @Test
   void theFaultInjectorIsAbsentByDefault() {

--- a/engine/src/test/java/com/arcadedb/engine/Issue6282BrokenChainDeleteAndProbeTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6282BrokenChainDeleteAndProbeTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -259,6 +260,28 @@ class Issue6282BrokenChainDeleteAndProbeTest extends TestHelper {
     });
   }
 
+  /**
+   * A chunk that does not describe itself legally is corruption too, and the walk used to follow its continuation
+   * pointer straight past it: a size running off the end of the page reached the end of a chain of nonsense and was
+   * reported CLEAN. {@code loadMultiPageRecord} could then never confirm the break the read had just hit, so the
+   * record spent its whole retry budget and came back as a concurrency problem that did not exist (PR review).
+   */
+  @Test
+  void aChunkSizeThatRunsOffThePageIsABreakRatherThanACleanWalk() {
+    final RID rid = createMultiPageVertex();
+    corruptFirstChunkSize(rid.getBucketId());
+
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
+
+    assertThat(bucket.isChunkChainBroken(rid))
+        .as("a chunk whose declared size leaves the page cannot be walked past as if the chain were sound").isTrue();
+
+    database.transaction(() -> assertThatThrownBy(() -> database.lookupByRID(rid, true).asVertex().toJSON())
+        .as("and the read must confirm it rather than spend TX_RETRIES calling it contention")
+        .isInstanceOf(BrokenChunkChainException.class)
+        .isNotInstanceOf(NeedRetryException.class));
+  }
+
   /** The hook is absent unless a test installs it, which is what makes it free in production. */
   @Test
   void theFaultInjectorIsAbsentByDefault() {
@@ -364,6 +387,40 @@ class Issue6282BrokenChainDeleteAndProbeTest extends TestHelper {
       }
     });
     db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+  }
+
+  /**
+   * Declares a head-chunk size far larger than the page can hold - the shape a torn or mis-written header leaves.
+   * <p>
+   * Written straight into the CLOSED file rather than through a transaction: a commit compresses the pages it
+   * touched, and that pass has a size guard of its own which deletes the record before the walk under test ever
+   * sees it. Corrupting the bytes on disk is also the more honest fixture for the fault this is about. The database
+   * is left closed; the caller reopens it.
+   */
+  private void corruptFirstChunkSize(final int bucketId) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(bucketId);
+    final int pageSize = file.getPageSize();
+    final String path = file.getFilePath();
+
+    final int[] chunkOffset = new int[1];
+    db.transaction(() -> {
+      try {
+        chunkOffset[0] = firstChunkOffset(db.getTransaction().getPage(new PageId(db, bucketId, 0), pageSize));
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    database.close();
+    try (final RandomAccessFile raw = new RandomAccessFile(path, "rw")) {
+      // Page 0, content-relative offset: the marker is one byte, then the declared chunk size.
+      raw.seek(BasePage.PAGE_HEADER_SIZE + chunkOffset[0] + 1L);
+      raw.writeInt(Integer.MAX_VALUE / 2);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+    database = factory.open();
   }
 
   private int firstChunkOffset(final BasePage page) throws IOException {

--- a/engine/src/test/java/com/arcadedb/engine/Issue6282BrokenChainDeleteAndProbeTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6282BrokenChainDeleteAndProbeTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.BrokenChunkChainException;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6282: the three places the corruption-is-not-contention distinction #6258 drew on the read path was missing
+ * from, plus the hook that makes the highest-consequence of them testable at all.
+ * <ol>
+ * <li><b>The delete path</b> positively identified a structurally broken chunk chain and then reported it as a
+ * {@link ConcurrentModificationException} - the #4932 retry signal - costing the caller a full round of transactions
+ * before it gave up, and forcing five call sites to walk the chain a SECOND time just to find out which of the two
+ * they were holding.</li>
+ * <li><b>{@code isChunkChainBroken}</b>, the probe those call sites used, walked the chain through the CALLER's
+ * transaction. Under {@code REPEATABLE_READ} that is a pinned - possibly stale - snapshot, and the answer gates
+ * FORCE-DELETE, so a false positive removes a healthy record.</li>
+ * <li><b>{@code IOException} meant two opposite things</b> within a few lines of the same walk: "the disk failed,
+ * prove nothing" at the page load, and "this record is corrupt, report a break" from the slot-offset check. The only
+ * thing keeping them apart was where the {@code try} sat.</li>
+ * <li><b>No fault-injection hook</b> for page reads, so the path whose wrong answer is a permanent corruption verdict
+ * on a healthy record had no coverage.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6282BrokenChainDeleteAndProbeTest extends TestHelper {
+
+  private static final String TYPE = "Chunked";
+
+  /** The healthy continuation pointer {@link #createBrokenMultiPageVertex()} overwrote. */
+  private long originalChunkPointer;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // Every fixture here injects on-disk corruption on purpose, which the post-test integrity check would flag.
+    return false;
+  }
+
+  @AfterEach
+  void clearFaultInjection() {
+    PageManager.setPageReadFaultInjector(null);
+  }
+
+  /**
+   * Item 1. The delete path has already established, from the bytes, that the continuation pointer leads nowhere.
+   * Saying "modified concurrently. Please retry" about it is wrong twice over: the retry cannot succeed, and the
+   * exception is a {@link NeedRetryException}, so the machinery above re-runs the whole transaction for it.
+   */
+  @Test
+  void aBrokenChunkChainIsNamedByTheDeletePathInsteadOfBeingCalledContention() {
+    final RID broken = createBrokenMultiPageVertex();
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(broken.getBucketId());
+
+    database.begin();
+    try {
+      assertThatThrownBy(() -> bucket.deleteRecord(broken))
+          .as("a chain the delete path itself proved broken is corruption, not contention")
+          .isInstanceOf(BrokenChunkChainException.class)
+          .hasMessageContaining("broken chunk chain")
+          .hasMessageContaining("CHECK DATABASE FIX")
+          // THE POINT OF THE TYPE, NOT MERELY OF THE MESSAGE: NOTHING ABOVE MAY SPEND A RETRY BUDGET ON IT
+          .isNotInstanceOf(NeedRetryException.class);
+    } finally {
+      database.rollback();
+    }
+
+    assertThat(bucket.existsRecord(broken)).as("a refused delete must leave the record where it was").isTrue();
+
+    // THE PAIRED HALF: THE RECORD IS STILL REMOVABLE, SO THE NEW VERDICT DID NOT MAKE IT UNDELETABLE
+    database.transaction(() -> bucket.deleteRecord(broken, true));
+    assertThat(bucket.existsRecord(broken)).isFalse();
+  }
+
+  /**
+   * Item 1, through the public API: the arm #6258 deliberately left out of {@code LocalDatabase}'s plain-record
+   * branch, with a comment saying it would be dead code because {@code deleteRecordInternal} never named a broken
+   * chain as one, is live now. The record is deletable through it WITHOUT the second structural walk that branch
+   * used to need.
+   */
+  @Test
+  void theTolerantDeletePathTakesTheLoaderVerdictOnTheDeleteSideToo() {
+    final RID broken = createBrokenMultiPageVertex();
+    database.getConfiguration().setValue(GlobalConfiguration.DELETE_TOLERATE_BROKEN_CHAIN, true);
+
+    database.transaction(() -> database.command("sql", "DELETE FROM " + broken));
+
+    assertThat(database.getSchema().getBucketById(broken.getBucketId()).existsRecord(broken)).isFalse();
+  }
+
+  /**
+   * Item 1, the other direction and the one that keeps the change honest: a chain the committed image does NOT agree
+   * is broken must keep the retryable exception. Here the record is healthy and the delete is made to fail on a page
+   * it cannot resolve - it must not be promoted to a permanent corruption verdict.
+   */
+  @Test
+  void aBreakTheCommittedImageDoesNotConfirmKeepsTheRetrySignal() {
+    final RID healthy = createMultiPageVertex();
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(healthy.getBucketId());
+
+    // The delete's own walk reads its chunk pages with getPageToModify; the CONFIRMATION reads the head page from
+    // the page manager. Failing every read after the delete's own ones leaves the confirmation unable to prove
+    // anything, which must fall back to the retry rather than condemn a healthy record.
+    database.begin();
+    try {
+      final AtomicInteger reads = new AtomicInteger();
+      PageManager.setPageReadFaultInjector(pageId -> {
+        if (pageId.getFileId() == healthy.getBucketId() && reads.incrementAndGet() > 1)
+          throw new IOException("injected fault on " + pageId);
+      });
+
+      assertThatThrownBy(() -> bucket.deleteRecord(healthy))
+          .as("a delete that could not read its chain must never end in a permanent corruption verdict")
+          .isNotInstanceOf(BrokenChunkChainException.class);
+    } finally {
+      PageManager.setPageReadFaultInjector(null);
+      database.rollback();
+    }
+
+    assertThat(bucket.existsRecord(healthy)).as("and the healthy record is still there").isTrue();
+  }
+
+  /**
+   * Item 2. The probe used to walk the chain through the caller's transaction, so under {@code REPEATABLE_READ} it
+   * answered from whatever that transaction had PINNED. Here the transaction pins a page whose chain is broken, a
+   * concurrent commit repairs it, and the probe has to report the committed truth - because every caller escalates a
+   * {@code true} to a force-delete, and {@code check(fix)} deletes the record it flags.
+   */
+  @Test
+  void theStructuralProbeJudgesFromTheCommittedImageAndNotFromThePinnedOne() throws Exception {
+    final RID broken = createBrokenMultiPageVertex();
+    final long originalPointer = originalChunkPointer;
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(broken.getBucketId());
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(broken.getBucketId())).getPageSize();
+
+    db.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+    try {
+      // PIN THE BROKEN IMAGE OF THE HEAD PAGE IN THIS TRANSACTION'S SNAPSHOT
+      db.getTransaction().getPage(new PageId(db, broken.getBucketId(), 0), pageSize);
+
+      assertThat(bucket.isChunkChainBroken(broken))
+          .as("precondition: the chain really is broken in the committed image right now").isTrue();
+
+      // ANOTHER THREAD REPAIRS THE POINTER AND COMMITS. THIS TRANSACTION KEEPS ITS PINNED, STILL-BROKEN PAGE
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final Thread repairer = new Thread(() -> {
+        try {
+          db.transaction(() -> writeFirstChunkPointer(broken.getBucketId(), originalPointer));
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6282-repairer");
+      repairer.start();
+      repairer.join(30_000);
+      assertThat(failure.get()).isNull();
+
+      assertThat(bucket.isChunkChainBroken(broken))
+          .as("the probe must answer from the newest committed image: this transaction's pinned page still says "
+              + "broken, and a true here would force-delete a record that is healthy on disk")
+          .isFalse();
+    } finally {
+      db.rollback();
+    }
+  }
+
+  /**
+   * Item 3. A slot-table entry pointing inside the page header is CORRUPTION - the page read fine, its bytes are
+   * nonsense - and it used to leave the delete path as a bare {@link IOException}, indistinguishable to the caller
+   * from a disk that had just failed. It is now the same structural verdict as a pointer that leads off the end of
+   * the file, which is what it has always been.
+   */
+  @Test
+  void aCorruptChunkSlotIsCorruptionAndNotAnIoError() {
+    final RID rid = createMultiPageVertex();
+    corruptFirstContinuationSlot(rid.getBucketId());
+    reopenDatabase();
+
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
+
+    assertThat(bucket.isChunkChainBroken(rid))
+        .as("the version-blind walk has to read a corrupt slot offset as a break").isTrue();
+
+    database.begin();
+    try {
+      assertThatThrownBy(() -> bucket.deleteRecord(rid))
+          .as("and the delete path must name it rather than let a raw IOException out")
+          .isInstanceOf(BrokenChunkChainException.class)
+          .isNotInstanceOf(NeedRetryException.class);
+    } finally {
+      database.rollback();
+    }
+
+    // THE PAIRED HALF: THE RECORD IS STILL REMOVABLE WITH FORCE
+    database.transaction(() -> bucket.deleteRecord(rid, true));
+    assertThat(bucket.existsRecord(rid)).isFalse();
+  }
+
+  /**
+   * Item 4, and the reason it was filed first: the confirmation walk answering "the chain is broken" for a page it
+   * merely could not READ condemns a healthy record permanently and points the operator at
+   * {@code CHECK DATABASE FIX}, which deletes it. There was no way to make a page read fail on demand, so this path
+   * had no coverage at all.
+   */
+  @Test
+  void aPageReadFaultIsNeverALicenceToForceDeleteARecord() {
+    final RID broken = createBrokenMultiPageVertex();
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(broken.getBucketId());
+
+    database.transaction(() -> {
+      assertThat(bucket.isChunkChainBroken(broken))
+          .as("precondition: with a healthy disk the probe does prove the break, so the assertion below is not "
+              + "passing for the wrong reason").isTrue();
+
+      PageManager.setPageReadFaultInjector(pageId -> {
+        if (pageId.getFileId() == broken.getBucketId())
+          throw new IOException("injected fault on " + pageId);
+      });
+
+      assertThat(bucket.isChunkChainBroken(broken))
+          .as("a probe that could not read the page has proved nothing, and every caller reads a true here as "
+              + "permission to force-delete").isFalse();
+    });
+  }
+
+  /** The hook is absent unless a test installs it, which is what makes it free in production. */
+  @Test
+  void theFaultInjectorIsAbsentByDefault() {
+    assertThat(PageManager.getPageReadFaultInjector()).isNull();
+  }
+
+  // ------------------------------------------------------------------------------------------------------ HELPERS
+
+  /** A vertex whose payload spans several pages, so it is stored as a FIRST_CHUNK with a real continuation chain. */
+  private RID createMultiPageVertex() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final int[] bucketIdHolder = new int[1];
+    db.transaction(() -> {
+      final VertexType type = db.getSchema().createVertexType(TYPE, 1);
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("data", Type.STRING);
+      bucketIdHolder[0] = type.getBuckets(false).getFirst().getFileId();
+    });
+
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(bucketIdHolder[0])).getPageSize();
+    final String bigData = "x".repeat(pageSize * 4);
+
+    final RID[] rids = new RID[1];
+    db.transaction(() -> {
+      // FIRST, SO IT LANDS AT PAGE 0 / SLOT 0
+      rids[0] = db.newVertex(TYPE).set("id", 0).set("data", bigData).save().getIdentity();
+      db.newVertex(TYPE).set("id", 1).set("data", "small").save();
+    });
+    assertThat(rids[0].getPosition()).isZero();
+
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+    return rids[0];
+  }
+
+  /**
+   * The same record, with the FIRST_CHUNK's continuation pointer aimed at a page well beyond the file, and the
+   * database reopened so the chain is walked from the corrupted page rather than from a cached one.
+   */
+  private RID createBrokenMultiPageVertex() {
+    final RID rid = createMultiPageVertex();
+    final int maxRecordsInPage = ((LocalBucket) database.getSchema().getBucketById(rid.getBucketId())).getMaxRecordsInPage();
+    // KEPT SO A TEST CAN PUT THE CHAIN BACK TOGETHER AGAIN, WHICH IS HOW THE PINNED-VIEW GAP IS PROVOKED
+    originalChunkPointer = readFirstChunkPointer(rid.getBucketId());
+    assertThat(originalChunkPointer).as("the fixture record must really have a continuation chunk").isPositive();
+    writeFirstChunkPointer(rid.getBucketId(), 1_000_000L * maxRecordsInPage);
+    reopenDatabase();
+    return rid;
+  }
+
+  private long readFirstChunkPointer(final int bucketId) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(bucketId)).getPageSize();
+    final long[] holder = new long[1];
+    db.transaction(() -> {
+      try {
+        final BasePage page = db.getTransaction().getPage(new PageId(db, bucketId, 0), pageSize);
+        final int recordOffset = firstChunkOffset(page);
+        holder[0] = page.readLong(recordOffset + 1 + Binary.INT_SERIALIZED_SIZE);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    return holder[0];
+  }
+
+  /** Overwrites the continuation pointer of the FIRST_CHUNK at page 0 / slot 0. */
+  private void writeFirstChunkPointer(final int bucketId, final long pointer) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(bucketId)).getPageSize();
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, bucketId, 0), pageSize, false);
+        page.writeLong(firstChunkOffset(page) + 1 + Binary.INT_SERIALIZED_SIZE, pointer);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  /**
+   * Points the slot-table entry of the record's FIRST continuation chunk inside the page header, which no writer can
+   * produce: the page reads fine and its bytes are nonsense. That is what {@code PageCorruptionException} names.
+   */
+  private void corruptFirstContinuationSlot(final int bucketId) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(bucketId)).getPageSize();
+    final int maxRecordsInPage = ((LocalBucket) db.getSchema().getBucketById(bucketId)).getMaxRecordsInPage();
+    final long pointer = readFirstChunkPointer(bucketId);
+    assertThat(pointer).as("the fixture record must really have a continuation chunk").isPositive();
+
+    final int chunkPageNumber = (int) (pointer / maxRecordsInPage);
+    final int chunkSlot = (int) (pointer % maxRecordsInPage);
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction()
+            .getPageToModify(new PageId(db, bucketId, chunkPageNumber), pageSize, false);
+        // ANY NON-ZERO VALUE BELOW contentHeaderSize IS ILLEGAL; 1 IS BELOW EVERY POSSIBLE ONE
+        page.writeInt(LocalBucket.PAGE_RECORD_TABLE_OFFSET + chunkSlot * Binary.INT_SERIALIZED_SIZE, 1);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+  }
+
+  private int firstChunkOffset(final BasePage page) throws IOException {
+    final int recordOffset = (int) page.readUnsignedInt(LocalBucket.PAGE_RECORD_TABLE_OFFSET);
+    // FIRST_CHUNK (-2) IS ZIGZAG-ENCODED AS THE SINGLE BYTE 0x03
+    assertThat(page.readByte(recordOffset)).as("record at page 0 / slot 0 must be a multi-page head")
+        .isEqualTo((byte) 3);
+    return recordOffset;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6282BrokenChainDeleteAndProbeTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6282BrokenChainDeleteAndProbeTest.java
@@ -32,6 +32,8 @@ import com.arcadedb.schema.VertexType;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -265,11 +267,16 @@ class Issue6282BrokenChainDeleteAndProbeTest extends TestHelper {
    * pointer straight past it: a size running off the end of the page reached the end of a chain of nonsense and was
    * reported CLEAN. {@code loadMultiPageRecord} could then never confirm the break the read had just hit, so the
    * record spent its whole retry budget and came back as a concurrency problem that did not exist (PR review).
+   * <p>
+   * Three sizes, because the bound has two ways to be wrong: a large one that stays in range of an int, the largest
+   * representable one - which overflows {@code offset + header + size} to a NEGATIVE number and so passes any
+   * {@code >} test written in int arithmetic - and a negative one.
    */
-  @Test
-  void aChunkSizeThatRunsOffThePageIsABreakRatherThanACleanWalk() {
+  @ParameterizedTest(name = "declared chunk size {0}")
+  @ValueSource(ints = { 1_073_741_823, Integer.MAX_VALUE, -1 })
+  void aChunkSizeThatRunsOffThePageIsABreakRatherThanACleanWalk(final int corruptSize) {
     final RID rid = createMultiPageVertex();
-    corruptFirstChunkSize(rid.getBucketId());
+    corruptFirstChunkSize(rid.getBucketId(), corruptSize);
 
     final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
 
@@ -396,8 +403,13 @@ class Issue6282BrokenChainDeleteAndProbeTest extends TestHelper {
    * touched, and that pass has a size guard of its own which deletes the record before the walk under test ever
    * sees it. Corrupting the bytes on disk is also the more honest fixture for the fault this is about. The database
    * is left closed; the caller reopens it.
+   *
+   * @param corruptSize the size to declare. {@code Integer.MAX_VALUE} is the case that matters most: it makes
+   *                    {@code offset + header + size} overflow an int to a NEGATIVE number, so a bounds check
+   *                    written in int arithmetic lets the largest corrupt size representable straight through the
+   *                    guard meant to stop it (PR review).
    */
-  private void corruptFirstChunkSize(final int bucketId) {
+  private void corruptFirstChunkSize(final int bucketId, final int corruptSize) {
     final DatabaseInternal db = (DatabaseInternal) database;
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(bucketId);
     final int pageSize = file.getPageSize();
@@ -416,7 +428,7 @@ class Issue6282BrokenChainDeleteAndProbeTest extends TestHelper {
     try (final RandomAccessFile raw = new RandomAccessFile(path, "rw")) {
       // Page 0, content-relative offset: the marker is one byte, then the declared chunk size.
       raw.seek(BasePage.PAGE_HEADER_SIZE + chunkOffset[0] + 1L);
-      raw.writeInt(Integer.MAX_VALUE / 2);
+      raw.writeInt(corruptSize);
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2463,7 +2463,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     final int pageSize = file.getPageSize();
 
     // #5443: the page COUNT and the page CONTENT must both come from the page manager, never from the
-    // file on disk. PaginatedComponentFile.getTotalPages() is channel.size()/pageSize, so it only sees
+    // file on disk. PaginatedComponentFile.getTotalPages() counts the pages the file HOLDS, so it only sees
     // what the asynchronous writer has already persisted: a compaction that has just published 13 pages
     // can still measure 10 on disk. Serializing from the file then shipped a TRUNCATED index - the
     // follower's compacted sub-index came out three pages short, and every key that lived in them became
@@ -2527,9 +2527,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * Serializes {@code pageCount} pages starting at {@code firstPage} as one synthetic WAL transaction.
    * <p>
    * Both the page count and the content come from the page manager, never from the file:
-   * {@code PaginatedComponentFile.getTotalPages()} is {@code channel.size()/pageSize}, so it only sees
-   * what the asynchronous writer has already persisted, and reading the file directly can serialize a
-   * page that has not been written yet.
+   * {@code PaginatedComponentFile.getTotalPages()} counts the pages the file HOLDS, so it only sees what the
+   * asynchronous writer has already persisted, and reading the file directly can serialize a page that has not
+   * been written yet.
    */
   private void appendPageRangeAsWal(final int fileId, final int pageSize, final int firstPage,
       final int pageCount, final List<byte[]> walOut, final List<Map<Integer, Integer>> bucketDeltasOut)

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2463,7 +2463,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     final int pageSize = file.getPageSize();
 
     // #5443: the page COUNT and the page CONTENT must both come from the page manager, never from the
-    // file on disk. PaginatedComponentFile.getTotalPages() counts the pages the file HOLDS, so it only sees
+    // file on disk. The count used below is PaginatedComponent.getTotalPages(), which is bumped synchronously at
+    // commit and so includes pages that are published but not yet written; the FILE's own
+    // PaginatedComponentFile.getTotalPages() advances only once a physical write has landed, so it only sees
     // what the asynchronous writer has already persisted: a compaction that has just published 13 pages
     // can still measure 10 on disk. Serializing from the file then shipped a TRUNCATED index - the
     // follower's compacted sub-index came out three pages short, and every key that lived in them became
@@ -2526,10 +2528,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   /**
    * Serializes {@code pageCount} pages starting at {@code firstPage} as one synthetic WAL transaction.
    * <p>
-   * Both the page count and the content come from the page manager, never from the file:
-   * {@code PaginatedComponentFile.getTotalPages()} counts the pages the file HOLDS, so it only sees what the
-   * asynchronous writer has already persisted, and reading the file directly can serialize a page that has not
-   * been written yet.
+   * Both the page count and the content come from the page manager, never from the file: the count is
+   * {@code PaginatedComponent.getTotalPages()}, which includes pages pending persistence, where the file's own
+   * {@code PaginatedComponentFile.getTotalPages()} advances only once a physical write has landed - and reading the
+   * file directly can serialize a page that has not been written yet.
    */
   private void appendPageRangeAsWal(final int fileId, final int pageSize, final int firstPage,
       final int pageCount, final List<byte[]> walOut, final List<Map<Integer, Integer>> bucketDeltasOut)

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -145,6 +145,16 @@ public final class EngineMetricsBinder implements MeterBinder {
         "Total time spent in the snapshot t0 barrier", "snapshotBarrierTime", MILLIS_TO_SECONDS);
     counter(registry, "arcadedb.engine.snapshot.barrier.inexact",
         "Barriers that could not prove the flush pipeline was empty at t0", "snapshotBarriersInexact");
+    // #6132: the barrier failing BEFORE a window exists is the one snapshot outcome nothing else could see -
+    // windows.invalidated and its two halves are all incremented from a window, and the consumer's fallback to
+    // suspend-and-freeze completes the backup anyway, just by throttling every writer on the server. Split by the
+    // step that gave up: suspend is transient and expected under load, flush is a write that never landed.
+    counter(registry, "arcadedb.engine.snapshot.barrier.failed",
+        "Snapshot t0 barriers that gave up before publishing a window", "snapshotBarriersFailed");
+    counter(registry, "arcadedb.engine.snapshot.barrier.failed.suspend",
+        "Snapshot t0 barriers that gave up because the page flush could not be suspended", "snapshotBarriersFailedSuspend");
+    counter(registry, "arcadedb.engine.snapshot.barrier.failed.flush",
+        "Snapshot t0 barriers that gave up because an in-flight page flush never completed", "snapshotBarriersFailedFlush");
     // A HIGH-WATER MARK: MONOTONIC, BUT A rate() OVER IT WOULD BE MEANINGLESS, WHICH IS WHY IT IS THE ONE MONOTONIC
     // READING HERE THAT STAYS A GAUGE
     gauge(registry, "arcadedb.engine.snapshot.barrier.max.seconds",


### PR DESCRIPTION
Closes #6282
Closes #6132

Two independent follow-up issues, taken together because both land in `PageManager`/`LocalBucket` and would have conflicted.

## #6282 - corruption is not contention, on the two paths either side of the read

#6258 taught the READ path to tell a chunk chain that does not parse from a record that moved under it. These are the paths on either side of it.

**1. The delete path names the break instead of calling it contention.** `LocalBucket.deleteRecordInternal` positively identified a structurally broken chain - a pointer past the end of the file, a cleaned slot, a marker that is not `NEXT_CHUNK` - and then raised the #4932 `ConcurrentModificationException`, a `NeedRetryException`. The caller spent a full round of transactions on a retry that could not possibly succeed, and five call sites had to walk the chain a SECOND time just to find out which of the two they were holding.

It now confirms first, with the delete-side counterpart of #6258's `confirmBrokenChunkChain`. A delete consumes no bytes, so it cannot ask "are the chunks this read consumed still current"; it asks a sharper question instead - **does the newest committed image break at the SAME HOP, to the SAME TARGET?** A committed image that walks cleanly is a chain caught mid-publication; one that breaks somewhere else is a record that was rewritten under the delete. Both keep the retry. Only when the two agree does it raise `BrokenChunkChainException`, which is deliberately not a `NeedRetryException`.

That makes live the `BrokenChunkChainException` arm #6258 left out of `LocalDatabase`'s plain-record branch as dead code, and lets `LocalBucket.deleteCorruptedRecord` escalate without a probe.

> One thing worth flagging for review: `deleteRecordInternal` ends in a blanket `catch (Exception) -> log, zero the slot, return success`. Without an explicit rethrow arm - the same arm #4932 had to add for the CME - the new exception was swallowed and the delete silently "succeeded", orphaning every chunk past the break. The arm is in this PR, and a test pins it.

**2. `isChunkChainBroken` judges from the newest committed image.** It walked the chain through the CALLER's transaction, so under `REPEATABLE_READ` it read a pinned - possibly stale - snapshot: a chain a concurrent commit had since rewritten still presented as broken. Every caller escalates a `true` to a FORCE delete and `check(fix)` deletes the record it flags, so a false positive removes a healthy record. Its body is now `findBrokenChunkChainInNewestCommitted(rid) != null`, the walk #6258 already built for exactly this.

**3. `IOException` no longer means two opposite things in one walk.** New `PageCorruptionException extends IOException`, thrown by `getRecordPositionInPage` for a slot offset that points inside the page header. `findBrokenChunkChain` now answers by TYPE and not by where the `try` sits: `PageCorruptionException` -> a break; any other `IOException` -> **null, cannot prove a break**; the unchecked out-of-page-bounds family -> a break, as before. Java's "subclass first" rule makes the compiler keep the ordering, which is the whole point - the invariant used to be positional, and the hazard in the live direction (a genuine I/O failure reading the slot table swallowed as corruption) is closed. `deleteRecordInternal`'s chunk-read catch got the same split, so a corrupt chunk slot no longer escapes as a bare `IOException`.

**4. A page-read fault-injection hook.** `PageManager.setPageReadFaultInjector(...)`, test-only, hooked at `getCachedPage` - the funnel both `getImmutablePage` and `getMutablePage` go through - and NOT at the physical read in `loadPage`: a test cannot keep a page out of the read cache, so a physical-read hook would never fire for a page the engine has just written. Cost when nothing is installed: one read of a `static volatile` that is always null, the same shape as `activeSnapshots` on the write path.

**Beyond the issue text, deliberately:** `BucketIterator`'s two `ConcurrentModificationException` + `isChunkChainBroken` arms are removed. The issue counted them among the delete-path disambiguations; they are on the READ path, where the loader now answers the same question more strongly (committed image broken AND the read's own chunks current). A CME reaching them therefore means the break could NOT be confirmed - the record moved - and a probe saying "broken" about it silently drops a HEALTHY record from a scan. The delete-path probes stay: there the CME can come from the delete's own walk, which has no byte-level second question.

## #6132 - the last unbounded FS I/O under the barrier, a failure nobody counted, a cap below its own RAM budget

**1. `getTotalPages()` is a field read, not N syscalls under the JVM-wide lock.** The issue proposed reusing `PaginatedComponent.pageCount`, and then listed the three reasons it is not a drop-in: it is monotonic (so a shrunk file over-reports), `buildSnapshot` iterates FILES rather than components (so a fallback is still needed), and being wrong is silent.

**A better place to put the counter is the FILE, where all three objections disappear.** `PaginatedComponentFile` now keeps its own `totalPages`: seeded from the real length at `open()`, advanced past every successful `write(MutablePage)`, re-seeded on every reopen and rename. It is exact by construction rather than authoritative-if-you-squint - `write` is the only operation that extends a paginated component file, it always writes one whole page at a known page number, and nothing truncates one - so there is no monotonicity caveat, no component lookup and no fallback path. It also removes the syscall from the second caller, `loadPage`'s new-page test on every read-cache miss, which is as hot as the engine gets.

`getTotalPagesFromChannel()` is kept for one purpose: the regression test asserts the counter and the filesystem agree, at t0, across appends, an index compaction and a reopen. (Mutation-checked: `pageNumber` instead of `pageNumber + 1` turns it red.)

> Trap for the next person: `open()` runs from the `ComponentFile` constructor, BEFORE this class's field initializers, so an `AtomicInteger` field is still null when it has to be seeded. It is a `volatile int` with no initializer plus a static `AtomicIntegerFieldUpdater`.

**2. A barrier that fails is counted.** `snapshotBarriersFailed`, split into `...FailedSuspend` and `...FailedFlush`, incremented from a new catch in `openSnapshotInternal`. `PageSnapshotException.Reason` already existed (#6394); only the counters were missing. Wired through `PPageManagerStats` -> `Profiler` -> `EngineMetricsBinder` as `arcadedb.engine.snapshot.barrier.failed[.suspend|.flush]`. Until now the only trace of a backup that had quietly gone back to throttling every writer on the server was a WARNING in the log: every other snapshot counter is incremented from a window that EXISTS, and the consumer's fallback completes the backup anyway.

**3. The automatic cap never falls below the RAM budget.** `max(1, min(databaseSize, max(pageSnapshotMaxRAM, usable/2)))`. On a spill volume with 40 MB free the cap used to resolve to 20 MB, below the 64 MB default RAM budget - so a shadow that would have lived entirely in memory and never written a byte to that volume was invalidated anyway, in exactly the case `pageSnapshotSpillPath` exists for. `GlobalConfiguration`'s own description now says so, and `Issue6125SnapshotBarrierAndCapTest.theAutomaticCapNeverDegeneratesIntoTheUncappedSentinel` sets `pageSnapshotMaxRAM=0` first, or the sentinel edge it guards is no longer reachable.

## Behaviour changes

- A `DELETE` over a confirmed-broken chunk chain now raises `BrokenChunkChainException` where it raised a retryable `ConcurrentModificationException`. `DELETE_TOLERATE_BROKEN_CHAIN` and `CHECK DATABASE FIX` behave exactly as before. `BrokenMultiPageRecordDeleteTest` updated.
- A bucket scan no longer skips a record on an unconfirmed `ConcurrentModificationException`; it propagates so the caller can retry, which is what `getSkippedRecordCount`'s contract already documented.

## Tests

- `Issue6282BrokenChainDeleteAndProbeTest` (7) - the delete-side verdict and its non-`NeedRetryException` type, the tolerant path through the newly live arm, a break the committed image does not confirm keeping its retry, the pinned-vs-committed probe gap (provoked by pinning a BROKEN head page in a `REPEATABLE_READ` transaction and repairing it from another thread - the direction that force-deletes a healthy record), a corrupt chunk slot as corruption rather than an I/O error, and an injected page-read fault never becoming a licence to force-delete.
- `Issue6132SnapshotBarrierFollowupsTest` (3) - the counter agrees with the filesystem at t0 across appends/compaction/reopen, a failed barrier is counted with the split matching the reason it reported, and the cap's RAM floor.

## Docs

The new `arcadedb.engine.snapshot.barrier.failed*` metrics and the `pageSnapshotMaxSize` floor are worth a line in the observability and configuration pages of the docs repo - happy to prepare that separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added snapshot-barrier failure metrics, including total, suspend-timeout, and flush-timeout counts.
  - Improved automatic snapshot storage sizing using database size, available disk space, and RAM limits.
  - Added more accurate page-count tracking during writes, compaction, and reopening.

- **Bug Fixes**
  - Improved detection and handling of corrupted multi-page records during iteration and deletion.
  - Corruption is now distinguished from temporary I/O or concurrency issues, enabling safer retries and tolerant cleanup.
  - Added safeguards against deleting records after transient page-read failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->