### PR TITLE
fix(ci): unpin ServerProfilingIT and GrpcAuthInterceptorTest from implementation details that moved under them

### DIFF
--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAuthInterceptorTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAuthInterceptorTest.java
@@ -119,6 +119,9 @@ class GrpcAuthInterceptorTest {
 
     // getUsers() returns Set<String> - need at least one user for security to be enabled
     when(mockSecurity.getUsers()).thenReturn(Collections.singleton("testuser"));
+    // The interceptor re-resolves the session's principal against the live users map on every call, so a
+    // session alone is not enough to be accepted: the principal has to still exist (see #6808).
+    when(mockSecurity.getUser("testuser")).thenReturn(mockUser);
 
     GrpcAuthInterceptor interceptorWithSession = new GrpcAuthInterceptor(mockSecurity, mockSessionManager);
 
@@ -134,6 +137,38 @@ class GrpcAuthInterceptorTest {
     // Handler's startCall should be invoked (call proceeds)
     verify(mockHandler).startCall(any(), any());
     verify(mockCall, never()).close(any(), any());
+  }
+
+  @Test
+  void validateTokenReturnsFalseWhenPrincipalNoLongerExists() {
+    // #6808: an AU- login token is minted against a principal captured at login time. Once that principal
+    // is dropped (or its password rotated), the token must stop working AT ONCE rather than lingering
+    // until the session idle-expires, so the interceptor re-checks the name against the live users map and
+    // drops the now-orphaned session.
+    final HttpAuthSession mockSession = mock(HttpAuthSession.class);
+    final ServerSecurityUser mockUser = mock(ServerSecurityUser.class);
+    when(mockSession.getUser()).thenReturn(mockUser);
+    when(mockUser.getName()).thenReturn("droppeduser");
+    when(mockSessionManager.getSessionByToken("orphan-token")).thenReturn(mockSession);
+
+    // Security is enabled and still holds other principals, but not the one this token was minted for.
+    when(mockSecurity.getUsers()).thenReturn(Collections.singleton("testuser"));
+    when(mockSecurity.getUser("droppeduser")).thenReturn(null);
+
+    final GrpcAuthInterceptor interceptorWithSession = new GrpcAuthInterceptor(mockSecurity, mockSessionManager);
+
+    final Metadata headers = new Metadata();
+    headers.put(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER), "Bearer orphan-token");
+    headers.put(Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER), "testdb");
+
+    when(mockMethodDescriptor.getFullMethodName()).thenReturn("com.arcadedb.grpc.ArcadeDbService/Query");
+
+    interceptorWithSession.interceptCall(mockCall, headers, mockHandler);
+
+    verify(mockCall).close(any(), any());
+    verify(mockHandler, never()).startCall(any(), any());
+    // The orphaned session is evicted, so it cannot keep answering getSessionByToken() until it expires.
+    verify(mockSessionManager).removeSession("orphan-token");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/security/ServerProfilingIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/ServerProfilingIT.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -594,8 +595,14 @@ class ServerProfilingIT {
     assertThat(authJohn.getName()).isEqualTo(albert.getName());
 
     final SecurityUserFileRepository repository = new SecurityUserFileRepository("./target/config");
-    assertThat(repository.getUsers().size()).isEqualTo(2);
-    assertThat(repository.getUsers().getFirst().getString("name")).isEqualTo("albert");
+    // Assert WHICH principals were persisted, not which line each landed on: the order of
+    // server-users.jsonl is whatever order ServerSecurity happens to serialize its user store in, and
+    // that is not part of any contract. It used to come out of a ConcurrentHashMap, whose hash order put
+    // "albert" first by luck; persisting the mutation before publishing it now appends the new user, so
+    // "root" comes first. Nothing read the order either way - only this assertion did, and it turned an
+    // internal implementation detail into 11 red tests.
+    final List<String> persistedUsers = repository.getUsers().stream().map(user -> user.getString("name")).toList();
+    assertThat(persistedUsers).containsExactlyInAnyOrder("root", "albert");
   }
 
   private ServerSecurityUser setCurrentUser(final String userName, final DatabaseInternal database) {


### PR DESCRIPTION
Fixes the two test failures red on `main` in [run 33266454013](https://github.com/ArcadeData/arcadedb/actions/runs/33266454013). Both are tests asserting something the code never promised. Neither covers a regression in the code under test - the production behaviour in both cases is the intended one, and in one case it is a security fix that shipped without a test.

## `ServerProfilingIT` - 11 failures + 1 cascading error (`integration-tests` lane)

```
expected: "albert"
 but was: "root"
	at ServerProfilingIT.checkJohnUser(ServerProfilingIT.java:598)
```

`checkJohnUser()` asserted that `"albert"` is the **first line** of `server-users.jsonl`:

```java
assertThat(repository.getUsers().getFirst().getString("name")).isEqualTo("albert");
```

That order is whatever order `ServerSecurity` happens to serialize its user store in. Nothing reads it - this assertion was its only consumer.

It used to be produced by `usersToJSON()` iterating `users`, a `ConcurrentHashMap`, whose hash order for these two names happens to be `[albert, root]` (verified). Since 9fbbb0652a ("persist before publishing a user mutation") `createUser` persists `snapshotWith(name, cfg)`, which walks the **pre-mutation** map and appends the new user, so the file is now `[root, albert]`. Deterministic append order rather than hash order - the better of the two, and no reason to change it back to satisfy a test.

The assertion now names **which** principals were persisted rather than which line each landed on:

```java
final List<String> persistedUsers = repository.getUsers().stream().map(user -> user.getString("name")).toList();
assertThat(persistedUsers).containsExactlyInAnyOrder("root", "albert");
```

Strictly stronger than the pair it replaces (`size() == 2` plus a positional name check), and immune to the next change in serialization order.

The 12th test, `multipleGroupsAnyType`, errored with `Cannot create bucket 'Bucket1' because already exists`. That is a **cascade**, not a separate cause: an earlier test failed at `checkJohnUser()` before reaching its `dropSchema()`, leaving the schema behind. It goes green with the assertion fixed.

## `GrpcAuthInterceptorTest.validateTokenReturnsTrueForValidSession` (`unit-tests` lane)

```
Wanted but not invoked: serverCallHandler.startCall(<any>, <any>);
Actually, there were zero interactions with this mock.
```

7c4e44ae17 (#6808) closed a revocation hole: the gRPC bearer branch trusted the `ServerSecurityUser` the `HttpAuthSession` captured at login, so a dropped or rotated principal kept authenticating until its token idle-expired. `getValidSession()` now re-resolves the name against the live users map.

The test stubs `getUsers()` (to make security enabled) but not `getUser()`, so the Mockito mock returned `null` and **every** token read as an orphan - the call was closed and `startCall` never reached. Stubbed, with the reason stated at the stub so the next person does not read it as boilerplate.

### Added coverage for the revocation itself

That branch shipped with no gRPC test, so the behaviour #6808 exists to enforce was unguarded on this transport. `validateTokenReturnsFalseWhenPrincipalNoLongerExists` asserts both halves:

- the call is closed and the handler never starts, and
- the orphaned session is **evicted** (`removeSession`), so it cannot keep answering `getSessionByToken()` until it idle-expires.

Proven able to fail: with the `security.getUser(...) == null` branch disabled, the new test fails on the `removeSession` verification and the other 8 stay green.

## Verification

| Suite | Result |
|---|---|
| `mvn -o -pl grpcw verify` | 201/201 green |
| `mvn -o -pl server verify -DskipITs=false -Dtest='com.arcadedb.server.security.**' -Dit.test='com.arcadedb.server.security.**'` | 139/139 green, incl. `ServerProfilingIT` 13/13 |
| Both failures reproduced on `main` first | identical to CI (11F+1E, and 1F) |

Test-only change: no `src/main` file is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gRPC authentication so sessions for removed users are rejected immediately.
  * Invalid or orphaned sessions are now closed, preventing further requests from reaching handlers.

* **Tests**
  * Expanded authentication coverage for revoked users and inactive sessions.
  * Improved persisted-user verification to work regardless of result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->