### PR TITLE
fix(#6792): separate GAV node count from ID bound

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/DenseNodeIdProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/DenseNodeIdProvider.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.database.RID;
+
+import java.util.Arrays;
+import java.util.function.IntConsumer;
+
+/**
+ * A {@link GraphTraversalProvider} whose node ID space has no holes in it, wrapped around one whose has.
+ * <p>
+ * A provider that allocates node IDs monotonically and does not renumber when a node is deleted - which is what
+ * a Graph Analytical View's delta overlay does - reports a live node count smaller than the exclusive bound of
+ * its own ID space. Every consumer that indexes an array by node ID then has two ways to be wrong at once, and
+ * neither of them is an error it can attribute (issue #6792):
+ * <ul>
+ *   <li>sizing the array from {@link GraphTraversalProvider#getNodeCount()} leaves the highest live nodes
+ *       outside it, so they are silently absent from the answer;</li>
+ *   <li>sizing it from {@link GraphTraversalProvider#getNodeIdUpperBound()} covers them, but then every array
+ *       carries a slot per deleted node and every enumeration of it has to remember to skip those slots -
+ *       a rule that has to hold in every one of the fifty-odd {@code algo.*} procedures to be worth anything.</li>
+ * </ul>
+ * This removes the choice rather than restating it. The holes are renumbered away once, here, and the whole
+ * graph is handed on as the compact {@code 0..getNodeCount()} space the SPI documents - so a consumer needs no
+ * rule at all, and one written before overlays existed is correct in front of one.
+ * <p>
+ * {@link #wrap(GraphTraversalProvider)} returns the provider unchanged when its IDs are already compact, so the
+ * translation costs nothing on the ordinary path: holes exist only while an overlay is holding deletions.
+ * <p>
+ * The mapping is built once, from the ID space as it stood at construction, and every answer this instance gives
+ * is consistent with that one reading. A node deleted afterwards keeps its dense ID and resolves to a RID that
+ * no longer loads - the same "deleted since the graph was loaded" case every consumer of this SPI already
+ * handles - rather than shifting the IDs of its neighbours underneath a running algorithm.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class DenseNodeIdProvider implements GraphTraversalProvider {
+  private static final int[] EMPTY_NEIGHBORS = new int[0];
+
+  private final GraphTraversalProvider delegate;
+  /** Dense ID -> delegate ID, one entry per live node. */
+  private final int[]                  toDelegate;
+  /** Delegate ID -> dense ID, {@code -1} for a hole. */
+  private final int[]                  toDense;
+
+  /**
+   * Returns {@code provider} itself when its node IDs are already compact, and a renumbering wrapper around it
+   * when they are not.
+   * <p>
+   * Asking is one comparison, so a caller that may be handed either shape calls this unconditionally rather than
+   * testing for a Graph Analytical View, or for an overlay, at the call site: the question is about the ID space,
+   * not about who produced it.
+   */
+  public static GraphTraversalProvider wrap(final GraphTraversalProvider provider) {
+    if (provider == null)
+      return null;
+    final int bound = provider.getNodeIdUpperBound();
+    if (bound == provider.getNodeCount())
+      // Compact already: every ID below the bound is a live node, which is the space this class would build.
+      return provider;
+    return new DenseNodeIdProvider(provider, bound);
+  }
+
+  private DenseNodeIdProvider(final GraphTraversalProvider delegate, final int bound) {
+    this.delegate = delegate;
+    this.toDense = new int[bound];
+    int live = 0;
+    for (int id = 0; id < bound; id++)
+      toDense[id] = delegate.isNodeLive(id) ? live++ : -1;
+
+    // Sized from the scan rather than from getNodeCount(): the two must agree, and if a provider ever reports a
+    // count its own liveness predicate does not back up, the scan is the one this class can stand behind.
+    this.toDelegate = new int[live];
+    for (int id = 0; id < bound; id++)
+      if (toDense[id] >= 0)
+        toDelegate[toDense[id]] = id;
+  }
+
+  /** The provider being renumbered, for a caller that has to reach past the dense ID space. */
+  public GraphTraversalProvider getDelegate() {
+    return delegate;
+  }
+
+  private int delegateId(final int denseId) {
+    return denseId >= 0 && denseId < toDelegate.length ? toDelegate[denseId] : -1;
+  }
+
+  private int denseId(final int delegateId) {
+    return delegateId >= 0 && delegateId < toDense.length ? toDense[delegateId] : -1;
+  }
+
+  /**
+   * Renumbers a neighbour row into a new array, compacting away any entry pointing at a hole.
+   * <p>
+   * A new array rather than the delegate's own: a CSR-backed provider is free to hand back a slice of its
+   * adjacency arrays when it has nothing to merge into them, and renumbering that in place would rewrite the
+   * graph itself. The copy is what makes this class safe to put in front of any provider rather than only in
+   * front of the ones whose rows are known to be fresh.
+   * <p>
+   * A hole cannot normally appear in a row - deleting a vertex deletes its edges, so the overlay drops both
+   * together - but a row that did carry one would otherwise renumber it to {@code -1} and hand the caller a
+   * negative array index, which is the very failure this class exists to remove.
+   */
+  private int[] translate(final int[] neighbors) {
+    if (neighbors == null || neighbors.length == 0)
+      return EMPTY_NEIGHBORS;
+    final int[] dense = new int[neighbors.length];
+    int kept = 0;
+    for (final int neighbor : neighbors) {
+      final int id = denseId(neighbor);
+      if (id >= 0)
+        dense[kept++] = id;
+    }
+    return kept == dense.length ? dense : Arrays.copyOf(dense, kept);
+  }
+
+  @Override
+  public int getNodeCount() {
+    return toDelegate.length;
+  }
+
+  @Override
+  public int getNodeIdUpperBound() {
+    return toDelegate.length;
+  }
+
+  @Override
+  public boolean isNodeLive(final int nodeId) {
+    return nodeId >= 0 && nodeId < toDelegate.length;
+  }
+
+  @Override
+  public boolean hasPendingChanges() {
+    // Renumbering the IDs says nothing about whether the delegate's own CSR arrays are the whole graph, and a
+    // caller reaching for those arrays has to get the delegate's honest answer, not a reassuring one.
+    return delegate.hasPendingChanges();
+  }
+
+  @Override
+  public boolean isReady() {
+    return delegate.isReady();
+  }
+
+  @Override
+  public String getName() {
+    return delegate.getName();
+  }
+
+  @Override
+  public boolean coversVertexType(final String typeName) {
+    return delegate.coversVertexType(typeName);
+  }
+
+  @Override
+  public boolean coversEdgeType(final String edgeTypeName) {
+    return delegate.coversEdgeType(edgeTypeName);
+  }
+
+  @Override
+  public int getNodeId(final RID rid) {
+    return denseId(delegate.getNodeId(rid));
+  }
+
+  @Override
+  public RID getRID(final int nodeId) {
+    final int id = delegateId(nodeId);
+    return id < 0 ? null : delegate.getRID(id);
+  }
+
+  @Override
+  public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+    final int id = delegateId(nodeId);
+    if (id < 0)
+      return EMPTY_NEIGHBORS;
+    return translate(delegate.getNeighborIds(id, direction, edgeTypes));
+  }
+
+  @Override
+  public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+    final int id = delegateId(nodeId);
+    return id < 0 ? 0 : delegate.countEdges(id, direction, edgeTypes);
+  }
+
+  @Override
+  public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+      final String... edgeTypes) {
+    final int a = delegateId(nodeA);
+    final int b = delegateId(nodeB);
+    return a >= 0 && b >= 0 && delegate.isConnectedTo(a, b, direction, edgeTypes);
+  }
+
+  @Override
+  public long countEdgesBetween(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+      final String... edgeTypes) {
+    final int a = delegateId(nodeA);
+    final int b = delegateId(nodeB);
+    return a < 0 || b < 0 ? 0 : delegate.countEdgesBetween(a, b, direction, edgeTypes);
+  }
+
+  @Override
+  public Object getProperty(final int nodeId, final String propertyName) {
+    final int id = delegateId(nodeId);
+    return id < 0 ? null : delegate.getProperty(id, propertyName);
+  }
+
+  @Override
+  public double getMeanEdgesPerConnectedPair(final String edgeType) {
+    return delegate.getMeanEdgesPerConnectedPair(edgeType);
+  }
+
+  @Override
+  public String[] getMaterializedEdgeTypes() {
+    return delegate.getMaterializedEdgeTypes();
+  }
+
+  @Override
+  public boolean hasEdgeProperties() {
+    return delegate.hasEdgeProperties();
+  }
+
+  @Override
+  public boolean hasEdgeProperty(final String edgeType, final String propertyName) {
+    return delegate.hasEdgeProperty(edgeType, propertyName);
+  }
+
+  @Override
+  public boolean servesEdgeProperty(final String propertyName, final String... edgeTypes) {
+    return delegate.servesEdgeProperty(propertyName, edgeTypes);
+  }
+
+  @Override
+  public NodeEdgeWeights edgeWeightsForSlice(final int nodeId, final Vertex.DIRECTION direction,
+      final String edgeType, final String propertyName, final double defaultWeight, final IntConsumer edgeCheckpoint) {
+    final int id = delegateId(nodeId);
+    if (id < 0)
+      return null;
+    return translate(
+        delegate.edgeWeightsForSlice(id, direction, edgeType, propertyName, defaultWeight, edgeCheckpoint));
+  }
+
+  @Override
+  public NodeEdgeWeights edgeWeightsOf(final int nodeId, final Vertex.DIRECTION direction,
+      final String propertyName, final double defaultWeight, final IntConsumer edgeCheckpoint,
+      final String[] edgeTypes) {
+    final int id = delegateId(nodeId);
+    if (id < 0)
+      return null;
+    return translate(
+        delegate.edgeWeightsOf(id, direction, propertyName, defaultWeight, edgeCheckpoint, edgeTypes));
+  }
+
+  /**
+   * Renumbers a weighted row, dropping a {@code (neighbour, weight)} pair whose neighbour is a hole - both
+   * halves of it, so the two arrays stay paired by construction the way the SPI promises.
+   */
+  private NodeEdgeWeights translate(final NodeEdgeWeights row) {
+    if (row == null)
+      return null;
+    final int[] neighbors = row.neighbors();
+    final double[] sourceWeights = row.weights();
+    final int[] denseNeighbors = new int[neighbors.length];
+    final double[] weights = new double[neighbors.length];
+    int kept = 0;
+    for (int i = 0; i < neighbors.length; i++) {
+      final int dense = denseId(neighbors[i]);
+      if (dense >= 0) {
+        denseNeighbors[kept] = dense;
+        weights[kept] = sourceWeights[i];
+        kept++;
+      }
+    }
+    if (kept == denseNeighbors.length)
+      return new NodeEdgeWeights(denseNeighbors, weights);
+    return new NodeEdgeWeights(Arrays.copyOf(denseNeighbors, kept), Arrays.copyOf(weights, kept));
+  }
+
+  @Override
+  public boolean isStale() {
+    return delegate.isStale();
+  }
+
+  @Override
+  public NeighborView getNeighborView(final Vertex.DIRECTION direction, final String... edgeTypes) {
+    // A packed view IS the delegate's own CSR arrays, addressed by its own node IDs. Renumbering it would mean
+    // copying the whole graph, which is the allocation the view exists to avoid, so the honest answer is the one
+    // the SPI already reserves for "I cannot serve this": the caller falls back to per-node lookups, which this
+    // class does renumber.
+    return null;
+  }
+
+  @Override
+  public void getDegrees(final int[] degrees, final Vertex.DIRECTION direction, final String edgeType) {
+    final int[] scratch = new int[toDense.length];
+    delegate.getDegrees(scratch, direction, edgeType);
+    Arrays.fill(degrees, 0);
+    final int n = Math.min(degrees.length, toDelegate.length);
+    for (int dense = 0; dense < n; dense++)
+      degrees[dense] = scratch[toDelegate[dense]];
+  }
+
+  @Override
+  public String toString() {
+    return "DenseNodeIdProvider(" + delegate.getName() + ", " + toDelegate.length + " of " + toDense.length + ")";
+  }
+}

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -52,13 +52,53 @@ public interface GraphTraversalProvider {
    * Returns the exclusive upper bound of node IDs this provider can expose.
    * <p>
    * Every ID returned by {@link #getNodeId(RID)} or {@link #getNeighborIds(int, Vertex.DIRECTION, String...)} is
-   * smaller than this bound. The range may contain holes, so node-indexed arrays must be sized from this method
-   * while result enumeration must still tolerate an ID that does not resolve to a live node.
+   * smaller than this bound. The range may contain holes - IDs whose node is gone - so an array indexed by node
+   * ID has to be sized from this method rather than from {@link #getNodeCount()}, and an enumeration of it has
+   * to ask {@link #isNodeLive(int)} about every ID it visits.
+   * <p>
+   * The two answers differ only for a provider that allocates IDs monotonically and does not renumber when a
+   * node is deleted, which is what a delta overlay does: the live count shrinks while the largest live ID does
+   * not move. Sizing from the count then leaves the highest live nodes outside every array - silently absent
+   * from the answer - and lets a neighbour ID index past the end of one (issue #6792).
+   * <p>
+   * A consumer that would rather not carry holes at all wraps the provider in
+   * {@link DenseNodeIdProvider#wrap(GraphTraversalProvider)}, which renumbers them away.
    * <p>
    * The default preserves the compact-ID contract of existing providers.
    */
   default int getNodeIdUpperBound() {
     return getNodeCount();
+  }
+
+  /**
+   * Returns true when {@code nodeId} addresses a node this provider still holds, false for a hole left behind by
+   * a deleted one.
+   * <p>
+   * The companion of {@link #getNodeIdUpperBound()}: the bound says how far the ID space reaches, this says
+   * which of those IDs mean anything. The default is the compact-ID contract - every ID below the bound is
+   * live - which is exactly true for a provider that never leaves holes.
+   */
+  default boolean isNodeLive(final int nodeId) {
+    return nodeId >= 0 && nodeId < getNodeIdUpperBound();
+  }
+
+  /**
+   * Returns true while this provider is serving changes that its raw CSR arrays do not contain.
+   * <p>
+   * <b>The predicate a consumer that reads those arrays directly has to check before it may believe them.</b>
+   * {@link #getNeighborIds}, {@link #countEdges} and every other per-node accessor on this SPI apply the pending
+   * changes themselves and need no such check; the ones that bypass them do:
+   * {@link #getNeighborView(Vertex.DIRECTION, String...)} already answers {@code null} rather than hand back a
+   * stale packed view, and the kernels in {@code GraphAlgorithms} read a
+   * {@code GraphAnalyticalView}'s CSR indices straight off the view, so a caller reaching for one of them must
+   * refuse here and read the graph through this SPI instead.
+   * <p>
+   * Two things go wrong otherwise, and neither raises anything the caller can attribute: the answer is the graph
+   * as it stood at the last build rather than as it stands now, and the arrays those kernels size from the base
+   * node mapping are shorter than the ID space this provider now reports (issue #6792).
+   */
+  default boolean hasPendingChanges() {
+    return false;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -41,10 +41,25 @@ import java.util.function.IntConsumer;
 public interface GraphTraversalProvider {
 
   /**
-   * Returns the total number of nodes in this provider's CSR structure.
-   * Dense node IDs range from 0 (inclusive) to getNodeCount() (exclusive).
+   * Returns the number of live nodes in this provider's graph.
+   * <p>
+   * Providers whose node ID space can contain holes must expose the exclusive bound of that space through
+   * {@link #getNodeIdUpperBound()} instead of requiring callers to infer it from this count.
    */
   int getNodeCount();
+
+  /**
+   * Returns the exclusive upper bound of node IDs this provider can expose.
+   * <p>
+   * Every ID returned by {@link #getNodeId(RID)} or {@link #getNeighborIds(int, Vertex.DIRECTION, String...)} is
+   * smaller than this bound. The range may contain holes, so node-indexed arrays must be sized from this method
+   * while result enumeration must still tolerate an ID that does not resolve to a live node.
+   * <p>
+   * The default preserves the compact-ID contract of existing providers.
+   */
+  default int getNodeIdUpperBound() {
+    return getNodeCount();
+  }
 
   /**
    * Returns true if this provider is ready to serve queries.

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -523,6 +523,16 @@ class DeltaOverlay {
   }
 
   /**
+   * Returns the exclusive upper bound of the node ID space.
+   * <p>
+   * Overflow slots are allocated monotonically and are not renumbered or reused when a node is deleted, so the
+   * bound includes deleted base and overflow slots even though {@link #getTotalNodeCount()} does not.
+   */
+  int getNodeIdUpperBound() {
+    return baseNodeCount + overflowCount;
+  }
+
+  /**
    * Returns the number of live overflow vertices, i.e. the allocated overflow slots minus the
    * ones that have been deleted. The internal {@code overflowCount} field is a monotonic
    * slot-allocation counter (it drives overflow id assignment and the {@link #isDeleted} bounds

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1245,6 +1245,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     return snap.nodeMapping.size();
   }
 
+  @Override
+  public int getNodeIdUpperBound() {
+    final Snapshot snap = checkBuilt();
+    final DeltaOverlay ov = snap.overlay;
+    if (ov != null)
+      return ov.getNodeIdUpperBound();
+    return snap.nodeMapping.size();
+  }
+
   public int getEdgeCount() {
     final Snapshot snap = checkBuilt();
     int total = 0;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1245,6 +1245,11 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     return snap.nodeMapping.size();
   }
 
+  /**
+   * The exclusive bound of the dense node ID space, which is <b>not</b> {@link #getNodeCount()} while an overlay
+   * is active: the overlay retains the slot of every deleted node and allocates the ID of every added one above
+   * the base mapping, so the live count shrinks while the largest live ID does not move (issue #6792).
+   */
   @Override
   public int getNodeIdUpperBound() {
     final Snapshot snap = checkBuilt();
@@ -1252,6 +1257,33 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     if (ov != null)
       return ov.getNodeIdUpperBound();
     return snap.nodeMapping.size();
+  }
+
+  /**
+   * True for a node ID this view still holds, false for the slot of one the overlay has deleted.
+   * <p>
+   * Deliberately not phrased as "{@link #getRID(int)} answers non-null": a base node the overlay deleted is
+   * still in the base mapping, so its RID is still there to be read - it just no longer names a node of this
+   * graph. The liveness question has to be asked of the overlay, which is the only thing that knows.
+   */
+  @Override
+  public boolean isNodeLive(final int nodeId) {
+    if (nodeId < 0)
+      return false;
+    final Snapshot snap = checkBuilt();
+    final DeltaOverlay ov = snap.overlay;
+    if (ov == null)
+      return nodeId < snap.nodeMapping.size();
+    return nodeId < ov.getNodeIdUpperBound() && !ov.isDeleted(nodeId);
+  }
+
+  /**
+   * True while committed changes are being served from the delta overlay rather than from the base CSR arrays,
+   * which is the SPI form of {@link #hasActiveOverlay()} - see there for what a caller must do about it.
+   */
+  @Override
+  public boolean hasPendingChanges() {
+    return hasActiveOverlay();
   }
 
   public int getEdgeCount() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountStep.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.graph.DenseNodeIdProvider;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
@@ -58,6 +59,14 @@ public final class CSRCountStep extends AbstractExecutionStep {
       // vertex; one built over a subset of the vertex types would count a subset of the graph (issue #5757).
       if (provider != null && op.requiresFullVertexCoverage() && !provider.coversVertexType(null))
         provider = null;
+
+      // Every CountOp indexes its scratch arrays by node id and iterates the id space from the node count, so
+      // the two have to be the same number. They are not for a provider holding overlay deletions, which keeps
+      // the slot of every deleted node and allocates the id of every added one above the base mapping: the
+      // count then names neither the size of the space nor the ids in it, and the operator both skips the
+      // highest live nodes and indexes past the end of its own arrays (issue #6792). Renumbering here hands the
+      // operators the compact space they are written against; it is a no-op when there are no holes.
+      provider = DenseNodeIdProvider.wrap(provider);
 
       final WorkGuard guard = WorkGuard.forCommandDeadline(context);
       final long count;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -687,7 +687,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         // A Graph Analytical View is shared, pre-built state this call neither allocates nor frees, so its own
         // footprint is not the call's to price. What is the call's is the copy adjacency() takes out of it, and
         // that is reserved there.
-        return new GraphData(provider, provider.getNodeCount(), memory);
+        return new GraphData(provider, provider.getNodeIdUpperBound(), memory);
       }
     }
     return new GraphData(loadVertices(db, nodeLabels, memory), memory);
@@ -701,6 +701,10 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     private static final int[]    EMPTY_NEIGHBORS = new int[0];
     private static final double[] EMPTY_WEIGHTS   = new double[0];
 
+    /**
+     * Size of every node-ID-indexed structure. For a provider-backed graph this is the exclusive node ID bound,
+     * which can exceed the live node count when the provider retains deleted slots as holes.
+     */
     public final int                     nodeCount;
     private final GraphTraversalProvider provider;
     private final List<Vertex>           vertices;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.DenseNodeIdProvider;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphEngine;
@@ -649,7 +650,10 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
    */
   protected int[][] buildAdjacencyFromProvider(final GraphTraversalProvider provider, final Vertex.DIRECTION dir,
       final String[] relTypes) {
-    final int n = provider.getNodeCount();
+    // The ID space, not the live count: the two differ for a provider that leaves holes behind deleted nodes,
+    // and sizing from the count would leave the highest live nodes out of the adjacency and let a neighbour id
+    // index past the end of it (issue #6792).
+    final int n = provider.getNodeIdUpperBound();
     final int[][] adj = new int[n][];
     for (int i = 0; i < n; i++)
       adj[i] = provider.getNeighborIds(i, dir, relTypes);
@@ -687,7 +691,14 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         // A Graph Analytical View is shared, pre-built state this call neither allocates nor frees, so its own
         // footprint is not the call's to price. What is the call's is the copy adjacency() takes out of it, and
         // that is reserved there.
-        return new GraphData(provider, provider.getNodeIdUpperBound(), memory);
+        //
+        // Wrapped so that the node ids reaching the fifty-odd procedures built on GraphData are the compact
+        // 0..nodeCount space they all assume. A view holding overlay deletions does not renumber, so its ids
+        // have holes in them; renumbering here once means no procedure has to size an array from the id bound
+        // and then remember to skip the holes in it, and every procedure written before overlays existed is
+        // correct in front of one (issue #6792). wrap() is a no-op for a compact id space.
+        final GraphTraversalProvider dense = DenseNodeIdProvider.wrap(provider);
+        return new GraphData(dense, dense.getNodeIdUpperBound(), memory);
       }
     }
     return new GraphData(loadVertices(db, nodeLabels, memory), memory);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.DenseNodeIdProvider;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
@@ -111,7 +112,10 @@ public class AlgoArticleRank extends AbstractAlgoProcedure {
     final WorkGuard guard = newWorkGuard(context);
 
     // Try CSR-accelerated path
-    final GraphTraversalProvider provider = findProvider(db, null);
+    // Renumbered when the provider's id space has holes in it, so that n below is both the array size and the
+    // exclusive id bound - the two have to be the same number for a rank array indexed by neighbour id
+    // (issue #6792). wrap() is a no-op for a compact id space.
+    final GraphTraversalProvider provider = DenseNodeIdProvider.wrap(findProvider(db, null));
     if (provider != null) {
       context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
       return executeWithCSR(provider, dampingFactor, maxIterations, tolerance, guard);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBFS.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBFS.java
@@ -105,7 +105,10 @@ public class AlgoBFS extends AbstractAlgoProcedure {
 
     // Try CSR-accelerated path: delegate to parallel BFS on CSR arrays
     final GraphTraversalProvider provider = findProvider(db, relTypes);
-    if (provider instanceof GraphAnalyticalView gav) {
+    // Only while the view is not serving pending changes: the GraphAlgorithms kernel below reads its base CSR
+    // arrays directly and sizes its result from the base node mapping, which is neither the current graph nor
+    // as wide as the id space the view now reports - see GraphTraversalProvider#hasPendingChanges (issue #6792).
+    if (provider instanceof GraphAnalyticalView gav && !gav.hasPendingChanges()) {
       context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
       final int startIdx = gav.getNodeId(startNode.getIdentity());
       if (startIdx < 0)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
@@ -115,7 +115,11 @@ public class AlgoDijkstraSingleSource extends AbstractAlgoProcedure {
     // Not the coarser hasEdgeProperties(): the CSR kernel below reads the weight column directly and falls back
     // to a unit weight when it is missing, so a view materialising some OTHER property would silently answer an
     // unweighted shortest path to a weighted question (issue #6301).
-    if (provider instanceof GraphAnalyticalView gav && gav.servesEdgeProperty(weightProperty, relTypes)) {
+    // Only while the view is not serving pending changes: the GraphAlgorithms kernel below reads its base CSR
+    // arrays directly and sizes its result from the base node mapping, which is neither the current graph nor
+    // as wide as the id space the view now reports - see GraphTraversalProvider#hasPendingChanges (issue #6792).
+    if (provider instanceof GraphAnalyticalView gav && !gav.hasPendingChanges()
+        && gav.servesEdgeProperty(weightProperty, relTypes)) {
       final Stream<Result> accelerated = executeWithCSR(context, gav, startNode.getIdentity(), relTypes, weightProperty, dir);
       // Null means the kernel refused: it reads the CSR arrays directly, and a delta overlay holds edges those
       // arrays do not have (issue #6315). Serving edge properties and being readable array-by-array are two

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLabelPropagation.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLabelPropagation.java
@@ -106,7 +106,10 @@ public class AlgoLabelPropagation extends AbstractAlgoProcedure {
 
     // Try CSR-accelerated path: delegate to native label propagation on CSR arrays
     final GraphTraversalProvider provider = findProvider(db, null);
-    if (provider instanceof GraphAnalyticalView gav) {
+    // Only while the view is not serving pending changes: the GraphAlgorithms kernel below reads its base CSR
+    // arrays directly and sizes its result from the base node mapping, which is neither the current graph nor
+    // as wide as the id space the view now reports - see GraphTraversalProvider#hasPendingChanges (issue #6792).
+    if (provider instanceof GraphAnalyticalView gav && !gav.hasPendingChanges()) {
       context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
       return executeWithCSR(context, gav, maxIterations, guard);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLocalClusteringCoefficient.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLocalClusteringCoefficient.java
@@ -97,7 +97,10 @@ public class AlgoLocalClusteringCoefficient extends AbstractAlgoProcedure {
 
     // Try CSR-accelerated path
     final GraphTraversalProvider provider = findProvider(db, relTypes);
-    if (provider instanceof GraphAnalyticalView gav) {
+    // Only while the view is not serving pending changes: the GraphAlgorithms kernel below reads its base CSR
+    // arrays directly and sizes its result from the base node mapping, which is neither the current graph nor
+    // as wide as the id space the view now reports - see GraphTraversalProvider#hasPendingChanges (issue #6792).
+    if (provider instanceof GraphAnalyticalView gav && !gav.hasPendingChanges()) {
       context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
       return executeWithCSR(context, gav, relTypes);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -116,7 +116,10 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
 
     // Try CSR-accelerated path (only for unweighted PageRank)
     final GraphTraversalProvider provider = weightProperty == null ? findProvider(db, null) : null;
-    if (provider instanceof GraphAnalyticalView gav) {
+    // Only while the view is not serving pending changes: the GraphAlgorithms kernel below reads its base CSR
+    // arrays directly and sizes its result from the base node mapping, which is neither the current graph nor
+    // as wide as the id space the view now reports - see GraphTraversalProvider#hasPendingChanges (issue #6792).
+    if (provider instanceof GraphAnalyticalView gav && !gav.hasPendingChanges()) {
       context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
       return executeWithCSR(context, gav, dampingFactor, maxIterations, direction, guard);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPersonalizedPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPersonalizedPageRank.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.graph.DenseNodeIdProvider;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.NeighborView;
 import com.arcadedb.graph.Vertex;
@@ -93,7 +94,10 @@ public class AlgoPersonalizedPageRank extends AbstractAlgoProcedure {
     final WorkGuard guard = newWorkGuard(context);
 
     // Try CSR-accelerated path
-    final GraphTraversalProvider provider = findProvider(db, relTypes);
+    // Renumbered when the provider's id space has holes in it, so that n below is both the array size and the
+    // exclusive id bound - the two have to be the same number for a rank array indexed by neighbour id
+    // (issue #6792). wrap() is a no-op for a compact id space.
+    final GraphTraversalProvider provider = DenseNodeIdProvider.wrap(findProvider(db, relTypes));
     if (provider != null) {
       final int sourceIdx = provider.getNodeId(sourceVertex.getIdentity());
       if (sourceIdx >= 0) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoWCC.java
@@ -96,7 +96,10 @@ public class AlgoWCC extends AbstractAlgoProcedure {
     // own CSR index (GraphAnalyticalView#getCSRIndex), so passing the filter through keeps the
     // parallel algorithm for a filtered call instead of dropping to the single-threaded BFS below.
     final GraphTraversalProvider provider = findProvider(db, relTypes);
-    if (provider instanceof GraphAnalyticalView gav) {
+    // Only while the view is not serving pending changes: the GraphAlgorithms kernel below reads its base CSR
+    // arrays directly and sizes its result from the base node mapping, which is neither the current graph nor
+    // as wide as the id space the view now reports - see GraphTraversalProvider#hasPendingChanges (issue #6792).
+    if (provider instanceof GraphAnalyticalView gav && !gav.hasPendingChanges()) {
       context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
       return executeWithCSR(context, gav, relTypes);
     }

--- a/engine/src/test/java/com/arcadedb/graph/DenseNodeIdProviderTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/DenseNodeIdProviderTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit coverage for {@link DenseNodeIdProvider}, the renumbering wrapper issue #6792 puts in front of a provider
+ * whose node ID space has holes in it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class DenseNodeIdProviderTest {
+  private Database            database;
+  private GraphAnalyticalView view;
+  private RID                 a;
+  private RID                 b;
+  private RID                 fresh;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-dense-node-id-provider");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    database.getSchema().createEdgeType("E");
+
+    final MutableVertex[] created = new MutableVertex[3];
+    database.transaction(() -> {
+      created[0] = database.newVertex("N").set("name", "SPARE").save();
+      created[1] = database.newVertex("N").set("name", "A").save();
+      created[2] = database.newVertex("N").set("name", "B").save();
+      created[1].newEdge("E", created[2]).save();
+    });
+    a = created[1].getIdentity();
+    b = created[2].getIdentity();
+
+    view = GraphAnalyticalView.builder(database)
+        .withName("dense-node-id-provider")
+        .withVertexTypes("N")
+        .withEdgeTypes("E")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .withCompactionThreshold(Integer.MAX_VALUE)
+        .build();
+  }
+
+  @AfterEach
+  void teardown() {
+    if (view != null)
+      view.drop();
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void aCompactProviderIsHandedBackUnwrapped() {
+    // Nothing pending, so the view's IDs are already 0..getNodeCount(): wrapping would only cost a translation.
+    assertThat(DenseNodeIdProvider.wrap(view)).isSameAs(view);
+    assertThat(DenseNodeIdProvider.wrap(null)).isNull();
+  }
+
+  @Test
+  void aHoleInTheIdSpaceIsRenumberedAway() {
+    deleteSpareAndAddFresh();
+
+    assertThat(view.getNodeCount()).isNotEqualTo(view.getNodeIdUpperBound());
+    final GraphTraversalProvider dense = DenseNodeIdProvider.wrap(view);
+    assertThat(dense).isNotSameAs(view);
+
+    assertThat(dense.getNodeCount()).isEqualTo(3);
+    assertThat(dense.getNodeIdUpperBound()).isEqualTo(3);
+
+    final Set<RID> resolved = new HashSet<>();
+    for (int id = 0; id < dense.getNodeCount(); id++) {
+      assertThat(dense.isNodeLive(id)).isTrue();
+      final RID rid = dense.getRID(id);
+      assertThat(rid).isNotNull();
+      resolved.add(rid);
+      // Round trip: the dense id of the RID this id resolves to is this id.
+      assertThat(dense.getNodeId(rid)).isEqualTo(id);
+    }
+    assertThat(resolved).containsExactlyInAnyOrder(a, b, fresh);
+    assertThat(dense.isNodeLive(3)).isFalse();
+    assertThat(dense.isNodeLive(-1)).isFalse();
+  }
+
+  @Test
+  void neighbourIdsAreTranslatedIntoTheDenseSpace() {
+    deleteSpareAndAddFresh();
+    final GraphTraversalProvider dense = DenseNodeIdProvider.wrap(view);
+
+    final int denseA = dense.getNodeId(a);
+    final int denseB = dense.getNodeId(b);
+    final int denseFresh = dense.getNodeId(fresh);
+
+    assertThat(dense.getNeighborIds(denseA, Vertex.DIRECTION.OUT, "E")).containsExactly(denseB);
+    assertThat(dense.getNeighborIds(denseB, Vertex.DIRECTION.OUT, "E")).containsExactly(denseFresh);
+    assertThat(dense.getNeighborIds(denseFresh, Vertex.DIRECTION.OUT, "E")).isEmpty();
+    assertThat(dense.getNeighborIds(denseFresh, Vertex.DIRECTION.IN, "E")).containsExactly(denseB);
+
+    assertThat(dense.isConnectedTo(denseB, denseFresh, Vertex.DIRECTION.OUT, "E")).isTrue();
+    assertThat(dense.isConnectedTo(denseA, denseFresh, Vertex.DIRECTION.OUT, "E")).isFalse();
+    assertThat(dense.countEdges(denseB, Vertex.DIRECTION.OUT, "E")).isEqualTo(1);
+    assertThat(dense.countEdgesBetween(denseB, denseFresh, Vertex.DIRECTION.OUT, "E")).isEqualTo(1);
+
+    final int[] degrees = new int[dense.getNodeCount()];
+    dense.getDegrees(degrees, Vertex.DIRECTION.OUT, "E");
+    assertThat(degrees[denseA]).isEqualTo(1);
+    assertThat(degrees[denseB]).isEqualTo(1);
+    assertThat(degrees[denseFresh]).isZero();
+  }
+
+  @Test
+  void theWrapperRefusesThePackedViewAndKeepsTheDelegatesOwnAnswers() {
+    deleteSpareAndAddFresh();
+    final GraphTraversalProvider dense = DenseNodeIdProvider.wrap(view);
+
+    // A packed NeighborView is the delegate's own CSR arrays, addressed by the delegate's own ids: it cannot be
+    // renumbered without copying the graph, so it is refused and the caller uses the per-node lookups.
+    assertThat(dense.getNeighborView(Vertex.DIRECTION.OUT, "E")).isNull();
+
+    // Renumbering says nothing about the freshness of those arrays, so the delegate's answer is passed through.
+    assertThat(dense.hasPendingChanges()).isTrue();
+    assertThat(dense.isReady()).isEqualTo(view.isReady());
+    assertThat(dense.getName()).isEqualTo(view.getName());
+    assertThat(dense.coversVertexType("N")).isTrue();
+    assertThat(dense.coversEdgeType("E")).isTrue();
+  }
+
+  private void deleteSpareAndAddFresh() {
+    final MutableVertex[] added = new MutableVertex[1];
+    database.transaction(() -> {
+      database.query("sql", "SELECT FROM N WHERE name = 'SPARE'").next().getRecord().get().asVertex().delete();
+      added[0] = database.newVertex("N").set("name", "FRESH").save();
+      b.asVertex().modify().newEdge("E", added[0]).save();
+    });
+    fresh = added[0].getIdentity();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6792AddedVertexIdSpaceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6792AddedVertexIdSpaceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The other half of issue #6792: a vertex added to a {@code SYNCHRONOUS} Graph Analytical View takes an ID above
+ * the base node mapping, so the view's node count outgrows the arrays the {@code GraphAlgorithms} kernels size
+ * from that mapping. Every CSR-accelerated procedure then threw {@code ArrayIndexOutOfBoundsException} on the
+ * added vertex's ID - one added vertex was enough, no deletion involved.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6792AddedVertexIdSpaceTest {
+  private Database            database;
+  private GraphAnalyticalView view;
+  private RID                 a;
+  private RID                 b;
+  private RID                 c;
+  private RID                 fresh;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6792-added-vertex");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    database.getSchema().createEdgeType("E");
+
+    final MutableVertex[] created = new MutableVertex[3];
+    database.transaction(() -> {
+      created[0] = database.newVertex("N").set("name", "A").save();
+      created[1] = database.newVertex("N").set("name", "B").save();
+      created[2] = database.newVertex("N").set("name", "C").save();
+      created[0].newEdge("E", created[1]).save();
+    });
+    a = created[0].getIdentity();
+    b = created[1].getIdentity();
+    c = created[2].getIdentity();
+
+    view = GraphAnalyticalView.builder(database)
+        .withName("issue-6792-added-vertex")
+        .withVertexTypes("N")
+        .withEdgeTypes("E")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .withCompactionThreshold(Integer.MAX_VALUE)
+        .build();
+
+    final MutableVertex[] added = new MutableVertex[1];
+    database.transaction(() -> {
+      added[0] = database.newVertex("N").set("name", "FRESH").save();
+      c.asVertex().modify().newEdge("E", added[0]).save();
+    });
+    fresh = added[0].getIdentity();
+  }
+
+  @AfterEach
+  void teardown() {
+    if (view != null)
+      view.drop();
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void theAddedVertexIsNumberedAboveTheBaseMapping() {
+    assertThat(view.hasPendingChanges()).isTrue();
+    assertThat(view.getNodeCount()).isEqualTo(4);
+    assertThat(view.getNodeIdUpperBound()).isEqualTo(4);
+    // No holes here, so the ID space is compact - and still one wider than the base mapping the CSR kernels
+    // size their result arrays from.
+    assertThat(view.getNodeId(fresh)).isEqualTo(view.getNodeMapping().size());
+    assertThat(view.isNodeLive(view.getNodeId(fresh))).isTrue();
+  }
+
+  @Test
+  void everyWholeGraphProcedureAnswersForTheAddedVertex() {
+    final String[][] procedures = {
+        { "algo.wcc()", "node" },
+        { "algo.pagerank()", "node" },
+        { "algo.articlerank()", "node" },
+        { "algo.labelpropagation()", "node" },
+        { "algo.localClusteringCoefficient()", "node" },
+        { "algo.degree()", "node" },
+        { "algo.closeness()", "node" },
+        { "algo.harmonic(null, 'BOTH', true)", "node" },
+        { "algo.eigenvector(null, 'BOTH')", "node" },
+        { "algo.betweenness()", "node" },
+        { "algo.kcore()", "node" },
+        { "algo.scc()", "node" },
+        { "algo.triangleCount()", "node" },
+        { "algo.katz()", "nodeId" },
+    };
+
+    for (final String[] procedure : procedures) {
+      final String query = "CALL " + procedure[0] + " YIELD " + procedure[1] + " RETURN " + procedure[1];
+      final Set<RID> nodes = new HashSet<>();
+      final ResultSet rs = database.query("opencypher", query);
+      while (rs.hasNext())
+        nodes.add((RID) rs.next().getProperty(procedure[1]));
+      assertThat(nodes).as(query).containsExactlyInAnyOrder(a, b, c, fresh);
+    }
+  }
+
+  @Test
+  void wccJoinsTheAddedVertexToTheComponentItsEdgeReaches() {
+    final ResultSet rs = database.query("opencypher", "CALL algo.wcc() YIELD node, componentId RETURN node, componentId");
+    final Map<RID, Object> components = new HashMap<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      components.put(row.getProperty("node"), row.getProperty("componentId"));
+    }
+    assertThat(components).hasSize(4);
+    assertThat(components.get(a)).isEqualTo(components.get(b));
+    // The edge added to the overlay is what joins C to FRESH; a kernel reading only the base CSR would put them
+    // in two components of their own.
+    assertThat(components.get(c)).isEqualTo(components.get(fresh));
+    assertThat(components.get(a)).isNotEqualTo(components.get(c));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6792GraphDataNodeIdBoundTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6792GraphDataNodeIdBoundTest.java
@@ -27,22 +27,38 @@ import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
-
+import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Regression coverage for issue #6792. */
+/**
+ * Regression coverage for issue #6792: a Graph Analytical View serving a delta overlay reports a live node count
+ * smaller than the exclusive bound of its own node ID space, because the overlay keeps the slot of every deleted
+ * node and allocates the ID of every added one above the base mapping.
+ * <p>
+ * The fixture builds exactly that shape - one base vertex deleted, one vertex added above the base mapping, and
+ * an edge reaching it - and asserts that no {@code algo.*} procedure either drops the added vertex or trips over
+ * the ID that names it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
 class Issue6792GraphDataNodeIdBoundTest {
-  private Database database;
+  private Database           database;
+  private GraphAnalyticalView view;
+  private RID                a;
+  private RID                b;
+  private RID                fresh;
+  private RID                deleted;
 
   @BeforeEach
   void setup() {
@@ -52,10 +68,42 @@ class Issue6792GraphDataNodeIdBoundTest {
     database = factory.create();
     database.getSchema().createVertexType("N");
     database.getSchema().createEdgeType("E");
+
+    // SPARE first so that it is the one the base mapping is most likely to number lowest; which vertex actually
+    // gets which ID is read back below rather than assumed.
+    final MutableVertex[] created = new MutableVertex[3];
+    database.transaction(() -> {
+      created[0] = database.newVertex("N").set("name", "SPARE").save();
+      created[1] = database.newVertex("N").set("name", "A").save();
+      created[2] = database.newVertex("N").set("name", "B").save();
+      created[1].newEdge("E", created[2]).save();
+    });
+
+    view = GraphAnalyticalView.builder(database)
+        .withName("issue-6792-node-id-bound")
+        .withVertexTypes("N")
+        .withEdgeTypes("E")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .withCompactionThreshold(Integer.MAX_VALUE)
+        .build();
+
+    a = created[1].getIdentity();
+    b = created[2].getIdentity();
+    deleted = created[0].getIdentity();
+
+    final MutableVertex[] added = new MutableVertex[1];
+    database.transaction(() -> {
+      deleted.asVertex().delete();
+      added[0] = database.newVertex("N").set("name", "FRESH").save();
+      b.asVertex().modify().newEdge("E", added[0]).save();
+    });
+    fresh = added[0].getIdentity();
   }
 
   @AfterEach
   void teardown() {
+    if (view != null)
+      view.drop();
     if (database != null) {
       if (database.isTransactionActive())
         database.rollback();
@@ -64,65 +112,139 @@ class Issue6792GraphDataNodeIdBoundTest {
   }
 
   @Test
-  void graphDataUsesTheNodeIdSpaceRatherThanTheLiveNodeCount() {
-    final List<MutableVertex> baseVertices = new ArrayList<>();
-    database.transaction(() -> {
-      for (int i = 0; i < 3; i++)
-        baseVertices.add(database.newVertex("N").set("name", "base-" + i).save());
-      baseVertices.get(0).newEdge("E", baseVertices.get(1)).save();
+  void theViewSeparatesItsLiveNodeCountFromItsNodeIdSpace() {
+    assertThat(view.hasPendingChanges()).isTrue();
+    assertThat(view.getNodeCount()).isEqualTo(3);
+    assertThat(view.getNodeIdUpperBound()).isEqualTo(4);
+
+    final int freshId = view.getNodeId(fresh);
+    // The whole of issue #6792 in one assertion: a live node whose ID is not smaller than the live count.
+    assertThat(freshId).isGreaterThanOrEqualTo(view.getNodeCount());
+    assertThat(freshId).isLessThan(view.getNodeIdUpperBound());
+
+    assertThat(view.isNodeLive(freshId)).isTrue();
+    assertThat(view.isNodeLive(view.getNodeId(a))).isTrue();
+    assertThat(view.isNodeLive(view.getNodeId(b))).isTrue();
+    // The deleted base node keeps its slot, and its RID is still in the base mapping - which is exactly why
+    // liveness has to be asked of the view rather than inferred from getRID() answering non-null.
+    assertThat(view.isNodeLive(deletedBaseId())).isFalse();
+
+    assertThat(view.getNeighborIds(view.getNodeId(b), Vertex.DIRECTION.OUT, "E")).contains(freshId);
+  }
+
+  @Test
+  void graphDataHandsTheProceduresACompactNodeIdSpace() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    final ProbeAPSP procedure = new ProbeAPSP();
+    final AbstractAlgoProcedure.GraphData graph = procedure.loadGraph(database, context);
+
+    // Every node-indexed array a procedure allocates is nodeCount long, so nodeCount has to be both the size of
+    // the ID space and the number of live nodes in it. The renumbering is what makes those the same number.
+    assertThat(graph.nodeCount).isEqualTo(view.getNodeCount());
+    assertThat(graph.isCSRBacked()).isTrue();
+
+    final Set<RID> resolved = new HashSet<>();
+    for (int i = 0; i < graph.nodeCount; i++) {
+      assertThat(graph.getRID(i)).isNotNull();
+      resolved.add(graph.getRID(i));
+    }
+    assertThat(resolved).containsExactlyInAnyOrder(a, b, fresh);
+
+    final int denseB = graph.indexOf(b);
+    final int denseFresh = graph.indexOf(fresh);
+    assertThat(denseB).isBetween(0, graph.nodeCount - 1);
+    assertThat(denseFresh).isBetween(0, graph.nodeCount - 1);
+    assertThat(graph.adjacency(Vertex.DIRECTION.OUT)[denseB]).contains(denseFresh);
+    assertThat(graph.degrees(Vertex.DIRECTION.OUT, "E")[denseB]).isEqualTo(1);
+  }
+
+  @Test
+  void apspReachesTheAddedVertexThroughTheSurvivingOne() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    final ProbeAPSP procedure = new ProbeAPSP();
+    final List<Result> rows = drain(procedure.execute(new Object[0], null, context));
+
+    assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR)).isEqualTo(true);
+    assertThat(rows).anySatisfy(row -> {
+      assertThat((RID) row.getProperty("source")).isEqualTo(b);
+      assertThat((RID) row.getProperty("target")).isEqualTo(fresh);
+      assertThat(((Number) row.getProperty("distance")).doubleValue()).isEqualTo(1.0);
+    });
+    assertThat(rows).anySatisfy(row -> {
+      assertThat((RID) row.getProperty("source")).isEqualTo(a);
+      assertThat((RID) row.getProperty("target")).isEqualTo(fresh);
+      assertThat(((Number) row.getProperty("distance")).doubleValue()).isEqualTo(2.0);
+    });
+    assertThat(rows).noneSatisfy(row -> assertThat((RID) row.getProperty("source")).isEqualTo(deleted));
+    assertThat(rows).noneSatisfy(row -> assertThat((RID) row.getProperty("target")).isEqualTo(deleted));
+  }
+
+  /**
+   * The sweep issue #6792 asks for: every whole-graph procedure that emits one row per node has to emit one for
+   * each of the three live vertices and none for the deleted one. Before the fix the CSR-accelerated ones threw
+   * {@code ArrayIndexOutOfBoundsException} on the added vertex's ID, and the ones reading the graph through
+   * {@code GraphData} silently left it out of the answer.
+   */
+  @Test
+  void everyWholeGraphProcedureSeesExactlyTheLiveVertices() {
+    final String[][] procedures = {
+        { "algo.wcc()", "node" },
+        { "algo.pagerank()", "node" },
+        { "algo.articlerank()", "node" },
+        { "algo.labelpropagation()", "node" },
+        { "algo.localClusteringCoefficient()", "node" },
+        { "algo.degree()", "node" },
+        { "algo.closeness()", "node" },
+        { "algo.harmonic(null, 'BOTH', true)", "node" },
+        { "algo.eigenvector(null, 'BOTH')", "node" },
+        { "algo.betweenness()", "node" },
+        { "algo.kcore()", "node" },
+        { "algo.scc()", "node" },
+        { "algo.triangleCount()", "node" },
+        { "algo.katz()", "nodeId" },
+    };
+
+    for (final String[] procedure : procedures) {
+      final String query = "CALL " + procedure[0] + " YIELD " + procedure[1] + " RETURN " + procedure[1];
+      final Set<RID> nodes = new HashSet<>();
+      final ResultSet rs = database.query("opencypher", query);
+      while (rs.hasNext())
+        nodes.add((RID) rs.next().getProperty(procedure[1]));
+      assertThat(nodes).as(query).containsExactlyInAnyOrder(a, b, fresh);
+    }
+  }
+
+  @Test
+  void traversalProceduresReachTheAddedVertex() {
+    final ResultSet bfs = database.query("opencypher",
+        "MATCH (s:N {name: 'A'}) CALL algo.bfs(s, 'E', 'OUT') YIELD node, depth RETURN node, depth");
+    final List<Result> hops = new ArrayList<>();
+    while (bfs.hasNext())
+      hops.add(bfs.next());
+    assertThat(hops).anySatisfy(row -> {
+      assertThat((RID) row.getProperty("node")).isEqualTo(fresh);
+      assertThat(((Number) row.getProperty("depth")).intValue()).isEqualTo(2);
     });
 
-    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
-        .withName("issue-6792-node-id-bound")
-        .withVertexTypes("N")
-        .withEdgeTypes("E")
-        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
-        .withCompactionThreshold(Integer.MAX_VALUE)
-        .build();
+    final ResultSet dijkstra = database.query("opencypher",
+        "MATCH (s:N {name: 'A'}) CALL algo.dijkstra.singleSource(s, 'E', 'w', 'OUT') YIELD node, cost RETURN node, cost");
+    final Set<RID> reached = new HashSet<>();
+    while (dijkstra.hasNext())
+      reached.add((RID) dijkstra.next().getProperty("node"));
+    assertThat(reached).contains(fresh);
+    assertThat(reached).doesNotContain(deleted);
+  }
 
-    try {
-      final MutableVertex lowestId = baseVertices.stream()
-          .min(Comparator.comparingInt(v -> view.getNodeId(v.getIdentity())))
-          .orElseThrow();
-      final MutableVertex highestId = baseVertices.stream()
-          .max(Comparator.comparingInt(v -> view.getNodeId(v.getIdentity())))
-          .orElseThrow();
-
-      final MutableVertex[] fresh = new MutableVertex[1];
-      database.transaction(() -> {
-        lowestId.getIdentity().asVertex().delete();
-        fresh[0] = database.newVertex("N").set("name", "fresh").save();
-        highestId.getIdentity().asVertex().modify().newEdge("E", fresh[0]).save();
-      });
-
-      final int freshId = view.getNodeId(fresh[0].getIdentity());
-      assertThat(view.getNodeCount()).isEqualTo(3);
-      assertThat(freshId).isGreaterThanOrEqualTo(view.getNodeCount());
-      assertThat(view.getNodeIdUpperBound()).isEqualTo(freshId + 1);
-      assertThat(view.getNeighborIds(view.getNodeId(highestId.getIdentity()), Vertex.DIRECTION.OUT, "E"))
-          .contains(freshId);
-      assertThat(view.getNeighborIds(view.getNodeId(highestId.getIdentity()), Vertex.DIRECTION.OUT))
-          .contains(freshId);
-
-      final BasicCommandContext context = new BasicCommandContext();
-      context.setDatabase(database);
-      final ProbeAPSP procedure = new ProbeAPSP();
-      final AbstractAlgoProcedure.GraphData graph = procedure.loadGraph(database, context);
-      assertThat(graph.nodeCount).isEqualTo(view.getNodeIdUpperBound());
-      assertThat(graph.adjacency(Vertex.DIRECTION.OUT)[view.getNodeId(highestId.getIdentity())])
-          .contains(freshId);
-
-      final List<Result> rows = drain(procedure.execute(new Object[0], null, context));
-
-      assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR)).isEqualTo(true);
-      assertThat(rows).anySatisfy(row -> {
-        assertThat((RID) row.getProperty("source")).isEqualTo(highestId.getIdentity());
-        assertThat((RID) row.getProperty("target")).isEqualTo(fresh[0].getIdentity());
-        assertThat(((Number) row.getProperty("distance")).doubleValue()).isEqualTo(1.0);
-      });
-    } finally {
-      view.drop();
-    }
+  private int deletedBaseId() {
+    // The deleted vertex's RID no longer resolves through the overlay, so its base ID is the one below the base
+    // mapping's size that neither survivor holds.
+    final Set<Integer> live = Set.of(view.getNodeId(a), view.getNodeId(b));
+    for (int id = 0; id < view.getNodeMapping().size(); id++)
+      if (!live.contains(id))
+        return id;
+    throw new IllegalStateException("no deleted base id");
   }
 
   private static List<Result> drain(final Stream<Result> rows) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6792GraphDataNodeIdBoundTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6792GraphDataNodeIdBoundTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Regression coverage for issue #6792. */
+class Issue6792GraphDataNodeIdBoundTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6792-node-id-bound");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    database.getSchema().createEdgeType("E");
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void graphDataUsesTheNodeIdSpaceRatherThanTheLiveNodeCount() {
+    final List<MutableVertex> baseVertices = new ArrayList<>();
+    database.transaction(() -> {
+      for (int i = 0; i < 3; i++)
+        baseVertices.add(database.newVertex("N").set("name", "base-" + i).save());
+      baseVertices.get(0).newEdge("E", baseVertices.get(1)).save();
+    });
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("issue-6792-node-id-bound")
+        .withVertexTypes("N")
+        .withEdgeTypes("E")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .withCompactionThreshold(Integer.MAX_VALUE)
+        .build();
+
+    try {
+      final MutableVertex lowestId = baseVertices.stream()
+          .min(Comparator.comparingInt(v -> view.getNodeId(v.getIdentity())))
+          .orElseThrow();
+      final MutableVertex highestId = baseVertices.stream()
+          .max(Comparator.comparingInt(v -> view.getNodeId(v.getIdentity())))
+          .orElseThrow();
+
+      final MutableVertex[] fresh = new MutableVertex[1];
+      database.transaction(() -> {
+        lowestId.getIdentity().asVertex().delete();
+        fresh[0] = database.newVertex("N").set("name", "fresh").save();
+        highestId.getIdentity().asVertex().modify().newEdge("E", fresh[0]).save();
+      });
+
+      final int freshId = view.getNodeId(fresh[0].getIdentity());
+      assertThat(view.getNodeCount()).isEqualTo(3);
+      assertThat(freshId).isGreaterThanOrEqualTo(view.getNodeCount());
+      assertThat(view.getNodeIdUpperBound()).isEqualTo(freshId + 1);
+      assertThat(view.getNeighborIds(view.getNodeId(highestId.getIdentity()), Vertex.DIRECTION.OUT, "E"))
+          .contains(freshId);
+      assertThat(view.getNeighborIds(view.getNodeId(highestId.getIdentity()), Vertex.DIRECTION.OUT))
+          .contains(freshId);
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      final ProbeAPSP procedure = new ProbeAPSP();
+      final AbstractAlgoProcedure.GraphData graph = procedure.loadGraph(database, context);
+      assertThat(graph.nodeCount).isEqualTo(view.getNodeIdUpperBound());
+      assertThat(graph.adjacency(Vertex.DIRECTION.OUT)[view.getNodeId(highestId.getIdentity())])
+          .contains(freshId);
+
+      final List<Result> rows = drain(procedure.execute(new Object[0], null, context));
+
+      assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR)).isEqualTo(true);
+      assertThat(rows).anySatisfy(row -> {
+        assertThat((RID) row.getProperty("source")).isEqualTo(highestId.getIdentity());
+        assertThat((RID) row.getProperty("target")).isEqualTo(fresh[0].getIdentity());
+        assertThat(((Number) row.getProperty("distance")).doubleValue()).isEqualTo(1.0);
+      });
+    } finally {
+      view.drop();
+    }
+  }
+
+  private static List<Result> drain(final Stream<Result> rows) {
+    final List<Result> results = new ArrayList<>();
+    for (final Iterator<Result> it = rows.iterator(); it.hasNext(); )
+      results.add(it.next());
+    return results;
+  }
+
+  private static final class ProbeAPSP extends AlgoAPSP {
+    private GraphData loadGraph(final Database database, final CommandContext context) {
+      return loadGraph(database, null, null, context);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- preserve `GraphTraversalProvider.getNodeCount()` as the live-node count
- add a backward-compatible `getNodeIdUpperBound()` contract for node-ID-indexed storage
- expose the monotonic overlay ID bound from `GraphAnalyticalView` and size provider-backed `GraphData` from it
- add a regression that deletes the lowest base ID, adds an overflow vertex and edge, and verifies `algo.apsp` returns the high-ID vertex

## Why

A synchronous delta overlay retains deleted ID slots and allocates overflow IDs monotonically. The live-node count can therefore be smaller than the largest live ID plus one. Sizing algorithm arrays and iteration from the live count silently omitted high-ID vertices and could leave a neighbor ID outside those arrays.

The new accessor keeps the existing live-count meaning while giving node-indexed consumers the exclusive bound they require. Its default implementation preserves compatibility for providers with compact IDs.

## Validation

```text
./mvnw -pl engine -Dtest=Issue6792GraphDataNodeIdBoundTest,GraphTraversalProviderCountEdgesBetweenTest,DeltaOverlayTest,GraphAnalyticalViewTest,AlgoAPSPTest,Issue6296AlgoAPSPLazyRowsTest,AlgoMaxFlowTest test

Tests run: 190, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Closes #6792

@lvca, this issue is assigned to you; I went ahead because the change is small and follows the third option described in the issue. If you had a different implementation planned, I am happy to withdraw this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analytical graph processing for graphs with deleted or sparse node IDs.
  - Corrected graph sizing to preserve valid node-ID ranges, including gaps.
  - Ensured neighbor lookups, shortest-path analysis, and CSR-accelerated operations continue to return correct results after node deletion and insertion.
  - Updated graph algorithms to use a safe fallback when recent graph changes are not yet reflected in analytical data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->