### PR TITLE
fix(#6837,#6838): bound the remaining MCP numeric tool inputs, and stop server.json drifting from the release

### DIFF
--- a/.github/workflows/mvn-release.yml
+++ b/.github/workflows/mvn-release.yml
@@ -55,6 +55,18 @@ jobs:
           jq --arg version "${{ github.event.inputs.releaseversion }}" '.version = $version' package.json > package.json.tmp
           mv package.json.tmp package.json
 
+      # server.json is the manifest the MCP registry publishes this server from. It is not a Maven artifact, so
+      # versions:set never reaches it and it silently drifted six releases behind HEAD (#6838). Rewrite it here, and
+      # only here: it names the last RELEASE, so the next-development step below deliberately leaves it alone rather
+      # than pinning a -SNAPSHOT container tag that was never pushed.
+      - name: Update server.json MCP registry manifest version
+        run: |
+          jq --arg version "${{ github.event.inputs.releaseversion }}" \
+            '.version = $version | .packages |= map(.identifier |= sub(":[^:]+$"; ":" + $version))' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
       - name: Publish package
         run: |
           export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3993,3 +3993,49 @@ the moment the question is actually useful: right before a query pays the deferr
 to `0` the moment that rebuild - deferred or not - actually completes.
 
 [#6657](https://github.com/ArcadeData/arcadedb/issues/6657)
+
+## MCP: `full_text_search` and `efSearch` are bounded, and `set_server_setting` no longer accepts a missing value (#6837)
+
+#6762 capped the windows on `query`, `execute_command` and `profiler_start`, and its description said the full-text
+tool was capped too. It was not: `full_text_search` rejected only `limit < 1`. The per-bucket push-down bounds the
+index scan, but every surviving hit is then loaded with `lookupByRID`, serialized in full and accumulated into the
+reply's `JSONArray`, so `"limit": 2147483647` from a read-only caller still meant "return every matching document
+in one message". `limit` is now bounded at 1,000 - the ceiling the sibling search tools already use for a candidate
+window - and the tool's declared JSON Schema carries the same `minimum`/`maximum`, so a client can reject the call
+before it is sent.
+
+`efSearch` had the same half-bounded shape in `vector_search` and `hybrid_search`: a declared `minimum` of 1, no
+`maximum`, and a server-side check for the lower end only. It sizes the HNSW dynamic candidate list, so it is now
+bounded at 10,000, which leaves every useful recall/latency trade-off reachable while making the queue a function of
+a constant rather than of whatever integer arrived.
+
+`set_server_setting` declared both `key` and `value` required and then read them with empty-string defaults,
+re-checking only the key. A call that omitted `value` therefore returned `isError: false` and stored `""` in the
+server's `ContextConfiguration` - for a numeric key, a `NumberFormatException` deferred to whichever component read
+that setting next, far from the call that caused it. Both members are now re-checked where they are read: an absent
+`value` is rejected, and an explicitly empty one is rejected for every setting whose type is not `String` (for a
+`String` setting `""` stays valid, because that is how a caller clears one). This matches the HTTP twin,
+`PostServerCommandHandler.setServerSetting`, which already refused the value-less form.
+
+The regression test that generalises this asserts the rule across the whole tool surface rather than for one tool:
+every numeric input that declares a lower bound must declare an upper one too, and `full_text_search` must advertise
+exactly the window it enforces.
+
+[#6837](https://github.com/ArcadeData/arcadedb/issues/6837)
+
+## MCP registry manifest no longer drifts from the released version (#6838)
+
+`server.json` is the manifest the MCP registry publishes this server from, and nothing in the build touched it: it
+declared `"version": "26.3.1"` and pinned `docker.io/arcadedata/arcadedb:26.3.1` while the project was at
+26.9.1-SNAPSHOT. A client installing from the registry entry resolved a container six releases old - missing every
+HA, Raft and security fix from 26.4.x through 26.8.x - while reading the tool surface of HEAD, and the stale
+`version` field made the entry look abandoned.
+
+The release workflow now rewrites both the `version` field and the OCI tag from the release version it is already
+given, next to the step that does the same for `studio/package.json`. It runs only on the release side, not on the
+next-development bump, so the manifest always names a container tag that was actually pushed rather than a
+`-SNAPSHOT` that never exists. A regression test holds the two halves together - the declared version and the pinned
+tag have to agree, and neither may be a SNAPSHOT - and fails if the manifest falls more than a quarter behind the
+POM, which is what noticing this in the first place required a human to do.
+
+[#6838](https://github.com/ArcadeData/arcadedb/issues/6838)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3996,13 +3996,13 @@ to `0` the moment that rebuild - deferred or not - actually completes.
 
 ## MCP: `full_text_search` and `efSearch` are bounded, and `set_server_setting` no longer accepts a missing value (#6837)
 
-#6762 capped the windows on `query`, `execute_command` and `profiler_start`, and its description said the full-text
-tool was capped too. It was not: `full_text_search` rejected only `limit < 1`. The per-bucket push-down bounds the
-index scan, but every surviving hit is then loaded with `lookupByRID`, serialized in full and accumulated into the
-reply's `JSONArray`, so `"limit": 2147483647` from a read-only caller still meant "return every matching document
-in one message". `limit` is now bounded at 1,000 - the ceiling the sibling search tools already use for a candidate
-window - and the tool's declared JSON Schema carries the same `minimum`/`maximum`, so a client can reject the call
-before it is sent.
+Issue #6762 capped the windows on `query`, `execute_command` and `profiler_start`, and its description said the
+full-text tool was capped too. It was not: `full_text_search` rejected only `limit < 1`. The per-bucket push-down
+bounds the index scan, but every surviving hit is then loaded with `lookupByRID`, serialized in full and accumulated
+into the reply's `JSONArray`, so `"limit": 2147483647` from a read-only caller still meant "return every matching
+document in one message". `limit` is now bounded at 1,000 - the ceiling the sibling search tools already use for a
+candidate window - and the tool's declared JSON Schema carries the same `minimum`/`maximum`, so a client can reject
+the call before it is sent.
 
 `efSearch` had the same half-bounded shape in `vector_search` and `hybrid_search`: a declared `minimum` of 1, no
 `maximum`, and a server-side check for the lower end only. It sizes the HNSW dynamic candidate list, so it is now

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/FullTextSearchTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/FullTextSearchTool.java
@@ -41,6 +41,14 @@ import java.util.Map;
 public class FullTextSearchTool {
 
   private static final int DEFAULT_LIMIT = 10;
+  /**
+   * Upper bound on the requested window (issue #6837). The per-bucket push-down bounds the index scan, but every
+   * surviving hit is then loaded with {@code lookupByRID}, serialized in full and accumulated into the reply's
+   * JSONArray, so an unbounded 'limit' still turns one call into "return every matching document". The cap matches
+   * the ceiling the sibling search tools already use for a candidate window ({@link MCPVectorLeg#MAX_K},
+   * {@link HybridSearchTool#MAX_LEG_CANDIDATES}), which keeps one number to reason about across the search surface.
+   */
+  public static final  int MAX_LIMIT     = 1_000;
 
   public static JSONObject getDefinition() {
     return new JSONObject()
@@ -79,7 +87,11 @@ public class FullTextSearchTool {
                 .put("limit", new JSONObject()
                     .put("type", "integer")
                     .put("default", DEFAULT_LIMIT)
-                    .put("description", "Maximum number of results to return (default: 10)")))
+                    .put("minimum", 1)
+                    .put("maximum", MAX_LIMIT)
+                    .put("description",
+                        "Maximum number of results to return (default: " + DEFAULT_LIMIT + ", maximum: " + MAX_LIMIT
+                            + ")")))
             .put("required", new JSONArray().put("database").put("queryText")));
   }
 
@@ -93,9 +105,12 @@ public class FullTextSearchTool {
       throw new IllegalArgumentException("'queryText' must not be blank. Provide at least one term, for example 'java' "
           + "or '+java -python'.");
 
+    // The declared JSON-Schema window is advisory - the client is the one that would enforce it - so re-check it
+    // here, before the index is resolved, so an out-of-range limit is reported as a limit fault rather than as
+    // whatever addressing error the same call would also have produced.
     final int limit = args.getInt("limit", DEFAULT_LIMIT);
-    if (limit < 1)
-      throw new IllegalArgumentException("'limit' must be at least 1, got " + limit);
+    if (limit < 1 || limit > MAX_LIMIT)
+      throw new IllegalArgumentException("'limit' must be between 1 and " + MAX_LIMIT + ", got " + limit);
 
     final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
         server, user, databaseName, config, MCPToolUtils.RequiredAccess.READ);

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/FullTextSearchTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/FullTextSearchTool.java
@@ -48,7 +48,7 @@ public class FullTextSearchTool {
    * the ceiling the sibling search tools already use for a candidate window ({@link MCPVectorLeg#MAX_K},
    * {@link HybridSearchTool#MAX_LEG_CANDIDATES}), which keeps one number to reason about across the search surface.
    */
-  public static final  int MAX_LIMIT     = 1_000;
+  public static final int MAX_LIMIT = 1_000;
 
   public static JSONObject getDefinition() {
     return new JSONObject()

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/HybridSearchTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/HybridSearchTool.java
@@ -138,7 +138,10 @@ public class HybridSearchTool {
                 .put("efSearch", new JSONObject()
                     .put("type", "integer")
                     .put("minimum", 1)
-                    .put("description", "Dense-index search beam width; higher values improve recall at higher cost"))
+                    .put("maximum", MCPVectorLeg.MAX_EF_SEARCH)
+                    .put("description",
+                        "Dense-index search beam width; higher values improve recall at higher cost (maximum: "
+                            + MCPVectorLeg.MAX_EF_SEARCH + ")"))
                 .put("filter", new JSONObject()
                     .put("type", "string")
                     .put("description",

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/MCPVectorLeg.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/MCPVectorLeg.java
@@ -50,6 +50,13 @@ import java.util.TreeSet;
 public final class MCPVectorLeg {
   public static final int DEFAULT_K             = 10;
   public static final int MAX_K                 = 1_000;
+  /**
+   * Upper bound on 'efSearch' (issue #6837). efSearch sizes the HNSW dynamic candidate list, so an unbounded value
+   * lets one caller ask a single traversal to keep an arbitrarily large priority queue alive. Ten times MAX_K leaves
+   * every legitimate recall/latency trade-off reachable - efSearch is only useful above k - while keeping the queue
+   * bounded by a constant instead of by whatever integer the caller sent.
+   */
+  public static final int MAX_EF_SEARCH         = 10_000;
   public static final int FILTER_OVERFETCH      = 8;
   public static final int MAX_FILTER_CANDIDATES = 8_000;
   public static final int MAX_FILTER_EXPRESSION = 4_096;
@@ -76,8 +83,8 @@ public final class MCPVectorLeg {
     MCPToolUtils.requireString(args, indexNameField);
     final boolean sparse = args.getBoolean("sparse", false);
     final Integer efSearch = args.has("efSearch") ? args.getInt("efSearch") : null;
-    if (efSearch != null && efSearch < 1)
-      throw new IllegalArgumentException("'efSearch' must be at least 1");
+    if (efSearch != null && (efSearch < 1 || efSearch > MAX_EF_SEARCH))
+      throw new IllegalArgumentException("'efSearch' must be between 1 and " + MAX_EF_SEARCH + ", got " + efSearch);
     if (sparse && efSearch != null)
       throw new IllegalArgumentException("'efSearch' applies only to dense LSM_VECTOR indexes");
     if (!sparse && args.has("queryIndices"))

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/SetServerSettingTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/SetServerSettingTool.java
@@ -60,16 +60,24 @@ public class SetServerSettingTool {
     // reached this server-administration operation (GHSA-pff6-hp53-pj54).
     MCPToolUtils.checkServerAdmin(user, "set_server_setting");
 
-    final String key = args.getString("key", "");
-    final String value = args.getString("value", "");
-
-    if (key.isEmpty())
-      throw new IllegalArgumentException("Setting key is required");
+    // Both members are declared required, so both have to be re-checked here: the declared schema is advisory, and
+    // reading 'value' with an empty-string default turned a call that omitted it into a success that stored "" -
+    // for a numeric key, a NumberFormatException deferred to whichever component read the setting next (#6837).
+    final String key = MCPToolUtils.requireString(args, "key");
+    final String value = args.getString("value", null);
+    if (value == null)
+      throw new IllegalArgumentException("'value' is required");
 
     // Validate the key exists
     final GlobalConfiguration cfg = GlobalConfiguration.findByKey(key);
     if (cfg == null)
       throw new IllegalArgumentException("Unknown server setting: " + key);
+
+    // "" is a legitimate value for a String setting - it is how a caller clears one - and is a valid value for no
+    // other type, so it is rejected exactly where it would otherwise be stored unparseable.
+    if (value.isEmpty() && cfg.getType() != String.class)
+      throw new IllegalArgumentException(
+          "'value' must not be empty for setting '" + key + "' of type " + cfg.getType().getSimpleName());
 
     final Object oldValue = server.getConfiguration().getValue(cfg);
     server.getConfiguration().setValue(key, value);

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/VectorSearchTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/VectorSearchTool.java
@@ -77,7 +77,10 @@ public class VectorSearchTool {
                 .put("efSearch", new JSONObject()
                     .put("type", "integer")
                     .put("minimum", 1)
-                    .put("description", "Dense-index search beam width; higher values improve recall at higher cost"))
+                    .put("maximum", MCPVectorLeg.MAX_EF_SEARCH)
+                    .put("description",
+                        "Dense-index search beam width; higher values improve recall at higher cost (maximum: "
+                            + MCPVectorLeg.MAX_EF_SEARCH + ")"))
                 .put("filter", new JSONObject()
                     .put("type", "string")
                     .put("description",

--- a/mcp/src/test/java/com/arcadedb/mcp/Issue6838ServerManifestVersionTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/Issue6838ServerManifestVersionTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mcp;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Issue #6838: {@code server.json} is the manifest the MCP registry publishes this server from, and nothing in the
+ * build touched it. It declared {@code "version": "26.3.1"} and pinned {@code arcadedata/arcadedb:26.3.1} while the
+ * project was at 26.9.1-SNAPSHOT, so a client installing from the registry resolved a container six releases old
+ * while reading the tool surface of HEAD.
+ * <p>
+ * The release workflow now rewrites both fields (see {@code .github/workflows/mvn-release.yml}); this test is what
+ * notices if that step is removed, reordered or only half applied.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6838ServerManifestVersionTest {
+  /**
+   * How many CalVer minors (year*12 + month) the published manifest may trail the development POM by. The release
+   * workflow keeps it at 0 or 1 - the manifest names the last release, the POM the next SNAPSHOT - so this bound is
+   * deliberately slack: it exists to catch drift of the reported magnitude (26.3 against 26.9, six apart) without
+   * turning a quarter with no release into a red main.
+   */
+  private static final int MAX_MINOR_LAG = 3;
+
+  private static final Pattern VERSION = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)$");
+
+  @Test
+  void theManifestVersionAndTheImageTagAgree() throws IOException {
+    final JSONObject manifest = readManifest();
+    final String version = manifest.getString("version");
+
+    final JSONArray packages = manifest.getJSONArray("packages");
+    assertThat(packages.length()).isGreaterThan(0);
+
+    for (int i = 0; i < packages.length(); i++) {
+      final String identifier = packages.getJSONObject(i).getString("identifier");
+      final int tagSeparator = identifier.lastIndexOf(':');
+      assertThat(tagSeparator)
+          .withFailMessage("server.json package '%s' pins no explicit tag, so the registry resolves a floating image",
+              identifier)
+          .isGreaterThan(0);
+
+      assertThat(identifier.substring(tagSeparator + 1))
+          .withFailMessage("server.json declares version '%s' but package '%s' pins another tag; bump both together",
+              version, identifier)
+          .isEqualTo(version);
+    }
+  }
+
+  @Test
+  void theManifestNamesAReleaseAndNotASnapshot() throws IOException {
+    final String version = readManifest().getString("version");
+
+    assertThat(VERSION.matcher(version).matches())
+        .withFailMessage("server.json version '%s' is not a released <major>.<minor>.<patch>; the registry cannot "
+            + "resolve a SNAPSHOT container image", version)
+        .isTrue();
+  }
+
+  @Test
+  void theManifestDoesNotTrailTheProjectVersion() throws IOException {
+    final String manifestVersion = readManifest().getString("version");
+    final String projectVersion = readProjectVersion();
+
+    final int lag = calendarMinor(projectVersion) - calendarMinor(manifestVersion);
+
+    assertThat(lag)
+        .withFailMessage("server.json publishes the MCP server as '%s' while the project is at '%s'. The release "
+                + "workflow rewrites server.json - check that step still runs.", manifestVersion, projectVersion)
+        .isBetween(0, MAX_MINOR_LAG);
+  }
+
+  /** CalVer position of a version, counted in months, so 26.12 -> 27.1 is a distance of one rather than -11. */
+  private static int calendarMinor(final String version) {
+    final Matcher matcher = VERSION.matcher(stripSnapshot(version));
+    if (!matcher.matches())
+      return fail("Cannot parse version '%s' as <major>.<minor>.<patch>", version);
+
+    return Integer.parseInt(matcher.group(1)) * 12 + Integer.parseInt(matcher.group(2));
+  }
+
+  private static String stripSnapshot(final String version) {
+    final int dash = version.indexOf('-');
+    return dash < 0 ? version : version.substring(0, dash);
+  }
+
+  private static JSONObject readManifest() throws IOException {
+    return new JSONObject(Files.readString(repositoryRoot().resolve("server.json")));
+  }
+
+  /**
+   * Reads the reactor root's own {@code <version>}, which is the first one declared after the {@code <parent>} block
+   * closes. Parsing it textually keeps the test free of an XML dependency and of any Maven-injected property, so it
+   * asserts against the file a release actually rewrites.
+   */
+  private static String readProjectVersion() throws IOException {
+    final String pom = Files.readString(repositoryRoot().resolve("pom.xml"));
+    final int afterParent = pom.indexOf("</parent>");
+    final Matcher matcher = Pattern.compile("<version>([^<]+)</version>")
+        .matcher(afterParent < 0 ? pom : pom.substring(afterParent));
+
+    if (!matcher.find())
+      return fail("No <version> element found in the reactor root pom.xml");
+
+    return matcher.group(1).trim();
+  }
+
+  /** Walks up from the module directory to the checkout holding server.json, so the test runs from any module. */
+  private static Path repositoryRoot() {
+    Path current = Paths.get("").toAbsolutePath();
+    while (current != null) {
+      if (Files.isRegularFile(current.resolve("server.json")) && Files.isRegularFile(current.resolve("pom.xml")))
+        return current;
+      current = current.getParent();
+    }
+    return fail("Cannot locate the repository root: no ancestor of %s holds both server.json and pom.xml",
+        Paths.get("").toAbsolutePath());
+  }
+}

--- a/mcp/src/test/java/com/arcadedb/mcp/Issue6838ServerManifestVersionTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/Issue6838ServerManifestVersionTest.java
@@ -119,9 +119,11 @@ class Issue6838ServerManifestVersionTest {
   }
 
   /**
-   * Reads the reactor root's own {@code <version>}, which is the first one declared after the {@code <parent>} block
-   * closes. Parsing it textually keeps the test free of an XML dependency and of any Maven-injected property, so it
-   * asserts against the file a release actually rewrites.
+   * Reads the reactor root's own {@code <version>}. The root POM is {@code arcadedb-parent} itself and declares no
+   * {@code <parent>}, so today that is simply the first {@code <version>} in the file; the {@code </parent>} skip is
+   * there so the answer stays the root's own version rather than an inherited one if that ever changes. Parsing it
+   * textually keeps the test free of an XML dependency and of any Maven-injected property, so it asserts against the
+   * file a release actually rewrites.
    */
   private static String readProjectVersion() throws IOException {
     final String pom = Files.readString(repositoryRoot().resolve("pom.xml"));

--- a/mcp/src/test/java/com/arcadedb/mcp/MCPServerPluginTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/MCPServerPluginTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.mcp;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.mcp.tools.MCPVectorLeg;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
@@ -1601,7 +1602,18 @@ class MCPServerPluginTest extends BaseGraphServerTest {
         .put("efSearch", 0)
         .put("k", 1));
     assertThat(invalidEfSearch.getJSONArray("content").getJSONObject(0).getString("text"))
-        .contains("'efSearch' must be at least 1");
+        .contains("'efSearch' must be between 1 and " + MCPVectorLeg.MAX_EF_SEARCH);
+
+    // The upper end of the same window (#6837): efSearch sizes the HNSW candidate list, so leaving it unbounded let
+    // one call size that queue from an arbitrary caller-supplied integer.
+    final JSONObject oversizedEfSearch = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("efSearch", Integer.MAX_VALUE)
+        .put("k", 1));
+    assertThat(oversizedEfSearch.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("'efSearch' must be between 1 and " + MCPVectorLeg.MAX_EF_SEARCH);
 
     final JSONObject sparseEfSearch = callTool("vector_search", new JSONObject()
         .put("database", getDatabaseName())

--- a/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6837ToolInputBoundsFollowUpTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6837ToolInputBoundsFollowUpTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mcp.tools;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.mcp.MCPConfiguration;
+import com.arcadedb.mcp.MCPPlugin;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6837, a follow-up to #6762: the #6762 hardening described the full-text tool as capping its window, but
+ * {@code FullTextSearchTool} only rejected {@code limit < 1}, so an unbounded limit still degenerated to "load,
+ * serialize and accumulate every match". {@code set_server_setting} declared {@code value} required and then read
+ * it with an empty-string default, so a call omitting it succeeded and left {@code ""} in the ContextConfiguration
+ * for a numeric key - a NumberFormatException deferred to whichever component reads it next.
+ * <p>
+ * The schema-wide test below is the part that prevents the next instance: every numeric tool input that declares a
+ * lower bound must also declare an upper one, and the declared window must be the one the server enforces.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6837ToolInputBoundsFollowUpTest extends BaseGraphServerTest {
+  private MCPConfiguration   config;
+  private ServerSecurityUser user;
+
+  @BeforeEach
+  void setupMCP() {
+    config = MCPPlugin.of(getServer(0)).getConfiguration();
+    config.setEnabled(true);
+    config.setAllowReads(true);
+    config.setAllowAdmin(true);
+    config.setAllowedUsers(List.of("root"));
+    final JSONObject clearOverrides = new JSONObject();
+    clearOverrides.put("databases", (Object) null);
+    config.updateFrom(clearOverrides);
+    user = getServer(0).getSecurity().authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
+  }
+
+  @Test
+  void fullTextSearchRejectsALimitAboveItsWindow() {
+    assertThatThrownBy(() -> FullTextSearchTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "Person[name]")
+        .put("queryText", "a")
+        .put("limit", Integer.MAX_VALUE), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'limit' must be between 1 and " + FullTextSearchTool.MAX_LIMIT);
+
+    assertThatThrownBy(() -> FullTextSearchTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "Person[name]")
+        .put("queryText", "a")
+        .put("limit", FullTextSearchTool.MAX_LIMIT + 1), config))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * The lower bound stays rejected, and the check happens before the index is resolved, so it is the limit the
+   * caller hears about rather than a downstream addressing error.
+   */
+  @Test
+  void fullTextSearchStillRejectsANonPositiveLimit() {
+    assertThatThrownBy(() -> FullTextSearchTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "Person[name]")
+        .put("queryText", "a")
+        .put("limit", 0), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'limit' must be between 1 and");
+  }
+
+  @Test
+  void vectorSearchRejectsAnEfSearchAboveItsWindow() {
+    assertThatThrownBy(() -> VectorSearchTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "Doc[embedding]")
+        .put("queryVector", new JSONArray().put(1.0f))
+        .put("efSearch", Integer.MAX_VALUE), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'efSearch' must be between 1 and " + MCPVectorLeg.MAX_EF_SEARCH);
+  }
+
+  @Test
+  void setServerSettingRejectsAnAbsentValue() {
+    assertThatThrownBy(() -> SetServerSettingTool.execute(getServer(0), user,
+        new JSONObject().put("key", "arcadedb.asyncWorkerThreads"), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'value' is required");
+  }
+
+  /** An explicit empty string is not a value for a numeric setting either: it is what the caller must not store. */
+  @Test
+  void setServerSettingRejectsAnEmptyValueForANonStringSetting() {
+    assertThatThrownBy(() -> SetServerSettingTool.execute(getServer(0), user,
+        new JSONObject().put("key", "arcadedb.asyncWorkerThreads").put("value", ""), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be empty");
+
+    // and the setting is untouched, so the rejected call cannot have been the one that broke a later read
+    assertThatCode(() -> getServer(0).getConfiguration().getValueAsInteger(
+        GlobalConfiguration.ASYNC_WORKER_THREADS)).doesNotThrowAnyException();
+  }
+
+  /** A String-typed setting keeps accepting "", which is how a caller clears one. */
+  @Test
+  void setServerSettingStillAcceptsAnEmptyValueForAStringSetting() {
+    final String key = GlobalConfiguration.SERVER_DEFAULT_DATABASES.getKey();
+    final Object previous = getServer(0).getConfiguration().getValue(GlobalConfiguration.SERVER_DEFAULT_DATABASES);
+    try {
+      final JSONObject result = SetServerSettingTool.execute(getServer(0), user,
+          new JSONObject().put("key", key).put("value", ""), config);
+
+      assertThat(result.getString("newValue")).isEmpty();
+      assertThat(getServer(0).getConfiguration().getValueAsString(GlobalConfiguration.SERVER_DEFAULT_DATABASES)).isEmpty();
+    } finally {
+      getServer(0).getConfiguration().setValue(key, previous);
+    }
+  }
+
+  @Test
+  void setServerSettingRejectsAnAbsentKey() {
+    assertThatThrownBy(() -> SetServerSettingTool.execute(getServer(0), user,
+        new JSONObject().put("value", "8"), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'key' is required");
+  }
+
+  /**
+   * The rule #6762 asserted for {@code query} alone, applied to every tool: a numeric input that declares a
+   * {@code minimum} must declare a {@code maximum} too. An input bounded on one side only is the exact shape both
+   * {@code full_text_search} and {@code efSearch} had - a window a client cannot pre-validate and, historically,
+   * one the server did not enforce either.
+   */
+  @Test
+  void everyNumericToolInputDeclaresBothEndsOfItsWindow() {
+    final List<Supplier<JSONObject>> definitions = List.of(
+        QueryTool::getDefinition, ExecuteCommandTool::getDefinition, SampleRecordsTool::getDefinition,
+        VectorSearchTool::getDefinition, FullTextSearchTool::getDefinition, HybridSearchTool::getDefinition,
+        ProfilerStartTool::getDefinition, UpsertEntityTool::getDefinition, UpsertRelationshipTool::getDefinition,
+        GetSchemaTool::getDefinition, ListDatabasesTool::getDefinition, ServerStatusTool::getDefinition,
+        GetServerSettingsTool::getDefinition, SetServerSettingTool::getDefinition, ProfilerStopTool::getDefinition,
+        ProfilerStatusTool::getDefinition);
+
+    final List<String> unbounded = new ArrayList<>();
+    for (final Supplier<JSONObject> definition : definitions) {
+      final JSONObject tool = definition.get();
+      collectHalfBoundedNumbers(tool.getString("name"), tool.getJSONObject("inputSchema"), unbounded);
+    }
+
+    assertThat(unbounded).isEmpty();
+  }
+
+  /** And full_text_search advertises exactly the window it enforces, so a client can reject the call itself. */
+  @Test
+  void fullTextSearchDeclaresTheWindowItEnforces() {
+    final JSONObject limit = FullTextSearchTool.getDefinition().getJSONObject("inputSchema")
+        .getJSONObject("properties").getJSONObject("limit");
+
+    assertThat(limit.getInt("minimum")).isEqualTo(1);
+    assertThat(limit.getInt("maximum")).isEqualTo(FullTextSearchTool.MAX_LIMIT);
+  }
+
+  /**
+   * Walks a JSON-Schema fragment and records every numeric input that declares a 'minimum' without a 'maximum',
+   * recursing into nested objects so a bound inside a structured input (filter.graphExpansion.maxDepth) counts too.
+   * Array 'items' are deliberately not walked: an element of 'queryIndices' is a coordinate into the caller's own
+   * vector, whose upper bound is the index dimension and so cannot be a constant in the schema. What bounds an
+   * array input is its length, which the vector leg checks against the resolved index dimensions.
+   */
+  private static void collectHalfBoundedNumbers(final String path, final JSONObject schema, final List<String> unbounded) {
+    final String type = schema.getString("type", "");
+    if (("integer".equals(type) || "number".equals(type)) && schema.has("minimum") && !schema.has("maximum"))
+      unbounded.add(path);
+
+    final JSONObject properties = schema.getJSONObject("properties", null);
+    if (properties != null)
+      for (final String name : properties.keySet())
+        collectHalfBoundedNumbers(path + "." + name, properties.getJSONObject(name), unbounded);
+  }
+}

--- a/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6837ToolInputBoundsFollowUpTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6837ToolInputBoundsFollowUpTest.java
@@ -45,6 +45,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>
  * The schema-wide test below is the part that prevents the next instance: every numeric tool input that declares a
  * lower bound must also declare an upper one, and the declared window must be the one the server enforces.
+ * <p>
+ * The bound cases deliberately name indexes that do not exist in the fixture ({@code Person[name]},
+ * {@code Doc[embedding]}). Every check under test runs before the index is resolved - {@code FullTextSearchTool}
+ * validates 'limit' ahead of {@code resolveIndex}, and {@code VectorSearchTool} calls
+ * {@code MCPVectorLeg.validateArguments} ahead of {@code resolveDatabase} - so a test that reached the lookup would
+ * be reporting an addressing error rather than the bound. Asserting on the message is what keeps that distinction
+ * honest: if a check ever moved behind index resolution, these tests would fail rather than pass for a new reason.
  *
  * @author Roberto Franchini (r.franchini@arcadedata.com)
  */

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "com.arcadedb/mcp-server",
   "title": "ArcadeDB MCP Server",
   "description": "Built-in MCP server for ArcadeDB multi-model database (graph, document, vector, time-series)",
-  "version": "26.3.1",
+  "version": "26.8.1",
   "repository": {
     "url": "https://github.com/ArcadeData/arcadedb",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "docker.io/arcadedata/arcadedb:26.3.1",
+      "identifier": "docker.io/arcadedata/arcadedb:26.8.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Closes #6837
Closes #6838

Both open `mcp`-labelled issues, in one branch: the remaining unbounded MCP tool inputs, and the registry manifest that no build step ever rewrote.

## #6837 - the input bounds #6762 did not actually close

### `full_text_search` had no upper bound on `limit`

`FullTextSearchTool` declared the property with only `default` and `description`, and enforced only `limit < 1`. The per-bucket push-down bounds the *index scan*, but every surviving hit is then loaded with `lookupByRID`, serialized in full and accumulated into the reply's `JSONArray`, so `{"limit": 2147483647}` from a read-only, non-root MCP caller still meant "return every matching document, fully serialized, in one message": O(N) record loads and O(N) documents live in the heap at once.

`MAX_LIMIT = 1_000`, matching the ceiling the sibling search tools already use for a candidate window (`MCPVectorLeg.MAX_K`, `HybridSearchTool.MAX_LEG_CANDIDATES`) so there is one number to reason about across the search surface. The schema now declares `minimum`/`maximum` too, so a client can reject the call without a round trip. The check stays ahead of index resolution, so an out-of-range limit is reported as a limit fault rather than as whatever addressing error the same call would also have produced.

### `efSearch` had the identical half-bounded shape

Not named in the issue, but found by the generalised test below: `vector_search` and `hybrid_search` declare `efSearch` with a `minimum` of 1 and no `maximum`, and `MCPVectorLeg.validateArguments` checked only the lower end. `efSearch` sizes the HNSW dynamic candidate list, so it is exactly the same class of defect - one caller sizing an in-memory priority queue from an arbitrary integer. Bounded at `MAX_EF_SEARCH = 10_000` in the shared vector leg, which both tools already route through, so there is one message rather than two divergent ones. Ten times `MAX_K` leaves every useful recall/latency trade-off reachable (`efSearch` is only useful above `k`).

### `set_server_setting` accepted a missing required value as `""`

The schema marked both `key` and `value` required; the body read them with empty-string defaults and re-checked only the key. `tools/call set_server_setting {"key":"arcadedb.asyncWorkerThreads"}` returned `isError: false` with `{"newValue":"", "message":"... updated successfully."}`, leaving `""` in the server's `ContextConfiguration` for a numeric key - a `NumberFormatException` deferred to whichever component read that setting next, surfacing far from the call that caused it. And because the model got a success envelope for a call its own schema said was malformed, nothing prompted a retry with a value.

Both members are now re-checked where they are read (`key` through `MCPToolUtils.requireString`, as the newer tools do), and:

- an **absent** `value` is rejected - that is the required-ness the schema declares;
- an **explicitly empty** `value` is rejected for every setting whose type is not `String`. `""` is a legitimate value for a `String` setting - it is how a caller clears one - and is a valid value for no other type, so it is refused exactly where it would otherwise be stored unparseable.

This matches the HTTP twin, `PostServerCommandHandler.setServerSetting`, which already raises `Expected <key> <value>` for the value-less form, so it is not a deliberate parity choice being broken.

### The test that prevents the next one

`Issue6837ToolInputBoundsFollowUpTest.everyNumericToolInputDeclaresBothEndsOfItsWindow` applies the rule `Issue6762ToolInputBoundsTest` asserted for `query` alone to all sixteen tool definitions: a numeric input declaring a `minimum` must declare a `maximum`. It recurses into nested objects (so `filter.graphExpansion.maxDepth` counts) but deliberately not into array `items` - an element of `queryIndices` is a coordinate into the caller's own vector, whose upper bound is the index dimension and so cannot be a constant in the schema; what bounds that input is its *length*, which the vector leg already checks against the resolved dimensions.

## #6838 - the MCP registry manifest was six releases behind

`server.json` declared `"version": "26.3.1"` and pinned `docker.io/arcadedata/arcadedb:26.3.1` while the project was at `26.9.1-SNAPSHOT`. It is not a Maven artifact, so `versions:set` never reached it, and `git log -- server.json` shows three chores with no release automation. A client installing this server from the MCP registry entry resolved the pinned OCI tag and ran ArcadeDB 26.3.1 - missing every HA, Raft and security fix from 26.4.x through 26.8.x - while reading the tool surface of HEAD.

- `server.json` now names **26.8.1**, the last release tag, and pins the matching image.
- `mvn-release.yml` rewrites both the `version` field and the OCI tag with `jq`, immediately after the step that does the same for `studio/package.json`, so the manifest cannot drift from the POM again. It runs **only on the release side**, not on the next-development bump: the manifest names the last *released* container tag rather than a `-SNAPSHOT` that was never pushed. The existing `git commit -am` picks it up.

`Issue6838ServerManifestVersionTest` holds the halves together: the declared `version` and every pinned tag must agree, every package must pin an explicit tag, the version must be a released `major.minor.patch` rather than a SNAPSHOT, and the manifest may not trail the reactor POM by more than three CalVer minors. The lag bound is deliberately slack - the workflow keeps it at 0 or 1 - so it catches drift of the reported magnitude (26.3 against 26.9, six apart) without turning a quarter with no release into a red `main`. The comparison is done in months (`major * 12 + minor`) so `26.12 -> 27.1` reads as a distance of one rather than -11.

## Verification

Each new test was run against the pre-fix behaviour first (enforcement reverted in place, constants kept so the file still compiles): **8 of 12 failed**, including all four `set_server_setting` cases, both limit/efSearch bounds, the schema-wide sweep, and the manifest-lag check. The four that stayed green are the intended controls - the preserved lower bound on `limit`, `""` still accepted for a `String` setting, and the two manifest-consistency assertions, which 26.3.1 satisfies because it was internally consistent while being stale.

With the fixes:

- `mvn -o test -pl mcp` - **312 tests, 0 failures**
- `mvn -o verify -pl mcp -DskipITs=false -Dit.test=MCPServerAdminAuthorizationIT,GetServerSettingsToolRedactionIT` - **4 tests, 0 failures** (both ITs exercise `set_server_setting`)

`MCPServerPluginTest.vectorSearchRejectsInvalidOptionsAndIndexSelection` asserted the old `'efSearch' must be at least 1` text; it is updated to the new message and extended to cover the upper end of the same window in the same place.

Release notes for both issues appended to `docs/release-26.9.1.md`.

## Deliberately out of scope

`ContextConfiguration.setValue` still performs no *type* validation, so `set_server_setting {"key":"arcadedb.asyncWorkerThreads","value":"abc"}` is stored and fails later. Rejecting that properly is not a one-liner: the two read paths disagree about what parses. `GlobalConfiguration.getValueAsInteger()` goes through `FileUtils.getSizeAsNumber`, which accepts `"1MB"`; `ContextConfiguration.getValueAsInteger(GlobalConfiguration)` does a plain `Integer.parseInt`. A validator written against either one would reject values the other accepts. That belongs in its own change, with the dual path resolved first - filing a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clear upper limits for full-text search result windows and vector search accuracy settings.
  - Tool schemas now display supported minimum and maximum values for numeric inputs.

- **Bug Fixes**
  - Improved server-setting validation for missing and invalid empty values while preserving valid empty strings.
  - Updated the server manifest and container image tags to version 26.8.1.

- **Documentation**
  - Added release notes covering search limits, setting validation, and manifest version consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->