### PR TITLE
fix(ci): shutdown() must join the watcher, not await a latch run() opens from inside itself

### DIFF
--- a/server/src/main/java/com/arcadedb/server/http/ws/DatabaseEventWatcherThread.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/DatabaseEventWatcherThread.java
@@ -25,7 +25,6 @@ import com.arcadedb.event.AfterRecordUpdateListener;
 import com.arcadedb.log.LogManager;
 
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -34,7 +33,6 @@ final public class DatabaseEventWatcherThread extends Thread {
   private final    ArrayBlockingQueue<ChangeEvent> eventQueue;
   private final    Database                        database;
   private volatile boolean                         running = true;
-  private final    CountDownLatch                  runningLock;
   private final    WebSocketEventListener          listener;
 
   public DatabaseEventWatcherThread(final WebSocketEventBus eventBus, final Database database, final int queueSize) {
@@ -43,7 +41,6 @@ final public class DatabaseEventWatcherThread extends Thread {
     this.eventQueue = new ArrayBlockingQueue<>(queueSize);
     this.database = database;
     this.listener = new WebSocketEventListener(this);
-    this.runningLock = new CountDownLatch(1);
 
     this.database.getEvents()
         .registerListener((AfterRecordCreateListener) listener)
@@ -85,8 +82,14 @@ final public class DatabaseEventWatcherThread extends Thread {
    * that only its own {@code run()} finally-block can count down, deadlocking it forever.
    * <p>
    * Deliberately no "already stopped, nothing to do" shortcut: {@link #signalStop()} may have run first, and returning
-   * on that would skip the join this method exists for. Once {@code run()} has finished the latch is already down, so
-   * a repeated call still returns immediately.
+   * on that would skip the join this method exists for. Once the thread has died {@link #join()} returns immediately,
+   * so a repeated call still costs nothing.
+   * <p>
+   * The wait is a {@link #join()} and not a latch counted down by {@code run()}: such a latch opens from INSIDE
+   * {@code run()}, which leaves the thread still alive for the JVM's own teardown after {@code run()} returns, so
+   * {@code shutdown()} could return on a watcher that was not yet terminated - roughly once in 300 calls, which is how
+   * it reached CI as a flake. {@code join()} is the barrier this method's contract claims, and it also cannot hang on a
+   * watcher that was constructed but never started, where a latch would have waited forever.
    */
   public void shutdown() {
     signalStop();
@@ -95,7 +98,7 @@ final public class DatabaseEventWatcherThread extends Thread {
       return;
 
     try {
-      runningLock.await();
+      join();
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
     }
@@ -113,15 +116,11 @@ final public class DatabaseEventWatcherThread extends Thread {
 
     } catch (final InterruptedException ignored) {
     } finally {
-      try {
-        this.database.getEvents().unregisterListener((AfterRecordCreateListener) listener)
-            .unregisterListener((AfterRecordUpdateListener) listener)
-            .unregisterListener((AfterRecordDeleteListener) listener);
+      this.database.getEvents().unregisterListener((AfterRecordCreateListener) listener)
+          .unregisterListener((AfterRecordUpdateListener) listener)
+          .unregisterListener((AfterRecordDeleteListener) listener);
 
-        eventQueue.clear();
-      } finally {
-        runningLock.countDown();
-      }
+      eventQueue.clear();
     }
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/ws/Issue5024WebSocketEventBusConcurrencyTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/Issue5024WebSocketEventBusConcurrencyTest.java
@@ -72,8 +72,10 @@ class Issue5024WebSocketEventBusConcurrencyTest {
 
   /**
    * Defect 1: when the watcher thread itself triggers a stop (the last subscriber turns out to be a zombie during
-   * {@code publish}), {@code shutdown()} must not block on its own termination latch. Before the fix the thread parks
-   * in {@code runningLock.await()} inside {@code publish()} inside {@code run()} and never terminates.
+   * {@code publish}), {@code shutdown()} must not block on its own termination. Before the fix the thread waited on
+   * that barrier from inside {@code publish()} inside {@code run()} - so it waited on a termination that only its own
+   * return could produce, and never terminated. The barrier was a latch then and is {@link Thread#join()} now; the
+   * self-shutdown guard is what makes either one safe.
    */
   @Test
   void watcherSelfShutdownDoesNotHang() throws Exception {

--- a/server/src/test/java/com/arcadedb/server/http/ws/Issue6762WebSocketEventBusTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/Issue6762WebSocketEventBusTest.java
@@ -118,8 +118,14 @@ class Issue6762WebSocketEventBusTest {
    * shot is not a regression test for it: {@code shutdown()} used to wait on a latch that {@code run()} counts down
    * from INSIDE itself, so it returned during the JVM's own thread teardown with the watcher still alive. That lost
    * roughly one call in 300 - often enough to redden CI (run 33201895826), far too rarely for one attempt to catch
-   * it. The loop is cheap: each watcher observes {@code running == false} on its first pass and unwinds without ever
-   * polling the queue.
+   * it.
+   * <p>
+   * The {@code interrupt()} is what keeps the loop cheap under load. A watcher that reads {@code running} before
+   * {@link DatabaseEventWatcherThread#signalStop()} stores {@code false} parks in the 500ms queue poll, and
+   * {@code shutdown()} then waits it out - measured at 446ms per occurrence, which 5,000 iterations could turn into
+   * minutes on a loaded runner. Interrupting releases the poll, and it costs the assertion nothing: either exit path
+   * runs the same {@code finally} and leaves the same window between {@code run()} returning and the thread dying
+   * (PR #6885 review).
    */
   @Test
   void shutdownStillJoinsAfterASeparateStopSignal() throws Exception {
@@ -131,6 +137,7 @@ class Issue6762WebSocketEventBusTest {
       watcher.start();
 
       watcher.signalStop();
+      watcher.interrupt();
       watcher.shutdown();
 
       if (watcher.isAlive())

--- a/server/src/test/java/com/arcadedb/server/http/ws/Issue6762WebSocketEventBusTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/Issue6762WebSocketEventBusTest.java
@@ -113,19 +113,33 @@ class Issue6762WebSocketEventBusTest {
    * {@code shutdown()} used to return early when {@code running} was already false, so once {@code signalStop()}
    * exists the join it is there to perform would be skipped - and the caller would carry on while the watcher's
    * listeners were still registered.
+   * <p>
+   * Repeated rather than checked once, because the second half of the same contract is a narrow race and a single
+   * shot is not a regression test for it: {@code shutdown()} used to wait on a latch that {@code run()} counts down
+   * from INSIDE itself, so it returned during the JVM's own thread teardown with the watcher still alive. That lost
+   * roughly one call in 300 - often enough to redden CI (run 33201895826), far too rarely for one attempt to catch
+   * it. The loop is cheap: each watcher observes {@code running == false} on its first pass and unwinds without ever
+   * polling the queue.
    */
   @Test
   void shutdownStillJoinsAfterASeparateStopSignal() throws Exception {
     final WebSocketEventBus bus = new WebSocketEventBus(null);
-    final DatabaseEventWatcherThread watcher = new DatabaseEventWatcherThread(bus, database, 16);
-    watcher.start();
 
-    watcher.signalStop();
-    watcher.shutdown();
+    int stillAlive = 0;
+    for (int i = 0; i < 5_000; i++) {
+      final DatabaseEventWatcherThread watcher = new DatabaseEventWatcherThread(bus, database, 16);
+      watcher.start();
 
-    assertThat(watcher.isAlive())
-        .as("shutdown() must have waited for run() to unwind and unregister its listeners")
-        .isFalse();
+      watcher.signalStop();
+      watcher.shutdown();
+
+      if (watcher.isAlive())
+        ++stillAlive;
+    }
+
+    assertThat(stillAlive)
+        .as("shutdown() must have waited for run() to unwind, unregister its listeners AND the thread to die")
+        .isZero();
   }
 
   /**


### PR DESCRIPTION
## The failure

CI run [33201895826](https://github.com/ArcadeData/arcadedb/actions/runs/33201895826/job/98954707041) went red on `main` with exactly one failure out of 18,407 tests:

```
Issue6762WebSocketEventBusTest.shutdownStillJoinsAfterASeparateStopSignal:128
[shutdown() must have waited for run() to unwind and unregister its listeners]
Expecting value to be false but was true
```

## Root cause

`DatabaseEventWatcherThread.shutdown()` waited on a `CountDownLatch` that `run()` counts down **in its own `finally` block**:

```java
public void shutdown() {
  signalStop();
  if (Thread.currentThread() == this) return;
  runningLock.await();          // opened from inside run()
}

public void run() {
  ...
  } finally {
    ... unregisterListener ...
    runningLock.countDown();    // <- still on the thread, run() has not returned
  }
}
```

The latch therefore opens from **inside** `run()`. The thread is still alive for the JVM's own teardown after `run()` returns, so `shutdown()` could return on a watcher that had not terminated and `isAlive()` was still `true`.

The latch does guarantee the safety-relevant half - the database listeners are unregistered and the queue cleared before it opens - which is why this never showed up as a duplicate-delivery bug. But it is strictly weaker than what two places in the code claim:

- `shutdown()`'s own javadoc: *"Sends the shutdown signal to the thread and waits for termination."*
- `WebSocketEventBus.unsubscribe()`: *"shutdown() blocks until the watcher thread terminates"*

## Reproduction

A 2000-iteration harness (`start(); signalStop(); shutdown(); isAlive()`) against unpatched `main`, five runs:

```
alive-after-shutdown 3/2000
alive-after-shutdown 4/2000
alive-after-shutdown 17/2000
alive-after-shutdown 4/2000
alive-after-shutdown 4/2000
```

Roughly 1 call in 300. Rare enough to survive the review of #6762, frequent enough to redden a nightly.

## The fix

`join()` is the barrier the contract already claims, and it returns strictly later than the latch did. It also cannot hang on a watcher that was constructed but never started, where `runningLock.await()` would have waited forever. The latch has no other reader, so it goes; `run()`'s nested `try/finally` collapses to one.

Behaviour is otherwise unchanged: `signalStop()` still flips the watcher off inside the per-database lock, and `shutdown()` invoked *from* the watcher thread still returns early rather than deadlocking on itself.

## The test

The failing assertion was left as-is in shape but is now repeated 5,000 times. A single shot caught the old code about one time in 300 - that reddens CI without being a regression test. The loop is cheap because each watcher observes `running == false` on its first pass and unwinds without ever polling the queue.

Proven to fail before it was trusted:

| | result |
|---|---|
| strengthened test vs. **unfixed** `DatabaseEventWatcherThread` | **3/3 red**, ~0.3s each |
| strengthened test vs. fixed | 5/5 green |

## Verification

| Suite | Result |
|---|---|
| `Issue6762WebSocketEventBusTest`, `Issue5024WebSocketEventBusConcurrencyTest`, `ChangeEventTest` x5 | 14/14 green each run |
| `WebSocketEventBusIT` (failsafe) | 20/20 green |
| `server` module unit tests, `-DexcludedGroups=benchmark,slow,vector` | **873/873 green** |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket event watcher shutdown reliability.
  * Shutdown now waits until watcher processes have fully stopped, preventing lingering background activity.
  * Improved cleanup of event listeners and queued events during shutdown.
  * Prevented shutdown deadlocks when a watcher stops itself.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->