### PR TITLE
fix(#6843): REMOVE of a subtype label must keep the labels it inherited

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -333,8 +333,12 @@ public final class Labels {
         if (i == j)
           continue;
         final DocumentType other = schema.getTypeOrNull(candidates.get(j));
-        // A type that implies `label` while `label` also implies it is the same type reached twice (or a schema
-        // cycle): the index comparison breaks the tie so exactly one of the pair survives.
+        // The second half of the condition is unreachable on any schema the engine can build: two DISTINCT
+        // candidate names (the set comes from a TreeSet, so there are no repeats) that are each other's instance
+        // require a cycle in the type hierarchy, which the schema refuses to create. It is kept as a guard rather
+        // than as live logic - without it a cycle would mark both members implied and drop them BOTH, silently
+        // costing the vertex a label it still answers to, which is the exact failure this method exists to stop.
+        // The index comparison breaks such a tie so that exactly one of the pair survives.
         if (other != null && other.instanceOf(label) && (!isImpliedBy(schema, label, candidates.get(j)) || j < i))
           implied = true;
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -291,6 +291,65 @@ public final class Labels {
   }
 
   /**
+   * The labels a vertex keeps after a {@code REMOVE n:A:B}, expressed the way {@link #ensureCompositeType} wants
+   * them: the most specific of the labels the vertex still answers to, with every label one of those already
+   * implies left out.
+   * <p>
+   * The set has to be computed from the FULL label set ({@link #getLabels}) and not from the own-label set, which
+   * is what issue #6843 reports: for a vertex of a type declared {@code Cust_Agent EXTENDS Entity}, the own labels
+   * are {@code [Cust_Agent]} alone, so removing {@code Cust_Agent} left nothing behind and the vertex was moved to
+   * {@link #NO_LABEL_TYPE} - losing {@code Entity}, a label the removal never named and one the node kept
+   * answering to a moment earlier. Starting from every label it answers to keeps {@code Entity} in the picture.
+   * <p>
+   * Reducing that set back to its most specific members is what keeps the hierarchy intact, and is the reason the
+   * own-label set was used in the first place (issue #6363): a vertex of type {@code Extra~Manager}, with
+   * {@code Manager EXTENDS Employee}, answers to {@code [Employee, Extra, Manager]}, and rebuilding its type from
+   * all three after {@code REMOVE n:Extra} would build {@code Employee~Manager} - a type extending both, which
+   * flattens the very {@code EXTENDS} it was supposed to preserve. {@code Manager} already implies
+   * {@code Employee}, so {@code Employee} is dropped and the vertex simply becomes a {@code Manager} again.
+   * <p>
+   * With nothing removed, this returns exactly {@link #getOwnLabels}, which is what makes a {@code REMOVE} of a
+   * label the vertex does not carry leave its type untouched.
+   *
+   * @param schema         the database schema
+   * @param vertex         the vertex the labels are being taken from
+   * @param labelsToRemove the labels named by the clause
+   *
+   * @return the minimal label set to rebuild the vertex's type from, sorted alphabetically, possibly empty
+   */
+  public static List<String> remainingLabels(final Schema schema, final Vertex vertex, final List<String> labelsToRemove) {
+    final List<String> candidates = new ArrayList<>(getLabels(vertex));
+    candidates.removeAll(labelsToRemove);
+    if (candidates.size() < 2)
+      return candidates;
+
+    // Keep a label only when no other surviving label already implies it: an implied one is reached through its
+    // subtype and naming it alongside would extend both instead of only the subtype.
+    final List<String> minimal = new ArrayList<>(candidates.size());
+    for (int i = 0; i < candidates.size(); i++) {
+      final String label = candidates.get(i);
+      boolean implied = false;
+      for (int j = 0; j < candidates.size() && !implied; j++) {
+        if (i == j)
+          continue;
+        final DocumentType other = schema.getTypeOrNull(candidates.get(j));
+        // A type that implies `label` while `label` also implies it is the same type reached twice (or a schema
+        // cycle): the index comparison breaks the tie so exactly one of the pair survives.
+        if (other != null && other.instanceOf(label) && (!isImpliedBy(schema, label, candidates.get(j)) || j < i))
+          implied = true;
+      }
+      if (!implied)
+        minimal.add(label);
+    }
+    return minimal;
+  }
+
+  private static boolean isImpliedBy(final Schema schema, final String label, final String other) {
+    final DocumentType type = schema.getTypeOrNull(label);
+    return type != null && type.instanceOf(other);
+  }
+
+  /**
    * Whether a label is still carried by a set of labels, which is what decides if a {@code REMOVE n:Label} can be
    * honoured: an inherited label cannot be taken away on its own, because every type answering to the subtype that
    * implies it answers to it too (issue #6363).

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -263,22 +263,20 @@ public class RemoveStep extends AbstractExecutionStep {
     // have been resolved by the caller - and it costs one map lookup that is skipped until a label write happens.
     vertex = replacements.resolve(vertex);
 
-    // The reduced type is rebuilt from the vertex's OWN labels: an inherited one is carried by the subtype that
-    // remains and must not be listed alongside it, or the vertex would be moved out of that subtype (issue #6363).
+    // The reduced type is rebuilt from every label the vertex still answers to, narrowed back down to its most
+    // specific members: starting from the own labels alone dropped an inherited label the clause never named
+    // (issue #6843 - removing Cust_Agent from a Cust_Agent EXTENDS Entity vertex left it with no label at all
+    // instead of with Entity), while keeping every implied label would flatten the hierarchy (issue #6363).
     final DocumentType currentType = vertex.getType();
-    final List<String> currentLabels = Labels.getOwnLabels(vertex);
+    final Schema schema = context.getDatabase().getSchema();
     final List<String> labelsToRemove = item.getLabels();
-
-    // Compute remaining labels
-    final List<String> remainingLabels = new ArrayList<>(currentLabels);
-    remainingLabels.removeAll(labelsToRemove);
+    final List<String> remainingLabels = Labels.remainingLabels(schema, vertex, labelsToRemove);
 
     // Count the labels the vertex actually carries - a label it does not have is a no-op, exactly as in Neo4j, and
     // a label named twice in one clause is one label, since a label is set membership and not a count. A label the
     // vertex only answers to through a type it keeps is a different matter: no type it could be moved to answers
     // 'no' to that label and 'yes' to the subtype implying it, so the removal is refused rather than reported as
     // done and silently not done.
-    final Schema schema = context.getDatabase().getSchema();
     int removedLabelsCount = 0;
     for (int i = 0; i < labelsToRemove.size(); i++) {
       final String label = labelsToRemove.get(i);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubtypeLabelTransitionIssue6843Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubtypeLabelTransitionIssue6843Test.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.query.sql.executor.QueryStatistics;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6843: a {@code REMOVE n:Subtype} on a vertex whose type was declared with
+ * {@code EXTENDS} left the node with no label at all.
+ * <p>
+ * The reduced type was rebuilt from the vertex's OWN labels, which for {@code Cust_Agent EXTENDS Entity} is
+ * {@code [Cust_Agent]} alone. Take {@code Cust_Agent} away and that set is empty, so the vertex was moved to the
+ * unlabelled sentinel type - dropping {@code Entity}, a label the clause never named and one the node answered to
+ * a moment earlier. The user's whole point in writing {@code SET n:Entity REMOVE n:Cust_Agent} was to keep the base
+ * label, and the query silently did the opposite.
+ * <p>
+ * The invariant under test is Neo4j's, the same one issue #6363 pinned for the other direction:
+ * {@code labels(n)} after {@code REMOVE n:A} is {@code labels(n)} before it, minus {@code A} - never minus more.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherSubtypeLabelTransitionIssue6843Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-subtype-label-transition-6843");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Entity");
+      database.command("sql", "CREATE VERTEX TYPE Cust_Agent EXTENDS Entity");
+      database.command("sql", "CREATE VERTEX TYPE EntityType");
+      database.command("sql", "CREATE EDGE TYPE INSTANCE");
+      database.command("sql", "INSERT INTO Cust_Agent SET project_id = 'p1', name = 'a1', class_iris = ['keep','drop']");
+      database.command("sql", "INSERT INTO EntityType SET name = 'et1', id = 't1'");
+      database.command("sql",
+          "CREATE EDGE INSTANCE FROM (SELECT FROM Cust_Agent WHERE name = 'a1') TO (SELECT FROM EntityType WHERE name = 'et1')");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void removingTheSubtypeLabelKeepsTheInheritedBaseLabel() {
+    // The reduced form from the issue. Was: type '~NO_LABEL~', labels [] - the node stopped being an Entity.
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (entity:`Cust_Agent` {project_id: 'p1'}) SET entity:`Entity` REMOVE entity:`Cust_Agent` RETURN entity"));
+
+    assertThat(typeOf("a1")).isEqualTo("Entity");
+    assertThat(labels("MATCH (n {name:'a1'}) RETURN labels(n) AS l")).containsExactly("Entity");
+    assertThat(count("MATCH (n:Entity) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(count("MATCH (n:Cust_Agent) RETURN count(n) AS c")).isEqualTo(0);
+  }
+
+  @Test
+  void theTransitionKeepsPropertiesAndConnectedEdges() {
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (entity:`Cust_Agent` {project_id: 'p1'}) SET entity:`Entity` REMOVE entity:`Cust_Agent`"));
+
+    assertThat(count("MATCH (n:Entity {project_id:'p1'}) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(count("MATCH (:Entity {name:'a1'})-[:INSTANCE]->(:EntityType {id:'t1'}) RETURN count(*) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void theBatchQueryFromTheIssueLeavesEveryVertexAnEntity() {
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++)
+        database.command("sql",
+            "INSERT INTO Cust_Agent SET project_id = 'p1', name = 'b" + i + "', class_iris = ['keep','drop']");
+      database.command("sql",
+          "CREATE EDGE INSTANCE FROM (SELECT FROM Cust_Agent WHERE name LIKE 'b%') TO (SELECT FROM EntityType WHERE name = 'et1')");
+      // An edge between two vertices that are BOTH relabelled by the same clause: the second row must follow the
+      // first row's rewrite instead of touching the record it displaced (issues #6312 / #6313).
+      database.command("sql",
+          "CREATE EDGE INSTANCE FROM (SELECT FROM Cust_Agent WHERE name = 'b0') TO (SELECT FROM Cust_Agent WHERE name = 'b1')");
+    });
+
+    database.transaction(() -> database.command("opencypher", """
+        MATCH (entity:`Cust_Agent` {project_id: 'p1'})
+        WITH entity LIMIT 100
+        OPTIONAL MATCH (entity)-[instance:`INSTANCE`]->(entity_type:`EntityType` {id: 't1'})
+        DELETE instance
+        SET entity.class_iris = [ class_iri IN entity.class_iris WHERE class_iri <> 'drop' ]
+        SET entity:`Entity`
+        REMOVE entity:`Cust_Agent`
+        """));
+
+    assertThat(count("MATCH (n:Cust_Agent) RETURN count(n) AS c")).isEqualTo(0);
+    assertThat(count("MATCH (n:Entity {project_id:'p1'}) RETURN count(n) AS c")).isEqualTo(6);
+    assertThat(labels("MATCH (n {name:'b0'}) RETURN labels(n) AS l")).containsExactly("Entity");
+    // The property rewrite in the same clause survived the type move.
+    assertThat(labels("MATCH (n {name:'b0'}) RETURN n.class_iris AS l")).containsExactly("keep");
+    // The edge the clause deleted is gone; the one it did not name still connects the two relabelled vertices.
+    assertThat(count("MATCH (:Entity)-[:INSTANCE]->(:EntityType) RETURN count(*) AS c")).isEqualTo(0);
+    assertThat(count("MATCH (:Entity {name:'b0'})-[:INSTANCE]->(:Entity {name:'b1'}) RETURN count(*) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void onlyTheNamedLabelIsCountedAsRemoved() {
+    // Entity is kept, not removed: it must not be counted, and Cust_Agent must be.
+    assertThat(labelsRemoved("MATCH (entity:`Cust_Agent`) REMOVE entity:`Cust_Agent`")).isEqualTo(1);
+    assertThat(labels("MATCH (n {name:'a1'}) RETURN labels(n) AS l")).containsExactly("Entity");
+  }
+
+  @Test
+  void aDeeperHierarchyKeepsTheNearestSurvivingAncestorOnly() {
+    database.command("sql", "CREATE VERTEX TYPE Middle EXTENDS Entity");
+    database.command("sql", "CREATE VERTEX TYPE Leaf EXTENDS Middle");
+    database.transaction(() -> database.command("sql", "INSERT INTO Leaf SET name = 'l1'"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Leaf) REMOVE n:Leaf"));
+
+    // Middle already implies Entity, so the rebuilt type is Middle and not an Entity~Middle that would have
+    // flattened the EXTENDS chain (issue #6363).
+    assertThat(typeOf("l1")).isEqualTo("Middle");
+    assertThat(labels("MATCH (n {name:'l1'}) RETURN labels(n) AS l")).containsExactly("Entity", "Middle");
+  }
+
+  @Test
+  void removingEveryLabelOfTheChainStillLeavesTheNodeUnlabelled() {
+    database.transaction(
+        () -> database.command("opencypher", "MATCH (n:Cust_Agent) REMOVE n:Cust_Agent:Entity"));
+
+    assertThat(typeOf("a1")).isEqualTo(Labels.NO_LABEL_TYPE);
+    assertThat(labels("MATCH (n {name:'a1'}) RETURN labels(n) AS l")).isEmpty();
+  }
+
+  @Test
+  void removingOnlyTheInheritedLabelIsStillRefused() {
+    // The counterpart the fix must not weaken: Cust_Agent IS-A Entity, so no type the vertex could be moved to
+    // answers 'no' to :Entity while still answering 'yes' to :Cust_Agent.
+    assertThatThrownBy(
+        () -> database.transaction(() -> database.command("opencypher", "MATCH (n:Cust_Agent) REMOVE n:Entity")))
+        .hasMessageContaining("Entity")
+        .hasMessageContaining("Cust_Agent");
+
+    assertThat(typeOf("a1")).isEqualTo("Cust_Agent");
+  }
+
+  @Test
+  void aMultiLabelSubtypeVertexKeepsItsSubtypeWhenTheExtraLabelGoes() {
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Cust_Agent {name:'a1'}) SET n:Extra"));
+    assertThat(typeOf("a1")).isEqualTo("Cust_Agent~Extra");
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n {name:'a1'}) REMOVE n:Extra"));
+
+    assertThat(typeOf("a1")).isEqualTo("Cust_Agent");
+    assertThat(labels("MATCH (n {name:'a1'}) RETURN labels(n) AS l")).containsExactly("Cust_Agent", "Entity");
+  }
+
+  private int labelsRemoved(final String command) {
+    final int[] value = new int[] { -1 };
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("opencypher", command)) {
+        while (rs.hasNext())
+          rs.next();
+        value[0] = rs.getStatistics().map(QueryStatistics::getLabelsRemoved).orElse(-1);
+      }
+    });
+    return value[0];
+  }
+
+  private String typeOf(final String name) {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n {name:'" + name + "'}) RETURN n")) {
+      final Document doc = (Document) rs.next().getProperty("n");
+      return doc.getTypeName();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> labels(final String cypher) {
+    try (final ResultSet rs = database.query("opencypher", cypher)) {
+      return (List<String>) rs.next().getProperty("l");
+    }
+  }
+
+  private int count(final String cypher) {
+    try (final ResultSet rs = database.query("opencypher", cypher)) {
+      return ((Number) rs.next().getProperty("c")).intValue();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubtypeLabelTransitionIssue6843Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubtypeLabelTransitionIssue6843Test.java
@@ -153,6 +153,42 @@ class CypherSubtypeLabelTransitionIssue6843Test {
   }
 
   @Test
+  void aTypeWithSeveralDirectSupertypesKeepsBothBranches() {
+    // A diamond declared with EXTENDS rather than with a ~ composite: Bottom IS-A both Left and Right, and both of
+    // those IS-A Entity. Removing Bottom has to keep BOTH branches - reducing to one of them, or collapsing to the
+    // shared Entity, would cost the vertex a label the clause never named, which is the whole point of the fix.
+    database.command("sql", "CREATE VERTEX TYPE Left EXTENDS Entity");
+    database.command("sql", "CREATE VERTEX TYPE Right EXTENDS Entity");
+    database.command("sql", "CREATE VERTEX TYPE Bottom EXTENDS Left, Right");
+    database.transaction(() -> database.command("sql", "INSERT INTO Bottom SET name = 'd1'"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Bottom) REMOVE n:Bottom"));
+
+    // Entity is implied by both survivors and must not be named alongside them.
+    assertThat(typeOf("d1")).isEqualTo("Left~Right");
+    assertThat(labels("MATCH (n {name:'d1'}) RETURN labels(n) AS l")).containsExactly("Entity", "Left", "Right");
+    assertThat(count("MATCH (n:Entity {name:'d1'}) RETURN count(n) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void twoIndependentInheritanceChainsBothSurviveTheRemoval() {
+    // Same shape, but the two branches share no ancestor: the reduction has to keep the two most specific labels
+    // and drop the two roots they each already imply.
+    database.command("sql", "CREATE VERTEX TYPE RootA");
+    database.command("sql", "CREATE VERTEX TYPE RootB");
+    database.command("sql", "CREATE VERTEX TYPE MidA EXTENDS RootA");
+    database.command("sql", "CREATE VERTEX TYPE MidB EXTENDS RootB");
+    database.command("sql", "CREATE VERTEX TYPE Both EXTENDS MidA, MidB");
+    database.transaction(() -> database.command("sql", "INSERT INTO Both SET name = 'i1'"));
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Both) REMOVE n:Both"));
+
+    assertThat(typeOf("i1")).isEqualTo("MidA~MidB");
+    assertThat(labels("MATCH (n {name:'i1'}) RETURN labels(n) AS l"))
+        .containsExactly("MidA", "MidB", "RootA", "RootB");
+  }
+
+  @Test
   void removingEveryLabelOfTheChainStillLeavesTheNodeUnlabelled() {
     database.transaction(
         () -> database.command("opencypher", "MATCH (n:Cust_Agent) REMOVE n:Cust_Agent:Entity"));


### PR DESCRIPTION
Closes #6843

`REMOVE n:Subtype` on a vertex whose type was declared with `EXTENDS` stripped the node of every label, not just the one the clause named. `RemoveStep` rebuilt the reduced type from the vertex's **own** labels, which for `Cust_Agent EXTENDS Entity` is `[Cust_Agent]` alone: take `Cust_Agent` away and the set is empty, so the vertex was rewritten under the unlabelled sentinel `~NO_LABEL~` and stopped being an `Entity` - the very label the reporter wrote `SET entity:`Entity`` to keep, and one the removal never named. The fix computes the surviving set from every label the vertex answers to (`Labels.getLabels`), then narrows it back to its most specific members, which is what the own-label set was standing in for in #6363: `Manager` already implies `Employee`, so an `Extra~Manager` vertex losing `Extra` still becomes a plain `Manager` rather than a hierarchy-flattening `Employee~Manager`. With nothing actually removed the new computation returns exactly the old own-label set, so a `REMOVE` of a label the vertex does not carry still leaves its type untouched, and the refusal of `REMOVE n:Entity` on a `Cust_Agent` (no type answers "no" to `:Entity` while answering "yes" to `:Cust_Agent`) is unchanged.

The invariant this restores is Neo4j's, the same one #6363 pinned from the other direction: `labels(n)` after `REMOVE n:A` is `labels(n)` before it, minus `A` - never minus more.

On the reporter's second point, the generic `Neo.DatabaseError.General.UnknownError`: it could not be reproduced on `main`, only the silent label loss above. 26.8.1 predates the label-write work in #6312/#6313/#6363/#6395, which rewrote how a label change moves a record and how later rows follow that move; the error surface it describes is gone on `main` before this change. This PR fixes the semantic half that was still there.

### Changes

- `Labels.remainingLabels(schema, vertex, labelsToRemove)` - new: the minimal label set to rebuild a vertex's type from after a removal, derived from the full label set and reduced to its most specific members.
- `RemoveStep.removeLabels` now uses it in place of `getOwnLabels() - labelsToRemove`. Nothing else changed: the removed-label count, the inherited-label refusal, the unchanged-type early return, and the `~NO_LABEL~` landing for a genuinely last label all behave as before.

## Test plan

New `engine/src/test/java/com/arcadedb/query/opencypher/CypherSubtypeLabelTransitionIssue6843Test.java` (8 tests; 5 of them fail on `main` and pass with the fix, 3 are guardrails that must keep passing both ways):

- [x] `removingTheSubtypeLabelKeepsTheInheritedBaseLabel` - the reduced repro from the issue; type becomes `Entity`, `labels(n) = ["Entity"]`, `:Cust_Agent` matches nothing
- [x] `theTransitionKeepsPropertiesAndConnectedEdges` - properties and the `INSTANCE` edge survive the rewrite
- [x] `theBatchQueryFromTheIssueLeavesEveryVertexAnEntity` - the reporter's full batch query (`WITH … LIMIT`, `OPTIONAL MATCH`, `DELETE`, list-comprehension `SET`, `SET`/`REMOVE` labels) over 6 vertices, including an edge between two vertices both relabelled by the same clause
- [x] `onlyTheNamedLabelIsCountedAsRemoved` - `labelsRemoved == 1`, not 2
- [x] `aDeeperHierarchyKeepsTheNearestSurvivingAncestorOnly` - `Leaf EXTENDS Middle EXTENDS Entity`, `REMOVE n:Leaf` lands on `Middle`, not on `Entity~Middle`
- [x] `removingEveryLabelOfTheChainStillLeavesTheNodeUnlabelled` - `REMOVE n:Cust_Agent:Entity` still lands on the sentinel
- [x] `removingOnlyTheInheritedLabelIsStillRefused` - the #6363 refusal is not weakened
- [x] `aMultiLabelSubtypeVertexKeepsItsSubtypeWhenTheExtraLabelGoes` - `Cust_Agent~Extra` minus `Extra` is `Cust_Agent`, not `Entity~…`

Regression runs, all green:

- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.query.opencypher.**'` - 9069 tests, 0 failures
- [x] `mvn -o -pl engine test -Dsurefire.includes='**/*Suite.java'` (openCypher TCK) - 3897 tests, 0 failures

### Review cycles

- **cycle 1** - `41573ef` - `claude` reviewed and confirmed the algorithm by hand (chain, diamond, composite, refusal, no-op cases), with two minor items: the tie-break branch in `remainingLabels` looks unreachable and deserves a comment saying so, and the tests cover no type with several direct `EXTENDS` supertypes.
- **cycle 2** - `e6ed35a` - both applied. The tie-break now carries a comment stating it is unreachable on any schema the engine can build (it needs a hierarchy cycle) and explaining why it is kept as a guard: without it a cycle would mark both members implied and drop them both. Two tests added - `aTypeWithSeveralDirectSupertypesKeepsBothBranches` (a diamond `Bottom EXTENDS Left, Right`, both `EXTENDS Entity`; removing `Bottom` lands on `Left~Right`, not on either branch alone and not on the shared `Entity`) and `twoIndependentInheritanceChainsBothSurviveTheRemoval` (`Both EXTENDS MidA, MidB` over two disjoint roots; lands on `MidA~MidB`). Both fail on `main`. Suites re-run green: 9071 opencypher tests, 3897 TCK.
- The `claude-review` run on `e6ed35a` (33173546799) finished `success` but posted no comment - it hit its 300s budget at `num_turns: 4`. Nothing in cycle 2 changed the algorithm, only a comment and two additive tests, so there is no outstanding feedback; a re-review can be requested with an `@claude review` comment if wanted.

### CI

`unit-tests` and `opencypher-tck-tests` - the two lanes this change can affect - are green, along with every e2e, build and analysis lane. `integration-tests` and `vector-unit-tests` are red, and both are red on every one of the last five `main` runs (33161892670, 33161642399, 33160941219, 33151135675, 33140801714) - pre-existing, not from this PR. `main` also has `unit-tests` red in three of those five, where this branch is green.
