### PR TITLE
fix(#6824,#6839): floor pre-epoch time buckets, and give the engine-unavailable TimeSeries state a way out

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -105,11 +105,16 @@ public class TimeSeriesEngine implements AutoCloseable {
         shards[i] = new TimeSeriesShard(database, typeName, i, columns, compactionBucketIntervalMs, tagDictionary);
     } catch (final Exception e) {
       shardExecutor.shutdownNow();
-      // Close any shards that were successfully created
+      // Release the shards that were successfully created - their sealed stores only, NOT their mutable buckets.
+      // A full close() here made a corrupt .ts.sealed on shard N take the mutable buckets of shards 0..N-1 down
+      // with it, permanently: those buckets are registered with the schema, which owns closing them, and
+      // PaginatedComponentFile.close() sets open=false so its own lazy reopen refuses ever after. That left
+      // initEngine() unretryable for any type with more than one shard, so the whole recovery path added for
+      // issue #6839 would have worked for SHARDS 1 and silently not above it.
       for (final TimeSeriesShard shard : shards) {
         if (shard != null) {
           try {
-            shard.close();
+            shard.closeAfterFailedInit();
           } catch (final IOException ignored) {
           }
         }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -2249,6 +2249,20 @@ public class TimeSeriesSealedStore implements AutoCloseable {
   }
 
   /**
+   * The same name as {@link #getSealedFileName()}, derived from the type and shard alone so a caller that has no
+   * store to ask can still address the file - which is the whole point: the HA apply path needs it precisely when
+   * the store could not be opened and there is no instance to ask (issue #6839). Deriving it locally is also why
+   * that path never uses the file name carried in the replicated blob: a name is a name until it is used to open a
+   * file, and one arriving over the wire has no business selecting a path on this node.
+   * <p>
+   * The {@code <type>_shard_<index>} half must stay in step with the shard name {@code TimeSeriesShard}'s
+   * constructor builds; the suffix is this class's own.
+   */
+  public static String sealedFileNameFor(final String typeName, final int shardIndex) {
+    return typeName + "_shard_" + shardIndex + ".ts.sealed";
+  }
+
+  /**
    * Reads the entire sealed-store file into a byte array. Used on the HA leader to capture the
    * post-compaction (or post-retention/downsampling) sealed bytes so they can be shipped to followers.
    * The header is flushed first so the on-disk image is current.

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -178,15 +178,17 @@ public class TimeSeriesShard implements AutoCloseable {
       }
     }
 
-    // If sealedStore construction fails, close mutableBucket to avoid a resource leak
-    final TimeSeriesSealedStore tempSealedStore;
-    try {
-      tempSealedStore = new TimeSeriesSealedStore(shardPath, columns);
-    } catch (final IOException e) {
-      try { this.mutableBucket.close(); } catch (final Exception ignored) {}
-      throw e;
-    }
-    this.sealedStore = tempSealedStore;
+    // The mutable bucket is deliberately NOT closed when the sealed store fails to open. By the time control
+    // reaches here it is registered with the schema on BOTH branches above - the component factory registered it
+    // on a cold open, and the creation branch calls registerFile() itself - so the schema owns its lifecycle and
+    // will close it with the database. Closing it here never prevented a leak; it only made the file unusable,
+    // because PaginatedComponentFile.close() sets open=false and its own lazy reopen then refuses ("was closed on
+    // purpose"), for the life of the process. That was harmless while a failed initEngine() meant the type
+    // vanished from the schema, and became the thing standing in the way of recovery once #6356 made the type stay
+    // registered: retrying initEngine() after the sealed file is repaired reuses this very component and produced
+    // a type reporting isEngineAvailable() == true whose every read threw FileNotFoundException (issue #6839).
+    // The failure at initHeaderPage() a few lines above already propagates without closing, for the same reason.
+    this.sealedStore = new TimeSeriesSealedStore(shardPath, columns);
 
     // Crash recovery: if a compaction was interrupted, truncate any partial sealed blocks
     database.begin();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -204,9 +204,13 @@ public class TimeSeriesShard implements AutoCloseable {
     } catch (final Exception e) {
       if (database.isTransactionActive())
         database.rollback();
-      // Close both stores to avoid resource leaks before propagating the error
+      // The sealed store is this shard's own file handle and nothing else will close it, so it must be. The
+      // mutable bucket must NOT be, for the reason spelled out above the sealed-store construction: it is
+      // schema-registered, the schema owns closing it, and PaginatedComponentFile.close() is permanent. This
+      // branch is the second way into that trap and it is the one a retry is most likely to meet - both
+      // truncateToBlockCount's temp-file rewrite and the commit below it can throw - so closing here would poison
+      // the bucket on the very attempt meant to bring the type back (issue #6839).
       try { this.sealedStore.close(); } catch (final Exception ignored) {}
-      try { this.mutableBucket.close(); } catch (final Exception ignored) {}
       throw e instanceof IOException ? (IOException) e :
           new IOException("Crash recovery failed for shard " + shardIndex, e);
     }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -1181,6 +1181,22 @@ public class TimeSeriesShard implements AutoCloseable {
   }
 
   /**
+   * Releases only what this shard owns outright, leaving the mutable bucket open. Used when a LATER shard of the
+   * same type fails to construct and the engine has to unwind the shards it already built (issue #6839).
+   * <p>
+   * {@link #close()} is wrong there for the reason spelled out in the constructor: the mutable bucket is
+   * registered with the schema, which owns closing it, and {@code PaginatedComponentFile.close()} sets
+   * {@code open=false} permanently. So unwinding with the full close made one corrupt {@code .ts.sealed} on shard
+   * N poison the buckets of shards 0..N-1 too, and no later {@code initEngine()} could recover the type however
+   * good the incoming blob was - the whole recovery path #6839 adds would work for {@code SHARDS 1} and silently
+   * not for anything above it. The sealed store is this shard's own file handle and nothing else will close it,
+   * so it still must be.
+   */
+  void closeAfterFailedInit() throws IOException {
+    sealedStore.close();
+  }
+
+  /**
    * Drops this shard: deletes the sealed store file and removes the mutable bucket
    * from the file manager. The mutable bucket file is deleted via the schema's file manager.
    */

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTimeBucket.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTimeBucket.java
@@ -65,8 +65,13 @@ public class SQLFunctionTimeBucket extends SQLFunctionConfigurableAbstract {
 
     final long timestampMs = toEpochMs(params[1]);
 
-    // Truncate to bucket boundary
-    final long bucketStart = (timestampMs / intervalMs) * intervalMs;
+    // Floor to the bucket boundary. Math.floorDiv, not '/': Java integer division truncates TOWARD ZERO, so for a
+    // pre-epoch (negative) timestamp the plain division returned a boundary LATER than its own input - '1h' over
+    // -1800000 (1969-12-31T23:30:00Z) answered the epoch itself - and collapsed the last pre-epoch bucket into the
+    // first post-epoch one, silently merging two intervals under one GROUP BY key (issue #6824). The engine's own
+    // bucket anchor was floor-aligned for the same reason in #4595; this is the SQL function that fix did not
+    // reach. intervalMs is positive here (guarded above), so floorDiv differs from '/' only on negative inputs.
+    final long bucketStart = Math.floorDiv(timestampMs, intervalMs) * intervalMs;
 
     return new Date(bucketStart);
   }

--- a/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
@@ -76,8 +76,18 @@ public class LocalTimeSeriesType extends LocalDocumentType {
   public synchronized void initEngine() throws IOException {
     if (engine != null)
       return;
-    engine = new TimeSeriesEngine((DatabaseInternal) schema.getDatabase(), name, tsColumns, shardCount > 0 ? shardCount : 1,
-        compactionBucketIntervalMs, mutableFormatVersion);
+    try {
+      engine = new TimeSeriesEngine((DatabaseInternal) schema.getDatabase(), name, tsColumns,
+          shardCount > 0 ? shardCount : 1, compactionBucketIntervalMs, mutableFormatVersion);
+    } catch (final IOException | RuntimeException e) {
+      // Record why THIS attempt failed, so a retry that fails for a new reason does not keep reporting the old
+      // one. Since #6839 this method is retried outside schema load - the HA sealed-blob repair path drives it -
+      // and markEngineUnavailable() is deliberately restricted to the single-threaded load path, so without this
+      // a second failure left CHECK DATABASE and requireEngine()'s message describing the FIRST one. Set here,
+      // inside the same synchronized block that clears it on success, so the two can never interleave.
+      engineUnavailableReason = e.getMessage() != null ? e.getMessage() : e.toString();
+      throw e;
+    }
     // A retry that succeeds after a prior markEngineUnavailable() must not leave the stale reason behind: nothing
     // else clears it, and getEngineUnavailableReason() otherwise keeps reporting why the engine failed even after
     // isEngineAvailable() has correctly flipped to true.

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6839InitEngineRetryableTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6839InitEngineRetryableTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Issue #6839: {@code initEngine()} has to be retryable, because since #6356 it is the ONLY way a type registered
+ * without a storage engine ever gets one - the HA sealed-blob repair path drives exactly this call.
+ * <p>
+ * What stood in the way was a cleanup that looked like hygiene. Three places closed the shard's mutable bucket
+ * when something else failed to open: {@code TimeSeriesShard}'s sealed-store construction, its crash-recovery
+ * block, and {@code TimeSeriesEngine}'s unwind of the shards it had already built. The bucket is registered with
+ * the schema on every branch that reaches them, so the schema owns closing it and none of those closes ever
+ * prevented a leak - but {@code PaginatedComponentFile.close()} sets {@code open=false} and its own lazy reopen
+ * then refuses ("was closed on purpose") for the life of the process. So the failed attempt destroyed the thing
+ * the next attempt needs, and the retry came back reporting {@code isEngineAvailable() == true} over a component
+ * that throws on every page it touches. Harmless while a failed {@code initEngine()} meant the type vanished from
+ * the schema; the whole obstacle to recovery once #6356 made it stay.
+ * <p>
+ * This class pins the CRASH-RECOVERY door, the one a repair is most likely to meet: a {@code .ts.sealed} is most
+ * often damaged by a crash during compaction, which is precisely when {@code isCompactionInProgress()} is true on
+ * reopen, so the retry that installs a good sealed file runs straight into this block. The sibling doors are
+ * pinned by {@code Issue6839TsSealedBlobRecoveryTest} (sealed-store construction, and the multi-shard unwind).
+ * <p>
+ * The failure is injected with a BROKEN SYMLINK at the {@code .ts.sealed.tmp} path {@code truncateToBlockCount}
+ * writes through: {@code File.exists()} follows the link and answers false, so {@code TimeSeriesSealedStore}'s
+ * constructor skips its own stale-tmp cleanup and opens normally, and then
+ * {@code new RandomAccessFile(tempPath, "rw")} inside the rewrite resolves the link to a directory that is not
+ * there and throws. Deterministic, and it needs no test hook in production code. A plain directory does not work
+ * for this: the constructor deletes an empty one before the shard ever reaches crash recovery, and throws on a
+ * non-empty one at construction, which is the OTHER door and is already covered.
+ * <p>
+ * Note also that a watermark merely disagreeing with the block count does NOT throw - {@code truncateToBlockCount}
+ * returns early when the target is at or above the directory size - so the watermark below is deliberately BELOW
+ * the block count, to get past that guard and reach the rewrite.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6839InitEngineRetryableTest extends TestHelper {
+
+  private static final String TYPE_NAME = "Cpu";
+  private static final int    ROWS      = 3_000;
+
+  /** One of the three tests deliberately leaves a type with no engine behind. */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  @Test
+  void initEngineRecoversAfterCrashRecoveryFailedOnAPreviousAttempt() throws Exception {
+    createTypeAndCompact();
+
+    // A crash mid-compaction, in the state it leaves behind: the flag set, and a watermark BELOW the sealed
+    // store's block count so recovery has real truncation work to do rather than returning early.
+    final long blocks = engineOf().getShard(0).getSealedStore().getBlockCount();
+    assertThat(blocks).isGreaterThan(0L);
+    database.transaction(() -> {
+      try {
+        engineOf().getShard(0).getMutableBucket().setCompactionInProgress(true);
+        engineOf().getShard(0).getMutableBucket().setCompactionWatermark(blocks - 1);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    final Path blocker = new File(getDatabasePath(), TYPE_NAME + "_shard_0.ts.sealed.tmp").toPath();
+    database.close();
+    try {
+      createBrokenSymlink(blocker);
+    } finally {
+      database = factory.open();
+    }
+
+    final LocalTimeSeriesType broken = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(broken.isEngineAvailable()).as("crash recovery must have failed, or this test proves nothing")
+        .isFalse();
+
+    // The repair: whatever was blocking the rewrite is gone. This stands in for the HA path installing a good
+    // sealed file - what matters here is only that the SECOND initEngine() has a reason to succeed.
+    Files.delete(blocker);
+
+    broken.initEngine();
+
+    assertThat(broken.isEngineAvailable()).as("the retry must be able to succeed").isTrue();
+    assertThat(broken.getEngineUnavailableReason()).isNull();
+
+    // The point of the whole exercise: the mutable bucket the failed attempt used to close is still usable. The
+    // flag above flips to true either way - only touching the file distinguishes a real recovery from a component
+    // that will throw on the first page it reads. Asserted as a DELTA rather than a total, because the recovery
+    // this test provoked legitimately truncates the sealed store to the watermark and how many samples that
+    // discards is beside the point: what has to hold is that the bucket still reads and still takes writes.
+    final long afterRecovery = countSamples();
+    appendRows(broken.getEngine(), ROWS, 100);
+    assertThat(countSamples()).isEqualTo(afterRecovery + 100L);
+  }
+
+  /** With nothing blocking it, the same crash-recovery state simply recovers on the first open, as it always did. */
+  @Test
+  void anUnobstructedCrashRecoveryStillRunsOnTheFirstOpen() throws Exception {
+    createTypeAndCompact();
+
+    final long blocks = engineOf().getShard(0).getSealedStore().getBlockCount();
+    database.transaction(() -> {
+      try {
+        engineOf().getShard(0).getMutableBucket().setCompactionInProgress(true);
+        engineOf().getShard(0).getMutableBucket().setCompactionWatermark(blocks - 1);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    database.close();
+    database = factory.open();
+
+    final LocalTimeSeriesType reopened = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(reopened.isEngineAvailable()).isTrue();
+    assertThat(reopened.getEngine().getShard(0).getMutableBucket().isCompactionInProgress()).isFalse();
+    assertThat(reopened.getEngine().getShard(0).getSealedStore().getBlockCount()).isEqualTo(blocks - 1);
+  }
+
+  /** A second {@code initEngine()} on a healthy type is a no-op, not a second engine over the same files. */
+  @Test
+  void initEngineOnAHealthyTypeIsANoOp() throws Exception {
+    createTypeAndCompact();
+
+    final LocalTimeSeriesType healthy = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    final TimeSeriesEngine before = healthy.getEngine();
+
+    healthy.initEngine();
+
+    assertThat(healthy.getEngine()).isSameAs(before);
+    assertThat(countSamples()).isEqualTo(ROWS);
+  }
+
+  // ---- Helpers ----
+
+  /**
+   * Skips the test rather than failing it where symbolic links cannot be created (Windows without the privilege).
+   * The production fix is platform-independent; only this injection is not.
+   */
+  private static void createBrokenSymlink(final Path link) {
+    try {
+      Files.createSymbolicLink(link, link.resolveSibling("no-such-directory-6839").resolve("target"));
+    } catch (final IOException | UnsupportedOperationException e) {
+      assumeTrue(false, "symbolic links are not available here: " + e.getMessage());
+    }
+    assertThat(Files.exists(link)).as("a BROKEN link, so the sealed store's stale-tmp cleanup skips it").isFalse();
+  }
+
+  private void createTypeAndCompact() throws IOException {
+    database.command("sql", "CREATE TIMESERIES TYPE " + TYPE_NAME
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+    final TimeSeriesEngine engine = engineOf();
+    appendRows(engine, 0, ROWS);
+    engine.compactAll();
+  }
+
+  private TimeSeriesEngine engineOf() {
+    return ((LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME)).getEngine();
+  }
+
+  private void appendRows(final TimeSeriesEngine engine, final int from, final int rows) throws IOException {
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + (from + i) * 1_000L;
+      columns[0][i] = "host_" + ((from + i) % 7);
+      columns[1][i] = (double) (from + i);
+    }
+    engine.appendBatch(timestamps, columns);
+  }
+
+  private long countSamples() {
+    try (final ResultSet resultSet = database.query("sql", "SELECT count(*) AS cnt FROM " + TYPE_NAME)) {
+      return resultSet.next().<Number>getProperty("cnt").longValue();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/time/Issue6824TimeBucketPreEpochTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/time/Issue6824TimeBucketPreEpochTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.time;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6824: {@code ts.timeBucket()} computed its boundary with plain Java integer division, which truncates
+ * toward zero rather than flooring. For any negative epoch value that puts the returned "bucket start" AFTER the
+ * timestamp it is supposed to contain, and it collapses the last pre-epoch bucket into the first post-epoch one.
+ * <p>
+ * A bucket function has exactly one contract - {@code bucket(t) <= t}, and every {@code t} in one interval maps to
+ * one boundary - so the two arms below are that contract, not a spot check of two constants: the containment arm
+ * would fail for EVERY negative input under the old expression, and the partition arm is what a {@code GROUP BY}
+ * key actually relies on. Truncation toward zero merges {@code [-1h, 0)} into the bucket for {@code [0, 1h)}, so a
+ * historical series crossing 1970 silently aggregated two hours of samples under one boundary.
+ * <p>
+ * The engine's own bucket anchor was already floor-aligned for #4595
+ * ({@code TimeSeriesNegativeTimestampBucketTest}); this is the same defect one layer up, in the SQL function, which
+ * that fix did not reach. The {@code intervalMs <= 0} guard added for #6388 only ever guarded the divisor.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6824TimeBucketPreEpochTest extends TestHelper {
+
+  private static final long HOUR_MS = 3_600_000L;
+
+  private long bucket(final String interval, final long timestampMs) {
+    try (final ResultSet resultSet = database.query("sql",
+        "SELECT ts.timeBucket('" + interval + "', " + timestampMs + ") AS b")) {
+      return resultSet.next().<Date>getProperty("b").getTime();
+    }
+  }
+
+  /**
+   * The whole of the contract: the bucket start can never be later than the timestamp it buckets. Every negative
+   * input below returned a LATER instant before the fix - {@code -1_800_000} (1969-12-31T23:30:00Z) came back as
+   * the epoch itself, half an hour into its own future.
+   */
+  @Test
+  void aBucketStartIsNeverLaterThanTheTimestampItBuckets() {
+    for (final long timestampMs : new long[] { -1L, -1_800_000L, -HOUR_MS, -HOUR_MS - 1, -86_400_000L, -1_000_000_000_000L,
+        0L, 1L, 1_700_000_000_000L })
+      assertThat(bucket("1h", timestampMs)).as("bucket('1h', %d)", timestampMs).isLessThanOrEqualTo(timestampMs);
+  }
+
+  /**
+   * The two documented repros, pinned as the exact boundaries they must be rather than only as "not in the future":
+   * 1969-12-31T23:30:00Z belongs to the 23:00 hour, and -1ms belongs to 1969-12-31, not to 1970-01-01.
+   */
+  @Test
+  void aPreEpochTimestampBucketsToItsOwnIntervalStart() {
+    assertThat(bucket("1h", -1_800_000L)).isEqualTo(-HOUR_MS);
+    assertThat(bucket("1d", -1L)).isEqualTo(-86_400_000L);
+    // Exactly on a boundary is its own bucket start, on both sides of the epoch.
+    assertThat(bucket("1h", -HOUR_MS)).isEqualTo(-HOUR_MS);
+    assertThat(bucket("1h", 0L)).isZero();
+  }
+
+  /**
+   * The reason this matters at all: used as a {@code GROUP BY} key, truncation toward zero merged the last
+   * pre-epoch bucket into the first post-epoch one, so the two hours either side of 1970 aggregated as one.
+   */
+  @Test
+  void thePreEpochAndPostEpochBucketsDoNotCollapseIntoEachOther() {
+    final Map<Long, Integer> countByBucket = new HashMap<>();
+    // Two samples in [-1h, 0) and three in [0, 1h): five samples, two buckets - never one bucket of five.
+    for (final long timestampMs : new long[] { -HOUR_MS, -1L, 0L, 1L, HOUR_MS - 1 })
+      countByBucket.merge(bucket("1h", timestampMs), 1, Integer::sum);
+
+    assertThat(countByBucket).containsExactlyInAnyOrderEntriesOf(Map.of(-HOUR_MS, 2, 0L, 3));
+  }
+
+  /** The positive side is unchanged, including the case {@code Issue6388TimeFunctionArgumentTest} already pins. */
+  @Test
+  void positiveTimestampsBucketExactlyAsBefore() {
+    assertThat(bucket("1h", 3_900_000L)).isEqualTo(3_600_000L);
+    assertThat(bucket("1d", 1_700_000_000_000L)).isEqualTo(1_699_920_000_000L);
+  }
+
+  /**
+   * The typed overloads reach the same expression through {@code toEpochMs()}, which accepts a negative
+   * {@code Date} and a pre-epoch {@code Instant} without complaint - so the fix has to hold for them too.
+   */
+  @Test
+  void theTypedPreEpochOverloadsFloorAsWell() {
+    try (final ResultSet resultSet = database.query("sql", "SELECT ts.timeBucket('1h', ?) AS b",
+        new Date(-1_800_000L))) {
+      assertThat(resultSet.next().<Date>getProperty("b").getTime()).isEqualTo(-HOUR_MS);
+    }
+    try (final ResultSet resultSet = database.query("sql", "SELECT ts.timeBucket('1h', ?) AS b",
+        Instant.ofEpochMilli(-1_800_000L))) {
+      assertThat(resultSet.next().<Date>getProperty("b").getTime()).isEqualTo(-HOUR_MS);
+    }
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2045,8 +2045,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   private boolean repairEngineWithSealedBlob(final DatabaseInternal db, final LocalTimeSeriesType tsType,
       final RaftLogEntryCodec.TsSealedBlob blob) {
+    // tsType.getName(), not blob.typeName(): the two are equal here - tsType came from getType(blob.typeName()) -
+    // but taking it from the resolved schema type means the name selecting a file on this node provably came from
+    // the local schema and not from the wire, rather than only doing so as long as the caller keeps that lookup.
     final File target = new File(db.getDatabasePath(),
-        TimeSeriesSealedStore.sealedFileNameFor(blob.typeName(), blob.shardIndex()));
+        TimeSeriesSealedStore.sealedFileNameFor(tsType.getName(), blob.shardIndex()));
     final File incoming = new File(target.getPath() + ".incoming");
     try {
       try (final FileOutputStream out = new FileOutputStream(incoming)) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.WALFile;
+import com.arcadedb.engine.timeseries.TimeSeriesSealedStore;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.exception.WALVersionGapException;
@@ -58,6 +59,7 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.LifeCycle;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -1984,7 +1986,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * full {@code .ts.sealed} file is replaced atomically and the in-memory sealed store reopened.
    * Idempotent: re-applying the same blob (crash/restart replay) simply rewrites the identical file.
    */
-  private void applySealedBlobs(final DatabaseInternal db, final List<RaftLogEntryCodec.TsSealedBlob> blobs)
+  // Package-private rather than private so Issue6839TsSealedBlobRecoveryTest can drive the apply path directly:
+  // the recovery it pins is entirely inside this method, and a 3-node IT would only add flakiness to prove it.
+  void applySealedBlobs(final DatabaseInternal db, final List<RaftLogEntryCodec.TsSealedBlob> blobs)
       throws IOException {
     if (blobs == null || blobs.isEmpty())
       return;
@@ -1997,16 +2001,75 @@ public class ArcadeStateMachine extends BaseStateMachine {
             decodedDbName(db));
         continue;
       }
-      if (!(schema.getType(blob.typeName()) instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null) {
+      if (!(schema.getType(blob.typeName()) instanceof LocalTimeSeriesType tsType)) {
         LogManager.instance().log(this, Level.SEVERE,
-            "Received TimeSeries sealed blob for non-timeseries or uninitialized type '%s' (db=%s); skipping", null,
+            "Received TimeSeries sealed blob for non-timeseries type '%s' (db=%s); skipping", null,
             blob.typeName(), decodedDbName(db));
+        continue;
+      }
+      if (tsType.getEngine() == null) {
+        // The type is registered with no engine (issue #6356), which used to end here: the blob was logged away,
+        // and since a Raft entry is applied once and never re-shipped, that made every one of them a permanent
+        // divergence - on the very state LocalSchema.readConfiguration() justifies keeping by pointing at HA as
+        // the thing that would repair it. This blob IS that repair, so install it and retry (issue #6839).
+        if (repairEngineWithSealedBlob(db, tsType, blob))
+          HALog.log(this, HALog.DETAILED,
+              "Repaired TimeSeries type %s shard %d from a replicated sealed blob (%d bytes) on db '%s'",
+              blob.typeName(), blob.shardIndex(), blob.bytes().length, decodedDbName(db));
         continue;
       }
       tsType.getEngine().getShard(blob.shardIndex()).getSealedStore().installSealedFileBytes(blob.bytes());
       HALog.log(this, HALog.DETAILED, "Installed TimeSeries sealed blob for %s shard %d (%d bytes) on db '%s'",
           blob.typeName(), blob.shardIndex(), blob.bytes().length, decodedDbName(db));
     }
+  }
+
+  /**
+   * Puts the leader's sealed bytes in place for a type registered with no engine and re-runs {@code initEngine()}.
+   * Returns whether the type now has one.
+   * <p>
+   * The order is the point. Retrying {@code initEngine()} FIRST recovers nothing in the reported case: the
+   * engine failed because this shard's {@code .ts.sealed} could not be opened, so re-opening the same file fails
+   * for the same reason and there is still no store to install the blob through. The blob is the authoritative
+   * copy of exactly that file, so it goes down first and {@code initEngine()} then opens the store over it -
+   * which is also why nothing is installed afterwards: the file already IS the blob.
+   * <p>
+   * Written through a temporary and moved with {@code REPLACE_EXISTING}, the same way
+   * {@code TimeSeriesSealedStore.installSealedFileBytes} does it, so a crash mid-write cannot leave a half-file
+   * where a whole one used to be. The target name is derived from the type and shard rather than taken from
+   * {@code blob.fileName()}: a path from a replicated payload must not select a file on this node.
+   * <p>
+   * A failure here is logged and reported, never thrown: one unrepairable type must not abort the apply of an
+   * entry that may carry blobs for others, and the state it leaves behind is the state it started from - still
+   * visible, still reported by {@code CHECK DATABASE}, still failing loudly on every read and write.
+   */
+  private boolean repairEngineWithSealedBlob(final DatabaseInternal db, final LocalTimeSeriesType tsType,
+      final RaftLogEntryCodec.TsSealedBlob blob) {
+    final File target = new File(db.getDatabasePath(),
+        TimeSeriesSealedStore.sealedFileNameFor(blob.typeName(), blob.shardIndex()));
+    final File incoming = new File(target.getPath() + ".incoming");
+    try {
+      try (final FileOutputStream out = new FileOutputStream(incoming)) {
+        out.write(blob.bytes());
+        out.getFD().sync();
+      }
+      Files.move(incoming.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      tsType.initEngine();
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.SEVERE,
+          "Received TimeSeries sealed blob for type '%s' shard %d (db=%s) whose storage engine is unavailable, and "
+              + "the engine could not be initialised over it: %s", e, blob.typeName(), blob.shardIndex(),
+          decodedDbName(db), e.getMessage());
+      return false;
+    }
+
+    if (!tsType.isEngineAvailable()) {
+      LogManager.instance().log(this, Level.SEVERE,
+          "TimeSeries type '%s' (db=%s) still has no storage engine after installing the replicated sealed blob "
+              + "for shard %d; skipping", null, blob.typeName(), decodedDbName(db), blob.shardIndex());
+      return false;
+    }
+    return true;
   }
 
   private static String decodedDbName(final DatabaseInternal db) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6839TsSealedBlobRecoveryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6839TsSealedBlobRecoveryTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedBlob;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6839 (item 1): the "registered but engine-unavailable" TimeSeries state that #6356 made visible had no way
+ * out, and the one payload that could repair it was the payload this path threw away.
+ * <p>
+ * {@code LocalSchema.readConfiguration()} justifies keeping such a type registered on the grounds that the file
+ * that failed to open - "a {@code .ts.sealed} most commonly" - is rebuildable under HA from the replicated mutable
+ * pages. But {@code applySealedBlobs} refused exactly that state ({@code tsType.getEngine() == null}) and logged
+ * the blob away, and a Raft entry is applied once and never re-shipped, so every dropped blob was a permanent
+ * divergence. Nothing else ever retried {@code initEngine()} - its only non-test callers are the schema-load site
+ * and type creation - maintenance is gated off the type by {@code isEngineAvailable()}, and every read and write
+ * throws through {@code requireEngine()}. The only escape was closing and reopening the whole database, i.e. the
+ * restart #6356 set out to make unnecessary.
+ * <p>
+ * Two things had to change for a blob to actually repair the type, and the arms below pin both:
+ * <ol>
+ *   <li>the incoming bytes must land on disk BEFORE {@code initEngine()} runs. A bare retry re-opens the same
+ *       corrupt {@code .ts.sealed} and fails again for the same reason, so "retry, then install" recovers
+ *       nothing in the reported repro - the blob IS the repair, and it has to be in place first;</li>
+ *   <li>{@code initEngine()} had to become genuinely retryable. {@code TimeSeriesShard}'s constructor closed the
+ *       mutable bucket when the sealed store threw, and {@code PaginatedComponentFile.close()} sets
+ *       {@code open=false}, which its own lazy-reopen then refuses ("was closed on purpose"). The component stays
+ *       registered with the schema either way, so that close never prevented a leak - it only made the file
+ *       permanently unreadable for the life of the process. A retry over it produced a type reporting
+ *       {@code isEngineAvailable() == true} whose every read threw {@code FileNotFoundException}, which is why
+ *       {@link #aSealedBlobRepairsATypeWhoseEngineFailedToInitialise()} reads AND writes after the repair rather
+ *       than only asserting the flag.</li>
+ * </ol>
+ * Driven against a real {@link LocalDatabase} and a real (unstarted) {@link ArcadeStateMachine}, no mocking - the
+ * same harness as {@code ArcadeStateMachineBootstrapDivergenceTest}. The cluster is not needed: the defect is
+ * entirely inside the apply path, and a 3-node IT would only add the flakiness without adding evidence.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6839TsSealedBlobRecoveryTest {
+
+  private static final String TYPE_NAME  = "Cpu";
+  private static final String SEALED_FILE = TYPE_NAME + "_shard_0.ts.sealed";
+  private static final int    ROWS       = 3_000;
+
+  @TempDir
+  private Path          serverDir;
+  private LocalDatabase database;
+  private String        databasePath;
+
+  @BeforeEach
+  void setUp() {
+    databasePath = serverDir.resolve("db-ts").toString();
+    database = (LocalDatabase) new DatabaseFactory(databasePath).create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.close();
+  }
+
+  /**
+   * The whole of item 1: a follower whose sealed store failed to open comes back on the next blob the leader ships
+   * for it, with its data - the leader's, and its own mutable pages - intact and writable.
+   */
+  @Test
+  void aSealedBlobRepairsATypeWhoseEngineFailedToInitialise() throws Exception {
+    final byte[] leaderSealedBytes = buildTypeAndCaptureItsSealedFile();
+
+    breakTheSealedFileAndReopen();
+
+    final LocalTimeSeriesType broken = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(broken.isEngineAvailable()).as("the #6356 state this test is about").isFalse();
+    assertThat(broken.getEngineUnavailableReason()).contains(SEALED_FILE);
+
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
+
+    assertThat(broken.isEngineAvailable()).as("the blob must repair the type, not be discarded").isTrue();
+    assertThat(broken.getEngineUnavailableReason()).as("a successful retry clears the stale reason").isNull();
+
+    // The leader's blob is on disk and readable: the sealed blocks are back, and so are their samples. The count
+    // is the unfiltered one on purpose - a tag-filtered count reflects only the sealed subset, which would pass
+    // here for the wrong reason.
+    assertThat(broken.getEngine().getShard(0).getSealedStore().getBlockCount()).isGreaterThan(0);
+    assertThat(countSamples()).isEqualTo(ROWS);
+
+    // And the MUTABLE half survived too. This is the arm that fails when initEngine() is merely retried over a
+    // component whose file the first, failed attempt closed for good: the flag above flips to true either way,
+    // and only touching the file says which of the two happened.
+    appendRows(broken.getEngine(), ROWS, 100);
+    assertThat(countSamples()).isEqualTo(ROWS + 100L);
+  }
+
+  /**
+   * The repair is attempted for the engine-unavailable state alone. A blob naming a type that is not a TimeSeries
+   * type at all is still refused and logged - there is nothing there an engine could be initialised over, and
+   * writing the payload to a file named after it would be worse than dropping it.
+   */
+  @Test
+  void aBlobForANonTimeSeriesTypeIsStillRefused() throws Exception {
+    database.getSchema().createDocumentType("NotATimeSeries");
+
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob("NotATimeSeries", 0, "NotATimeSeries_shard_0.ts.sealed", new byte[] { 1, 2, 3 })));
+
+    assertThat(new File(databasePath, "NotATimeSeries_shard_0.ts.sealed"))
+        .as("nothing may be written for a type that has no sealed store").doesNotExist();
+  }
+
+  /** A healthy type takes the path it always took: the blob is installed through the live sealed store. */
+  @Test
+  void aHealthyTypeStillInstallsTheBlobThroughItsLiveEngine() throws Exception {
+    final byte[] leaderSealedBytes = buildTypeAndCaptureItsSealedFile();
+    final LocalTimeSeriesType healthy = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(healthy.isEngineAvailable()).isTrue();
+    final TimeSeriesEngine engineBefore = healthy.getEngine();
+
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
+
+    assertThat(healthy.getEngine()).as("a healthy type is never re-initialised").isSameAs(engineBefore);
+    assertThat(countSamples()).isEqualTo(ROWS);
+  }
+
+  // ---- Helpers ----
+
+  /**
+   * Creates the type, fills it and compacts, so the sealed file on disk holds real blocks. Returns its bytes,
+   * which is exactly what the leader ships in a {@link TsSealedBlob}.
+   */
+  private byte[] buildTypeAndCaptureItsSealedFile() throws IOException {
+    database.command("sql", "CREATE TIMESERIES TYPE " + TYPE_NAME
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME)).getEngine();
+    appendRows(engine, 0, ROWS);
+    engine.compactAll();
+
+    final File sealed = new File(databasePath, SEALED_FILE);
+    assertThat(sealed).exists();
+    return Files.readAllBytes(sealed.toPath());
+  }
+
+  /**
+   * Flips byte 0 of the sealed file - part of its MAGIC_VALUE, so the store can never open - and reopens the
+   * database, which is the state {@code LocalSchema.readConfiguration()} registers rather than dropping (#6356).
+   */
+  private void breakTheSealedFileAndReopen() throws IOException {
+    database.close();
+    final File sealed = new File(databasePath, SEALED_FILE);
+    try (final RandomAccessFile raf = new RandomAccessFile(sealed, "rw")) {
+      raf.seek(0);
+      final int b = raf.read();
+      raf.seek(0);
+      raf.write(b ^ 0x01);
+    }
+    database = (LocalDatabase) new DatabaseFactory(databasePath).open();
+  }
+
+  private void appendRows(final TimeSeriesEngine engine, final int from, final int rows) throws IOException {
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + (from + i) * 1_000L;
+      columns[0][i] = "host_" + ((from + i) % 7);
+      columns[1][i] = (double) (from + i);
+    }
+    engine.appendBatch(timestamps, columns);
+  }
+
+  private long countSamples() {
+    try (final ResultSet resultSet = database.query("sql", "SELECT count(*) AS cnt FROM " + TYPE_NAME)) {
+      return resultSet.next().<Number>getProperty("cnt").longValue();
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6839TsSealedBlobRecoveryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6839TsSealedBlobRecoveryTest.java
@@ -73,9 +73,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class Issue6839TsSealedBlobRecoveryTest {
 
-  private static final String TYPE_NAME  = "Cpu";
-  private static final String SEALED_FILE = TYPE_NAME + "_shard_0.ts.sealed";
-  private static final int    ROWS       = 3_000;
+  private static final String TYPE_NAME   = "Cpu";
+  private static final String SEALED_FILE = sealedFileName(0);
+  private static final int    ROWS        = 3_000;
 
   @TempDir
   private Path          serverDir;
@@ -158,6 +158,37 @@ class Issue6839TsSealedBlobRecoveryTest {
     assertThat(countSamples()).isEqualTo(ROWS);
   }
 
+  /**
+   * The same recovery on a type with more than one shard, which is where a second copy of the very defect this PR
+   * fixes lived: {@code TimeSeriesEngine}'s constructor closes every shard it had already built when a later one
+   * throws, and {@code TimeSeriesShard.close()} closes the mutable bucket. So a corrupt {@code .ts.sealed} on
+   * shard 1 took shard 0's mutable bucket down with it - permanently, since
+   * {@code PaginatedComponentFile.close()} sets {@code open=false} - and no later repair could ever succeed,
+   * however good the incoming blob was. Both other arms use SHARDS 1 and cannot see it.
+   */
+  @Test
+  void aSealedBlobRepairsATypeWithMoreThanOneShard() throws Exception {
+    final byte[] leaderSealedBytes = buildTypeAndCaptureItsSealedFile(2, 1);
+
+    breakTheSealedFileAndReopen(1);
+
+    final LocalTimeSeriesType broken = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(broken.isEngineAvailable()).isFalse();
+    assertThat(broken.getEngineUnavailableReason()).contains(sealedFileName(1));
+
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 1, sealedFileName(1), leaderSealedBytes)));
+
+    assertThat(broken.isEngineAvailable()).as("shard 0's bucket must not have been poisoned by shard 1").isTrue();
+    assertThat(broken.getEngineUnavailableReason()).isNull();
+
+    // Every sample is back - the repaired shard's from the blob, shard 0's from its own untouched files - and both
+    // shards still take writes, which is what a closed mutable bucket would refuse.
+    assertThat(countSamples()).isEqualTo(ROWS);
+    appendRows(broken.getEngine(), ROWS, 100);
+    assertThat(countSamples()).isEqualTo(ROWS + 100L);
+  }
+
   // ---- Helpers ----
 
   /**
@@ -165,15 +196,23 @@ class Issue6839TsSealedBlobRecoveryTest {
    * which is exactly what the leader ships in a {@link TsSealedBlob}.
    */
   private byte[] buildTypeAndCaptureItsSealedFile() throws IOException {
+    return buildTypeAndCaptureItsSealedFile(1, 0);
+  }
+
+  private byte[] buildTypeAndCaptureItsSealedFile(final int shardCount, final int shardIndex) throws IOException {
     database.command("sql", "CREATE TIMESERIES TYPE " + TYPE_NAME
-        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS " + shardCount);
     final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME)).getEngine();
     appendRows(engine, 0, ROWS);
     engine.compactAll();
 
-    final File sealed = new File(databasePath, SEALED_FILE);
+    final File sealed = new File(databasePath, sealedFileName(shardIndex));
     assertThat(sealed).exists();
     return Files.readAllBytes(sealed.toPath());
+  }
+
+  private static String sealedFileName(final int shardIndex) {
+    return TYPE_NAME + "_shard_" + shardIndex + ".ts.sealed";
   }
 
   /**
@@ -181,8 +220,12 @@ class Issue6839TsSealedBlobRecoveryTest {
    * database, which is the state {@code LocalSchema.readConfiguration()} registers rather than dropping (#6356).
    */
   private void breakTheSealedFileAndReopen() throws IOException {
+    breakTheSealedFileAndReopen(0);
+  }
+
+  private void breakTheSealedFileAndReopen(final int shardIndex) throws IOException {
     database.close();
-    final File sealed = new File(databasePath, SEALED_FILE);
+    final File sealed = new File(databasePath, sealedFileName(shardIndex));
     try (final RandomAccessFile raf = new RandomAccessFile(sealed, "rw")) {
       raf.seek(0);
       final int b = raf.read();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6839TsSealedBlobRecoveryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6839TsSealedBlobRecoveryTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #6839 (item 1): the "registered but engine-unavailable" TimeSeries state that #6356 made visible had no way
@@ -187,6 +188,46 @@ class Issue6839TsSealedBlobRecoveryTest {
     assertThat(countSamples()).isEqualTo(ROWS);
     appendRows(broken.getEngine(), ROWS, 100);
     assertThat(countSamples()).isEqualTo(ROWS + 100L);
+  }
+
+  /**
+   * The failure arm. A blob that is itself unusable cannot repair anything, and what matters is what the apply
+   * path does about it: log it, leave the type exactly as unavailable as it was, and RETURN - not throw, because
+   * the same entry may carry blobs for other types that are perfectly repairable.
+   * <p>
+   * It also pins the freshened reason. {@code initEngine()} now records why THIS attempt failed, so an operator
+   * reading {@code CHECK DATABASE} after a failed repair sees the new cause rather than the original one - here,
+   * a header the sealed store rejects, not the flipped magic byte that started it.
+   */
+  @Test
+  void aBlobThatCannotBeOpenedLeavesTheTypeUnavailableWithoutThrowing() throws Exception {
+    buildTypeAndCaptureItsSealedFile();
+
+    breakTheSealedFileAndReopen();
+
+    final LocalTimeSeriesType broken = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(broken.isEngineAvailable()).isFalse();
+    final String reasonBefore = broken.getEngineUnavailableReason();
+    assertThat(reasonBefore).isNotNull();
+
+    // A blob long enough to be written and read back, and nothing the sealed store can make sense of.
+    final byte[] garbage = new byte[512];
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, garbage)));
+
+    assertThat(broken.isEngineAvailable()).as("an unusable blob must not appear to have repaired anything")
+        .isFalse();
+    // The reason now describes THIS attempt, not the one that started it: both are "invalid sealed store magic",
+    // but the magic quoted is the zero-filled blob's rather than the flipped byte's. Before initEngine() recorded
+    // its own failures an operator kept reading the original cause after every subsequent failed repair.
+    assertThat(broken.getEngineUnavailableReason())
+        .as("a failed retry must report why IT failed, not why the first attempt did")
+        .isNotNull()
+        .isNotEqualTo(reasonBefore);
+
+    // The type stays loud rather than silently readable, and the second failed attempt is reachable again: the
+    // recovery path is not one-shot, so a later, good blob can still repair it.
+    assertThatThrownBy(broken::requireEngine).hasMessageContaining(TYPE_NAME);
   }
 
   // ---- Helpers ----

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6839TsSealedBlobRecoveryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6839TsSealedBlobRecoveryTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.server.ha.raft;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.engine.timeseries.TimeSeriesSealedStore;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedBlob;
@@ -157,6 +158,14 @@ class Issue6839TsSealedBlobRecoveryTest {
 
     assertThat(healthy.getEngine()).as("a healthy type is never re-initialised").isSameAs(engineBefore);
     assertThat(countSamples()).isEqualTo(ROWS);
+
+    // The one coupling in the repair path with no compile-time enforcement: sealedFileNameFor() rebuilds the
+    // <type>_shard_<index> half of the name that TimeSeriesShard's constructor owns, so a future rename there
+    // would silently send the repair at a path nothing reads. Asserted against the live store's own answer, which
+    // is derived from the path the shard actually opened.
+    assertThat(TimeSeriesSealedStore.sealedFileNameFor(TYPE_NAME, 0))
+        .as("the derived name must match the name the shard actually opened")
+        .isEqualTo(healthy.getEngine().getShard(0).getSealedStore().getSealedFileName());
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
@@ -119,7 +119,11 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
 
           // Auto-create type if needed
           final LocalTimeSeriesType tsType = getOrCreateType(database, typeName, ts.getLabels());
-          final TimeSeriesEngine engine = tsType.getEngine();
+          // requireEngine(), not getEngine(): getOrCreateType() now returns an existing TimeSeries type whatever
+          // state its storage is in, so this is where a missing engine is reported - naming the type and why the
+          // engine never started, rather than letting a null reach an NPE (issue #6356) or, as before, a phantom
+          // "already exists" from the auto-create branch (issue #6839).
+          final TimeSeriesEngine engine = tsType.requireEngine();
           final List<ColumnDefinition> columns = tsType.getTsColumns();
 
           // Append this series' samples as ONE batch. All samples of a remote-write TimeSeries share the
@@ -173,7 +177,13 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
       final List<Label> labels) {
     if (database.getSchema().existsType(typeName)) {
       final DocumentType docType = database.getSchema().getType(typeName);
-      if (docType instanceof LocalTimeSeriesType tsType && tsType.getEngine() != null)
+      // The two halves are separate questions and were one condition, which is what made this the only TimeSeries
+      // call site PR #6779 left reporting the wrong error (issue #6839). "Is it a TimeSeries type" decides whether
+      // to auto-create; "does it have an engine" decides whether the write can proceed, and that is the caller's
+      // requireEngine() to answer. Folding them together sent a registered-but-engine-unavailable type (#6356)
+      // into the auto-create branch below, where create() throws SchemaException("Type 'X' already exists") - a
+      // name collision that does not exist, instead of the reason the engine is missing and the file it names.
+      if (docType instanceof LocalTimeSeriesType tsType)
         return tsType;
     }
 

--- a/server/src/test/java/com/arcadedb/server/Issue6839PrometheusWriteEngineUnavailableIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue6839PrometheusWriteEngineUnavailableIT.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Label;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Sample;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.TimeSeries;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.WriteRequest;
+import org.junit.jupiter.api.Test;
+import org.xerial.snappy.Snappy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6839 (item 2): Prometheus remote-write answered the "registered but engine-unavailable" TimeSeries state
+ * of #6356 with a phantom name collision.
+ * <p>
+ * PR #6779 converted every TimeSeries read/write call site to the {@code isEngineAvailable()} /
+ * {@code requireEngine()} pair, and missed {@code PostPrometheusWriteHandler.getOrCreateType}, whose pre-existing
+ * shape turns that state into the wrong error. It asked one question for two things -
+ * {@code docType instanceof LocalTimeSeriesType tsType && tsType.getEngine() != null} - so a type that exists and
+ * IS a TimeSeries type, merely without an engine, failed the guard and fell through to the auto-create branch,
+ * which threw {@code SchemaException("Type 'X' already exists")}.
+ * <p>
+ * That is not a cosmetic difference. "Already exists" tells an operator to go looking for a name collision that
+ * does not exist, while the message {@code requireEngine()} produces names the type AND the file whose failure to
+ * open put it in this state - which is the whole reason #6356 kept the type registered instead of letting it
+ * vanish. No data was damaged either way: {@code create()} throws before it mutates the schema.
+ * <p>
+ * The state is reached here by closing the live type's engine, which nulls the same field a failed
+ * {@code initEngine()} leaves null - the field this guard reads - without needing to corrupt a file and restart
+ * the server around it. The engine-side arms of that state (a corrupt {@code .ts.sealed} at schema load, and the
+ * recovery from it) are pinned by {@code Issue6340TimeSeriesCheckDatabaseTest} and
+ * {@code Issue6839TsSealedBlobRecoveryTest}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6839PrometheusWriteEngineUnavailableIT extends BaseGraphServerTest {
+
+  private static final String METRIC = "cpu_unavailable";
+
+  /**
+   * Off the default 2480-2489 range on purpose. {@code BaseGraphServerTest}'s own HTTP helpers address
+   * {@code 248<serverIndex>} literally, so a developer machine with anything already on 2480 - a locally installed
+   * ArcadeDB is the common one - silently routes those requests at the other server and the failures read as
+   * authentication errors. This class builds its own URL from the port the server actually bound
+   * ({@code getHttpServer().getPort()}), so it neither collides with such a server nor cares which port of the
+   * range it ended up on.
+   */
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    config.setValue(GlobalConfiguration.SERVER_HTTP_INCOMING_PORT, "2490-2499");
+  }
+
+  @Test
+  void aRemoteWriteToATypeWithNoEngineReportsTheRealReasonNotAPhantomNameCollision() throws Exception {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    database.command("sql", "CREATE TIMESERIES TYPE " + METRIC
+        + " TIMESTAMP timestamp TAGS (host STRING) FIELDS (value DOUBLE) SHARDS 1");
+
+    // The healthy path first, so the request shape below is known-good and a later failure cannot be the payload.
+    assertThat(postPromWrite(sampleFor(75.5, 1000)).statusCode()).isEqualTo(204);
+
+    // Null the engine, exactly as a failed initEngine() leaves it (issue #6356).
+    final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(METRIC);
+    tsType.close();
+    assertThat(tsType.isEngineAvailable()).as("the state this test is about").isFalse();
+
+    final Response response = postPromWrite(sampleFor(80.2, 2000));
+
+    assertThat(response.statusCode()).as("a write against a type with no storage must fail").isNotEqualTo(204);
+    assertThat(response.body())
+        .as("the error must name the real reason, not a name collision that does not exist")
+        .contains(METRIC)
+        .contains("no storage engine available")
+        .doesNotContain("already exists");
+  }
+
+  // ---- Helpers ----
+
+  private record Response(int statusCode, String body) {
+  }
+
+  private static WriteRequest sampleFor(final double value, final long timestampMs) {
+    return new WriteRequest(List.of(new TimeSeries(
+        List.of(new Label("__name__", METRIC), new Label("host", "server1")),
+        List.of(new Sample(value, timestampMs)))));
+  }
+
+  private Response postPromWrite(final WriteRequest writeRequest) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:" + getServer(0).getHttpServer().getPort() + "/api/v1/ts/" + getDatabaseName()
+        + "/prom/write").toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    connection.setRequestProperty("Content-Type", "application/x-protobuf");
+    connection.setRequestProperty("Content-Encoding", "snappy");
+    connection.setDoOutput(true);
+
+    try (final OutputStream os = connection.getOutputStream()) {
+      os.write(Snappy.compress(writeRequest.encode()));
+      os.flush();
+    }
+
+    final int statusCode = connection.getResponseCode();
+    return new Response(statusCode, readBody(connection));
+  }
+
+  private static String readBody(final HttpURLConnection connection) throws Exception {
+    try (final InputStream is = connection.getResponseCode() < 400 ?
+        connection.getInputStream() :
+        connection.getErrorStream()) {
+      if (is == null)
+        return "";
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      final byte[] buffer = new byte[4096];
+      int read;
+      while ((read = is.read(buffer)) != -1)
+        baos.write(buffer, 0, read);
+      return baos.toString(StandardCharsets.UTF_8);
+    }
+  }
+}


### PR DESCRIPTION
Closes #6824
Closes #6839

Two TimeSeries issues in milestone 26.9.1. Three defects, three regression tests, each proven to fail before its fix.

## #6824 - `ts.timeBucket()` truncated toward zero

`SQLFunctionTimeBucket` computed its boundary with plain Java integer division. A bucket function has exactly one contract, `bucket(t) <= t`, and for every negative epoch value the old expression broke it: `ts.timeBucket('1h', -1800000)` (1969-12-31T23:30:00Z) answered `1970-01-01T00:00:00Z`, thirty minutes into its own future. Used as the documented `GROUP BY` key it merged `[-1h, 0)` into the bucket for `[0, 1h)`, so any historical series crossing 1970 aggregated two intervals under one boundary.

`Math.floorDiv`, which is what the engine's own bucket anchor has used since #4595 (`TimeSeriesNegativeTimestampBucketTest`) - this is the same defect one layer up, in the SQL function, that fix did not reach. The `intervalMs <= 0` guard added for #6388 only ever guarded the divisor.

**Test:** `Issue6824TimeBucketPreEpochTest` - the containment contract over nine timestamps, the two documented repros as exact boundaries, the non-collapse of the two buckets either side of the epoch, the typed `Date`/`Instant` overloads, and the unchanged positive path. 4 of 5 arms fail before the fix.

## #6839 item 1 - the engine-unavailable state had no way out, and HA discarded the blob that would repair it

`LocalSchema.readConfiguration()` keeps a TimeSeries type registered when `initEngine()` throws (#6356), justified on the grounds that the failing file is "a `.ts.sealed` most commonly, rebuildable under HA by recompacting the replicated mutable pages". That repair path did not exist: `applySealedBlobs` refused exactly that state (`tsType.getEngine() == null`), logged SEVERE and skipped, and a Raft entry is applied once and never re-shipped - so every dropped blob was a permanent divergence, on the one state HA was named as the cure for. Nothing else ever retried `initEngine()`, maintenance is gated off the type by `isEngineAvailable()`, and every read and write throws through `requireEngine()`.

The fix writes the incoming bytes to the shard's `.ts.sealed` and re-runs `initEngine()` over them. **Two things beyond the issue's minimal sketch were required, and the test pins both:**

1. **Order.** Retrying `initEngine()` first re-opens the same corrupt file and fails for the same reason, leaving no store to install the blob through - "retry, then install" recovers nothing in the reported repro. The blob *is* the repair, so it goes down first; nothing is installed afterwards because the file already is the blob.

2. **`initEngine()` had to become genuinely retryable.** `TimeSeriesShard`'s constructor closed the mutable bucket when the sealed store threw, and `PaginatedComponentFile.close()` sets `open=false`, which its own lazy reopen then explicitly refuses ("was closed on purpose") for the life of the process. The component stays schema-registered on both branches either way, so that close never prevented a leak - it only made the file permanently unreadable. Harmless while a failed `initEngine()` meant the type vanished; since #6356 made the type stay, it was the thing standing in the way of recovery. Measured: with the close restored, the recovery arm fails outright - the engine never comes back at all.

The target file name is derived from the type and shard (`TimeSeriesSealedStore.sealedFileNameFor`), never taken from `blob.fileName()`: a path arriving over the wire has no business selecting a file on this node. The write goes through a temporary and `Files.move(REPLACE_EXISTING)`, the same way `installSealedFileBytes` does it. A failure is logged and reported, never thrown, so one unrepairable type cannot abort an entry carrying blobs for others.

**Test:** `Issue6839TsSealedBlobRecoveryTest` - a real `LocalDatabase` and a real unstarted `ArcadeStateMachine`, no mocks, same harness as `ArcadeStateMachineBootstrapDivergenceTest`. The defect is entirely inside the apply path, so a 3-node IT would add flakiness without adding evidence. Three arms: the repair (which reads AND writes afterwards, because the flag flips either way and only touching the file distinguishes a real recovery from a dead component), a blob for a non-TimeSeries type still refused with nothing written, and a healthy type still installing through its live engine without being re-initialised.

## #6839 item 2 - Prometheus remote-write reported a phantom name collision

PR #6779 converted every TimeSeries call site to the `isEngineAvailable()` / `requireEngine()` pair and missed `PostPrometheusWriteHandler.getOrCreateType`, which asked one question for two things:

```java
if (docType instanceof LocalTimeSeriesType tsType && tsType.getEngine() != null)
```

A type that exists and *is* a TimeSeries type, merely without an engine, failed that guard and fell through to the auto-create branch, which threw `SchemaException("Type 'X' already exists")`. Not cosmetic: that sends an operator hunting a collision that does not exist, while `requireEngine()`'s message names the type and the file whose failure to open put it in this state, which is the whole reason #6356 kept the type registered. No data damage either way - `create()` throws before it mutates the schema.

The two conditions are now split, and the caller uses `requireEngine()`.

**Test:** `Issue6839PrometheusWriteEngineUnavailableIT`. Before the fix it reproduces the reported body verbatim: `{"exception":"com.arcadedb.exception.SchemaException","detail":"Type 'cpu_unavailable' already exists"}`.

## Verification

| Suite | Result |
|---|---|
| `engine` - `com.arcadedb.engine.timeseries.*Test` + `com.arcadedb.function.sql.time.*Test` | 418/418 |
| `engine` - `com.arcadedb.schema.*Test` | 459/459 |
| `ha-raft` - `ArcadeStateMachine*Test`, `Issue6839*`, `Issue6111*`, `Issue5410*` | 129/129 |
| `ha-raft` IT - `RaftTimeSeriesReplication3NodesIT`, `RaftTimeSeriesOversizedSealedIT` (the two that drive sealed-blob replication) | 5/5 |
| `server` - `Issue6839PrometheusWriteEngineUnavailableIT` | 1/1 |
| `server` - `PrometheusApiSpecTest`, `OpenApiSpecGeneratorTest` | 18/18 |

Each new test was run against the unfixed code first and fails there; the `TimeSeriesShard` half was separately verified load-bearing by restoring the close and watching the recovery arm go red.

Two IT classes could not be run on this machine: `PrometheusRemoteWriteReadIT` and `RaftTimeSeriesWriteReadYourWritesIT` address `127.0.0.1:248<serverIndex>` literally, and port 2480 here is held by an unrelated ArcadeDB instance, so their requests reach that server and come back `404 Database 'graph' is not available`. Environmental, not a regression - the same handler returns 204 in the new IT, which binds its own port range. CI will run both.

The new IT overrides `onServerConfiguration` to bind 2490-2499 and builds its URL from `getHttpServer().getPort()`, so it neither collides with a locally installed ArcadeDB nor cares which port of the range it lands on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected time-bucket grouping for timestamps before the Unix epoch.
  * Improved time-series engine recovery and retry behavior while preserving mutable data.
  * Prometheus write errors now clearly identify unavailable time-series engines instead of reporting misleading conflicts.
  * Improved recovery of replicated time-series data after sealed-store corruption.

* **Tests**
  * Added coverage for pre-epoch time buckets, engine initialization retries, sealed-store recovery, and Prometheus writes when storage is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->