### PR TITLE
fix(#6795): six incomplete merged fixes flagged in follow-up review

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -738,10 +738,12 @@ public class MergeStep extends AbstractExecutionStep {
       if (bound instanceof Vertex v) {
         if (vertex != null && !vertex.equals(v))
           return;
-        // #6461: vertex == null here means v is the row's own anchor instance (forcedVertex is only
-        // ever non-null when this node was just reached via a live edge traversal below, which is
+        // #6461/#6795: vertex == null here means v is the row's own anchor instance (forcedVertex is
+        // only ever non-null when this node was just reached via a live edge traversal above, which is
         // already fresh) - reload it before its edges are enumerated below. See reloadAnchorVertex.
-        vertex = vertex == null ? reloadAnchorVertex(v) : v;
+        // When forcedVertex IS non-null, keep it: a pre-bound *middle* node reached via traversal must
+        // still use the fresh instance, not the possibly-stale one carried from an earlier MATCH.
+        vertex = vertex == null ? reloadAnchorVertex(v) : vertex;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -1066,6 +1066,11 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
       final RecordRowReader reader = new RecordRowReader();
+      // Issue #6795 (follow-up on #6715): mirrors weightedAdjacencyFromColumns's own checkpoint interval - a
+      // weighted entry costs INT_BYTES + DOUBLE_BYTES like there too, and this path was left on the full
+      // unweighted ADJACENCY_CHECKPOINT_ENTRIES with no capacityFor cap, letting it overshoot the budget by up
+      // to three times as many bytes (~12 MB at the default constant) before ever checkpointing.
+      final long maxEntryCheckpoint = ADJACENCY_CHECKPOINT_ENTRIES / 3;
       long entries = 0;
       long totalEntries = 0;
 
@@ -1075,7 +1080,8 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         weights[i] = row.weights();
         entries += row.neighbors().length;
         totalEntries += row.neighbors().length;
-        if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
+        final long entryCheckpoint = Math.min(maxEntryCheckpoint, memory.capacityFor(INT_BYTES + DOUBLE_BYTES));
+        if (entries >= entryCheckpoint || (i & 1023) == 1023) {
           reserveWeightedAdjacency(0, entries);
           entries = 0;
         }

--- a/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
@@ -30,7 +30,9 @@ import com.arcadedb.utility.DateUtils;
 
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -97,7 +99,7 @@ public class JsonGraphSerializer extends JsonSerializer {
         else if (value.equals(Double.NEGATIVE_INFINITY) || value.equals(Float.NEGATIVE_INFINITY))
           // JSON DOES NOT SUPPORT INFINITY
           value = "NegInfinity";
-        else if (type != null && value instanceof Temporal && type.existsProperty(prop.getKey()))
+        else if (type != null && isEncodableTemporal(value) && type.existsProperty(prop.getKey()))
           value = encodeTemporalForWriteBack(value, type.getProperty(prop.getKey()).getType());
       }
       properties.put(prop.getKey(), value);
@@ -177,6 +179,16 @@ public class JsonGraphSerializer extends JsonSerializer {
   public JsonGraphSerializer setPrecisionAwareTemporals(final boolean precisionAwareTemporals) {
     this.precisionAwareTemporals = precisionAwareTemporals;
     return this;
+  }
+
+  /**
+   * Issue #6795 (follow-up on #6455): {@code arcadedb.dateImplementation=java.util.Date} (or {@code Calendar})
+   * makes the binary serializer hand back a DATE property as a {@link Date}/{@link Calendar} rather than a
+   * {@link Temporal}, so the write-back encoding must recognize those too - {@link DateUtils#dateToEpochDays}
+   * already handles both.
+   */
+  private static boolean isEncodableTemporal(final Object value) {
+    return value instanceof Temporal || value instanceof Date || value instanceof Calendar;
   }
 
   private static Object encodeTemporalForWriteBack(final Object value, final Type propertyType) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6461MergeAnchorStaleEdgeListTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6461MergeAnchorStaleEdgeListTest.java
@@ -59,8 +59,12 @@ class Issue6461MergeAnchorStaleEdgeListTest {
     database.getSchema().createVertexType("Par");
     database.getSchema().createVertexType("Chi");
     database.getSchema().createVertexType("A");
+    database.getSchema().createVertexType("Mid");
+    database.getSchema().createVertexType("Leaf");
     database.getSchema().createEdgeType("HAS");
     database.getSchema().createEdgeType("L");
+    database.getSchema().createEdgeType("R");
+    database.getSchema().createEdgeType("S");
   }
 
   @AfterEach
@@ -109,5 +113,33 @@ class Issue6461MergeAnchorStaleEdgeListTest {
 
     final ResultSet edgeCount = database.query("opencypher", "MATCH (:A)-[r:L]->(:A) RETURN count(r) AS c");
     assertThat(edgeCount.next().<Number>getProperty("c").longValue()).isEqualTo(1);
+  }
+
+  /**
+   * Follow-up form reported on #6795: a *middle* node of a multi-hop path, reached via a live edge
+   * traversal in the same MERGE (giving {@code traverseFromNode} a fresh {@code forcedVertex}), is ALSO
+   * directly pre-bound by the outer MATCH. {@code traverseFromNode} discarded the fresh instance in
+   * favour of the stale pre-bound one, so the second UNWIND row - which must observe the edge the first
+   * row appended to that middle node - missed it and created a duplicate leaf and edge.
+   */
+  @Test
+  void unwindMergeThroughPreboundMiddleNodeDoesNotDuplicateEdgeOrLeaf() {
+    database.command("opencypher", "CREATE (a:Mid {id:1})");
+    database.command("opencypher", "CREATE (b:Mid {id:2})");
+    database.command("opencypher", "MATCH (a:Mid {id:1}),(b:Mid {id:2}) CREATE (a)-[:R]->(b)");
+
+    database.command("opencypher",
+        "MATCH (a:Mid {id:1}),(b:Mid {id:2}) UNWIND [100,100,200] AS cid MERGE (a)-[:R]->(b)-[:S]->(c:Leaf {id:cid})");
+
+    final ResultSet edgeCount = database.query("opencypher", "MATCH (:Mid)-[r:S]->(:Leaf) RETURN count(r) AS c");
+    assertThat(edgeCount.next().<Number>getProperty("c").longValue()).isEqualTo(2);
+
+    final Map<Object, Long> leafCountsById = new HashMap<>();
+    final ResultSet leaves = database.query("opencypher", "MATCH (c:Leaf) RETURN c.id AS id, count(*) AS c");
+    while (leaves.hasNext()) {
+      final Result r = leaves.next();
+      leafCountsById.put(r.getProperty("id"), ((Number) r.getProperty("c")).longValue());
+    }
+    assertThat(leafCountsById).containsEntry(100L, 1L).containsEntry(200L, 1L);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
@@ -168,16 +168,23 @@ class Issue6300AlgoMSTEdgeBudgetTest {
   void theRefusalNamesTheActualEdgeCountOnceTheRowHeadersFit() {
     // A budget wide enough for the graph (1056) plus the row headers (704) - 1760 - but not for the 10 edges'
     // entries on top of that (12 bytes each: an int neighbour id plus a double weight, 120 bytes total) fires the
-    // second reservation, which quotes the edge count it actually reached: for an 11-node graph the per-edge
-    // checkpoint stride (every 1024 nodes, or 1_048_576 entries) never triggers mid-walk, so every edge has
-    // already been read into the arrays by the time this fires - the same "counted then refused" shape the old
-    // MST-local counting pass had, now living in the shared helper instead.
+    // second reservation, which quotes the edge count it actually reached.
+    //
+    // Issue #6795: before that fix, weightedAdjacencyFromRecords (the OLTP path this 11-node/no-view graph takes)
+    // checkpointed only every 1024 nodes or 1_048_576 entries - neither ever reached here - so every edge was
+    // already read into the arrays by the time the single post-loop reservation fired, reporting the full 10.
+    // The fix makes it also consult capacityFor(), recomputed after every reservation exactly like the columnar
+    // path already did: with this budget only 40 bytes remain once the row headers are admitted, so the interval
+    // shrinks fast and the walk is refused after just 1 more edge entry - proof the checkpoint now fires mid-walk
+    // instead of only once the whole adjacency list is already built.
     database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1800L);
 
+    // "1 edge entries" (not the full EDGE_COUNT): the record path must refuse well before materialising all 10
+    // edges, mirroring the columnar path's own capacityFor-scaled checkpoint.
     assertThatThrownBy(() -> drain("CALL algo.mst('w') YIELD source RETURN source"))
         .hasStackTraceContaining("algo.mst(): the weighted adjacency list would need")
         .hasStackTraceContaining("more than the 1800 bytes allowed")
-        .hasStackTraceContaining(EDGE_COUNT + " edge entries");
+        .hasStackTraceContaining("1 edge entries");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6795WeightedAdjacencyRecordsCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6795WeightedAdjacencyRecordsCheckpointTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6795 (follow-up on #6375/#6300): {@code weightedAdjacencyFromColumns} (the CSR path, see
+ * {@link Issue6300AlgoMSTEdgeBudgetTest}) checkpoints its edge-entry reservation at
+ * {@code min(ADJACENCY_CHECKPOINT_ENTRIES / 3, memory.capacityFor(INT_BYTES + DOUBLE_BYTES))}, recomputed
+ * after every reservation so the checkpoint stride shrinks as the budget fills. {@code weightedAdjacencyFromRecords}
+ * (the plain OLTP fallback, exercised here since no Graph Analytical View is built) used the flat
+ * {@code ADJACENCY_CHECKPOINT_ENTRIES} constant with no {@code capacityFor} cap, so on a graph small enough that
+ * neither that constant nor the every-1024-nodes boundary is ever reached mid-walk, the mid-loop checkpoint never
+ * fired at all: the whole weighted adjacency list was built in memory before the single unconditional
+ * post-loop reservation call finally refused it - the "up to ~12 MB overshoot before refusing" this issue
+ * describes.
+ * <p>
+ * Pins the fix by budget: with a tight enough {@code arcadedb.cypher.algo.maxWorkingMemory}, the refusal must name
+ * FEWER edge entries than the graph actually has - proof the checkpoint fired mid-walk instead of only after every
+ * edge was already read into the adjacency arrays.
+ */
+class Issue6795WeightedAdjacencyRecordsCheckpointTest {
+  /** Below the every-1024-nodes checkpoint boundary and far below ADJACENCY_CHECKPOINT_ENTRIES (1_048_576). */
+  private static final int  NODE_COUNT  = 200;
+  private static final long GRAPH_BYTES = (NODE_COUNT + 1) * 96L; // OLTP_VERTEX_BYTES, +1 for the load's own headroom check
+  private static final long ROW_HEADER_BYTES = NODE_COUNT * 64L; // 2 * MATRIX_ROW_OVERHEAD_BYTES per node
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6795-weighted-adjacency-records");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    // No edge property declared, and no Graph Analytical View built anywhere in this test: both keep the call on
+    // weightedAdjacencyFromRecords rather than the CSR-columnar weightedAdjacencyFromColumns (see Issue6300's
+    // setup note on the same distinction).
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final List<MutableVertex> nodes = new ArrayList<>(NODE_COUNT);
+      for (int i = 0; i < NODE_COUNT; i++)
+        nodes.add(database.newVertex("Node").set("idx", i).save());
+      for (int i = 0; i < NODE_COUNT - 1; i++)
+        nodes.get(i).newEdge("LINK", nodes.get(i + 1), true, new Object[] { "w", (double) (i + 1) }).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void theRecordPathChecksInMidWalkInsteadOfOnlyAfterMaterialisingEveryEdge() {
+    // Enough to admit the graph load and the weighted-adjacency row headers, but only a handful of edge entries
+    // on top - nowhere near the (NODE_COUNT - 1) = 199 edges the walk would fully materialise before a single
+    // flat-threshold checkpoint ever fired.
+    final long budget = GRAPH_BYTES + ROW_HEADER_BYTES + 200L;
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, budget);
+
+    final Throwable failure = catchFailure(() -> drain("CALL algo.mst('w') YIELD source RETURN source"));
+
+    assertThat(failure).as("a graph this far over budget must still be refused").isNotNull();
+    assertThat(failure).hasStackTraceContaining("the weighted adjacency list would need");
+
+    final Integer reportedEntries = reportedEdgeEntries(failure);
+    assertThat(reportedEntries).as("the refusal message must name the edge-entry count it actually reached").isNotNull();
+    // The unfixed code checkpoints only every 1024 nodes or ADJACENCY_CHECKPOINT_ENTRIES (1_048_576) entries -
+    // neither ever reached by 199 total edges - so it reports the FULL edge count (199, measured) at the single
+    // unconditional post-loop reservation: the whole adjacency list was already built by the time it refuses.
+    // A checkpoint that also consults capacityFor(), sized against this test's tight budget, refuses within the
+    // first handful of entries instead (1, measured) - comfortably under half of the full count either way.
+    assertThat(reportedEntries)
+        .as("a checkpoint that consults capacityFor must refuse mid-walk, well before every one of this "
+            + "chain's " + (NODE_COUNT - 1) + " edge entries has been read into the adjacency arrays")
+        .isLessThan((NODE_COUNT - 1) / 2);
+  }
+
+  private Throwable catchFailure(final Runnable body) {
+    try {
+      body.run();
+      return null;
+    } catch (final Throwable t) {
+      return t;
+    }
+  }
+
+  private static final Pattern EDGE_ENTRIES_PATTERN = Pattern.compile("(\\d+) edge entries");
+
+  private static Integer reportedEdgeEntries(final Throwable failure) {
+    // The refusal's own message may be wrapped by the query engine's own exception, so scan every cause's
+    // message rather than only the outermost one - the same span assertj's hasStackTraceContaining covers.
+    for (Throwable t = failure; t != null; t = t.getCause()) {
+      final Matcher matcher = EDGE_ENTRIES_PATTERN.matcher(String.valueOf(t.getMessage()));
+      if (matcher.find())
+        return Integer.valueOf(matcher.group(1));
+    }
+    return null;
+  }
+
+  @Test
+  void aBudgetThatFitsLetsTheCallThrough() {
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, -1L);
+    assertThat(drain("CALL algo.mst('w') YIELD source RETURN source")).hasSize(NODE_COUNT - 1);
+  }
+
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
+    final ResultSet rs = database.query("opencypher", query);
+    while (rs.hasNext())
+      rows.add(rs.next());
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/serializer/JsonGraphSerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/JsonGraphSerializerTest.java
@@ -19,16 +19,26 @@
 package com.arcadedb.serializer;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Property;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.DateUtils;
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class JsonGraphSerializerTest extends TestHelper {
 
@@ -83,6 +93,107 @@ class JsonGraphSerializerTest extends TestHelper {
     assertThat(JsonPath.<String>read(json, "$.i")).isNotEmpty();
     assertThat(JsonPath.<String>read(json, "$.o")).isNotEmpty();
 
+  }
+
+  /**
+   * Issue #6795 (follow-up on #6455): {@code encodeTemporalForWriteBack}'s write-back encoding used to be gated
+   * on {@code value instanceof Temporal}, which the default {@code java.time.LocalDate}/{@code LocalDateTime}
+   * implementations satisfy but the supported non-default {@code arcadedb.dateImplementation=java.util.Date} (or
+   * {@code Calendar}) does not - the binary serializer hands a DATE property back as a plain {@link Date} or
+   * {@link Calendar} there, so the guard never fired, the value fell through to the raw epoch-millis encoding
+   * {@link com.arcadedb.serializer.json.JSONObject#put(String, Object)}'s default temporal branch uses, and the
+   * re-import decoded that millis number as epoch DAYS - the original #6455 data-loss symptom returns. A real
+   * {@link Document}/{@link DocumentType}/{@link Property} chain isn't needed to pin the encoding decision itself,
+   * so this drives {@link JsonGraphSerializer#serializeGraphElement(Document)} directly against a minimal mocked
+   * DATE property, sidestepping how the engine's storage layer happens to represent {@code dateImplementation}
+   * internally.
+   */
+  @Test
+  void dateWrittenAsJavaUtilDateIsEncodedAsEpochDaysForWriteBack() {
+    final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.clear();
+    calendar.set(2024, Calendar.JANUARY, 15);
+    final Date birth = calendar.getTime();
+
+    final Property property = mock(Property.class);
+    when(property.getType()).thenReturn(Type.DATE);
+
+    final DocumentType type = mock(DocumentType.class);
+    when(type.existsProperty("birth")).thenReturn(true);
+    when(type.getProperty("birth")).thenReturn(property);
+
+    final Document document = mock(Document.class);
+    when(document.getTypeName()).thenReturn("Person");
+    when(document.getType()).thenReturn(type);
+    when(document.toMap(false)).thenReturn(Map.of("birth", birth));
+
+    final JsonGraphSerializer serializer = JsonGraphSerializer.createJsonGraphSerializer()
+        .setIncludeMetadata(false)
+        .setPrecisionAwareTemporals(true);
+
+    final Object encoded = serializer.serializeGraphElement(document).getJSONObject("p").get("birth");
+
+    assertThat(encoded).isEqualTo(DateUtils.dateToEpochDays(birth));
+  }
+
+  /**
+   * Same gap, {@code java.util.Calendar} side - the two implementations {@code arcadedb.dateImplementation}
+   * supports besides the default {@code java.time.LocalDate}.
+   */
+  @Test
+  void dateWrittenAsCalendarIsEncodedAsEpochDaysForWriteBack() {
+    final Calendar birth = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    birth.clear();
+    birth.set(2024, Calendar.JANUARY, 15);
+
+    final Property property = mock(Property.class);
+    when(property.getType()).thenReturn(Type.DATE);
+
+    final DocumentType type = mock(DocumentType.class);
+    when(type.existsProperty("birth")).thenReturn(true);
+    when(type.getProperty("birth")).thenReturn(property);
+
+    final Document document = mock(Document.class);
+    when(document.getTypeName()).thenReturn("Person");
+    when(document.getType()).thenReturn(type);
+    when(document.toMap(false)).thenReturn(Map.of("birth", birth));
+
+    final JsonGraphSerializer serializer = JsonGraphSerializer.createJsonGraphSerializer()
+        .setIncludeMetadata(false)
+        .setPrecisionAwareTemporals(true);
+
+    final Object encoded = serializer.serializeGraphElement(document).getJSONObject("p").get("birth");
+
+    assertThat(encoded).isEqualTo(DateUtils.dateToEpochDays(birth));
+  }
+
+  /**
+   * Sanity check that the fix did not change the well-covered default path: a {@link LocalDate} value must still
+   * take the {@code Temporal} branch and encode identically.
+   */
+  @Test
+  void dateWrittenAsLocalDateStillEncodesAsEpochDaysForWriteBack() {
+    final LocalDate birth = LocalDate.of(2024, 1, 15);
+
+    final Property property = mock(Property.class);
+    when(property.getType()).thenReturn(Type.DATE);
+
+    final DocumentType type = mock(DocumentType.class);
+    when(type.existsProperty("birth")).thenReturn(true);
+    when(type.getProperty("birth")).thenReturn(property);
+
+    final Document document = mock(Document.class);
+    when(document.getTypeName()).thenReturn("Person");
+    when(document.getType()).thenReturn(type);
+    when(document.toMap(false)).thenReturn(Map.of("birth", birth));
+
+    final JsonGraphSerializer serializer = JsonGraphSerializer.createJsonGraphSerializer()
+        .setIncludeMetadata(false)
+        .setPrecisionAwareTemporals(true);
+
+    final Object encoded = serializer.serializeGraphElement(document).getJSONObject("p").get("birth");
+
+    assertThat(encoded).isEqualTo(birth.toEpochDay());
   }
 
 }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2697,7 +2697,18 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             // Issue #6607: honour TransactionContext on the first chunk
             final boolean hasTx = c.hasTransaction();
             final String incomingTxId = hasTx ? c.getTransaction().getTransactionId() : "";
-            final TransactionContext txCtx = resolveAuthorizedTransaction(incomingTxId, c.getCredentials());
+            // Issue #6795: resolved outside the per-chunk catch below, mirroring bulkInsert/insertBidirectional,
+            // so a StatusRuntimeException (e.g. PERMISSION_DENIED from authorizeTransactionAccess) reaches the
+            // client as-is instead of being folded by that catch into a transaction-level error entry inside an
+            // otherwise "successful" InsertSummary.
+            final TransactionContext txCtx;
+            try {
+              txCtx = resolveAuthorizedTransaction(incomingTxId, c.getCredentials());
+            } catch (final StatusRuntimeException sre) {
+              cancelled.set(true);
+              out.onError(sre);
+              return;
+            }
 
             if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
               streamFailed.set(true);
@@ -3340,6 +3351,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final AtomicReference<InsertContext> ref = new AtomicReference<>();
     final AtomicBoolean cancelled = new AtomicBoolean(false);
     final AtomicBoolean started = new AtomicBoolean(false);
+    // Issue #6795: the external TransactionContext resolved from Start.transaction, if any. CHUNK dispatches
+    // its insertRows() call onto this transaction's own dedicated executor (mirroring insertStream/bulkInsert),
+    // since the ArcadeDB transaction begun there is bound via ThreadLocal to that executor's thread, not to
+    // this stream's own streamExecutor thread.
+    final AtomicReference<TransactionContext> extTxCtxRef = new AtomicReference<>();
 
     // Issue #5041 (CON-1): capture the gRPC Context here, on the inbound thread where the auth
     // interceptor has attached it, so the header/Bearer-authenticated user (USER_CONTEXT_KEY) is
@@ -3414,12 +3430,39 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                   return;
                 }
 
-                final InsertOptions opts = defaults(reqMsg.getStart().getOptions());
-                final InsertContext ctx = new InsertContext(opts);
+                final Start startMsg = reqMsg.getStart();
+                final InsertOptions opts = defaults(startMsg.getOptions());
+
+                // Issue #6795: honour Start.transaction, mirroring insertStream/bulkInsert. Before this,
+                // insertBidirectional always began its OWN transaction (getStart().getTransaction() was never
+                // read), so rows never joined the caller's transaction and a client rollback could not undo them.
+                final boolean hasTx = startMsg.hasTransaction();
+                final String incomingTxId = hasTx ? startMsg.getTransaction().getTransactionId() : "";
+                final TransactionContext txCtx;
+                try {
+                  txCtx = resolveAuthorizedTransaction(incomingTxId, startMsg.getCredentials());
+                } catch (final StatusRuntimeException sre) {
+                  out.onError(sre);
+                  streamExecutor.shutdown();
+                  return;
+                }
+
+                if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+                  out.onError(unknownTransactionStatus(incomingTxId).asException());
+                  streamExecutor.shutdown();
+                  return;
+                }
+
+                // External transaction: skip begin/commit/rollback (the caller's TransactionContext owns the
+                // lifecycle) and, below, dispatch CHUNK's insertRows() onto its own dedicated executor. COMMIT's
+                // ctx.flushCommit(true) is already a no-op for an external transaction (InsertContext.close()
+                // too), so the stream's own COMMIT/half-close never touches the caller's transaction.
+                final InsertContext ctx = txCtx != null ? new InsertContext(txCtx.db, opts) : new InsertContext(opts);
                 ctx.startedAt = System.currentTimeMillis();
                 ctx.totals = new Counts();
 
                 ref.set(ctx);
+                extTxCtxRef.set(txCtx);
                 sessionWatermark.put(ctx.sessionId, 0L);
 
                 sendResponse.accept(
@@ -3447,7 +3490,23 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
                 Counts perChunk;
                 try {
-                  perChunk = insertRows(ctx, c.getRowsList().iterator());
+                  if (ctx.externalTransaction) {
+                    // Issue #6795: dispatch onto the external transaction's own dedicated executor, the same
+                    // way insertStream/bulkInsert do - the transaction begun there is bound via ThreadLocal to
+                    // that executor's thread, not to this stream's streamExecutor thread. Also touches the
+                    // transaction (issue #6755's fix for insertStream): resolveAuthorizedTransaction only ran
+                    // once, on START, so later chunks must refresh it themselves or the idle reaper can reap a
+                    // transaction that is still actively receiving chunks.
+                    final TransactionContext extTxCtx = extTxCtxRef.get();
+                    extTxCtx.touch();
+                    try {
+                      perChunk = submitToActiveTransaction(extTxCtx, () -> insertRows(ctx, c.getRowsList().iterator())).get();
+                    } catch (final ExecutionException ee) {
+                      final Throwable cause = ee.getCause();
+                      throw cause instanceof Exception ex ? ex : ee;
+                    }
+                  } else
+                    perChunk = insertRows(ctx, c.getRowsList().iterator());
                   ctx.totals.add(perChunk);
                   sessionWatermark.put(ctx.sessionId, c.getChunkSeq());
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6795InsertBidirectionalExternalTransactionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6795InsertBidirectionalExternalTransactionIT.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6795 (follow-up on #6607, reported as a comment on the closed issue):
+ * {@code insertBidirectional}'s {@code START} handler never read {@code Start.transaction} - it always built
+ * its {@code InsertContext} with {@code new InsertContext(opts)}, which begins and owns its OWN transaction,
+ * exactly the bug {@code insertStream}/{@code bulkInsert} were fixed for in #6607. Rows streamed under a
+ * {@code transaction_id} therefore landed in a fresh internal transaction the stream itself committed on
+ * {@code COMMIT}/half-close, never joining the caller's transaction: a client rollback of that transaction
+ * could not undo them.
+ * <p>
+ * Same shape as {@link Issue6607InsertStreamExternalTransactionIT}, driving the START/CHUNK/COMMIT
+ * request/response protocol {@code insertBidirectional} uses instead of {@code insertStream}'s flatter one.
+ */
+class Issue6795InsertBidirectionalExternalTransactionIT extends BaseGraphServerTest {
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private GrpcValue stringValue(final String s) {
+    return GrpcValue.newBuilder().setStringValue(s).build();
+  }
+
+  private long countRows(final String typeName) {
+    return getServer(0).getDatabase(getDatabaseName())
+        .query("sql", "SELECT count(*) AS total FROM " + typeName).next().<Long>getProperty("total");
+  }
+
+  /**
+   * Rows sent via {@code insertBidirectional} under an external transaction must not survive a rollback of
+   * that transaction: the whole point of passing {@code Start.transaction} is that the caller controls
+   * commit/rollback, not the stream's own {@code COMMIT} message.
+   */
+  @Test
+  void rowsSentViaInsertBidirectionalUnderExternalTransactionDoNotSurviveRollback() throws Exception {
+    final String typeName = "Issue6795BidiExtTxRollback_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BeginTransactionResponse begin = beginTransaction(service);
+      final String txId = begin.getTransactionId();
+      assertThat(txId).isNotBlank();
+
+      final RecordingInsertResponseObserver resp = new RecordingInsertResponseObserver();
+      final StreamObserver<InsertRequest> req = service.insertBidirectional(resp);
+
+      req.onNext(InsertRequest.newBuilder().setStart(Start.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setCredentials(credentials())
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .build())
+          .build()).build());
+
+      final Started started = resp.awaitStarted();
+      assertThat(started.getSessionId()).isNotBlank();
+
+      final InsertChunk.Builder chunk = InsertChunk.newBuilder()
+          .setSessionId(started.getSessionId())
+          .setChunkSeq(1);
+      for (int i = 0; i < 15; i++)
+        chunk.addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+      req.onNext(InsertRequest.newBuilder().setChunk(chunk.build()).build());
+
+      final BatchAck ack = resp.awaitBatchAck();
+      assertThat(ack.getInserted()).isEqualTo(15);
+      assertThat(ack.getFailed()).isZero();
+
+      req.onNext(InsertRequest.newBuilder()
+          .setCommit(Commit.newBuilder().setSessionId(started.getSessionId()).setCommit(true).build()).build());
+      final Committed committed = resp.awaitCommitted();
+      assertThat(committed.getSummary().getInserted()).isEqualTo(15);
+
+      // The stream's own COMMIT must be a no-op for an external transaction: the rows are visible inside the
+      // still-open external transaction before it is rolled back...
+      final RollbackTransactionResponse rollback = rollbackTransaction(service, txId);
+      assertThat(rollback.getSuccess()).isTrue();
+      assertThat(rollback.getRolledBack()).isTrue();
+
+      // ...but once rolled back, none of them may have survived outside it.
+      assertThat(countRows(typeName))
+          .as("rows sent via insertBidirectional under an external transaction must not survive its rollback")
+          .isZero();
+    } finally {
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  /**
+   * Sanity companion: rows sent via {@code insertBidirectional} under an external transaction must still
+   * commit normally when the client commits it, so the fix does not just make everything vanish.
+   */
+  @Test
+  void rowsSentViaInsertBidirectionalUnderExternalTransactionPersistOnCommit() throws Exception {
+    final String typeName = "Issue6795BidiExtTxCommit_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BeginTransactionResponse begin = beginTransaction(service);
+      final String txId = begin.getTransactionId();
+
+      final RecordingInsertResponseObserver resp = new RecordingInsertResponseObserver();
+      final StreamObserver<InsertRequest> req = service.insertBidirectional(resp);
+
+      req.onNext(InsertRequest.newBuilder().setStart(Start.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setCredentials(credentials())
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .build())
+          .build()).build());
+
+      final Started started = resp.awaitStarted();
+
+      final InsertChunk.Builder chunk = InsertChunk.newBuilder()
+          .setSessionId(started.getSessionId())
+          .setChunkSeq(1);
+      for (int i = 0; i < 9; i++)
+        chunk.addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+      req.onNext(InsertRequest.newBuilder().setChunk(chunk.build()).build());
+      resp.awaitBatchAck();
+
+      req.onNext(InsertRequest.newBuilder()
+          .setCommit(Commit.newBuilder().setSessionId(started.getSessionId()).setCommit(true).build()).build());
+      resp.awaitCommitted();
+
+      final AtomicReference<CommitTransactionResponse> commitRef = new AtomicReference<>();
+      service.commitTransaction(
+          CommitTransactionRequest.newBuilder()
+              .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+              .setCredentials(credentials())
+              .build(),
+          capturing(commitRef));
+      assertThat(commitRef.get().getSuccess()).isTrue();
+
+      assertThat(countRows(typeName)).isEqualTo(9L);
+    } finally {
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  private BeginTransactionResponse beginTransaction(final ArcadeDbGrpcService service) {
+    final AtomicReference<BeginTransactionResponse> ref = new AtomicReference<>();
+    service.beginTransaction(
+        BeginTransactionRequest.newBuilder().setDatabase(getDatabaseName()).setCredentials(credentials()).build(),
+        capturing(ref));
+    return ref.get();
+  }
+
+  private RollbackTransactionResponse rollbackTransaction(final ArcadeDbGrpcService service, final String txId) {
+    final AtomicReference<RollbackTransactionResponse> ref = new AtomicReference<>();
+    service.rollbackTransaction(
+        RollbackTransactionRequest.newBuilder()
+            .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+            .setCredentials(credentials())
+            .build(),
+        capturing(ref));
+    return ref.get();
+  }
+
+  private <T> StreamObserver<T> capturing(final AtomicReference<T> ref) {
+    return new StreamObserver<>() {
+      @Override public void onNext(final T value) { ref.set(value); }
+      @Override public void onError(final Throwable t) { throw new RuntimeException(t); }
+      @Override public void onCompleted() { }
+    };
+  }
+
+  /**
+   * Minimal {@link ServerCallStreamObserver} double for the bidi-streaming {@code insertBidirectional}
+   * handler. {@code onNext} runs on the service's own per-stream executor thread (a different thread than
+   * the test's), so each expected response is handed to the test thread through its own latch instead of a
+   * plain field read.
+   */
+  private static final class RecordingInsertResponseObserver extends ServerCallStreamObserver<InsertResponse> {
+    private final AtomicReference<Started>   startedRef   = new AtomicReference<>();
+    private final AtomicReference<BatchAck>  batchAckRef  = new AtomicReference<>();
+    private final AtomicReference<Committed> committedRef = new AtomicReference<>();
+    private final AtomicReference<Throwable> errorRef     = new AtomicReference<>();
+
+    private volatile CountDownLatch startedLatch   = new CountDownLatch(1);
+    private volatile CountDownLatch batchAckLatch   = new CountDownLatch(1);
+    private volatile CountDownLatch committedLatch  = new CountDownLatch(1);
+
+    @Override
+    public void onNext(final InsertResponse value) {
+      switch (value.getMsgCase()) {
+        case STARTED -> {
+          startedRef.set(value.getStarted());
+          startedLatch.countDown();
+        }
+        case BATCH_ACK -> {
+          batchAckRef.set(value.getBatchAck());
+          batchAckLatch.countDown();
+        }
+        case COMMITTED -> {
+          committedRef.set(value.getCommitted());
+          committedLatch.countDown();
+        }
+        default -> {
+        }
+      }
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+      errorRef.set(t);
+      startedLatch.countDown();
+      batchAckLatch.countDown();
+      committedLatch.countDown();
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+
+    Started awaitStarted() throws InterruptedException {
+      assertThat(startedLatch.await(10, TimeUnit.SECONDS)).as("timed out waiting for Started").isTrue();
+      if (errorRef.get() != null)
+        throw new AssertionError("insertBidirectional errored before Started", errorRef.get());
+      return startedRef.get();
+    }
+
+    BatchAck awaitBatchAck() throws InterruptedException {
+      assertThat(batchAckLatch.await(10, TimeUnit.SECONDS)).as("timed out waiting for BatchAck").isTrue();
+      if (errorRef.get() != null)
+        throw new AssertionError("insertBidirectional errored before BatchAck", errorRef.get());
+      return batchAckRef.get();
+    }
+
+    Committed awaitCommitted() throws InterruptedException {
+      assertThat(committedLatch.await(10, TimeUnit.SECONDS)).as("timed out waiting for Committed").isTrue();
+      if (errorRef.get() != null)
+        throw new AssertionError("insertBidirectional errored before Committed", errorRef.get());
+      return committedRef.get();
+    }
+
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6795InsertStreamAuthFailureNotDowngradedIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6795InsertStreamAuthFailureNotDowngradedIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6795 (follow-up on #6607, reported as a comment on the closed issue):
+ * {@code insertStream}'s first-chunk call to {@code resolveAuthorizedTransaction(...)} sat inside the chunk
+ * handler's folding {@code try/catch}, so a {@code StatusRuntimeException} it throws (e.g.
+ * {@code PERMISSION_DENIED} from {@code authorizeTransactionAccess} when the caller is not the transaction's
+ * owner) was caught by the generic per-chunk handler and downgraded into a structured error entry inside an
+ * otherwise "successful" {@link InsertSummary} delivered via {@code onCompleted} - instead of reaching the
+ * client as the real gRPC status via {@code onError}, the way {@code bulkInsert} already did for the same
+ * failure (see {@code Issue6607InsertStreamExternalTransactionIT.bulkInsertWithExternalTransactionBadCredentialsPreservesRealStatusCode}).
+ */
+class Issue6795InsertStreamAuthFailureNotDowngradedIT extends BaseGraphServerTest {
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  @Test
+  void insertStreamPreservesRealStatusCodeOnTransactionAuthorizationFailure() throws Exception {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BeginTransactionResponse begin = beginTransaction(service);
+      final String txId = begin.getTransactionId();
+      try {
+        final CapturingInsertSummaryObserver resp = new CapturingInsertSummaryObserver();
+        final StreamObserver<InsertChunk> req = service.insertStream(resp);
+
+        final InsertChunk chunk = InsertChunk.newBuilder()
+            .setSessionId("issue-6795-auth")
+            .setChunkSeq(0)
+            .setLast(true)
+            .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+            // Top-level chunk credentials, distinct from InsertOptions.credentials: resolveAuthorizedTransaction()
+            // authorizes the external-transaction path off THIS field (see InsertChunk.credentials in the proto)
+            // - deliberately wrong here, exactly the shape a caller guessing another user's transaction id, or
+            // supplying a stale password, would hit.
+            .setCredentials(DatabaseCredentials.newBuilder().setUsername("root").setPassword("definitely-wrong-password").build())
+            .setOptions(InsertOptions.newBuilder()
+                .setDatabase(getDatabaseName())
+                .setCredentials(credentials())
+                .setTargetClass("Person")
+                .build())
+            .build();
+
+        req.onNext(chunk);
+        req.onCompleted();
+
+        assertThat(resp.awaitTerminal()).as("timed out waiting for a terminal call").isTrue();
+        assertThat(resp.errorRef.get())
+            .as("a bad-credentials rejection must reach the client unmodified via onError, not be folded into a "
+                + "\"successful\" InsertSummary")
+            .isInstanceOf(StatusRuntimeException.class);
+        assertThat(((StatusRuntimeException) resp.errorRef.get()).getStatus().getCode())
+            .isIn(Status.Code.PERMISSION_DENIED, Status.Code.UNAUTHENTICATED);
+        assertThat(resp.summaryRef.get())
+            .as("no InsertSummary should be delivered when the transaction-authorization check itself failed")
+            .isNull();
+      } finally {
+        rollbackTransaction(service, txId);
+      }
+    } finally {
+      service.close();
+    }
+  }
+
+  private BeginTransactionResponse beginTransaction(final ArcadeDbGrpcService service) {
+    final AtomicReference<BeginTransactionResponse> ref = new AtomicReference<>();
+    service.beginTransaction(
+        BeginTransactionRequest.newBuilder().setDatabase(getDatabaseName()).setCredentials(credentials()).build(),
+        capturing(ref));
+    return ref.get();
+  }
+
+  private void rollbackTransaction(final ArcadeDbGrpcService service, final String txId) {
+    final AtomicReference<RollbackTransactionResponse> ref = new AtomicReference<>();
+    service.rollbackTransaction(
+        RollbackTransactionRequest.newBuilder()
+            .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+            .setCredentials(credentials())
+            .build(),
+        capturing(ref));
+  }
+
+  private <T> StreamObserver<T> capturing(final AtomicReference<T> ref) {
+    return new StreamObserver<>() {
+      @Override public void onNext(final T value) { ref.set(value); }
+      @Override public void onError(final Throwable t) { throw new RuntimeException(t); }
+      @Override public void onCompleted() { }
+    };
+  }
+
+  /**
+   * Minimal {@link ServerCallStreamObserver} double for {@code insertStream}'s response observer, recording
+   * either the {@link InsertSummary} delivered via {@code onNext}/{@code onCompleted} or the {@link Throwable}
+   * passed to {@code onError}, without throwing.
+   */
+  private static final class CapturingInsertSummaryObserver extends ServerCallStreamObserver<InsertSummary> {
+    final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+    final AtomicReference<Throwable>     errorRef   = new AtomicReference<>();
+    private final CountDownLatch          terminalLatch = new CountDownLatch(1);
+
+    @Override
+    public void onNext(final InsertSummary value) {
+      summaryRef.set(value);
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+      errorRef.set(t);
+      terminalLatch.countDown();
+    }
+
+    @Override
+    public void onCompleted() {
+      terminalLatch.countDown();
+    }
+
+    boolean awaitTerminal() throws InterruptedException {
+      return terminalLatch.await(10, TimeUnit.SECONDS);
+    }
+
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
@@ -199,27 +199,39 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
     for (final String type : vertexTypes) {
       for (final Iterator<Record> cursor = database.iterateType(type, false); cursor.hasNext(); ) {
         Vertex vertex = null;
+        final Iterable<Edge> outEdges;
         try {
           vertex = cursor.next().asVertex(true);
 
           if (settings.includeRecords != null && !settings.includeRecords.contains(vertex.getIdentity().toString()))
             continue;
 
-          for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT)) {
-            if (!(edge instanceof LightEdge))
-              continue;
-            if (settings.excludeTypes != null && settings.excludeTypes.contains(edge.getTypeName()))
-              continue;
-            if (settings.includeTypes != null && !settings.includeTypes.contains(edge.getTypeName()))
-              continue;
-
-            writeJsonLine("e", graphSerializer.serializeGraphElement(edge));
-            context.edges.incrementAndGet();
-          }
+          outEdges = vertex.getEdges(Vertex.DIRECTION.OUT);
         } catch (Exception e) {
           context.skippedRecords.incrementAndGet();
           LogManager.instance().log(this, Level.SEVERE, "Error on exporting lightweight edges of vertex %s", e,
               vertex != null ? vertex.getIdentity() : null);
+          continue;
+        }
+
+        // Issue #6795 (follow-up on #6471): each edge gets its OWN try/catch, so a failure on one edge is
+        // counted on its own and does not silently drop the rest of this vertex's edges.
+        for (final Edge edge : outEdges) {
+          if (!(edge instanceof LightEdge))
+            continue;
+          if (settings.excludeTypes != null && settings.excludeTypes.contains(edge.getTypeName()))
+            continue;
+          if (settings.includeTypes != null && !settings.includeTypes.contains(edge.getTypeName()))
+            continue;
+
+          try {
+            writeJsonLine("e", graphSerializer.serializeGraphElement(edge));
+            context.edges.incrementAndGet();
+          } catch (Exception e) {
+            context.skippedRecords.incrementAndGet();
+            LogManager.instance().log(this, Level.SEVERE, "Error on exporting lightweight edge %s of vertex %s", e,
+                edge.getIdentity(), vertex.getIdentity());
+          }
         }
       }
     }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -73,9 +73,16 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
   // loaded (loadProperties() below). A value that cannot be resolved yet - it references a record appearing LATER in
   // the source stream - is a forward reference: the referenced record's old-to-new RID mapping does not exist yet.
   // Rather than leaving it silently wrong (the original bug) or failing the whole record, the record's own new RID
-  // and the names of its still-unresolved properties are remembered here and revisited in a reconciliation pass once
-  // the entire file has been read and every RID mapping is known (see reconcileUnresolvedLinks()).
-  private final Map<RID, Set<String>> pendingLinkReconciliation = new HashMap<>();
+  // and, per still-unresolved property, the OLD/source RID value(s) that failed to resolve are remembered here and
+  // revisited in a reconciliation pass once the entire file has been read and every RID mapping is known (see
+  // reconcileUnresolvedLinks()).
+  //
+  // Issue #6795: the value used to be just the set of unresolved PROPERTY NAMES, so reconciliation re-applied
+  // ridIndex to every RID element of a LIST/MAP property, including ones pass 1 already resolved. On a normal
+  // same-schema restore the source and target RID spaces overlap, so an already-correct element (now holding its
+  // NEW target RID) could equal another record's OLD source RID and get silently re-pointed a second time.
+  // Recording the specific old-source RIDs left unresolved lets reconciliation touch only those elements.
+  private final Map<RID, Map<String, Set<RID>>> pendingLinkReconciliation = new HashMap<>();
 
   @Override
   public void load(SourceSchema sourceSchema,
@@ -460,14 +467,14 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
    * regular LINK-typed property was passed through untouched, so after import it silently pointed at the source
    * database's RID - now a different, unrelated record, or none.
    *
-   * @return the names of properties whose LINK value(s) could not be resolved yet because they reference a record
-   * that has not been imported so far (a forward reference); empty when every LINK value resolved immediately. The
-   * caller is expected to remember these against the record's own (new) identity so {@link #reconcileUnresolvedLinks}
-   * can revisit them once every RID mapping is known.
+   * @return per still-unresolved property, the OLD/source RID value(s) that could not be resolved yet because they
+   * reference a record that has not been imported so far (a forward reference); empty when every LINK value
+   * resolved immediately. The caller is expected to remember these against the record's own (new) identity so
+   * {@link #reconcileUnresolvedLinks} can revisit them once every RID mapping is known.
    */
-  private Set<String> loadProperties(DatabaseInternal database, MutableDocument imported, JSONObject properties) {
+  private Map<String, Set<RID>> loadProperties(DatabaseInternal database, MutableDocument imported, JSONObject properties) {
     Map<String, Object> json2map = json2map(database, properties);
-    final Set<String> unresolved = remapLinkProperties(imported.getType(), json2map);
+    final Map<String, Set<RID>> unresolved = remapLinkProperties(imported.getType(), json2map);
     imported.fromMap(json2map);
     return unresolved;
   }
@@ -475,16 +482,17 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
   /**
    * Remaps every LINK-typed value in {@code properties} in place, consulting {@code ridIndex} for the schema-declared
    * LINK properties of {@code type} (scalar LINK, and LIST/MAP declared {@code OF LINK}). A value that {@code
-   * ridIndex} does not (yet) know about is left untouched and its property name is added to the returned set.
+   * ridIndex} does not (yet) know about is left untouched and its OLD/source RID is added to the returned map,
+   * keyed by property name.
    * <p>
    * Only schema-declared properties are inspected: without a declared type there is no reliable way to tell a LINK
    * string ("#12:34") apart from an ordinary string that merely looks like one.
    */
-  private Set<String> remapLinkProperties(final DocumentType type, final Map<String, Object> properties) {
+  private Map<String, Set<RID>> remapLinkProperties(final DocumentType type, final Map<String, Object> properties) {
     if (type == null || properties.isEmpty())
-      return Set.of();
+      return Map.of();
 
-    Set<String> unresolved = null;
+    Map<String, Set<RID>> unresolved = null;
 
     for (final Map.Entry<String, Object> entry : properties.entrySet()) {
       final Object value = entry.getValue();
@@ -497,37 +505,42 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
       final Type propertyType = property.getType();
 
+      final Set<RID> propertyUnresolved;
       if (propertyType == Type.LINK) {
-        if (unresolved == null)
-          unresolved = new HashSet<>();
-        entry.setValue(remapLinkValue(value, unresolved, entry.getKey()));
+        propertyUnresolved = new HashSet<>();
+        entry.setValue(remapLinkValue(value, propertyUnresolved));
       } else if (propertyType == Type.LIST && "LINK".equalsIgnoreCase(property.getOfType()) && value instanceof List<?> list) {
-        if (unresolved == null)
-          unresolved = new HashSet<>();
+        propertyUnresolved = new HashSet<>();
         final List<Object> remapped = new ArrayList<>(list.size());
         for (final Object item : list)
-          remapped.add(remapLinkValue(item, unresolved, entry.getKey()));
+          remapped.add(remapLinkValue(item, propertyUnresolved));
         entry.setValue(remapped);
       } else if (propertyType == Type.MAP && "LINK".equalsIgnoreCase(property.getOfType()) && value instanceof Map<?, ?> valueMap) {
-        if (unresolved == null)
-          unresolved = new HashSet<>();
+        propertyUnresolved = new HashSet<>();
         final Map<Object, Object> remapped = new HashMap<>();
         for (final Map.Entry<?, ?> mapEntry : valueMap.entrySet())
-          remapped.put(mapEntry.getKey(), remapLinkValue(mapEntry.getValue(), unresolved, entry.getKey()));
+          remapped.put(mapEntry.getKey(), remapLinkValue(mapEntry.getValue(), propertyUnresolved));
         entry.setValue(remapped);
+      } else
+        continue;
+
+      if (!propertyUnresolved.isEmpty()) {
+        if (unresolved == null)
+          unresolved = new HashMap<>();
+        unresolved.put(entry.getKey(), propertyUnresolved);
       }
     }
 
-    return unresolved == null ? Set.of() : unresolved;
+    return unresolved == null ? Map.of() : unresolved;
   }
 
   /**
    * Resolves a single LINK value (the exported source RID, as a String) to the RID the referenced record was
    * actually recreated at. If {@code ridIndex} has no mapping yet for it - the referenced record has not been
-   * imported so far - {@code propertyName} is recorded into {@code unresolved} and the original value is returned
+   * imported so far - its OLD/source RID is recorded into {@code unresolved} and the original value is returned
    * unchanged, to be revisited by {@link #reconcileUnresolvedLinks}.
    */
-  private Object remapLinkValue(final Object value, final Set<String> unresolved, final String propertyName) {
+  private Object remapLinkValue(final Object value, final Set<RID> unresolved) {
     if (!(value instanceof String string))
       return value;
 
@@ -544,7 +557,7 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     if (newRid != null)
       return newRid.toString();
 
-    unresolved.add(propertyName);
+    unresolved.add(oldRid);
     return value;
   }
 
@@ -573,7 +586,7 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       return;
 
     int reconciled = 0;
-    for (final Map.Entry<RID, Set<String>> entry : pendingLinkReconciliation.entrySet()) {
+    for (final Map.Entry<RID, Map<String, Set<RID>>> entry : pendingLinkReconciliation.entrySet()) {
       try {
         final Record record = database.lookupByRID(entry.getKey(), true);
         if (!(record instanceof Document document))
@@ -583,7 +596,14 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
         final MutableDocument mutable = document.modify();
         boolean changed = false;
 
-        for (final String propertyName : entry.getValue()) {
+        for (final Map.Entry<String, Set<RID>> propertyEntry : entry.getValue().entrySet()) {
+          final String propertyName = propertyEntry.getKey();
+          // Issue #6795: only an element whose CURRENT value is one of the OLD/source RIDs pass 1 actually left
+          // unresolved for this property is a candidate for remapping - an element pass 1 already resolved (now
+          // holding its NEW target RID) is left untouched even if that value happens to also be a key in
+          // ridIndex, which a normal same-schema restore (overlapping source/target RID spaces) makes routine.
+          final Set<RID> stillUnresolved = propertyEntry.getValue();
+
           final Property property = type.getPolymorphicPropertyIfExists(propertyName);
           if (property == null)
             continue;
@@ -593,16 +613,18 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
             continue;
 
           if (property.getType() == Type.LINK && currentValue instanceof RID currentRid) {
-            final RID newRid = ridIndex.get(currentRid);
-            if (newRid != null) {
-              mutable.set(propertyName, newRid);
-              changed = true;
+            if (stillUnresolved.contains(currentRid)) {
+              final RID newRid = ridIndex.get(currentRid);
+              if (newRid != null) {
+                mutable.set(propertyName, newRid);
+                changed = true;
+              }
             }
           } else if (currentValue instanceof List<?> list) {
             final List<Object> updated = new ArrayList<>(list.size());
             boolean listChanged = false;
             for (final Object item : list) {
-              if (item instanceof RID itemRid) {
+              if (item instanceof RID itemRid && stillUnresolved.contains(itemRid)) {
                 final RID newRid = ridIndex.get(itemRid);
                 if (newRid != null) {
                   updated.add(newRid);
@@ -621,7 +643,7 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
             boolean mapChanged = false;
             for (final Map.Entry<?, ?> mapEntry : valueMap.entrySet()) {
               Object mapValue = mapEntry.getValue();
-              if (mapValue instanceof RID itemRid) {
+              if (mapValue instanceof RID itemRid && stillUnresolved.contains(itemRid)) {
                 final RID newRid = ridIndex.get(itemRid);
                 if (newRid != null) {
                   mapValue = newRid;

--- a/integration/src/test/java/com/arcadedb/integration/exporter/JsonlExporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/JsonlExporterIT.java
@@ -21,7 +21,14 @@ package com.arcadedb.integration.exporter;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.IterableGraph;
+import com.arcadedb.graph.LightEdge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.integration.importer.OrientDBImporter;
 import com.arcadedb.integration.importer.OrientDBImporterIT;
@@ -41,6 +48,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.util.Iterator;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -277,6 +285,157 @@ class JsonlExporterIT {
       // its own first record: only the second, unaffected widget makes it into exportVertices' output.
       assertThat(vertexLines).isEqualTo(1);
 
+    } finally {
+      if (realDatabase.isOpen())
+        realDatabase.close();
+    }
+  }
+
+  /**
+   * Issue #6471 follow-up (#6795, comment on the closed issue): {@code exportLightweightEdges} wrapped a whole
+   * vertex's per-edge loop in ONE try/catch, so a failure on any single edge counted {@code skippedRecords} +1
+   * and silently dropped the REST of that vertex's remaining edges too - the same silent-drop class #6471
+   * targeted, surviving inside the very file the fix landed in. The primary guarantee still held (any skip still
+   * fails the export loudly via {@code ExportException}), so this pins the finer-grained guarantee: a failure on
+   * one edge must not cost its siblings.
+   */
+  @Test
+  void exportLightweightEdgesContinuesAfterOneEdgeFailsToSerialize() throws Exception {
+    final File file = new File(FILE);
+
+    final RID hubRid;
+    final RID leafARid;
+    final RID leafBRid;
+    try (final Database db = new DatabaseFactory(DATABASE_PATH).create()) {
+      db.transaction(() -> {
+        db.getSchema().buildVertexType().withName("Node").create();
+        db.getSchema().buildEdgeType().withName("Follows").withLightweight(true).create();
+      });
+
+      final MutableVertex[] holder = new MutableVertex[3];
+      db.transaction(() -> {
+        holder[0] = db.newVertex("Node").set("id", 0).save();
+        holder[1] = db.newVertex("Node").set("id", 1).save();
+        holder[2] = db.newVertex("Node").set("id", 2).save();
+        holder[0].newEdge("Follows", holder[1]);
+        holder[0].newEdge("Follows", holder[2]);
+      });
+
+      hubRid = holder[0].getIdentity();
+      leafARid = holder[1].getIdentity();
+      leafBRid = holder[2].getIdentity();
+    }
+
+    final DatabaseInternal realDatabase = (DatabaseInternal) new DatabaseFactory(DATABASE_PATH).open();
+    try {
+      final Vertex realHub = (Vertex) realDatabase.lookupByRID(hubRid, true);
+      Edge realEdgeToA = null;
+      Edge realEdgeToB = null;
+      for (final Edge e : realHub.getEdges(Vertex.DIRECTION.OUT)) {
+        if (leafARid.equals(e.getIn().getIdentity()))
+          realEdgeToA = e;
+        else if (leafBRid.equals(e.getIn().getIdentity()))
+          realEdgeToB = e;
+      }
+      assertThat(realEdgeToA).isNotNull();
+      assertThat(realEdgeToB).isNotNull();
+
+      // The edge to leaf A always throws when serialized; the edge to leaf B must still make it into the export.
+      final Edge finalRealEdgeToA = realEdgeToA;
+      final Edge failingEdgeToA = (Edge) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { LightEdge.class },
+          (proxy, method, args) -> {
+            if ("toMap".equals(method.getName()))
+              throw new RuntimeException("Simulated edge serialization failure");
+            try {
+              return method.invoke(finalRealEdgeToA, args);
+            } catch (final InvocationTargetException e) {
+              throw e.getCause();
+            }
+          });
+
+      final List<Edge> craftedOutEdges = List.of(failingEdgeToA, realEdgeToB);
+      final IterableGraph<Edge> craftedIterable = new IterableGraph<>() {
+        @Override
+        public Class<? extends Document> getEntryType() {
+          return Edge.class;
+        }
+
+        @Override
+        public Iterator<Edge> iterator() {
+          return craftedOutEdges.iterator();
+        }
+      };
+
+      final Vertex hubVertexProxy = (Vertex) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { Vertex.class },
+          (proxy, method, args) -> {
+            if ("getEdges".equals(method.getName()) && args != null && args.length >= 1 && Vertex.DIRECTION.OUT.equals(args[0]))
+              return craftedIterable;
+            try {
+              return method.invoke(realHub, args);
+            } catch (final InvocationTargetException e) {
+              throw e.getCause();
+            }
+          });
+
+      // Same proxying idiom as exportFailsLoudlyWhenARecordCannotBeSerialized above: every call forwards to the
+      // real database, except iterateType("Node", false), whose returned records are passed through unchanged -
+      // EXCEPT the hub, whose asVertex(true) hands back hubVertexProxy instead.
+      final DatabaseInternal proxyDatabase = (DatabaseInternal) Proxy.newProxyInstance(
+          DatabaseInternal.class.getClassLoader(), new Class<?>[] { DatabaseInternal.class },
+          (proxy, method, args) -> {
+            if ("iterateType".equals(method.getName()) && "Node".equals(args[0]) && Boolean.FALSE.equals(args[1])) {
+              final Iterator<Record> real = (Iterator<Record>) method.invoke(realDatabase, args);
+              return new Iterator<Record>() {
+                @Override
+                public boolean hasNext() {
+                  return real.hasNext();
+                }
+
+                @Override
+                public Record next() {
+                  final Record record = real.next();
+                  if (!hubRid.equals(record.getIdentity()))
+                    return record;
+
+                  return (Record) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { Record.class },
+                      (recordProxy, recordMethod, recordArgs) -> {
+                        if ("asVertex".equals(recordMethod.getName()))
+                          return hubVertexProxy;
+                        try {
+                          return recordMethod.invoke(record, recordArgs);
+                        } catch (final InvocationTargetException e) {
+                          throw e.getCause();
+                        }
+                      });
+                }
+              };
+            }
+            try {
+              return method.invoke(realDatabase, args);
+            } catch (final InvocationTargetException e) {
+              throw e.getCause();
+            }
+          });
+
+      final Exporter exporter = new Exporter(proxyDatabase, FILE);
+      exporter.setFormat("jsonl").setOverwrite(true);
+
+      assertThatThrownBy(exporter::exportDatabase)//
+          .isInstanceOf(ExportException.class)//
+          .hasMessageContaining("skipped");
+
+      boolean foundEdgeToLeafB = false;
+      try (final BufferedReader in = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(file))))) {
+        while (in.ready()) {
+          final String line = in.readLine();
+          final JSONObject json = new JSONObject(line);
+          if ("e".equals(json.getString("t")) && leafBRid.toString().equals(json.getJSONObject("c").getString("i")))
+            foundEdgeToLeafB = true;
+        }
+      }
+      assertThat(foundEdgeToLeafB)
+          .as("the edge to the SECOND leaf must still be exported despite the first edge's failure")
+          .isTrue();
     } finally {
       if (realDatabase.isOpen())
         realDatabase.close();

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -400,6 +400,74 @@ class JsonLImporterIT {
   }
 
   /**
+   * Issue #6460 follow-up (#6795, comment on the closed issue): {@code reconcileUnresolvedLinks} used to remap
+   * EVERY RID element of a mixed-resolution LIST-of-LINK, not only the ones pass 1 actually left unresolved. On a
+   * normal same-schema restore the source and target RID spaces overlap, so an already-correct element can equal
+   * some OTHER record's source RID and get silently re-pointed a second time.
+   * <p>
+   * Person#1 (source "#1:20") is imported first and always lands at the fresh bucket's first position "#1:0" (a
+   * database created for this schema - a single Person type and no other user type - always allocates its first
+   * user bucket as bucket 1). Person#3's source "r" is deliberately set to that exact value "#1:0" - a coincidence
+   * that is completely ordinary in a same-schema restore, since the source and target bucket sequences both start
+   * counting from 0. Person#2.friends mixes a backward reference to Person#1 (resolved immediately on pass 1, to
+   * "#1:0") with a forward reference to Person#4 (source "#1:99", unresolved until the reconciliation pass) in the
+   * SAME list. The bug re-applies {@code ridIndex.get(...)} to the already-resolved "#1:0" element during
+   * reconciliation, finds Person#3's mapping under that same key purely by coincidence, and silently replaces
+   * Person#1's identity with Person#3's.
+   */
+  @Test
+  void importDatabaseReconcileDoesNotRemapAlreadyResolvedListElement() throws Exception {
+    Path jsonlFile = Files.createTempFile("arcadedb-6795-reconcile-overlap-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},"
+          + "\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{"
+          + "\"id\":{\"type\":\"INTEGER\",\"custom\":{}},"
+          + "\"friends\":{\"type\":\"LIST\",\"of\":\"LINK\",\"custom\":{}}"
+          + "},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#1:20\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2,\"friends\":[\"#1:20\",\"#1:99\"]},\"r\":\"#1:21\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":3},\"r\":\"#1:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":4},\"r\":\"#1:99\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true").split(" "));
+      Map<String, Object> result = importer.load();
+
+      assertThat(result).containsEntry("createdVertices", 4L);
+      assertThat(result).doesNotContainKey("errors");
+
+      try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
+        final Map<Integer, Document> byId = new HashMap<>();
+        for (final Iterator<Record> it = db.iterateType("Person", true); it.hasNext(); ) {
+          final Document doc = it.next().asDocument(true);
+          byId.put((Integer) doc.get("id"), doc);
+        }
+
+        final RID person1Rid = byId.get(1).getIdentity();
+        final RID person3Rid = byId.get(3).getIdentity();
+        final RID person4Rid = byId.get(4).getIdentity();
+
+        // Person#1 always lands at the fresh bucket's first position - the coincidence this test relies on.
+        assertThat(person1Rid.toString()).isEqualTo("#1:0");
+
+        final List<?> friends = (List<?>) byId.get(2).get("friends");
+        assertThat(friends).hasSize(2);
+        // Already resolved on pass 1 (backward reference): must stay Person#1's identity, not be silently
+        // re-pointed at Person#3 just because Person#3's SOURCE rid happens to equal Person#1's TARGET rid.
+        assertThat(friends.get(0)).isEqualTo(person1Rid);
+        assertThat(friends.get(0)).isNotEqualTo(person3Rid);
+        // Genuinely unresolved on pass 1 (forward reference): must still be fixed up by reconciliation.
+        assertThat(friends.get(1)).isEqualTo(person4Rid);
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  /**
    * Issue #6561: {@code -onRowError skip} commits/rolls back per record, so - exactly like CSV/JSON (see
    * {@code Issue5968ImporterSkipOnRowErrorTest}) - it must own the transaction outright and reject an already-active
    * caller-managed transaction eagerly, rather than silently committing/discarding whatever the caller had pending


### PR DESCRIPTION
## Summary

Closes #6795, and via that closes/addresses the follow-up gaps reported as comments on six closed issues: #6461, #6460, #6455, #6471, #6607, #6375. Each gap was re-verified in source before being fixed here.

- **#6461** (`MergeStep.java`): a pre-bound *middle* node reached via traversal discarded its fresh instance in favour of the stale one carried from an earlier `MATCH`, so multi-hop `MERGE` could still create duplicate edges. Now keeps the fresh instance.
- **#6460** (`JsonlImporterFormat.java`): `reconcileUnresolvedLinks` re-mapped *every* RID element of a mixed link collection, including ones pass 1 already resolved, so an already-correct element could be silently re-pointed whenever source/target RID spaces overlap (the normal same-schema restore case). Now tracks the specific old-source RIDs left unresolved per (record, property) and only remaps those.
- **#6455** (`JsonGraphSerializer.java`): the temporal write-back encoding gated on `value instanceof Temporal`, which the supported non-default `arcadedb.dateImplementation=java.util.Date`/`Calendar` doesn't satisfy, so a DATE was exported as epoch-millis and re-imported as epoch-days (the original data-loss symptom). Now also recognizes `Date`/`Calendar`.
- **#6471** (`JsonlExporterFormat.java`): `exportLightweightEdges` wrapped a whole vertex's per-edge loop in one `try`, so a failure on one edge counted `skippedRecords` +1 and silently dropped the rest of that vertex's edges. Now each edge gets its own `try`/`catch`.
- **#6607** (`ArcadeDbGrpcService.java`): `insertBidirectional` never read `Start.transaction`, always beginning its own transaction, so rows never joined the caller's transaction. Also, `insertStream` downgraded a transaction-authorization failure into a "successful" `InsertSummary` instead of surfacing it via `onError`, unlike `bulkInsert`. Both now fixed, mirroring `bulkInsert`'s existing behaviour.
- **#6375** (`AbstractAlgoProcedure.java`): the memory-budget/checkpoint hardening was applied to `weightedAdjacencyFromColumns` but not its twin `weightedAdjacencyFromRecords` (the OLTP path), which could overshoot the configured budget by ~12 MB before refusing. Now also consults `capacityFor`, matching the columnar path.

## Test plan

Each fix ships with a regression test that was verified to **fail** against the pre-fix code and **pass** with the fix:

- [x] `Issue6461MergeAnchorStaleEdgeListTest` (new method) - engine
- [x] `JsonLImporterIT#importDatabaseReconcileDoesNotRemapAlreadyResolvedListElement` - integration
- [x] `JsonGraphSerializerTest` (3 new methods, Date/Calendar/LocalDate) - engine
- [x] `JsonlExporterIT#exportLightweightEdgesContinuesAfterOneEdgeFailsToSerialize` - integration
- [x] `Issue6795InsertBidirectionalExternalTransactionIT`, `Issue6795InsertStreamAuthFailureNotDowngradedIT` - grpcw
- [x] `Issue6795WeightedAdjacencyRecordsCheckpointTest`, plus `Issue6300AlgoMSTEdgeBudgetTest` updated for the now-earlier checkpoint - engine

Broader regression sweeps run clean with zero failures:
- engine: full `algo` package (1049 tests), plus the merge/serializer suites touched
- integration: `JsonLImporterIT` (16), `JsonlExporterIT` (6), `Issue6455JsonlDateTimeRoundTripIT` (1)
- grpcw: full insertStream/insertBidirectional suite (40 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for externally managed transactions in bidirectional gRPC inserts, including commit and rollback behavior.
  * Improved date and calendar serialization with precision-aware encoding.
* **Bug Fixes**
  * Fixed MERGE operations that could create duplicate records or edges from stale graph data.
  * Improved link reconciliation during imports, preserving already-resolved links.
  * Exports now continue processing remaining edges when an individual edge fails.
  * Improved authorization error reporting for streaming inserts.
* **Performance**
  * Improved memory-budget enforcement during weighted graph processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->