### PR TITLE
fix(#6771,#6793): relocate or drop every third-party library in the gremlin uber-jar

### DIFF
--- a/gremlin-it/pom.xml
+++ b/gremlin-it/pom.xml
@@ -72,7 +72,6 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
-
         <!-- Self-contained shaded Gremlin uber-jar: bundles tinkerpop + groovy + netty +
              gremlin classes + the RELOCATED antlr 4.9.1. The wildcard exclusion prevents its
              non-reduced pom from re-pulling the original org.antlr / tinkerpop and
@@ -104,20 +103,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Compiled gremlin test classes + resources, executed via dependenciesToScan. -->
-        <dependency>
-            <groupId>com.arcadedb</groupId>
-            <artifactId>arcadedb-gremlin</artifactId>
-            <version>${project.parent.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <!-- Server module used by the com.arcadedb.server.gremlin.* tests, which start an
              embedded ArcadeDBServer. It is provided-scope in gremlin/pom.xml (assembled by the
@@ -135,6 +120,32 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
+        </dependency>
+
+        <!-- Importer/Exporter, used by the com.arcadedb.gremlin.integration.* tests. A real consumer
+             gets it transitively (arcadedb-gremlin declares it at compile scope for the GraphML and
+             GraphSON format handlers), but the shaded dependency above wildcard-excludes everything
+             transitive and the uber-jar deliberately does not bundle it, so re-declare it here. -->
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-integration</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Compiled gremlin test classes + resources, executed via dependenciesToScan. -->
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-gremlin</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- TinkerPop conformance-suite runner; use the shaded jar's bundled tinkerpop + antlr. -->

--- a/gremlin-it/pom.xml
+++ b/gremlin-it/pom.xml
@@ -50,7 +50,8 @@
 
     <!-- NOTE: because the shaded/tests arcadedb-gremlin artifacts below use a wildcard (*:*)
          exclusion, this module must re-declare by hand every dependency the migrated gremlin
-         tests need (engine, network, server + test-jar, gremlin-test, junit-vintage). If a new
+         tests need (engine, network, server + test-jar, integration, gremlin-test, junit-vintage).
+         If a new
          test dependency is added to the gremlin module, mirror it here or the migrated tests
          will fail to resolve it. -->
     <dependencies>
@@ -102,7 +103,6 @@
             <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
-
 
         <!-- Server module used by the com.arcadedb.server.gremlin.* tests, which start an
              embedded ArcadeDBServer. It is provided-scope in gremlin/pom.xml (assembled by the

--- a/gremlin-it/src/test/java/com/arcadedb/gremlin/shading/ShadedJarLayoutTest.java
+++ b/gremlin-it/src/test/java/com/arcadedb/gremlin/shading/ShadedJarLayoutTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin.shading;
+
+import com.arcadedb.gremlin.ArcadeGraph;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Structural contract of the {@code shaded} uber-jar: every third-party library merged into it is
+ * either relocated under {@code com.arcadedb.gremlin.shaded} or explicitly allowed to keep its own
+ * coordinates, and Groovy's extension-module descriptors are not published at all.
+ *
+ * <p>Regression test for <a href="https://github.com/ArcadeData/arcadedb/issues/6771">#6771</a>
+ * (a bundled {@code groovy-swing} descriptor collided with the consumer's own copy and Groovy
+ * aborted with "Conflicting module versions") and
+ * <a href="https://github.com/ArcadeData/arcadedb/issues/6793">#6793</a> (bundled-but-unrelocated
+ * libraries cannot be excluded or overridden by a consumer, so they silently win or lose against
+ * the consumer's own version).
+ *
+ * <p>The allow-list below is the contract, not an observation: adding a package to it means
+ * accepting that consumers can no longer choose their own version of that library.
+ */
+class ShadedJarLayoutTest {
+
+  /** Package prefixes (in JAR path form) that are deliberately NOT relocated. */
+  private static final List<String> ALLOWED_UNRELOCATED = List.of(
+      // ArcadeDB's own code, and the relocation target itself.
+      "com/arcadedb/",
+      // TinkerPop IS the API this jar exposes; relocating it would leave consumers nothing to call.
+      // Its own privately shaded Jackson (org/apache/tinkerpop/shaded) travels with it.
+      "org/apache/tinkerpop/",
+      // TinkerPop's public signatures take commons-configuration2 types, e.g.
+      // GraphFactory.open(Configuration). Relocating it turns every such call into a
+      // NoSuchMethodError for consumers compiled against plain TinkerPop.
+      "org/apache/commons/configuration2/",
+      // Same reason: TinkerPop returns javatuples types from public API, e.g.
+      // TraversalExplanation.getIntermediates() -> List<Triplet<...>>. Relocating it makes
+      // ExplainTest fail with "com.arcadedb.gremlin.shaded.org.javatuples.Pair cannot be cast to
+      // org.javatuples.Pair".
+      "org/javatuples/",
+      // A logging FACADE is meant to be shared with the host application: relocating it would
+      // detach the uber-jar's logging from whatever binding the consumer configured.
+      "org/slf4j/",
+      // Groovy CANNOT be relocated. maven-shade rewrites string constants without respecting
+      // package boundaries, so the pattern "groovy" also rewrites ".groovy" (the script
+      // extension), "groovy.target.indy" (a system property) and "groovydoc"; the Groovy compiler
+      // then fails with "ASM reporting processing error ... Script1.com.arcadedb.gremlin.shaded.groovy".
+      // On top of that its META-INF descriptors carry class names as plain text that shade does
+      // not rewrite. See GremlinGroovyEngineTest for the runtime half of this contract.
+      "groovy/",
+      "org/apache/groovy/",
+      "org/codehaus/groovy/",
+      // Groovy's own privately vendored ANTLR/ASM/picocli - already namespaced by Groovy itself.
+      "groovyjarjar");
+
+  private static JarFile shadedJar;
+
+  @BeforeAll
+  static void openShadedJar() throws Exception {
+    final URL location = ArcadeGraph.class.getProtectionDomain().getCodeSource().getLocation();
+    final File file = new File(location.toURI());
+    assertThat(file.getName())
+        .as("arcadedb-gremlin must be on the test classpath as the shaded uber-jar, not as target/classes")
+        .endsWith("-shaded.jar");
+    shadedJar = new JarFile(file);
+  }
+
+  @Test
+  void everyBundledThirdPartyPackageIsRelocated() {
+    final Set<String> leaked = new TreeSet<>();
+
+    for (final JarEntry entry : (Iterable<JarEntry>) shadedJar.stream()::iterator) {
+      final String name = entry.getName();
+      if (entry.isDirectory() || !name.endsWith(".class"))
+        continue;
+
+      // A multi-release overlay is a second copy of a class under its ORIGINAL name; shade does
+      // not relocate it, so it has to be held to the same contract as the base entries.
+      final String path = name.startsWith("META-INF/versions/")
+          ? name.substring(name.indexOf('/', "META-INF/versions/".length()) + 1)
+          : name;
+
+      if (path.startsWith("com/arcadedb/gremlin/shaded/"))
+        continue;
+      if (ALLOWED_UNRELOCATED.stream().anyMatch(path::startsWith))
+        continue;
+
+      leaked.add(path.substring(0, path.lastIndexOf('/') + 1));
+    }
+
+    assertThat(leaked)
+        .as("third-party packages bundled under their original names: a consumer can neither "
+            + "exclude nor override these (#6793). Relocate them in gremlin/pom.xml, or add them "
+            + "to ALLOWED_UNRELOCATED with the reason they must keep their coordinates")
+        .isEmpty();
+  }
+
+  @Test
+  void noGroovyExtensionModuleDescriptorIsPublished() {
+    // Single-module properties file at a fixed path: it cannot be merged, so whichever copy
+    // survives the shade advertises its moduleVersion to every classpath the uber-jar lands on
+    // and collides with the consumer's own copy of that module (#6771).
+    assertThat(shadedJar.getEntry("META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule"))
+        .as("bundling an extension-module descriptor makes Groovy abort with 'Conflicting module "
+            + "versions' whenever the consumer resolves the same module at another version")
+        .isNull();
+    assertThat(shadedJar.getEntry("META-INF/services/org.codehaus.groovy.runtime.ExtensionModule")).isNull();
+  }
+
+  @Test
+  void noSwingUserInterfaceIsBundled() {
+    // groovy-console/groovy-swing reach a headless server only as dead weight, and groovy-swing
+    // was the module whose descriptor triggered #6771.
+    final Set<String> swing = new TreeSet<>();
+    for (final JarEntry entry : (Iterable<JarEntry>) shadedJar.stream()::iterator) {
+      final String name = entry.getName();
+      if (name.startsWith("groovy/swing/") || name.startsWith("groovy/console/"))
+        swing.add(name);
+    }
+    assertThat(swing).isEmpty();
+  }
+}

--- a/gremlin-it/src/test/java/com/arcadedb/gremlin/shading/ShadedJarLayoutTest.java
+++ b/gremlin-it/src/test/java/com/arcadedb/gremlin/shading/ShadedJarLayoutTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.gremlin.shading;
 
 import com.arcadedb.gremlin.ArcadeGraph;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -90,6 +91,12 @@ class ShadedJarLayoutTest {
         .as("arcadedb-gremlin must be on the test classpath as the shaded uber-jar, not as target/classes")
         .endsWith("-shaded.jar");
     shadedJar = new JarFile(file);
+  }
+
+  @AfterAll
+  static void closeShadedJar() throws Exception {
+    if (shadedJar != null)
+      shadedJar.close();
   }
 
   @Test

--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -138,9 +138,54 @@
             <artifactId>commons-beanutils</artifactId>
             <version>${commons-beanutils.version}</version>
         </dependency>
+        <!-- ARCADEDB DOES NOT USE THIS LIBRARY BUT GREMLIN DOES. REPLACING IT WITH THE LAST RELEASE BECAUSE OF THE SECURITY ISSUE
+ https://nvd.nist.gov/vuln/detail/CVE-2022-1471 -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+
+        <!-- ARCADEDB DOES NOT USE THIS LIBRARY BUT GREMLIN DOES: gremlin-groovy pulls Ivy in to
+             back Groovy's Grape dependency loader. TinkerPop 3.8.1 resolves 2.5.3, which is
+             affected by the PackagerResolver path traversal
+             https://nvd.nist.gov/vuln/detail/CVE-2026-26032 -->
+        <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <version>${ivy.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy</artifactId>
+            <artifactId>groovy-groovysh</artifactId>
+            <version>${groovy.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+                <!-- groovy-console drags in groovy-swing, i.e. an AWT/Swing UI that a headless
+                     server never opens. It also ships META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule.
+                     That descriptor is a single-module properties file at a fixed path, so a
+                     consumer that resolves groovy-swing normally (gremlin-groovy pulls 4.0.25)
+                     ends up with two descriptors naming module groovy-swing at different versions
+                     and Groovy aborts with "Conflicting module versions" (issue #6771). Dropping
+                     groovy-swing removes the descriptor, and with it the conflict. -->
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-console</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
             <version>${groovy.version}</version>
         </dependency>
         <dependency>
@@ -185,31 +230,6 @@
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-groovy</artifactId>
             <version>${gremlin.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>jline</groupId>
-                    <artifactId>jline</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-
-        <!-- ARCADEDB DOES NOT USE THIS LIBRARY BUT GREMLIN DOES. REPLACING IT WITH THE LAST RELEASE BECAUSE OF THE SECURITY ISSUE
-         https://nvd.nist.gov/vuln/detail/CVE-2022-1471 -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>${snakeyaml.version}</version>
-        </dependency>
-
-        <!-- ARCADEDB DOES NOT USE THIS LIBRARY BUT GREMLIN DOES: gremlin-groovy pulls Ivy in to
-             back Groovy's Grape dependency loader. TinkerPop 3.8.1 resolves 2.5.3, which is
-             affected by the PackagerResolver path traversal
-             https://nvd.nist.gov/vuln/detail/CVE-2026-26032 -->
-        <dependency>
-            <groupId>org.apache.ivy</groupId>
-            <artifactId>ivy</artifactId>
-            <version>${ivy.version}</version>
         </dependency>
 
         <dependency>
@@ -267,15 +287,126 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
-                    <!-- Relocate ANTLR 4.9.1 (TinkerPop's precompiled parser needs the v3 ATN
-                         format) into a private package so it never collides with the engine's
-                         org.antlr 4.13.2 on a shared classpath. -->
+                    <!-- Every third-party library bundled here is relocated into a private package, so a
+                         consumer can pin their own version of it without the uber-jar's copy silently
+                         outvoting theirs (issue #6793). ShadedJarLayoutTest enforces that; its
+                         ALLOWED_UNRELOCATED list carries the reason for each deliberate exception.
+
+                         Two of those exceptions are worth repeating here, because both were learnt the
+                         hard way and both look like omissions:
+
+                         - GROOVY CANNOT BE RELOCATED. maven-shade rewrites string constants without
+                           respecting package boundaries, so a "groovy" pattern also rewrites ".groovy"
+                           (the script extension), "groovy.target.indy" (a system property) and
+                           "groovydoc". The Groovy compiler then dies on its own script class name with
+                           "ASM reporting processing error ... Script1.com.arcadedb.gremlin.shaded.groovy",
+                           which reaches the user as
+                           "MissingPropertyException: No such property: metaClass for class: java.util.Map"
+                           while TinkerPop's ObjectLoader.groovy initialises the engine. Its META-INF
+                           descriptors compound this: they name classes in plain text that shade does not
+                           rewrite. GremlinGroovyEngineTest is the guard.
+                         - commons-configuration2 must keep its coordinates because TinkerPop's PUBLIC API
+                           takes those types, e.g. GraphFactory.open(Configuration). Relocating it turns
+                           every such call into a NoSuchMethodError. Same for org.javatuples, which
+                           TraversalExplanation returns. -->
                     <relocations>
+                        <!-- ANTLR 4.9.1: TinkerPop's precompiled parser needs the v3 ATN format, so it must
+                             never collide with the engine's org.antlr 4.13.2 on a shared classpath. -->
                         <relocation>
                             <pattern>org.antlr</pattern>
                             <shadedPattern>com.arcadedb.gremlin.shaded.org.antlr</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>io.netty</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.io.netty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.jctools</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.org.jctools</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.apache.commons</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.org.apache.commons</shadedPattern>
+                            <excludes>
+                                <exclude>org.apache.commons.configuration2.**</exclude>
+                            </excludes>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.github</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.com.github</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.objectweb</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.org.objectweb</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.carrotsearch</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.com.carrotsearch</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.codahale</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.com.codahale</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.yaml</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.org.yaml</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.apache.ivy</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.org.apache.ivy</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.abego</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.org.abego</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>nl.altindag</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.nl.altindag</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>net.objecthunter</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.net.objecthunter</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.mindrot</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.org.mindrot</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.squareup.javapoet</pattern>
+                            <shadedPattern>com.arcadedb.gremlin.shaded.com.squareup.javapoet</shadedPattern>
+                        </relocation>
+
                     </relocations>
+                    <!-- Groovy's extension-module descriptor is a SINGLE-module properties file at a
+                         fixed path, so it cannot be merged: of the modules bundled here only one
+                         copy survives the shade, and the survivor then advertises its own
+                         moduleVersion to every classpath the uber-jar lands on. A consumer that
+                         also resolves that module normally (gremlin-groovy 3.8.1 pulls groovy 4.0.25)
+                         gets two descriptors for the same moduleName at different versions and Groovy
+                         aborts at startup with "Conflicting module versions" (issue #6771). Nothing
+                         Gremlin does needs the extension methods these descriptors register
+                         (XmlExtensions, ScriptExtensions), so the uber-jar publishes none of them
+                         and the conflict cannot arise. -->
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule</exclude>
+                                <exclude>META-INF/services/org.codehaus.groovy.runtime.ExtensionModule</exclude>
+                                <!-- The shade plugin does not relocate the multi-release overlay, so
+                                     snakeyaml's Java 9 copy of org.yaml.snakeyaml.internal.Logger
+                                     survives under its ORIGINAL name while the base copy is
+                                     relocated. On Java 9+ that orphan shadows a consumer's own
+                                     snakeyaml (issue #6793); nothing in the uber-jar can reach it,
+                                     because every reference was rewritten. Same for the bundled
+                                     module-info descriptors, which still export the pre-relocation
+                                     packages. -->
+                                <exclude>META-INF/versions/*/org/yaml/**</exclude>
+                                <exclude>META-INF/versions/*/module-info.class</exclude>
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <artifactSet>
                         <excludes>
                             <!-- Do NOT bundle the engine: its SQL/Cypher parsers are v4-ATN (antlr 4.13.2) and the
@@ -284,12 +415,46 @@
                                  the arcadedb-gremlin-it module both provide it), so the relocation must touch only
                                  TinkerPop's own 4.9.1 parser. -->
                             <exclude>com.arcadedb:arcadedb-engine</exclude>
-                            <!-- Do NOT bundle network either: it is now a real compile-scope dependency (#5879),
+                            <!-- Do NOT bundle network either: it is a real compile-scope dependency (#5879),
                                  so Maven resolves it transitively for every consumer of either the plain or the
                                  shaded jar. Bundling it here as well would duplicate its classes on the classpath
                                  of any consumer who, like arcadedb-server or arcadedb-gremlin-it, also pulls the
                                  plain arcadedb-network jar directly. -->
                             <exclude>com.arcadedb:arcadedb-network</exclude>
+                            <!-- Same for integration, which the GraphML/GraphSON format handlers in
+                                 src/main/java compile against and which is therefore compile-scope too. -->
+                            <exclude>com.arcadedb:arcadedb-integration</exclude>
+                            <!-- The server is provided-scope, so shade drops it anyway; the exclude states the
+                                 intent, because the server is the assembly point that loads this jar. -->
+                            <exclude>com.arcadedb:arcadedb-server</exclude>
+                            <!-- ...and neither the engine's own dependency tree. Excluding an artifact does NOT
+                                 exclude what it drags in, so before this list the uber-jar carried a full unrelocated
+                                 copy of Lucene, GraalJS/Truffle, gson and friends: ~50MB that nothing inside the jar
+                                 can even reach, because the engine that uses them is not here. For a consumer they
+                                 are worse than dead weight - a bundled Lucene silently outvotes their own newer one
+                                 and the first mismatched call dies with NoSuchMethodError, which is exactly what
+                                 issue #6793 reports. Every artifact below travels with arcadedb-engine, so the
+                                 consumer already has it, at the version the engine asked for.
+                                 ShadedJarLayoutTest fails if a new one appears and is not listed here. -->
+                            <exclude>at.yawk.lz4:*</exclude>
+                            <exclude>com.conversantmedia:*</exclude>
+                            <exclude>com.google.code.gson:*</exclude>
+                            <exclude>com.google.errorprone:*</exclude>
+                            <exclude>io.github.jbellis:*</exclude>
+                            <exclude>io.sgr:*</exclude>
+                            <exclude>org.agrona:*</exclude>
+                            <exclude>org.apache.commons:commons-math3</exclude>
+                            <exclude>org.apache.lucene:*</exclude>
+                            <exclude>org.graalvm.js:*</exclude>
+                            <exclude>org.graalvm.polyglot:*</exclude>
+                            <exclude>org.graalvm.regex:*</exclude>
+                            <exclude>org.graalvm.sdk:*</exclude>
+                            <exclude>org.graalvm.shadowed:*</exclude>
+                            <exclude>org.graalvm.truffle:*</exclude>
+                            <exclude>org.locationtech.jts:*</exclude>
+                            <exclude>org.locationtech.spatial4j:*</exclude>
+                            <!-- ...and the same for arcadedb-integration's tree. -->
+                            <exclude>com.sonofab1rd:univocity-parsers</exclude>
                         </excludes>
                     </artifactSet>
                 </configuration>

--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -156,6 +156,17 @@
             <version>${ivy.version}</version>
         </dependency>
 
+        <!-- Groovy core is declared directly so its version is pinned at depth 1. It also arrives
+             transitively from groovy-groovysh (4.0.33) and from gremlin-groovy (4.0.25), both at
+             depth 2, so without this declaration Maven picks the winner by DECLARATION ORDER:
+             moving the gremlin-groovy block above groovy-groovysh silently drops the whole
+             uber-jar back to Groovy 4.0.25. A silent version divergence of exactly that kind is
+             what issue #6771 was, so the pin is explicit rather than positional. -->
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-groovysh</artifactId>
@@ -336,10 +347,6 @@
                             <shadedPattern>com.arcadedb.gremlin.shaded.com.github</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>org.objectweb</pattern>
-                            <shadedPattern>com.arcadedb.gremlin.shaded.org.objectweb</shadedPattern>
-                        </relocation>
-                        <relocation>
                             <pattern>com.carrotsearch</pattern>
                             <shadedPattern>com.arcadedb.gremlin.shaded.com.carrotsearch</shadedPattern>
                         </relocation>
@@ -354,10 +361,6 @@
                         <relocation>
                             <pattern>org.apache.ivy</pattern>
                             <shadedPattern>com.arcadedb.gremlin.shaded.org.apache.ivy</shadedPattern>
-                        </relocation>
-                        <relocation>
-                            <pattern>org.abego</pattern>
-                            <shadedPattern>com.arcadedb.gremlin.shaded.org.abego</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>nl.altindag</pattern>


### PR DESCRIPTION
Closes #6771
Closes #6793

## Problem

The `arcadedb-gremlin:shaded` classifier relocated only ANTLR. Every other library it merged in kept its original package names, so a consumer could neither exclude it (it is not a resolvable artifact) nor override it (their own copy and the bundled one collide under the same class names). Both linked issues are instances of that.

## What changed

**Relocate what can be relocated.** netty, jctools, commons-lang3/beanutils/collections, caffeine, asm, hppc, metrics, snakeyaml, ivy, exp4j, jbcrypt, javapoet.

**Stop bundling other modules' dependency trees.** Excluding an artifact from the shade does *not* exclude what it drags in, so the uber-jar carried a complete unrelocated Lucene, GraalJS/Truffle, gson and univocity: roughly 50MB that nothing inside the jar can even reach, because the module that uses them (`arcadedb-engine`, `arcadedb-integration`) is deliberately not there. That bundled Lucene is precisely what #6793 reports as a silent `NoSuchMethodError: BooleanClause.query()`. Every one of these artifacts travels with the engine, so the consumer already has it at the version the engine asked for.

**94MB → 42MB.**

**Fix the Groovy module conflict (#6771).** Two changes:
- drop `groovy-console` (and with it `groovy-swing`), an AWT/Swing UI a headless server never opens;
- filter `META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule` out of the jar entirely.

That descriptor is a single-module properties file at a fixed path, so it *cannot* be merged. Of the three modules that ship one (`groovy-jsr223`, `groovy-swing`, `groovy-xml`) only one survived the shade, and the survivor then advertised its `moduleVersion` to every classpath the jar landed on. A consumer resolving that same module at another version got two descriptors for one `moduleName` and Groovy aborted at startup. Nothing Gremlin does needs the extension methods these register.

**Filter what shade cannot relocate.** The multi-release overlay is not rewritten, so snakeyaml's Java 9 `org.yaml.snakeyaml.internal.Logger` survived under its original name while the base copy was relocated — an orphan that can only shadow a consumer's own snakeyaml. Same for the bundled `module-info` descriptors, which still export pre-relocation packages.

**Restore `arcadedb-network` and `arcadedb-integration` to compile scope.** Scope was being used to keep them out of the uber-jar; `artifactSet/excludes` does that without breaking the Maven contract that #5879 established.

## Why Groovy itself is not relocated

Relocating it does not work, and the failure is spectacular rather than subtle. maven-shade rewrites string constants without respecting package boundaries, so a `groovy` pattern also rewrites strings that merely start with those six letters. From the shaded `CompilerConfiguration`:

```
ldc  // String .com.arcadedb.gremlin.shaded.groovy          <- was ".groovy", the script extension
ldc  // String com.arcadedb.gremlin.shaded.groovy.target.indy   <- a system property name
ldc  // String com.arcadedb.gremlin.shaded.groovydoc            <- not even a package
```

The Groovy compiler then fails on its own script class name:

```
GroovyRuntimeException: ASM reporting processing error for
Script1_com_arcadedb_gremlin_shaded#$getStaticMetaClass ... in Script1.com.arcadedb.gremlin.shaded.groovy:-1
Caused by: NullPointerException: ...ClassNode.isDerivedFrom(...) because "c" is null
```

which reaches the user as `MissingPropertyException: No such property: metaClass for class: java.util.Map` while TinkerPop's `ObjectLoader.groovy` initialises the engine. Its `META-INF` descriptors compound the problem: they carry class names as plain text that shade does not rewrite.

Two more libraries keep their coordinates because TinkerPop's **public API** uses them: `commons-configuration2` (`GraphFactory.open(Configuration)` — relocating it turns every such call into a `NoSuchMethodError`, which failed 198 tests here) and `org.javatuples` (`TraversalExplanation` returns `Pair`/`Triplet`).

The pom records each of these with its reason, so the next person does not rediscover them.

## Regression tests

`ShadedJarLayoutTest` (new) asserts the contract rather than the current state:
- every bundled package is relocated, except an explicit `ALLOWED_UNRELOCATED` list that carries the reason per entry — adding to it means consciously accepting that consumers can no longer choose their own version of that library;
- no Groovy extension-module descriptor is published;
- no Swing UI is bundled.

It was confirmed to fail (naming the offending packages) before being trusted. `GremlinGroovyEngineTest`, which already existed, is the runtime guard against re-relocating Groovy: it fails with the `metaClass` error above.

## Verification

| | |
|---|---|
| `gremlin-it` unit | 386 pass, 0 fail |
| `gremlin-it` integration (`-Pintegration`, full TinkerPop structure + process suites) | 1870 pass, 0 fail |
| `graphql` (consumes the shaded jar) | 82 pass, 0 fail |
| Full distribution | builds; server starts, `Available query languages: [... gremlin]`, and `g.V().hasLabel('Person').values('name')` and `math('1 + 2')` answer correctly over HTTP |

#6771 reproduced end to end: the shaded jar plus a consumer's own `groovy-swing` at a different version throws `GroovyRuntimeException: Conflicting module versions. Module [groovy-swing is loaded in version 4.0.33 and you are trying to load version 4.0.25` against released 26.8.1, and evaluates cleanly on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gremlin packaging to prevent unwanted libraries, Groovy console components, and extension metadata from being included.
  * Enhanced dependency isolation for more reliable Gremlin integration behavior.
* **Tests**
  * Added validation for shaded archive contents, package isolation, multi-release classes, and excluded Groovy components.
  * Expanded integration coverage to verify the packaged Gremlin artifact’s structure and contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->