### PR TITLE
fix(#6880): a non-throwing Select.timeout() must truncate, not throw NoSuchElementException

### DIFF
--- a/engine/src/main/java/com/arcadedb/utility/MultiIterator.java
+++ b/engine/src/main/java/com/arcadedb/utility/MultiIterator.java
@@ -62,6 +62,10 @@ public class MultiIterator<T> implements ResettableIterator<T>, IterableGraph<T>
 
   @Override
   public boolean hasNext() {
+    // #6880: THE SKIP PRE-LOOP IS THE ONE PATH IN hasNext() THAT NEVER TOUCHES promised, AND THAT IS NOT AN OVERSIGHT:
+    // IT CAN ONLY RUN WHILE skipped < skip, AND A PROMISE CAN ONLY EXIST ONCE THE LOOP HAS ALREADY COMPLETED
+    // (skipped == skip), SO IT NEVER LEAVES A PROMISED ELEMENT ON THE TABLE AND ITS EARLY EXIT NEVER STRANDS ONE.
+    // setSkip() HAS NO PRODUCTION CALLER, SO skip CANNOT BE WIDENED MID-ITERATION EITHER
     while (skipped < skip) {
       if (!hasNextInternal()) {
         return false;

--- a/engine/src/main/java/com/arcadedb/utility/MultiIterator.java
+++ b/engine/src/main/java/com/arcadedb/utility/MultiIterator.java
@@ -41,6 +41,16 @@ public class MultiIterator<T> implements ResettableIterator<T>, IterableGraph<T>
   private       int     skipped            = 0;
   private final long    beginTime          = System.currentTimeMillis();
 
+  // #6880: true WHILE A hasNext() THAT ANSWERED true HAS NOT YET BEEN CONSUMED BY next(). WITHOUT IT next() RE-RAN
+  // hasNext() - AND SO THE DEADLINE CHECK - A SECOND TIME FOR THE SAME ELEMENT, SO A DEADLINE EXPIRING *BETWEEN* THE
+  // CALLER'S hasNext() AND ITS next() SURFACED AS A BARE NoSuchElementException INSTEAD OF THE CLEAN TRUNCATION
+  // Select.timeout(v, unit, false) PROMISES (SelectExecutor.executeExists()/executeCount() AND SelectIterator ALL
+  // DRIVE THAT EXACT hasNext()/next() SHAPE). THE EXPIRY IS NOW DECIDED ONCE PER ELEMENT: ONE ALREADY PROMISED STAYS
+  // DELIVERABLE, AND THE DEADLINE STOPS THE ITERATION ON THE FOLLOWING hasNext().
+  // NOTE THE PROMISE IS ONLY EVER READ BY next(): hasNext() STILL RE-EVALUATES THE DEADLINE ON EVERY CALL, SO
+  // REPEATED hasNext() WITHOUT AN INTERVENING next() REPORTS THE EXPIRY AS BEFORE (#6816)
+  private       boolean promised           = false;
+
   public MultiIterator() {
     sources = new ArrayList<>();
   }
@@ -59,7 +69,8 @@ public class MultiIterator<T> implements ResettableIterator<T>, IterableGraph<T>
       partialIterator.next();
       skipped++;
     }
-    return hasNextInternal();
+    promised = hasNextInternal();
+    return promised;
   }
 
   private boolean hasNextInternal() {
@@ -98,9 +109,10 @@ public class MultiIterator<T> implements ResettableIterator<T>, IterableGraph<T>
 
   @Override
   public T next() {
-    if (!hasNext())
+    if (!promised && !hasNext())
       throw new NoSuchElementException();
 
+    promised = false;
     browsed++;
     return partialIterator.next();
   }
@@ -124,6 +136,7 @@ public class MultiIterator<T> implements ResettableIterator<T>, IterableGraph<T>
     partialIterator = null;
     browsed = 0;
     skipped = 0;
+    promised = false;
   }
 
   public MultiIterator<T> addIterator(final Object iValue) {

--- a/engine/src/test/java/com/arcadedb/utility/Issue6880MultiIteratorTimeoutBetweenHasNextAndNextTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/Issue6880MultiIteratorTimeoutBetweenHasNextAndNextTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import com.arcadedb.exception.TimeoutException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6880
+ * <p>
+ * {@code MultiIterator.next()} used to re-run {@code hasNext()}, and {@code hasNextInternal()} consults the deadline.
+ * A deadline that expired *between* the caller's {@code hasNext()} and its {@code next()} therefore turned into a bare
+ * {@link NoSuchElementException} instead of the clean truncation {@code timeout(v, unit, false)} promises. Every
+ * consumer driving a {@code MultiIterator} with a non-throwing deadline is exposed - {@code SelectExecutor.executeExists()},
+ * {@code executeCount()} and {@code SelectIterator.fetchNext()} all have the same
+ * {@code hasNext()} / {@code checkForTimeout()} / {@code next()} shape - which is why it only ever showed up under load.
+ * <p>
+ * The expiry decision is now made once per element rather than twice: an element {@code hasNext()} has already
+ * promised stays deliverable, and the deadline stops the iteration on the *following* {@code hasNext()}.
+ * <p>
+ * These tests plant the expiry deterministically (the deadline is put in the past between the two calls) rather than
+ * racing a 1 ms budget, which is what made the original symptom a 1-in-12 flake.
+ */
+public class Issue6880MultiIteratorTimeoutBetweenHasNextAndNextTest {
+
+  /**
+   * The statement of the bug: a non-throwing deadline that expires after {@code hasNext()} answered {@code true} must
+   * not turn the promised element into a {@link NoSuchElementException}.
+   */
+  @Test
+  void nonThrowingExpiryAfterHasNextStillDeliversThePromisedElement() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+
+    assertThat(it.hasNext()).isTrue();
+    expireDeadline(it, false);
+
+    assertThatNoException().isThrownBy(it::next);
+  }
+
+  /**
+   * ...and the truncation itself still happens, one element later: the promised element is the last one.
+   */
+  @Test
+  void nonThrowingExpiryTruncatesOnTheFollowingHasNext() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+
+    assertThat(it.hasNext()).isTrue();
+    expireDeadline(it, false);
+
+    assertThat(it.next()).isEqualTo(1);
+    assertThat(it.hasNext()).isFalse();
+  }
+
+  /**
+   * The throwing mode keeps reporting the expiry - also one element later, and still as a {@link TimeoutException},
+   * never as a {@link NoSuchElementException}.
+   */
+  @Test
+  void throwingExpiryAfterHasNextDeliversThenThrowsTimeout() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+
+    assertThat(it.hasNext()).isTrue();
+    expireDeadline(it, true);
+
+    assertThat(it.next()).isEqualTo(1);
+    assertThatThrownBy(it::hasNext).isInstanceOf(TimeoutException.class).hasMessageContaining("Timeout on iteration");
+  }
+
+  /**
+   * An expiry that lands BEFORE any {@code hasNext()} promise must still stop the iteration immediately - the promise
+   * is per element, it does not survive as a general licence to keep going.
+   */
+  @Test
+  void expiryBeforeAnyPromiseStopsImmediately() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+    expireDeadline(it, false);
+
+    assertThat(it.hasNext()).isFalse();
+    assertThatThrownBy(it::next).isInstanceOf(NoSuchElementException.class);
+  }
+
+  /**
+   * A promise consumed by {@code next()} is spent: a second expiry check happens on the next element, so a repeated
+   * {@code next()} without an intervening {@code hasNext()} cannot walk past the deadline either.
+   */
+  @Test
+  void aPromiseIsSpentByTheNextThatConsumesIt() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+
+    assertThat(it.hasNext()).isTrue();
+    expireDeadline(it, false);
+
+    assertThat(it.next()).isEqualTo(1);
+    assertThatThrownBy(it::next).isInstanceOf(NoSuchElementException.class);
+  }
+
+  /**
+   * {@code reset()} drops any outstanding promise along with the rest of the iteration state.
+   */
+  @Test
+  void resetDropsTheOutstandingPromise() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3));
+
+    assertThat(it.hasNext()).isTrue();
+    expireDeadline(it, false);
+    it.reset();
+
+    assertThat(it.hasNext()).isFalse();
+  }
+
+  /**
+   * Nothing about the ordinary, un-expired iteration changes - skip and limit included, since both are enforced
+   * through the very {@code hasNext()} path that now caches its verdict.
+   */
+  @Test
+  void unexpiredIterationIsUnaffectedBySkipAndLimit() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3, 4, 5).iterator());
+    it.setTimeout(TimeUnit.MINUTES.toMillis(10), false);
+    it.setSkip(1);
+    it.setLimit(2);
+
+    final List<Integer> got = new ArrayList<>();
+    while (it.hasNext())
+      got.add(it.next());
+
+    assertThat(got).containsExactly(2, 3);
+  }
+
+  /**
+   * Puts the iterator's deadline in the past without sleeping: {@code beginTime} is captured at construction, so a
+   * zero-millisecond budget is already spent once the clock has ticked at least once past it.
+   */
+  private static void expireDeadline(final MultiIterator<?> it, final boolean exceptionOnTimeout) {
+    it.setTimeout(0, exceptionOnTimeout);
+    // GUARANTEE STRICTLY MORE THAN 0 ms HAVE ELAPSED SINCE beginTime, SINCE THE CHECK IS `elapsed > timeout`
+    final long begin = System.currentTimeMillis();
+    while (System.currentTimeMillis() == begin)
+      Thread.onSpinWait();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/Issue6880MultiIteratorTimeoutBetweenHasNextAndNextTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/Issue6880MultiIteratorTimeoutBetweenHasNextAndNextTest.java
@@ -135,6 +135,20 @@ public class Issue6880MultiIteratorTimeoutBetweenHasNextAndNextTest {
   }
 
   /**
+   * The skip pre-loop is the one path in {@code hasNext()} that bypasses the promise entirely. An expiry reaching it
+   * must stop the iteration outright and, crucially, leave nothing promised behind for {@code next()} to deliver.
+   */
+  @Test
+  void expiryReachingTheSkipLoopStopsWithoutPromising() {
+    final MultiIterator<Integer> it = new MultiIterator<Integer>().addIterator(List.of(1, 2, 3).iterator());
+    it.setSkip(2);
+    expireDeadline(it, false);
+
+    assertThat(it.hasNext()).isFalse();
+    assertThatThrownBy(it::next).isInstanceOf(NoSuchElementException.class);
+  }
+
+  /**
    * Nothing about the ordinary, un-expired iteration changes - skip and limit included, since both are enforced
    * through the very {@code hasNext()} path that now caches its verdict.
    */


### PR DESCRIPTION
Closes #6880

## Root cause

`MultiIterator.next()` re-ran `hasNext()`, and `hasNextInternal()` consults the deadline (`checkForTimeout()`, #6816). So the expiry decision was taken **twice per element**, and a deadline that expired *between* the caller's `hasNext()` and its `next()` turned the element `hasNext()` had already promised into a bare `NoSuchElementException`:

1. `SelectExecutor.executeExists()` calls `iterator.hasNext()` -> `true` (deadline not yet expired)
2. `SelectExecutor.checkForTimeout()` -> `false` (still not expired)
3. `iterator.next()` -> `MultiIterator.hasNext()` -> deadline **now** expired -> `false` -> `NoSuchElementException`

With `exceptionOnTimeout == false` the contract for `Select.timeout(v, unit, false)` is "stop early and give me what you have", so an exception escaping to the caller is a behaviour bug - and one that only fires under load, the exact condition the budget exists for. The narrower the budget, the wider the window relative to it, which is why a 1 ms timeout exposed it.

## Blast radius

Not test-only. Every consumer that drives a `MultiIterator` with a non-throwing deadline has the same `hasNext()` / `checkForTimeout()` / `next()` shape:

| Call site | Shape |
|---|---|
| `SelectExecutor.executeExists()` | the one the issue's stack trace came from |
| `SelectExecutor.executeCount()` | identical loop |
| `SelectIterator.fetchNext()` | identical loop, drives `Select` streaming |

`SelectParallelIterator` is not affected: it reads `it.checkForTimeout()` directly and its producers iterate `getSources()`, never `hasNext()`/`next()`, so the new field is never touched concurrently (and needs no `volatile`, matching `browsed`/`skipped`/`partialIterator`).

## Fix

One `boolean promised` field on `MultiIterator`, set by `hasNext()` when it answers `true` and cleared by the `next()` that consumes it (and by `reset()`). `next()` skips its own `hasNext()` re-check while a promise is outstanding, so the expiry is decided **once per element**: an element already promised stays deliverable, and the deadline stops the iteration on the *following* `hasNext()`.

Deliberately, the promise is only ever read by `next()`. `hasNext()` still re-evaluates the deadline on every call, so two consecutive `hasNext()` calls with no `next()` in between report the expiry exactly as before - which is what `Issue6816MultiIteratorTimeoutTruncationTest.expiredDeadlineWithExceptionStillThrows` pins. An earlier draft that cached the verdict across `hasNext()` calls broke that test; this one leaves #6816's semantics untouched.

The throwing mode (`exceptionOnTimeout == true`, what `LocalDatabase.iterateType()` passes) still reports the expiry as a `TimeoutException`, one element later. A bare `next()` with no outstanding promise is unchanged and still fully deadline-checked.

## Test plan

New `engine/src/test/java/com/arcadedb/utility/Issue6880MultiIteratorTimeoutBetweenHasNextAndNextTest.java` - 8 tests, all deterministic. The expiry is **planted** (the deadline is put in the past between the two calls, reusing #6816's sleep-free `expireDeadline()` idiom) rather than raced against a 1 ms budget, which is what made the original symptom a 1-in-12 flake.

- [x] `nonThrowingExpiryAfterHasNextStillDeliversThePromisedElement` - the statement of the bug
- [x] `nonThrowingExpiryTruncatesOnTheFollowingHasNext` - the truncation still happens, one element later
- [x] `throwingExpiryAfterHasNextDeliversThenThrowsTimeout` - throwing mode still reports a `TimeoutException`, never a `NoSuchElementException`
- [x] `expiryBeforeAnyPromiseStopsImmediately` - the promise is per element, not a licence to keep going
- [x] `aPromiseIsSpentByTheNextThatConsumesIt` - a second `next()` without an intervening `hasNext()` cannot walk past the deadline
- [x] `expiryReachingTheSkipLoopStopsWithoutPromising` - the skip pre-loop is the one path in `hasNext()` that bypasses the promise; an expiry reaching it must stop outright and strand nothing
- [x] `resetDropsTheOutstandingPromise`
- [x] `unexpiredIterationIsUnaffectedBySkipAndLimit` - both are enforced through the very `hasNext()` path that changed

**Proof the tests can fail:** 4 of the 7 fail at base (`nonThrowingExpiryAfterHasNextStillDeliversThePromisedElement`, `nonThrowingExpiryTruncatesOnTheFollowingHasNext`, `throwingExpiryAfterHasNextDeliversThenThrowsTimeout`, `aPromiseIsSpentByTheNextThatConsumesIt`) with exactly the reported `NoSuchElementException`.

**Regression runs (all green):**
- `mvn -o -pl engine test -DexcludedGroups=benchmark,slow,vector` - full engine lane, BUILD SUCCESS
- `com.arcadedb.utility.*Test` + `com.arcadedb.query.select.*Test` + `MultiValueTest` + `TypeTest` + `ExceptionTest` + `BasicGraphTest` + `Issue5976AfterReadReentrancyRaceTest` - 780 tests, 0 failures
- `Issue6815SelectTimeoutNotInstalledTest` (the class that exposed the flake) run **15 consecutive times: 0 failures**, against a measured base rate of 1 failure in 12 runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198H1K2gE5qUbcUDYAWDvKF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iterator behavior when a timeout occurs between checking for the next item and retrieving it.
  * Ensured confirmed available items are delivered reliably before timeout handling is applied.
  * Preserved expected reset, skip, and limit behavior during timed iteration.

* **Tests**
  * Added regression coverage for timeout, expiry, reset, and promised-item scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Review history

- **cycle 1** (`fd49a9e`) - no blocking issues. Two suggestions, both applied in `2cccaa4`: document *why* the skip pre-loop is exempt from `promised` (it can only run while `skipped < skip`, and a promise only exists once that loop has finished; `setSkip()` has no production caller, so `skip` cannot be widened mid-iteration), and pin that reasoning with `expiryReachingTheSkipLoopStopsWithoutPromising` rather than leaving it to inspection.
- **cycle 2** (`2cccaa4`) - no blocking issues. Reviewed against every production call site of `MultiIterator`; confirmed none double-`hasNext()`s or calls `next()` without a preceding `hasNext()`, so nothing depends on the re-check this PR removes. Flagged the test-count drift in this description (fixed above) and one **pre-existing, out-of-scope** observation, recorded here so it is not lost: `next()` does `browsed++` before `partialIterator.next()` returns, so a throwing source iterator leaves `browsed` counting an element never delivered. Same ordering as before this PR; not changed here.
