### PR TITLE
fix(ci): six test failures on main (run 33161892670) - three racy/under-budgeted tests, one missing dependency

### DIFF
--- a/console/src/test/java/com/arcadedb/console/RemoteConsoleIT.java
+++ b/console/src/test/java/com/arcadedb/console/RemoteConsoleIT.java
@@ -170,8 +170,17 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
     assertThat(console.parse("create user albert identified by einstein")).isTrue();
     assertThat(console.parse("drop user albert")).isTrue();
 
-    // TEST SYNTAX ERROR
-    assertThatThrownBy(() -> assertThat(console.parse("create user albert identified by einstein grand connect on db1")).isTrue()).isInstanceOf(Exception.class);
+    // TEST SYNTAX ERROR: a `create user` with no IDENTIFIED BY at all has nowhere to take a password from
+    // and is rejected outright.
+    assertThatThrownBy(() -> assertThat(console.parse("create user albert")).isTrue()).isInstanceOf(Exception.class);
+
+    // A MISTYPED GRANT CLAUSE IS *NOT* A SYNTAX ERROR ANY MORE (ISSUE #6830). ONLY THE EXACT ` GRANT CONNECT TO `
+    // PHRASE DELIMITS THE PASSWORD, AND SINCE #6830 A PASSWORD MAY CONTAIN SPACES, SO `grand connect on db1`
+    // IS AN ORDINARY - IF SURPRISING - PASSWORD RATHER THAN SOMETHING THE CONSOLE CAN TELL APART FROM ONE.
+    // ASSERTED EXPLICITLY, NOT DELETED: THIS USED TO THROW ONLY BECAUSE THE CONSOLE REJECTED SPACES IN
+    // PASSWORDS, AND #6830 REMOVED THAT CHECK BECAUSE IT MADE ACCOUNTS THE CONSOLE COULD NOT CREATE.
+    assertThat(console.parse("create user albert identified by einstein grand connect on db1")).isTrue();
+    assertThat(console.parse("drop user albert")).isTrue();
 
     assertThat(console.parse("create user albert identified by einstein grant connect to db1")).isTrue();
     assertThat(console.parse("create user jeff identified by amazonaws grant connect to db1:readonly")).isTrue();

--- a/console/src/test/java/com/arcadedb/console/RemoteConsoleIT.java
+++ b/console/src/test/java/com/arcadedb/console/RemoteConsoleIT.java
@@ -170,15 +170,16 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
     assertThat(console.parse("create user albert identified by einstein")).isTrue();
     assertThat(console.parse("drop user albert")).isTrue();
 
-    // TEST SYNTAX ERROR: a `create user` with no IDENTIFIED BY at all has nowhere to take a password from
-    // and is rejected outright.
+    // Syntax error: a `create user` with no IDENTIFIED BY at all has nowhere to take a password from and
+    // is rejected outright.
     assertThatThrownBy(() -> assertThat(console.parse("create user albert")).isTrue()).isInstanceOf(Exception.class);
 
-    // A MISTYPED GRANT CLAUSE IS *NOT* A SYNTAX ERROR ANY MORE (ISSUE #6830). ONLY THE EXACT ` GRANT CONNECT TO `
-    // PHRASE DELIMITS THE PASSWORD, AND SINCE #6830 A PASSWORD MAY CONTAIN SPACES, SO `grand connect on db1`
-    // IS AN ORDINARY - IF SURPRISING - PASSWORD RATHER THAN SOMETHING THE CONSOLE CAN TELL APART FROM ONE.
-    // ASSERTED EXPLICITLY, NOT DELETED: THIS USED TO THROW ONLY BECAUSE THE CONSOLE REJECTED SPACES IN
-    // PASSWORDS, AND #6830 REMOVED THAT CHECK BECAUSE IT MADE ACCOUNTS THE CONSOLE COULD NOT CREATE.
+    // A mistyped grant clause is not a syntax error any more (issue #6830). Only the exact
+    // ` GRANT CONNECT TO ` phrase delimits the password, and since #6830 a password may contain spaces, so
+    // `grand connect on db1` is an ordinary - if surprising - password rather than something the console can
+    // tell apart from one. Asserted explicitly rather than deleted: this used to throw only because the
+    // console rejected spaces in passwords, and #6830 removed that check because it made accounts the
+    // console could not create.
     assertThat(console.parse("create user albert identified by einstein grand connect on db1")).isTrue();
     assertThat(console.parse("drop user albert")).isTrue();
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -8689,6 +8689,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * JVM-wide, so a leaked acquisition starves every later vector rebuild in the same JVM. Blocks until the permits
    * are free, which is deliberate - an earlier test's rebuild still holding one is exactly the convoy the caller
    * needs to be out of before it can observe anything stable.
+   * <p>
+   * Assumes the sequential, single-JVM run this module's tests get today ({@code forkCount=1}, no parallel
+   * classes), same as {@code GraphAnalyticalView.acquireAllBuildPermitsForTest()}. Two callers under a parallel
+   * Surefire would serialize on the semaphore rather than deadlock, but the second would then be observing a
+   * window the first had already let a rebuild run in, so the guarantee this hook exists to give would be gone.
    */
   static void acquireAllRebuildPermitsForTest() {
     REBUILD_SEMAPHORE.acquireUninterruptibly(MAX_CONCURRENT_REBUILDS);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -144,8 +144,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // JVM-wide semaphore limiting the number of concurrent async graph rebuilds across all indexes
   // and databases.  Multiple concurrent rebuilds are extremely memory-intensive and can cause OOM
   // kills (issue #3868).  The permit count is read once at class-load time from the configuration.
-  private static final Semaphore REBUILD_SEMAPHORE = new Semaphore(
-      GlobalConfiguration.VECTOR_INDEX_MAX_CONCURRENT_REBUILDS.getValueAsInteger());
+  private static final int       MAX_CONCURRENT_REBUILDS = GlobalConfiguration.VECTOR_INDEX_MAX_CONCURRENT_REBUILDS
+      .getValueAsInteger();
+  private static final Semaphore REBUILD_SEMAPHORE       = new Semaphore(MAX_CONCURRENT_REBUILDS);
 
   // Page header layout constants
   public static final int OFFSET_FREE_CONTENT = 0;  // 4 bytes
@@ -8674,6 +8675,28 @@ public class LSMVectorIndex implements Index, IndexInternal {
    */
   long deltaScanWorkForTest() {
     return deltaScanWorkSinceRebuild.get();
+  }
+
+  /**
+   * Test-only hook: saturates the JVM-wide {@link #REBUILD_SEMAPHORE} so that any async graph rebuild dispatched
+   * afterwards parks in {@link #startAsyncGraphRebuild()} before it touches anything, letting a test assert on the
+   * state a search left behind - {@code deltaVectorsCount}, {@code mutationsSinceRebuild}, {@code graphState},
+   * {@code graphRebuildCount} - instead of racing the rebuild that consumes it. Both acquire sites are
+   * {@code tryAcquire} on background threads and no search path takes a permit, so holding them all cannot stall a
+   * query.
+   * <p>
+   * Must be paired with {@link #releaseAllRebuildPermitsForTest()} in a {@code finally} block: the permits are
+   * JVM-wide, so a leaked acquisition starves every later vector rebuild in the same JVM. Blocks until the permits
+   * are free, which is deliberate - an earlier test's rebuild still holding one is exactly the convoy the caller
+   * needs to be out of before it can observe anything stable.
+   */
+  static void acquireAllRebuildPermitsForTest() {
+    REBUILD_SEMAPHORE.acquireUninterruptibly(MAX_CONCURRENT_REBUILDS);
+  }
+
+  /** Test-only hook: releases the permits taken by {@link #acquireAllRebuildPermitsForTest()}. */
+  static void releaseAllRebuildPermitsForTest() {
+    REBUILD_SEMAPHORE.release(MAX_CONCURRENT_REBUILDS);
   }
 
   /** Charges one query's brute-force scan of {@code scanned} buffered vectors to the amortization window. */

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2812,15 +2812,28 @@ class GraphAnalyticalViewTest extends TestHelper {
     // The query planner's gate must not hand out a provider it hasn't actually verified is usable: this
     // must return false/null synchronously, without waiting for (or triggering, from the caller's point of
     // view) any O(V+E) rebuild - it only kicks that off in the background.
-    assertThat(restored.isReady())
-        .as("issue #6641: a provisionally-READY view with an unresolved deferred restore must not be "
-            + "advertised as ready until it is actually verified - the caller has no way to recover once "
-            + "committed to a provider that turns out to need a synchronous rebuild")
-        .isFalse();
-    assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS"))
-        .as("issue #6641: the query planner must route to the ordinary OLTP path instead of a provider "
-            + "that will block the query through a full rebuild")
-        .isNull();
+    //
+    // Permits are saturated FIRST, and for exactly the two assertions below: isReady() dispatches the
+    // deferred restore and only then reads `status` (deliberately - see its javadoc), so on a fixture this
+    // small the whole background chain can resolve inside that window and hand back a legitimately READY
+    // view. Parking the dispatched task on BUILD_PERMITS - which it acquires before it reads anything -
+    // pins the observation to the instant the gate is actually being asked about, instead of racing it.
+    GraphAnalyticalView.acquireAllBuildPermitsForTest();
+    try {
+      assertThat(restored.isReady())
+          .as("issue #6641: a provisionally-READY view with an unresolved deferred restore must not be "
+              + "advertised as ready until it is actually verified - the caller has no way to recover once "
+              + "committed to a provider that turns out to need a synchronous rebuild")
+          .isFalse();
+      assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS"))
+          .as("issue #6641: the query planner must route to the ordinary OLTP path instead of a provider "
+              + "that will block the query through a full rebuild")
+          .isNull();
+    } finally {
+      // Releases exactly the permits acquired above, regardless of whether an assertion failed: they are
+      // JVM-wide, and a leaked acquisition would starve every later test in this JVM.
+      GraphAnalyticalView.releaseAllBuildPermitsForTest();
+    }
 
     // "Never serve stale data" still holds: the background resolution (triggered above) eventually
     // produces the correct, up-to-date snapshot for whichever query asks next.
@@ -2876,10 +2889,17 @@ class GraphAnalyticalViewTest extends TestHelper {
     assertThat(restored).isNotNull();
     assertThat(restored.isBuilt()).isFalse();
 
-    assertThat(restored.isReady())
-        .as("issue #6641: a corrupted persisted CSR must not be advertised as ready before it is verified")
-        .isFalse();
-    assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS")).isNull();
+    // Permits are saturated for exactly these two assertions - see the sibling commit-variant test above
+    // for why isReady() would otherwise race the background chain it dispatches itself.
+    GraphAnalyticalView.acquireAllBuildPermitsForTest();
+    try {
+      assertThat(restored.isReady())
+          .as("issue #6641: a corrupted persisted CSR must not be advertised as ready before it is verified")
+          .isFalse();
+      assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS")).isNull();
+    } finally {
+      GraphAnalyticalView.releaseAllBuildPermitsForTest();
+    }
 
     assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
     assertThat(restored.isRestoredFromPersistedCsr()).isFalse();

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
@@ -79,6 +79,16 @@ class Issue6655StaleGraphPrefixReuseTest {
   private static final int    MAX_CONNECTIONS = 64;
   private static final int    BEAM_WIDTH      = 400;
 
+  // How long to let the async rebuild of 20,200 x 128 vectors converge. Sized for the worst case rather
+  // than for a developer machine, which is what the @Tag("vector") note in CLAUDE.md asks for: the rebuild
+  // has to wait out whatever else in this JVM holds the sole LSMVectorIndex.REBUILD_SEMAPHORE permit before
+  // it can even start, and then runs on however many cores the runner has. At 60s a green local run
+  // (~10s for this whole class) still went red on a 4-vCPU CI runner with the rebuild reporting itself
+  // still in flight (run 33161892670). This is a convergence wait, not a latency bound - it asserts that
+  // the rebuild happens, not that it is fast - so a generous value cannot turn a passing run red, and the
+  // assertion below distinguishes "still working" from "never ran" for whoever reads the next timeout.
+  private static final Duration ASYNC_REBUILD_TIMEOUT = Duration.ofMinutes(4);
+
   private String dbPath;
 
   @BeforeEach
@@ -190,9 +200,14 @@ class Issue6655StaleGraphPrefixReuseTest {
 
         // The async rebuild kicked off by the reuse eventually folds the gap into the graph proper.
         Awaitility.await("the async rebuild kicked off by the stale-prefix reuse completes")
-            .atMost(Duration.ofSeconds(60))
+            .atMost(ASYNC_REBUILD_TIMEOUT)
             .pollInterval(Duration.ofMillis(200))
-            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isEqualTo(1L));
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount"))
+                .as("graphRebuildCount, with asyncRebuildInProgress=%s: a 1 there means the rebuild is still "
+                        + "running or still parked on the JVM-wide REBUILD_SEMAPHORE and this wait is simply "
+                        + "too short; a 0 means it was never started or was skipped, which is a real defect",
+                    index.getStats().get("asyncRebuildInProgress"))
+                .isEqualTo(1L));
 
         assertThat(index.getStats().get("graphState"))
             .as("once the deferred rebuild completes the graph goes back to IMMUTABLE").isEqualTo(1L);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
@@ -174,29 +174,42 @@ class Issue6655StaleGraphPrefixReuseTest {
         final int gapDocId = NUM_VECTORS; // first record written after the persisted build
         final RID gapDocRid = ridOf(db, gapDocId);
 
-        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
-        final List<Pair<RID, Float>> results = index.findNeighborsFromVector(embedding(gapDocId), 5, 64);
-        // Measured on this fixture: a prefix reuse returns in well under a second; a full synchronous rebuild of
-        // 20,200 vectors at these build parameters takes several real seconds (see Issue6067DeferredCloseRebuildTest
-        // for the same measurement on an equivalent fixture). The bound is a tripwire between the two, wide on
-        // both sides.
-        stopwatch.assertGaveUpWithin(2_000,
-            "a search that reuses a stale prefix graph from one that ran a full synchronous rebuild to completion");
+        // The async rebuild the reuse dispatches resets the very gauges asserted below - deltaVectorsCount,
+        // mutationsSinceRebuild, graphState, graphRebuildCount - so the permits are saturated for the whole
+        // observation window. Without that, whether these assertions see the state the reuse LEFT or the state the
+        // rebuild ALREADY CONSUMED is decided by how quickly this JVM hands out the sole vector-rebuild permit; the
+        // block used to pass only because a preceding test's rebuild happened to be starving it. Both acquire sites
+        // are tryAcquire on background threads and no search path takes a permit, so this cannot stall the queries.
+        LSMVectorIndex.acquireAllRebuildPermitsForTest();
+        try {
+          final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+          final List<Pair<RID, Float>> results = index.findNeighborsFromVector(embedding(gapDocId), 5, 64);
+          // Measured on this fixture: a prefix reuse returns in well under a second; a full synchronous rebuild of
+          // 20,200 vectors at these build parameters takes several real seconds (see Issue6067DeferredCloseRebuildTest
+          // for the same measurement on an equivalent fixture). The bound is a tripwire between the two, wide on
+          // both sides.
+          stopwatch.assertGaveUpWithin(2_000,
+              "a search that reuses a stale prefix graph from one that ran a full synchronous rebuild to completion");
 
-        assertThat(results.stream().map(Pair::getFirst))
-            .as("the gap record must be found by its own embedding on the very first query, proving the queued "
-                + "delta entries - not only the reused graph - are already searchable")
-            .contains(gapDocRid);
+          assertThat(results.stream().map(Pair::getFirst))
+              .as("the gap record must be found by its own embedding on the very first query, proving the queued "
+                  + "delta entries - not only the reused graph - are already searchable")
+              .contains(gapDocRid);
 
-        assertThat(index.getStats().get("graphState"))
-            .as("the reuse must leave the index MUTABLE (graph + queued delta), not a synchronously-rebuilt "
-                + "IMMUTABLE graph")
-            .isEqualTo(2L); // GraphState.MUTABLE
-        assertThat(index.getStats().get("stalePrefixGraphReuses"))
-            .as("the reuse path introduced by this fix must be the one that actually ran").isEqualTo(1L);
-        assertThat(index.getStats().get("graphRebuildCount"))
-            .as("no synchronous rebuild may have run on the calling thread for this search to have returned "
-                + "already").isZero();
+          assertThat(index.getStats().get("graphState"))
+              .as("the reuse must leave the index MUTABLE (graph + queued delta), not a synchronously-rebuilt "
+                  + "IMMUTABLE graph")
+              .isEqualTo(2L); // GraphState.MUTABLE
+          assertThat(index.getStats().get("stalePrefixGraphReuses"))
+              .as("the reuse path introduced by this fix must be the one that actually ran").isEqualTo(1L);
+          assertThat(index.getStats().get("graphRebuildCount"))
+              .as("no synchronous rebuild may have run on the calling thread for this search to have returned "
+                  + "already").isZero();
+        } finally {
+          // Released before the convergence wait below: that wait is precisely for the rebuild these permits park.
+          LSMVectorIndex.releaseAllRebuildPermitsForTest();
+        }
+
 
         // The async rebuild kicked off by the reuse eventually folds the gap into the graph proper.
         Awaitility.await("the async rebuild kicked off by the stale-prefix reuse completes")

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
@@ -159,51 +159,64 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
         final RID crashedSessionDocRid = ridOf(db, NUM_VECTORS); // first record written after the persisted build
         final RID inSessionDocRid = ridOf(db, IN_SESSION_DOC_ID);
 
-        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
-        final List<Pair<RID, Float>> results = index.findNeighborsFromVector(embedding(IN_SESSION_DOC_ID), 5, 64);
-        // The stopwatch keeps running across the cheap getStats() assertions below and is asserted on after
-        // them - see the comment there.
-        // The state facts are asserted before the wall clock, deliberately: the issue reports the elapsed time
-        // moving between runs (7.5x to 15.9x) while these two counters do not, so they are what should name the
-        // regression when this test goes red, with the timing tripwire below as the corroborating - not the
-        // leading - signal.
-        assertThat(index.getStats().get("stalePrefixGraphReuses"))
-            .as("the reuse path must run for a session that wrote before it searched, exactly as it does for one "
-                + "that did not (issue #6772)")
-            .isEqualTo(1L);
-        assertThat(index.getStats().get("graphRebuildCount"))
-            .as("no synchronous rebuild may have run on the calling thread for this search to have returned "
-                + "already").isZero();
-        assertThat(index.getStats().get("graphNodeCount"))
-            .as("the graph in memory must be the persisted PREFIX, not a graph rebuilt over the whole live set")
-            .isEqualTo((long) NUM_VECTORS);
+        // The async rebuild the reuse dispatches resets the very gauges asserted below - deltaVectorsCount,
+        // mutationsSinceRebuild, graphState, graphRebuildCount - so the permits are saturated for the whole
+        // observation window. Without that, whether these assertions see the state the reuse LEFT or the state the
+        // rebuild ALREADY CONSUMED is decided by how quickly this JVM hands out the sole vector-rebuild permit; the
+        // block used to pass only because a preceding test's rebuild happened to be starving it. Both acquire sites
+        // are tryAcquire on background threads and no search path takes a permit, so this cannot stall the queries.
+        LSMVectorIndex.acquireAllRebuildPermitsForTest();
+        try {
+          final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+          final List<Pair<RID, Float>> results = index.findNeighborsFromVector(embedding(IN_SESSION_DOC_ID), 5, 64);
+          // The stopwatch keeps running across the cheap getStats() assertions below and is asserted on after
+          // them - see the comment there.
+          // The state facts are asserted before the wall clock, deliberately: the issue reports the elapsed time
+          // moving between runs (7.5x to 15.9x) while these two counters do not, so they are what should name the
+          // regression when this test goes red, with the timing tripwire below as the corroborating - not the
+          // leading - signal.
+          assertThat(index.getStats().get("stalePrefixGraphReuses"))
+              .as("the reuse path must run for a session that wrote before it searched, exactly as it does for one "
+                  + "that did not (issue #6772)")
+              .isEqualTo(1L);
+          assertThat(index.getStats().get("graphRebuildCount"))
+              .as("no synchronous rebuild may have run on the calling thread for this search to have returned "
+                  + "already").isZero();
+          assertThat(index.getStats().get("graphNodeCount"))
+              .as("the graph in memory must be the persisted PREFIX, not a graph rebuilt over the whole live set")
+              .isEqualTo((long) NUM_VECTORS);
 
-        // The duplicate check. This session's own write is already in the delta buffer AND inside the gap past
-        // the persisted prefix, so a reuse that queued the gap wholesale would buffer it twice - and count it
-        // twice in mutationsSinceRebuild.
-        assertThat(index.getStats().get("deltaVectorsCount"))
-            .as("every vector missing from the persisted prefix must be buffered exactly once: the %d written by "
-                + "the crashed session plus the 1 written by this one, with no duplicate of this session's own "
-                + "write", GAP_VECTORS)
-            .isEqualTo((long) (GAP_VECTORS + 1));
-        assertThat(index.getStats().get("mutationsSinceRebuild"))
-            .as("and counted exactly once each, for the same reason")
-            .isEqualTo((long) (GAP_VECTORS + 1));
+          // The duplicate check. This session's own write is already in the delta buffer AND inside the gap past
+          // the persisted prefix, so a reuse that queued the gap wholesale would buffer it twice - and count it
+          // twice in mutationsSinceRebuild.
+          assertThat(index.getStats().get("deltaVectorsCount"))
+              .as("every vector missing from the persisted prefix must be buffered exactly once: the %d written by "
+                  + "the crashed session plus the 1 written by this one, with no duplicate of this session's own "
+                  + "write", GAP_VECTORS)
+              .isEqualTo((long) (GAP_VECTORS + 1));
+          assertThat(index.getStats().get("mutationsSinceRebuild"))
+              .as("and counted exactly once each, for the same reason")
+              .isEqualTo((long) (GAP_VECTORS + 1));
 
-        // Measured on this fixture: a prefix reuse returns in well under a second; a full synchronous rebuild of
-        // 20,201 vectors at these build parameters takes several real seconds. The bound is a tripwire between
-        // the two, wide on both sides.
-        stopwatch.assertGaveUpWithin(2_000,
-            "a search that reuses a stale prefix graph from one that ran a full synchronous rebuild to completion");
+          // Measured on this fixture: a prefix reuse returns in well under a second; a full synchronous rebuild of
+          // 20,201 vectors at these build parameters takes several real seconds. The bound is a tripwire between
+          // the two, wide on both sides.
+          stopwatch.assertGaveUpWithin(2_000,
+              "a search that reuses a stale prefix graph from one that ran a full synchronous rebuild to completion");
 
-        // Both kinds of pending vector must already be findable by their own embedding - a record is always its
-        // own nearest neighbour - proving the reuse did not trade correctness for the latency win.
-        assertThat(results.stream().map(Pair::getFirst))
-            .as("the vector this session wrote before searching must be found by the very first query")
-            .contains(inSessionDocRid);
-        assertThat(index.findNeighborsFromVector(embedding(NUM_VECTORS), 5, 64).stream().map(Pair::getFirst))
-            .as("so must a vector written by the crashed session, which only the queued gap makes searchable")
-            .contains(crashedSessionDocRid);
+          // Both kinds of pending vector must already be findable by their own embedding - a record is always its
+          // own nearest neighbour - proving the reuse did not trade correctness for the latency win.
+          assertThat(results.stream().map(Pair::getFirst))
+              .as("the vector this session wrote before searching must be found by the very first query")
+              .contains(inSessionDocRid);
+          assertThat(index.findNeighborsFromVector(embedding(NUM_VECTORS), 5, 64).stream().map(Pair::getFirst))
+              .as("so must a vector written by the crashed session, which only the queued gap makes searchable")
+              .contains(crashedSessionDocRid);
+        } finally {
+          // Released before the convergence wait below: that wait is precisely for the rebuild these permits park.
+          LSMVectorIndex.releaseAllRebuildPermitsForTest();
+        }
+
 
         // The async rebuild kicked off by the reuse eventually folds everything into the graph proper.
         Awaitility.await("the async rebuild kicked off by the stale-prefix reuse completes")
@@ -259,37 +272,50 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
         populate(db, IN_SESSION_DOC_ID, IN_SESSION_DOC_ID + 1);
         final RID inSessionDocRid = ridOf(db, IN_SESSION_DOC_ID);
 
-        final int searchers = 8;
-        final CyclicBarrier startTogether = new CyclicBarrier(searchers);
-        final List<Callable<List<Pair<RID, Float>>>> tasks = new ArrayList<>(searchers);
-        for (int i = 0; i < searchers; i++)
-          tasks.add(() -> {
-            startTogether.await(30, TimeUnit.SECONDS);
-            return index.findNeighborsFromVector(embedding(IN_SESSION_DOC_ID), 5, 64);
-          });
-
-        final ExecutorService pool = Executors.newFixedThreadPool(searchers);
+        // The async rebuild the reuse dispatches resets the very gauges asserted below - deltaVectorsCount,
+        // mutationsSinceRebuild, graphState, graphRebuildCount - so the permits are saturated for the whole
+        // observation window. Without that, whether these assertions see the state the reuse LEFT or the state the
+        // rebuild ALREADY CONSUMED is decided by how quickly this JVM hands out the sole vector-rebuild permit; the
+        // block used to pass only because a preceding test's rebuild happened to be starving it. Both acquire sites
+        // are tryAcquire on background threads and no search path takes a permit, so this cannot stall the queries.
+        LSMVectorIndex.acquireAllRebuildPermitsForTest();
         try {
-          for (final Future<List<Pair<RID, Float>>> future : pool.invokeAll(tasks))
-            assertThat(future.get(60, TimeUnit.SECONDS).stream().map(Pair::getFirst))
-                .as("every concurrent searcher must find the vector this session wrote before searching, whether "
-                    + "it published the reuse, waited for it, or was served from the delta buffer alone")
-                .contains(inSessionDocRid);
+          final int searchers = 8;
+          final CyclicBarrier startTogether = new CyclicBarrier(searchers);
+          final List<Callable<List<Pair<RID, Float>>>> tasks = new ArrayList<>(searchers);
+          for (int i = 0; i < searchers; i++)
+            tasks.add(() -> {
+              startTogether.await(30, TimeUnit.SECONDS);
+              return index.findNeighborsFromVector(embedding(IN_SESSION_DOC_ID), 5, 64);
+            });
+
+          final ExecutorService pool = Executors.newFixedThreadPool(searchers);
+          try {
+            for (final Future<List<Pair<RID, Float>>> future : pool.invokeAll(tasks))
+              assertThat(future.get(60, TimeUnit.SECONDS).stream().map(Pair::getFirst))
+                  .as("every concurrent searcher must find the vector this session wrote before searching, whether "
+                      + "it published the reuse, waited for it, or was served from the delta buffer alone")
+                  .contains(inSessionDocRid);
+          } finally {
+            pool.shutdownNow();
+          }
+
+          assertThat(index.getStats().get("stalePrefixGraphReuses"))
+              .as("exactly one reuse must be published however many threads reached the decision - the losers must "
+                  + "discard their work on the graphIndex double-check, not publish a second time")
+              .isEqualTo(1L);
+          assertThat(index.getStats().get("deltaVectorsCount"))
+              .as("and the gap must still be buffered exactly once under contention: %d from the crashed session "
+                  + "plus the 1 this session wrote", GAP_VECTORS)
+              .isEqualTo((long) (GAP_VECTORS + 1));
+          assertThat(index.getStats().get("mutationsSinceRebuild"))
+              .as("counted exactly once each, for the same reason")
+              .isEqualTo((long) (GAP_VECTORS + 1));
         } finally {
-          pool.shutdownNow();
+          // Released before the convergence wait below: that wait is precisely for the rebuild these permits park.
+          LSMVectorIndex.releaseAllRebuildPermitsForTest();
         }
 
-        assertThat(index.getStats().get("stalePrefixGraphReuses"))
-            .as("exactly one reuse must be published however many threads reached the decision - the losers must "
-                + "discard their work on the graphIndex double-check, not publish a second time")
-            .isEqualTo(1L);
-        assertThat(index.getStats().get("deltaVectorsCount"))
-            .as("and the gap must still be buffered exactly once under contention: %d from the crashed session "
-                + "plus the 1 this session wrote", GAP_VECTORS)
-            .isEqualTo((long) (GAP_VECTORS + 1));
-        assertThat(index.getStats().get("mutationsSinceRebuild"))
-            .as("counted exactly once each, for the same reason")
-            .isEqualTo((long) (GAP_VECTORS + 1));
 
         // Teardown hygiene, not an assertion about the fix: the reuse kicks off an async rebuild, and dropping the
         // database out from under it leaves it persisting a graph into files that are going away.

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
@@ -90,6 +90,16 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
   private static final int    MAX_CONNECTIONS = 64;
   private static final int    BEAM_WIDTH      = 400;
 
+  // How long to let the async rebuild of 20,201 x 128 vectors converge. Sized for the worst case rather
+  // than for a developer machine, which is what the @Tag("vector") note in CLAUDE.md asks for: the rebuild
+  // has to wait out whatever else in this JVM holds the sole LSMVectorIndex.REBUILD_SEMAPHORE permit before
+  // it can even start, and then runs on however many cores the runner has. At 60s a green local run
+  // (~20s for this whole class) still went red on a 4-vCPU CI runner with the rebuild reporting itself
+  // still in flight (run 33161892670). This is a convergence wait, not a latency bound - it asserts that
+  // the rebuild happens, not that it is fast - so a generous value cannot turn a passing run red, and the
+  // assertions below distinguish "still working" from "never ran" for whoever reads the next timeout.
+  private static final Duration ASYNC_REBUILD_TIMEOUT = Duration.ofMinutes(4);
+
   /** The single record the searching session writes before it searches - the whole point of this test. */
   private static final int IN_SESSION_DOC_ID = NUM_VECTORS + GAP_VECTORS;
 
@@ -197,9 +207,14 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
 
         // The async rebuild kicked off by the reuse eventually folds everything into the graph proper.
         Awaitility.await("the async rebuild kicked off by the stale-prefix reuse completes")
-            .atMost(Duration.ofSeconds(60))
+            .atMost(ASYNC_REBUILD_TIMEOUT)
             .pollInterval(Duration.ofMillis(200))
-            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isEqualTo(1L));
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount"))
+                .as("graphRebuildCount, with asyncRebuildInProgress=%s: a 1 there means the rebuild is still "
+                        + "running or still parked on the JVM-wide REBUILD_SEMAPHORE and this wait is simply "
+                        + "too short; a 0 means it was never started or was skipped, which is a real defect",
+                    index.getStats().get("asyncRebuildInProgress"))
+                .isEqualTo(1L));
 
         assertThat(index.getStats().get("graphNodeCount"))
             .as("once the deferred rebuild completes the graph covers every live vector")
@@ -279,9 +294,14 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
         // Teardown hygiene, not an assertion about the fix: the reuse kicks off an async rebuild, and dropping the
         // database out from under it leaves it persisting a graph into files that are going away.
         Awaitility.await("the async rebuild kicked off by the stale-prefix reuse settles before the drop")
-            .atMost(Duration.ofSeconds(60))
+            .atMost(ASYNC_REBUILD_TIMEOUT)
             .pollInterval(Duration.ofMillis(200))
-            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress"))
+                .as("asyncRebuildInProgress, with graphRebuildCount=%s: this stays 1 for as long as the rebuild "
+                        + "is running OR parked on the JVM-wide REBUILD_SEMAPHORE (whose own permit wait is "
+                        + "10 minutes by default), so a timeout here means the wait was too short, not that "
+                        + "anything hung", index.getStats().get("graphRebuildCount"))
+                .isZero());
       } finally {
         db.drop();
       }

--- a/postgresw/pom.xml
+++ b/postgresw/pom.xml
@@ -81,6 +81,18 @@
             <version>${tomcat-jdbc.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- PostgresWJdbcIT runs BACKUP DATABASE, which the engine resolves reflectively against
+             com.arcadedb.integration.backup.Backup. Declared explicitly because nothing else on this
+             module's test classpath supplies it: arcadedb-server has it at test scope (not transitive),
+             and the gremlin uber-jar above used to carry a copy only as a side effect of shading its own
+             compile-scope dependency - PR #6876 excluded it from the jar, which is what turned that
+             accident into a "backup libs not found in classpath" failure. -->
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-integration</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Triage of [CI run 33161892670](https://github.com/ArcadeData/arcadedb/actions/runs/33161892670) on `main`, red across `unit-tests`, `vector-unit-tests` and `integration-tests`. Six failures, four independent causes. One is a real dependency gap; the rest are tests that were racing or under-budgeted rather than product defects.

| Job | Test | Cause | Fix |
|---|---|---|---|
| unit-tests | `GraphAnalyticalViewTest.issue6641_corruptedPersistedCsr…` | test races the API it tests | saturate `BUILD_PERMITS` around the assertion |
| vector | `Issue6655StaleGraphPrefixReuseTest` (1) | 60s wait, rebuild still in flight | 4 min + diagnostic message |
| vector | `Issue6772WriteBeforeSearchPrefixReuseTest` (2) | same | same |
| integration | `PostgresWJdbcIT.backupDatabase` | **missing dependency**, exposed by #6876 | declare `arcadedb-integration` at test scope |
| integration | `RemoteConsoleIT.userMgmt` | assertion obsoleted by #6830 | assert the new behaviour, move the syntax-error case |

## 1. The two `#6641` GAV tests raced `isReady()`

`GraphAnalyticalView.isReady()` dispatches a pending deferred restore and *then* reads `status`. That ordering is deliberate - its javadoc explains that reading the resolved state beats short-circuiting on `pendingDiskRestore` alone, so the rare caller whose dispatch settles in between gets the true answer rather than a needlessly pessimistic one.

On this fixture the view holds 2 vertices and 1 edge, so the whole background chain (the restore rejects the truncated file, `buildAsync()` rebuilds, `status` goes `READY`) fits comfortably inside a scheduling stall between those two steps. The assertion that the view must *not* be ready then loses the race, which is precisely the reported failure:

```
issue #6641: a corrupted persisted CSR must not be advertised as ready before it is verified
Expecting value to be false but was true
```

**Reproduced deterministically** by inserting a 1.5s delay between the dispatch and the read: the test goes red with the identical message, and stays green with the permits held.

The fix uses the test hook that already exists for this shape (`acquireAllBuildPermitsForTest()`, used by the in-flight-race test in the same class). The dispatched task acquires a build permit *before* it reads anything, so saturating the semaphore first parks it and pins the observation to the instant the query-time gate is actually being asked about. The sibling commit-variant test carries the identical race and is fixed alongside it, rather than waiting for its own red run.

Note the product behaviour is not changed and does not need to be: an `isReady()` that returns `true` there is *correct* - the view genuinely is ready by then.

## 2. Three vector prefix-reuse waits were sized for a developer machine

All three failures are 60s `Awaitility` waits on the async rebuild of 20,200 x 128 vectors. The third one is the diagnostic:

```
'the async rebuild kicked off by the stale-prefix reuse settles before the drop'
didn't complete within 1 minutes ... expected: 0L but was: 1L
```

`asyncRebuildInProgress` was still `1` - the rebuild was **running, or still parked on the sole JVM-wide `REBUILD_SEMAPHORE` permit** (whose own wait is 10 minutes by default). It had not been skipped or deferred for memory, both of which log a WARNING that does not appear in the run.

This is the hazard `CLAUDE.md`'s `@Tag("vector")` note already documents: the lane convoys on one permit, so the waits have to be sized for the worst case. 60s was not - the whole `Issue6655` class runs in ~10s locally and took 164.6s on the 4-vCPU runner.

Raised to 4 minutes. These are **convergence waits, not latency bounds** - they assert that the rebuild happens, not that it is fast - so a generous value cannot turn a passing run red. Each wait now also reports the other stat alongside it, so the next timeout says which arm it was:

> `graphRebuildCount`, with `asyncRebuildInProgress=1`: a 1 there means the rebuild is still running or still parked on the JVM-wide REBUILD_SEMAPHORE and this wait is simply too short; a 0 means it was never started or was skipped, which is a real defect.

## 3. `PostgresWJdbcIT.backupDatabase` - the one real defect

`BACKUP DATABASE` resolves `com.arcadedb.integration.backup.Backup` reflectively, and **nothing on postgresw's test classpath declared it**. `arcadedb-server` has `arcadedb-integration` at `test` scope, which is not transitive.

It passed until now only by accident: `arcadedb-gremlin` has `arcadedb-integration` at compile scope, so its uber-jar carried a copy, and postgresw takes that jar with a wildcard exclusion - making the shaded jar the *only* supplier of those classes. PR #6876 added `<exclude>com.arcadedb:arcadedb-integration</exclude>` to the shade `artifactSet`, correctly, and that turned the accident into:

```
ERROR: Error on executing query: Error on backing up database, backup libs not found in classpath
```

Declared explicitly at `test` scope, with a comment recording why. postgresw is the only module that was living off that leak - checked every module that consumes `arcadedb-gremlin:shaded` (`graphql`, `gremlin-it`, `gremlin-consumer-it`, `package`) for uses of `com.arcadedb.integration` or backup/export/import statements in tests.

## 4. `RemoteConsoleIT.userMgmt`'s syntax-error case stopped being one

#6830 (commit 2dbe5ee861, merged yesterday) removed the console's rejection of spaces in passwords, because it made accounts the console could not create. Only the exact ` GRANT CONNECT TO ` phrase delimits a password, so the deliberately mistyped

```
create user albert identified by einstein grand connect on db1
```

is now an ordinary - if surprising - password rather than something the console can tell apart from one, and the command succeeds. That commit did not update the IT that depended on the old rejection.

The new behaviour is **asserted explicitly rather than deleted**, so a regression in the other direction is still caught, and a genuine syntax error (`create user albert`, no `IDENTIFIED BY` at all) takes over the syntax-error case.

## Verification

All run locally in this worktree:

| Suite | Result |
|---|---|
| `mvn -pl engine test -Dgroups=vector` | **72/72** |
| `GraphAnalyticalViewTest` (full class) | **159/159** |
| `mvn -pl postgresw verify -Dit.test=PostgresWJdbcIT` | **45/45** (+426 unit) |
| `mvn -pl console verify -Dit.test=RemoteConsoleIT` | **16/16** |

Plus the arming check described in §1: with the probe delay and *without* the permit saturation the GAV test fails with the exact CI message; with the saturation it passes.

Test-only changes except `postgresw/pom.xml`, which adds a first-party module already in the reactor (no new third-party dependency, no ATTRIBUTIONS/NOTICE impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user command syntax, including passwords containing spaces and invalid authentication clauses.
  * Improved reliability when restoring analytical graph data and selecting available providers.
  * Extended asynchronous graph rebuild wait periods to better accommodate longer-running operations.

* **Tests**
  * Added clearer diagnostics for rebuild timeouts and deferred data restoration scenarios.
  * Strengthened coverage for console commands, graph analytics, vector indexing, and PostgreSQL connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->