### PR TITLE
fix(#6794): guard the tag filters no command line may narrow

### DIFF
--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -66,3 +66,31 @@ Two things about how it hid, both worth generalizing:
 Since #6220 `TRUNCATE` only batches when **it** owns the transaction - when none was active as it started. Inside a caller's transaction it commits nothing at all, because committing through a caller silently breaks that caller's `ROLLBACK`. So the shape that reproduces #5492 is now `command("sql", "TRUNCATE ...")` with **no** enclosing transaction; wrapping it in one, which `Issue5492TruncateBatchNotReplicatedIT` used to do, leaves nothing mid-execution to commit and the test passes for the wrong reason. `REBUILD INDEX` and `BatchStep` still commit unconditionally.
 
 When adding any code path that commits, ask which instance it holds. `Issue5492TruncateBatchNotReplicatedIT` guards the statement path; it asserts the WAL gap counter *before* querying the follower, because the resync reinstalls the follower's database and a stale handle then throws `DatabaseIsClosed`, which reads like infrastructure noise rather than divergence.
+
+## A repo-wide pom guard lives in this module's tests
+
+`PomTagFilterContractTest` is not about Raft. It reads every `pom.xml` in the repository and checks how
+surefire's and failsafe's `groups`/`excludedGroups` are configured, because those parameters each have a
+same-named `-D` user property and getting the precedence wrong is invisible: the build runs the wrong set of
+tests and passes.
+
+It enforces two rules that point in opposite directions:
+
+- a **plugin-wide** default must be a property reference (`${excludedGroups}`, `${failsafe.excludedGroups}`), so
+  a CI lane's `-DexcludedGroups=...` still reaches it. A literal there wins over the command line and every lane
+  that filters by tag quietly runs whatever the pom named instead. That is issue #5697;
+- a **named execution** that is one half of a tag *partition* must write out both parameters, so no `-Dgroups`
+  or `-DexcludedGroups` aimed at another module can narrow it. Leaving one out is the same as setting it from
+  the command line, and the result is the quiet one: measured on this tree with surefire 3.5.6,
+  `./mvnw -o -pl ha-raft test -Dgroups=bogus-tag` reports `Tests run: 0` and `BUILD SUCCESS`. That is issue
+  #6794 - step 5 of the fork-split re-verification recipe, the one step that had no automated guard.
+
+The second rule is here rather than in `engine` because the only executions ever meant to be a tag partition are
+this module's: the `ha-heavy` split from issue #6343. That split is not on `main` - it was reverted in
+f4567f6176 because it surfaced issue #6848 - so the rule currently has nothing in the reactor to judge and is
+proven able to fail against the split's own configuration as a fixture. It needs no edit to arm itself when the
+split comes back.
+
+It reads the poms as written, not `help:effective-pom`, on purpose: interpolation is the distinction being
+tested, and the effective pom resolves `${excludedGroups}` to `benchmark`, which is exactly the literal the
+first rule rejects.

--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -74,18 +74,22 @@ surefire's and failsafe's `groups`/`excludedGroups` are configured, because thos
 same-named `-D` user property and getting the precedence wrong is invisible: the build runs the wrong set of
 tests and passes.
 
-It enforces two rules that point in opposite directions:
+It enforces three rules, the first and the last of which point in opposite directions:
 
 - a **plugin-wide** default must be a property reference (`${excludedGroups}`, `${failsafe.excludedGroups}`), so
   a CI lane's `-DexcludedGroups=...` still reaches it. A literal there wins over the command line and every lane
   that filters by tag quietly runs whatever the pom named instead. That is issue #5697;
-- a **named execution** that is one half of a tag *partition* must write out both parameters, so no `-Dgroups`
-  or `-DexcludedGroups` aimed at another module can narrow it. Leaving one out is the same as setting it from
-  the command line, and the result is the quiet one: measured on this tree with surefire 3.5.6,
+- **failsafe's** plugin-wide `<excludedGroups>` must not read the property surefire's reads. Failsafe's own
+  parameter default *is* `${excludedGroups}`, so sharing it applies the unit lane's exclusion to the integration
+  lane and drops e.g. `@Tag("benchmark")` ITs from every `-Pintegration` run. That is the second half of #5697;
+- a **named execution** that is one half of a tag *partition* must write out both parameters, and neither may
+  mention `${groups}` or `${excludedGroups}` anywhere in its value, so no `-Dgroups` or `-DexcludedGroups` aimed
+  at another module can reach it. Leaving one out, or interpolating one into a larger expression, is the same as
+  handing it to the command line, and the result is the quiet one: measured on this tree with surefire 3.5.6,
   `./mvnw -o -pl ha-raft test -Dgroups=bogus-tag` reports `Tests run: 0` and `BUILD SUCCESS`. That is issue
   #6794 - step 5 of the fork-split re-verification recipe, the one step that had no automated guard.
 
-The second rule is here rather than in `engine` because the only executions ever meant to be a tag partition are
+The partition rule is here rather than in `engine` because the only executions ever meant to be a tag partition are
 this module's: the `ha-heavy` split from issue #6343. That split is not on `main` - it was reverted in
 f4567f6176 because it surfaced issue #6848 - so the rule currently has nothing in the reactor to judge and is
 proven able to fail against the split's own configuration as a fixture. It needs no edit to arm itself when the

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PomTagFilterContractTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PomTagFilterContractTest.java
@@ -210,7 +210,13 @@ class PomTagFilterContractTest {
    */
   @Test
   void theScanReachesTheBuild() {
-    assertThat(reactorPoms()).as("pom.xml files found under %s", repositoryRoot()).hasSizeGreaterThan(20);
+    final Path root = repositoryRoot();
+    final List<String> scanned = reactorPoms().stream().map(pom -> root.relativize(pom).toString()).toList();
+
+    // A count alone is a loose canary - a pruning bug that drops several real modules can still clear a floor.
+    // Naming the parent and a module makes it precise: the parent is where the two live rules find their
+    // subject, and a module pom proves the walk descends rather than stopping at the root.
+    assertThat(scanned).as("poms found under %s", root).contains("pom.xml", "ha-raft/pom.xml", "engine/pom.xml").hasSizeGreaterThan(20);
     assertThat(reactorTagParameters())
         .as("plugin-wide tag parameters in the reactor: the parent configures one for surefire and one for failsafe")
         .filteredOn(p -> p.executionId() == null)
@@ -330,6 +336,18 @@ class PomTagFilterContractTest {
   // The rules, expressed over collected parameters so the fixtures above run the same code as the reactor scan.
   // -----------------------------------------------------------------------------------------------------------
 
+  /**
+   * Treats an execution-level parameter that is absent, blank, or nothing but its own user property as equally
+   * open to the command line.
+   * <p>
+   * "Absent" leans on {@link #inheritedTagDefaultsStayOverridableFromTheCommandLine}, and the two rules are load
+   * bearing for each other: Maven merges the plugin-wide {@code <configuration>} into a named execution for
+   * every parameter the execution does not override, so an omitted parameter resolves either to the mojo's own
+   * {@code ${groups}}/{@code ${excludedGroups}} default or to whatever the plugin-wide block says - and it is
+   * the first rule that keeps the latter a property reference rather than a literal. Either way it stays
+   * narrowable from the command line, which is what this rule forbids. Relaxing the first rule would quietly
+   * remove that half of the premise, so relax neither alone.
+   */
   private static List<String> unpinnedPartitionParameters(final List<TagParameter> parameters) {
     final Set<ExecutionKey> partitions = new LinkedHashSet<>();
     for (final TagParameter p : parameters)

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PomTagFilterContractTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PomTagFilterContractTest.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the property of this build that fails in the worst possible direction: a tag filter that selects the
+ * wrong set of tests and reports success while doing it.
+ * <p>
+ * Surefire's and failsafe's {@code groups}/{@code excludedGroups} parameters each have a same-named {@code -D}
+ * user property, and Maven resolves such a parameter from the plugin configuration first, falling back to the
+ * user property only where the configuration leaves it unset. Which way round that lands decides whether a
+ * command-line tag filter reaches the run, and the build behaves plausibly either way, so both mistakes are
+ * invisible:
+ * <ul>
+ * <li>a <b>literal</b> where a property reference belongs makes {@code -DexcludedGroups=...} a no-op, so a CI
+ * lane that narrows or widens the default exclusion silently runs the set the pom named instead. That is issue
+ * #5697, and it is why the parent's two defaults are written as {@code ${excludedGroups}} and
+ * {@code ${failsafe.excludedGroups}} rather than as the tags they resolve to;</li>
+ * <li>an <b>unset</b> parameter where an explicit expression belongs lets a stray {@code -Dgroups=...} narrow an
+ * execution that was meant to own every class it can see. Measured on surefire 3.5.6: an execution whose
+ * {@code <groups>} is left out runs <b>0 tests and passes</b> under {@code -Dgroups=bogus-tag}. That is step 5
+ * of the {@code ha-raft} fork-split checklist, and issue #6794.</li>
+ * </ul>
+ * Both are checked against the poms as written rather than against {@code help:effective-pom}, which is how
+ * issue #6794 originally sketched it. Interpolation is precisely the distinction under test - the effective pom
+ * resolves {@code ${excludedGroups}} to {@code benchmark} and so cannot tell a passthrough from the literal that
+ * breaks it - and reading the sources costs no Maven invocation, so this runs in the ordinary unit lane and on a
+ * developer's machine instead of only in a workflow step.
+ * <p>
+ * <b>Why the check lives in this module.</b> The partition rule is the one issue #6794 asked for, and the only
+ * executions in this repository ever meant to be a tag partition are {@code ha-raft}'s: the {@code ha-heavy}
+ * split from issue #6343. That split is not on {@code main} today - it was reverted in f4567f6176 because it
+ * surfaced issue #6848 - so the partition rule currently finds nothing in the reactor to judge, and is instead
+ * proven able to fail against the split's own configuration as a fixture. It arms itself, with no edit here, on
+ * the day the split returns.
+ */
+class PomTagFilterContractTest {
+
+  private static final Set<String> TAG_PLUGINS = Set.of("maven-surefire-plugin", "maven-failsafe-plugin");
+  private static final List<String> TAG_PARAMS = List.of("groups", "excludedGroups");
+
+  /** A value that is nothing but one property reference: what a caller's {@code -D} can still override. */
+  private static final Pattern PROPERTY_ONLY = Pattern.compile("\\$\\{[^{}$\\s]+}");
+
+  /** Directories holding build output, tool state, or a nested checkout rather than sources of this build. */
+  private static final Set<String> PRUNED = Set.of("target", "node_modules", ".git", ".worktrees", ".m2repo", ".idea", "dist", "venv", ".venv");
+
+  /**
+   * One {@code <groups>} or {@code <excludedGroups>} as written in a pom.
+   *
+   * @param executionId the enclosing {@code <execution>}'s id, or {@code null} for the plugin-wide configuration
+   *                    that every inherited execution reads
+   */
+  private record TagParameter(String pom, String plugin, String executionId, String name, String value) {
+    ExecutionKey execution() {
+      return new ExecutionKey(pom, plugin, executionId);
+    }
+
+    String where() {
+      return execution() + " -> <" + name + ">";
+    }
+  }
+
+  private record ExecutionKey(String pom, String plugin, String executionId) {
+    @Override
+    public String toString() {
+      return pom + " -> " + plugin + (executionId == null ? " (plugin configuration)" : " execution '" + executionId + "'");
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------------------
+  // The live checks, against the reactor's own poms.
+  // -----------------------------------------------------------------------------------------------------------
+
+  /**
+   * Issue #5697. A plugin-wide {@code <groups>}/{@code <excludedGroups>} is inherited by every module and applies
+   * to the executions CI drives, so a literal there outranks the command line and every {@code -DexcludedGroups}
+   * in {@code .github/workflows/} quietly stops meaning anything.
+   */
+  @Test
+  void inheritedTagDefaultsStayOverridableFromTheCommandLine() {
+    final List<TagParameter> literals = reactorTagParameters().stream()
+        .filter(p -> p.executionId() == null)
+        .filter(p -> !PROPERTY_ONLY.matcher(p.value().trim()).matches())
+        .toList();
+
+    assertThat(literals)
+        .as("""
+            A plugin-wide tag filter is written as a literal instead of as a property reference.
+
+            Plugin configuration beats the same-named -D user property, so this value wins over every
+            -Dgroups/-DexcludedGroups on the command line, and the build says nothing while it does. The lanes in
+            .github/workflows/ that pass their own tag filter would silently run the set named here instead
+            (issue #5697).
+
+            Write the default as a property reference and put the value in <properties>, so a caller can still
+            override it.
+
+            Offenders:
+            %s""".formatted(render(literals)))
+        .isEmpty();
+  }
+
+  /**
+   * Issue #5697's second half. Failsafe's {@code excludedGroups} parameter defaults to the <em>same</em>
+   * {@code ${excludedGroups}} user property surefire uses, so a build that gives failsafe no parameter of its own
+   * silently applies the unit lane's exclusion to integration tests. The parent gives it a namespaced property
+   * instead; deleting that override is a one-line regression with no other symptom.
+   */
+  @Test
+  void integrationTestsDoNotInheritTheUnitLaneTagExclusion() {
+    // The parent alone, not every module: a module is free to override the default for itself, and the rule
+    // above already holds it to being overridable. What must never merge is the two plugins' sources here.
+    final List<TagParameter> parent = reactorTagParameters().stream()
+        .filter(p -> p.executionId() == null && p.pom().equals("pom.xml"))
+        .toList();
+
+    final TagParameter surefire = onlyOne(parent, "maven-surefire-plugin", "excludedGroups");
+    final TagParameter failsafe = onlyOne(parent, "maven-failsafe-plugin", "excludedGroups");
+
+    assertThat(failsafe.value().trim())
+        .as("""
+            maven-failsafe-plugin's <excludedGroups> must not read the same property maven-surefire-plugin does.
+
+            Failsafe's own parameter default IS ${excludedGroups} - the surefire property - so sharing it makes
+            the unit lane's tag exclusion apply to integration tests too, dropping e.g. @Tag("benchmark") ITs from
+            every -Pintegration run without a word (issue #5697). Give failsafe a namespaced property of its own.
+
+            surefire: %s
+            failsafe: %s""".formatted(surefire.value().trim(), failsafe.value().trim()))
+        .isNotEqualTo(surefire.value().trim());
+  }
+
+  /**
+   * Issue #6794, and the exact inverse of the two rules above. An execution that is one half of a tag
+   * <em>partition</em> owns a fixed set of classes, so its selection has to be written out rather than left to
+   * resolve through the mojo's user property, where a {@code -Dgroups} aimed at some other lane would narrow it.
+   * It is the quietest of the three failures: the execution runs zero tests and the build passes, so ~118 ITs
+   * leave the lane with nothing red anywhere.
+   */
+  @Test
+  void aTagPartitionedExecutionPinsBothOfItsTagFilters() {
+    final List<String> violations = unpinnedPartitionParameters(reactorTagParameters());
+
+    assertThat(violations)
+        .as("""
+            An execution that filters by tag has left a tag parameter open to the command line.
+
+            Both halves of a tag partition have to name both parameters. An omitted one resolves through
+            surefire's own ${groups}/${excludedGroups} user property, and so does a value that is nothing but a
+            reference to that same property, so a -Dgroups or -DexcludedGroups meant for another module narrows
+            this execution to whatever it names. Measured on 3.5.6: with <groups> omitted, -Dgroups=bogus-tag
+            makes the execution run 0 tests and the build succeed (issue #6794).
+
+            "Everything" is spelled any() | none() - any() alone matches only classes carrying at least one tag.
+            "Nothing extra" is spelled any() & none(), because an empty value does not compose into an expression.
+
+            Offenders:
+            %s""".formatted(String.join("\n", violations)))
+        .isEmpty();
+  }
+
+  /**
+   * The three checks above all assert that a collected set holds no offenders, so an empty collection would
+   * satisfy them for the wrong reason. This is what says the scan reached the build at all.
+   */
+  @Test
+  void theScanReachesTheBuild() {
+    assertThat(reactorPoms()).as("pom.xml files found under %s", repositoryRoot()).hasSizeGreaterThan(20);
+    assertThat(reactorTagParameters())
+        .as("plugin-wide tag parameters in the reactor: the parent configures one for surefire and one for failsafe")
+        .filteredOn(p -> p.executionId() == null)
+        .hasSizeGreaterThanOrEqualTo(2);
+  }
+
+  // -----------------------------------------------------------------------------------------------------------
+  // Evidence the rules can fail. The reactor holds no tag-partitioned execution today - the ha-heavy split was
+  // reverted in f4567f6176 pending issue #6848 - so the partition rule is exercised against that split's own
+  // configuration, in the shape it had and in the shapes issue #6794 says would reopen the hole.
+  // -----------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theSplitAsItWasWrittenSatisfiesThePartitionRule() {
+    final List<TagParameter> split = parse(pomWithExecutions("""
+        <execution>
+          <id>default</id>
+          <configuration>
+            <groups>any() | none()</groups>
+            <excludedGroups>ha-heavy | (${failsafe.excludedGroups})</excludedGroups>
+          </configuration>
+        </execution>
+        <execution>
+          <id>heavy-its-in-their-own-fork</id>
+          <configuration>
+            <groups>ha-heavy</groups>
+            <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
+          </configuration>
+        </execution>
+        """));
+
+    assertThat(split).as("both executions of the split, both parameters each").hasSize(4);
+    assertThat(unpinnedPartitionParameters(split)).isEmpty();
+  }
+
+  @Test
+  void anOmittedTagParameterIsReported() {
+    final List<String> violations = unpinnedPartitionParameters(parse(pomWithExecutions("""
+        <execution>
+          <id>default</id>
+          <configuration>
+            <excludedGroups>ha-heavy</excludedGroups>
+          </configuration>
+        </execution>
+        """)));
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations.getFirst()).contains("execution 'default'").contains("<groups>").contains("is not configured");
+  }
+
+  /**
+   * The regression issue #6794 names by hand: {@code <groups>any() | none()</groups>} "simplified" away, or
+   * written as the very user property it has to be immune to. Both leave the parameter resolving through
+   * {@code -Dgroups}, which is what makes the execution narrowable.
+   */
+  @Test
+  void aBareUserPropertyIsReportedLikeAnOmission() {
+    final List<String> violations = unpinnedPartitionParameters(parse(pomWithExecutions("""
+        <execution>
+          <id>heavy-its-in-their-own-fork</id>
+          <configuration>
+            <groups>${groups}</groups>
+            <excludedGroups>${excludedGroups}</excludedGroups>
+          </configuration>
+        </execution>
+        """)));
+
+    assertThat(violations).hasSize(2);
+    assertThat(String.join("\n", violations))
+        .contains("<groups>")
+        .contains("<excludedGroups>")
+        .contains("the command line can still narrow it");
+  }
+
+  @Test
+  void aBlankTagParameterIsReported() {
+    final List<String> violations = unpinnedPartitionParameters(parse(pomWithExecutions("""
+        <execution>
+          <id>heavy-its-in-their-own-fork</id>
+          <configuration>
+            <groups>ha-heavy</groups>
+            <excludedGroups></excludedGroups>
+          </configuration>
+        </execution>
+        """)));
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations.getFirst()).contains("<excludedGroups>").contains("is blank");
+  }
+
+  /**
+   * The plugin-wide rule and the partition rule pull in opposite directions, so each has to leave the other's
+   * shape alone. A property reference is what a plugin-wide default must be, and it is exactly what a partitioned
+   * execution must not be.
+   */
+  @Test
+  void thePluginWideRuleSeesLiteralsAndNotExecutions() {
+    assertThat(parse(pomWithPluginBody("<configuration><excludedGroups>benchmark</excludedGroups></configuration>")))
+        .singleElement()
+        .matches(p -> p.executionId() == null, "plugin-wide")
+        .matches(p -> !PROPERTY_ONLY.matcher(p.value().trim()).matches(), "a literal, which the rule rejects");
+
+    assertThat(parse(pomWithPluginBody("<configuration><excludedGroups>${excludedGroups}</excludedGroups></configuration>")))
+        .singleElement()
+        .matches(p -> PROPERTY_ONLY.matcher(p.value().trim()).matches(), "a passthrough, which the rule allows");
+
+    // An execution-level parameter is not a plugin-wide default and must not be judged by the plugin-wide rule.
+    assertThat(parse(pomWithExecutions("<execution><id>x</id><configuration><groups>ha-heavy</groups></configuration></execution>")))
+        .singleElement()
+        .matches(p -> "x".equals(p.executionId()), "attributed to its execution");
+
+    // An execution with no id of its own carries no partition: the parent declares exactly one such execution.
+    assertThat(parse(pomWithExecutions("<execution><configuration><groups>ha-heavy</groups></configuration></execution>"))).isEmpty();
+  }
+
+  // -----------------------------------------------------------------------------------------------------------
+  // The rules, expressed over collected parameters so the fixtures above run the same code as the reactor scan.
+  // -----------------------------------------------------------------------------------------------------------
+
+  private static List<String> unpinnedPartitionParameters(final List<TagParameter> parameters) {
+    final Set<ExecutionKey> partitions = new LinkedHashSet<>();
+    for (final TagParameter p : parameters)
+      if (p.executionId() != null)
+        partitions.add(p.execution());
+
+    final List<String> violations = new ArrayList<>();
+    for (final ExecutionKey partition : partitions)
+      for (final String name : TAG_PARAMS) {
+        final TagParameter declared = parameters.stream()
+            .filter(p -> p.execution().equals(partition) && p.name().equals(name))
+            .findFirst().orElse(null);
+
+        if (declared == null)
+          violations.add("  " + partition + " -> <" + name + "> is not configured, so it resolves through the ${" + name + "} user property");
+        else if (declared.value().isBlank())
+          violations.add("  " + declared.where() + " is blank, which is not an expression; write any() & none() for \"nothing\"");
+        else if (declared.value().trim().equals("${" + name + "}"))
+          violations.add("  " + declared.where() + " is only the ${" + name
+              + "} user property, so the command line can still narrow it exactly as if it were unset");
+      }
+    return violations;
+  }
+
+  private static TagParameter onlyOne(final List<TagParameter> parameters, final String plugin, final String name) {
+    final List<TagParameter> found = parameters.stream().filter(p -> p.plugin().equals(plugin) && p.name().equals(name)).toList();
+    assertThat(found).as("exactly one plugin-wide <%s> for %s in the parent pom", name, plugin).hasSize(1);
+    return found.getFirst();
+  }
+
+  private static String render(final List<TagParameter> parameters) {
+    return parameters.isEmpty() ? "  (none)"
+        : parameters.stream().map(p -> "  " + p.where() + " = " + p.value().trim()).reduce((a, b) -> a + "\n" + b).orElseThrow();
+  }
+
+  // -----------------------------------------------------------------------------------------------------------
+  // Reading the poms.
+  // -----------------------------------------------------------------------------------------------------------
+
+  private static List<TagParameter> reactorTagParameters() {
+    final Path root = repositoryRoot();
+    final List<TagParameter> parameters = new ArrayList<>();
+    for (final Path pom : reactorPoms())
+      parameters.addAll(collect(read(pom), root.relativize(pom).toString()));
+    return parameters;
+  }
+
+  private static List<Path> reactorPoms() {
+    final List<Path> poms = new ArrayList<>();
+    try {
+      Files.walkFileTree(repositoryRoot(), new SimpleFileVisitor<>() {
+        @Override
+        public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) {
+          return PRUNED.contains(dir.getFileName().toString()) ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {
+          if ("pom.xml".equals(file.getFileName().toString()))
+            poms.add(file);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return poms;
+  }
+
+  /**
+   * Walks up from the working directory to the one holding both the Maven wrapper and the parent pom.
+   * Deliberately not a hardcoded {@code ../}: the same test resolves from a module basedir under surefire, from a
+   * checkout root under an IDE, and from a git worktree.
+   */
+  private static Path repositoryRoot() {
+    Path candidate = Path.of("").toAbsolutePath();
+    while (candidate != null) {
+      if (Files.isRegularFile(candidate.resolve("mvnw")) && Files.isRegularFile(candidate.resolve("pom.xml")))
+        return candidate;
+      candidate = candidate.getParent();
+    }
+    throw new IllegalStateException("no directory holding both mvnw and pom.xml above " + Path.of("").toAbsolutePath());
+  }
+
+  /** Every {@code <groups>}/{@code <excludedGroups>} configured for surefire or failsafe in one pom. */
+  private static List<TagParameter> collect(final Document doc, final String pom) {
+    final List<TagParameter> parameters = new ArrayList<>();
+    final NodeList plugins = doc.getElementsByTagName("plugin");
+    for (int i = 0; i < plugins.getLength(); i++) {
+      final Element plugin = (Element) plugins.item(i);
+      final String artifactId = childText(plugin, "artifactId");
+      if (artifactId == null || !TAG_PLUGINS.contains(artifactId))
+        continue;
+
+      for (final Element configuration : children(plugin, "configuration"))
+        add(parameters, pom, artifactId, null, configuration);
+
+      for (final Element executions : children(plugin, "executions"))
+        for (final Element execution : children(executions, "execution")) {
+          // An execution with no id of its own is Maven's unnamed "default"; the parent declares one and it
+          // carries no tag filter. Attributing a partition to it would invent one the pom does not describe.
+          final String id = childText(execution, "id");
+          if (id == null)
+            continue;
+          for (final Element configuration : children(execution, "configuration"))
+            add(parameters, pom, artifactId, id, configuration);
+        }
+    }
+    return parameters;
+  }
+
+  private static void add(final List<TagParameter> into, final String pom, final String plugin, final String executionId,
+      final Element configuration) {
+    for (final String name : TAG_PARAMS)
+      for (final Element parameter : children(configuration, name))
+        into.add(new TagParameter(pom, plugin, executionId, name, parameter.getTextContent()));
+  }
+
+  private static List<Element> children(final Element parent, final String name) {
+    final List<Element> found = new ArrayList<>();
+    final NodeList nodes = parent.getChildNodes();
+    for (int i = 0; i < nodes.getLength(); i++) {
+      final Node node = nodes.item(i);
+      if (node.getNodeType() == Node.ELEMENT_NODE && name.equals(node.getNodeName()))
+        found.add((Element) node);
+    }
+    return found;
+  }
+
+  private static String childText(final Element parent, final String name) {
+    final List<Element> found = children(parent, name);
+    return found.isEmpty() ? null : found.getFirst().getTextContent().trim();
+  }
+
+  private static String pomWithExecutions(final String executions) {
+    return pomWithPluginBody("<executions>" + executions + "</executions>");
+  }
+
+  /** A minimal surefire declaration wrapping the fragment, so a fixture reads as the pom snippet it stands for. */
+  private static String pomWithPluginBody(final String pluginBody) {
+    return "<project><build><plugins><plugin><artifactId>maven-surefire-plugin</artifactId>" + pluginBody + "</plugin></plugins></build></project>";
+  }
+
+  private static List<TagParameter> parse(final String xml) {
+    try {
+      return collect(newDocumentBuilder().parse(new InputSource(new StringReader(xml))), "fixture");
+    } catch (final IOException | SAXException e) {
+      throw new IllegalStateException("cannot parse the fixture pom", e);
+    }
+  }
+
+  private static Document read(final Path pom) {
+    try {
+      return newDocumentBuilder().parse(pom.toFile());
+    } catch (final IOException | SAXException e) {
+      throw new IllegalStateException("cannot parse " + pom, e);
+    }
+  }
+
+  private static DocumentBuilder newDocumentBuilder() {
+    try {
+      final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      factory.setExpandEntityReferences(false);
+      return factory.newDocumentBuilder();
+    } catch (final ParserConfigurationException e) {
+      throw new IllegalStateException("cannot configure an XML parser", e);
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PomTagFilterContractTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PomTagFilterContractTest.java
@@ -211,12 +211,17 @@ class PomTagFilterContractTest {
   @Test
   void theScanReachesTheBuild() {
     final Path root = repositoryRoot();
-    final List<String> scanned = reactorPoms().stream().map(pom -> root.relativize(pom).toString()).toList();
+    // Kept as Path rather than String: a relative path renders with backslashes on Windows, and a canary that
+    // fires on the separator instead of on the thing it watches is worse than no canary.
+    final List<Path> scanned = reactorPoms().stream().map(root::relativize).toList();
 
     // A count alone is a loose canary - a pruning bug that drops several real modules can still clear a floor.
     // Naming the parent and a module makes it precise: the parent is where the two live rules find their
     // subject, and a module pom proves the walk descends rather than stopping at the root.
-    assertThat(scanned).as("poms found under %s", root).contains("pom.xml", "ha-raft/pom.xml", "engine/pom.xml").hasSizeGreaterThan(20);
+    assertThat(scanned)
+        .as("poms found under %s", root)
+        .contains(Path.of("pom.xml"), Path.of("ha-raft", "pom.xml"), Path.of("engine", "pom.xml"))
+        .hasSizeGreaterThan(20);
     assertThat(reactorTagParameters())
         .as("plugin-wide tag parameters in the reactor: the parent configures one for surefire and one for failsafe")
         .filteredOn(p -> p.executionId() == null)
@@ -231,7 +236,7 @@ class PomTagFilterContractTest {
 
   @Test
   void theSplitAsItWasWrittenSatisfiesThePartitionRule() {
-    final List<TagParameter> split = parse(pomWithExecutions("""
+    final List<TagParameter> split = parse(pomWithExecutions("maven-failsafe-plugin", """
         <execution>
           <id>default</id>
           <configuration>
@@ -288,7 +293,49 @@ class PomTagFilterContractTest {
     assertThat(String.join("\n", violations))
         .contains("<groups>")
         .contains("<excludedGroups>")
-        .contains("the command line can still narrow it");
+        .contains("the command line can still narrow it exactly as if it were unset");
+  }
+
+  /**
+   * The same hole one step less obvious, and the reason the check is a containment rather than an equality: Maven
+   * interpolates before surefire parses, so a reference buried in a larger expression, or a reference to the
+   * OTHER parameter's property, hands the command line a term in an expression that was meant to be immune to it.
+   */
+  @Test
+  void anEmbeddedOrCrossReferencedUserPropertyIsReported() {
+    final List<String> violations = unpinnedPartitionParameters(parse(pomWithExecutions("maven-failsafe-plugin", """
+        <execution>
+          <id>default</id>
+          <configuration>
+            <groups>${excludedGroups}</groups>
+            <excludedGroups>ha-heavy | (${excludedGroups})</excludedGroups>
+          </configuration>
+        </execution>
+        """)));
+
+    assertThat(violations).hasSize(2);
+    assertThat(violations.getFirst()).contains("<groups>").contains("interpolates ${excludedGroups}");
+    assertThat(violations.get(1)).contains("<excludedGroups>").contains("interpolates ${excludedGroups}")
+        .doesNotContain("as if it were unset");
+  }
+
+  /**
+   * The namespaced property the split composes in is not the hole above and must not be reported as one: nobody
+   * sets {@code -Dfailsafe.excludedGroups} by accident, and it is the one knob this module's ITs deliberately
+   * still honour. Covered by the whole-split fixture too, isolated here so a tightening of the rule that swallows
+   * it fails with the reason rather than as one line of a larger diff.
+   */
+  @Test
+  void aNamespacedPropertyIsNotAUserPropertyReference() {
+    assertThat(unpinnedPartitionParameters(parse(pomWithExecutions("maven-failsafe-plugin", """
+        <execution>
+          <id>heavy-its-in-their-own-fork</id>
+          <configuration>
+            <groups>ha-heavy</groups>
+            <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
+          </configuration>
+        </execution>
+        """)))).isEmpty();
   }
 
   @Test
@@ -361,13 +408,25 @@ class PomTagFilterContractTest {
             .filter(p -> p.execution().equals(partition) && p.name().equals(name))
             .findFirst().orElse(null);
 
-        if (declared == null)
+        if (declared == null) {
           violations.add("  " + partition + " -> <" + name + "> is not configured, so it resolves through the ${" + name + "} user property");
-        else if (declared.value().isBlank())
+          continue;
+        }
+        if (declared.value().isBlank()) {
           violations.add("  " + declared.where() + " is blank, which is not an expression; write any() & none() for \"nothing\"");
-        else if (declared.value().trim().equals("${" + name + "}"))
-          violations.add("  " + declared.where() + " is only the ${" + name
-              + "} user property, so the command line can still narrow it exactly as if it were unset");
+          continue;
+        }
+
+        // Anywhere in the value, not only as the whole of it. Maven interpolates before surefire ever parses the
+        // tag expression, so "ha-heavy | (${excludedGroups})" hands the command line a term inside an expression
+        // that was supposed to be immune to it - and a reference to the OTHER parameter's property is the same
+        // hole wearing a different name. A namespaced property (${failsafe.excludedGroups}) is not this: it is
+        // the one knob the split composes in on purpose, and it does not contain either literal below.
+        final List<String> reachable = TAG_PARAMS.stream().map(n -> "${" + n + "}").filter(declared.value()::contains).toList();
+        if (!reachable.isEmpty())
+          violations.add("  " + declared.where() + " interpolates " + String.join(" and ", reachable)
+              + ", which -D sets, so the command line can still narrow it"
+              + (declared.value().trim().equals("${" + name + "}") ? " exactly as if it were unset" : ""));
       }
     return violations;
   }
@@ -432,7 +491,15 @@ class PomTagFilterContractTest {
     throw new IllegalStateException("no directory holding both mvnw and pom.xml above " + Path.of("").toAbsolutePath());
   }
 
-  /** Every {@code <groups>}/{@code <excludedGroups>} configured for surefire or failsafe in one pom. */
+  /**
+   * Every {@code <groups>}/{@code <excludedGroups>} configured for surefire or failsafe in one pom.
+   * <p>
+   * Deliberately blind to WHERE the {@code <plugin>} block sits: {@code <build>}, {@code <pluginManagement>} and
+   * any {@code <profile>} are all scanned. A profile is exactly where somebody would put a tag filter that a lane
+   * activates, and neither rule is easier to break there. Descent below the block is the opposite - only direct
+   * children are read, so a same-named element inside an unrelated nested configuration cannot be mistaken for
+   * one of these parameters.
+   */
   private static List<TagParameter> collect(final Document doc, final String pom) {
     final List<TagParameter> parameters = new ArrayList<>();
     final NodeList plugins = doc.getElementsByTagName("plugin");
@@ -483,12 +550,24 @@ class PomTagFilterContractTest {
   }
 
   private static String pomWithExecutions(final String executions) {
-    return pomWithPluginBody("<executions>" + executions + "</executions>");
+    return pomWithExecutions("maven-surefire-plugin", executions);
   }
 
-  /** A minimal surefire declaration wrapping the fragment, so a fixture reads as the pom snippet it stands for. */
+  private static String pomWithExecutions(final String artifactId, final String executions) {
+    return pomWithPluginBody(artifactId, "<executions>" + executions + "</executions>");
+  }
+
   private static String pomWithPluginBody(final String pluginBody) {
-    return "<project><build><plugins><plugin><artifactId>maven-surefire-plugin</artifactId>" + pluginBody + "</plugin></plugins></build></project>";
+    return pomWithPluginBody("maven-surefire-plugin", pluginBody);
+  }
+
+  /**
+   * A minimal plugin declaration wrapping the fragment, so a fixture reads as the pom snippet it stands for. The
+   * artifactId is a parameter only so a fixture modelling a real block can name the plugin that block belongs to;
+   * the rules treat surefire and failsafe identically.
+   */
+  private static String pomWithPluginBody(final String artifactId, final String pluginBody) {
+    return "<project><build><plugins><plugin><artifactId>" + artifactId + "</artifactId>" + pluginBody + "</plugin></plugins></build></project>";
   }
 
   private static List<TagParameter> parse(final String xml) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PomTagFilterContractTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PomTagFilterContractTest.java
@@ -95,9 +95,9 @@ class PomTagFilterContractTest {
    * @param executionId the enclosing {@code <execution>}'s id, or {@code null} for the plugin-wide configuration
    *                    that every inherited execution reads
    */
-  private record TagParameter(String pom, String plugin, String executionId, String name, String value) {
+  private record TagParameter(String pom, String plugin, int declaration, String scope, String executionId, String name, String value) {
     ExecutionKey execution() {
-      return new ExecutionKey(pom, plugin, executionId);
+      return new ExecutionKey(pom, plugin, declaration, scope, executionId);
     }
 
     String where() {
@@ -105,10 +105,19 @@ class PomTagFilterContractTest {
     }
   }
 
-  private record ExecutionKey(String pom, String plugin, String executionId) {
+  /**
+   * Identifies one execution. {@code declaration} is the position of its {@code <plugin>} block in the document,
+   * and it is what keeps two executions apart when nothing else does: an execution id is unique only within one
+   * plugin block, so two profiles - or a profile and {@code <build>} - may each declare {@code <execution>} with
+   * the same id and different halves of a tag filter. Merged, those two look like one properly pinned execution
+   * while each on its own is narrowable, which is the failure this whole class exists to catch. {@code scope} is
+   * for the message only; the index is what makes the identity correct.
+   */
+  private record ExecutionKey(String pom, String plugin, int declaration, String scope, String executionId) {
     @Override
     public String toString() {
-      return pom + " -> " + plugin + (executionId == null ? " (plugin configuration)" : " execution '" + executionId + "'");
+      return pom + " -> " + plugin + (scope.isEmpty() ? "" : " in " + scope)
+          + (executionId == null ? " (plugin configuration)" : " execution '" + executionId + "'");
     }
   }
 
@@ -338,6 +347,62 @@ class PomTagFilterContractTest {
         """)))).isEmpty();
   }
 
+  /**
+   * An execution id is unique only inside one {@code <plugin>} block, so two profiles can each declare an
+   * execution called {@code default} carrying a different half of the filter. Keyed by id alone they merge into
+   * one execution that looks properly pinned, while each on its own is narrowable from the command line.
+   */
+  @Test
+  void executionsSharingAnIdAcrossProfilesAreJudgedSeparately() {
+    final List<String> violations = unpinnedPartitionParameters(parse("""
+        <project><profiles>
+          <profile>
+            <id>fast</id>
+            <build><plugins><plugin><artifactId>maven-failsafe-plugin</artifactId><executions>
+              <execution><id>default</id><configuration><groups>any() | none()</groups></configuration></execution>
+            </executions></plugin></plugins></build>
+          </profile>
+          <profile>
+            <id>thorough</id>
+            <build><plugins><plugin><artifactId>maven-failsafe-plugin</artifactId><executions>
+              <execution><id>default</id><configuration><excludedGroups>ha-heavy</excludedGroups></configuration></execution>
+            </executions></plugin></plugins></build>
+          </profile>
+        </profiles></project>
+        """));
+
+    assertThat(violations).hasSize(2);
+    assertThat(String.join("\n", violations))
+        .contains("profile 'fast'")
+        .contains("profile 'thorough'")
+        .contains("<excludedGroups> is not configured")
+        .contains("<groups> is not configured");
+  }
+
+  /**
+   * The deliberate limit of the partition rule, pinned so it is a decision rather than an oversight. An execution
+   * that names NO tag filter is not half of a partition - it is an ordinary execution set up for something else
+   * (its own {@code <includes>}, its own {@code reuseForks}), and there is nothing in the pom that says otherwise.
+   * Demanding both parameters of every named execution would fail on those, and inventing a partition where the
+   * pom describes none is how a guard starts costing more than it catches. Declaring one parameter is the signal;
+   * that is the moment the other one has to be pinned too.
+   */
+  @Test
+  void anExecutionWithNoTagFilterIsNotAPartition() {
+    final List<TagParameter> parameters = parse(pomWithExecutions("maven-failsafe-plugin", """
+        <execution>
+          <id>slow-its-last</id>
+          <configuration>
+            <reuseForks>false</reuseForks>
+            <includes><include>**/*SlowIT.java</include></includes>
+          </configuration>
+        </execution>
+        """));
+
+    assertThat(parameters).isEmpty();
+    assertThat(unpinnedPartitionParameters(parameters)).isEmpty();
+  }
+
   @Test
   void aBlankTagParameterIsReported() {
     final List<String> violations = unpinnedPartitionParameters(parse(pomWithExecutions("""
@@ -394,6 +459,11 @@ class PomTagFilterContractTest {
    * the first rule that keeps the latter a property reference rather than a literal. Either way it stays
    * narrowable from the command line, which is what this rule forbids. Relaxing the first rule would quietly
    * remove that half of the premise, so relax neither alone.
+   * <p>
+   * The message for an omitted parameter names {@code ${groups}}/{@code ${excludedGroups}} specifically, which
+   * is exact today because that is what this repository's plugin-wide defaults are called. A plugin-wide default
+   * under some other property name would still satisfy the first rule and would still be settable from the
+   * command line, so the verdict would stay right while the property named in the message would not.
    */
   private static List<String> unpinnedPartitionParameters(final List<TagParameter> parameters) {
     final Set<ExecutionKey> partitions = new LinkedHashSet<>();
@@ -509,8 +579,9 @@ class PomTagFilterContractTest {
       if (artifactId == null || !TAG_PLUGINS.contains(artifactId))
         continue;
 
+      final String scope = scopeOf(plugin);
       for (final Element configuration : children(plugin, "configuration"))
-        add(parameters, pom, artifactId, null, configuration);
+        add(parameters, pom, artifactId, i, scope, null, configuration);
 
       for (final Element executions : children(plugin, "executions"))
         for (final Element execution : children(executions, "execution")) {
@@ -520,17 +591,31 @@ class PomTagFilterContractTest {
           if (id == null)
             continue;
           for (final Element configuration : children(execution, "configuration"))
-            add(parameters, pom, artifactId, id, configuration);
+            add(parameters, pom, artifactId, i, scope, id, configuration);
         }
     }
     return parameters;
   }
 
-  private static void add(final List<TagParameter> into, final String pom, final String plugin, final String executionId,
-      final Element configuration) {
+  private static void add(final List<TagParameter> into, final String pom, final String plugin, final int declaration,
+      final String scope, final String executionId, final Element configuration) {
     for (final String name : TAG_PARAMS)
       for (final Element parameter : children(configuration, name))
-        into.add(new TagParameter(pom, plugin, executionId, name, parameter.getTextContent()));
+        into.add(new TagParameter(pom, plugin, declaration, scope, executionId, name, parameter.getTextContent()));
+  }
+
+  /** Where a plugin block sits, for the message: the profile that holds it, and whether it is only managed. */
+  private static String scopeOf(final Element plugin) {
+    final StringBuilder scope = new StringBuilder();
+    for (Node ancestor = plugin.getParentNode(); ancestor != null; ancestor = ancestor.getParentNode()) {
+      if ("pluginManagement".equals(ancestor.getNodeName()))
+        scope.append("pluginManagement");
+      else if ("profile".equals(ancestor.getNodeName())) {
+        final String id = childText((Element) ancestor, "id");
+        scope.append(scope.isEmpty() ? "" : " of ").append("profile '").append(id == null ? "?" : id).append('\'');
+      }
+    }
+    return scope.toString();
   }
 
   private static List<Element> children(final Element parent, final String name) {

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,9 @@
                     <!-- Skip @Tag("benchmark") classes by default (issue #5697). Sourced from the
                          ${excludedGroups} property above so -DexcludedGroups=... on the command line
                          still overrides it, e.g. benchmark-tests.yml clears it to run benchmarks and
-                         mvn-test.yml widens it to slow,benchmark,vector for the default lane. -->
+                         mvn-test.yml widens it to slow,benchmark,vector for the default lane.
+                         Turning this into a literal breaks those lanes silently, so PomTagFilterContractTest
+                         (ha-raft) fails the build if it ever stops being a property reference. -->
                     <excludedGroups>${excludedGroups}</excludedGroups>
                     <properties>
                         <!-- Work around. Surefire does not include enough
@@ -330,7 +332,9 @@
                         <exclude>**/*ReplicationServerLeaderChanges3TimesIT</exclude>
                     </excludes>
                     <!-- Explicit, namespaced override of failsafe's excludedGroups (issue #5697): keeps
-                         it independent of the surefire-only ${excludedGroups} default set above. -->
+                         it independent of the surefire-only ${excludedGroups} default set above. Dropping it,
+                         or pointing it back at ${excludedGroups}, fails PomTagFilterContractTest (ha-raft) -
+                         there is no other symptom, the ITs simply inherit the unit lane's exclusion. -->
                     <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
                     <skipTests>${skipITs}</skipTests>
                     <skipITs>${skipITs}</skipITs>


### PR DESCRIPTION
Closes #6794

## What this does

Issue #6794 asked for an automated guard behind step 5 of the `ha-raft` fork-split re-verification recipe: *no command-line tag filter can narrow either failsafe execution*. That step matters most and had the least behind it, and its failure mode is the quiet one - the execution runs **0 tests and the build passes**, so ~118 ITs leave the lane with nothing red anywhere.

`PomTagFilterContractTest` (in `ha-raft`, 13 tests, under a second, no Maven subprocess) reads every `pom.xml` in the repository and checks how surefire's and failsafe's `groups`/`excludedGroups` are configured. Those parameters each carry a same-named `-D` user property, and Maven resolves a plugin parameter from the configuration first and from the user property only where the configuration leaves it unset. Both ways of getting that precedence wrong are invisible, and they point in opposite directions, so the test enforces both:

| rule | what it catches | issue |
|---|---|---|
| a **plugin-wide** default must be a property reference | a literal outranks the command line, so every `-Dgroups`/`-DexcludedGroups` in `.github/workflows/` quietly stops meaning anything | #5697 |
| failsafe's default must not read surefire's property | ITs silently inherit the unit lane's exclusion (e.g. `@Tag("benchmark")` ITs vanish from every `-Pintegration` run) | #5697 |
| a **named execution** that is half of a tag partition must write out **both** parameters, neither blank nor a bare `${groups}`/`${excludedGroups}` | a `-Dgroups` aimed at another module narrows the execution to nothing, silently | **#6794** |

## Why not `help:effective-pom`

The issue sketched option (2) as a CI step that greps the effective POM. Interpolation is precisely the distinction under test: the effective pom resolves `${excludedGroups}` to `benchmark`, so it cannot tell a passthrough from the literal that breaks it. Reading the sources as written is both more accurate and free - no `mvnw` invocation, no new plugin, no new lane - so it runs in the ordinary unit lane and on a developer's machine rather than only in a workflow step. Option (1), `maven-invoker-plugin`, would prove runtime behaviour at the cost of a build-time dependency and lane time; the precondition it would be proving is exactly what is asserted here.

## The awkward part, stated plainly

**The `ha-heavy` split is not on `main`.** It was reverted in f4567f6176 (in the very PR, #6789, that #6794 was filed as a follow-up to) because it surfaced a real product failure, now issue #6848. `ha-raft/pom.xml` has one plugin block and no failsafe executions, and the CLAUDE.md checklist the issue quotes was removed with it.

So the partition rule currently has nothing in the reactor to judge. Rather than ship a test that cannot fail, it is:

- **proven able to fail against the split's own configuration** - the pre-revert `default` / `heavy-its-in-their-own-fork` pair is a fixture that must pass, and the three shapes #6794 names as regressions (parameter omitted, parameter written as the bare user property, parameter blank) are fixtures that must be reported, by execution id and parameter name;
- **verified to arm itself in the reactor** - planting an execution missing its `<groups>` in `ha-raft/pom.xml` fails the build with `ha-raft/pom.xml -> maven-failsafe-plugin execution 'heavy-its-in-their-own-fork' -> <groups> is not configured, so it resolves through the ${groups} user property`. No edit here will be needed when the split returns.

The other two rules are live and armed today against the parent pom, which is what stops this from being a test with no subject.

## Verification

Every rule was shown able to fail before being trusted, by perturbing the tree and re-running:

| perturbation | result |
|---|---|
| surefire's `<excludedGroups>${excludedGroups}</excludedGroups>` -> `benchmark` | `inheritedTagDefaultsStayOverridableFromTheCommandLine` fails |
| failsafe's `${failsafe.excludedGroups}` -> `${excludedGroups}` | `integrationTestsDoNotInheritTheUnitLaneTagExclusion` fails |
| a partitioned execution planted in `ha-raft/pom.xml` without `<groups>` | `aTagPartitionedExecutionPinsBothOfItsTagFilters` fails, naming it |
| a partitioned execution with an embedded `${excludedGroups}` planted in `ha-raft/pom.xml` | the same rule fails, naming the interpolation |
| `engine/` added to the scan's prune list | `theScanReachesTheBuild` fails, though the pom count still clears its floor |
| `ExecutionKey`'s plugin-declaration identity collapsed back to `(pom, plugin, id)` | `executionsSharingAnIdAcrossProfilesAreJudgedSeparately` fails |
| unperturbed | 13/13 green |

The premise was re-measured on this tree (surefire 3.5.6) rather than taken from the issue:

```
./mvnw -o -pl ha-raft test -Dgroups=bogus-tag
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`theScanReachesTheBuild` exists so the three "collection is empty" assertions cannot pass by scanning nothing.

## Test plan

- [ ] `./mvnw -o -pl ha-raft test -Dtest=PomTagFilterContractTest -DfailIfNoSpecifiedTests=false` - 13 tests green
- [ ] `./mvnw -o -pl ha-raft test` - the module's unit tests green (991 at the time of the first commit). Note: this dies in a fork start (`The forked VM terminated without properly saying goodbye`, at `LeaveClusterTest`) whenever a second `ha-raft` run is live in another worktree; a control run of that class on unmodified `main` reproduces it, so it is not this change
- [ ] Change `<excludedGroups>${excludedGroups}</excludedGroups>` in the parent pom to a literal and confirm the build now fails with the #5697 message
- [ ] Point failsafe's `<excludedGroups>` back at `${excludedGroups}` and confirm the second rule fires
- [ ] Add a `<execution>` with an id and only one of the two tag parameters to any module's surefire/failsafe block and confirm the partition rule names it

## Notes for the reviewer

- No new dependency, no new workflow step, no change to what any lane runs today. The two `pom.xml` edits are comments pointing at the guard, so the next person editing those lines learns what will fail.
- The check is in `ha-raft` because that is the only module whose executions are ever meant to be a tag partition, and it is where the split will return. `ha-raft/CLAUDE.md` says so, since a repo-wide pom test in this module is otherwise a surprise.

## Review rounds

Three rounds of bot review; two rounds found real gaps in the guard itself, both now closed and pinned by fixtures that fail if the fix is undone:

1. an interpolated `${groups}`/`${excludedGroups}` **anywhere** in a partitioned execution's value, not only as the whole of it, still hands the command line a term in an expression meant to be immune to it. The check is containment over both property names now; `${failsafe.excludedGroups}` is deliberately not caught, and a fixture pins that too;
2. `ExecutionKey` was `(pom, plugin, executionId)`, but an execution id is unique only inside one `<plugin>` block - two profiles declaring `<execution><id>default</id>` with complementary halves of the filter merged into one execution that looked pinned. The key carries the plugin block's document position now.

Also applied: Windows-safe path assertions, the failsafe-exclusion rule added to `ha-raft/CLAUDE.md`, a note that the plugin scan deliberately covers `pluginManagement` and profiles, and fixtures naming the plugin they model.

Declined with reasons (see the [review-round-3 comment](https://github.com/ArcadeData/arcadedb/pull/6915#issuecomment-5469515499)): requiring both parameters of an execution that declares *neither* (that is an ordinary execution, not half of a partition - pinned as a decision by `anExecutionWithNoTagFilterIsNotAPartition`), caching the scan in a `@BeforeAll` static, and dropping the `hasSizeGreaterThan(20)` floor.
