### PR TITLE
fix(sql): native Select must honour its own timeout() and round-trip its JSON (#6815, #6816, #6817)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/select/Select.java
+++ b/engine/src/main/java/com/arcadedb/query/select/Select.java
@@ -192,12 +192,12 @@ public class Select {
       fromType(json.getString("fromType"));
       if (json.has("polymorphic"))
         polymorphic(json.getBoolean("polymorphic"));
-    } else if (json.has("fromBuckets")) {
-      final JSONArray buckets = json.getJSONArray("fromBuckets");
-      fromBuckets(
-          buckets.toList().stream().map(b -> database.getSchema().getBucketByName(b.toString())).collect(Collectors.toList())
-              .toArray(new String[buckets.length()]));
-    }
+    } else if (json.has("fromBuckets"))
+      // #6817: fromBuckets(String...) RESOLVES THE NAMES ITSELF, SO MAPPING THEM TO Bucket OBJECTS FIRST WAS BOTH
+      // POINTLESS AND FATAL: List<Bucket>.toArray(new String[size]) COMPILES - <T> T[] toArray(T[])'S TYPE VARIABLE
+      // IS INDEPENDENT OF THE ELEMENT TYPE - AND THEN TAKES ArrayList'S System.arraycopy BRANCH, WHICH RAISES
+      // ArrayStoreException FOR EVERY NON-EMPTY BUCKET LIST. PASS THE NAMES STRAIGHT THROUGH INSTEAD
+      fromBuckets(json.getJSONArray("fromBuckets").toList().stream().map(Object::toString).toArray(String[]::new));
 
     if (json.has("where")) {
       where();
@@ -209,10 +209,34 @@ public class Select {
     if (json.has("skip"))
       skip(json.getInt("skip"));
 
+    // #6817: THE STATE BELOW IS WRITTEN BY SelectCompiled.json() BUT USED TO BE DROPPED HERE, SO json() AND
+    // json(JSONObject) WERE NOT INVERSE - A ROUND-TRIPPED SELECT RAN WITH NO DEADLINE AND NO ORDER BY
+    if (json.has("orderBy")) {
+      final JSONArray parsedOrderBy = json.getJSONArray("orderBy");
+      for (int i = 0; i < parsedOrderBy.length(); i++) {
+        final JSONObject entry = parsedOrderBy.getJSONObject(i);
+        orderBy(entry.getString("property"), entry.getBoolean("ascending", true));
+      }
+    }
+    if (json.has("timeoutInMs"))
+      timeout(json.getLong("timeoutInMs"), TimeUnit.MILLISECONDS, json.getBoolean("exceptionOnTimeout", false));
+    if (json.getBoolean("parallel", false))
+      // NOT VIA SelectCompiled.parallel(): THAT IS ONLY REACHABLE AFTER compile(), AND THIS SELECT IS STILL BEING BUILT
+      parallel = true;
+
     return this;
   }
 
   private void parseJsonCondition(final JSONArray condition) {
+    // #6817: A SELECT WITH A SINGLE WHERE LEAF SERIALIZES AS A ONE-ELEMENT ARRAY - compile() WRAPS THE LEAF IN A
+    // SYNTHETIC `run` ROOT WHOSE OPERATOR SelectTreeNode.toJSON() DELIBERATELY OMITS AND WHOSE RIGHT SIDE IS null.
+    // REJECTING THAT SHAPE MADE THE COMMONEST SELECT OF ALL IMPOSSIBLE TO READ BACK, SO UNWRAP IT INSTEAD: compile()
+    // RE-ADDS THE SAME `run` ROOT ON THE WAY OUT, WHICH IS WHAT MAKES THE TWO json METHODS INVERSE FOR THIS SHAPE
+    if (condition.length() == 1 && condition.get(0) instanceof JSONArray nested) {
+      parseJsonCondition(nested);
+      return;
+    }
+
     if (condition.length() != 3)
       throw new IllegalArgumentException("Invalid condition " + condition);
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectCompiled.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectCompiled.java
@@ -20,7 +20,9 @@ package com.arcadedb.query.select;/*
 import com.arcadedb.database.Document;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.Pair;
 
 import java.util.HashMap;
 import java.util.stream.Collectors;
@@ -68,6 +70,18 @@ public class SelectCompiled {
       json.put("timeoutInMs", select.timeoutInMs);
       json.put("exceptionOnTimeout", select.exceptionOnTimeout);
     }
+
+    // #6817: orderBy AND parallel WERE NEITHER WRITTEN HERE NOR READ BACK BY Select.json(JSONObject), SO A
+    // ROUND-TRIPPED SELECT SILENTLY LOST ITS ORDERING AND RAN SERIALLY. ONLY NON-DEFAULT STATE IS EMITTED, SO A
+    // SELECT THAT NEVER SET EITHER STILL SERIALIZES TO EXACTLY THE SAME DOCUMENT AS BEFORE
+    if (select.orderBy != null && !select.orderBy.isEmpty()) {
+      final JSONArray orderBy = new JSONArray();
+      for (final Pair<String, Boolean> entry : select.orderBy)
+        orderBy.put(new JSONObject().put("property", entry.getFirst()).put("ascending", entry.getSecond()));
+      json.put("orderBy", orderBy);
+    }
+    if (select.parallel)
+      json.put("parallel", select.parallel);
 
     return json;
   }

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -21,6 +21,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.Bucket;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexInternal;
@@ -49,6 +50,14 @@ public class SelectExecutor {
   // skip) TO A MultiIndexCursor
   int             indexCandidateLimit = -1;
 
+  // #6815: THE ABSOLUTE DEADLINE FOR THIS EXECUTION, OWNED BY THE CONSUMER INSTEAD OF BY THE SOURCE ITERATOR.
+  // buildIterator() CAN RETURN FOUR DIFFERENT SOURCES AND ONLY ONE OF THEM (MultiIterator) CARRIES A TIMEOUT OF ITS
+  // OWN, SO INSTALLING select.timeoutInMs THERE - THE ONLY THING THAT USED TO HAPPEN - SILENTLY DROPPED IT FOR EVERY
+  // INDEX-ANSWERED PLAN (A MultiIndexCursor) AND FOR A SINGLE-BUCKET fromBuckets() (A BARE BUCKET ITERATOR), I.E. FOR
+  // THE COMMONEST QUERY SHAPE OF ALL. Long.MAX_VALUE MEANS "NO TIMEOUT REQUESTED" AND KEEPS THE PER-RECORD CHECK A
+  // SINGLE PERFECTLY PREDICTED COMPARE ON THE HOT PATH
+  private long timeoutDeadline = Long.MAX_VALUE;
+
   // #6577: THE SINGLE SOURCE OF TRUTH FOR "WHICH OPERATORS CAN filterWithIndexesFinalNode() ACTUALLY TURN INTO AN
   // IndexCursor" - isTheNodeFullyIndexed() MUST TREAT EXACTLY THIS SET, AND NO MORE, AS "THIS LEAF IS INDEXED".
   // TREATING A WIDER SET AS INDEXED IS WHAT LET #6577 THROUGH: A neq/like/ilike LEAF PASSED THE "UNDER AN or, BOTH
@@ -74,7 +83,33 @@ public class SelectExecutor {
     this.select = select;
   }
 
+  /**
+   * Arms the deadline for one execution. Called from the three entry points ({@link #execute()},
+   * {@link #executeCount()}, {@link #executeExists()}) rather than from the constructor, so the window it covers is
+   * exactly the work the caller asked to bound - index lookup included, since that is part of answering the query.
+   */
+  private void startTimeout() {
+    if (select.timeoutInMs > 0)
+      timeoutDeadline = System.currentTimeMillis() + select.timeoutInMs;
+  }
+
+  /**
+   * #6815: enforces the select deadline on the consumer side, where every source shape passes, instead of on the one
+   * source that happens to know how to enforce it itself. Mirrors {@link com.arcadedb.utility.MultiIterator#checkForTimeout()}:
+   * with {@code exceptionOnTimeout} the expiry is thrown, otherwise the caller is told to stop and keep what it has.
+   *
+   * @return {@code true} when the deadline expired and the caller asked NOT to be thrown at
+   */
+  boolean checkForTimeout() {
+    if (timeoutDeadline == Long.MAX_VALUE || System.currentTimeMillis() <= timeoutDeadline)
+      return false;
+    if (select.exceptionOnTimeout)
+      throw new TimeoutException("Timeout on iteration");
+    return true;
+  }
+
   <T extends Document> SelectIterator<T> execute() {
+    startTimeout();
     final MultiIndexCursor iteratorFromIndexes = lookForIndexes();
     final Iterator<? extends Identifiable> iterator = buildIterator(iteratorFromIndexes);
 
@@ -90,6 +125,7 @@ public class SelectExecutor {
    * would keep a retired compacted file undroppable until the next restart.
    */
   long executeCount() {
+    startTimeout();
     final MultiIndexCursor iteratorFromIndexes = lookForIndexes();
     try {
       final Iterator<? extends Identifiable> iterator = buildIterator(iteratorFromIndexes);
@@ -99,6 +135,12 @@ public class SelectExecutor {
       long count = 0;
       int skipped = 0;
       while (iterator.hasNext()) {
+        // #6815: count() NEVER BUILDS A SelectIterator, IT DRAINS THE SOURCE IN THIS LOOP, SO THE DEADLINE HAS TO BE
+        // CHECKED HERE TOO. A NON-THROWING TIMEOUT RETURNS THE PARTIAL TALLY, MATCHING THE TRUNCATED RESULT SET THE
+        // STREAMING PATH RETURNS
+        if (checkForTimeout())
+          break;
+
         final Document record = iterator.next().asDocument();
         if (filterOutRecords != null && filterOutRecords.contains(record.getIdentity()))
           continue;
@@ -138,11 +180,17 @@ public class SelectExecutor {
    * cursor is abandoned partway on every positive answer.
    */
   boolean executeExists() {
+    startTimeout();
     final MultiIndexCursor iteratorFromIndexes = lookForIndexes();
     try {
       final Iterator<? extends Identifiable> iterator = buildIterator(iteratorFromIndexes);
 
       while (iterator.hasNext()) {
+        // #6815: SAME AS executeCount(). A NON-THROWING TIMEOUT ANSWERS false - THE SCAN NEVER FOUND A MATCH WITHIN
+        // THE BUDGET IT WAS GIVEN, WHICH IS THE PARTIAL ANSWER THE CALLER ASKED TO BE GIVEN RATHER THAN AN EXCEPTION
+        if (checkForTimeout())
+          return false;
+
         final Document record = iterator.next().asDocument();
         if (select.rootTreeElement == null || evaluateWhere(record))
           return true;
@@ -221,6 +269,9 @@ public class SelectExecutor {
       iterator = multiIterator;
     }
 
+    // #6815: KEPT AS THE FAST PATH ONLY - THE AUTHORITATIVE DEADLINE IS checkForTimeout(), WHICH EVERY SOURCE SHAPE
+    // GOES THROUGH. THIS ALSO STAYS BECAUSE SelectParallelIterator READS THE MultiIterator'S OWN checkForTimeout() TO
+    // DRIVE ITS PRODUCER SHUTDOWN
     if (select.timeoutInMs > 0 && iterator instanceof MultiIterator<? extends Identifiable> multiIterator)
       multiIterator.setTimeout(select.timeoutInMs, select.exceptionOnTimeout);
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -89,8 +89,15 @@ public class SelectExecutor {
    * exactly the work the caller asked to bound - index lookup included, since that is part of answering the query.
    */
   private void startTimeout() {
-    if (select.timeoutInMs > 0)
-      timeoutDeadline = System.currentTimeMillis() + select.timeoutInMs;
+    if (select.timeoutInMs > 0) {
+      // SATURATE INSTEAD OF WRAPPING: TimeUnit.toMillis() CLAMPS AN OUT-OF-RANGE CONVERSION TO Long.MAX_VALUE RATHER
+      // THAN REJECTING IT, SO timeout(Long.MAX_VALUE, DAYS, ...) REACHES US AS Long.MAX_VALUE AND A PLAIN
+      // now + timeoutInMs WOULD OVERFLOW INTO A NEGATIVE DEADLINE - TURNING AN EFFECTIVELY INFINITE BUDGET INTO ONE
+      // THAT HAS ALREADY EXPIRED, SO THE FIRST RECORD WOULD THROW. CLAMPING TO Long.MAX_VALUE LANDS ON THE
+      // "NO TIMEOUT" SENTINEL, WHICH IS EXACTLY WHAT A BUDGET THAT LARGE MEANS
+      final long now = System.currentTimeMillis();
+      timeoutDeadline = select.timeoutInMs > Long.MAX_VALUE - now ? Long.MAX_VALUE : now + select.timeoutInMs;
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/select/SelectIterator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectIterator.java
@@ -113,10 +113,15 @@ public class SelectIterator<T extends Document> implements Iterator<T>, AutoClos
   }
 
   protected T fetchNext() {
-    if (!iterator.hasNext())
-      return null;
+    while (iterator.hasNext()) {
+      // #6815: THE SELECT DEADLINE IS ENFORCED HERE, ON THE CONSUMER SIDE, BECAUSE ONLY ONE OF THE FOUR SOURCES
+      // SelectExecutor.buildIterator() CAN RETURN CARRIES A TIMEOUT OF ITS OWN - AN INDEX-ANSWERED PLAN AND A
+      // SINGLE-BUCKET fromBuckets() BOTH USED TO IGNORE timeout() ENTIRELY. RETURNING null ENDS THE STREAM WITH
+      // WHAT THE CALLER ALREADY RECEIVED (THE NON-THROWING MODE); checkForTimeout() THROWS BY ITSELF OTHERWISE.
+      // THE CHECK ALSO COVERS A LONG RUN OF NON-MATCHING RECORDS, WHICH NEVER RETURNS TO hasNext()
+      if (executor.checkForTimeout())
+        return null;
 
-    do {
       final Document record = iterator.next().asDocument();
 
       if (filterOutRecords != null && filterOutRecords.contains(record.getIdentity()))
@@ -131,8 +136,7 @@ public class SelectIterator<T extends Document> implements Iterator<T>, AutoClos
 
         return (T) record;
       }
-
-    } while (iterator.hasNext());
+    }
 
     // NOT FOUND
     return null;

--- a/engine/src/main/java/com/arcadedb/utility/MultiIterator.java
+++ b/engine/src/main/java/com/arcadedb/utility/MultiIterator.java
@@ -63,9 +63,15 @@ public class MultiIterator<T> implements ResettableIterator<T>, IterableGraph<T>
   }
 
   private boolean hasNextInternal() {
-    if (timeout > -1L && System.currentTimeMillis() - beginTime > timeout) {
-      throw new TimeoutException("Timeout on iteration");
-    }
+    // #6816: DELEGATE TO checkForTimeout() RATHER THAN RE-IMPLEMENTING THE CHECK HERE. IT IS THE ONLY PLACE THAT
+    // HONOURS exceptionOnTimeout, AND THE INLINE COPY THAT USED TO LIVE HERE THREW UNCONDITIONALLY - SO A CALLER
+    // ASKING FOR "STOP EARLY AND GIVE ME WHAT YOU HAVE" (Select.timeout(v, unit, false)) GOT A TimeoutException
+    // INSTEAD, AND checkForTimeout()'S NON-THROWING BRANCH WAS UNREACHABLE FROM THE ITERATION PATH: ITS TWO INTERNAL
+    // CALLERS (getNextPartial(), countEntries()) ARE ONLY EVER REACHED ONCE THIS CHECK HAS ALREADY PASSED, I.E. ONLY
+    // WHILE THE DEADLINE HAS *NOT* EXPIRED. EVERY PRE-EXISTING CALLER PASSES exceptionOnTimeout == true
+    // (LocalDatabase.iterateType()), SO NONE OF THEM CAN SEE A BEHAVIOUR CHANGE
+    if (checkForTimeout())
+      return false;
 
     if (sourcesIterator == null) {
       if (sources == null || sources.isEmpty())

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6815SelectTimeoutNotInstalledTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6815SelectTimeoutNotInstalledTest.java
@@ -192,6 +192,39 @@ public class Issue6815SelectTimeoutNotInstalledTest extends TestHelper {
         .where().property("id").ge().value(0).count()).isEqualTo(SCAN_ROWS);
   }
 
+  /**
+   * A deadline so far away it can never expire must behave like no deadline at all. Computing it as
+   * {@code now + timeoutInMs} overflows into a negative value once {@code timeoutInMs} approaches {@code Long.MAX_VALUE}
+   * - which {@link TimeUnit#toMillis} saturates to rather than rejecting - turning an effectively infinite budget into
+   * one that has already expired, so the very first record throws. Deterministic: no clock reading decides the outcome.
+   */
+  @Test
+  void anEffectivelyInfiniteTimeoutNeverExpires() {
+    assertThat(database.select().fromType("V")//
+        .where().property("id").ge().value(0)//
+        .timeout(Long.MAX_VALUE, TimeUnit.MILLISECONDS, true).vertices().toList()).hasSize(ROWS);
+
+    assertThat(database.select().fromType("Scan")//
+        .where().property("id").ge().value(0)//
+        .timeout(Long.MAX_VALUE, TimeUnit.DAYS, true).count()).isEqualTo(SCAN_ROWS);
+
+    assertThat(database.select().fromType("Scan")//
+        .where().property("name").eq().value("John")//
+        .timeout(Long.MAX_VALUE, TimeUnit.DAYS, true).exists()).isTrue();
+  }
+
+  /**
+   * The single-bucket source shape has to survive the same saturation.
+   */
+  @Test
+  void anEffectivelyInfiniteTimeoutNeverExpiresOnASingleBucket() {
+    final String bucket = database.getSchema().getType("V").getBuckets(false).getFirst().getName();
+
+    assertThat(database.select().fromBuckets(bucket)//
+        .where().property("name").eq().value("John")//
+        .timeout(Long.MAX_VALUE, TimeUnit.DAYS, true).vertices().toList()).hasSize(ROWS);
+  }
+
   private static List<Vertex> drainSlowly(final SelectIterator<Vertex> iter) {
     final List<Vertex> got = new ArrayList<>();
     while (iter.hasNext()) {

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6815SelectTimeoutNotInstalledTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6815SelectTimeoutNotInstalledTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6815
+ * <p>
+ * {@code SelectExecutor.buildIterator()} installed the caller's {@code timeout()} on the source iterator only when
+ * that source happened to be a {@link com.arcadedb.utility.MultiIterator}. Two of the four sources it can return are
+ * not: an index-answered plan yields a {@code MultiIndexCursor}, and a single-bucket {@code fromBuckets(...)} yields
+ * the bucket iterator itself. Neither carries a deadline, so {@code timeout()} was a silent no-op for every indexed
+ * query - by far the common shape - and for a one-bucket scan, on {@code documents()}/{@code vertices()}/
+ * {@code edges()}, {@code count()} and {@code exists()} alike.
+ * <p>
+ * The deadline is now owned by the consumer ({@link SelectExecutor#checkForTimeout()}), which every source shape goes
+ * through, so it no longer depends on which iterator the planner picked.
+ * <p>
+ * The assertions here are one-sided on purpose: each states that a bounded operation gave up, never that it survived
+ * for at least some duration. A JVM stall can only make a deadline expire sooner, so it cannot turn a passing run red.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6815SelectTimeoutNotInstalledTest extends TestHelper {
+
+  // BIG ENOUGH THAT A FULL SCAN CANNOT FINISH INSIDE THE 1 ms BUDGET count()/exists() ARE GIVEN BELOW. A SLOWER
+  // MACHINE ONLY MAKES THAT MORE TRUE, WHICH IS THE DIRECTION THAT KEEPS THESE ASSERTIONS STABLE
+  private static final int SCAN_ROWS = 20_000;
+  private static final int ROWS      = 100;
+
+  public Issue6815SelectTimeoutNotInstalledTest() {
+    autoStartTx = false;
+  }
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("V")//
+        .createProperty("id", Type.INTEGER)//
+        .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+
+    database.getSchema().createDocumentType("Scan")//
+        .createProperty("id", Type.INTEGER)//
+        .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newVertex("V").set("id", i, "name", "John").save();
+      for (int i = 0; i < SCAN_ROWS; i++)
+        database.newDocument("Scan").set("id", i, "name", "John").save();
+    });
+  }
+
+  /**
+   * The issue's own repro: an indexed WHERE leaf makes the plan index-answered, so the source is a
+   * {@code MultiIndexCursor} and the timeout used to be dropped on the floor.
+   */
+  @Test
+  void indexAnsweredIterationThrowsOnTimeout() {
+    assertThatThrownBy(() -> {
+      final SelectIterator<Vertex> iter = database.select().fromType("V")//
+          .where().property("id").ge().value(0)//
+          .timeout(1, TimeUnit.MILLISECONDS, true).vertices();
+      drainSlowly(iter);
+    }).isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  /**
+   * Same plan shape with {@code exceptionOnTimeout = false}: the iteration must end early rather than throw, and the
+   * result set must therefore be a strict prefix of the full one.
+   */
+  @Test
+  void indexAnsweredIterationTruncatesWhenNotThrowing() {
+    final SelectIterator<Vertex> iter = database.select().fromType("V")//
+        .where().property("id").ge().value(0)//
+        .timeout(1, TimeUnit.MILLISECONDS, false).vertices();
+
+    final List<Vertex> got = drainSlowly(iter);
+    assertThat(got.size()).isLessThan(ROWS);
+  }
+
+  /**
+   * The second uninstrumented source: {@code fromBuckets(oneBucket)} returns {@code database.iterateBucket(...)},
+   * a plain bucket iterator with no deadline of its own.
+   */
+  @Test
+  void singleBucketIterationThrowsOnTimeout() {
+    final String bucket = database.getSchema().getType("V").getBuckets(false).getFirst().getName();
+
+    assertThatThrownBy(() -> {
+      final SelectIterator<Vertex> iter = database.select().fromBuckets(bucket)//
+          .where().property("name").eq().value("John")//
+          .timeout(1, TimeUnit.MILLISECONDS, true).vertices();
+      drainSlowly(iter);
+    }).isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  @Test
+  void singleBucketIterationTruncatesWhenNotThrowing() {
+    final String bucket = database.getSchema().getType("V").getBuckets(false).getFirst().getName();
+
+    final SelectIterator<Vertex> iter = database.select().fromBuckets(bucket)//
+        .where().property("name").eq().value("John")//
+        .timeout(1, TimeUnit.MILLISECONDS, false).vertices();
+
+    final List<Vertex> got = drainSlowly(iter);
+    assertThat(got.size()).isLessThan(ROWS);
+  }
+
+  /**
+   * {@code count()} never builds a {@link SelectIterator}: it drains {@code buildIterator()} in its own loop, so it
+   * needs the deadline enforced there too.
+   */
+  @Test
+  void countThrowsOnTimeout() {
+    assertThatThrownBy(() -> database.select().fromType("Scan")//
+        .where().property("id").ge().value(0)//
+        .timeout(1, TimeUnit.MILLISECONDS, true).count())//
+        .isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  /**
+   * The non-throwing counterpart returns the partial tally instead of the full one.
+   */
+  @Test
+  void countTruncatesWhenNotThrowing() {
+    final long count = database.select().fromType("Scan")//
+        .where().property("id").ge().value(0)//
+        .timeout(1, TimeUnit.MILLISECONDS, false).count();
+
+    assertThat(count).isLessThan(SCAN_ROWS);
+  }
+
+  /**
+   * {@code exists()} has the same shape as {@code count()}. A WHERE that matches nothing forces the full scan the
+   * deadline has to cut short - a matching WHERE would return on the first record, long before any budget expires.
+   */
+  @Test
+  void existsThrowsOnTimeout() {
+    assertThatThrownBy(() -> database.select().fromType("Scan")//
+        .where().property("name").eq().value("NoSuchName")//
+        .timeout(1, TimeUnit.MILLISECONDS, true).exists())//
+        .isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  @Test
+  void existsReturnsFalseWhenNotThrowing() {
+    assertThat(database.select().fromType("Scan")//
+        .where().property("name").eq().value("NoSuchName")//
+        .timeout(1, TimeUnit.MILLISECONDS, false).exists()).isFalse();
+  }
+
+  /**
+   * A select with no timeout must keep streaming the whole type: the deadline machinery has to stay inert when
+   * {@code timeout()} was never called.
+   */
+  @Test
+  void noTimeoutStillReturnsEverything() {
+    assertThat(database.select().fromType("V")//
+        .where().property("id").ge().value(0).vertices().toList()).hasSize(ROWS);
+    assertThat(database.select().fromType("Scan")//
+        .where().property("id").ge().value(0).count()).isEqualTo(SCAN_ROWS);
+  }
+
+  private static List<Vertex> drainSlowly(final SelectIterator<Vertex> iter) {
+    final List<Vertex> got = new ArrayList<>();
+    while (iter.hasNext()) {
+      got.add(iter.next());
+      try {
+        Thread.sleep(2);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+    }
+    return got;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6815SelectTimeoutNotInstalledTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6815SelectTimeoutNotInstalledTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
+import com.arcadedb.utility.MultiIterator;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * https://github.com/ArcadeData/arcadedb/issues/6815
  * <p>
  * {@code SelectExecutor.buildIterator()} installed the caller's {@code timeout()} on the source iterator only when
- * that source happened to be a {@link com.arcadedb.utility.MultiIterator}. Two of the four sources it can return are
+ * that source happened to be a {@link MultiIterator}. Two of the four sources it can return are
  * not: an index-answered plan yields a {@code MultiIndexCursor}, and a single-bucket {@code fromBuckets(...)} yields
  * the bucket iterator itself. Neither carries a deadline, so {@code timeout()} was a silent no-op for every indexed
  * query - by far the common shape - and for a one-bucket scan, on {@code documents()}/{@code vertices()}/

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6816MultiIteratorTimeoutTruncationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6816MultiIteratorTimeoutTruncationTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.MultiIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6816
+ * <p>
+ * {@link MultiIterator} stored {@code exceptionOnTimeout} but its hot-path check in {@code hasNextInternal()} ignored
+ * it and threw unconditionally. {@code checkForTimeout()} - the method that does honour the flag - was only reachable
+ * from {@code getNextPartial()} and {@code countEntries()}, both of which run only *after* the throwing check has
+ * already passed, i.e. only while the deadline has NOT expired. So its non-throwing branch was dead code, and the one
+ * producer of {@code exceptionOnTimeout == false} in the engine - {@code Select.timeout(v, unit, false)}, meaning
+ * "stop early and give me what you have" - got a {@link TimeoutException} instead.
+ * <p>
+ * The direct {@link MultiIterator} tests below are deterministic: the deadline is set on an iterator whose
+ * {@code beginTime} is already in the past, so no assertion depends on how fast the scan runs.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6816MultiIteratorTimeoutTruncationTest extends TestHelper {
+
+  private static final int ROWS = 100;
+
+  public Issue6816MultiIteratorTimeoutTruncationTest() {
+    autoStartTx = false;
+  }
+
+  @Override
+  protected void beginTest() {
+    // NO INDEX ON name: THE WHERE LEAF BELOW MUST NOT BE INDEX-ANSWERED, SO THE SOURCE REALLY IS A MultiIterator
+    database.getSchema().createVertexType("V").createProperty("name", Type.STRING);
+
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newVertex("V").set("id", i, "name", "John").save();
+    });
+  }
+
+  /**
+   * The unit-level statement of the bug: with the flag off, an expired deadline must end the iteration, not throw.
+   */
+  @Test
+  void expiredDeadlineWithoutExceptionEndsIteration() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+    assertThat(it.hasNext()).isTrue();
+    assertThat(it.next()).isEqualTo(1);
+
+    expireDeadline(it, false);
+
+    assertThatNoException().isThrownBy(it::hasNext);
+    assertThat(it.hasNext()).isFalse();
+  }
+
+  /**
+   * The flag on keeps the pre-existing behaviour every other caller relies on ({@code LocalDatabase.iterateType()}
+   * passes {@code true}).
+   */
+  @Test
+  void expiredDeadlineWithExceptionStillThrows() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+    assertThat(it.hasNext()).isTrue();
+
+    expireDeadline(it, true);
+
+    assertThatThrownBy(it::hasNext).isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  /**
+   * A deadline that has not expired must leave the iteration completely alone.
+   */
+  @Test
+  void unexpiredDeadlineIteratesEverything() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+    it.setTimeout(TimeUnit.MINUTES.toMillis(10), false);
+
+    final List<Integer> got = new ArrayList<>();
+    while (it.hasNext())
+      got.add(it.next());
+
+    assertThat(got).containsExactly(1, 2, 3);
+  }
+
+  /**
+   * The end-to-end shape from the issue: an unindexed WHERE over a type, so {@code buildIterator()} really does hand
+   * back a {@link MultiIterator}, asked not to throw. Only the upper bound is asserted - a JVM stall can only cut the
+   * result set shorter, never longer, so this cannot flake in the other direction.
+   */
+  @Test
+  void selectTruncatesInsteadOfThrowing() {
+    final SelectIterator<Vertex> iter = database.select().fromType("V")//
+        .where().property("name").eq().value("John")//
+        .timeout(1, TimeUnit.MILLISECONDS, false).vertices();
+
+    final List<Vertex> got = new ArrayList<>();
+    assertThatNoException().isThrownBy(() -> {
+      while (iter.hasNext()) {
+        got.add(iter.next());
+        Thread.sleep(2);
+      }
+    });
+
+    assertThat(got.size()).isLessThan(ROWS);
+  }
+
+  /**
+   * ...and the throwing counterpart of the same plan shape is unchanged.
+   */
+  @Test
+  void selectStillThrowsWhenAskedTo() {
+    assertThatThrownBy(() -> {
+      final SelectIterator<Vertex> iter = database.select().fromType("V")//
+          .where().property("name").eq().value("John")//
+          .timeout(1, TimeUnit.MILLISECONDS, true).vertices();
+      while (iter.hasNext()) {
+        iter.next();
+        Thread.sleep(2);
+      }
+    }).isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  /**
+   * Puts the iterator's deadline in the past without sleeping: {@code beginTime} is captured at construction, so a
+   * zero-millisecond budget is already spent by the time the constructor has returned and the first record consumed.
+   */
+  private static void expireDeadline(final MultiIterator<?> it, final boolean exceptionOnTimeout) {
+    it.setTimeout(0, exceptionOnTimeout);
+    // GUARANTEE STRICTLY MORE THAN 0 ms HAVE ELAPSED SINCE beginTime, SINCE THE CHECK IS `elapsed > timeout`
+    final long begin = System.currentTimeMillis();
+    while (System.currentTimeMillis() == begin)
+      Thread.onSpinWait();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6817SelectJsonRoundTripTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6817SelectJsonRoundTripTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.select;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.engine.Bucket;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
@@ -111,7 +112,7 @@ public class Issue6817SelectJsonRoundTripTest extends TestHelper {
   @Test
   void multipleBucketsRoundTrip() {
     final List<String> buckets = database.getSchema().getType("Multi").getBuckets(false).stream()//
-        .map(com.arcadedb.engine.Bucket::getName).toList();
+        .map(Bucket::getName).toList();
     assertThat(buckets.size()).isGreaterThan(1);
 
     final JSONObject json = database.select().fromBuckets(buckets.toArray(new String[0]))//

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6817SelectJsonRoundTripTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6817SelectJsonRoundTripTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6817
+ * <p>
+ * {@code Select.json(JSONObject)} mapped the serialized bucket NAMES back to {@code Bucket} objects and then poured
+ * that {@code List<Bucket>} into a {@code String[]}. That compiles - {@code <T> T[] toArray(T[])}'s type variable is
+ * independent of the element type - and throws {@link ArrayStoreException} at runtime for every non-empty bucket list,
+ * so a {@code fromBuckets} select could never be round-tripped at all. {@code fromBuckets(String...)} resolves the
+ * names itself, so the mapping step was pointless as well as fatal.
+ * <p>
+ * The same method also silently dropped state that {@code SelectCompiled.json()} writes ({@code timeoutInMs} /
+ * {@code exceptionOnTimeout}) and never covered {@code orderBy} or {@code parallel} on either side, so the two
+ * {@code json} methods were not inverse. {@code SelectExecutionTest.okJSON()} exercises only {@code fromType}, which
+ * is why none of this showed up.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6817SelectJsonRoundTripTest extends TestHelper {
+
+  public Issue6817SelectJsonRoundTripTest() {
+    autoStartTx = false;
+  }
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("V")//
+        .createProperty("name", Type.STRING);
+    database.getSchema().getType("V").createProperty("id", Type.INTEGER);
+
+    // THE DEFAULT IS ONE BUCKET PER TYPE (GlobalConfiguration.TYPE_DEFAULT_BUCKETS), SO THE MULTI-BUCKET ROUND TRIP
+    // NEEDS A TYPE THAT EXPLICITLY ASKS FOR MORE
+    database.getSchema().createVertexType("Multi", 3).createProperty("name", Type.STRING);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++) {
+        database.newVertex("V").set("id", i, "name", "John").save();
+        database.newVertex("Multi").set("id", i, "name", "John").save();
+      }
+    });
+  }
+
+  /**
+   * The issue's repro: this used to fail with {@code java.lang.ArrayStoreException: com.arcadedb.engine.LocalBucket}.
+   */
+  @Test
+  void fromBucketsRoundTripsInsteadOfThrowing() {
+    final String bucket = database.getSchema().getType("V").getBuckets(false).getFirst().getName();
+
+    final JSONObject json = database.select().fromBuckets(bucket)//
+        .where().property("name").eq().value("John").compile().json();
+
+    assertThatNoException().isThrownBy(() -> database.select().json(json));
+
+    final JSONObject roundTripped = database.select().json(json).compile().json();
+    assertThat(roundTripped).isEqualTo(json);
+  }
+
+  /**
+   * A rebuilt select must also still run, and return what the original one returned.
+   */
+  @Test
+  void fromBucketsRoundTrippedSelectStillExecutes() {
+    final String bucket = database.getSchema().getType("V").getBuckets(false).getFirst().getName();
+
+    final JSONObject json = database.select().fromBuckets(bucket)//
+        .where().property("name").eq().value("John").compile().json();
+
+    final List<Vertex> expected = database.select().fromBuckets(bucket)//
+        .where().property("name").eq().value("John").vertices().toList();
+
+    final List<Vertex> got = database.select().json(json).vertices().toList();
+    assertThat(got).hasSameSizeAs(expected);
+  }
+
+  /**
+   * Several buckets at once: the throwing {@code toArray} path only ever ran with {@code a.length == size}, which is
+   * exactly what the old code produced, so a multi-bucket list was just as fatal as a single one.
+   */
+  @Test
+  void multipleBucketsRoundTrip() {
+    final List<String> buckets = database.getSchema().getType("Multi").getBuckets(false).stream()//
+        .map(com.arcadedb.engine.Bucket::getName).toList();
+    assertThat(buckets.size()).isGreaterThan(1);
+
+    final JSONObject json = database.select().fromBuckets(buckets.toArray(new String[0]))//
+        .where().property("name").eq().value("John").compile().json();
+
+    assertThat(database.select().json(json).compile().json()).isEqualTo(json);
+  }
+
+  /**
+   * {@code timeoutInMs}/{@code exceptionOnTimeout} were written by {@code SelectCompiled.json()} and never read back,
+   * so a round-tripped select ran with no deadline at all.
+   */
+  @Test
+  void timeoutSurvivesTheRoundTrip() {
+    final JSONObject json = database.select().fromType("V")//
+        .where().property("name").eq().value("John")//
+        .timeout(1234, TimeUnit.MILLISECONDS, true).compile().json();
+
+    assertThat(json.getLong("timeoutInMs")).isEqualTo(1234L);
+    assertThat(json.getBoolean("exceptionOnTimeout")).isTrue();
+
+    final Select rebuilt = database.select().json(json);
+    assertThat(rebuilt.timeoutInMs).isEqualTo(1234L);
+    assertThat(rebuilt.exceptionOnTimeout).isTrue();
+    assertThat(rebuilt.compile().json()).isEqualTo(json);
+  }
+
+  @Test
+  void nonThrowingTimeoutSurvivesTheRoundTrip() {
+    final JSONObject json = database.select().fromType("V")//
+        .where().property("name").eq().value("John")//
+        .timeout(50, TimeUnit.MILLISECONDS, false).compile().json();
+
+    final Select rebuilt = database.select().json(json);
+    assertThat(rebuilt.timeoutInMs).isEqualTo(50L);
+    assertThat(rebuilt.exceptionOnTimeout).isFalse();
+    assertThat(rebuilt.compile().json()).isEqualTo(json);
+  }
+
+  /**
+   * {@code orderBy} was neither written nor read, so a round-tripped select lost its ordering entirely.
+   */
+  @Test
+  void orderBySurvivesTheRoundTrip() {
+    final JSONObject json = database.select().fromType("V")//
+        .where().property("name").eq().value("John")//
+        .orderBy("id", false).compile().json();
+
+    final Select rebuilt = database.select().json(json);
+    assertThat(rebuilt.orderBy).hasSize(1);
+    assertThat(rebuilt.orderBy.getFirst().getFirst()).isEqualTo("id");
+    assertThat(rebuilt.orderBy.getFirst().getSecond()).isFalse();
+    assertThat(rebuilt.compile().json()).isEqualTo(json);
+
+    final List<Vertex> got = database.select().json(json).vertices().toList();
+    assertThat(got.stream().map(v -> v.getInteger("id")).toList()).containsExactly(9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+  }
+
+  @Test
+  void multipleOrderBySurvivesTheRoundTrip() {
+    final JSONObject json = database.select().fromType("V")//
+        .where().property("name").eq().value("John")//
+        .orderBy("name", true).orderBy("id", false).compile().json();
+
+    final Select rebuilt = database.select().json(json);
+    assertThat(rebuilt.orderBy).hasSize(2);
+    assertThat(rebuilt.orderBy.getFirst().getFirst()).isEqualTo("name");
+    assertThat(rebuilt.orderBy.getFirst().getSecond()).isTrue();
+    assertThat(rebuilt.orderBy.getLast().getFirst()).isEqualTo("id");
+    assertThat(rebuilt.orderBy.getLast().getSecond()).isFalse();
+    assertThat(rebuilt.compile().json()).isEqualTo(json);
+  }
+
+  /**
+   * {@code parallel} lives on {@code SelectCompiled} but is stored on the {@code Select}, and was dropped too.
+   */
+  @Test
+  void parallelSurvivesTheRoundTrip() {
+    final JSONObject json = database.select().fromType("V")//
+        .where().property("name").eq().value("John").compile().parallel().json();
+
+    assertThat(json.getBoolean("parallel")).isTrue();
+
+    final Select rebuilt = database.select().json(json);
+    assertThat(rebuilt.parallel).isTrue();
+    assertThat(rebuilt.compile().json()).isEqualTo(json);
+  }
+
+  /**
+   * A select with none of the optional state must not gain keys for it - otherwise every existing round trip
+   * (including {@code SelectExecutionTest.okJSON()}) would start comparing unequal.
+   */
+  @Test
+  void defaultsAreNotSerialized() {
+    final JSONObject json = database.select().fromType("V")//
+        .where().property("name").eq().value("John").compile().json();
+
+    assertThat(json.has("orderBy")).isFalse();
+    assertThat(json.has("parallel")).isFalse();
+    assertThat(json.has("timeoutInMs")).isFalse();
+    assertThat(json.has("exceptionOnTimeout")).isFalse();
+
+    assertThat(database.select().json(json).compile().json()).isEqualTo(json);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
@@ -297,9 +297,28 @@ public class SelectExecutionTest extends TestHelper {
     }
 
     {
+      // #6815/#6816: THIS BLOCK USED TO BUILD THE ITERATOR AND NEVER ITERATE IT, SO IT ASSERTED NOTHING - WHICH IS
+      // EXACTLY HOW BOTH BUGS STAYED INVISIBLE HERE. THE PLAN IS INDEX-ANSWERED (id IS INDEXED), SO IT ALSO COVERS
+      // THE SOURCE SHAPE THAT USED TO IGNORE timeout() ALTOGETHER
       final SelectIterator<Vertex> iter = database.select().fromType("Vertex")//
           .where().property("id").lt().value(10)//
           .and().property("name").eq().value("John").timeout(1, TimeUnit.MILLISECONDS, false).vertices();
+
+      int browsed = 0;
+      while (iter.hasNext()) {
+        iter.next();
+        ++browsed;
+        try {
+          Thread.sleep(2);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+
+      // NO EXCEPTION WAS THROWN (exceptionOnTimeout == false) AND THE RESULT SET WAS CUT SHORT. ONLY THE UPPER BOUND
+      // IS ASSERTED: A JVM STALL CAN ONLY MAKE THE DEADLINE EXPIRE SOONER, NEVER LATER
+      assertThat(browsed).isLessThan(10);
     }
   }
 


### PR DESCRIPTION
Fixes three bugs in the native fluent `Select` API, all reported against `9c9d024db`. They are grouped in one PR because the first two are the same defect seen from opposite ends (a timeout that is never installed, and a timeout that ignores the flag telling it how to fire) and all three land in the same four files.

Closes #6815
Closes #6816
Closes #6817

## #6815 - `Select.timeout()` was a silent no-op for index-answered and single-bucket plans

`SelectExecutor.buildIterator()` can return four different sources, and only one of them is a `MultiIterator`:

| plan shape | source | carried a deadline? |
|---|---|---|
| index-answered (`fromType` + an indexed WHERE leaf) | `MultiIndexCursor` | no |
| `fromType`, unindexed WHERE | `LocalDatabase.iterateType()` -> `MultiIterator` | yes |
| `fromBuckets(one)` | `bucket.iterator()` | no |
| `fromBuckets(many)` | `MultiIterator` | yes |

The timeout was installed with `multiIterator.setTimeout(...)` under an `instanceof` guard, so the two rows that are not a `MultiIterator` dropped it entirely - including the index-answered plan, by far the commonest shape. Nothing else on the serial path read `select.timeoutInMs`, so `documents()`/`vertices()`/`edges()`, `count()` and `exists()` were all affected.

**Fix:** the deadline now belongs to the consumer, which every source shape passes through, instead of to the one source that knew how to enforce it.

- `SelectExecutor` gains `startTimeout()` (armed at the head of `execute()`, `executeCount()` and `executeExists()`, so index lookup counts against the budget) and `checkForTimeout()`, which throws or reports expiry per `exceptionOnTimeout` - the same contract as `MultiIterator.checkForTimeout()`.
- `SelectIterator.fetchNext()` checks it once per candidate record, so a long run of non-matching rows is cut short too, not just a slow consumer.
- `executeCount()` and `executeExists()` check it in their own drain loops, since neither builds a `SelectIterator`.
- The `MultiIterator.setTimeout()` call stays as the fast path, and because `SelectParallelIterator` drives its producer shutdown off that iterator's own `checkForTimeout()`.

`Long.MAX_VALUE` encodes "no timeout requested", so a select without `timeout()` pays one perfectly-predicted compare per record.

## #6816 - `MultiIterator` ignored `exceptionOnTimeout` and always threw

`hasNextInternal()` carried an inline copy of the deadline check that threw unconditionally. `checkForTimeout()` - the method that honours the flag - was unreachable from the iteration path: its two internal callers (`getNextPartial()`, `countEntries()`) are only reached *after* the inline check has already passed, i.e. only while the deadline has **not** expired. So `Select.timeout(v, unit, false)`, meaning "stop early and give me what you have", got a `TimeoutException` instead, and the non-throwing branch was dead code.

**Fix:** `hasNextInternal()` delegates to `checkForTimeout()` and returns `false` when it reports expiry.

No existing caller can see a behaviour change: `setTimeout(` has exactly two producers in main, `LocalDatabase.java:834` (hard-coded `true`) and `SelectExecutor` (forwards the user's flag), so `exceptionOnTimeout == false` was previously unreachable in production.

## #6817 - `Select.json(JSONObject)` threw `ArrayStoreException`, and was not the inverse of `json()`

Four separate defects in the round trip:

1. **`ArrayStoreException` on every `fromBuckets` select.** The method mapped the serialized bucket *names* to `Bucket` objects and then poured that `List<Bucket>` into a `String[]`. It compiles because `<T> T[] toArray(T[])`'s type variable is independent of the element type; at runtime, with `a.length == size`, `ArrayList` takes the `System.arraycopy` branch and blows up. The `map` step was pointless anyway - `fromBuckets(String...)` resolves the names itself. Now the names are passed straight through.
2. **`timeoutInMs`/`exceptionOnTimeout` were written by `SelectCompiled.json()` and never read back**, so a round-tripped select ran with no deadline.
3. **`orderBy` and `parallel` were neither written nor read.** Both are now serialized (only when non-default, so an unaffected select produces byte-identical JSON) and parsed back. `parallel` is set on the field directly rather than through `SelectCompiled.parallel()`, which is only reachable after `compile()`.
4. **A single-condition WHERE could not be read back at all.** `compile()` wraps a lone leaf in a synthetic `run` root whose operator `SelectTreeNode.toJSON()` omits and whose right side is null, producing a one-element array that `parseJsonCondition()` rejected with `Invalid condition`. That is the commonest select shape there is; it is now unwrapped, and `compile()` re-adds the same root on the way out.

## Verification

New regression tests, each written to fail against the current `main` first:

- `Issue6815SelectTimeoutNotInstalledTest` (9 tests) - index-answered and single-bucket iteration, throwing and truncating, plus `count()` and `exists()`, plus a control asserting a select with no timeout still returns everything.
- `Issue6816MultiIteratorTimeoutTruncationTest` (5 tests) - three of them drive `MultiIterator` directly with an already-expired deadline, so they are fully deterministic; two cover the end-to-end select shape.
- `Issue6817SelectJsonRoundTripTest` (9 tests) - single and multi bucket, timeout (both flags), single and multiple `orderBy`, `parallel`, plus a control asserting defaults still produce no extra keys.

`SelectExecutionTest.errorTimeout()`'s second block, which built an iterator with `exceptionOnTimeout = false` and then never iterated it (asserting nothing - which is exactly how both timeout bugs stayed invisible), is now armed.

Timing discipline per `CLAUDE.md`: no assertion measures elapsed time. Every timeout assertion is one-sided in the safe direction - "this bounded operation gave up" or "the result set was cut short" - so a JVM stall can only make it more true, never flip it red. The two `count()`/`exists()` tests scan 20,000 rows against a 1 ms budget for the same reason.

**Test runs (all on this branch):**
- `mvn -o -pl engine test -DexcludedGroups=benchmark,vector,slow` -> **13,760 tests, 0 failures, 0 errors**
- `mvn -o -pl engine test -Dgroups=slow` -> 261 tests, **1 failure: `Issue6459GraphPathfindingCommandTimeoutTest.dijkstraHonoursTheCommandTimeoutOnAnUnreachableDestination`**

That one failure is **pre-existing and unrelated**, proved rather than assumed:

- A control worktree checked out at unmodified `origin/main` (`9cf4d2623b`) reproduces the *identical* single failure on the same 261-test lane.
- The class passes 3/3 in isolation on both `main` and this branch, so it only fails in the warm shared JVM of the full lane - the SQL search finishes inside its 50 ms `command.timeout` budget on a fast machine, and the test asserts that it must NOT finish.
- Statically it cannot be reached by this diff: `SQLFunctionAstar` and `SQLFunctionDijkstra` reference none of `MultiIterator`, `SelectIterator`, `SelectExecutor` or `database.select()`. The only SQL-visible caller of `MultiIterator.setTimeout()` is `LocalDatabase.iterateType()`, which passes `exceptionOnTimeout = true` - the branch #6816 leaves byte-for-byte unchanged.

## Compatibility

- The native `Select` timeout is unrelated to the SQL-side `arcadedb.command.timeout` of #6266/#6465; neither is touched.
- No production code consumes the `Select` JSON round trip - `Select.json(JSONObject)` has no caller in main outside tests - so #6817 is a self-contained API fix.
- `SelectCompiled.json()` emits `orderBy`/`parallel` only when they are non-default, so a select that sets neither serializes to exactly the same document as before (a control test asserts this).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query timeout handling for result retrieval, counting, and existence checks.
  * Queries configured to avoid timeout exceptions now stop cleanly and return partial results when applicable.
  * Fixed serialized query round trips to preserve bucket selection, ordering, timeout, and parallel execution settings.
  * Improved parsing of standalone `WHERE` conditions in serialized queries.

* **Tests**
  * Added coverage for timeout behavior, partial results, and serialized query round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->