### PR TITLE
fix(#6875): coerce a server setting to its declared type, and make the two read paths one parse

### DIFF
--- a/engine/src/main/java/com/arcadedb/ContextConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/ContextConfiguration.java
@@ -201,7 +201,7 @@ public class ContextConfiguration implements Serializable {
     final Object v = getValue(iConfig);
     if (v == null)
       return 0;
-    return v instanceof Number n ? n.intValue() : (int) FileUtils.getSizeAsNumber(v.toString().trim());
+    return iConfig.narrowToInteger(v instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(v.toString().trim()));
   }
 
   public long getValueAsLong(final GlobalConfiguration iConfig) {

--- a/engine/src/main/java/com/arcadedb/ContextConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/ContextConfiguration.java
@@ -19,6 +19,7 @@
 package com.arcadedb;
 
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.SystemVariableResolver;
 
 import java.io.Serializable;
@@ -188,25 +189,33 @@ public class ContextConfiguration implements Serializable {
     return getVariable(v.toString(), "");
   }
 
+  /**
+   * Issue #6875: this reads through {@link FileUtils#getSizeAsNumber(Object)}, not {@code Integer.parseInt}, so that
+   * it and {@link GlobalConfiguration#getValueAsInteger()} are one parse rather than two that disagree. The context
+   * map can hold a raw string that never passed through {@link GlobalConfiguration#coerce(Object)} - {@link #fromJSON}
+   * and the {@link Map} constructor both put one straight in - and such a value used to read as 1048576 through the
+   * global accessor and throw {@code NumberFormatException} through this one. {@code getSizeAsNumber} is a strict
+   * superset of {@code Integer.parseInt}, so nothing that read before stops reading.
+   */
   public int getValueAsInteger(final GlobalConfiguration iConfig) {
     final Object v = getValue(iConfig);
     if (v == null)
       return 0;
-    return v instanceof Integer i ? i : Integer.parseInt(v.toString().trim());
+    return v instanceof Number n ? n.intValue() : (int) FileUtils.getSizeAsNumber(v.toString().trim());
   }
 
   public long getValueAsLong(final GlobalConfiguration iConfig) {
     final Object v = getValue(iConfig);
     if (v == null)
       return 0;
-    return v instanceof Long l ? l : Long.parseLong(v.toString().trim());
+    return v instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(v.toString().trim());
   }
 
   public float getValueAsFloat(final GlobalConfiguration iConfig) {
     final Object v = getValue(iConfig);
     if (v == null)
       return 0;
-    return v instanceof Float f ? f : Float.parseFloat(v.toString().trim());
+    return v instanceof Number n ? n.floatValue() : Float.parseFloat(v.toString().trim());
   }
 
   public Set<String> getContextKeys() {

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2528,15 +2528,11 @@ public enum GlobalConfiguration {
       if (type == Boolean.class)
         return iValue instanceof Boolean b ? b : Boolean.parseBoolean(iValue.toString().trim());
 
-      if (type == Integer.class) {
+      if (type == Integer.class)
         // the range check has to cover a boxed Number too, not just the parsed-from-text path: Number.intValue()
         // keeps the low 32 bits, so a Long outside the int range would be stored silently truncated - where the
         // Integer.parseInt this method replaced threw. Every input reaches the same bound.
-        final long parsed = iValue instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(iValue.toString().trim());
-        if (parsed < Integer.MIN_VALUE || parsed > Integer.MAX_VALUE)
-          throw new IllegalArgumentException("outside the range of an Integer");
-        return (int) parsed;
-      }
+        return narrowToInteger(iValue instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(iValue.toString().trim()));
 
       if (type == Long.class)
         return iValue instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(iValue.toString().trim());
@@ -2578,17 +2574,21 @@ public enum GlobalConfiguration {
   }
 
   /**
-   * Returns whether {@link #coerce(Object)} would accept {@code iValue}. Intended for callers that want to reject a
-   * value before storing it rather than handle the exception - see {@link #coerce(Object)} for why the two writers
-   * outside this class have to ask.
+   * Narrows an integral value to the {@code int} an {@code Integer} setting holds, refusing rather than truncating
+   * one outside the range.
+   * <p>
+   * Issue #6875: this is shared by {@link #coerce(Object)}, {@link #getValueAsInteger()} and
+   * {@link ContextConfiguration#getValueAsInteger(GlobalConfiguration)} so that the bound holds on the READ side
+   * too. Not every value reaches a configuration map through {@code coerce}:
+   * {@link ContextConfiguration#setValue(GlobalConfiguration, Object)} is a plain map put, so a boxed {@code Long}
+   * outside the {@code int} range can be stored, and {@code Number.intValue()} would then hand back its
+   * wrapped-around low 32 bits instead of failing.
    */
-  public boolean isAssignable(final Object iValue) {
-    try {
-      coerce(iValue);
-      return true;
-    } catch (final IllegalArgumentException e) {
-      return false;
-    }
+  int narrowToInteger(final long value) {
+    if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE)
+      throw new NumberFormatException(
+          "Value '" + value + "' is not valid for setting '" + key + "' of type Integer: outside the range of an Integer");
+    return (int) value;
   }
 
   public void setValue(final Object iValue) {
@@ -2640,7 +2640,7 @@ public enum GlobalConfiguration {
    */
   public int getValueAsInteger() {
     final Object v = value != nullValue && value != null ? value : defValue;
-    return v instanceof Number n ? n.intValue() : (int) FileUtils.getSizeAsNumber(v.toString().trim());
+    return narrowToInteger(v instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(v.toString().trim()));
   }
 
   public long getValueAsLong() {

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2566,11 +2566,16 @@ public enum GlobalConfiguration {
    * fractional one rather than truncating it.
    * <p>
    * Issue #6875: the {@code Integer.parseInt}/{@code Long.parseLong} this replaced threw on {@code "6.7"}, and
-   * both routes into here can carry a fraction - {@code FileUtils.getSizeAsNumber} reads a plain {@code "6.7"} as
-   * a double and keeps its integral part, and {@code ALTER DATABASE ... SETTING} hands over whatever an arbitrary
-   * SQL expression evaluated to, so an unquoted {@code 6.7} arrives already boxed as a {@code Double}. A
-   * size-suffixed {@code "1.5MB"} is a different thing - a fraction OF A UNIT whose byte count is a whole number -
-   * and stays accepted.
+   * both routes into here can carry a fraction - {@code FileUtils.getSizeAsNumber} reads a decimal mantissa as a
+   * {@code float} and keeps only the integral part of the result, and {@code ALTER DATABASE ... SETTING} hands
+   * over whatever an arbitrary SQL expression evaluated to, so an unquoted {@code 6.7} arrives already boxed as a
+   * {@code Double}.
+   * <p>
+   * A decimal mantissa is refused outright rather than accepted when the product happens to land on a whole
+   * number. {@code "1.5MB"} would, {@code "6.7KB"} (6860.8 bytes) would not, and a rule that turns on which
+   * decimal fraction happens to be a power of two is not one an operator can predict; refusing every decimal is
+   * also exactly what the parsers this replaced did. A size SUFFIX on a whole mantissa - {@code "64MB"} - stays
+   * accepted, which is the widening this issue argued for.
    */
   private long coerceToIntegral(final Object iValue) {
     try {
@@ -2585,10 +2590,9 @@ public enum GlobalConfiguration {
       }
 
       final String text = iValue.toString().trim();
-      final long parsed = FileUtils.getSizeAsNumber(text);
-      if (!text.isEmpty() && text.indexOf('.') > -1 && Character.isDigit(text.charAt(text.length() - 1)))
+      if (text.indexOf('.') > -1)
         throw new IllegalArgumentException("not a whole number");
-      return parsed;
+      return FileUtils.getSizeAsNumber(text);
     } catch (final RuntimeException e) {
       throw invalidValue(iValue, e);
     }

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2529,9 +2529,10 @@ public enum GlobalConfiguration {
         return iValue instanceof Boolean b ? b : Boolean.parseBoolean(iValue.toString().trim());
 
       if (type == Integer.class) {
-        if (iValue instanceof Number n)
-          return n.intValue();
-        final long parsed = FileUtils.getSizeAsNumber(iValue.toString().trim());
+        // the range check has to cover a boxed Number too, not just the parsed-from-text path: Number.intValue()
+        // keeps the low 32 bits, so a Long outside the int range would be stored silently truncated - where the
+        // Integer.parseInt this method replaced threw. Every input reaches the same bound.
+        final long parsed = iValue instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(iValue.toString().trim());
         if (parsed < Integer.MIN_VALUE || parsed > Integer.MAX_VALUE)
           throw new IllegalArgumentException("outside the range of an Integer");
         return (int) parsed;

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2524,18 +2524,18 @@ public enum GlobalConfiguration {
     if (iValue == null)
       return null;
 
+    // Both integral types share one parse, and it is applied OUTSIDE the wrapping below: coerceToIntegral and
+    // narrowToInteger each produce a message that already names the key, the type and the value, so re-wrapping
+    // them here would only bury the specific reason ("not a whole number", "outside the range") in a cause.
+    if (type == Integer.class)
+      return narrowToInteger(coerceToIntegral(iValue));
+
+    if (type == Long.class)
+      return coerceToIntegral(iValue);
+
     try {
       if (type == Boolean.class)
         return iValue instanceof Boolean b ? b : Boolean.parseBoolean(iValue.toString().trim());
-
-      if (type == Integer.class)
-        // the range check has to cover a boxed Number too, not just the parsed-from-text path: Number.intValue()
-        // keeps the low 32 bits, so a Long outside the int range would be stored silently truncated - where the
-        // Integer.parseInt this method replaced threw. Every input reaches the same bound.
-        return narrowToInteger(iValue instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(iValue.toString().trim()));
-
-      if (type == Long.class)
-        return iValue instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(iValue.toString().trim());
 
       if (type == Float.class)
         return iValue instanceof Number n ? n.floatValue() : Float.parseFloat(iValue.toString().trim());
@@ -2557,20 +2557,61 @@ public enum GlobalConfiguration {
 
       return iValue;
     } catch (final RuntimeException e) {
-      final String message =
-          "Value '" + iValue + "' is not valid for setting '" + key + "' of type " + type.getSimpleName();
-
-      // A numeric setting keeps reporting a bad value as a NumberFormatException. It is a subclass of
-      // IllegalArgumentException, so a caller that catches the general form is unaffected either way, while one
-      // that distinguishes a malformed number - GlobalConfigurationTest.typeConversion does - still can. The
-      // message is the enriched one regardless: 'For input string: "A"', which is what FileUtils.getSizeAsNumber
-      // surfaces for "abc", names neither the setting nor what was actually sent.
-      final IllegalArgumentException failure = type == Integer.class || type == Long.class || type == Float.class ?
-          new NumberFormatException(message) :
-          new IllegalArgumentException(message);
-      failure.initCause(e);
-      throw failure;
+      throw invalidValue(iValue, e);
     }
+  }
+
+  /**
+   * Reads {@code iValue} as the whole number an {@code Integer} or {@code Long} setting holds, refusing a
+   * fractional one rather than truncating it.
+   * <p>
+   * Issue #6875: the {@code Integer.parseInt}/{@code Long.parseLong} this replaced threw on {@code "6.7"}, and
+   * both routes into here can carry a fraction - {@code FileUtils.getSizeAsNumber} reads a plain {@code "6.7"} as
+   * a double and keeps its integral part, and {@code ALTER DATABASE ... SETTING} hands over whatever an arbitrary
+   * SQL expression evaluated to, so an unquoted {@code 6.7} arrives already boxed as a {@code Double}. A
+   * size-suffixed {@code "1.5MB"} is a different thing - a fraction OF A UNIT whose byte count is a whole number -
+   * and stays accepted.
+   */
+  private long coerceToIntegral(final Object iValue) {
+    try {
+      if (iValue instanceof Integer || iValue instanceof Long || iValue instanceof Short || iValue instanceof Byte)
+        return ((Number) iValue).longValue();
+
+      if (iValue instanceof Number n) {
+        final double asDouble = n.doubleValue();
+        if (Double.isNaN(asDouble) || Double.isInfinite(asDouble) || asDouble != Math.rint(asDouble))
+          throw new IllegalArgumentException("not a whole number");
+        return n.longValue();
+      }
+
+      final String text = iValue.toString().trim();
+      final long parsed = FileUtils.getSizeAsNumber(text);
+      if (!text.isEmpty() && text.indexOf('.') > -1 && Character.isDigit(text.charAt(text.length() - 1)))
+        throw new IllegalArgumentException("not a whole number");
+      return parsed;
+    } catch (final RuntimeException e) {
+      throw invalidValue(iValue, e);
+    }
+  }
+
+  /**
+   * The rejection {@link #coerce(Object)} and {@link #coerceToIntegral(Object)} raise for a value that is not this
+   * setting's type. A numeric setting keeps reporting it as a {@link NumberFormatException} - a subclass of
+   * {@link IllegalArgumentException}, so a caller that catches the general form is unaffected either way, while one
+   * that distinguishes a malformed number ({@code GlobalConfigurationTest.typeConversion} does) still can. The
+   * message is the enriched one regardless: {@code For input string: "A"}, which is what
+   * {@link FileUtils#getSizeAsNumber(Object)} surfaces for {@code "abc"}, names neither the setting nor what was
+   * actually sent.
+   */
+  private IllegalArgumentException invalidValue(final Object iValue, final RuntimeException cause) {
+    final String message =
+        "Value '" + iValue + "' is not valid for setting '" + key + "' of type " + type.getSimpleName();
+
+    final IllegalArgumentException failure = type == Integer.class || type == Long.class || type == Float.class ?
+        new NumberFormatException(message) :
+        new IllegalArgumentException(message);
+    failure.initCause(cause);
+    return failure;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2495,46 +2495,107 @@ public enum GlobalConfiguration {
     }
   }
 
+  /**
+   * Converts {@code iValue} to this setting's declared {@link #getType() type}, or throws
+   * {@link IllegalArgumentException} naming the key, the type and the offending value when it does not parse.
+   * <p>
+   * Issue #6875: this is the single place a value is turned into a setting's type, so that {@link #setValue(Object)}
+   * and the administrative writers that store into a {@link ContextConfiguration} instead
+   * ({@code set_server_setting} and {@code POST /api/v1/server "set server setting"}) accept and refuse exactly
+   * the same strings. Before it existed the writers stored whatever they were handed and the
+   * {@code NumberFormatException} surfaced later, inside whichever component read the setting next.
+   * <p>
+   * The integral parse is {@link FileUtils#getSizeAsNumber(Object)} on the trimmed text, which is what
+   * {@link #getValueAsInteger()} and {@link #getValueAsLong()} have always used to read one back; it is a strict
+   * superset of {@code Integer.parseInt}/{@code Long.parseLong}, so nothing that parsed before stops parsing.
+   * <p>
+   * {@code Boolean} stays as permissive as {@code Boolean.parseBoolean}, deliberately: {@link #readConfiguration()}
+   * feeds every system property and environment variable through here during this class's static initializer, so
+   * turning a boolean typo into a throw would turn it into an {@code ExceptionInInitializerError} that takes the
+   * whole engine down instead of the setting.
+   *
+   * @param iValue the value to convert, or {@code null}
+   *
+   * @return the value as an instance of {@link #getType()}, or {@code null} when {@code iValue} is {@code null}
+   *
+   * @throws IllegalArgumentException if {@code iValue} cannot be represented as this setting's type
+   */
+  public Object coerce(final Object iValue) {
+    if (iValue == null)
+      return null;
+
+    try {
+      if (type == Boolean.class)
+        return iValue instanceof Boolean b ? b : Boolean.parseBoolean(iValue.toString().trim());
+
+      if (type == Integer.class) {
+        if (iValue instanceof Number n)
+          return n.intValue();
+        final long parsed = FileUtils.getSizeAsNumber(iValue.toString().trim());
+        if (parsed < Integer.MIN_VALUE || parsed > Integer.MAX_VALUE)
+          throw new IllegalArgumentException("outside the range of an Integer");
+        return (int) parsed;
+      }
+
+      if (type == Long.class)
+        return iValue instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(iValue.toString().trim());
+
+      if (type == Float.class)
+        return iValue instanceof Number n ? n.floatValue() : Float.parseFloat(iValue.toString().trim());
+
+      if (type == String.class)
+        return iValue.toString();
+
+      if (type.isEnum()) {
+        if (type.isInstance(iValue))
+          return iValue;
+
+        if (iValue instanceof String string)
+          for (final Object constant : type.getEnumConstants())
+            if (((Enum<?>) constant).name().equalsIgnoreCase(string))
+              return constant;
+
+        throw new IllegalArgumentException("Invalid value of `" + key + "` option");
+      }
+
+      return iValue;
+    } catch (final RuntimeException e) {
+      final String message =
+          "Value '" + iValue + "' is not valid for setting '" + key + "' of type " + type.getSimpleName();
+
+      // A numeric setting keeps reporting a bad value as a NumberFormatException. It is a subclass of
+      // IllegalArgumentException, so a caller that catches the general form is unaffected either way, while one
+      // that distinguishes a malformed number - GlobalConfigurationTest.typeConversion does - still can. The
+      // message is the enriched one regardless: 'For input string: "A"', which is what FileUtils.getSizeAsNumber
+      // surfaces for "abc", names neither the setting nor what was actually sent.
+      final IllegalArgumentException failure = type == Integer.class || type == Long.class || type == Float.class ?
+          new NumberFormatException(message) :
+          new IllegalArgumentException(message);
+      failure.initCause(e);
+      throw failure;
+    }
+  }
+
+  /**
+   * Returns whether {@link #coerce(Object)} would accept {@code iValue}. Intended for callers that want to reject a
+   * value before storing it rather than handle the exception - see {@link #coerce(Object)} for why the two writers
+   * outside this class have to ask.
+   */
+  public boolean isAssignable(final Object iValue) {
+    try {
+      coerce(iValue);
+      return true;
+    } catch (final IllegalArgumentException e) {
+      return false;
+    }
+  }
+
   public void setValue(final Object iValue) {
     final Object oldValue = value;
     explicitlySet = true;
 
     try {
-      if (iValue == null)
-        value = null;
-      else if (type == Boolean.class)
-        value = Boolean.parseBoolean(iValue.toString());
-      else if (type == Integer.class)
-        value = Integer.parseInt(iValue.toString());
-      else if (type == Long.class)
-        value = Long.parseLong(iValue.toString());
-      else if (type == Float.class)
-        value = Float.parseFloat(iValue.toString());
-      else if (type == String.class)
-        value = iValue.toString();
-      else if (type.isEnum()) {
-        boolean accepted = false;
-
-        if (type.isInstance(iValue)) {
-          value = iValue;
-          accepted = true;
-        } else if (iValue instanceof String string) {
-
-          for (final Object constant : type.getEnumConstants()) {
-            final Enum<?> enumConstant = (Enum<?>) constant;
-
-            if (enumConstant.name().equalsIgnoreCase(string)) {
-              value = enumConstant;
-              accepted = true;
-              break;
-            }
-          }
-        }
-
-        if (!accepted)
-          throw new IllegalArgumentException("Invalid value of `" + key + "` option");
-      } else
-        value = iValue;
+      value = coerce(iValue);
 
       if (callback != null)
         try {
@@ -2570,19 +2631,25 @@ public enum GlobalConfiguration {
         defValue != null ? SystemVariableResolver.INSTANCE.resolveSystemVariables(defValue.toString(), "") : null;
   }
 
+  /**
+   * Issue #6875: the trim, and the {@link Number} test widened from {@code Float}, keep this accessor and
+   * {@link ContextConfiguration#getValueAsInteger(GlobalConfiguration)} on exactly one parse. A value that reaches
+   * either holder without passing through {@link #coerce(Object)} - {@code ContextConfiguration.fromJSON}, the
+   * {@code Map} constructor - used to read back differently depending on which of the two a component happened to call.
+   */
   public int getValueAsInteger() {
     final Object v = value != nullValue && value != null ? value : defValue;
-    return (int) (v instanceof Number n ? n.intValue() : FileUtils.getSizeAsNumber(v.toString()));
+    return v instanceof Number n ? n.intValue() : (int) FileUtils.getSizeAsNumber(v.toString().trim());
   }
 
   public long getValueAsLong() {
     final Object v = value != nullValue && value != null ? value : defValue;
-    return v instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(v.toString());
+    return v instanceof Number n ? n.longValue() : FileUtils.getSizeAsNumber(v.toString().trim());
   }
 
   public float getValueAsFloat() {
     final Object v = value != nullValue && value != null ? value : defValue;
-    return v instanceof Float f ? f : Float.parseFloat(v.toString());
+    return v instanceof Number n ? n.floatValue() : Float.parseFloat(v.toString().trim());
   }
 
   public String getKey() {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterDatabaseStatement.java
@@ -98,6 +98,11 @@ public class AlterDatabaseStatement extends DDLStatement {
     }
 
     if (saveInDatabaseConfiguration) {
+      // Issue #6875: the third writer into a ContextConfiguration, after the set_server_setting MCP tool and the
+      // "set server setting" HTTP command. ContextConfiguration.setValue is a plain map put, so without this the
+      // SQL surface could store a value that is not the setting's declared type - accepted here with a result row,
+      // and thrown on later inside whichever component read the setting next.
+      finalValue = cfg.coerce(finalValue);
       db.getConfiguration().setValue(cfg, finalValue);
       try {
         db.saveConfiguration();

--- a/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
@@ -208,6 +208,34 @@ class Issue6875SettingValueCoercionTest {
     assertThat(okCtx.getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS)).isEqualTo(12);
   }
 
+  /**
+   * A fraction is refused rather than truncated for an integral setting, from either route in: the
+   * {@code Integer.parseInt} this replaced threw on {@code "6.7"}, and {@code ALTER DATABASE ... SETTING} hands
+   * over whatever an arbitrary SQL expression evaluated to, so an unquoted {@code 6.7} arrives already boxed.
+   */
+  @Test
+  void coerceRefusesAFractionalValueForAnIntegralSetting() {
+    assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(6.7d))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.asyncWorkerThreads");
+    assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(6.7f))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.coerce("6.7"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce(6.7d))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.commitLockTimeout");
+    assertThatThrownBy(() -> GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("6.7"))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // a Double that IS a whole number is fine, and so is a fraction OF A UNIT whose byte count is whole
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(6.0d)).isEqualTo(6);
+    assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("1.5MB")).isEqualTo(1024L * 1024 * 3 / 2);
+
+    // a Float setting is unaffected: a fraction is exactly what it holds
+    assertThat(GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE.coerce(0.25d)).isEqualTo(0.25f);
+  }
+
   /** {@code coerce} returns the DECLARED type, not merely something numeric: a Long setting must not yield an Integer. */
   @Test
   void coerceReturnsTheDeclaredType() {

--- a/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
@@ -97,7 +97,6 @@ class Issue6875SettingValueCoercionTest {
 
   private void assertReadableThroughBothAccessors(final GlobalConfiguration cfg, final String value) {
     final Object coerced = cfg.coerce(value);
-    assertThat(cfg.isAssignable(value)).as("isAssignable('%s') for %s", value, cfg.getKey()).isTrue();
 
     final ContextConfiguration ctx = new ContextConfiguration();
     ctx.setValue(cfg.getKey(), coerced);
@@ -143,10 +142,6 @@ class Issue6875SettingValueCoercionTest {
     assertThatThrownBy(() -> GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE.coerce("half"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("arcadedb.serverMetrics.tracing.samplingRate");
-
-    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.isAssignable("abc")).isFalse();
-    assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.isAssignable("soon")).isFalse();
-    assertThat(GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE.isAssignable("half")).isFalse();
   }
 
   /** An Integer setting cannot hold a value only a Long can represent: truncating it would be a silent wrong answer. */
@@ -155,7 +150,6 @@ class Issue6875SettingValueCoercionTest {
     assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.coerce("64GB"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("arcadedb.asyncWorkerThreads");
-    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.isAssignable("64GB")).isFalse();
 
     // the same magnitude is fine for a Long setting
     assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("64GB")).isEqualTo(64L * 1024 * 1024 * 1024);
@@ -171,7 +165,6 @@ class Issue6875SettingValueCoercionTest {
     assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(5_000_000_000L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("arcadedb.asyncWorkerThreads");
-    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.isAssignable(5_000_000_000L)).isFalse();
 
     // and the setter built on it refuses the same input rather than storing the truncated low 32 bits
     final Object previous = GlobalConfiguration.ASYNC_WORKER_THREADS.getValue();
@@ -186,6 +179,33 @@ class Issue6875SettingValueCoercionTest {
     // a value inside the range still goes through untouched, from either form
     assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(12L)).isEqualTo(12);
     assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(12)).isEqualTo(12);
+  }
+
+  /**
+   * The same bound has to hold when READING, because not every value reaches a configuration map through
+   * {@code coerce}: {@link ContextConfiguration#setValue(GlobalConfiguration, Object)} is a plain map put, and
+   * {@code ALTER DATABASE ... SETTING} used it directly. Widening the accessor's {@code instanceof} from
+   * {@code Integer} to {@code Number} would otherwise have turned the {@code Integer.parseInt} that used to throw
+   * on such a value into a silent truncation to its low 32 bits.
+   */
+  @Test
+  void bothAccessorsRefuseAStoredIntegralValueOutsideTheIntegerRange() {
+    final ContextConfiguration ctx = new ContextConfiguration();
+    ctx.setValue(GlobalConfiguration.ASYNC_WORKER_THREADS, 5_000_000_000L);
+    assertThatThrownBy(() -> ctx.getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.asyncWorkerThreads");
+
+    // the same text stored as a string is refused identically, so the two accessors still agree
+    final ContextConfiguration textCtx = new ContextConfiguration();
+    textCtx.setValue(GlobalConfiguration.ASYNC_WORKER_THREADS.getKey(), "5000000000");
+    assertThatThrownBy(() -> textCtx.getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // a Long inside the range is still read, not refused
+    final ContextConfiguration okCtx = new ContextConfiguration();
+    okCtx.setValue(GlobalConfiguration.ASYNC_WORKER_THREADS, 12L);
+    assertThat(okCtx.getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS)).isEqualTo(12);
   }
 
   /** {@code coerce} returns the DECLARED type, not merely something numeric: a Long setting must not yield an Integer. */

--- a/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
@@ -161,6 +161,33 @@ class Issue6875SettingValueCoercionTest {
     assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("64GB")).isEqualTo(64L * 1024 * 1024 * 1024);
   }
 
+  /**
+   * The bound has to hold for a boxed {@link Number} too, and not only for text parsed by
+   * {@code FileUtils.getSizeAsNumber}: {@code Number.intValue()} keeps the low 32 bits, so an out-of-range
+   * {@code Long} would be stored silently truncated - where the {@code Integer.parseInt} this replaced threw.
+   */
+  @Test
+  void coerceRejectsAnOutOfRangeNumberAsWellAsAnOutOfRangeString() {
+    assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(5_000_000_000L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.asyncWorkerThreads");
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.isAssignable(5_000_000_000L)).isFalse();
+
+    // and the setter built on it refuses the same input rather than storing the truncated low 32 bits
+    final Object previous = GlobalConfiguration.ASYNC_WORKER_THREADS.getValue();
+    try {
+      assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.setValue(5_000_000_000L))
+          .isInstanceOf(IllegalArgumentException.class);
+      assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.getValueAsInteger()).isNotEqualTo((int) 5_000_000_000L);
+    } finally {
+      GlobalConfiguration.ASYNC_WORKER_THREADS.setValue(previous);
+    }
+
+    // a value inside the range still goes through untouched, from either form
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(12L)).isEqualTo(12);
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(12)).isEqualTo(12);
+  }
+
   /** {@code coerce} returns the DECLARED type, not merely something numeric: a Long setting must not yield an Integer. */
   @Test
   void coerceReturnsTheDeclaredType() {

--- a/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
@@ -228,9 +228,18 @@ class Issue6875SettingValueCoercionTest {
     assertThatThrownBy(() -> GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("6.7"))
         .isInstanceOf(IllegalArgumentException.class);
 
-    // a Double that IS a whole number is fine, and so is a fraction OF A UNIT whose byte count is whole
+    // a decimal mantissa is refused with a size suffix too, whether or not the product lands on a whole number:
+    // 6.7KB is 6860.8 bytes, and 1.5MB is whole only because 0.5 is a power of two. A rule that turns on which
+    // fraction happens to be binary-exact is not one an operator can predict, so neither is accepted.
+    assertThatThrownBy(() -> GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("6.7KB"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.commitLockTimeout");
+    assertThatThrownBy(() -> GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("1.5MB"))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // a Double that IS a whole number is fine, and so is a size suffix on a whole mantissa
     assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.coerce(6.0d)).isEqualTo(6);
-    assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("1.5MB")).isEqualTo(1024L * 1024 * 3 / 2);
+    assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("2MB")).isEqualTo(2L * 1024 * 1024);
 
     // a Float setting is unaffected: a fraction is exactly what it holds
     assertThat(GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE.coerce(0.25d)).isEqualTo(0.25f);

--- a/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6875SettingValueCoercionTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6875, a follow-up to #6837. Two defects that compound.
+ * <p>
+ * The writers ({@code set_server_setting} and its HTTP twin) stored the caller's raw string in the
+ * {@link ContextConfiguration} map without checking it against {@link GlobalConfiguration#getType()}, so an
+ * unparseable value was accepted with a success envelope and blew up later, inside whichever component read
+ * the setting next.
+ * <p>
+ * Underneath that, the two accessors for the same setting did not agree on what parses:
+ * {@link GlobalConfiguration#getValueAsInteger()} coerces a non-{@code Number} through
+ * {@link FileUtils#getSizeAsNumber(Object)} (so {@code "1MB"} reads), while
+ * {@link ContextConfiguration#getValueAsInteger(GlobalConfiguration)} used {@code Integer.parseInt} (so the
+ * same stored string threw). A validator written against either one alone would have been wrong for the
+ * other, which is why the accessors are reconciled here first and the coercion helper built on top of it.
+ * <p>
+ * These tests hold a {@link ContextConfiguration} of their own rather than mutating the JVM-wide
+ * {@link GlobalConfiguration} values, except where the global accessor itself is under test - those cases
+ * restore the previous value in a {@code finally}.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6875SettingValueCoercionTest {
+
+  /**
+   * The bug, at the accessor level: a raw string reaching the context map (from a writer, from
+   * {@code fromJSON}, from the {@code Map} constructor) had to read back the same through both accessors.
+   * Before the fix this threw {@code NumberFormatException} on the context path while the global path
+   * returned 1048576 for the very same text.
+   */
+  @Test
+  void bothAccessorsAgreeOnASizeSuffixedIntegralValue() {
+    final ContextConfiguration ctx = new ContextConfiguration();
+    ctx.setValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.getKey(), "1MB");
+
+    assertThat(ctx.getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT)).isEqualTo(1024L * 1024L);
+    assertThat(ctx.getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT))
+        .isEqualTo(FileUtils.getSizeAsNumber("1MB"));
+
+    final ContextConfiguration intCtx = new ContextConfiguration();
+    intCtx.setValue(GlobalConfiguration.ASYNC_WORKER_THREADS.getKey(), "1KB");
+    assertThat(intCtx.getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS)).isEqualTo(1024);
+  }
+
+  /** Whitespace around a value is tolerated identically on both paths - the HTTP twin used to leave a leading space. */
+  @Test
+  void bothAccessorsTolerateSurroundingWhitespace() {
+    final ContextConfiguration ctx = new ContextConfiguration();
+    ctx.setValue(GlobalConfiguration.ASYNC_WORKER_THREADS.getKey(), " 7 ");
+    assertThat(ctx.getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS)).isEqualTo(7);
+
+    final Object previous = GlobalConfiguration.ASYNC_WORKER_THREADS.getValue();
+    try {
+      GlobalConfiguration.ASYNC_WORKER_THREADS.setValue(" 7 ");
+      assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.getValueAsInteger()).isEqualTo(7);
+    } finally {
+      GlobalConfiguration.ASYNC_WORKER_THREADS.setValue(previous);
+    }
+  }
+
+  /** The regression the issue asks for: what {@code coerce} accepts must read back through BOTH accessors. */
+  @Test
+  void aCoercedValueIsReadableThroughBothAccessors() {
+    assertReadableThroughBothAccessors(GlobalConfiguration.ASYNC_WORKER_THREADS, "12");
+    assertReadableThroughBothAccessors(GlobalConfiguration.ASYNC_WORKER_THREADS, "1KB");
+    assertReadableThroughBothAccessors(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, "7500");
+    assertReadableThroughBothAccessors(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, "2MB");
+    assertReadableThroughBothAccessors(GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE, "0.25");
+    assertReadableThroughBothAccessors(GlobalConfiguration.DATE_TIME_FORMAT, "yyyy-MM-dd HH:mm:ss");
+  }
+
+  private void assertReadableThroughBothAccessors(final GlobalConfiguration cfg, final String value) {
+    final Object coerced = cfg.coerce(value);
+    assertThat(cfg.isAssignable(value)).as("isAssignable('%s') for %s", value, cfg.getKey()).isTrue();
+
+    final ContextConfiguration ctx = new ContextConfiguration();
+    ctx.setValue(cfg.getKey(), coerced);
+
+    final Object previous = cfg.getValue();
+    try {
+      cfg.setValue(value);
+      if (cfg.getType() == Integer.class)
+        assertThat(ctx.getValueAsInteger(cfg)).isEqualTo(cfg.getValueAsInteger());
+      else if (cfg.getType() == Long.class)
+        assertThat(ctx.getValueAsLong(cfg)).isEqualTo(cfg.getValueAsLong());
+      else if (cfg.getType() == Float.class)
+        assertThat(ctx.getValueAsFloat(cfg)).isEqualTo(cfg.getValueAsFloat());
+      else
+        assertThat(ctx.getValueAsString(cfg)).isEqualTo(cfg.getValueAsString());
+    } finally {
+      cfg.setValue(previous);
+    }
+
+    // and the raw string, stored uncoerced the way fromJSON stores it, reads back the same
+    final ContextConfiguration rawCtx = new ContextConfiguration();
+    rawCtx.setValue(cfg.getKey(), value);
+    if (cfg.getType() == Integer.class)
+      assertThat(rawCtx.getValueAsInteger(cfg)).isEqualTo(((Number) coerced).intValue());
+    else if (cfg.getType() == Long.class)
+      assertThat(rawCtx.getValueAsLong(cfg)).isEqualTo(((Number) coerced).longValue());
+    else if (cfg.getType() == Float.class)
+      assertThat(rawCtx.getValueAsFloat(cfg)).isEqualTo(((Number) coerced).floatValue());
+  }
+
+  @Test
+  void coerceRejectsAnUnparseableValueForATypedSetting() {
+    assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.coerce("abc"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.asyncWorkerThreads")
+        .hasMessageContaining("Integer")
+        .hasMessageContaining("abc");
+
+    assertThatThrownBy(() -> GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("soon"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.commitLockTimeout");
+
+    assertThatThrownBy(() -> GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE.coerce("half"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.serverMetrics.tracing.samplingRate");
+
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.isAssignable("abc")).isFalse();
+    assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.isAssignable("soon")).isFalse();
+    assertThat(GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE.isAssignable("half")).isFalse();
+  }
+
+  /** An Integer setting cannot hold a value only a Long can represent: truncating it would be a silent wrong answer. */
+  @Test
+  void coerceRejectsAnIntegralValueOutsideTheIntegerRange() {
+    assertThatThrownBy(() -> GlobalConfiguration.ASYNC_WORKER_THREADS.coerce("64GB"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.asyncWorkerThreads");
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.isAssignable("64GB")).isFalse();
+
+    // the same magnitude is fine for a Long setting
+    assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("64GB")).isEqualTo(64L * 1024 * 1024 * 1024);
+  }
+
+  /** {@code coerce} returns the DECLARED type, not merely something numeric: a Long setting must not yield an Integer. */
+  @Test
+  void coerceReturnsTheDeclaredType() {
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.coerce("3")).isInstanceOf(Integer.class);
+    assertThat(GlobalConfiguration.COMMIT_LOCK_TIMEOUT.coerce("3")).isInstanceOf(Long.class);
+    assertThat(GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE.coerce("0.5")).isInstanceOf(Float.class);
+    assertThat(GlobalConfiguration.DATE_TIME_FORMAT.coerce("yyyy")).isInstanceOf(String.class);
+  }
+
+  /**
+   * The global setter and the coercion helper are the same parse by construction, so a value the helper
+   * accepts is a value {@code setValue} stores, and one it refuses is one {@code setValue} refuses.
+   */
+  @Test
+  void theGlobalSetterAndTheCoercionHelperAgree() {
+    final Object previous = GlobalConfiguration.COMMIT_LOCK_TIMEOUT.getValue();
+    try {
+      assertThatCode(() -> GlobalConfiguration.COMMIT_LOCK_TIMEOUT.setValue("1KB")).doesNotThrowAnyException();
+      assertThat((Object) GlobalConfiguration.COMMIT_LOCK_TIMEOUT.getValue()).isEqualTo(1024L);
+
+      assertThatThrownBy(() -> GlobalConfiguration.COMMIT_LOCK_TIMEOUT.setValue("soon"))
+          .isInstanceOf(IllegalArgumentException.class);
+      // a rejected set leaves the previous value in place
+      assertThat((Object) GlobalConfiguration.COMMIT_LOCK_TIMEOUT.getValue()).isEqualTo(1024L);
+    } finally {
+      GlobalConfiguration.COMMIT_LOCK_TIMEOUT.setValue(previous);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue6875AlterDatabaseSettingCoercionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue6875AlterDatabaseSettingCoercionTest.java
@@ -60,6 +60,19 @@ class Issue6875AlterDatabaseSettingCoercionTest extends TestHelper {
     assertThat(database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS)).isEqualTo(6);
   }
 
+  /**
+   * The SQL value is an arbitrary expression, so an unquoted {@code 6.7} reaches the setting already boxed as a
+   * floating-point number rather than as text. It must be refused, not truncated to 6.
+   */
+  @Test
+  void alterDatabaseRefusesAFractionalValueForAnIntegralSetting() {
+    assertThatThrownBy(() -> database.command("sql", "alter database `arcadedb.asyncWorkerThreads` 6.7"))
+        .hasMessageContaining("arcadedb.asyncWorkerThreads");
+
+    assertThatCode(() -> database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS))
+        .doesNotThrowAnyException();
+  }
+
   /** A String setting is unaffected: it takes any text, quotes stripped by the expression evaluator as before. */
   @Test
   void alterDatabaseStillAcceptsAnyTextForAStringSetting() {

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue6875AlterDatabaseSettingCoercionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue6875AlterDatabaseSettingCoercionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6875: {@code ALTER DATABASE ... SETTING} is the third writer into a {@code ContextConfiguration}, after the
+ * {@code set_server_setting} MCP tool and the {@code "set server setting"} HTTP command, and it stored the evaluated
+ * SQL expression with the same plain map put the other two used. It now goes through
+ * {@link GlobalConfiguration#coerce(Object)} as well, so a value that is not the setting's declared type is refused
+ * by the statement that names it rather than by whichever component reads the setting next.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6875AlterDatabaseSettingCoercionTest extends TestHelper {
+
+  @Test
+  void alterDatabaseRefusesAValueThatIsNotTheSettingType() {
+    assertThatThrownBy(() -> database.command("sql", "alter database `arcadedb.asyncWorkerThreads` 'abc'"))
+        .hasMessageContaining("arcadedb.asyncWorkerThreads");
+
+    // the refused statement is not the one that breaks a later read
+    assertThatCode(() -> database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void alterDatabaseStoresACoercedTypedValue() {
+    try (final ResultSet result = database.command("sql", "alter database `arcadedb.asyncWorkerThreads` '6'")) {
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().<Object>getProperty("newValue")).isEqualTo(6);
+    }
+
+    assertThat((Object) database.getConfiguration().getValue(GlobalConfiguration.ASYNC_WORKER_THREADS))
+        .isInstanceOf(Integer.class).isEqualTo(6);
+    assertThat(database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS)).isEqualTo(6);
+  }
+
+  /** A String setting is unaffected: it takes any text, quotes stripped by the expression evaluator as before. */
+  @Test
+  void alterDatabaseStillAcceptsAnyTextForAStringSetting() {
+    database.command("sql", "alter database `arcadedb.externalPropertyBucketPath` 'not a number at all'").close();
+    assertThat(database.getConfiguration().getValueAsString(GlobalConfiguration.EXTERNAL_PROPERTY_BUCKET_PATH))
+        .isEqualTo("not a number at all");
+  }
+}

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/SetServerSettingTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/SetServerSettingTool.java
@@ -79,8 +79,16 @@ public class SetServerSettingTool {
       throw new IllegalArgumentException(
           "'value' must not be empty for setting '" + key + "' of type " + cfg.getType().getSimpleName());
 
+    // A non-empty value still has to BE the setting's type (#6875). ContextConfiguration.setValue is a plain map
+    // put, so before this coercion "arcadedb.asyncWorkerThreads"="abc" was answered with isError:false and the
+    // NumberFormatException surfaced later, inside whichever component read the setting next. Coercing here also
+    // means the map holds a typed value, which both GlobalConfiguration's and ContextConfiguration's accessors
+    // return without re-parsing. GlobalConfiguration.coerce is the same parse the global setter uses, so this tool
+    // and its HTTP twin refuse exactly what setValue refuses.
+    final Object coerced = cfg.coerce(value);
+
     final Object oldValue = server.getConfiguration().getValue(cfg);
-    server.getConfiguration().setValue(key, value);
+    server.getConfiguration().setValue(cfg.getKey(), coerced);
 
     final JSONObject result = new JSONObject();
     result.put("key", key);
@@ -90,7 +98,8 @@ public class SetServerSettingTool {
     // so an unset secret cannot be distinguished from a set one either.
     result.put("previousValue",
         cfg.isHidden() ? "*****" : oldValue != null ? oldValue.toString() : JSONObject.NULL);
-    result.put("newValue", value);
+    // the value as STORED, which for a typed setting is the coerced form rather than the text the caller sent
+    result.put("newValue", coerced != null ? coerced.toString() : JSONObject.NULL);
     result.put("message", "Setting '" + key + "' updated successfully.");
     return result;
   }

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/SetServerSettingTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/SetServerSettingTool.java
@@ -98,8 +98,11 @@ public class SetServerSettingTool {
     // so an unset secret cannot be distinguished from a set one either.
     result.put("previousValue",
         cfg.isHidden() ? "*****" : oldValue != null ? oldValue.toString() : JSONObject.NULL);
-    // the value as STORED, which for a typed setting is the coerced form rather than the text the caller sent
-    result.put("newValue", coerced != null ? coerced.toString() : JSONObject.NULL);
+    // the value as STORED, which for a typed setting is the coerced form rather than the text the caller sent -
+    // masked for a secret on the same terms as previousValue above, so that a response the caller may log, cache
+    // or hand on does not carry a credential this server otherwise refuses to hand back
+    result.put("newValue",
+        cfg.isHidden() ? "*****" : coerced != null ? coerced.toString() : JSONObject.NULL);
     result.put("message", "Setting '" + key + "' updated successfully.");
     return result;
   }

--- a/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6875SetServerSettingCoercionTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6875SetServerSettingCoercionTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mcp.tools;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.mcp.MCPConfiguration;
+import com.arcadedb.mcp.MCPPlugin;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6875, a follow-up to #6837. #6874 stopped {@code set_server_setting} accepting a missing or empty
+ * {@code value}; it left a NON-empty value that is not parseable as the setting's declared type alone, so
+ * {@code {"key":"arcadedb.asyncWorkerThreads","value":"abc"}} still answered {@code isError: false} and deferred
+ * the {@code NumberFormatException} to whichever component read the setting next.
+ * <p>
+ * The tool now coerces through {@link GlobalConfiguration#coerce(Object)} - the same parse
+ * {@link GlobalConfiguration#setValue(Object)} uses - so what it stores is a typed value rather than the caller's
+ * text, and what it refuses is what the global setter refuses.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6875SetServerSettingCoercionTest extends BaseGraphServerTest {
+  private MCPConfiguration   config;
+  private ServerSecurityUser user;
+
+  @BeforeEach
+  void setupMCP() {
+    config = MCPPlugin.of(getServer(0)).getConfiguration();
+    config.setEnabled(true);
+    config.setAllowReads(true);
+    config.setAllowAdmin(true);
+    config.setAllowedUsers(List.of("root"));
+    final JSONObject clearOverrides = new JSONObject();
+    clearOverrides.put("databases", (Object) null);
+    config.updateFrom(clearOverrides);
+    user = getServer(0).getSecurity().authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
+  }
+
+  @Test
+  void rejectsAValueThatIsNotParseableAsTheSettingType() {
+    assertThatThrownBy(() -> SetServerSettingTool.execute(getServer(0), user,
+        new JSONObject().put("key", "arcadedb.asyncWorkerThreads").put("value", "abc"), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("arcadedb.asyncWorkerThreads")
+        .hasMessageContaining("Integer");
+
+    // the rejected call did not become the one that breaks a later read, on either accessor
+    assertThatCode(() -> getServer(0).getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS))
+        .doesNotThrowAnyException();
+    assertThat(getServer(0).getConfiguration().hasValue(GlobalConfiguration.ASYNC_WORKER_THREADS.getKey())).isFalse();
+  }
+
+  @Test
+  void rejectsAFloatValueThatIsNotANumber() {
+    assertThatThrownBy(() -> SetServerSettingTool.execute(getServer(0), user,
+        new JSONObject().put("key", GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE.getKey())
+            .put("value", "half"), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Float");
+  }
+
+  /** What the tool stores is the setting's type, so neither accessor has to re-parse a string to read it back. */
+  @Test
+  void storesACoercedTypedValue() {
+    final GlobalConfiguration setting = GlobalConfiguration.SQL_STATEMENT_CACHE;
+    final boolean hadValue = getServer(0).getConfiguration().hasValue(setting.getKey());
+    final Object previous = getServer(0).getConfiguration().getValue(setting);
+    try {
+      final JSONObject result = SetServerSettingTool.execute(getServer(0), user,
+          new JSONObject().put("key", setting.getKey()).put("value", "500"), config);
+
+      assertThat(result.getString("newValue")).isEqualTo("500");
+      assertThat((Object) getServer(0).getConfiguration().getValue(setting)).isInstanceOf(Integer.class).isEqualTo(500);
+      assertThat(getServer(0).getConfiguration().getValueAsInteger(setting)).isEqualTo(500);
+    } finally {
+      getServer(0).getConfiguration().setValue(setting.getKey(), hadValue ? previous : null);
+    }
+  }
+
+  /**
+   * A size-suffixed value is what {@link GlobalConfiguration#getValueAsLong()} has always read back, so the writer
+   * accepts it too, and stores the number it means rather than the text.
+   */
+  @Test
+  void acceptsASizeSuffixedValueForAnIntegralSetting() {
+    final GlobalConfiguration setting = GlobalConfiguration.COMMIT_LOCK_TIMEOUT;
+    final boolean hadValue = getServer(0).getConfiguration().hasValue(setting.getKey());
+    final Object previous = getServer(0).getConfiguration().getValue(setting);
+    try {
+      SetServerSettingTool.execute(getServer(0), user,
+          new JSONObject().put("key", setting.getKey()).put("value", "1KB"), config);
+
+      assertThat(getServer(0).getConfiguration().getValueAsLong(setting)).isEqualTo(1024L);
+    } finally {
+      getServer(0).getConfiguration().setValue(setting.getKey(), hadValue ? previous : null);
+    }
+  }
+
+  /** A String setting takes any text, including one that would not parse as a number. */
+  @Test
+  void stillAcceptsAnyTextForAStringSetting() {
+    final GlobalConfiguration setting = GlobalConfiguration.DATE_TIME_FORMAT;
+    final boolean hadValue = getServer(0).getConfiguration().hasValue(setting.getKey());
+    final Object previous = getServer(0).getConfiguration().getValue(setting);
+    try {
+      final JSONObject result = SetServerSettingTool.execute(getServer(0), user,
+          new JSONObject().put("key", setting.getKey()).put("value", "yyyy-MM-dd"), config);
+
+      assertThat(result.getString("newValue")).isEqualTo("yyyy-MM-dd");
+      assertThat(getServer(0).getConfiguration().getValueAsString(setting)).isEqualTo("yyyy-MM-dd");
+    } finally {
+      getServer(0).getConfiguration().setValue(setting.getKey(), hadValue ? previous : null);
+    }
+  }
+}

--- a/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6875SetServerSettingCoercionTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/tools/Issue6875SetServerSettingCoercionTest.java
@@ -122,6 +122,29 @@ class Issue6875SetServerSettingCoercionTest extends BaseGraphServerTest {
     }
   }
 
+  /** A secret is masked on the way out of the setter, not only out of the getter. */
+  @Test
+  void masksTheNewValueOfAHiddenSetting() {
+    final GlobalConfiguration setting = GlobalConfiguration.NETWORK_SSL_KEYSTORE_PASSWORD;
+    assertThat(setting.isHidden()).isTrue();
+
+    final boolean hadValue = getServer(0).getConfiguration().hasValue(setting.getKey());
+    final Object previous = getServer(0).getConfiguration().getValue(setting);
+    try {
+      final JSONObject result = SetServerSettingTool.execute(getServer(0), user,
+          new JSONObject().put("key", setting.getKey()).put("value", "s3cr3t-not-in-the-response"), config);
+
+      assertThat(result.getString("newValue")).isEqualTo("*****");
+      assertThat(result.getString("previousValue")).isEqualTo("*****");
+      assertThat(result.toString()).doesNotContain("s3cr3t-not-in-the-response");
+
+      // masked in the response, but still actually stored
+      assertThat(getServer(0).getConfiguration().getValueAsString(setting)).isEqualTo("s3cr3t-not-in-the-response");
+    } finally {
+      getServer(0).getConfiguration().setValue(setting.getKey(), hadValue ? previous : null);
+    }
+  }
+
   /** A String setting takes any text, including one that would not parse as a number. */
   @Test
   void stillAcceptsAnyTextForAStringSetting() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -930,6 +930,12 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
    * validate against, and rejecting it would change behaviour this endpoint has long allowed. The {@code
    * set_server_setting} MCP tool is stricter on that point only - for a DECLARED setting the two now accept and
    * refuse exactly the same values, both through {@link GlobalConfiguration#coerce(Object)}.
+   * <p>
+   * The command is still tokenized on the first space(s) BEFORE the quotes are stripped, so quoting does not make a
+   * space part of a token: a database name or a setting key containing one would split wrong. That is unchanged
+   * here and harmless for what the grammar can address - every {@link GlobalConfiguration} key is a dotted
+   * identifier - and only the trailing {@code <value>}, which is whatever remains after the last split, can hold a
+   * quoted space.
    */
   private void applySetting(final ContextConfiguration configuration, final String rawKey, final String rawValue) {
     final String key = FileUtils.getStringContent(rawKey.trim());

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -884,21 +884,19 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   private void setDatabaseSetting(final String triple) throws IOException {
 
     final String tripleTrimmed = triple.trim();
-    final Integer firstSpace = tripleTrimmed.indexOf(" ");
+    final int firstSpace = tripleTrimmed.indexOf(" ");
     if (firstSpace == -1)
       throw new IllegalArgumentException("Expected <database> <key> <value>");
 
     final String pairTrimmed = tripleTrimmed.substring(firstSpace).trim();
-    final Integer secondSpace = pairTrimmed.indexOf(" ");
+    final int secondSpace = pairTrimmed.indexOf(" ");
     if (secondSpace == -1)
       throw new IllegalArgumentException("Expected <database> <key> <value>");
 
     final String db = tripleTrimmed.substring(0, firstSpace);
-    final String key = pairTrimmed.substring(0, secondSpace);
-    final String value = pairTrimmed.substring(secondSpace);
 
     final DatabaseInternal database = httpServer.getServer().getDatabase(db);
-    database.getConfiguration().setValue(key, value);
+    applySetting(database.getConfiguration(), pairTrimmed.substring(0, secondSpace), pairTrimmed.substring(secondSpace + 1));
     database.saveConfiguration();
   }
 
@@ -906,14 +904,48 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
     final String pairTrimmed = pair.trim();
 
-    final Integer firstSpace = pairTrimmed.indexOf(" ");
+    final int firstSpace = pairTrimmed.indexOf(" ");
     if (firstSpace == -1)
       throw new IllegalArgumentException("Expected <key> <value>");
 
-    final String key = pairTrimmed.substring(0, firstSpace);
-    final String value = pairTrimmed.substring(firstSpace);
+    applySetting(httpServer.getServer().getConfiguration(), pairTrimmed.substring(0, firstSpace),
+        pairTrimmed.substring(firstSpace + 1));
+  }
 
-    httpServer.getServer().getConfiguration().setValue(key, value);
+  /**
+   * Stores one {@code <key> <value>} pair of a "set ... setting" command into {@code configuration}.
+   * <p>
+   * Issue #6875: both callers used to hand the raw tokens to {@link ContextConfiguration#setValue(String, Object)},
+   * which is a plain map put. Three things went wrong there and are fixed here:
+   * <ul>
+   * <li>the value kept the separating space that {@code substring(firstSpace)} left on it, so every value was
+   * stored with a leading blank;</li>
+   * <li>the tokens kept the backticks and quotes the documented command syntax uses
+   * ({@code SET SERVER SETTING `arcadedb.foo` 10}), so a quoted key was stored under a name nothing reads - a
+   * silent no-op answered with a 200;</li>
+   * <li>nothing checked the value against the setting's declared type, so an unparseable one was accepted here and
+   * threw later, inside whichever component read the setting next.</li>
+   * </ul>
+   * A key that names no declared setting is still stored verbatim, as it always has been: it carries no type to
+   * validate against, and rejecting it would change behaviour this endpoint has long allowed. The {@code
+   * set_server_setting} MCP tool is stricter on that point only - for a DECLARED setting the two now accept and
+   * refuse exactly the same values, both through {@link GlobalConfiguration#coerce(Object)}.
+   */
+  private void applySetting(final ContextConfiguration configuration, final String rawKey, final String rawValue) {
+    final String key = FileUtils.getStringContent(rawKey.trim());
+    final String value = FileUtils.getStringContent(rawValue.trim());
+
+    final GlobalConfiguration setting = GlobalConfiguration.findByKey(key);
+    if (setting == null) {
+      configuration.setValue(key, value);
+      return;
+    }
+
+    if (value.isEmpty() && setting.getType() != String.class)
+      throw new IllegalArgumentException(
+          "Value must not be empty for setting '" + setting.getKey() + "' of type " + setting.getType().getSimpleName());
+
+    configuration.setValue(setting.getKey(), setting.coerce(value));
   }
 
   private JSONObject getServerEvents(final String fileName) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -949,7 +949,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
     if (value.isEmpty() && setting.getType() != String.class)
       throw new IllegalArgumentException(
-          "Value must not be empty for setting '" + setting.getKey() + "' of type " + setting.getType().getSimpleName());
+          "'value' must not be empty for setting '" + setting.getKey() + "' of type " + setting.getType().getSimpleName());
 
     configuration.setValue(setting.getKey(), setting.coerce(value));
   }

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6875SetServerSettingHttpIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6875SetServerSettingHttpIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Issue #6875, the HTTP twin of {@code set_server_setting}. {@code POST /api/v1/server} with
+ * "set server setting &lt;key&gt; &lt;value&gt;" enforced the two-token shape and nothing about the value: it split
+ * on the first space and handed both halves to {@code ContextConfiguration.setValue}, a plain map put. So the value
+ * kept the separating space, a backtick-quoted key was stored under a name nothing reads, and an unparseable value
+ * was answered with a 200 and threw later, inside whichever component read the setting next.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6875SetServerSettingHttpIT extends BaseGraphServerTest {
+  private final HttpClient client = HttpClient.newHttpClient();
+
+  @Test
+  void rejectsAValueThatIsNotParseableAsTheSettingType() throws Exception {
+    final HttpResponse<String> response = executeServerCommand("set server setting arcadedb.asyncWorkerThreads abc");
+
+    assertThat(response.statusCode()).isEqualTo(400);
+    assertThat(response.body()).contains("arcadedb.asyncWorkerThreads");
+
+    // the rejected call is not the one that breaks a later read
+    assertThatCode(() -> getServer(0).getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS))
+        .doesNotThrowAnyException();
+    assertThat(getServer(0).getConfiguration().hasValue(GlobalConfiguration.ASYNC_WORKER_THREADS.getKey())).isFalse();
+  }
+
+  /** The value used to arrive with the separating space still on it, and as text rather than as the setting's type. */
+  @Test
+  void storesTheValueCoercedAndWithoutTheSeparatingSpace() throws Exception {
+    final ContextConfiguration configuration = getServer(0).getConfiguration();
+    final GlobalConfiguration setting = GlobalConfiguration.SQL_STATEMENT_CACHE;
+    try {
+      final HttpResponse<String> response = executeServerCommand("set server setting " + setting.getKey() + " 500");
+
+      assertThat(response.statusCode()).isEqualTo(200);
+      assertThat((Object) configuration.getValue(setting)).isInstanceOf(Integer.class).isEqualTo(500);
+      assertThat(configuration.getValueAsInteger(setting)).isEqualTo(500);
+    } finally {
+      configuration.setValue(setting.getKey(), null);
+    }
+  }
+
+  /** The documented command syntax quotes the key; the quoted form has to reach the setting it names. */
+  @Test
+  void resolvesABacktickQuotedKeyAndUnquotesTheValue() throws Exception {
+    final ContextConfiguration configuration = getServer(0).getConfiguration();
+    final GlobalConfiguration setting = GlobalConfiguration.DATE_TIME_FORMAT;
+    try {
+      final HttpResponse<String> response = executeServerCommand(
+          "set server setting `" + setting.getKey() + "` 'yyyy-MM-dd'");
+
+      assertThat(response.statusCode()).isEqualTo(200);
+      assertThat(configuration.hasValue(setting.getKey())).isTrue();
+      assertThat(configuration.getValueAsString(setting)).isEqualTo("yyyy-MM-dd");
+    } finally {
+      configuration.setValue(setting.getKey(), null);
+    }
+  }
+
+  /** A size-suffixed value is what the integral accessors read back, so the writer takes it and stores the number. */
+  @Test
+  void acceptsASizeSuffixedValueForAnIntegralSetting() throws Exception {
+    final ContextConfiguration configuration = getServer(0).getConfiguration();
+    final GlobalConfiguration setting = GlobalConfiguration.COMMIT_LOCK_TIMEOUT;
+    try {
+      final HttpResponse<String> response = executeServerCommand("set server setting " + setting.getKey() + " 1KB");
+
+      assertThat(response.statusCode()).isEqualTo(200);
+      assertThat(configuration.getValueAsLong(setting)).isEqualTo(1024L);
+    } finally {
+      configuration.setValue(setting.getKey(), null);
+    }
+  }
+
+  private HttpResponse<String> executeServerCommand(final String command) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI("http://localhost:2480/api/v1/server"))
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject().put("command", command).toString()))
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+    return client.send(request, BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
Closes #6875

## What was wrong

Two defects that compound.

**1. No coercion at the writer.** The `set_server_setting` MCP tool and `PostServerCommandHandler.setServerSetting` both handed the caller's raw string to `ContextConfiguration.setValue(String, Object)`, which is a plain `Map.put`. #6874 stopped a *missing* and an *empty* `value`; a non-empty one that is not parseable as the setting's declared type still went straight in, so

```json
tools/call set_server_setting {"key":"arcadedb.asyncWorkerThreads","value":"abc"}
```

answered `isError: false` and the `NumberFormatException` surfaced later, inside whichever component read the setting next.

**2. The two read paths disagreed about what parses.** `GlobalConfiguration.getValueAsInteger()/getValueAsLong()` coerce a non-`Number` through `FileUtils.getSizeAsNumber()`, so `"1MB"` reads as `1048576`; `ContextConfiguration.getValueAsInteger(GlobalConfiguration)/getValueAsLong(...)` used `Integer.parseInt`/`Long.parseLong`, so the same stored string threw. Any value reaching the context map without passing through `GlobalConfiguration.setValue` therefore read back differently depending on which accessor the reading component happened to call. A validator written against either one alone would have been wrong for the other, which is why this is fixed first and the coercion helper built on top of it.

Three more, found while wiring the helper in:

- the HTTP command split on the first space with `substring(firstSpace)` rather than `substring(firstSpace + 1)`, so **every** value was stored with a leading blank;
- it stored the `<key>` token verbatim, backticks included, so the documented ``SET SERVER SETTING `arcadedb.foo` 10`` form landed under a key nothing reads - a silent no-op answered with a 200;
- `ALTER DATABASE ... SETTING` is a **third** writer into a `ContextConfiguration`, using the same plain map put, so the identical defect was reachable from SQL.

## Which parse is canonical

`FileUtils.getSizeAsNumber` on the trimmed text, i.e. what the `GlobalConfiguration` accessor has always done, with two guards that keep it from being *looser* than the `Integer.parseInt`/`Long.parseLong` it replaces: an integral setting refuses a value outside the `int` range rather than truncating to its low 32 bits, and it refuses a decimal mantissa rather than dropping the fraction. Within those, it is a strict superset - `"64MB"` now works where `"64"` always did - so nothing that parsed before stops parsing.

## Changes

| File | Change |
|---|---|
| `GlobalConfiguration` | new `coerce(Object)`: the single place a value becomes a setting's declared type, or is rejected with a message naming the key, the type and the offending value. `setValue(Object)` delegates to it. `coerceToIntegral` refuses a fractional value from either route (a boxed `Double` or a decimal mantissa in text); `narrowToInteger` holds the `int` bound and is shared with the read accessors. The three `getValueAs*()` accessors trim and test `Number` rather than the exact box type |
| `ContextConfiguration` | `getValueAsInteger/Long/Float(GlobalConfiguration)` read through the same parse, and the same `int` bound, as their `GlobalConfiguration` counterparts |
| `SetServerSettingTool` | coerces before storing, under the setting's canonical key, so the map holds a typed value neither accessor has to re-parse. `newValue` reports what was stored, masked for a hidden setting on the same terms as `previousValue` |
| `PostServerCommandHandler` | `setServerSetting` and `setDatabaseSetting` share one `applySetting`: unquote the key/value tokens, resolve the setting, drop the separating space, reject an empty value for a non-`String` setting, coerce |
| `AlterDatabaseStatement` | the SQL writer goes through `coerce` too, and reports the coerced value as `newValue` |

### Deliberate calls, all raised in review

- **A numeric setting still reports a bad value as `NumberFormatException`** (a subclass of `IllegalArgumentException`). `GlobalConfigurationTest.typeConversion` asserts that type and is an existing test; the enriched message is used either way, because `For input string: "A"` - what `getSizeAsNumber` surfaces for `"abc"` - names neither the setting nor what was sent.
- **`Boolean` stays as permissive as `Boolean.parseBoolean`.** `readConfiguration()` feeds every system property and environment variable through `coerce` during `GlobalConfiguration`'s static initializer, so turning a boolean typo into a throw would turn it into an `ExceptionInInitializerError` that takes the engine down instead of the setting. `"yes"` therefore still becomes `false` silently; tightening that needs the static-init path handled first and is not this fix.
- **A decimal mantissa is refused outright, not checked for exactness.** An exactness check would accept `"1.5MB"` and reject `"6.7KB"` (6860.8 bytes), and "is this fraction binary-exact against the unit" is not a rule an operator can predict. Refusing every decimal is what the parsers this replaced did.
- **An unknown key is still stored verbatim by the HTTP endpoint**, as it always has been - it carries no type to validate against, and `PostServerCommandHandlerIT.serverSettingCommandsCaseSensitivity` exercises one (`server.httpSessionTimeout`, not a declared setting). The MCP tool remains stricter on that one point; for a *declared* setting all three writers now accept and refuse exactly the same values. Worth a follow-up issue.
- **The command tokenizes before it unquotes**, so quoting cannot put a space in a `<database>` or `<key>` token. Documented on `applySetting` rather than changed: only the trailing `<value>`, whatever remains after the last split, can hold a quoted space, and it does.

## Test plan

- [x] `engine`: `Issue6875SettingValueCoercionTest` - the two accessors agree on a size-suffixed value and on surrounding whitespace; a coerced value is readable through **both** accessors (the regression the issue asks for); both accessors refuse a stored value outside the `int` range, boxed or as text; `coerce` refuses unparseable text, an out-of-range magnitude and a fractional value (`6.7d`, `6.7f`, `"6.7"`, `"6.7KB"`, `"1.5MB"`) while accepting `6.0d` and `"2MB"`; `coerce` returns the declared type; the global setter and the helper agree
- [x] `engine`: `Issue6875AlterDatabaseSettingCoercionTest` - `ALTER DATABASE` refuses an unparseable and a fractional value and leaves the setting readable, stores a coerced typed value, still takes any text for a `String` setting
- [x] `mcp`: `Issue6875SetServerSettingCoercionTest` - rejects `"abc"` for an `Integer` setting and `"half"` for a `Float` one, leaves the setting untouched when it rejects, stores a coerced typed value, accepts a size-suffixed value, masks a hidden setting's new value while still storing it, still takes any text for a `String` setting
- [x] `server`: `Issue6875SetServerSettingHttpIT` - the HTTP twin answers 400 for an unparseable value, stores the value coerced and without the separating space, resolves a backtick-quoted key and unquotes the value, accepts a size-suffixed value
- [x] Bug proven present before the fix: with the two engine files reverted, a probe asserting `ctx.getValueAsLong(COMMIT_LOCK_TIMEOUT)` for a stored `"1MB"` fails with `java.lang.NumberFormatException: For input string: "1MB"`
- [x] `mvn -o -pl engine test -DexcludedGroups=benchmark,vector,slow` - 13782 tests, 0 failures
- [x] `mvn -o -pl server test -DexcludedGroups=benchmark,vector,slow` - 873 tests, 0 failures
- [x] `mvn -o -pl server verify -Dit.test='PostServerCommandHandlerIT,Issue6875SetServerSettingHttpIT,HTTP*IT'` - 95 tests, 0 failures
- [x] `mvn -o -pl mcp verify -DexcludedGroups=benchmark,vector,slow` - 318 tests, 0 failures
- [x] `mvn -o install -DskipTests` over the full reactor - BUILD SUCCESS

Two flakes seen once each across the repeated full-suite runs, both green in isolation and on rerun, neither touching code this PR changes: `Issue5596MergeCoverageTest.aCleanAppendConflictIsStillMerged` (a merge-count race between two writer threads) and `Issue6815SelectTimeoutNotInstalledTest.existsReturnsFalseWhenNotThrowing` (`NoSuchElementException` from `MultiIterator.next` via `SelectExecutor.executeExists` - the 1 ms deadline can trip between its `hasNext()` and its `next()`, which looks like a real latent race worth its own issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server and database settings now validate and convert values to their configured types.
  * Numeric settings accept surrounding whitespace and size-suffixed values while rejecting fractional or out-of-range values.
  * Invalid or empty values are rejected without changing existing settings.
  * Quoted and backtick-quoted setting names and values are handled correctly.
  * Responses show the stored value after conversion and consistently mask sensitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->