### PR TITLE
fix(#6873): bound the vector k-NN path with the native Select timeout

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/select/Select.java
+++ b/engine/src/main/java/com/arcadedb/query/select/Select.java
@@ -163,6 +163,19 @@ public class Select {
     return this;
   }
 
+  /**
+   * Bounds how long one execution of this select may take. The budget covers the whole answer - index lookup
+   * included - and is enforced by every plan shape, the vector k-NN search of {@link #nearestTo} among them.
+   *
+   * @param exceptionOnTimeout {@code true} to raise a {@link com.arcadedb.exception.TimeoutException} when the budget
+   *                           runs out, {@code false} to stop and hand back whatever was <b>already produced</b>: the
+   *                           records a {@link SelectIterator} had yielded, the tally {@link #count()} had reached.
+   *                           #6873: on the {@code nearestTo()} path "already produced" means the results already
+   *                           assembled, so an expiry before assembly starts answers with an <b>empty</b> list rather
+   *                           than a truncated one - the neighbours the index searches found are RIDs and distances,
+   *                           and turning any of them into a result would mean loading a record past a deadline that
+   *                           has already gone.
+   */
   public Select timeout(final long timeoutValue, final TimeUnit timeoutUnit, final boolean exceptionOnTimeout) {
     checkNotCompiled();
     this.timeoutInMs = timeoutUnit.toMillis(timeoutValue);

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -228,9 +228,9 @@ public class SelectExecutor {
    * compiled and silently dropped the budget.
    * <p>
    * Granularity caveat: a single {@code LSMVectorIndex.findNeighborsFromVector()} call is not interruptible from here,
-   * so the deadline is honoured <i>between</i> indexes and <i>per assembled result</i> (each of which loads a record
-   * and may run the post-filter WHERE). That will not cut short one long search inside a single index, but it is the
-   * difference between a no-op and a bound.
+   * so the deadline is honoured <i>between</i> indexes, <i>before the merge sort of what they returned</i> and
+   * <i>per assembled result</i> (each of which loads a record and may run the post-filter WHERE). That will not cut
+   * short one long search inside a single index, but it is the difference between a no-op and a bound.
    */
   @SuppressWarnings("unchecked")
   <T extends Document> List<SelectVectorResult<T>> executeVector() {
@@ -271,6 +271,14 @@ public class SelectExecutor {
         neighbors = lsmIndex.findNeighborsFromVector(select.vectorQuery, select.vectorK);
       allNeighbors.addAll(neighbors);
     }
+
+    // #6873: THE DEADLINE CAN ONLY EXPIRE INSIDE AN INDEX'S OWN (UNINTERRUPTIBLE) SEARCH, AND WHEN THAT IS THE *LAST*
+    // INDEX THE LOOP ENDS ON ITS BOUND RATHER THAN ON THE CHECKPOINT ABOVE - SO WITHOUT A CHECKPOINT HERE THE SORT OF
+    // UP TO indexes * k PAIRS AND THE RESULT-LIST ALLOCATION WOULD STILL RUN AFTER THE BUDGET IS GONE. IT ALSO MAKES
+    // exceptionOnTimeout RAISE THE EXPIRY EVEN WHEN THE SEARCH FOUND NO NEIGHBOUR AT ALL, WHICH LEAVES THE ASSEMBLY
+    // LOOP BELOW WITH NO ITERATION TO CHECK ON
+    if (checkForTimeout())
+      return new ArrayList<>();
 
     allNeighbors.sort(Comparator.comparing(Pair::getSecond));
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -66,7 +66,11 @@ public class SelectExecutor {
   // WRITTEN AGAINST THE WALL CLOCK WOULD BE A RACE THAT A FASTER MACHINE TURNS RED. DRIVING THE CLOCK KEEPS THE TEST
   // DETERMINISTIC WHILE STILL EXERCISING THE REAL startTimeout() SATURATION AND THE REAL throw/truncate DECISION.
   // COSTS NOTHING ON THE HOT PATH: checkForTimeout() RETURNS ON THE Long.MAX_VALUE SENTINEL BEFORE READING IT, SO A
-  // SELECT WITHOUT A TIMEOUT NEVER TOUCHES THE SUPPLIER AT ALL
+  // SELECT WITHOUT A TIMEOUT NEVER TOUCHES THE SUPPLIER AT ALL.
+  // NOT volatile, AND IT DOES NOT NEED TO BE: EVERY CALL SITE BUILDS A FRESH SelectExecutor PER EXECUTION, THE FIELD
+  // IS ONLY EVER ASSIGNED BEFORE THAT EXECUTION STARTS, AND THE ONE PLACE THAT HANDS THE EXECUTOR TO OTHER THREADS
+  // (SelectParallelIterator'S PRODUCERS) READS select/evaluateWhere() AND NEVER THE DEADLINE. IF THAT EVER CHANGES,
+  // THE PUBLICATION OF THIS FIELD HAS TO BE REVISITED ALONG WITH timeoutDeadline, WHICH IS IN THE SAME POSITION
   LongSupplier clock = System::currentTimeMillis;
 
   // #6577: THE SINGLE SOURCE OF TRUTH FOR "WHICH OPERATORS CAN filterWithIndexesFinalNode() ACTUALLY TURN INTO AN
@@ -231,6 +235,12 @@ public class SelectExecutor {
    * so the deadline is honoured <i>between</i> indexes, <i>before the merge sort of what they returned</i> and
    * <i>per assembled result</i> (each of which loads a record and may run the post-filter WHERE). That will not cut
    * short one long search inside a single index, but it is the difference between a no-op and a bound.
+   * <p>
+   * What a non-throwing expiry returns: the results <b>already assembled</b>, which is an empty list whenever the
+   * deadline goes before the assembly loop starts - the neighbours the index searches accumulated are RIDs and
+   * distances, not results, and promoting them would mean loading records past a deadline that has already expired.
+   * That is the same rule {@link #executeCount()} and {@link SelectIterator} follow: hand back what was produced, do
+   * not produce more.
    */
   @SuppressWarnings("unchecked")
   <T extends Document> List<SelectVectorResult<T>> executeVector() {
@@ -259,8 +269,12 @@ public class SelectExecutor {
 
     final List<Pair<RID, Float>> allNeighbors = new ArrayList<>();
     for (final LSMVectorIndex lsmIndex : vectorIndexes) {
-      // #6873: THE COARSEST OF THE TWO CHECKPOINTS - ONE PER BUCKET INDEX. A NON-THROWING TIMEOUT KEEPS WHATEVER THE
-      // INDEXES SEARCHED SO FAR CONTRIBUTED, WHICH IS THE TRUNCATED ANSWER THE STREAMING PATHS RETURN
+      // #6873: THE COARSEST OF THE THREE CHECKPOINTS - ONE PER BUCKET INDEX, SINCE THE SEARCH INSIDE ONE INDEX IS NOT
+      // INTERRUPTIBLE FROM HERE. WHAT THE INDEXES SEARCHED SO FAR PUT IN allNeighbors IS *NOT* A PARTIAL ANSWER: IT IS
+      // RIDs AND DISTANCES, AND TURNING ANY OF IT INTO A RESULT MEANS LOADING RECORDS AND RUNNING THE POST-FILTER
+      // WHERE - MORE WORK, PAST A DEADLINE THAT HAS ALREADY GONE. SO A NON-THROWING EXPIRY ANYWHERE BEFORE THE
+      // ASSEMBLY LOOP ANSWERS WITH AN EMPTY LIST, WHICH IS THE SAME RULE THE OTHER PATHS FOLLOW: KEEP WHAT WAS
+      // ALREADY *PRODUCED* (RECORDS YIELDED BY SelectIterator, THE TALLY IN executeCount()), NEVER PRODUCE MORE
       if (checkForTimeout())
         break;
 
@@ -276,7 +290,8 @@ public class SelectExecutor {
     // INDEX THE LOOP ENDS ON ITS BOUND RATHER THAN ON THE CHECKPOINT ABOVE - SO WITHOUT A CHECKPOINT HERE THE SORT OF
     // UP TO indexes * k PAIRS AND THE RESULT-LIST ALLOCATION WOULD STILL RUN AFTER THE BUDGET IS GONE. IT ALSO MAKES
     // exceptionOnTimeout RAISE THE EXPIRY EVEN WHEN THE SEARCH FOUND NO NEIGHBOUR AT ALL, WHICH LEAVES THE ASSEMBLY
-    // LOOP BELOW WITH NO ITERATION TO CHECK ON
+    // LOOP BELOW WITH NO ITERATION TO CHECK ON. THE EMPTY LIST IS DELIBERATE AND NOT A LOST PARTIAL RESULT - SEE THE
+    // PER-INDEX CHECKPOINT ABOVE FOR WHY allNeighbors IS NOT AN ANSWER YET
     if (checkForTimeout())
       return new ArrayList<>();
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -33,6 +33,7 @@ import com.arcadedb.utility.Pair;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 
 /**
  * Native Query engine is a simple query engine that covers most of the classic use cases, such as the retrieval of records
@@ -57,6 +58,16 @@ public class SelectExecutor {
   // THE COMMONEST QUERY SHAPE OF ALL. Long.MAX_VALUE MEANS "NO TIMEOUT REQUESTED" AND KEEPS THE PER-RECORD CHECK A
   // SINGLE PERFECTLY PREDICTED COMPARE ON THE HOT PATH
   private long timeoutDeadline = Long.MAX_VALUE;
+
+  // #6873: THE TIME SOURCE THE DEADLINE IS ARMED FROM AND CHECKED AGAINST. PRODUCTION ALWAYS USES
+  // System.currentTimeMillis(); THE SEAM EXISTS SO THE REGRESSION TEST CAN DRIVE THE ELAPSED TIME INSTEAD OF RACING
+  // THE WALL CLOCK. executeVector() IS EAGER - IT RETURNS A FULLY MATERIALIZED List - SO NO CONSUMER CAN PACE IT THE
+  // WAY drainSlowly() PACES THE LAZY SelectIterator IN THE #6815 TESTS, AND AN "A 1 ms BUDGET EXPIRED" ASSERTION
+  // WRITTEN AGAINST THE WALL CLOCK WOULD BE A RACE THAT A FASTER MACHINE TURNS RED. DRIVING THE CLOCK KEEPS THE TEST
+  // DETERMINISTIC WHILE STILL EXERCISING THE REAL startTimeout() SATURATION AND THE REAL throw/truncate DECISION.
+  // COSTS NOTHING ON THE HOT PATH: checkForTimeout() RETURNS ON THE Long.MAX_VALUE SENTINEL BEFORE READING IT, SO A
+  // SELECT WITHOUT A TIMEOUT NEVER TOUCHES THE SUPPLIER AT ALL
+  LongSupplier clock = System::currentTimeMillis;
 
   // #6577: THE SINGLE SOURCE OF TRUTH FOR "WHICH OPERATORS CAN filterWithIndexesFinalNode() ACTUALLY TURN INTO AN
   // IndexCursor" - isTheNodeFullyIndexed() MUST TREAT EXACTLY THIS SET, AND NO MORE, AS "THIS LEAF IS INDEXED".
@@ -84,9 +95,10 @@ public class SelectExecutor {
   }
 
   /**
-   * Arms the deadline for one execution. Called from the three entry points ({@link #execute()},
-   * {@link #executeCount()}, {@link #executeExists()}) rather than from the constructor, so the window it covers is
-   * exactly the work the caller asked to bound - index lookup included, since that is part of answering the query.
+   * Arms the deadline for one execution. Called from the four entry points ({@link #execute()},
+   * {@link #executeCount()}, {@link #executeExists()}, {@link #executeVector()}) rather than from the constructor, so
+   * the window it covers is exactly the work the caller asked to bound - index lookup included, since that is part of
+   * answering the query.
    */
   private void startTimeout() {
     if (select.timeoutInMs > 0) {
@@ -95,7 +107,7 @@ public class SelectExecutor {
       // now + timeoutInMs WOULD OVERFLOW INTO A NEGATIVE DEADLINE - TURNING AN EFFECTIVELY INFINITE BUDGET INTO ONE
       // THAT HAS ALREADY EXPIRED, SO THE FIRST RECORD WOULD THROW. CLAMPING TO Long.MAX_VALUE LANDS ON THE
       // "NO TIMEOUT" SENTINEL, WHICH IS EXACTLY WHAT A BUDGET THAT LARGE MEANS
-      final long now = System.currentTimeMillis();
+      final long now = clock.getAsLong();
       timeoutDeadline = select.timeoutInMs > Long.MAX_VALUE - now ? Long.MAX_VALUE : now + select.timeoutInMs;
     }
   }
@@ -108,7 +120,7 @@ public class SelectExecutor {
    * @return {@code true} when the deadline expired and the caller asked NOT to be thrown at
    */
   boolean checkForTimeout() {
-    if (timeoutDeadline == Long.MAX_VALUE || System.currentTimeMillis() <= timeoutDeadline)
+    if (timeoutDeadline == Long.MAX_VALUE || clock.getAsLong() <= timeoutDeadline)
       return false;
     if (select.exceptionOnTimeout)
       throw new TimeoutException("Timeout on iteration");
@@ -209,8 +221,21 @@ public class SelectExecutor {
     }
   }
 
+  /**
+   * #6873: the fifth plan shape. The four sources {@code buildIterator()} can return are all bounded by
+   * {@link #checkForTimeout()} since #6815, but the vector k-NN search never goes through {@code buildIterator()} at
+   * all and used to consult no deadline whatsoever - so {@code select().fromType(..).timeout(..).nearestTo(..)}
+   * compiled and silently dropped the budget.
+   * <p>
+   * Granularity caveat: a single {@code LSMVectorIndex.findNeighborsFromVector()} call is not interruptible from here,
+   * so the deadline is honoured <i>between</i> indexes and <i>per assembled result</i> (each of which loads a record
+   * and may run the post-filter WHERE). That will not cut short one long search inside a single index, but it is the
+   * difference between a no-op and a bound.
+   */
   @SuppressWarnings("unchecked")
   <T extends Document> List<SelectVectorResult<T>> executeVector() {
+    startTimeout();
+
     if (select.fromType == null)
       throw new IllegalArgumentException("FromType must be set for vector search");
     if (select.vectorProperty == null)
@@ -234,6 +259,11 @@ public class SelectExecutor {
 
     final List<Pair<RID, Float>> allNeighbors = new ArrayList<>();
     for (final LSMVectorIndex lsmIndex : vectorIndexes) {
+      // #6873: THE COARSEST OF THE TWO CHECKPOINTS - ONE PER BUCKET INDEX. A NON-THROWING TIMEOUT KEEPS WHATEVER THE
+      // INDEXES SEARCHED SO FAR CONTRIBUTED, WHICH IS THE TRUNCATED ANSWER THE STREAMING PATHS RETURN
+      if (checkForTimeout())
+        break;
+
       final List<Pair<RID, Float>> neighbors;
       if (select.vectorApproximate)
         neighbors = lsmIndex.findNeighborsFromVectorApproximate(select.vectorQuery, select.vectorK);
@@ -248,6 +278,11 @@ public class SelectExecutor {
     final List<SelectVectorResult<T>> results = new ArrayList<>(resultCount);
 
     for (int i = 0; i < resultCount; i++) {
+      // #6873: ASSEMBLY IS NOT FREE - EVERY ITERATION LOADS A RECORD FROM DISK AND MAY RUN THE POST-FILTER WHERE, SO
+      // THE BUDGET HAS TO BE HONOURED HERE TOO AND NOT ONLY AROUND THE NEIGHBOUR SEARCH
+      if (checkForTimeout())
+        break;
+
       final Pair<RID, Float> neighbor = allNeighbors.get(i);
       final T record = (T) neighbor.getFirst().asDocument();
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectVectorBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectVectorBuilder.java
@@ -25,6 +25,14 @@ import java.util.List;
 
 /**
  * Fluent builder for vector k-NN search. Provides options for approximate search and optional WHERE post-filtering.
+ * <p>
+ * #6873: a {@link Select#timeout} set on the select is honoured here too, between bucket indexes, before the merge
+ * sort of what they returned, and per assembled result. Two limits are worth knowing about. The search inside a single
+ * index is not interruptible, so the budget cannot cut one of those short. And a non-throwing budget that runs out
+ * before result assembly begins answers with an <b>empty</b> list, not a truncated one - unlike
+ * {@link SelectIterator}, which hands back the records it had already yielded, this path has almost all of its work
+ * after the last checkpoint, and promoting an unassembled neighbour would mean loading a record past a deadline that
+ * has already expired.
  */
 public class SelectVectorBuilder {
   private final Select select;
@@ -43,10 +51,18 @@ public class SelectVectorBuilder {
     return new SelectWhereLeftBlock(select);
   }
 
+  /**
+   * Runs the k-NN search and returns the neighbours as vertices, closest first. See the class Javadoc for what a
+   * {@link Select#timeout} does to this call.
+   */
   public List<SelectVectorResult<Vertex>> vertices() {
     return executeVector();
   }
 
+  /**
+   * Runs the k-NN search and returns the neighbours as documents, closest first. See the class Javadoc for what a
+   * {@link Select#timeout} does to this call.
+   */
   public List<SelectVectorResult<Document>> documents() {
     return executeVector();
   }

--- a/engine/src/main/java/com/arcadedb/query/select/SelectWhereAfterBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectWhereAfterBlock.java
@@ -71,21 +71,21 @@ public class SelectWhereAfterBlock {
     return select.stream();
   }
 
-  @SuppressWarnings("unchecked")
   /**
    * Runs the k-NN search with this WHERE as a post-filter. See {@link SelectVectorBuilder} for what a
    * {@link Select#timeout} does to this call.
    */
+  @SuppressWarnings("unchecked")
   public <T extends Document> List<SelectVectorResult<T>> vectorDocuments() {
     select.compile();
     return new SelectExecutor(select).executeVector();
   }
 
-  @SuppressWarnings("unchecked")
   /**
    * Runs the k-NN search with this WHERE as a post-filter. See {@link SelectVectorBuilder} for what a
    * {@link Select#timeout} does to this call.
    */
+  @SuppressWarnings("unchecked")
   public <T extends Document> List<SelectVectorResult<T>> vectorVertices() {
     select.compile();
     return new SelectExecutor(select).executeVector();

--- a/engine/src/main/java/com/arcadedb/query/select/SelectWhereAfterBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectWhereAfterBlock.java
@@ -72,12 +72,20 @@ public class SelectWhereAfterBlock {
   }
 
   @SuppressWarnings("unchecked")
+  /**
+   * Runs the k-NN search with this WHERE as a post-filter. See {@link SelectVectorBuilder} for what a
+   * {@link Select#timeout} does to this call.
+   */
   public <T extends Document> List<SelectVectorResult<T>> vectorDocuments() {
     select.compile();
     return new SelectExecutor(select).executeVector();
   }
 
   @SuppressWarnings("unchecked")
+  /**
+   * Runs the k-NN search with this WHERE as a post-filter. See {@link SelectVectorBuilder} for what a
+   * {@link Select#timeout} does to this call.
+   */
   public <T extends Document> List<SelectVectorResult<T>> vectorVertices() {
     select.compile();
     return new SelectExecutor(select).executeVector();

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java
@@ -67,6 +67,8 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
   private static final int  DIMENSIONS = 8;
   private static final int  PRODUCTS   = 50;
   private static final int  K          = 25;
+  /** Enough buckets that the {@code Spread} fixture puts rows in more than one bucket index. */
+  private static final int  SPREAD_BUCKETS = 4;
   /** Virtual milliseconds. Never compared against a real clock: {@link StepClock} decides when it is exceeded. */
   private static final long BUDGET_MS  = 1_000;
 
@@ -184,6 +186,30 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
   }
 
   /**
+   * The contract for a non-throwing expiry detected <i>before</i> the assembly loop: an empty list, not a partial one.
+   * <p>
+   * {@code allNeighbors} is not an answer - it holds RIDs and distances, and promoting any of them into a
+   * {@code SelectVectorResult} means loading a record and possibly running the post-filter WHERE, i.e. doing more work
+   * past a deadline that has already gone. So the rule is the one {@code executeCount()} and {@code SelectIterator}
+   * follow: hand back what was already produced, never produce more. This test pins that down with a fixture whose
+   * rows really are spread over several bucket indexes, so the budget dies with real candidates already accumulated.
+   */
+  @Test
+  void aNonThrowingExpiryBetweenIndexesReturnsEmptyRatherThanUnassembledNeighbours() {
+    createSchemaAndData();
+
+    // THE FIXTURE HAS TO ACTUALLY EXERCISE THE CASE: MORE THAN ONE BUCKET INDEX, AND NEIGHBOURS TO BE FOUND IN THEM
+    assertThat(countVectorBucketIndexes("Spread")).isGreaterThan(1);
+    assertThat(search("Spread", null)).isNotEmpty();
+
+    // startTimeout() PLUS THE FIRST INDEX'S CHECKPOINT ARE FREE, SO INDEX 1 IS SEARCHED IN FULL AND CONTRIBUTES
+    // CANDIDATES; THE SECOND INDEX'S CHECKPOINT IS THE FIRST READING PAST THE BUDGET
+    final List<SelectVectorResult<Vertex>> results = searchWithClock("Spread", new StepClock(2), false, false);
+
+    assertThat(results).isEmpty();
+  }
+
+  /**
    * Load-invariant: a budget nobody can exhaust must return exactly what an unbounded search returns. This is the
    * assertion that would catch a deadline armed wrongly (for instance one that expires immediately), and a JVM stall
    * can only make the real clock read later - which this test never looks at.
@@ -254,7 +280,11 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
    * Runs the same search through the public fluent API, optionally applying a timeout to the select first.
    */
   private List<SelectVectorResult<Vertex>> search(final UnaryOperator<Select> withTimeout) {
-    final Select select = database.select().fromType("Product");
+    return search("Product", withTimeout);
+  }
+
+  private List<SelectVectorResult<Vertex>> search(final String typeName, final UnaryOperator<Select> withTimeout) {
+    final Select select = database.select().fromType(typeName);
     return (withTimeout == null ? select : withTimeout.apply(select))//
         .nearestTo("embedding", queryVector(), K).vertices();
   }
@@ -303,6 +333,19 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
             "beamWidth" : 100
           }""");
 
+      // SAME SHAPE, SPREAD OVER SEVERAL BUCKETS SO MORE THAN ONE BUCKET INDEX HOLDS ROWS: THAT IS WHAT MAKES AN
+      // EXPIRY *BETWEEN* INDEXES OBSERVABLE, WITH REAL CANDIDATES ALREADY ACCUMULATED WHEN IT HAPPENS
+      database.command("sql", "CREATE VERTEX TYPE Spread IF NOT EXISTS BUCKETS " + SPREAD_BUCKETS);
+      database.command("sql", "CREATE PROPERTY Spread.embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON Spread (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions" : 8,
+            "similarity" : "EUCLIDEAN",
+            "maxConnections" : 16,
+            "beamWidth" : 100
+          }""");
+
       // SAME SHAPE, NO ROWS: A VECTOR SEARCH OVER IT RETURNS NO NEIGHBOUR AT ALL, WHICH IS WHAT MAKES THE PRE-SORT
       // CHECKPOINT DISTINGUISHABLE FROM THE ASSEMBLY ONE
       database.command("sql", "CREATE VERTEX TYPE Empty IF NOT EXISTS");
@@ -317,6 +360,12 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
           }""");
 
       final Random rng = new Random(42);
+      for (int i = 0; i < PRODUCTS; i++) {
+        final float[] spread = new float[DIMENSIONS];
+        for (int j = 0; j < DIMENSIONS; j++)
+          spread[j] = rng.nextFloat();
+        database.newVertex("Spread").set("embedding", spread).save();
+      }
       for (int i = 0; i < PRODUCTS; i++) {
         final float[] vec = new float[DIMENSIONS];
         for (int j = 0; j < DIMENSIONS; j++)

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.vector.LSMVectorIndex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import java.util.function.UnaryOperator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6873
+ * <p>
+ * Follow-up to #6815. That fix moved the native {@code Select} deadline to the consumer, covering the four sources
+ * {@code SelectExecutor.buildIterator()} can return. The vector k-NN search is a fifth plan shape that never goes
+ * through {@code buildIterator()}: {@link SelectExecutor#executeVector()} called neither {@code startTimeout()} nor
+ * {@code checkForTimeout()}, so
+ * <pre>{@code db.select().fromType("Product").timeout(1, MILLISECONDS, true).nearestTo("embedding", q, 25).vertices()}</pre>
+ * compiled and silently dropped the budget.
+ * <p>
+ * <b>Why these tests drive a clock instead of racing one.</b> {@code executeVector()} is <b>eager</b> - it returns a
+ * fully materialized {@code List} - so, unlike the lazy {@code SelectIterator} of the #6815 tests, no consumer can
+ * pace it with its own {@code Thread.sleep()}. Measured on this fixture a 50-vector search finishes in ~0.25 ms, a
+ * quarter of the smallest expressible budget, so an "a 1 ms budget expired" assertion is a straight wall-clock race
+ * that a <i>faster</i> machine turns red - exactly what {@code CLAUDE.md} forbids. The deadline is therefore driven
+ * through {@link SelectExecutor#clock}, the seam the production code reads its time from: the elapsed time inside the
+ * measured window becomes an input of the test rather than a property of the machine, while the real
+ * {@code startTimeout()} arithmetic and the real throw-or-truncate decision still run.
+ * <p>
+ * The remaining tests use the public fluent API and assert only load-invariant properties (a generous budget must not
+ * truncate; no budget must return everything), which a JVM stall can never turn red.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6873VectorSelectTimeoutTest extends TestHelper {
+
+  private static final int  DIMENSIONS = 8;
+  private static final int  PRODUCTS   = 50;
+  private static final int  K          = 25;
+  /** Virtual milliseconds. Never compared against a real clock: {@link StepClock} decides when it is exceeded. */
+  private static final long BUDGET_MS  = 1_000;
+
+  /**
+   * A time source that reports "no time has passed" for the first {@code freeReadings} calls and then jumps past any
+   * deadline armed from its first reading. Every decision it drives is a function of the call count alone, so the
+   * outcome of a test using it is identical on a fast machine, a slow machine and a machine that stalls mid-run.
+   */
+  private static final class StepClock implements LongSupplier {
+    private final int freeReadings;
+    private       int readings;
+
+    private StepClock(final int freeReadings) {
+      this.freeReadings = freeReadings;
+    }
+
+    @Override
+    public long getAsLong() {
+      return ++readings <= freeReadings ? 0 : BUDGET_MS + 1;
+    }
+  }
+
+  /**
+   * The head of the issue's repro, with the wall clock replaced by a deadline that has already expired by the time
+   * the first bucket index would be searched. Before the fix no {@code TimeoutException} was possible at all here:
+   * {@code executeVector()} consulted no deadline whatsoever.
+   */
+  @Test
+  void vectorSearchThrowsWhenTheDeadlineExpiredBeforeTheFirstIndex() {
+    createSchemaAndData();
+
+    // ONLY startTimeout() READS THE CLOCK BEFORE EXPIRY, SO THE VERY FIRST PER-INDEX CHECK IS ALREADY PAST THE BUDGET
+    assertThatThrownBy(() -> searchWithClock(new StepClock(1), true, false))//
+        .isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  /**
+   * Same shape with {@code exceptionOnTimeout = false}: the search must give up and hand back what it has - nothing,
+   * since it expired before searching a single index - instead of ignoring the budget and returning the full k.
+   */
+  @Test
+  void vectorSearchTruncatesInsteadOfThrowingWhenAskedNotToThrow() {
+    createSchemaAndData();
+
+    assertThat(searchWithClock(new StepClock(1), false, false)).isEmpty();
+  }
+
+  /**
+   * The second checkpoint, in the result-assembly loop: the budget survives the neighbour search of every index and
+   * expires after exactly two results have been assembled. Assembly is not free - each iteration loads a record and
+   * may run the post-filter WHERE - so a deadline honoured only around the index search would return the full k here.
+   */
+  @Test
+  void vectorSearchStopsAssemblingResultsOnceTheDeadlineExpires() {
+    createSchemaAndData();
+
+    final int assembled = 2;
+    // ONE READING FOR startTimeout(), ONE PER BUCKET INDEX, THEN ONE PER ASSEMBLED RESULT. COUNTING THE INDEXES
+    // RATHER THAN ASSUMING THEM KEEPS THIS EXACT WHATEVER THE DEFAULT BUCKET COUNT OF THE MACHINE IS
+    final StepClock clock = new StepClock(1 + countVectorBucketIndexes() + assembled);
+
+    final List<SelectVectorResult<Vertex>> results = searchWithClock(clock, false, false);
+
+    assertThat(results).hasSize(assembled);
+    assertThat(results).allSatisfy(r -> assertThat(r.getDocument()).isNotNull());
+  }
+
+  /**
+   * The throwing counterpart of the assembly-loop checkpoint.
+   */
+  @Test
+  void vectorSearchThrowsWhenTheDeadlineExpiresDuringAssembly() {
+    createSchemaAndData();
+
+    final StepClock clock = new StepClock(1 + countVectorBucketIndexes() + 2);
+
+    assertThatThrownBy(() -> searchWithClock(clock, true, false))//
+        .isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  /**
+   * The post-filter WHERE runs inside the assembly loop, so the deadline has to bound that shape too. The filter can
+   * only drop results, never add any, so the bound stays an upper one.
+   */
+  @Test
+  void vectorSearchWithAPostFilterAlsoStopsOnTheDeadline() {
+    createSchemaAndData();
+
+    final int assembled = 2;
+    final StepClock clock = new StepClock(1 + countVectorBucketIndexes() + assembled);
+
+    final List<SelectVectorResult<Vertex>> results = searchWithClock(clock, false, true);
+
+    assertThat(results).hasSizeLessThanOrEqualTo(assembled);
+    results.forEach(r -> assertThat(r.getDocument().getString("category")).isEqualTo("electronics"));
+  }
+
+  /**
+   * Load-invariant: a budget nobody can exhaust must return exactly what an unbounded search returns. This is the
+   * assertion that would catch a deadline armed wrongly (for instance one that expires immediately), and a JVM stall
+   * can only make the real clock read later - which this test never looks at.
+   */
+  @Test
+  void aGenerousTimeoutDoesNotTruncateTheResultSet() {
+    createSchemaAndData();
+
+    final int unbounded = search(null).size();
+    assertThat(unbounded).isPositive();
+
+    assertThat(search(select -> select.timeout(1, TimeUnit.HOURS, true))).hasSize(unbounded);
+    assertThat(search(select -> select.timeout(1, TimeUnit.HOURS, false))).hasSize(unbounded);
+  }
+
+  /**
+   * {@code TimeUnit.toMillis()} saturates rather than rejecting, so an effectively infinite budget reaches the
+   * executor as {@code Long.MAX_VALUE}; a plain {@code now + timeoutInMs} would overflow into a deadline already in
+   * the past and truncate the very first result. Deterministic: no clock reading decides the outcome.
+   */
+  @Test
+  void anEffectivelyInfiniteTimeoutNeverExpiresOnTheVectorPath() {
+    createSchemaAndData();
+
+    final int unbounded = search(null).size();
+
+    assertThat(search(select -> select.timeout(Long.MAX_VALUE, TimeUnit.MILLISECONDS, true))).hasSize(unbounded);
+    assertThat(search(select -> select.timeout(Long.MAX_VALUE, TimeUnit.DAYS, true))).hasSize(unbounded);
+  }
+
+  /**
+   * The deadline machinery must stay completely inert when {@code timeout()} was never called - the sentinel path
+   * that keeps the check a single predicted compare and never reads a clock at all.
+   */
+  @Test
+  void noTimeoutStillReturnsEveryNeighbour() {
+    createSchemaAndData();
+
+    final List<SelectVectorResult<Vertex>> results = search(null);
+    assertThat(results).isNotEmpty().hasSizeLessThanOrEqualTo(K);
+    for (int i = 1; i < results.size(); i++)
+      assertThat(results.get(i).getDistance()).isGreaterThanOrEqualTo(results.get(i - 1).getDistance());
+  }
+
+  /**
+   * Runs the k-NN search through an executor whose time source is {@code clock}, mirroring exactly what
+   * {@code SelectVectorBuilder.vertices()} does around {@link SelectExecutor#executeVector()}.
+   */
+  private List<SelectVectorResult<Vertex>> searchWithClock(final StepClock clock, final boolean exceptionOnTimeout,
+      final boolean withPostFilter) {
+    final Select select = database.select().fromType("Product").timeout(BUDGET_MS, TimeUnit.MILLISECONDS, exceptionOnTimeout);
+    final SelectVectorBuilder builder = select.nearestTo("embedding", queryVector(), K);
+    if (withPostFilter)
+      builder.where().property("category").eq().value("electronics");
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    executor.clock = clock;
+    return executor.executeVector();
+  }
+
+  /**
+   * Runs the same search through the public fluent API, optionally applying a timeout to the select first.
+   */
+  private List<SelectVectorResult<Vertex>> search(final UnaryOperator<Select> withTimeout) {
+    final Select select = database.select().fromType("Product");
+    return (withTimeout == null ? select : withTimeout.apply(select))//
+        .nearestTo("embedding", queryVector(), K).vertices();
+  }
+
+  /**
+   * Mirrors the index selection {@link SelectExecutor#executeVector()} performs, so the expected number of per-index
+   * deadline checks is derived from the schema instead of assumed.
+   */
+  private int countVectorBucketIndexes() {
+    final TypeIndex typeIndex = database.getSchema().getType("Product").getPolymorphicIndexByProperties("embedding");
+    int count = 0;
+    for (final IndexInternal bucketIndex : typeIndex.getIndexesOnBuckets())
+      if (bucketIndex instanceof LSMVectorIndex)
+        count++;
+    return count;
+  }
+
+  private static float[] queryVector() {
+    final float[] query = new float[DIMENSIONS];
+    Arrays.fill(query, 0.5f);
+    return query;
+  }
+
+  private void createSchemaAndData() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Product IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY Product.name IF NOT EXISTS STRING");
+      database.command("sql", "CREATE PROPERTY Product.category IF NOT EXISTS STRING");
+      database.command("sql", "CREATE PROPERTY Product.embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON Product (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions" : 8,
+            "similarity" : "EUCLIDEAN",
+            "maxConnections" : 16,
+            "beamWidth" : 100
+          }""");
+
+      final Random rng = new Random(42);
+      for (int i = 0; i < PRODUCTS; i++) {
+        final float[] vec = new float[DIMENSIONS];
+        for (int j = 0; j < DIMENSIONS; j++)
+          vec[j] = rng.nextFloat();
+        final String category = i < PRODUCTS / 2 ? "electronics" : "clothing";
+        database.newVertex("Product").set("name", "Product" + i, "category", category, "embedding", vec).save();
+      }
+    });
+
+    closeAndReopenDatabase();
+  }
+
+  private void closeAndReopenDatabase() {
+    final String dbPath = database.getDatabasePath();
+    database.close();
+    database = new DatabaseFactory(dbPath).open();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java
@@ -210,6 +210,26 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
   }
 
   /**
+   * The per-index checkpoint gates the approximate search exactly as it gates the exact one - the two differ only in
+   * which {@code LSMVectorIndex} call the loop body makes, and the deadline sits in front of both.
+   */
+  @Test
+  void approximateVectorSearchIsBoundedByTheSameDeadline() {
+    createSchemaAndData();
+
+    assertThatThrownBy(() -> searchWithClock("Product", new StepClock(1), true, false, true))//
+        .isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+
+    assertThat(searchWithClock("Product", new StepClock(1), false, false, true)).isEmpty();
+
+    // AND, LOAD-INVARIANT, A BUDGET NOBODY CAN EXHAUST LEAVES THE APPROXIMATE SEARCH ALONE
+    final List<SelectVectorResult<Vertex>> unbounded = database.select().fromType("Product")//
+        .nearestTo("embedding", queryVector(), K).approximate(true).vertices();
+    assertThat(database.select().fromType("Product").timeout(1, TimeUnit.HOURS, true)//
+        .nearestTo("embedding", queryVector(), K).approximate(true).vertices()).hasSize(unbounded.size());
+  }
+
+  /**
    * Load-invariant: a budget nobody can exhaust must return exactly what an unbounded search returns. This is the
    * assertion that would catch a deadline armed wrongly (for instance one that expires immediately), and a JVM stall
    * can only make the real clock read later - which this test never looks at.
@@ -265,8 +285,13 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
 
   private List<SelectVectorResult<Vertex>> searchWithClock(final String typeName, final StepClock clock,
       final boolean exceptionOnTimeout, final boolean withPostFilter) {
+    return searchWithClock(typeName, clock, exceptionOnTimeout, withPostFilter, false);
+  }
+
+  private List<SelectVectorResult<Vertex>> searchWithClock(final String typeName, final StepClock clock,
+      final boolean exceptionOnTimeout, final boolean withPostFilter, final boolean approximate) {
     final Select select = database.select().fromType(typeName).timeout(BUDGET_MS, TimeUnit.MILLISECONDS, exceptionOnTimeout);
-    final SelectVectorBuilder builder = select.nearestTo("embedding", queryVector(), K);
+    final SelectVectorBuilder builder = select.nearestTo("embedding", queryVector(), K).approximate(approximate);
     if (withPostFilter)
       builder.where().property("category").eq().value("electronics");
     select.compile();

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java
@@ -124,9 +124,8 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
     createSchemaAndData();
 
     final int assembled = 2;
-    // ONE READING FOR startTimeout(), ONE PER BUCKET INDEX, THEN ONE PER ASSEMBLED RESULT. COUNTING THE INDEXES
-    // RATHER THAN ASSUMING THEM KEEPS THIS EXACT WHATEVER THE DEFAULT BUCKET COUNT OF THE MACHINE IS
-    final StepClock clock = new StepClock(1 + countVectorBucketIndexes() + assembled);
+    // EVERY CHECKPOINT BEFORE ASSEMBLY STAYS INSIDE THE BUDGET, THEN ONE READING PER ASSEMBLED RESULT
+    final StepClock clock = new StepClock(readingsBeforeAssembly("Product") + assembled);
 
     final List<SelectVectorResult<Vertex>> results = searchWithClock(clock, false, false);
 
@@ -141,9 +140,29 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
   void vectorSearchThrowsWhenTheDeadlineExpiresDuringAssembly() {
     createSchemaAndData();
 
-    final StepClock clock = new StepClock(1 + countVectorBucketIndexes() + 2);
+    final StepClock clock = new StepClock(readingsBeforeAssembly("Product") + 2);
 
     assertThatThrownBy(() -> searchWithClock(clock, true, false))//
+        .isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  /**
+   * The checkpoint between the last index search and the merge sort. A search that expires inside the
+   * <i>last</i> index's own (uninterruptible) call leaves the loop on its bound, never on the per-index checkpoint, so
+   * without this third check the sort of up to {@code indexes * k} pairs would still run on an expired budget.
+   * <p>
+   * An index with nothing in it is what makes the checkpoint observable: with no neighbour to assemble, the loop that
+   * follows the sort never runs a single iteration, so the assembly checkpoint can never fire and only this one can
+   * report the expiry.
+   */
+  @Test
+  void vectorSearchStopsBeforeSortingWhenTheLastIndexSearchExhaustedTheBudget() {
+    createSchemaAndData();
+
+    // EVERY PER-INDEX CHECKPOINT IS STILL INSIDE THE BUDGET; THE PRE-SORT ONE IS THE FIRST READING PAST IT
+    final StepClock clock = new StepClock(readingsBeforeAssembly("Empty") - 1);
+
+    assertThatThrownBy(() -> searchWithClock("Empty", clock, true, false))//
         .isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
   }
 
@@ -156,7 +175,7 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
     createSchemaAndData();
 
     final int assembled = 2;
-    final StepClock clock = new StepClock(1 + countVectorBucketIndexes() + assembled);
+    final StepClock clock = new StepClock(readingsBeforeAssembly("Product") + assembled);
 
     final List<SelectVectorResult<Vertex>> results = searchWithClock(clock, false, true);
 
@@ -215,7 +234,12 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
    */
   private List<SelectVectorResult<Vertex>> searchWithClock(final StepClock clock, final boolean exceptionOnTimeout,
       final boolean withPostFilter) {
-    final Select select = database.select().fromType("Product").timeout(BUDGET_MS, TimeUnit.MILLISECONDS, exceptionOnTimeout);
+    return searchWithClock("Product", clock, exceptionOnTimeout, withPostFilter);
+  }
+
+  private List<SelectVectorResult<Vertex>> searchWithClock(final String typeName, final StepClock clock,
+      final boolean exceptionOnTimeout, final boolean withPostFilter) {
+    final Select select = database.select().fromType(typeName).timeout(BUDGET_MS, TimeUnit.MILLISECONDS, exceptionOnTimeout);
     final SelectVectorBuilder builder = select.nearestTo("embedding", queryVector(), K);
     if (withPostFilter)
       builder.where().property("category").eq().value("electronics");
@@ -239,13 +263,22 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
    * Mirrors the index selection {@link SelectExecutor#executeVector()} performs, so the expected number of per-index
    * deadline checks is derived from the schema instead of assumed.
    */
-  private int countVectorBucketIndexes() {
-    final TypeIndex typeIndex = database.getSchema().getType("Product").getPolymorphicIndexByProperties("embedding");
+  private int countVectorBucketIndexes(final String typeName) {
+    final TypeIndex typeIndex = database.getSchema().getType(typeName).getPolymorphicIndexByProperties("embedding");
     int count = 0;
     for (final IndexInternal bucketIndex : typeIndex.getIndexesOnBuckets())
       if (bucketIndex instanceof LSMVectorIndex)
         count++;
     return count;
+  }
+
+  /**
+   * How many times {@code executeVector()} reads the clock before it starts assembling results: once to arm the
+   * deadline, once per bucket index, and once between the last index search and the merge sort. Derived from the
+   * schema rather than assumed, so it stays exact whatever the machine's default bucket count is.
+   */
+  private int readingsBeforeAssembly(final String typeName) {
+    return 1 + countVectorBucketIndexes(typeName) + 1;
   }
 
   private static float[] queryVector() {
@@ -263,6 +296,19 @@ class Issue6873VectorSelectTimeoutTest extends TestHelper {
 
       database.command("sql", """
           CREATE INDEX IF NOT EXISTS ON Product (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions" : 8,
+            "similarity" : "EUCLIDEAN",
+            "maxConnections" : 16,
+            "beamWidth" : 100
+          }""");
+
+      // SAME SHAPE, NO ROWS: A VECTOR SEARCH OVER IT RETURNS NO NEIGHBOUR AT ALL, WHICH IS WHAT MAKES THE PRE-SORT
+      // CHECKPOINT DISTINGUISHABLE FROM THE ASSEMBLY ONE
+      database.command("sql", "CREATE VERTEX TYPE Empty IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY Empty.embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON Empty (embedding) LSM_VECTOR
           METADATA {
             "dimensions" : 8,
             "similarity" : "EUCLIDEAN",


### PR DESCRIPTION
Closes #6873

## Problem

Follow-up to #6815, which moved the native `Select` deadline from the source iterator to the consumer
(`SelectExecutor.checkForTimeout()`), covering the four sources `buildIterator()` can return. The vector k-NN search is a
**fifth** plan shape that never goes through `buildIterator()` at all: `SelectExecutor.executeVector()` called neither
`startTimeout()` nor `checkForTimeout()`, so it consulted no deadline whatsoever.

`Select.timeout()` returns `this` and `nearestTo()` is declared on `Select`, so this compiled and silently dropped the
budget - the chain is reachable straight from the public fluent API via `SelectVectorBuilder.vertices()`/`documents()`:

```java
db.select().fromType("Product")
    .timeout(1, TimeUnit.MILLISECONDS, true)     // silently dropped
    .nearestTo("embedding", query, 25)
    .vertices();
```

## Fix

`engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java`

1. `executeVector()` arms `startTimeout()` at its head, like the other three entry points.
2. Three checkpoints inside it, one at each place where work is about to be done:
   - the per-index neighbour search (one check per bucket index);
   - between the last index search and `allNeighbors.sort(...)` - the deadline can only expire inside an index's own
     uninterruptible call, and when that is the *last* index the loop ends on its bound rather than on the per-index
     checkpoint, so without this the merge sort of up to `indexes * k` pairs and the result-list allocation still ran on
     an expired budget (added in review, from CodeRabbit's catch);
   - the result-assembly loop (one check per result, each of which loads a record and may run the post-filter WHERE).

All three go through the existing `checkForTimeout()`, so `exceptionOnTimeout` keeps its meaning: throw, or stop and
return **what has already been assembled**.

Worth being precise about that second branch, because a review round turned on it. `checkForTimeout()` is a one-way
gate, so a non-throwing expiry anywhere *before* the assembly loop answers with an empty list - never a partial one
built from the indexes that did finish. That is the right answer rather than a lost result: `allNeighbors` holds RIDs
and distances, not results, and promoting any of them means loading a record and possibly running the post-filter
WHERE - more work, past a deadline that has already gone. It is the same rule the other paths follow (`SelectIterator`
hands back the records it already yielded, `executeCount()` the tally it already had); the vector path simply has more
of its work sitting after the last checkpoint. The Javadoc, the checkpoint comments and a dedicated test all say so now.

**Granularity caveat (unchanged from the issue):** a single `LSMVectorIndex.findNeighborsFromVector()` call is not
interruptible from `executeVector()`, so the deadline is honoured *between* indexes and *per assembled result*. It will
not cut short one long search inside a single index. That is still the difference between a no-op and a bound.

## The test seam, and why it is there

The issue explains why this fix was pulled out of #6872: `executeVector()` is **eager** - it returns a fully
materialized `List` - so, unlike the lazy `SelectIterator` the #6815 tests exercise, no consumer can pace it with its
own `Thread.sleep()`. Measured on this fixture a 50-vector search finishes in ~0.25 ms, a quarter of the smallest
expressible budget, so any "a 1 ms budget expired" assertion is a straight wall-clock race that a **faster** machine
turns red - precisely the failure mode the repo's timing discipline forbids.

So the deadline is driven through a seam instead of the wall clock. `SelectExecutor` now reads its time from a
package-private `LongSupplier clock` field, defaulted to `System::currentTimeMillis`. The elapsed time inside the
measured window becomes an input of the test rather than a property of the machine, while the real `startTimeout()`
saturation arithmetic and the real throw-or-truncate decision still run.

It is not on any hot path: `checkForTimeout()` returns on the `Long.MAX_VALUE` "no timeout requested" sentinel *before*
reading the supplier, so a select without a timeout never touches it; a select with one pays one virtual call instead of
a static one, next to the `currentTimeMillis()` reading it wraps.

## Test plan

New: `engine/src/test/java/com/arcadedb/query/select/Issue6873VectorSelectTimeoutTest.java` (11 tests).

Deterministic (clock-driven, outcome is a function of the call count alone - identical on a fast machine, a slow machine
and one that stalls mid-run):

- [x] `vectorSearchThrowsWhenTheDeadlineExpiredBeforeTheFirstIndex` - budget gone before any index is searched, `exceptionOnTimeout = true` -> `TimeoutException`
- [x] `vectorSearchTruncatesInsteadOfThrowingWhenAskedNotToThrow` - same shape, `false` -> empty result instead of the full k
- [x] `aNonThrowingExpiryBetweenIndexesReturnsEmptyRatherThanUnassembledNeighbours` - the contract above, on a fixture whose rows really do span several bucket indexes (asserted, not assumed) with neighbours to be found in them (asserted too), expiring on the second index's checkpoint so real candidates are already accumulated when the budget dies
- [x] `vectorSearchStopsBeforeSortingWhenTheLastIndexSearchExhaustedTheBudget` - the pre-sort checkpoint, discriminated from the assembly one by searching a vector index with **no rows**: with nothing to assemble, the loop after the sort never runs an iteration, so only this check can report the expiry
- [x] `vectorSearchStopsAssemblingResultsOnceTheDeadlineExpires` - budget survives every index and expires after exactly 2 assembled results -> `hasSize(2)`; the expected checkpoint count is derived from the schema (`countVectorBucketIndexes()`), never assumed, so it stays exact whatever the machine's default bucket count is
- [x] `vectorSearchThrowsWhenTheDeadlineExpiresDuringAssembly` - the throwing counterpart of the assembly checkpoint
- [x] `approximateVectorSearchIsBoundedByTheSameDeadline` - the per-index checkpoint sits in front of `findNeighborsFromVector()` and `findNeighborsFromVectorApproximate()` alike, so `approximate(true)` gets the same throw/truncate treatment (plus the load-invariant check that a generous budget leaves it alone)
- [x] `vectorSearchWithAPostFilterAlsoStopsOnTheDeadline` - the WHERE post-filter runs inside the assembly loop, so that shape is bounded too

Load-invariant (public fluent API; a JVM stall can only make these more true):

- [x] `aGenerousTimeoutDoesNotTruncateTheResultSet` - a 1-hour budget must return exactly what an unbounded search returns, throwing and non-throwing
- [x] `anEffectivelyInfiniteTimeoutNeverExpiresOnTheVectorPath` - `timeout(Long.MAX_VALUE, DAYS/MILLISECONDS, true)`; `TimeUnit.toMillis()` saturates rather than rejecting, so a plain `now + timeoutInMs` would overflow into a deadline already in the past and truncate the first result
- [x] `noTimeoutStillReturnsEveryNeighbour` - the sentinel path stays inert and the distance ordering is preserved

Proof the tests can fail: with the `executeVector()` instrumentation reverted (clock seam left in place), 5 of the 9
fail - exactly the ones that target the defect; the load-invariant guards stay green, as they should. Removing
only the pre-sort checkpoint fails 2, including the test written for it.

Regression runs (`mvn -o -pl engine surefire:test`):

- [x] `Select*Test,Issue68*Test,Issue65*Test,Issue69*Test` - 555 tests, 0 failures (includes `Issue6815SelectTimeoutNotInstalledTest`, `Issue6816MultiIteratorTimeoutTruncationTest`, `SelectVectorTest`, `SelectParallelIteratorTest`)
- [x] `Select*Test,Issue68*Test,Issue65*Test,Issue69*Test,*Vector*Test` re-run after each review commit - 1154 tests, 0 failures
- [x] full engine unit lane, `-DexcludedGroups=benchmark,vector,slow` - 13776 tests, 0 failures, 23 skipped

## Caller-facing documentation

The empty-vs-truncated divergence is documented where a caller reading the fluent API will meet it, not only in the
package-private `executeVector()`: on `Select.timeout()`, on `SelectVectorBuilder` and its `vertices()`/`documents()`,
and pointed at from `SelectWhereAfterBlock.vectorVertices()`/`vectorDocuments()`.

## Unrelated finding, filed separately

While running the regression lane, `Issue6815SelectTimeoutNotInstalledTest.existsReturnsFalseWhenNotThrowing` failed
once with a bare `NoSuchElementException` from `MultiIterator.next()`. It reproduces on unmodified `main` (1 failure in
12 consecutive runs of the class in a control worktree at `48fd1f7`), so it is **not** caused by this PR: a non-throwing
deadline that expires between a caller's `hasNext()` and its `next()` makes `MultiIterator.next()` throw instead of
truncating. Filed as #6880; not addressed here.
