### PR TITLE
fix(#6808): restore the user-file order, and teach GrpcAuthInterceptorTest that a token needs a live principal

### DIFF
--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAuthInterceptorTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAuthInterceptorTest.java
@@ -119,6 +119,10 @@ class GrpcAuthInterceptorTest {
 
     // getUsers() returns Set<String> - need at least one user for security to be enabled
     when(mockSecurity.getUsers()).thenReturn(Collections.singleton("testuser"));
+    // The token is only honored while its principal still exists (issue #6808): the session captured its
+    // ServerSecurityUser at login, so the interceptor re-checks the name against the live users map before
+    // letting the call through. A valid session therefore needs a principal that still resolves.
+    when(mockSecurity.getUser("testuser")).thenReturn(mockUser);
 
     GrpcAuthInterceptor interceptorWithSession = new GrpcAuthInterceptor(mockSecurity, mockSessionManager);
 
@@ -134,6 +138,35 @@ class GrpcAuthInterceptorTest {
     // Handler's startCall should be invoked (call proceeds)
     verify(mockHandler).startCall(any(), any());
     verify(mockCall, never()).close(any(), any());
+  }
+
+  @Test
+  void tokenOfADroppedPrincipalIsRejected() {
+    // Issue #6808: a session holds the ServerSecurityUser it captured at login, so without re-checking the
+    // live users map a token kept authenticating after its principal was dropped - until it idle-expired,
+    // up to 30 minutes after the operator believed the credentials were gone.
+    HttpAuthSession mockSession = mock(HttpAuthSession.class);
+    ServerSecurityUser mockUser = mock(ServerSecurityUser.class);
+    when(mockSession.getUser()).thenReturn(mockUser);
+    when(mockUser.getName()).thenReturn("droppeduser");
+    when(mockSessionManager.getSessionByToken("orphan-token")).thenReturn(mockSession);
+
+    when(mockSecurity.getUsers()).thenReturn(Collections.singleton("testuser"));
+    // The principal is gone from the live map, even though the session survives.
+    when(mockSecurity.getUser("droppeduser")).thenReturn(null);
+
+    GrpcAuthInterceptor interceptorWithSession = new GrpcAuthInterceptor(mockSecurity, mockSessionManager);
+
+    Metadata headers = new Metadata();
+    headers.put(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER), "Bearer orphan-token");
+    headers.put(Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER), "testdb");
+
+    when(mockMethodDescriptor.getFullMethodName()).thenReturn("com.arcadedb.grpc.ArcadeDbService/Query");
+
+    interceptorWithSession.interceptCall(mockCall, headers, mockHandler);
+
+    verify(mockHandler, never()).startCall(any(), any());
+    verify(mockCall).close(any(), any());
   }
 
   @Test

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -308,11 +308,18 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       throw new ServerSecurityException("User '" + name + "' already exists");
 
     final ServerSecurityUser user = new ServerSecurityUser(server, userConfiguration);
-    // Persist BEFORE publishing: saveUsers() propagates an I/O failure so the request fails, and publishing
-    // first would leave the new user live in memory while nothing reached the disk - authoritative until the
-    // next restart silently took it away again.
-    saveUsers(snapshotWith(name, userConfiguration));
+    // Publish, then persist, then UNDO the publish if the write failed. saveUsers() propagates an I/O
+    // failure so the request fails, and a failure must not leave the new user live in memory with nothing on
+    // disk - authoritative until the next restart silently took it away again. Writing a candidate list
+    // before publishing would achieve the same, but it also fixes the order users are written in (the new
+    // one last) rather than taking it from the map, which is a visible change to server-users.jsonl.
     users.put(name, user);
+    try {
+      saveUsers();
+    } catch (final RuntimeException e) {
+      users.remove(name);
+      throw e;
+    }
     return user;
   }
 
@@ -328,11 +335,16 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
       user = new ServerSecurityUser(server, userConfiguration);
       passwordChanged = !Objects.equals(previous.getPassword(), user.getPassword());
-      // Persist before publishing, as in createUser(): a failed save must leave the previous password in
-      // force rather than activate a new one that no longer exists after a restart - and the throw would
-      // also skip the session invalidation below, so the rotation would be half-applied.
-      saveUsers(snapshotWith(name, userConfiguration));
+      // Publish-then-persist-then-undo, as in createUser(): a failed save must leave the PREVIOUS password
+      // in force rather than activate one that no longer exists after a restart - and the throw would also
+      // skip the session invalidation below, so the rotation would otherwise be half-applied.
       users.put(name, user);
+      try {
+        saveUsers();
+      } catch (final RuntimeException e) {
+        users.put(name, previous);
+        throw e;
+      }
     }
 
     // Note: a metadata update does NOT force-rollback the principal's open transactions - per-request
@@ -371,12 +383,17 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    */
   public boolean dropUserLocally(final String userName) {
     synchronized (this) {
-      if (!users.containsKey(userName))
+      final ServerSecurityUser removed = users.remove(userName);
+      if (removed == null)
         return false;
-      // Persist before publishing, as in createUser()/updateUser(): a failed save must not leave a user
-      // removed in memory and still present on disk, which a restart would resurrect.
-      saveUsers(snapshotWith(userName, null));
-      users.remove(userName);
+      // Publish-then-persist-then-undo, as in createUser()/updateUser(): a failed save must not leave a user
+      // removed in memory but still present on disk, which a restart would resurrect.
+      try {
+        saveUsers();
+      } catch (final RuntimeException e) {
+        users.put(userName, removed);
+        throw e;
+      }
     }
     // Invalidate the dropped principal's live HTTP transaction sessions so a recreated same-name principal
     // cannot adopt (and commit) the prior principal's still-open session. Done OUTSIDE the security monitor:
@@ -722,20 +739,14 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     return json;
   }
 
-  public void saveUsers() {
-    saveUsers(usersToJSON());
-  }
-
   /**
-   * Writes an explicit user list to {@code server-users.jsonl}, so a mutation can be persisted <i>before</i>
-   * it is published to the in-memory map. Publishing first and saving after leaves the change authoritative
-   * in memory while nothing reached the disk when the write fails - and the propagated failure then also
-   * skips whatever the caller does afterwards (session invalidation, most importantly), so the mutation ends
-   * up half-applied instead of not applied at all.
+   * Writes the in-memory user map to {@code server-users.jsonl}. Propagates an I/O failure, so a mutator
+   * that has already published its change to the map must undo it - see {@link #createUser},
+   * {@link #updateUser} and {@link #dropUserLocally}, which all do.
    */
-  private void saveUsers(final List<JSONObject> snapshot) {
+  public void saveUsers() {
     try {
-      usersRepository.save(snapshot);
+      usersRepository.save(usersToJSON());
     } catch (final IOException e) {
       LogManager.instance()
           .log(this, Level.SEVERE, "Error on saving security configuration to file '%s'", e, SecurityUserFileRepository.FILE_NAME);
@@ -751,9 +762,10 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * the name is not present yet, or removed when {@code replacement} is {@code null}. Must be called while
    * holding this monitor.
    * <p>
-   * The single place the create/update/drop shape is expressed, on both the local and the replicated path:
-   * three hand-written copies of this loop is exactly how two of them ended up invalidating sessions and the
-   * third not.
+   * The single place the create/update/drop shape is expressed for the replicated payload: three
+   * hand-written copies of this loop is exactly how two of them ended up invalidating sessions and the third
+   * not. The local path does not use it - it saves the map itself, so the order users appear in
+   * {@code server-users.jsonl} keeps following the map rather than becoming "the changed one last".
    */
   private List<JSONObject> snapshotWith(final String name, final JSONObject replacement) {
     final List<JSONObject> snapshot = new ArrayList<>(users.size() + 1);


### PR DESCRIPTION
Follow-up to #6866, already merged. Two CI failures on that PR's run were genuinely caused by it.

**1. `server-users.jsonl` user order changed** (`ServerProfilingIT`, 12 methods red)

The persist-before-publish change built the file from a candidate list with the changed user appended last, instead of from the in-memory map — so a newly created user moved to the end of the file. Same protection, without touching the order: publish to the map, save, and undo the publish if the write failed. A failed write still leaves the previous state in force in memory and on disk alike. The replicated payload keeps using the shared snapshot helper, where appending matches what the replication path already did.

**2. `GrpcAuthInterceptorTest.validateTokenReturnsTrueForValidSession`**

The gRPC interceptor now re-checks the session's principal against the live users map, so a token stops working the moment its user is dropped rather than when it idle-expires. The test stubbed `getUsers()` but not `getUser()`, so its "valid" session had no principal and the call was correctly refused — the test asserted the old behaviour. Stubbed the lookup and added `tokenOfADroppedPrincipalIsRejected` to pin the new one.

Other failures on that run were checked and are not from #6866: `GraphAnalyticalViewTest.issue6641_*` and the `ha-integration-tests` lane are the documented chronic families, and `RemoteConsoleIT.userMgmt` failed because the branch predated the #6830 test update that `main` already carries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication validation for tokens backed by active sessions.
  * Tokens are now rejected when the associated user has been removed from the current security configuration.
  * Improved reliability when creating, updating, or deleting local security users; failed saves now restore the previous configuration.
  * Added regression coverage to help prevent authentication inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->