### PR TITLE
fix(#6848): arbitrate the abandoned-entry race so the leader never drops a committed write

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -407,9 +407,21 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // entry can take a long time to either commit or be overwritten by a new leader.
   private static final long              ABANDONED_TX_TTL_MS           = 10 * 60 * 1000L;
   // The origin-skip slot is written on the leader's hot commit path, so it cannot afford the full
-  // TTL scan the (rare) abandon path runs. The committing thread removes its own slot on every exit,
-  // so this sweep only ever collects slots stranded by a thread that died mid-commit: throttled to
-  // once per window, it keeps the hot path O(1) while still bounding the map.
+  // TTL scan the (rare) abandon path runs; throttled to once per window, this sweep keeps that path
+  // O(1) while still bounding the map.
+  //
+  // It is a backstop, not the main disposal route. Ratis completes a write's client reply from the
+  // applyTransaction future, so on the leader the apply - and therefore the slot - happens BEFORE
+  // replicateTransaction returns, and the committing thread's own finally removes it. What is left
+  // for the sweep is the slots nobody came back for: a committing thread that died, and any exit
+  // where the reply reached it by some other route than its own entry's apply.
+  //
+  // The TTL those slots are held for is deliberately NOT tightened to "a few seconds". A slot must
+  // outlive the whole window in which its committing thread can still abandon (2 x quorumTimeout
+  // plus the grace wait, i.e. 30 s at the default arcadedb.ha.quorumTimeout of 10 s), because a slot
+  // evicted inside that window would let the abandon claim a free key, roll back, and re-open the
+  // #6848 lost write. ABANDONED_TX_TTL_MS clears that bar by an order of magnitude, which is the
+  // point of reusing it.
   private static final long              ORIGIN_SKIP_PRUNE_EVERY_MS    = 60 * 1000L;
   private final        AtomicLong        lastOriginSkipPruneMs         = new AtomicLong();
 
@@ -1619,10 +1631,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   /**
-   * Drops origin-skip slots nothing came back for - the committing thread died mid-commit, or its
-   * outcome settled before this apply landed - at most once per {@link #ORIGIN_SKIP_PRUNE_EVERY_MS}.
-   * Throttled because this runs on the leader's commit path, where the unthrottled full scan
-   * {@link #markLocalTransactionAbandoned} can afford would be charged to every transaction.
+   * Drops origin-skip slots nothing came back for, at most once per
+   * {@link #ORIGIN_SKIP_PRUNE_EVERY_MS}. Throttled because this runs on the leader's commit path,
+   * where the unthrottled full scan {@link #markLocalTransactionAbandoned} can afford would be
+   * charged to every transaction. See {@link #ORIGIN_SKIP_PRUNE_EVERY_MS} for why the slots it
+   * collects are the exception rather than the rule, and why their TTL stays long.
    */
   private void pruneStrandedLocalTxOutcomes(final long now) {
     final long last = lastOriginSkipPruneMs.get();
@@ -1665,6 +1678,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * origin-skip case, where phase 2 already wrote the pages and released its own ticket.
    * <p>
    * Consuming is one-shot so a later replay of the same entry correctly origin-skips again.
+   * <p>
+   * <b>This is NOT the branch {@link #applyTxEntry} takes</b> - it stopped being that in #6848.
+   * Reading the mark is only half of what the apply thread has to do; the other half is publishing
+   * its own decision, and only {@link #claimLocalOriginatedEntry} does both atomically. What survives
+   * here is the read-and-clear on its own, for callers that want to inspect or drain one mark without
+   * claiming the entry: the map's own unit tests, which pin the mark/ticket correlation #5410 added,
+   * and which must keep testing exactly that and not the arbitration on top of it. Do not call this
+   * from an apply path - it would decide without publishing, which is precisely the shape of the
+   * #6848 lost write.
    */
   long consumeAbandonedLocalTransaction(final String databaseName, final long walTxId) {
     final LocalTxOutcome outcome = abandonedLocalTransactions.remove(abandonedKey(databaseName, walTxId));

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -411,10 +411,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // O(1) while still bounding the map.
   //
   // It is a backstop, not the main disposal route. Ratis completes a write's client reply from the
-  // applyTransaction future, so on the leader the apply - and therefore the slot - happens BEFORE
-  // replicateTransaction returns, and the committing thread's own finally removes it. What is left
-  // for the sweep is the slots nobody came back for: a committing thread that died, and any exit
+  // applyTransaction future, so on the leader the apply - and therefore the slot - normally happens
+  // BEFORE replicateTransaction returns and the committing thread's own finally removes it. What is
+  // left for the sweep is the slots nobody came back for: a committing thread that died, and any exit
   // where the reply reached it by some other route than its own entry's apply.
+  //
+  // Nothing here is load-bearing on that Ratis ordering. If a reply ever overtook its apply, the only
+  // consequence is a slot removed before it was written and then left for this sweep - map hygiene,
+  // not correctness. The arbitration itself is settled by putIfAbsent in either order, which is the
+  // whole reason it was moved into the map in the first place.
   //
   // The TTL those slots are held for is deliberately NOT tightened to "a few seconds". A slot must
   // outlive the whole window in which its committing thread can still abandon (2 x quorumTimeout

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1584,13 +1584,27 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
     final String key = abandonedKey(databaseName, walTxId);
     final LocalTxOutcome existing = abandonedLocalTransactions.putIfAbsent(key, new AbandonedPhase2(phase2Ticket, now));
-    if (!(existing instanceof OriginSkipped)) {
-      // Either the slot was free (the common case: the apply thread has not reached this entry yet,
-      // or the entry will never commit) or an earlier mark for the same transaction is already there.
-      // Both mean the mark now stands and applyTxEntry is the one that will write the pages.
+    if (existing == null) {
+      // The common case: the apply thread has not reached this entry yet, or the entry will never
+      // commit. Either way the mark now stands and applyTxEntry is the one that will write the pages.
       HALog.log(this, HALog.BASIC,
           "Marked locally-originated tx %d on database '%s' for local apply on commit (replication was indeterminate, #4790)",
           walTxId, databaseName);
+      return true;
+    }
+
+    if (existing instanceof final AbandonedPhase2 firstMark) {
+      // Two commits abandoned the SAME transaction id, which the WAL counter is supposed to make
+      // impossible. putIfAbsent keeps the first mark, so THIS caller's ticket is now held by nobody's
+      // apply - the #5410 pinned-checkpoint condition, for one ticket. Keeping the first mark is the
+      // safe direction (a held ticket costs log compaction, a wrongly released one costs a write), but
+      // it must not be silent: a future change that breaks the uniqueness assumption has to be
+      // diagnosable from the log rather than from an unexplained checkpoint that stops advancing.
+      LogManager.instance().log(this, Level.WARNING,
+          "Transaction id %d on database '%s' was marked abandoned twice (phase-2 tickets %d then %d). "
+              + "WAL transaction ids are expected to be unique per commit; keeping the first mark, so ticket %d "
+              + "stays held until this node restarts (#5410 checkpoint pinning).",
+          walTxId, databaseName, firstMark.phase2Ticket(), phase2Ticket, phase2Ticket);
       return true;
     }
 
@@ -1637,7 +1651,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * charged to every transaction. See {@link #ORIGIN_SKIP_PRUNE_EVERY_MS} for why the slots it
    * collects are the exception rather than the rule, and why their TTL stays long.
    */
-  private void pruneStrandedLocalTxOutcomes(final long now) {
+  // @VisibleForTesting - a backstop nothing reaches on a healthy path is exactly the code that rots
+  // unnoticed, and the invariant that matters (it must never evict an abandoned mark, whose ticket
+  // only the apply may release) is not observable through the handshake alone.
+  void pruneStrandedLocalTxOutcomes(final long now) {
     final long last = lastOriginSkipPruneMs.get();
     if (now - last < ORIGIN_SKIP_PRUNE_EVERY_MS || !lastOriginSkipPruneMs.compareAndSet(last, now))
       return;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -380,19 +380,38 @@ public class ArcadeStateMachine extends BaseStateMachine {
   private final        Map<String, Long> lastDivergedResyncLogByDb        = new ConcurrentHashMap<>();
   private static final long              DIVERGED_RESYNC_LOG_THROTTLE_MS   = 5_000L;
 
-  // Locally-originated transactions whose leader-side phase 2 was abandoned because replication
-  // returned an INDETERMINATE result (the entry was dispatched to Ratis but submitAndWait timed out
-  // before quorum was confirmed - see ReplicationDispatchedTimeoutException). Keyed by
-  // "<databaseName>/<walTxId>". If such an entry later reaches quorum and is applied here,
-  // applyTxEntry MUST apply it locally instead of origin-skipping it, otherwise the write lands on
-  // every follower but never on this leader: a silent, permanent divergence (issue #4790). Marking
-  // is always safe: it only changes behaviour IF the entry actually commits on this node's state
-  // machine (applying is then correct because the followers have it); if the entry never commits,
-  // the mark is inert and is pruned by TTL. Bounded by time-based pruning on insert.
-  private final        Map<String, AbandonedPhase2> abandonedLocalTransactions = new ConcurrentHashMap<>();
+  // Outcome slots for locally-originated transactions, keyed by "<databaseName>/<walTxId>". Two
+  // threads race to claim the same slot and the winner decides who writes the entry's pages:
+  //
+  //   - the committing thread writes an AbandonedPhase2 when replication returned an INDETERMINATE
+  //     result (the entry was dispatched to Ratis but submitAndWait timed out before quorum was
+  //     confirmed - see ReplicationDispatchedTimeoutException). If such an entry later reaches
+  //     quorum and is applied here, applyTxEntry MUST apply it locally instead of origin-skipping
+  //     it, otherwise the write lands on every follower but never on this leader: a silent,
+  //     permanent divergence (issue #4790);
+  //   - the Raft apply thread writes an OriginSkipped when it passes a locally-originated entry and
+  //     leaves the pages to phase 2.
+  //
+  // Whoever finds the other's slot already there knows the other side got in first, and the loser
+  // takes over the work. That handshake is the whole point of routing BOTH sides through this one
+  // map: before issue #6848 the abandoned mark was published only after the entry had already been
+  // dispatched, so on a cold JVM the apply thread reached applyTxEntry first, found no mark and
+  // origin-skipped an entry whose phase 2 never ran - the leader stayed one transaction behind its
+  // followers for the rest of its uptime.
+  //
+  // Marking is always safe: it only changes behaviour IF the entry actually commits on this node's
+  // state machine (applying is then correct because the followers have it); if the entry never
+  // commits, the slot is inert and is pruned by TTL. Bounded by time-based pruning on insert.
+  private final        Map<String, LocalTxOutcome> abandonedLocalTransactions = new ConcurrentHashMap<>();
   // Entries older than this are pruned on the next mark. Generous because a dispatched-but-stuck
   // entry can take a long time to either commit or be overwritten by a new leader.
   private static final long              ABANDONED_TX_TTL_MS           = 10 * 60 * 1000L;
+  // The origin-skip slot is written on the leader's hot commit path, so it cannot afford the full
+  // TTL scan the (rare) abandon path runs. The committing thread removes its own slot on every exit,
+  // so this sweep only ever collects slots stranded by a thread that died mid-commit: throttled to
+  // once per window, it keeps the hot path O(1) while still bounding the map.
+  private static final long              ORIGIN_SKIP_PRUNE_EVERY_MS    = 60 * 1000L;
+  private final        AtomicLong        lastOriginSkipPruneMs         = new AtomicLong();
 
   // In-flight leader-side phase 2 applies, ticket -> the applied index observed when the commit
   // started (its "replay floor"). A locally-originated entry is origin-skipped by applyTxEntry
@@ -418,12 +437,30 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   /**
+   * One claim on a locally-originated transaction, written by whichever of the committing thread and
+   * the Raft apply thread reaches {@link #abandonedLocalTransactions} first. {@code insertedAt} backs
+   * the TTL pruning that bounds the map.
+   */
+  private sealed interface LocalTxOutcome permits AbandonedPhase2, OriginSkipped {
+    long insertedAt();
+  }
+
+  /**
    * One abandoned locally-originated transaction: the phase-2 ticket its commit is still holding,
    * and when the mark was inserted (for TTL pruning). Carrying the ticket is what lets
    * {@link #applyTxEntry} release it once the entry finally applies here, instead of leaving the
    * snapshot checkpoint - and therefore Raft log purging - pinned until the node restarts (#5410).
    */
-  private record AbandonedPhase2(long phase2Ticket, long insertedAt) {
+  private record AbandonedPhase2(long phase2Ticket, long insertedAt) implements LocalTxOutcome {
+  }
+
+  /**
+   * The Raft apply thread passed this locally-originated entry and left its pages to phase 2. Its
+   * only purpose is to be visible to a committing thread that abandons afterwards: finding it there
+   * proves the entry committed AND that nothing else will ever write its pages on this node, so the
+   * committer has to apply it itself (issue #6848).
+   */
+  private record OriginSkipped(long insertedAt) implements LocalTxOutcome {
   }
 
   /**
@@ -1518,8 +1555,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * {@link #NO_PHASE2_TICKET} when it took none. Recording it here is the correlation the ticket
    * lacks at {@link #beginLocalPhase2()} time (the WAL txId does not exist yet), and it is what lets
    * the eventual apply release the ticket instead of pinning the checkpoint until restart (#5410).
+   *
+   * @return {@code true} when the mark now stands, so {@link #applyTxEntry} will write this entry's
+   * pages; {@code false} when the Raft apply thread had already passed the entry and origin-skipped
+   * it, which leaves the caller holding a committed entry nothing else will ever apply here - it must
+   * apply the transaction itself (issue #6848).
    */
-  void markLocalTransactionAbandoned(final String databaseName, final long walTxId, final long phase2Ticket) {
+  boolean markLocalTransactionAbandoned(final String databaseName, final long walTxId, final long phase2Ticket) {
     final long now = System.currentTimeMillis();
     // Prune stale marks (entries that were dispatched but never committed, e.g. the slot was
     // overwritten by a new leader) so the map cannot grow unbounded. A pruned mark deliberately does
@@ -1527,10 +1569,93 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // later it will now be origin-skipped (unapplied here), so it must stay inside the replay window.
     if (!abandonedLocalTransactions.isEmpty())
       abandonedLocalTransactions.values().removeIf(abandoned -> now - abandoned.insertedAt() > ABANDONED_TX_TTL_MS);
-    abandonedLocalTransactions.put(abandonedKey(databaseName, walTxId), new AbandonedPhase2(phase2Ticket, now));
+
+    final String key = abandonedKey(databaseName, walTxId);
+    final LocalTxOutcome existing = abandonedLocalTransactions.putIfAbsent(key, new AbandonedPhase2(phase2Ticket, now));
+    if (!(existing instanceof OriginSkipped)) {
+      // Either the slot was free (the common case: the apply thread has not reached this entry yet,
+      // or the entry will never commit) or an earlier mark for the same transaction is already there.
+      // Both mean the mark now stands and applyTxEntry is the one that will write the pages.
+      HALog.log(this, HALog.BASIC,
+          "Marked locally-originated tx %d on database '%s' for local apply on commit (replication was indeterminate, #4790)",
+          walTxId, databaseName);
+      return true;
+    }
+
+    // The apply thread got here first: it already passed this entry and origin-skipped it, so the
+    // entry IS committed and nothing else is ever going to write its pages on this node. Clear the
+    // slot and tell the caller it owns the apply (issue #6848).
+    abandonedLocalTransactions.remove(key, existing);
     HALog.log(this, HALog.BASIC,
-        "Marked locally-originated tx %d on database '%s' for local apply on commit (replication was indeterminate, #4790)",
+        "Locally-originated tx %d on database '%s' was origin-skipped before its abandoned mark was published; "
+            + "the committing thread must apply it locally (#6848)",
         walTxId, databaseName);
+    return false;
+  }
+
+  /**
+   * Claims a committed, locally-originated entry on the Raft apply thread and reports what to do with
+   * it: {@link #NO_ABANDONED_MARK} to origin-skip (phase 2 owns the pages), or the phase-2 ticket to
+   * release after applying when the committing thread already abandoned this transaction.
+   * <p>
+   * The origin-skip answer is not merely returned, it is <b>published</b>: the slot left behind is how
+   * a committing thread that abandons later discovers that the apply already happened without it and
+   * that it must write the pages itself. Without that publication the two threads raced with no
+   * arbiter and the leader silently dropped the write (issue #6848).
+   */
+  // @VisibleForTesting - the handshake with markLocalTransactionAbandoned is the load-bearing part
+  // of #6848, and driving it through applyTransaction would need a whole Ratis division stubbed out.
+  long claimLocalOriginatedEntry(final String databaseName, final long walTxId) {
+    final long now = System.currentTimeMillis();
+    final String key = abandonedKey(databaseName, walTxId);
+    final LocalTxOutcome existing = abandonedLocalTransactions.putIfAbsent(key, new OriginSkipped(now));
+    if (existing instanceof final AbandonedPhase2 abandoned) {
+      abandonedLocalTransactions.remove(key, abandoned);
+      return abandoned.phase2Ticket();
+    }
+    if (existing == null)
+      pruneStrandedLocalTxOutcomes(now);
+    return NO_ABANDONED_MARK;
+  }
+
+  /**
+   * Drops origin-skip slots nothing came back for - the committing thread died mid-commit, or its
+   * outcome settled before this apply landed - at most once per {@link #ORIGIN_SKIP_PRUNE_EVERY_MS}.
+   * Throttled because this runs on the leader's commit path, where the unthrottled full scan
+   * {@link #markLocalTransactionAbandoned} can afford would be charged to every transaction.
+   */
+  private void pruneStrandedLocalTxOutcomes(final long now) {
+    final long last = lastOriginSkipPruneMs.get();
+    if (now - last < ORIGIN_SKIP_PRUNE_EVERY_MS || !lastOriginSkipPruneMs.compareAndSet(last, now))
+      return;
+    abandonedLocalTransactions.values()
+        .removeIf(outcome -> outcome instanceof OriginSkipped && now - outcome.insertedAt() > ABANDONED_TX_TTL_MS);
+  }
+
+  /**
+   * Drops the slot a locally-originated transaction may hold once its outcome is settled by any exit
+   * other than "abandoned". A no-op when no slot exists, which is the common case: the slot only
+   * materializes when the Raft apply thread reached the entry before this method ran.
+   */
+  void forgetLocalOriginatedEntry(final String databaseName, final long walTxId) {
+    if (abandonedLocalTransactions.isEmpty())
+      return;
+    final String key = abandonedKey(databaseName, walTxId);
+    final LocalTxOutcome existing = abandonedLocalTransactions.get(key);
+    if (existing instanceof OriginSkipped)
+      abandonedLocalTransactions.remove(key, existing);
+  }
+
+  /**
+   * Reads a replicated WAL transaction's id without deserializing the pages behind it: the id is the
+   * first field {@link #deserializeWalTransaction(byte[])} writes, so it is the leading 8 bytes of the
+   * payload. Used on the leader's commit path, where the full deserialization would be pure waste for
+   * an entry that is about to be origin-skipped.
+   */
+  static long peekWalTransactionId(final byte[] walData) {
+    if (walData == null || walData.length < Long.BYTES)
+      throw new ReplicationException("Corrupted WAL transaction entry: truncated before the transaction id");
+    return ByteBuffer.wrap(walData, 0, Long.BYTES).getLong();
   }
 
   /**
@@ -1542,8 +1667,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * Consuming is one-shot so a later replay of the same entry correctly origin-skips again.
    */
   long consumeAbandonedLocalTransaction(final String databaseName, final long walTxId) {
-    final AbandonedPhase2 abandoned = abandonedLocalTransactions.remove(abandonedKey(databaseName, walTxId));
-    return abandoned != null ? abandoned.phase2Ticket() : NO_ABANDONED_MARK;
+    final LocalTxOutcome outcome = abandonedLocalTransactions.remove(abandonedKey(databaseName, walTxId));
+    return outcome instanceof final AbandonedPhase2 abandoned ? abandoned.phase2Ticket() : NO_ABANDONED_MARK;
   }
 
   private static String abandonedKey(final String databaseName, final long walTxId) {
@@ -1658,42 +1783,44 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
   private void applyTxEntry(final RaftLogEntryCodec.DecodedEntry decoded, final long entryIndex,
       final boolean originatedLocally) {
-    // Fast path (the leader's hot path): a locally-originated entry was already applied via
-    // commit2ndPhase() in RaftReplicatedDatabase, so skip to avoid double-apply. Using
+    // Origin skip (the leader's hot path): a locally-originated entry is normally applied via
+    // commit2ndPhase() in RaftReplicatedDatabase, so skip it here to avoid a double-apply. Using
     // originatedLocally (set by startTransaction) instead of isLeader() avoids TOCTOU races when
     // leadership changes between entry submission and state machine apply. After a crash and
     // restart, originatedLocally is always false (startTransaction was not called in this lifecycle),
     // so replayed entries are correctly re-applied with page-version guards providing idempotency.
-    // We short-circuit BEFORE deserializing the WAL when no abandoned transactions are pending (the
-    // common case), so the skip costs nothing extra on the hot path.
-    if (originatedLocally && abandonedLocalTransactions.isEmpty()) {
-      HALog.log(this, HALog.TRACE, "Skipping tx apply on originator for database '%s'", decoded.databaseName());
-      return;
-    }
-
-    final DatabaseInternal db = (DatabaseInternal) server.getDatabase(decoded.databaseName());
-    final WALFile.WALTransaction walTx = deserializeWalTransaction(decoded.walData());
-
+    //
     // EXCEPTION (issue #4790): commit() may have abandoned its phase 2 because replication returned
     // an indeterminate result (entry dispatched to Ratis but the quorum wait timed out before quorum
     // was confirmed). For such an entry phase 2 never ran, so it must be applied HERE instead of
     // origin-skipped, otherwise this leader silently loses a write the followers already have. The
     // mark is consumed (removed) so a later replay of the same entry correctly skips again.
+    //
+    // The claim below is a handshake, not a lookup (issue #6848): skipping also PUBLISHES the skip,
+    // so a committing thread that abandons after this point can see that the apply already happened
+    // without it and take over the write itself. Only the 8-byte transaction id is read here - the
+    // WAL is deserialized further down, on the branch that actually applies it, so the skip stays as
+    // cheap as the pre-#6848 short-circuit it replaces.
     // The ticket that commit() is still holding for this entry, when it was abandoned. Released
-    // below once applyChanges has written the pages - never on the origin-skip branch above, where
+    // below once applyChanges has written the pages - never on the origin-skip branch, where
     // releasing would reintroduce #5407.
     long abandonedPhase2Ticket = NO_PHASE2_TICKET;
     if (originatedLocally) {
-      final long abandoned = consumeAbandonedLocalTransaction(decoded.databaseName(), walTx.txId);
+      final long abandoned = claimLocalOriginatedEntry(decoded.databaseName(), peekWalTransactionId(decoded.walData()));
       if (abandoned == NO_ABANDONED_MARK) {
         HALog.log(this, HALog.TRACE, "Skipping tx apply on originator for database '%s'", decoded.databaseName());
         return;
       }
       abandonedPhase2Ticket = abandoned;
+    }
+
+    final DatabaseInternal db = (DatabaseInternal) server.getDatabase(decoded.databaseName());
+    final WALFile.WALTransaction walTx = deserializeWalTransaction(decoded.walData());
+
+    if (originatedLocally)
       HALog.log(this, HALog.BASIC,
           "Applying locally-originated tx %d on database '%s' whose phase 2 was abandoned (replication indeterminate, #4790)",
           walTx.txId, decoded.databaseName());
-    }
 
     HALog.log(this, HALog.DETAILED, "Applying tx %d to database '%s' (pages=%d)",
         walTx.txId, decoded.databaseName(), walTx.pages.length);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -533,6 +533,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   // @VisibleForTesting
   void replicateAndCommitLocally(final ReplicationPayload payload, final boolean leader,
       final ArcadeStateMachine stateMachine, final long phase2Ticket) {
+    // The correlation key between this thread and the Raft apply thread, read once (8 bytes off the
+    // front of the payload) so the abandoned mark and the cleanup below name the same slot (#6848).
+    final long walTxId = localWalTxId(payload);
+    boolean markedAbandoned = false;
+
     // --- REPLICATION (no lock held): send WAL to Raft and wait for quorum ---
     long committedLogIndex = -1;
     try {
@@ -557,8 +562,22 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // The ticket travels with the mark (#5410): this branch keeps holding it so a crash before the
       // entry applies still replays it, and whoever finally applies the entry releases it from the
       // mark - without that correlation the checkpoint stayed pinned until the node restarted.
-      markTransactionAbandonedForLocalApply(payload, phase2Ticket);
-      rollback();
+      markedAbandoned = markTransactionAbandonedForLocalApply(payload, walTxId, phase2Ticket);
+      if (markedAbandoned) {
+        rollback();
+      } else {
+        // The apply thread reached this entry before the mark existed and origin-skipped it, so the
+        // entry is committed and no one else will ever write its pages here. Recover exactly as the
+        // MAJORITY-committed branch above does - that is the same situation, learned a different way
+        // (issue #6848). Rolling back instead would leave this leader permanently one write behind
+        // its followers, which is the divergence #4790 exists to prevent.
+        LogManager.instance().log(this, Level.WARNING,
+            "Replication of tx %d on database '%s' timed out after the entry had already been applied and "
+                + "origin-skipped by the state machine; applying it locally to prevent leader divergence (#6848)",
+            walTxId, getName());
+        if (applyLocallyAfterMajorityCommit(payload))
+          releasePhase2Ticket(stateMachine, phase2Ticket);
+      }
       throw e;
     } catch (final ArcadeDBException e) {
       // Replication failed outright: the entry never reached the log, so there is nothing this node
@@ -570,6 +589,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       releasePhase2Ticket(stateMachine, phase2Ticket);
       rollback();
       throw new TransactionException("Error on commit distributed transaction (replication)", e);
+    } finally {
+      // Every exit except "abandoned" has settled who writes the pages, so the origin-skip slot the
+      // apply thread may have left behind has done its job and must not linger. The abandoned mark
+      // lives in the same map and MUST survive: it is what the eventual apply consumes. Only the
+      // leader origin-skips, so only the leader (the one holding a state machine here) has a slot.
+      if (!markedAbandoned && walTxId != UNKNOWN_WAL_TX_ID && stateMachine != null)
+        stateMachine.forgetLocalOriginatedEntry(getName(), walTxId);
     }
 
     // Test-only fault injection: simulate leader crash between replication and phase-2
@@ -735,18 +761,43 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * {@code phase2Ticket} rides along so the eventual apply can release it (issue #5410). When the
    * txId cannot be extracted the ticket stays held, which is the safe direction: an entry we cannot
    * correlate is one we cannot prove was applied.
+   *
+   * @return {@code true} when the mark now stands, so the state machine's apply of this entry is what
+   * will write its pages; {@code false} when the apply thread had already origin-skipped the entry
+   * before the mark could be published, which makes the CALLER responsible for applying it locally
+   * (issue #6848). An unreadable txId reports {@code true}: it keeps the conservative pre-#6848
+   * behaviour rather than applying an entry we cannot prove committed.
    */
-  private void markTransactionAbandonedForLocalApply(final ReplicationPayload payload, final long phase2Ticket) {
+  private boolean markTransactionAbandonedForLocalApply(final ReplicationPayload payload, final long walTxId,
+      final long phase2Ticket) {
     final ArcadeStateMachine stateMachine = stateMachineOrNull();
-    if (stateMachine == null)
-      return;
+    if (stateMachine == null || walTxId == UNKNOWN_WAL_TX_ID)
+      // Nothing to correlate against (no state machine wired yet, or an unreadable payload - already
+      // logged where it was read): keep the conservative behaviour of holding the ticket and rolling
+      // back, exactly as before the #6848 handshake existed.
+      return true;
+    return stateMachine.markLocalTransactionAbandoned(getName(), walTxId, phase2Ticket);
+  }
+
+  /**
+   * Sentinel for "this payload's WAL transaction id could not be read", which makes the whole #6848
+   * handshake inapplicable: an entry we cannot correlate is one we cannot prove was applied, so the
+   * caller keeps the conservative pre-#6848 behaviour (mark nothing, hold the ticket, roll back).
+   */
+  private static final long UNKNOWN_WAL_TX_ID = Long.MIN_VALUE;
+
+  /**
+   * Reads the WAL transaction id of a captured payload - the correlation key shared with the Raft
+   * apply thread. Best-effort: a payload we cannot parse yields {@link #UNKNOWN_WAL_TX_ID} rather
+   * than masking the replication failure that is already on its way to the caller.
+   */
+  private long localWalTxId(final ReplicationPayload payload) {
     try {
-      final long walTxId = ArcadeStateMachine.deserializeWalTransaction(payload.walData()).txId;
-      stateMachine.markLocalTransactionAbandoned(getName(), walTxId, phase2Ticket);
+      return ArcadeStateMachine.peekWalTransactionId(payload.walData());
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING,
-          "Could not mark transaction for local apply after indeterminate replication (db=%s): %s",
-          getName(), e.getMessage());
+          "Could not read the WAL transaction id of a replicated entry (db=%s): %s", getName(), e.getMessage());
+      return UNKNOWN_WAL_TX_ID;
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -535,7 +535,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       final ArcadeStateMachine stateMachine, final long phase2Ticket) {
     // The correlation key between this thread and the Raft apply thread, read once (8 bytes off the
     // front of the payload) so the abandoned mark and the cleanup below name the same slot (#6848).
-    final long walTxId = localWalTxId(payload);
+    // Only the leader origin-skips its own entries, so only the leader has a slot to name: a replica
+    // pays neither the peek nor a map entry, and its abandoned mark would have been inert anyway
+    // (applyTxEntry sees originatedLocally=false there and applies without ever consulting the map).
+    final long walTxId = leader ? localWalTxId(payload) : UNKNOWN_WAL_TX_ID;
     boolean markedAbandoned = false;
 
     // --- REPLICATION (no lock held): send WAL to Raft and wait for quorum ---

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -786,6 +786,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * Sentinel for "this payload's WAL transaction id could not be read", which makes the whole #6848
    * handshake inapplicable: an entry we cannot correlate is one we cannot prove was applied, so the
    * caller keeps the conservative pre-#6848 behaviour (mark nothing, hold the ticket, roll back).
+   * <p>
+   * It shares a value with {@link ArcadeStateMachine#NO_ABANDONED_MARK} and means something entirely
+   * unrelated - that one is a phase-2 ticket sentinel, this one a transaction id. The two are never
+   * compared, assigned to each other, or passed through the same variable; the shared value is a
+   * coincidence of both wanting the one number their domain cannot produce, not a shared protocol.
+   * <p>
+   * {@code Long.MIN_VALUE} is that number here because WAL transaction ids come from a per-database
+   * counter that starts at zero and is only ever negated to flag a compaction entry, so the smallest
+   * id reachable is {@code -Long.MAX_VALUE}. A real id can therefore never collide with this sentinel
+   * and be mistaken for an unreadable payload.
    */
   private static final long UNKNOWN_WAL_TX_ID = Long.MIN_VALUE;
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -792,10 +792,12 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * compared, assigned to each other, or passed through the same variable; the shared value is a
    * coincidence of both wanting the one number their domain cannot produce, not a shared protocol.
    * <p>
-   * {@code Long.MIN_VALUE} is that number here because WAL transaction ids come from a per-database
-   * counter that starts at zero and is only ever negated to flag a compaction entry, so the smallest
-   * id reachable is {@code -Long.MAX_VALUE}. A real id can therefore never collide with this sentinel
-   * and be mistaken for an unreadable payload.
+   * {@code Long.MIN_VALUE} is that number here because a replicated WAL transaction id is either the
+   * per-database counter ({@code TransactionManager.getNextTransactionId()}, an {@code AtomicLong}
+   * starting at zero) or the literal {@code -1} that flags a compaction/sealed-store entry for
+   * {@code forceApply} - the only negative value any writer puts in that header. Nothing negates the
+   * counter, so a real id can never collide with this sentinel and be mistaken for an unreadable
+   * payload.
    */
   private static final long UNKNOWN_WAL_TX_ID = Long.MIN_VALUE;
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6848AbandonedMarkRaceIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6848AbandonedMarkRaceIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.log.LogManager;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6848: the #4790 abandoned-entry mark used to be published AFTER the
+ * entry had already been dispatched, so the state machine could apply the entry on the leader
+ * BEFORE the mark existed - and origin-skip it, silently losing the write on the leader.
+ * <p>
+ * {@link Issue5410AbandonedTicketReleaseIT} exercises the same fault but wins the race by accident:
+ * its predicate returns immediately, so the client thread publishes the mark in microseconds while
+ * the group-commit flusher still has to hand the entry to Ratis. That made the class pass only when
+ * a long-running IT had warmed the JVM before it (issue #6848); on a cold JVM the apply thread got
+ * there first and the leader ended up one vertex short.
+ * <p>
+ * Here the ordering is made deterministic instead of hoped for: the injected predicate sleeps before
+ * returning {@code true}, which parks the committing thread past the point where Ratis has committed
+ * and applied the entry on the leader. Before the fix the leader origin-skips it and never converges.
+ *
+ * @see Issue5410AbandonedTicketReleaseIT for the ticket-release half of the #4790/#5410 contract
+ */
+@Tag("slow")
+class Issue6848AbandonedMarkRaceIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE = "AbandonedMarkRace";
+
+  /**
+   * How long the committing thread is parked after its entry has been enqueued for dispatch. It only
+   * has to exceed a local Raft round trip (single-digit ms on loopback); two seconds is generous so
+   * the ordering is decided by the fix and not by the machine the test runs on.
+   */
+  private static final long PARK_COMMITTER_MS = 2_000;
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @AfterEach
+  void clearHooks() {
+    RaftGroupCommitter.TEST_FORCE_DISPATCHED_TIMEOUT = null;
+  }
+
+  @Test
+  void abandonedEntryIsAppliedOnTheLeaderEvenWhenTheApplyBeatsTheMark() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    final ArcadeStateMachine leaderStateMachine = getRaftPlugin(leaderIndex).getRaftHAServer().getStateMachine();
+
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE, 1);
+    });
+
+    leaderDb.transaction(() -> {
+      final MutableVertex v = leaderDb.newVertex(VERTEX_TYPE);
+      v.set("id", 1);
+      v.set("name", "baseline");
+      v.save();
+    });
+    assertClusterConsistency();
+
+    // Arm the one-shot #4790 fault. The predicate runs on the committing thread AFTER the entry has
+    // been handed to the group-commit queue, so sleeping here lets the flusher dispatch it, Ratis
+    // commit it and the state machine apply it on this very leader - all before the committing
+    // thread gets to record that its phase 2 was abandoned.
+    final AtomicBoolean faultFired = new AtomicBoolean(false);
+    RaftGroupCommitter.TEST_FORCE_DISPATCHED_TIMEOUT = entry -> {
+      try {
+        final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(ByteString.copyFrom(entry));
+        if (decoded.type() == RaftLogEntryType.TX_ENTRY
+            && getDatabaseName().equals(decoded.databaseName())
+            && faultFired.compareAndSet(false, true)) {
+          LogManager.instance().log(this, Level.INFO,
+              "TEST: forcing dispatched-timeout for a TX_ENTRY on db=%s after parking the committer for %d ms",
+              decoded.databaseName(), PARK_COMMITTER_MS);
+          Thread.sleep(PARK_COMMITTER_MS);
+          return true;
+        }
+      } catch (final InterruptedException ie) {
+        Thread.currentThread().interrupt();
+      } catch (final Exception ignore) {
+        // Not a decodable/target entry; never force the timeout for it.
+      }
+      return false;
+    };
+
+    boolean threw = false;
+    try {
+      leaderDb.begin();
+      final MutableVertex v = leaderDb.newVertex(VERTEX_TYPE);
+      v.set("id", 2);
+      v.set("name", "abandoned");
+      v.save();
+      leaderDb.commit();
+    } catch (final ReplicationDispatchedTimeoutException expected) {
+      threw = true;
+    } finally {
+      if (leaderDb.isTransactionActive())
+        leaderDb.rollback();
+    }
+
+    assertThat(faultFired.get()).as("The dispatched-timeout fault must have fired").isTrue();
+    assertThat(threw).as("commit() must surface the indeterminate replication error").isTrue();
+
+    // The whole point: the LEADER must hold the abandoned entry too. Before the fix it origin-skipped
+    // the entry (the mark did not exist yet when applyTxEntry ran) and stayed one vertex behind the
+    // followers for the rest of its uptime.
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(awaitCountOn(i, VERTEX_TYPE, 2L))
+          .as("Node %d must hold both vertices", i)
+          .isEqualTo(2L);
+
+    // And the #5410 contract still holds: whoever applied the entry released its phase-2 ticket.
+    assertThat(awaitNoPendingPhase2(leaderStateMachine))
+        .as("applying the abandoned entry must release its phase-2 ticket, unpinning log compaction")
+        .isTrue();
+    assertThat(leaderStateMachine.lowestPendingLocalPhase2ReplayFloor())
+        .as("no replay floor may remain pinned once the abandoned entry is applied")
+        .isEqualTo(-1L);
+
+    assertClusterConsistency();
+  }
+
+  private static boolean awaitNoPendingPhase2(final ArcadeStateMachine stateMachine) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (System.currentTimeMillis() < deadline) {
+      if (stateMachine.pendingLocalPhase2Count() == 0)
+        return true;
+      Thread.sleep(100);
+    }
+    return false;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6848LocalOriginHandshakeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6848LocalOriginHandshakeTest.java
@@ -160,6 +160,42 @@ class Issue6848LocalOriginHandshakeTest {
         .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
   }
 
+  /**
+   * The sequence {@code applyTxEntry} actually performs, now that it claims instead of merely
+   * consuming: claim, write the pages, release the returned ticket. `Issue5410AbandonedPhase2TicketTest`
+   * pins this against {@code consumeAbandonedLocalTransaction}, which #6848 took off the apply path,
+   * so the #5410 contract is re-pinned here against the API the apply path really uses.
+   */
+  @Test
+  void claimingAnAbandonedEntryAndReleasingItsTicketUnpinsTheCheckpoint() {
+    final long ticket = stateMachine.beginLocalPhase2();
+    stateMachine.markLocalTransactionAbandoned(DB_NAME, 21L, ticket);
+    assertThat(stateMachine.pendingLocalPhase2Count()).isEqualTo(1);
+
+    stateMachine.endLocalPhase2(stateMachine.claimLocalOriginatedEntry(DB_NAME, 21L));
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("once the abandoned entry's pages are written the checkpoint must be free to advance")
+        .isZero();
+  }
+
+  /**
+   * The #5407 half of the same claim: an origin-skipped entry hands back nothing to release, because
+   * its phase 2 is still in flight and holding the replay window open on purpose. A claim that leaked
+   * a ticket here would let a snapshot checkpoint cover an entry whose pages are not on disk yet.
+   */
+  @Test
+  void claimingAnOriginSkippedEntryReleasesNothing() {
+    stateMachine.beginLocalPhase2();
+
+    assertThat(stateMachine.claimLocalOriginatedEntry(DB_NAME, 33L))
+        .as("no mark means the origin-skip branch, which must never release a ticket")
+        .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("the in-flight phase 2 must be untouched")
+        .isEqualTo(1);
+  }
+
   /** The cleanup on the settled paths removes the origin-skip slot and nothing else. */
   @Test
   void forgettingAnEntryDropsTheOriginSkipSlotButNeverAnAbandonedMark() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6848LocalOriginHandshakeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6848LocalOriginHandshakeTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #6848: the #4790 abandoned mark and the state machine's origin-skip are two threads deciding
+ * the same question - who writes a locally-originated entry's pages - and before this fix they never
+ * spoke to each other. The mark was published only after the entry had already been handed to Ratis,
+ * so a fast commit (or simply a JVM slow enough on the committing thread's side) let
+ * {@code applyTxEntry} run first, find nothing and origin-skip an entry whose phase 2 never ran. The
+ * leader then stayed one transaction behind its followers for the rest of its uptime.
+ * <p>
+ * Both sides now claim the same slot, so exactly one of them wins and the loser takes over the work.
+ * These tests pin both orderings and the cleanup that keeps the slot map bounded.
+ *
+ * @see Issue5410AbandonedPhase2TicketTest for the ticket-carrying half of the same marker
+ * @see Issue6848AbandonedMarkRaceIT for the same race driven through a real three-node cluster
+ */
+class Issue6848LocalOriginHandshakeTest {
+
+  private static final String DB_NAME = "issue6848";
+
+  // Only ever used as the DatabaseContext key (proxied is a mock, nothing touches the filesystem).
+  private final String dbPath = "issue6848-local-origin-handshake-" + UUID.randomUUID();
+
+  private LocalDatabase         proxied;
+  private RaftHAServer          raftServer;
+  private TransactionContext    tx;
+  private ArcadeStateMachine    stateMachine;
+  private RaftTransactionBroker broker;
+
+  @BeforeEach
+  void setUp() {
+    proxied = mock(LocalDatabase.class);
+    when(proxied.getDatabasePath()).thenReturn(dbPath);
+    when(proxied.getName()).thenReturn(DB_NAME);
+    when(proxied.getTransactionManager()).thenReturn(mock(TransactionManager.class));
+    when(proxied.getSchema()).thenReturn(mock(Schema.class, RETURNS_DEEP_STUBS));
+    when(proxied.executeInReadLock(any())).thenAnswer(inv -> ((Callable<?>) inv.getArgument(0)).call());
+
+    broker = mock(RaftTransactionBroker.class);
+    raftServer = mock(RaftHAServer.class, RETURNS_DEEP_STUBS);
+    when(raftServer.isLeader()).thenReturn(true);
+    when(raftServer.getTransactionBroker()).thenReturn(broker);
+    when(raftServer.getStateMachine()).thenAnswer(inv -> stateMachine);
+
+    tx = mock(TransactionContext.class);
+    stateMachine = new ArcadeStateMachine();
+  }
+
+  @AfterEach
+  void tearDown() {
+    DatabaseContext.INSTANCE.removeContext(dbPath);
+  }
+
+  /**
+   * The correlation key is read from the leading 8 bytes instead of deserializing the whole WAL,
+   * because it is read on the leader's hot commit path for an entry that is normally origin-skipped.
+   * The two readings must agree, or the committing thread and the apply thread would claim different
+   * slots and the handshake would silently stop working.
+   */
+  @Test
+  void peekingTheTransactionIdAgreesWithFullDeserialization() {
+    final byte[] walData = walTransactionBytes(4242L);
+
+    assertThat(ArcadeStateMachine.peekWalTransactionId(walData))
+        .as("the cheap read must name the same transaction as the full deserialization")
+        .isEqualTo(ArcadeStateMachine.deserializeWalTransaction(walData).txId);
+  }
+
+  /** A payload too short to hold an id is corruption, not transaction 0. */
+  @Test
+  void peekingATruncatedPayloadIsRejected() {
+    assertThatThrownBy(() -> ArcadeStateMachine.peekWalTransactionId(new byte[Long.BYTES - 1]))
+        .isInstanceOf(ReplicationException.class);
+    assertThatThrownBy(() -> ArcadeStateMachine.peekWalTransactionId(null))
+        .isInstanceOf(ReplicationException.class);
+  }
+
+  /**
+   * Ordering A (the pre-#6848 happy accident): the committing thread marks first, so the apply that
+   * follows finds the mark, applies the entry and gets the ticket to release.
+   */
+  @Test
+  void whenTheMarkIsPublishedFirstTheApplyClaimsTheTicket() {
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    assertThat(stateMachine.markLocalTransactionAbandoned(DB_NAME, 7L, ticket))
+        .as("an unclaimed slot means the state machine's apply will write the pages")
+        .isTrue();
+
+    assertThat(stateMachine.claimLocalOriginatedEntry(DB_NAME, 7L))
+        .as("the apply must pick up the ticket the abandoning commit left behind")
+        .isEqualTo(ticket);
+    assertThat(stateMachine.claimLocalOriginatedEntry(DB_NAME, 7L))
+        .as("a replay of the same entry must origin-skip instead of applying twice")
+        .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
+  }
+
+  /**
+   * Ordering B (the #6848 bug): the apply thread gets there first and origin-skips. The commit that
+   * abandons afterwards must be told it now owns the apply - before the fix it was told nothing and
+   * the write was lost on this node.
+   */
+  @Test
+  void whenTheApplyOriginSkipsFirstTheAbandoningCommitIsToldItOwnsTheApply() {
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    assertThat(stateMachine.claimLocalOriginatedEntry(DB_NAME, 9L))
+        .as("with no mark yet the apply must origin-skip")
+        .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
+
+    assertThat(stateMachine.markLocalTransactionAbandoned(DB_NAME, 9L, ticket))
+        .as("the apply already happened without writing the pages, so the committer must apply them")
+        .isFalse();
+
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 9L))
+        .as("a slot both sides are done with must not linger and pin a ticket forever")
+        .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
+  }
+
+  /** The cleanup on the settled paths removes the origin-skip slot and nothing else. */
+  @Test
+  void forgettingAnEntryDropsTheOriginSkipSlotButNeverAnAbandonedMark() {
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    stateMachine.claimLocalOriginatedEntry(DB_NAME, 3L);
+    stateMachine.forgetLocalOriginatedEntry(DB_NAME, 3L);
+    assertThat(stateMachine.markLocalTransactionAbandoned(DB_NAME, 3L, ticket))
+        .as("the origin-skip slot must be gone, so a later mark claims a free slot")
+        .isTrue();
+
+    stateMachine.forgetLocalOriginatedEntry(DB_NAME, 3L);
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 3L))
+        .as("forgetting must never drop the abandoned mark: the apply still has to release its ticket")
+        .isEqualTo(ticket);
+  }
+
+  /**
+   * The whole fix, end to end on the committing thread: the entry was origin-skipped before the
+   * dispatched timeout surfaced, so {@code replicateAndCommitLocally} must apply phase 2 itself and
+   * release the ticket. Before the fix it rolled back, left the pages unwritten and kept the ticket
+   * (and the snapshot checkpoint) pinned for the rest of the node's uptime.
+   */
+  @Test
+  void aDispatchedTimeoutAfterAnOriginSkipAppliesPhase2Locally() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    // The Raft apply thread got to the entry first (txId 0: see payload()).
+    stateMachine.claimLocalOriginatedEntry(DB_NAME, 0L);
+    dispatchedTimeoutOnReplicate();
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .as("the caller still learns the replication outcome was indeterminate")
+        .isInstanceOf(ReplicationDispatchedTimeoutException.class);
+
+    verify(tx, times(1)).commit2ndPhase(any());
+    verify(tx).setRemotelyCommitted(true);
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("the pages are written here, so nothing may keep pinning the snapshot checkpoint")
+        .isZero();
+  }
+
+  /**
+   * The unchanged path, restated so the fix cannot quietly turn every dispatched timeout into a local
+   * apply: with no origin-skip claim the mark stands, the transaction rolls back and the ticket stays
+   * held until the entry really applies (the #5407 contract).
+   */
+  @Test
+  void aDispatchedTimeoutWithoutAnOriginSkipStillRollsBackAndRetainsTheTicket() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    dispatchedTimeoutOnReplicate();
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(ReplicationDispatchedTimeoutException.class);
+
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 0L))
+        .as("the mark must stand so the eventual apply releases the ticket")
+        .isEqualTo(ticket);
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("the entry may still commit while unapplied here, so it must stay replayable")
+        .isEqualTo(1);
+  }
+
+  private void dispatchedTimeoutOnReplicate() {
+    doThrow(new ReplicationDispatchedTimeoutException("simulated dispatched-then-timed-out replication"))
+        .when(broker).replicateTransaction(anyString(), any(), any());
+  }
+
+  private RaftReplicatedDatabase newDatabase() {
+    final RaftReplicatedDatabase database = new RaftReplicatedDatabase(null, proxied, raftServer);
+    DatabaseContext.INSTANCE.init(proxied, tx);
+    return database;
+  }
+
+  /** 24 zero bytes deserialize to an empty WAL transaction (txId=0, 0 pages). */
+  private RaftReplicatedDatabase.ReplicationPayload payload() {
+    return new RaftReplicatedDatabase.ReplicationPayload(tx, null, new byte[24], Map.of());
+  }
+
+  /** An empty WAL transaction (no pages) carrying {@code txId}, in the replicated wire layout. */
+  private static byte[] walTransactionBytes(final long txId) {
+    final ByteBuffer buf = ByteBuffer.allocate(24);
+    buf.putLong(txId);   // txId
+    buf.putLong(1L);     // timestamp
+    buf.putInt(0);       // page count
+    buf.putInt(0);       // segment size
+    return buf.array();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6848LocalOriginHandshakeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6848LocalOriginHandshakeTest.java
@@ -61,6 +61,9 @@ class Issue6848LocalOriginHandshakeTest {
 
   private static final String DB_NAME = "issue6848";
 
+  /** Mirrors {@code ArcadeStateMachine.ABANDONED_TX_TTL_MS}; the sweep only collects slots older than it. */
+  private static final long ABANDONED_TX_TTL_MS = 10 * 60 * 1000L;
+
   // Only ever used as the DatabaseContext key (proxied is a mock, nothing touches the filesystem).
   private final String dbPath = "issue6848-local-origin-handshake-" + UUID.randomUUID();
 
@@ -211,6 +214,71 @@ class Issue6848LocalOriginHandshakeTest {
     assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 3L))
         .as("forgetting must never drop the abandoned mark: the apply still has to release its ticket")
         .isEqualTo(ticket);
+  }
+
+  /**
+   * The backstop sweep, which no healthy handshake reaches: it must collect an origin-skip slot the
+   * committing thread never came back for, and it must leave an abandoned mark of the same age alone.
+   * Evicting one of those would drop a phase-2 ticket only the apply is allowed to release, which is
+   * the #5410 pinned-checkpoint bug with the blame moved to a background sweep.
+   */
+  @Test
+  void theStrandedSlotSweepCollectsOriginSkipsAndNeverAbandonedMarks() {
+    final long ticket = stateMachine.beginLocalPhase2();
+    stateMachine.claimLocalOriginatedEntry(DB_NAME, 100L);          // an origin-skip slot
+    stateMachine.markLocalTransactionAbandoned(DB_NAME, 101L, ticket); // an abandoned mark, same age
+
+    stateMachine.pruneStrandedLocalTxOutcomes(System.currentTimeMillis() + ABANDONED_TX_TTL_MS + 1_000L);
+
+    assertThat(stateMachine.markLocalTransactionAbandoned(DB_NAME, 100L, ticket))
+        .as("the stranded origin-skip slot must be gone, so a fresh mark finds a free key")
+        .isTrue();
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 101L))
+        .as("an abandoned mark carries a ticket only the apply may release: the sweep must not touch it")
+        .isEqualTo(ticket);
+  }
+
+  /**
+   * The sweep is throttled because it runs on the leader's commit path. A stale slot that misses one
+   * window has to survive to the next one rather than being collected on every commit in between.
+   */
+  @Test
+  void theStrandedSlotSweepIsThrottled() {
+    final long farFuture = System.currentTimeMillis() + ABANDONED_TX_TTL_MS + 1_000L;
+    stateMachine.claimLocalOriginatedEntry(DB_NAME, 200L);
+    stateMachine.pruneStrandedLocalTxOutcomes(farFuture);
+
+    // Same age, so equally stale - but only 30 s of the throttle window has elapsed since that sweep.
+    stateMachine.claimLocalOriginatedEntry(DB_NAME, 201L);
+    stateMachine.pruneStrandedLocalTxOutcomes(farFuture + 30_000L);
+
+    // markLocalTransactionAbandoned is the probe that discriminates without disturbing the map:
+    // false means it found the origin-skip slot still there, true means the key was free. Probing
+    // with claimLocalOriginatedEntry instead would re-create the slot and report "still there"
+    // whether or not the sweep had collected it.
+    assertThat(stateMachine.markLocalTransactionAbandoned(DB_NAME, 201L, stateMachine.beginLocalPhase2()))
+        .as("a sweep inside the throttle window must not have run, so the slot is still standing")
+        .isFalse();
+  }
+
+  /**
+   * The uniqueness assumption the arbitration rests on, made loud rather than silent: a second mark
+   * for the same transaction id keeps the first (a held ticket is the safe direction) and reports the
+   * mark as standing, so the caller rolls back instead of double-applying.
+   */
+  @Test
+  void aSecondMarkForTheSameTransactionKeepsTheFirstTicket() {
+    final long firstTicket = stateMachine.beginLocalPhase2();
+    final long secondTicket = stateMachine.beginLocalPhase2();
+
+    assertThat(stateMachine.markLocalTransactionAbandoned(DB_NAME, 55L, firstTicket)).isTrue();
+    assertThat(stateMachine.markLocalTransactionAbandoned(DB_NAME, 55L, secondTicket))
+        .as("the mark still stands, so the caller must roll back rather than apply the entry itself")
+        .isTrue();
+
+    assertThat(stateMachine.claimLocalOriginatedEntry(DB_NAME, 55L))
+        .as("the apply releases the FIRST ticket; the second stays held, which is the safe direction")
+        .isEqualTo(firstTicket);
   }
 
   /**


### PR DESCRIPTION
Closes #6848

## The bug is real, and it is not a test-ordering artefact

`Issue5410AbandonedTicketReleaseIT` passes or fails depending on what ran before it in the same JVM
because the #4790 recovery it exercises is a **race between two threads with no arbiter**, and a warm
JVM happens to make the committing thread win it.

On the leader, a locally-originated entry has two candidate writers for its pages:

- `RaftReplicatedDatabase.replicateAndCommitLocally` phase 2, on the committing thread;
- `ArcadeStateMachine.applyTxEntry`, on the Raft apply thread - which normally **origin-skips**,
  precisely because phase 2 is expected to do the work.

Issue #4790's exception to that rule is the dispatched-timeout: replication came back indeterminate,
phase 2 never ran, so the entry has to be applied by the state machine after all. The signal was an
"abandoned" mark the committing thread published in `ArcadeStateMachine.abandonedLocalTransactions`.

The mark was published **after** the entry had already been handed to the group-commit queue. From
that moment the flusher can dispatch it, Ratis can commit it, and `applyTxEntry` can run - all before
the committing thread gets as far as `markTransactionAbandonedForLocalApply`. When that happens the
apply thread finds no mark, origin-skips, and *nobody* ever writes the pages on the leader. The write
lands on every follower and never on the leader, for the rest of that node's uptime - exactly the
divergence #4790 exists to prevent, reached through the door #4790 left open.

That is what the issue measured: `commitIndex=8` is the abandoned entry, committed and applied; the
leader is the node stuck at one vertex; and 344 s of prior `RaftHAComprehensiveIT` traffic "fixes" it
only by JIT-compiling the committing thread's unwind path so it beats a loopback Raft round trip.

## Reproduction

`Issue6848AbandonedMarkRaceIT` makes the losing ordering deterministic using only the existing
`RaftGroupCommitter.TEST_FORCE_DISPATCHED_TIMEOUT` hook: the injected predicate runs on the committing
thread *after* the entry is enqueued, so sleeping inside it parks that thread past the commit and the
apply. On `main` it fails 1/1 with the issue's own signature:

```
[Node 0 must hold both vertices] expected: 2L but was: 1L
  Suppressed: DatabaseComparator$DatabaseAreNotIdentical:
              Page PageId(graph/28/0) has different versions on databases. DB1 1 <> DB2 2
```

## The fix: make the two threads claim the same slot

`abandonedLocalTransactions` becomes an arbiter rather than a one-way signal. Both threads
`putIfAbsent` on the same `<db>/<walTxId>` key:

| who gets there first | what the loser does |
|---|---|
| committing thread writes `AbandonedPhase2` | the apply finds the mark, applies the entry and releases the carried phase-2 ticket (the #5410 path, unchanged) |
| apply thread writes `OriginSkipped` | `markLocalTransactionAbandoned` returns `false`, and the committing thread applies phase 2 itself via the existing `applyLocallyAfterMajorityCommit` - the same recovery the MAJORITY-committed branch already performs, learned a different way |

Exactly one `putIfAbsent` can win, so the outcome no longer depends on scheduling. The committing
thread drops its slot on every settled exit, and a throttled TTL sweep collects anything stranded by
a thread that died mid-commit.

### Hot-path cost

The origin-skip branch now publishes as well as decides, so it can no longer short-circuit on
`abandonedLocalTransactions.isEmpty()`. It stays cheap: `peekWalTransactionId` reads the leading
8 bytes of the payload (the txId is the first field `deserializeWalTransaction` writes) instead of
deserializing the WAL, and the full deserialization moved down to the branch that actually applies.

Stated in full, because the old path allocated nothing at all: per leader commit this adds one
`putIfAbsent` and one `remove` on a `ConcurrentHashMap`, the two short-lived `<db>/<walTxId>` key
strings those take, one `OriginSkipped` record, and one `ByteBuffer.wrap`. All O(1) and short-lived,
against a commit that already does a Raft round trip and a WAL write - but if this ever shows up in a
GC profile, a composite non-allocating key is the lever. Replicas pay none of it: they origin-skip
nothing, so the peek is gated on `leader`.

### Deliberately unchanged

- A dispatched timeout with **no** origin-skip still marks, rolls back and *retains* the ticket
  (#5407): the entry may yet commit while unapplied here, so it must stay replayable.
- A TTL-pruned mark still releases nothing, for the same reason.
- The caller still sees `ReplicationDispatchedTimeoutException` on both branches: the replication
  outcome really was indeterminate, and the #4790 contract for the caller does not change.

## Test plan

- [x] `Issue6848AbandonedMarkRaceIT` - new IT, deterministic losing ordering. Fails on `main`
      (1/1, 32 s, the signature above), passes with the fix (1/1, ~15 s).
- [x] `Issue6848LocalOriginHandshakeTest` - new unit test, 12 cases: both orderings of the handshake,
      the slot cleanup, the double-mark outcome, the stranded-slot sweep and its throttle,
      `peekWalTransactionId` agreeing with `deserializeWalTransaction` (and rejecting a truncated
      payload), the end-to-end "timeout after an origin-skip applies phase 2 locally and releases the
      ticket", and the unchanged "timeout without an origin-skip rolls back and retains the ticket".
- [x] `Issue5410AbandonedTicketReleaseIT` - the issue's own test, still green, and its log confirms it
      still takes the mark-wins branch (no #6848 recovery line).
- [x] Full `ha-raft` unit suite: 994 tests, 0 failures.
- [x] Targeted `ha-raft` ITs: `Issue4790PhantomCommitOriginSkipIT`, `OriginNodeSkipIT`,
      `Issue5064CommittedRemotelyContractIT`, `Issue4740Phase2ReconcileIT`,
      `Issue5503ConcurrentFollowerWritesIT`, `RaftReplication3NodesIT`, `Raft3PhaseCommitIT`,
      `RaftLogCompactionWiringIT`, `RaftLeaderCrashBetweenCommitAndApplyIT`,
      `RaftReplicationWriteAgainstReplicaIT`, `RaftEmbeddedWriteAgainstReplicaIT`,
      `Issue5410AbandonedTicketReleaseIT`, `Issue6848AbandonedMarkRaceIT`.
- [x] Broader `ha-raft` IT batch: `RaftHAComprehensiveIT` (13 tests), `RaftReplicationIT`,
      `RaftReplication2NodesIT`, `RaftBulkInsertCompactionRaceIT`, `RaftGraphIngestionStabilityIT`,
      `RaftIndexOperations3ServersIT`, `RaftLeaderFailoverIT`, `RaftPeriodicSnapshotCompactionIT`,
      `RaftReadConsistencyIT`, `RaftSchemaReplicationIT`.

### Flakes seen locally, none of them this change

- `RaftReadConsistencyIT` intermittently fails `assertClusterConsistency` with a *schema* mismatch
  (`Types: DB1 6 <> DB2 5`), i.e. a follower whose type list has not caught up. A control worktree at
  the base commit (`3822e4ee37`), unmodified, reproduces the identical failure: 1 failure in 12
  isolated runs there against 2 in 12 on this branch (one of those two while another `mvn` was
  recompiling into the same `target/`). Nothing here touches `applySchemaEntry`.
- `Raft3PhaseCommitIT` and `RaftReplicationWriteAgainstReplicaIT` each failed once with
  `Server is installing a snapshot, please retry` / `503` against `127.0.0.1:2480`, and passed on
  every rerun (3/3 and 2/2). That is the documented local hazard of a machine already listening on
  2480, not a property of this branch.

## Note on #6343 item 2

Isolating the heavy `ha-raft` ITs into their own failsafe fork is still worth doing, but it is no
longer blocked on this: with the arbiter in place `Issue5410AbandonedTicketReleaseIT` no longer needs
`RaftHAComprehensiveIT` to have run before it, in any fork arrangement.

## Review history

Four review cycles, no blocking defect found in any of them. What changed in response:

1. Gated the txId peek on `leader` (replicas origin-skip nothing, so their slot and their abandoned
   mark were both inert). Re-pinned the #5410 ticket release and the #5407 no-release against
   `claimLocalOriginatedEntry`, the API `applyTxEntry` now actually calls, and said in
   `consumeAbandonedLocalTransaction`'s javadoc that it is no longer an apply path and must not
   become one. Corrected the sweep comment, which claimed stranded slots could only come from a
   thread that died.
2. Made the "same txId marked abandoned twice" case loud instead of silent - it still keeps the first
   mark, since a held ticket costs compaction while a wrongly released one costs a write, but it now
   logs both tickets. Added tests for that, for the sweep's `OriginSkipped`-only scope, and for its
   throttle; all three verified armed by mutation (removing the throttle and removing the
   `OriginSkipped` filter each turn the matching assertion red).
3. Documented why `UNKNOWN_WAL_TX_ID` shares a value with `NO_ABANDONED_MARK` and is not a shared
   protocol.
4. Corrected that documentation: it claimed WAL txIds "bottom out at `-Long.MAX_VALUE`", which is not
   true and not what makes the sentinel safe. A replicated txId is either the `AtomicLong` from
   `TransactionManager.getNextTransactionId()` (starts at zero) or the literal `-1` flagging a
   compaction entry for `forceApply`; nothing negates the counter. Also stated that nothing depends on
   Ratis replying after applying - `putIfAbsent` settles the arbitration in either order, so a reply
   that overtook its apply would cost a slot left for the sweep, not a write.

Two further non-blocking observations from cycle 4 were left alone deliberately: a repeat claim of an
already-claimed key does not refresh `insertedAt` (an entry is applied once per lifecycle, so there is
no repeat claim to refresh), and the allocation accounting, which is stated in full above instead.
