### PR TITLE
fix(#4416): ship an oversized TimeSeries sealed store in slices instead of skipping the shard

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -4039,3 +4039,45 @@ tag have to agree, and neither may be a SNAPSHOT - and fails if the manifest fal
 POM, which is what noticing this in the first place required a human to do.
 
 [#6838](https://github.com/ArcadeData/arcadedb/issues/6838)
+
+## TimeSeries HA: a shard no longer stops sealing when its sealed store outgrows one Raft entry (#4416)
+
+Compaction of a replicated TimeSeries shard ships the rewritten `.ts.sealed` file to the followers inside the same
+Raft entry as the mutable-bucket clear, so the two land atomically and a query never sees a cleared bucket beside a
+stale sealed store. Because the whole file rode one entry, `arcadedb.ha.tsMaxSealedInlineSize` (clamped down to
+`min(arcadedb.ha.grpcMessageSizeMax, arcadedb.ha.appendBufferSize)`) was a ceiling on the sealed STORE and not
+merely on the entry: a shard that crossed it was skipped, and the skip was permanent. The store it refused to ship
+only grows, so the projected size never came back under the cap and that shard never sealed again - correct and
+fully replicated, since the samples stay in the mutable bucket, but never compressed, never retained, never
+downsampled, and the bucket itself unbounded.
+
+A sealed store above one entry is now SLICED. The leader cuts it into ordered slices of at most one entry's worth
+and ships every slice but the last as a delivery-only entry, which the follower stages on disk and nothing more;
+the final slice rides the publishing entry, so the install still happens in the same entry as the clear WAL and
+the atomicity that made the whole-file design safe is unchanged. This is the ordered-prefix contract #4743 built
+for oversized schema entries, applied to a file rather than to a WAL stream, so followers need no new state beyond
+the staging file.
+
+The staging file is on disk rather than in the state machine deliberately: a follower persists its applied index
+between entries, so one that restarts mid-sequence will never be sent the earlier slices again, and a file
+survives that restart. A slice at offset 0 truncates whatever is staged, which makes a sequence abandoned by a
+leader that died mid-shipment cost nothing; any other slice must find the staging file exactly that long. The
+reassembled file is checked against the length and CRC32 the leader recorded for the WHOLE image before it is
+installed - per-slice CRCs only prove each piece survived the wire - and a sequence that does not line up, or a
+reassembly that does not match, refuses to install and asks for a targeted snapshot resync instead of putting the
+node on a sealed store no other node has.
+
+`arcadedb.ha.tsMaxSealedInlineSize` keeps its name and its default (48MB) but now bounds one ENTRY rather than the
+store. The per-shard sealed ceiling becomes that value - still clamped to the transport limit - times 512 slices,
+capped at 2GB because the leader still materializes the file as a single array before slicing it. With stock
+settings that moves the ceiling from 48MB to ~2GB per shard. A shard above the new ceiling is still skipped, with a
+warning that now names what to raise; and a cap configured so small that a slice cannot even carry its own framing
+leaves the ceiling exactly where it was, so a deliberately tiny cap behaves as it always did.
+
+Rolling-upgrade note: the slices travel in a trailing section of `SCHEMA_ENTRY`, which a node running an older
+codec stops before, exactly as the sealed-blob section itself has done since #4382. Such a node installs nothing
+for a sliced store while still applying the mutable-bucket clear, and serves that shard from its previous sealed
+image until it is upgraded and resynced. A leader only produces slices once a store outgrows one entry, so a
+cluster whose stores fit inline is not exposed at all. Upgrade the followers first.
+
+[#4416](https://github.com/ArcadeData/arcadedb/issues/4416)

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2490,7 +2490,14 @@ public enum GlobalConfiguration {
    */
   public static long maxReplicatedSealedStoreSize(final ContextConfiguration configuration) {
     final long perEntry = maxReplicatedSealedEntrySize(configuration);
-    final long sliced = replicatedSealedChunkBudget(configuration) * MAX_REPLICATED_SEALED_CHUNKS;
+    // Saturating rather than wrapping. It cannot currently change an answer - a budget large enough to overflow
+    // this product needs a per-entry cap of ~18 petabytes, and THAT alone is already far above the
+    // Integer.MAX_VALUE clamp below, which is what the max() then returns either way - but a ceiling that is
+    // correct only because two unrelated bounds happen to cover for each other is one edit away from not being.
+    final long budget = replicatedSealedChunkBudget(configuration);
+    final long sliced = budget >= Long.MAX_VALUE / MAX_REPLICATED_SEALED_CHUNKS
+        ? Long.MAX_VALUE
+        : budget * MAX_REPLICATED_SEALED_CHUNKS;
     return Math.min(Integer.MAX_VALUE, Math.max(perEntry, sliced));
   }
 

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1941,11 +1941,15 @@ public enum GlobalConfiguration {
 
   HA_TS_MAX_SEALED_INLINE_SIZE("arcadedb.ha.tsMaxSealedInlineSize", SCOPE.SERVER,
       """
-      Maximum size in bytes of a TimeSeries sealed-store file that may be shipped inline inside a single \
-      Raft SCHEMA_ENTRY during compaction. When the projected sealed-store size would exceed this cap, the \
-      leader skips compacting that shard (data stays in the fully replicated mutable bucket) instead of \
-      producing an entry too large for the Raft transport. Always clamped down to the real per-entry ceiling, \
-      min(arcadedb.ha.grpcMessageSizeMax, arcadedb.ha.appendBufferSize), so a value above that has no effect.""",
+      Maximum size in bytes of TimeSeries sealed-store content a SINGLE Raft entry may carry during \
+      compaction. A sealed store up to this size ships inline in one SCHEMA_ENTRY; a larger one is sliced \
+      and shipped as an ordered sequence of entries of at most this size each, which the follower stages on \
+      disk and installs atomically with the mutable-bucket clear when the last slice lands (issue #4416). \
+      Always clamped down to the real per-entry ceiling, min(arcadedb.ha.grpcMessageSizeMax, \
+      arcadedb.ha.appendBufferSize), so a value above that has no effect. It therefore no longer bounds the \
+      sealed store itself: what does is this value times MAX_REPLICATED_SEALED_CHUNKS - see \
+      GlobalConfiguration.maxReplicatedSealedStoreSize - and a shard whose projected sealed store exceeds \
+      THAT is still skipped, leaving its samples in the fully replicated mutable bucket.""",
       Long.class, 48 * 1024 * 1024L),
 
   HA_SNAPSHOT_WATCHDOG_TIMEOUT("arcadedb.ha.snapshotWatchdogTimeout", SCOPE.SERVER,
@@ -2426,6 +2430,68 @@ public enum GlobalConfiguration {
     final long grpcMessageSizeMax = configuration.getValueAsLong(HA_GRPC_MESSAGE_SIZE_MAX);
     final long appendBufferSize = FileUtils.getSizeAsNumber(configuration.getValueAsString(HA_APPEND_BUFFER_SIZE));
     return Math.min(grpcMessageSizeMax, appendBufferSize);
+  }
+
+  /**
+   * Bytes reserved, per replicated sealed-store slice, for everything that is not the slice payload: the entry
+   * header, the type and file names, the offsets, the two CRCs and the compression framing. Deliberately generous -
+   * it is subtracted from a multi-megabyte budget, so over-reserving costs a fraction of one slice, while
+   * under-reserving produces an entry above the Raft ceiling, which makes the leader step down (issue #4743).
+   */
+  public static final int REPLICATED_SEALED_CHUNK_FRAMING_BYTES = 4 * 1024;
+
+  /**
+   * How many entries one sealed store may be sliced into. It bounds the burst a single compaction can put through
+   * the Raft pipeline - every slice is a quorum round trip taken while the compaction holds the database write
+   * lock - and, with the default 4MB per-entry ceiling, puts the per-shard sealed ceiling at ~2GB, which is also
+   * where {@code TimeSeriesSealedStore.readWholeSealedFile} stops (the leader materializes the file as one array).
+   */
+  public static final int MAX_REPLICATED_SEALED_CHUNKS = 512;
+
+  /**
+   * How many bytes of sealed-store payload one replicated entry may carry (issue #4416): the configured
+   * {@link #HA_TS_MAX_SEALED_INLINE_SIZE}, clamped down to the real per-entry ceiling and less the framing.
+   * <p>
+   * Zero when the configured cap is so small that the framing alone does not fit - a slice cannot be built at
+   * all then, which is why {@link #maxReplicatedSealedStoreSize} falls back to the per-entry cap in that case and
+   * the shard keeps being skipped exactly as it was before slicing existed.
+   */
+  public static long replicatedSealedChunkBudget(final ContextConfiguration configuration) {
+    final long perEntry = maxReplicatedSealedEntrySize(configuration);
+    // The 1/128 is what the FRAMING constant cannot cover: a slice is LZ4-compressed for the wire, and sealed
+    // blocks are ALREADY compressed by their own columnar codecs, so the "compressed" slice can come out LARGER
+    // than the raw one - by up to n/255 + 16 bytes in the worst case. A fixed reserve is the wrong shape for that,
+    // because the overflow grows with the slice while the reserve does not: at a 4MB entry cap the expansion alone
+    // is ~16KB, four times the framing. Reserving a proportion keeps the encoded slice under the cap at every cap.
+    return Math.max(0L, perEntry - REPLICATED_SEALED_CHUNK_FRAMING_BYTES - perEntry / 128);
+  }
+
+  /**
+   * The most sealed-store content one replicated entry may carry: the configured cap, never above what the
+   * transport accepts.
+   */
+  public static long maxReplicatedSealedEntrySize(final ContextConfiguration configuration) {
+    return Math.min(configuration.getValueAsLong(HA_TS_MAX_SEALED_INLINE_SIZE),
+        maxReplicatedRaftEntrySize(configuration));
+  }
+
+  /**
+   * The largest TimeSeries sealed store a replicated shard may hold (issue #4416): what fits one entry, or - when
+   * the cap leaves room for a slice - {@link #MAX_REPLICATED_SEALED_CHUNKS} slices of
+   * {@link #replicatedSealedChunkBudget}. A shard whose projected sealed store exceeds this is not compacted, so
+   * its samples stay in the fully replicated mutable bucket: correct, but uncompressed and unbounded, which is the
+   * state issue #4416 exists to push further away rather than to remove outright.
+   * <p>
+   * The {@code max} is what keeps a deliberately tiny cap behaving as it always did: a store that FITS one entry
+   * ships in one entry whether or not anything could be sliced.
+   * <p>
+   * Clamped to {@link Integer#MAX_VALUE} because the leader reads the whole sealed file into one byte array before
+   * slicing it. Removing that clamp means streaming the file instead, which is a separate change.
+   */
+  public static long maxReplicatedSealedStoreSize(final ContextConfiguration configuration) {
+    final long perEntry = maxReplicatedSealedEntrySize(configuration);
+    final long sliced = replicatedSealedChunkBudget(configuration) * MAX_REPLICATED_SEALED_CHUNKS;
+    return Math.min(Integer.MAX_VALUE, Math.max(perEntry, sliced));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2442,9 +2442,26 @@ public enum GlobalConfiguration {
 
   /**
    * How many entries one sealed store may be sliced into. It bounds the burst a single compaction can put through
-   * the Raft pipeline - every slice is a quorum round trip taken while the compaction holds the database write
-   * lock - and, with the default 4MB per-entry ceiling, puts the per-shard sealed ceiling at ~2GB, which is also
-   * where {@code TimeSeriesSealedStore.readWholeSealedFile} stops (the leader materializes the file as one array).
+   * the Raft pipeline: every slice is its own quorum round trip, taken sequentially.
+   * <p>
+   * WHAT THAT BURST ACTUALLY BLOCKS, because it is not the database write lock and an earlier revision of this
+   * javadoc said it was. The slicing loop in {@code RaftReplicatedDatabase.runWithCompactionReplication} runs
+   * AFTER the compaction callback has returned, so neither {@code TimeSeriesShard.compactionLock} nor the
+   * per-shard lock {@code TimeSeriesEngine.runSealedMaintenanceReplicated} takes is still held - both are
+   * released inside the callback. What stays open for the whole burst is the FileManager RECORDING SESSION, and
+   * its cost falls on other commits on the LEADER: each one calls {@code waitForActiveRecordingSession()} before
+   * dispatching its TX_ENTRY (issue #4083 ordering), which polls until the session ends and then gives up after
+   * {@link #HA_QUORUM_TIMEOUT}. So a long burst degrades leader commit latency up to that timeout and then lets
+   * commits through on the racy path - it does not stall them for the burst's full duration, and it does not
+   * touch reads or follower traffic at all.
+   * <p>
+   * At the stock settings this bound is slack, not binding: the per-entry ceiling is
+   * min({@link #HA_TS_MAX_SEALED_INLINE_SIZE}, min({@link #HA_GRPC_MESSAGE_SIZE_MAX},
+   * {@link #HA_APPEND_BUFFER_SIZE})) = 32MB, so ~68 slices already reach the ~2GB ceiling and nothing can ask for
+   * 512. Reaching this constant at all takes a deliberately lowered append buffer. The ~2GB ceiling itself comes
+   * from the {@link Integer#MAX_VALUE} clamp in {@link #maxReplicatedSealedStoreSize} - where
+   * {@code TimeSeriesSealedStore.readWholeSealedFile} stops, since the leader materializes the file as one array -
+   * NOT from this constant times the cap, which at the stock 32MB would be ~16GB.
    */
   public static final int MAX_REPLICATED_SEALED_CHUNKS = 512;
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -658,6 +658,15 @@ public class TimeSeriesEngine implements AutoCloseable {
    * rewritten sealed bytes of any shard whose store actually changed. On a standalone database the
    * default {@link DatabaseInternal#runWithCompactionReplication} simply runs the work; on a Raft
    * follower it is skipped entirely (the leader ships the result).
+   * <p>
+   * NO SIZE PRE-CHECK HERE, unlike {@code TimeSeriesShard.compactInternal}, and the asymmetry is deliberate
+   * (issue #4416). That guard exists because compaction GROWS the sealed store, so it can decide not to create a
+   * store it cannot replicate. Retention and downsampling only ever shrink or hold one: they cannot push a shard
+   * over a ceiling it was not already over, so a pre-check could only refuse to ship a store the leader has
+   * ALREADY rewritten, which would leave the followers on an image no node has any more - divergence, in place of
+   * a burst of entries. A store that is over the ceiling when it gets here arrived that way (a database that was
+   * standalone when it sealed, then joined a cluster), and the honest handling is the one
+   * {@code RaftReplicatedDatabase.sliceSealedBlob} applies: ship it, and report the oversized slice count.
    */
   private void runSealedMaintenanceReplicated(final SealedMaintenance work) throws IOException {
     final DatabaseInternal db = database.getWrappedDatabaseInstance();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -2292,6 +2292,23 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    * that forbid replacing a file while it is open.
    */
   public void installSealedFileBytes(final byte[] bytes) throws IOException {
+    final File incoming = new File(basePath + ".ts.sealed.incoming");
+    try (final FileOutputStream fos = new FileOutputStream(incoming)) {
+      fos.write(bytes);
+      fos.getFD().sync();
+    }
+    installSealedFile(incoming);
+  }
+
+  /**
+   * The same install as {@link #installSealedFileBytes(byte[])} for a replacement that is ALREADY a file
+   * (issue #4416): a sealed store too large for one Raft entry reaches a follower as an ordered sequence of
+   * slices, which it stages on disk rather than in heap, so what it has to install is a path and not an array.
+   * <p>
+   * {@code incoming} is CONSUMED - it is moved onto this store's file, so it no longer exists afterwards. On any
+   * failure it is left where it is, for the caller to remove or reuse.
+   */
+  public void installSealedFile(final File incoming) throws IOException {
     directoryLock.writeLock().lock();
     try {
       // Close current handles before replacing the file (required on Windows).
@@ -2307,11 +2324,6 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       }
 
       final File target = new File(basePath + ".ts.sealed");
-      final File incoming = new File(basePath + ".ts.sealed.incoming");
-      try (final FileOutputStream fos = new FileOutputStream(incoming)) {
-        fos.write(bytes);
-        fos.getFD().sync();
-      }
       Files.move(incoming.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
       indexFile = new RandomAccessFile(target, "rw");

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -935,22 +935,43 @@ public class TimeSeriesShard implements AutoCloseable {
   }
 
   /**
-   * Best-effort: clear the compaction-in-progress flag after a non-crash error.
+   * Warns, at most once a minute per shard, that this shard's sealed store is too large to replicate and that
+   * compaction is therefore being skipped (issues #4382, #4416).
+   * <p>
+   * The message SPELLS OUT THE ARITHMETIC THAT PRODUCED THE CEILING rather than asserting one shape of it,
+   * because {@link GlobalConfiguration#maxReplicatedSealedStoreSize} has three regimes and a fixed
+   * "N slices of B bytes each" sentence is arithmetically FALSE in two of them: when the budget is zero no slice
+   * can be built at all and the ceiling is a single entry, and when the
+   * {@code MAX_REPLICATED_SEALED_CHUNKS x budget} product runs past {@link Integer#MAX_VALUE} the clamp is what
+   * sets the ceiling, so the product does not equal the number printed next to it. An operator who does the
+   * multiplication in the message and gets a different number stops trusting the message.
    */
   private void warnOversizedSealedSkip(final long projectedBytes, final long capBytes) {
     final long now = System.currentTimeMillis();
     if (now - lastOversizedWarnMs < 60_000)
       return;
     lastOversizedWarnMs = now;
+
+    final long budget = GlobalConfiguration.replicatedSealedChunkBudget(database.getConfiguration());
+    final String ceilingExplanation;
+    if (budget <= 0)
+      ceilingExplanation = "one entry, because the configured cap leaves no room for a slice's own framing";
+    else if (capBytes >= Integer.MAX_VALUE)
+      ceilingExplanation = String.format(
+          "%d slices of %d bytes each, clamped to %d because the sealed file is materialized as one array",
+          GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS, budget, Integer.MAX_VALUE);
+    else
+      ceilingExplanation = String.format("%d slices of %d bytes each",
+          GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS, budget);
+
     LogManager.instance().log(this, Level.WARNING,
         """
         Skipping HA compaction of TimeSeries '%s' shard %d: projected sealed-store size %d bytes exceeds the %d bytes \
-        a sliced replication sequence can carry, which is %d slices of %d bytes each. One slice is bounded by \
+        a sliced replication sequence can carry, which is %s. One slice is bounded by \
         '%s' and by min(arcadedb.ha.grpcMessageSizeMax, arcadedb.ha.appendBufferSize), whichever is smaller. Data \
         remains in the replicated mutable bucket; raise either of those settings, or reduce retention, to re-enable \
         sealing.""",
-        null, typeName, shardIndex, projectedBytes, capBytes, GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS,
-        GlobalConfiguration.replicatedSealedChunkBudget(database.getConfiguration()),
+        null, typeName, shardIndex, projectedBytes, capBytes, ceilingExplanation,
         GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE.getKey());
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -945,11 +945,13 @@ public class TimeSeriesShard implements AutoCloseable {
     LogManager.instance().log(this, Level.WARNING,
         """
         Skipping HA compaction of TimeSeries '%s' shard %d: projected sealed-store size %d bytes exceeds the %d bytes \
-        a sliced replication sequence can carry (%s x %d slices, never above min(arcadedb.ha.grpcMessageSizeMax, \
-        arcadedb.ha.appendBufferSize) per slice). Data remains in the replicated mutable bucket; raise the cap, raise \
-        arcadedb.ha.appendBufferSize, or reduce retention to re-enable sealing.""",
-        null, typeName, shardIndex, projectedBytes, capBytes, GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE.getKey(),
-        GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS);
+        a sliced replication sequence can carry, which is %d slices of %d bytes each. One slice is bounded by \
+        '%s' and by min(arcadedb.ha.grpcMessageSizeMax, arcadedb.ha.appendBufferSize), whichever is smaller. Data \
+        remains in the replicated mutable bucket; raise either of those settings, or reduce retention, to re-enable \
+        sealing.""",
+        null, typeName, shardIndex, projectedBytes, capBytes, GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS,
+        GlobalConfiguration.replicatedSealedChunkBudget(database.getConfiguration()),
+        GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE.getKey());
   }
 
   private void clearCompactionFlagBestEffort() {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -535,16 +535,19 @@ public class TimeSeriesShard implements AutoCloseable {
             return;
           }
 
-          // HA safety valve (issue #4382): if the rewritten sealed store would be too large to ship
-          // inline in a single Raft entry, skip compaction entirely this cycle.
+          // HA safety valve (issue #4382): if the rewritten sealed store would be too large to REPLICATE,
+          // skip compaction entirely this cycle.
+          //
+          // What "too large to replicate" means changed with issue #4416. It used to be "too large for one
+          // Raft entry", which made HA_TS_MAX_SEALED_INLINE_SIZE the ceiling on the sealed store itself: a
+          // shard that once crossed it never sealed again, because the store it would have to ship only ever
+          // grows. A sealed store above one entry is now SLICED across an ordered sequence of entries
+          // (RaftReplicatedDatabase.sliceSealedBlob), so the ceiling is what that sequence can carry - see
+          // GlobalConfiguration.maxReplicatedSealedStoreSize, which still folds in the #4743 rule that the
+          // real per-entry ceiling is min(grpcMessageSizeMax, appendBufferSize) and NOT the configured cap
+          // alone: shipping an entry above it makes Ratis reject it and the leader step down, over and over.
           if (db.isReplicated()) {
-            // #4743: never trust the configured cap on its own - it defaults to 48MB on the assumption
-            // that a Raft entry may be up to 64MB, but the real per-entry ceiling is
-            // min(grpcMessageSizeMax, appendBufferSize) and the latter defaults to 4MB. Shipping a blob
-            // above it makes Ratis reject the entry and the leader step down, over and over.
-            final long cap = Math.min(
-                database.getConfiguration().getValueAsLong(GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE),
-                GlobalConfiguration.maxReplicatedRaftEntrySize(database.getConfiguration()));
+            final long cap = GlobalConfiguration.maxReplicatedSealedStoreSize(database.getConfiguration());
             final long projected = sealedStore.getFileSizeBytes() + (long) pageCount * mutableBucket.getPageSize();
             if (projected > cap) {
               db.rollback();
@@ -941,10 +944,12 @@ public class TimeSeriesShard implements AutoCloseable {
     lastOversizedWarnMs = now;
     LogManager.instance().log(this, Level.WARNING,
         """
-        Skipping HA compaction of TimeSeries '%s' shard %d: projected sealed-store size %d bytes exceeds the inline \
-        replication cap %d bytes (%s). Data remains in the replicated mutable bucket; raise the cap or reduce \
-        retention to re-enable sealing.""",
-        null, typeName, shardIndex, projectedBytes, capBytes, GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE.getKey());
+        Skipping HA compaction of TimeSeries '%s' shard %d: projected sealed-store size %d bytes exceeds the %d bytes \
+        a sliced replication sequence can carry (%s x %d slices, never above min(arcadedb.ha.grpcMessageSizeMax, \
+        arcadedb.ha.appendBufferSize) per slice). Data remains in the replicated mutable bucket; raise the cap, raise \
+        arcadedb.ha.appendBufferSize, or reduce retention to re-enable sealing.""",
+        null, typeName, shardIndex, projectedBytes, capBytes, GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE.getKey(),
+        GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS);
   }
 
   private void clearCompactionFlagBestEffort() {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2042,9 +2042,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * not. It is also what keeps a multi-gigabyte sealed store from having to fit in heap on the way in.
    * <p>
    * WHAT MAKES THE SEQUENCE SAFE. Raft applies entries in index order on every node, so the slices arrive in the
-   * order the leader cut them. {@code offset == 0} TRUNCATES the staging file, which is what makes a sequence
-   * abandoned by a leader that died mid-shipment cost nothing: the next leader's first slice discards whatever it
-   * left. Any other slice must find the staging file exactly {@code offset} bytes long - anything else means the
+   * order the leader cut them. {@code offset == 0} TRUNCATES the staging file - through the write handle, so the
+   * truncation cannot be silently skipped the way a failed delete could - which is what makes a sequence abandoned
+   * by a leader that died mid-shipment cost nothing: the next leader's first slice discards whatever it left. Any
+   * other slice must find the staging file exactly {@code offset} bytes long - anything else means the
    * sequence this node holds is not the sequence the leader is sending, and the only honest answer is to stop
    * trusting local state and resync, which is what {@link ReplicationException} asks for (it is caught in
    * {@code applyWithRetry} and turned into a targeted snapshot resync rather than halting the node).
@@ -2083,9 +2084,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
           TimeSeriesSealedStore.sealedFileNameFor(tsType.getName(), chunk.shardIndex()));
       final File staging = new File(target.getPath() + SEALED_STAGING_SUFFIX);
 
-      if (chunk.offset() == 0L)
-        deleteSealedStagingFile(staging);
-      else if (!staging.exists() || staging.length() != chunk.offset())
+      if (chunk.offset() > 0L && (!staging.exists() || staging.length() != chunk.offset()))
         throw new ReplicationException(String.format(
             "TimeSeries sealed slice for '%s' shard %d (db=%s) starts at offset %d but this node has staged %s; "
                 + "the slice sequence is broken, resyncing the database from the leader",
@@ -2093,6 +2092,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
             staging.exists() ? staging.length() + " bytes" : "nothing"));
 
       try (final RandomAccessFile out = new RandomAccessFile(staging, "rw")) {
+        // The first slice truncates, and it does so through the open handle rather than by deleting the file
+        // first. Deleting was the obvious way to write this and it is the wrong one: a delete that fails - a
+        // handle another process still holds on Windows, a permissions hiccup - can only be logged and stepped
+        // over, and RandomAccessFile.write never SHRINKS a file, so the tail of a longer abandoned sequence
+        // would survive underneath the new one. The guards below still catch that (the next slice's offset
+        // check, or the final length check), but only by forcing a full resync - which is precisely the cost
+        // "an abandoned sequence costs nothing" says a restart does not pay. setLength cannot be stepped over:
+        // it truncates or it throws, and throwing here IS the resync signal.
+        if (chunk.offset() == 0L)
+          out.setLength(0);
         out.seek(chunk.offset());
         out.write(chunk.bytes());
         if (chunk.last())

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2054,6 +2054,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * then CRC32. Per-slice CRCs are already checked by the decoder, but they only prove each piece survived the
    * wire, not that what this node assembled is what the leader had.
    * <p>
+   * ONLY THE LAST SLICE IS FSYNCED, and the earlier ones deliberately are not. A power loss between applying a
+   * slice and the OS flushing it can therefore leave a staging file SHORTER than this node's persisted applied
+   * index implies. That is not a hole, it is what the checks above are for: the next slice finds a staging file
+   * that is not {@code offset} bytes long, or the last one finds the wrong length or CRC, and either way the
+   * sequence is refused and the database resyncs rather than installing a truncated store. Paying an fsync per
+   * slice would buy a faster recovery from an event that already costs a restart, at the price of one flush per
+   * entry on the single Raft apply thread for every sliced compaction. The final slice IS synced because after it
+   * the file is moved into place and nothing checks it again.
+   * <p>
    * The install itself is the one {@code applySealedBlobs} performs - an atomic move onto the store's file - and
    * the target path is derived from THIS node's schema, never from the file name in the payload: a name arriving
    * over the wire has no business selecting a path here.
@@ -2165,11 +2174,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
     return crc.getValue();
   }
 
+  /**
+   * Removes a staging file a refused reassembly left behind. BEST EFFORT, and unlike the first slice's truncation
+   * that is fine here: nothing downstream depends on this succeeding. The next sequence starts with an
+   * {@code offset == 0} slice, which truncates through its own write handle whether or not this delete worked, so
+   * a failure costs disk until the next compaction and never correctness. That is exactly the difference from the
+   * first-slice case, where a silently skipped delete DID leave a longer sequence's tail under a shorter one.
+   */
   private void deleteSealedStagingFile(final File staging) {
     if (staging.exists() && !staging.delete())
       LogManager.instance().log(this, Level.WARNING,
-          "Failed to delete stale TimeSeries sealed staging file '%s'; the next slice sequence overwrites it",
-          null, staging.getAbsolutePath());
+          "Failed to delete stale TimeSeries sealed staging file '%s'; it costs disk until the next slice "
+              + "sequence truncates it, and nothing else depends on it being gone", null, staging.getAbsolutePath());
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -61,6 +61,7 @@ import org.apache.ratis.util.LifeCycle;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -85,6 +86,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
+import java.util.zip.CRC32;
 
 /**
  * Ratis state machine that bridges the Raft log and ArcadeDB storage.
@@ -1798,7 +1800,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // installSealedFileBytes already reopened the sealed store and the clear WAL applies to the live
     // mutable-bucket pages, so neither the schema update nor the reload is needed.
     final boolean sealedOnlyEntry = isEmptyMap(decoded.filesToAdd()) && isEmptyMap(decoded.filesToRemove())
-        && decoded.sealedFileBlobs() != null && !decoded.sealedFileBlobs().isEmpty();
+        && (isNotEmpty(decoded.sealedFileBlobs()) || isNotEmpty(decoded.sealedFileChunks()));
 
     // A non-final chunk of a schema change split across several entries (see
     // RaftTransactionBroker.splitSchemaEntry) only DELIVERS pages: the change is published by the last
@@ -1823,7 +1825,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // Same reasoning as sealedOnlyEntry above.
     final boolean walOnlyEntry = isEmptyMap(decoded.filesToAdd()) && isEmptyMap(decoded.filesToRemove())
         && (decoded.schemaJson() == null || decoded.schemaJson().isEmpty())
-        && (decoded.sealedFileBlobs() == null || decoded.sealedFileBlobs().isEmpty())
+        && !isNotEmpty(decoded.sealedFileBlobs()) && !isNotEmpty(decoded.sealedFileChunks())
         && decoded.walEntries() != null && !decoded.walEntries().isEmpty();
 
     try {
@@ -1834,6 +1836,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // below carries the mutable-bucket clear; installing the sealed file first guarantees a query
       // never observes "cleared mutable + stale sealed" (the data-loss window).
       applySealedBlobs(db, decoded.sealedFileBlobs());
+
+      // A sealed store too large for one entry arrives as an ordered sequence of slices (issue #4416). Every
+      // slice but the last only stages bytes; the last one installs the reassembled file, and it rides THIS
+      // entry - the publishing one - so the install still happens before the clear WAL below, closing the same
+      // data-loss window applySealedBlobs closes for a store that fits inline.
+      applySealedChunks(db, decoded.sealedFileChunks());
 
       if (!sealedOnlyEntry && decoded.schemaJson() != null && !decoded.schemaJson().isEmpty())
         db.getSchema().getEmbedded().update(new JSONObject(decoded.schemaJson()));
@@ -2025,6 +2033,137 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   /**
+   * Reassembles and installs a sealed store the leader shipped SLICED because it does not fit one Raft entry
+   * (issue #4416), the counterpart of {@link #applySealedBlobs}.
+   * <p>
+   * WHY THE STAGING FILE IS ON DISK and not a buffer in this state machine. The slices arrive as separate Raft
+   * entries, and this node persists its applied index between them, so a follower that restarts mid-sequence must
+   * not need the earlier slices again - it will never be sent them. A file survives that restart; a field does
+   * not. It is also what keeps a multi-gigabyte sealed store from having to fit in heap on the way in.
+   * <p>
+   * WHAT MAKES THE SEQUENCE SAFE. Raft applies entries in index order on every node, so the slices arrive in the
+   * order the leader cut them. {@code offset == 0} TRUNCATES the staging file, which is what makes a sequence
+   * abandoned by a leader that died mid-shipment cost nothing: the next leader's first slice discards whatever it
+   * left. Any other slice must find the staging file exactly {@code offset} bytes long - anything else means the
+   * sequence this node holds is not the sequence the leader is sending, and the only honest answer is to stop
+   * trusting local state and resync, which is what {@link ReplicationException} asks for (it is caught in
+   * {@code applyWithRetry} and turned into a targeted snapshot resync rather than halting the node).
+   * <p>
+   * The last slice is verified against the WHOLE file the leader hashed before it is installed: length first,
+   * then CRC32. Per-slice CRCs are already checked by the decoder, but they only prove each piece survived the
+   * wire, not that what this node assembled is what the leader had.
+   * <p>
+   * The install itself is the one {@code applySealedBlobs} performs - an atomic move onto the store's file - and
+   * the target path is derived from THIS node's schema, never from the file name in the payload: a name arriving
+   * over the wire has no business selecting a path here.
+   */
+  // Package-private for the same reason as applySealedBlobs: the whole mechanism lives in this method, and a
+  // 3-node IT can prove it end to end but cannot pin the broken-sequence arms without contriving a failure.
+  void applySealedChunks(final DatabaseInternal db, final List<RaftLogEntryCodec.TsSealedChunk> chunks)
+      throws IOException {
+    if (chunks == null || chunks.isEmpty())
+      return;
+    for (final RaftLogEntryCodec.TsSealedChunk chunk : chunks) {
+      final LocalSchema schema = db.getSchema().getEmbedded();
+      if (!schema.existsType(chunk.typeName())) {
+        // Should not happen: the type-creation entry has a lower Raft index and is applied first.
+        LogManager.instance().log(this, Level.SEVERE,
+            "Received TimeSeries sealed slice for unknown type '%s' (db=%s); skipping", null, chunk.typeName(),
+            decodedDbName(db));
+        continue;
+      }
+      if (!(schema.getType(chunk.typeName()) instanceof LocalTimeSeriesType tsType)) {
+        LogManager.instance().log(this, Level.SEVERE,
+            "Received TimeSeries sealed slice for non-timeseries type '%s' (db=%s); skipping", null,
+            chunk.typeName(), decodedDbName(db));
+        continue;
+      }
+
+      final File target = new File(db.getDatabasePath(),
+          TimeSeriesSealedStore.sealedFileNameFor(tsType.getName(), chunk.shardIndex()));
+      final File staging = new File(target.getPath() + SEALED_STAGING_SUFFIX);
+
+      if (chunk.offset() == 0L)
+        deleteSealedStagingFile(staging);
+      else if (!staging.exists() || staging.length() != chunk.offset())
+        throw new ReplicationException(String.format(
+            "TimeSeries sealed slice for '%s' shard %d (db=%s) starts at offset %d but this node has staged %s; "
+                + "the slice sequence is broken, resyncing the database from the leader",
+            chunk.typeName(), chunk.shardIndex(), decodedDbName(db), chunk.offset(),
+            staging.exists() ? staging.length() + " bytes" : "nothing"));
+
+      try (final RandomAccessFile out = new RandomAccessFile(staging, "rw")) {
+        out.seek(chunk.offset());
+        out.write(chunk.bytes());
+        if (chunk.last())
+          out.getFD().sync();
+      }
+
+      if (!chunk.last()) {
+        HALog.log(this, HALog.DETAILED,
+            "Staged TimeSeries sealed slice for %s shard %d at offset %d (%d bytes of %d) on db '%s'",
+            chunk.typeName(), chunk.shardIndex(), chunk.offset(), chunk.bytes().length, chunk.fileLength(),
+            decodedDbName(db));
+        continue;
+      }
+
+      final long stagedLength = staging.length();
+      if (stagedLength != chunk.fileLength()) {
+        deleteSealedStagingFile(staging);
+        throw new ReplicationException(String.format(
+            "TimeSeries sealed store for '%s' shard %d (db=%s) reassembled to %d bytes but the leader shipped %d; "
+                + "resyncing the database from the leader",
+            chunk.typeName(), chunk.shardIndex(), decodedDbName(db), stagedLength, chunk.fileLength()));
+      }
+
+      final long assembledCrc = crc32Of(staging);
+      if (assembledCrc != chunk.fileCrc()) {
+        deleteSealedStagingFile(staging);
+        throw new ReplicationException(String.format(
+            "TimeSeries sealed store for '%s' shard %d (db=%s) reassembled with CRC %d, the leader shipped %d; "
+                + "resyncing the database from the leader",
+            chunk.typeName(), chunk.shardIndex(), decodedDbName(db), assembledCrc, chunk.fileCrc()));
+      }
+
+      if (tsType.getEngine() == null) {
+        // Same repair as a whole-file blob performs (issue #6839): the slices ARE the authoritative copy of the
+        // file whose failure to open left this type without an engine, so they go down first and initEngine()
+        // opens the store over them.
+        if (repairEngineWithSealedFile(db, tsType, chunk.shardIndex(), staging))
+          HALog.log(this, HALog.DETAILED,
+              "Repaired TimeSeries type %s shard %d from a %d-byte replicated sealed store shipped in slices on db '%s'",
+              chunk.typeName(), chunk.shardIndex(), stagedLength, decodedDbName(db));
+        continue;
+      }
+
+      tsType.getEngine().getShard(chunk.shardIndex()).getSealedStore().installSealedFile(staging);
+      HALog.log(this, HALog.DETAILED,
+          "Installed TimeSeries sealed store for %s shard %d (%d bytes, shipped in slices) on db '%s'",
+          chunk.typeName(), chunk.shardIndex(), stagedLength, decodedDbName(db));
+    }
+  }
+
+  /** Where a sealed store shipped in slices is reassembled, beside the file it will replace. */
+  static final String SEALED_STAGING_SUFFIX = ".parts";
+
+  private static long crc32Of(final File file) throws IOException {
+    final CRC32 crc = new CRC32();
+    final byte[] buffer = new byte[64 * 1024];
+    try (final RandomAccessFile in = new RandomAccessFile(file, "r")) {
+      for (int read = in.read(buffer); read > 0; read = in.read(buffer))
+        crc.update(buffer, 0, read);
+    }
+    return crc.getValue();
+  }
+
+  private void deleteSealedStagingFile(final File staging) {
+    if (staging.exists() && !staging.delete())
+      LogManager.instance().log(this, Level.WARNING,
+          "Failed to delete stale TimeSeries sealed staging file '%s'; the next slice sequence overwrites it",
+          null, staging.getAbsolutePath());
+  }
+
+  /**
    * Puts the leader's sealed bytes in place for a type registered with no engine and re-runs {@code initEngine()}.
    * Returns whether the type now has one.
    * <p>
@@ -2051,13 +2190,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final File target = new File(db.getDatabasePath(),
         TimeSeriesSealedStore.sealedFileNameFor(tsType.getName(), blob.shardIndex()));
     final File incoming = new File(target.getPath() + ".incoming");
-    try {
-      try (final FileOutputStream out = new FileOutputStream(incoming)) {
-        out.write(blob.bytes());
-        out.getFD().sync();
-      }
-      Files.move(incoming.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
-      tsType.initEngine();
+    try (final FileOutputStream out = new FileOutputStream(incoming)) {
+      out.write(blob.bytes());
+      out.getFD().sync();
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE,
           "Received TimeSeries sealed blob for type '%s' shard %d (db=%s) whose storage engine is unavailable, and "
@@ -2065,11 +2200,35 @@ public class ArcadeStateMachine extends BaseStateMachine {
           decodedDbName(db), e.getMessage());
       return false;
     }
+    return repairEngineWithSealedFile(db, tsType, blob.shardIndex(), incoming);
+  }
+
+  /**
+   * The half of {@link #repairEngineWithSealedBlob} that runs once the leader's copy of the sealed file is a file
+   * on this node: move it into place and re-run {@code initEngine()} over it.
+   * <p>
+   * Shared with the sliced path (issue #4416), which reassembles the leader's copy on disk rather than in heap and
+   * so arrives here with a path instead of an array. {@code source} is CONSUMED on success.
+   */
+  private boolean repairEngineWithSealedFile(final DatabaseInternal db, final LocalTimeSeriesType tsType,
+      final int shardIndex, final File source) {
+    final File target = new File(db.getDatabasePath(),
+        TimeSeriesSealedStore.sealedFileNameFor(tsType.getName(), shardIndex));
+    try {
+      Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      tsType.initEngine();
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.SEVERE,
+          "Received TimeSeries sealed store for type '%s' shard %d (db=%s) whose storage engine is unavailable, and "
+              + "the engine could not be initialised over it: %s", e, tsType.getName(), shardIndex,
+          decodedDbName(db), e.getMessage());
+      return false;
+    }
 
     if (!tsType.isEngineAvailable()) {
       LogManager.instance().log(this, Level.SEVERE,
-          "TimeSeries type '%s' (db=%s) still has no storage engine after installing the replicated sealed blob "
-              + "for shard %d; skipping", null, blob.typeName(), decodedDbName(db), blob.shardIndex());
+          "TimeSeries type '%s' (db=%s) still has no storage engine after installing the replicated sealed store "
+              + "for shard %d; skipping", null, tsType.getName(), decodedDbName(db), shardIndex);
       return false;
     }
     return true;
@@ -2081,6 +2240,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
   private static boolean isEmptyMap(final Map<?, ?> map) {
     return map == null || map.isEmpty();
+  }
+
+  private static boolean isNotEmpty(final List<?> list) {
+    return list != null && !list.isEmpty();
   }
 
   private void applyInstallDatabaseEntry(final RaftLogEntryCodec.DecodedEntry decoded) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -144,15 +144,54 @@ public final class RaftLogEntryCodec {
    * identical, equally undeliverable payload.
    */
   private static void checkProducedPayloadLength(final int length, final String databaseName, final String context) {
+    checkProducedPayloadLength(length, databaseName, context,
+        "Reduce the batch size - fewer rows per GraphBatch / SQL transaction, or smaller records.");
+  }
+
+  /**
+   * @param remediation what the operator can actually DO about it, because that differs by section and a wrong
+   *                    answer here sends them at the wrong knob. A transaction's WAL shrinks by batching less; a
+   *                    TimeSeries sealed store does not shrink by batching anything at all (issue #4416) - it
+   *                    shrinks by lowering the per-entry sealed cap so the store is sliced more finely, or by
+   *                    shortening the type's retention.
+   */
+  private static void checkProducedPayloadLength(final int length, final String databaseName, final String context,
+      final String remediation) {
     if (length > MAX_ENTRY_BYTES)
       throw new ReplicatedEntryTooLargeException(String.format(
           """
           %s for database '%s' is %d bytes uncompressed, above the %d bytes of uncompressed payload a single \
           replicated Raft entry may carry. Compression is not what bounds it: the entry is LZ4-compressed for \
           the wire but every node has to materialize it in full to apply it, so a well-compressing bulk \
-          transaction can slip under arcadedb.ha.appendBufferSize and still be too large to apply. Reduce the \
-          batch size - fewer rows per GraphBatch / SQL transaction, or smaller records.""",
-          context, databaseName, length, MAX_ENTRY_BYTES));
+          transaction can slip under arcadedb.ha.appendBufferSize and still be too large to apply. %s""",
+          context, databaseName, length, MAX_ENTRY_BYTES, remediation));
+  }
+
+  /** What an operator does about a TimeSeries sealed payload that no single entry can carry (issue #4416). */
+  private static final String SEALED_REMEDIATION =
+      "Lower arcadedb.ha.tsMaxSealedInlineSize so the store is sliced more finely, or shorten the retention on "
+          + "this TimeSeries type so it holds fewer sealed blocks.";
+
+  /**
+   * Rejects a sealed slice whose offsets and lengths cannot describe a real file (issue #4416), HERE rather than
+   * where the bytes are written.
+   * <p>
+   * The applier turns "this sequence does not line up" into a targeted snapshot resync and never into a crash,
+   * and a negative offset would have escaped that: it reaches {@code RandomAccessFile.seek} and comes back as a
+   * raw {@code IOException} the apply path can only report as an unexpected error. Decoding is where every other
+   * malformed-payload check in this class already lives, and it is the one place that sees the field before
+   * anything acts on it. The last slice must END exactly at the declared file length - every producer satisfies
+   * that by construction, so a payload that does not is not a payload this codec wrote.
+   */
+  private static void checkSealedSliceGeometry(final String fileName, final long fileLength, final long offset,
+      final int sliceLength, final boolean last) {
+    final boolean valid = fileLength >= 0 && offset >= 0 && offset + (long) sliceLength <= fileLength
+        && (!last || offset + (long) sliceLength == fileLength);
+    if (!valid)
+      throw new IllegalStateException(
+          "Invalid SCHEMA_ENTRY sealed slice for '" + fileName + "': offset " + offset + " + " + sliceLength
+              + " bytes does not fit a " + fileLength + "-byte file" + (last ? " it claims to complete" : "")
+              + " (corrupted replication payload)");
   }
 
   private static void checkCollectionSize(final int size, final String context) {
@@ -396,7 +435,8 @@ public final class RaftLogEntryCodec {
       for (int i = 0; i < blobCount; i++) {
         final TsSealedBlob blob = sealedFileBlobs.get(i);
         final byte[] raw = blob.bytes() != null ? blob.bytes() : new byte[0];
-        checkProducedPayloadLength(raw.length, databaseName, "Sealed TimeSeries store '" + blob.fileName() + "'");
+        checkProducedPayloadLength(raw.length, databaseName, "Sealed TimeSeries store '" + blob.fileName() + "'",
+            SEALED_REMEDIATION);
         final CRC32 crc = new CRC32();
         crc.update(raw);
         final byte[] compressed = CompressionFactory.getDefault().compress(raw);
@@ -425,7 +465,7 @@ public final class RaftLogEntryCodec {
           final TsSealedChunk chunk = sealedFileChunks.get(i);
           final byte[] raw = chunk.bytes() != null ? chunk.bytes() : new byte[0];
           checkProducedPayloadLength(raw.length, databaseName,
-              "Sealed TimeSeries store slice '" + chunk.fileName() + "'");
+              "Sealed TimeSeries store slice '" + chunk.fileName() + "'", SEALED_REMEDIATION);
           final CRC32 crc = new CRC32();
           crc.update(raw);
           final byte[] compressed = CompressionFactory.getDefault().compress(raw);
@@ -736,6 +776,7 @@ public final class RaftLogEntryCodec {
           if (crc.getValue() != expectedCrc)
             throw new IllegalStateException("CRC mismatch decoding SCHEMA_ENTRY sealed slice for '" + fileName
                 + "' at offset " + offset + " (corrupted replication payload)");
+          checkSealedSliceGeometry(fileName, fileLength, offset, raw.length, last);
           sealedFileChunks.add(
               new TsSealedChunk(typeName, shardIndex, fileName, fileLength, fileCrc, offset, raw, last));
         }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -188,7 +188,13 @@ public final class RaftLogEntryCodec {
        * standalone DDL that adds files without changing the schema version, and skipping the reload for
        * THAT would leave the new files unregistered.
        */
-      boolean moreChunksFollow
+      boolean moreChunksFollow,
+      /**
+       * Slices of a TimeSeries sealed store too large to ride one Raft entry (issue #4416). Empty on every entry
+       * whose sealed stores fit inline - those arrive as {@code sealedFileBlobs} - and on entries produced by a
+       * node that predates this section.
+       */
+      List<TsSealedChunk> sealedFileChunks
   ) {
   }
 
@@ -204,6 +210,39 @@ public final class RaftLogEntryCodec {
    * @param bytes      the full sealed-store file content
    */
   public record TsSealedBlob(String typeName, int shardIndex, String fileName, byte[] bytes) {
+  }
+
+  /**
+   * One slice of a TimeSeries sealed-store file that does not fit a single Raft entry (issue #4416).
+   * <p>
+   * WHY SLICES AND NOT A SMALLER BLOB. A {@link TsSealedBlob} is the whole file, which made
+   * {@code arcadedb.ha.tsMaxSealedInlineSize} a ceiling on the sealed STORE and not merely on one entry: a shard
+   * whose store crossed it stopped sealing for good, because the file it would have to ship only ever grows. A
+   * sliced store is delivered by a sequence of entries that Raft applies in order on every node, each within the
+   * transport limit, so the ceiling becomes the sequence's length rather than one entry's size.
+   * <p>
+   * The sequence follows the same ordered-prefix contract as {@code RaftTransactionBroker.splitSchemaEntry}: every
+   * slice but the last is a delivery-only entry that the follower STAGES on disk and nothing more, and the final
+   * slice rides the publishing entry, so the install still happens in the same entry as the mutable-bucket clear
+   * WAL and a query can never observe "cleared mutable + stale sealed". A leader that dies mid-sequence leaves a
+   * partial staging file, which the next sequence's {@code offset == 0} slice truncates.
+   * <p>
+   * {@code fileLength} and {@code fileCrc} describe the WHOLE reassembled file and are carried on every slice, so
+   * a follower validates what it assembled against the leader's own image before installing it - a per-slice CRC
+   * alone would only prove each piece survived the wire.
+   *
+   * @param typeName   the TimeSeries type owning the shard
+   * @param shardIndex the shard index whose sealed store changed
+   * @param fileName   the sealed-store file name relative to the database directory, for diagnostics only: the
+   *                   follower derives the path it writes from its OWN schema, never from this
+   * @param fileLength the length of the whole reassembled file
+   * @param fileCrc    CRC32 of the whole reassembled file
+   * @param offset     where this slice starts in the reassembled file
+   * @param bytes      this slice's bytes, already decompressed and CRC-verified by the decoder
+   * @param last       true on the slice that completes the file, i.e. the one the follower installs on
+   */
+  public record TsSealedChunk(String typeName, int shardIndex, String fileName, long fileLength, long fileCrc,
+                              long offset, byte[] bytes, boolean last) {
   }
 
   /**
@@ -295,6 +334,29 @@ public final class RaftLogEntryCodec {
       final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
       final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
       final List<TsSealedBlob> sealedFileBlobs, final boolean moreChunksFollow) {
+    return encodeSchemaEntry(databaseName, schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas,
+        sealedFileBlobs, moreChunksFollow, Collections.emptyList());
+  }
+
+  /**
+   * @param sealedFileChunks slices of a sealed store too large to ride one entry (issue #4416). Written as a
+   *                         trailing section AFTER {@code moreChunksFollow}, which this encoder always emits, so
+   *                         the flag can never be confused with the section's own first byte and a node running an
+   *                         older codec stops right after the flag and decodes the entry exactly as it did before.
+   *                         <p>
+   *                         <b>During a rolling upgrade</b> that older node therefore installs nothing for a
+   *                         SLICED sealed store while still applying the mutable-bucket clear WAL the publishing
+   *                         entry carries, and serves that shard from its sealed store's previous image until it
+   *                         is upgraded and resynced - the same exposure the sealed-blob section itself has had
+   *                         since #4382, and for the same reason: a trailing section an old decoder cannot see. A
+   *                         leader only produces slices once a sealed store outgrows one entry, so a cluster whose
+   *                         stores fit inline is not exposed at all. Upgrade the followers first.
+   */
+  public static ByteString encodeSchemaEntry(final String databaseName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
+      final List<TsSealedBlob> sealedFileBlobs, final boolean moreChunksFollow,
+      final List<TsSealedChunk> sealedFileChunks) {
     try {
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
       final DataOutputStream dos = new DataOutputStream(baos);
@@ -347,10 +409,39 @@ public final class RaftLogEntryCodec {
         dos.write(compressed);
       }
 
-      // KEEP THIS LAST. The decoder detects it with available() > 0, so it can only be the final field:
-      // anything appended after it would make a false flag indistinguishable from an older entry that
-      // never wrote one. A future trailing section needs its own presence byte written BEFORE this.
+      // KEEP THIS BEFORE ANY LATER SECTION, unconditionally. The decoder detects it with available() > 0, so
+      // it must be written by every encoder that writes anything after it: an entry that OMITTED it and then
+      // wrote a section would make that section's first byte indistinguishable from the flag. It is written
+      // unconditionally here, which is precisely what lets the sealed-slice section below follow it (#4416),
+      // and an older decoder - which stops here - still reads the flag correctly.
       dos.writeBoolean(moreChunksFollow);
+
+      // TimeSeries sealed-store SLICE section (issue #4416). Trailing, self-describing, and written only when
+      // non-empty, so an entry with nothing to slice is byte-identical to what the previous codec produced.
+      final int chunkCount = sealedFileChunks != null ? sealedFileChunks.size() : 0;
+      if (chunkCount > 0) {
+        dos.writeInt(chunkCount);
+        for (int i = 0; i < chunkCount; i++) {
+          final TsSealedChunk chunk = sealedFileChunks.get(i);
+          final byte[] raw = chunk.bytes() != null ? chunk.bytes() : new byte[0];
+          checkProducedPayloadLength(raw.length, databaseName,
+              "Sealed TimeSeries store slice '" + chunk.fileName() + "'");
+          final CRC32 crc = new CRC32();
+          crc.update(raw);
+          final byte[] compressed = CompressionFactory.getDefault().compress(raw);
+          dos.writeUTF(chunk.typeName());
+          dos.writeInt(chunk.shardIndex());
+          dos.writeUTF(chunk.fileName());
+          dos.writeLong(chunk.fileLength());
+          dos.writeLong(chunk.fileCrc());
+          dos.writeLong(chunk.offset());
+          dos.writeBoolean(chunk.last());
+          dos.writeLong(crc.getValue());     // CRC of THIS slice
+          dos.writeInt(raw.length);          // uncompressed length
+          dos.writeInt(compressed.length);   // compressed length
+          dos.write(compressed);
+        }
+      }
 
       dos.flush();
       return ByteString.copyFrom(baos.toByteArray());
@@ -485,7 +576,7 @@ public final class RaftLogEntryCodec {
       final RaftLogEntryType type = RaftLogEntryType.fromId(typeByte);
       if (type == null)
         return new DecodedEntry(null, null, null, null, null, null, null, null, null, null, false, null, -1L,
-            Collections.emptyList(), false);
+            Collections.emptyList(), false, Collections.emptyList());
       final String databaseName = dis.readUTF();
 
       final DecodedEntry result = switch (type) {
@@ -493,7 +584,8 @@ public final class RaftLogEntryCodec {
         case SCHEMA_ENTRY -> decodeSchemaEntry(dis, databaseName);
         case INSTALL_DATABASE_ENTRY -> decodeInstallDatabaseEntry(dis, databaseName);
         case DROP_DATABASE_ENTRY -> new DecodedEntry(RaftLogEntryType.DROP_DATABASE_ENTRY, databaseName,
-            null, null, null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false);
+            null, null, null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false,
+            Collections.emptyList());
         case SECURITY_USERS_ENTRY -> decodeSecurityUsersEntry(dis);
         case BOOTSTRAP_FINGERPRINT_ENTRY -> decodeBootstrapFingerprintEntry(dis, databaseName);
       };
@@ -531,7 +623,7 @@ public final class RaftLogEntryCodec {
     }
 
     return new DecodedEntry(RaftLogEntryType.TX_ENTRY, databaseName, walData, bucketRecordDelta,
-        null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false);
+        null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false, Collections.emptyList());
   }
 
   private static DecodedEntry decodeSchemaEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -614,9 +706,45 @@ public final class RaftLogEntryCodec {
     // entries produced by an older codec, which decode as false.
     final boolean moreChunksFollow = dis.available() > 0 && dis.readBoolean();
 
+    // TimeSeries sealed-store SLICE section (issue #4416). It can only be read once the flag above has been
+    // consumed, which is why that flag is written unconditionally by the encoder; the same presence rule applies
+    // here, and a truncated slice makes the reads below hit EOF and propagate rather than being silently dropped.
+    List<TsSealedChunk> sealedFileChunks = Collections.emptyList();
+    if (dis.available() > 0) {
+      final int chunkCount = dis.readInt();
+      checkCollectionSize(chunkCount, "SCHEMA_ENTRY sealed slices");
+      if (chunkCount > 0) {
+        sealedFileChunks = new ArrayList<>(chunkCount);
+        for (int i = 0; i < chunkCount; i++) {
+          final String typeName = dis.readUTF();
+          final int shardIndex = dis.readInt();
+          final String fileName = dis.readUTF();
+          final long fileLength = dis.readLong();
+          final long fileCrc = dis.readLong();
+          final long offset = dis.readLong();
+          final boolean last = dis.readBoolean();
+          final long expectedCrc = dis.readLong();
+          final int uncompressedLen = dis.readInt();
+          final int compressedLen = dis.readInt();
+          checkByteLength(compressedLen, dis.available(), "SCHEMA_ENTRY sealed slice compressed");
+          checkDecompressedLength(uncompressedLen, compressedLen, "SCHEMA_ENTRY sealed slice uncompressed");
+          final byte[] compressed = new byte[compressedLen];
+          dis.readFully(compressed);
+          final byte[] raw = CompressionFactory.getDefault().decompress(compressed, uncompressedLen);
+          final CRC32 crc = new CRC32();
+          crc.update(raw);
+          if (crc.getValue() != expectedCrc)
+            throw new IllegalStateException("CRC mismatch decoding SCHEMA_ENTRY sealed slice for '" + fileName
+                + "' at offset " + offset + " (corrupted replication payload)");
+          sealedFileChunks.add(
+              new TsSealedChunk(typeName, shardIndex, fileName, fileLength, fileCrc, offset, raw, last));
+        }
+      }
+    }
+
     return new DecodedEntry(RaftLogEntryType.SCHEMA_ENTRY, databaseName, null, null,
         schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, null, false, null, -1L, sealedFileBlobs,
-        moreChunksFollow);
+        moreChunksFollow, sealedFileChunks);
   }
 
   private static DecodedEntry decodeInstallDatabaseEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -627,7 +755,8 @@ public final class RaftLogEntryCodec {
       forceSnapshot = dis.readBoolean();
     }
     return new DecodedEntry(RaftLogEntryType.INSTALL_DATABASE_ENTRY, databaseName,
-        null, null, null, null, null, null, null, null, forceSnapshot, null, -1L, Collections.emptyList(), false);
+        null, null, null, null, null, null, null, null, forceSnapshot, null, -1L, Collections.emptyList(), false,
+        Collections.emptyList());
   }
 
   private static DecodedEntry decodeBootstrapFingerprintEntry(final DataInputStream dis, final String databaseName)
@@ -639,7 +768,8 @@ public final class RaftLogEntryCodec {
     final String fingerprint = new String(fpBytes, StandardCharsets.UTF_8);
     final long lastTxId = dis.readLong();
     return new DecodedEntry(RaftLogEntryType.BOOTSTRAP_FINGERPRINT_ENTRY, databaseName,
-        null, null, null, null, null, null, null, null, false, fingerprint, lastTxId, Collections.emptyList(), false);
+        null, null, null, null, null, null, null, null, false, fingerprint, lastTxId, Collections.emptyList(), false,
+        Collections.emptyList());
   }
 
   private static DecodedEntry decodeSecurityUsersEntry(final DataInputStream dis) throws IOException {
@@ -649,7 +779,8 @@ public final class RaftLogEntryCodec {
     dis.readFully(bytes);
     final String usersJson = new String(bytes, StandardCharsets.UTF_8);
     return new DecodedEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, "",
-        null, null, null, null, null, null, null, usersJson, false, null, -1L, Collections.emptyList(), false);
+        null, null, null, null, null, null, null, usersJson, false, null, -1L, Collections.emptyList(), false,
+        Collections.emptyList());
   }
 
   private static void writeFileMap(final DataOutputStream dos, final Map<Integer, String> fileMap) throws IOException {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2277,6 +2277,18 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // being refused. Everything but the final slice of each store goes out HERE, ahead of the publishing entry,
       // as a delivery-only entry the follower merely stages; the final slice is handed to replicateSchema below
       // so the install lands in the same entry as the mutable-bucket clear WAL.
+      //
+      // WHAT A FAILURE PART-WAY THROUGH THIS LOOP LEAVES, since the loop makes several quorum round trips where
+      // the whole-file path made one, and nothing here retries or rolls back. The compaction has already run
+      // LOCALLY - the sealed file is swapped and the mutable-bucket clear is committed on this node, because
+      // commit() inside the session buffers the WAL for shipping AFTER applying it here - so a throw leaves this
+      // node sealed and the others still holding those samples in their (fully replicated) mutable bucket. Every
+      // node still answers the same sample count; what diverges is where the samples live, and the page versions
+      // this node advanced past theirs. The recovery is the one that already existed for a failed whole-file
+      // compaction, not a new one: the next entry touching those pages hits a version gap on the followers and
+      // escalates to a snapshot resync, and a follower's part-written staging file is truncated by the first
+      // slice of the next sequence. Deliberately not retried here - a retry would re-ship a sealed image the next
+      // compaction is about to rewrite anyway.
       final long sealedChunkBudget = GlobalConfiguration.replicatedSealedChunkBudget(proxied.getConfiguration());
       final List<RaftLogEntryCodec.TsSealedBlob> sealedBlobs = new ArrayList<>(recordedSealed.size());
       final List<RaftLogEntryCodec.TsSealedChunk> finalSealedChunks = new ArrayList<>();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -195,6 +195,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * shipping a store that would previously have been refused, and how much Raft traffic that costs per cycle.
    */
   private final        AtomicLong                                        sealedChunksShipped      = new AtomicLong();
+  private final        AtomicLong                                        sealedChunksMaxSequence  = new AtomicLong();
 
   /**
    * Memoized unreferenced-file count behind the (file modification count, schema version) gate (issue #6168).
@@ -2105,6 +2106,20 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   /**
+   * The most slices any ONE sealed store has been cut into since this database opened (issue #4416).
+   * <p>
+   * The cumulative {@link #getSealedStoreChunksShipped()} cannot answer the question an operator actually has,
+   * which is whether a SINGLE store is producing a burst: a thousand slices reads the same there whether it was
+   * one pathological store or a thousand healthy one-slice ones. This is the burst gauge. Anything at or above
+   * {@link GlobalConfiguration#MAX_REPLICATED_SEALED_CHUNKS} means the WARNING in {@link #sliceSealedBlob} fired
+   * and the leader is holding a FileManager recording session open across that many sequential quorum round
+   * trips, which shows up as leader commit latency (see that constant's javadoc for exactly what it blocks).
+   */
+  public long getSealedStoreMaxSliceSequence() {
+    return sealedChunksMaxSequence.get();
+  }
+
+  /**
    * Cuts a sealed-store image into the ordered slices that will carry it (issue #4416), or returns EMPTY when it
    * fits one entry and must ship inline as a {@link RaftLogEntryCodec.TsSealedBlob} exactly as before.
    * <p>
@@ -2303,6 +2318,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           broker.replicateSealedChunk(getName(), slices.get(i));
         finalSealedChunks.add(slices.getLast());
         sealedSlicesShipped += slices.size();
+        // Per-STORE, not per-session: the burst that costs latency is one store's sequence of round trips, and
+        // summing across stores would hide a single pathological shard behind a busy-but-healthy cycle.
+        sealedChunksMaxSequence.accumulateAndGet(slices.size(), Math::max);
       }
       sealedChunksShipped.addAndGet(sealedSlicesShipped);
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -104,6 +104,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -123,6 +124,7 @@ import java.util.function.IntPredicate;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
+import java.util.zip.CRC32;
 
 /**
  * A {@link DatabaseInternal} wrapper that intercepts commit() to submit WAL changes through Raft consensus.
@@ -186,6 +188,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private final        AtomicLong                                        schemaInstalmentsShipped = new AtomicLong();
   private final        AtomicLong                                        schemaInstalmentTotalMs  = new AtomicLong();
   private final        AtomicLong                                        schemaInstalmentMaxMs    = new AtomicLong();
+
+  /**
+   * Sealed-store slices this database has shipped since it opened (issue #4416). Zero on every node whose sealed
+   * stores fit one Raft entry, which is what makes it worth reading: a non-zero value says compaction is now
+   * shipping a store that would previously have been refused, and how much Raft traffic that costs per cycle.
+   */
+  private final        AtomicLong                                        sealedChunksShipped      = new AtomicLong();
 
   /**
    * Memoized unreferenced-file count behind the (file modification count, schema version) gate (issue #6168).
@@ -2090,6 +2099,62 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         toRetire.put(shipped.getKey(), shipped.getValue());
   }
 
+  /** Sealed-store slices this database has shipped since it opened - see {@link #sealedChunksShipped}. */
+  public long getSealedStoreChunksShipped() {
+    return sealedChunksShipped.get();
+  }
+
+  /**
+   * Cuts a sealed-store image into the ordered slices that will carry it (issue #4416), or returns EMPTY when it
+   * fits one entry and must ship inline as a {@link RaftLogEntryCodec.TsSealedBlob} exactly as before.
+   * <p>
+   * Static and side-effect-free so the arithmetic that a follower's reassembly depends on - contiguous offsets, a
+   * whole-file CRC every slice agrees on, exactly one slice flagged {@code last} - can be pinned without a cluster.
+   * <p>
+   * Slices are cut against {@code budget} rather than against the entry cap directly: the codec compresses each
+   * one, so a slice that fits uncompressed always fits encoded, and the framing the budget already subtracts
+   * covers the rest. A store needing more than {@code MAX_REPLICATED_SEALED_CHUNKS} slices is still shipped -
+   * refusing here would leave the follower holding a stale sealed file the leader has already replaced, which is
+   * divergence - but it is reported, because the shard guard in {@code TimeSeriesShard.compactInternal} is
+   * supposed to have kept it from ever getting this far and the maintenance path (retention, downsampling) has no
+   * such guard.
+   *
+   * @param budget how many raw bytes of sealed content one entry may carry; {@code <= 0} disables slicing
+   */
+  // @VisibleForTesting
+  static List<RaftLogEntryCodec.TsSealedChunk> sliceSealedBlob(final RaftLogEntryCodec.TsSealedBlob blob,
+      final long budget, final String databaseName) {
+    final byte[] bytes = blob.bytes() != null ? blob.bytes() : new byte[0];
+    if (budget <= 0 || bytes.length <= budget)
+      return Collections.emptyList();
+
+    final CRC32 crc = new CRC32();
+    crc.update(bytes);
+    final long fileCrc = crc.getValue();
+
+    final int sliceSize = (int) Math.min(budget, Integer.MAX_VALUE);
+    final int count = (int) (((long) bytes.length + sliceSize - 1) / sliceSize);
+
+    if (count > GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS)
+      LogManager.instance().log(RaftReplicatedDatabase.class, Level.WARNING,
+          """
+          Sealed TimeSeries store '%s' of database '%s' is %d bytes and needs %d replicated entries of %d bytes, \
+          above the %d one compaction is expected to produce. Shipping it anyway - withholding it would leave the \
+          other nodes on a sealed store this one has already replaced - but raise arcadedb.ha.appendBufferSize, or \
+          shorten the retention on this type, before the burst starts costing write latency.""",
+          null, blob.fileName(), databaseName, bytes.length, count, sliceSize,
+          GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS);
+
+    final List<RaftLogEntryCodec.TsSealedChunk> slices = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      final int from = (int) ((long) i * sliceSize);
+      final int to = (int) Math.min(bytes.length, (long) from + sliceSize);
+      slices.add(new RaftLogEntryCodec.TsSealedChunk(blob.typeName(), blob.shardIndex(), blob.fileName(),
+          bytes.length, fileCrc, from, Arrays.copyOfRange(bytes, from, to), i == count - 1));
+    }
+    return slices;
+  }
+
   /** Schema-WAL instalments this database has shipped since it opened - see {@link #schemaInstalmentsShipped}. */
   public long getSchemaWalInstalmentsShipped() {
     return schemaInstalmentsShipped.get();
@@ -2203,17 +2268,40 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       for (final Map.Entry<Integer, Integer> grown : pagesGrownDuringSession(pageCountsBefore, addFiles).entrySet())
         appendFilePagesAsWal(grown.getKey(), walChunkBudget, walEntries, bucketDeltas, grown.getValue());
 
-      final List<RaftLogEntryCodec.TsSealedBlob> sealedBlobs = new ArrayList<>(compactionSealedBuffer.get());
+      final List<RaftLogEntryCodec.TsSealedBlob> recordedSealed = new ArrayList<>(compactionSealedBuffer.get());
 
-      if (addFiles.isEmpty() && removeFiles.isEmpty() && walEntries.isEmpty() && sealedBlobs.isEmpty())
+      if (addFiles.isEmpty() && removeFiles.isEmpty() && walEntries.isEmpty() && recordedSealed.isEmpty())
         return result;
 
+      // #4416: a sealed store bigger than one Raft entry is shipped as an ordered sequence of slices instead of
+      // being refused. Everything but the final slice of each store goes out HERE, ahead of the publishing entry,
+      // as a delivery-only entry the follower merely stages; the final slice is handed to replicateSchema below
+      // so the install lands in the same entry as the mutable-bucket clear WAL.
+      final long sealedChunkBudget = GlobalConfiguration.replicatedSealedChunkBudget(proxied.getConfiguration());
+      final List<RaftLogEntryCodec.TsSealedBlob> sealedBlobs = new ArrayList<>(recordedSealed.size());
+      final List<RaftLogEntryCodec.TsSealedChunk> finalSealedChunks = new ArrayList<>();
+      int sealedSlicesShipped = 0;
+      for (final RaftLogEntryCodec.TsSealedBlob blob : recordedSealed) {
+        final List<RaftLogEntryCodec.TsSealedChunk> slices = sliceSealedBlob(blob, sealedChunkBudget, getName());
+        if (slices.isEmpty()) {
+          sealedBlobs.add(blob);
+          continue;
+        }
+        for (int i = 0; i < slices.size() - 1; i++)
+          broker.replicateSealedChunk(getName(), slices.get(i));
+        finalSealedChunks.add(slices.getLast());
+        sealedSlicesShipped += slices.size();
+      }
+      sealedChunksShipped.addAndGet(sealedSlicesShipped);
+
       final String serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
-      broker.replicateSchema(getName(), serializedSchema, addFiles, removeFiles, walEntries, bucketDeltas, sealedBlobs);
+      broker.replicateSchema(getName(), serializedSchema, addFiles, removeFiles, walEntries, bucketDeltas,
+          sealedBlobs, finalSealedChunks);
 
       HALog.log(this, HALog.DETAILED,
-          "Compaction for database '%s' replicated via Raft: addFiles=%d, removeFiles=%d, walEntries=%d, sealedBlobs=%d",
-          getName(), addFiles.size(), removeFiles.size(), walEntries.size(), sealedBlobs.size());
+          "Compaction for database '%s' replicated via Raft: addFiles=%d, removeFiles=%d, walEntries=%d, "
+              + "sealedBlobs=%d, sealedSlices=%d",
+          getName(), addFiles.size(), removeFiles.size(), walEntries.size(), sealedBlobs.size(), sealedSlicesShipped);
 
       if (HALog.isEnabled(HALog.DETAILED))
         logSchemaPayloadDiagnostics("compaction", serializedSchema, addFiles, removeFiles);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -111,8 +111,24 @@ public class RaftTransactionBroker {
       final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
       final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
       final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs) {
+    replicateSchema(dbName, schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, sealedFileBlobs,
+        Collections.emptyList());
+  }
+
+  /**
+   * @param sealedFileChunks the FINAL slice of every sealed store shipped sliced (issue #4416). The earlier slices
+   *                         went out ahead of this call through {@link #replicateSealedChunk}; the last one rides
+   *                         the publishing entry so that installing the sealed file and applying the
+   *                         mutable-bucket clear WAL stay in the same entry, which is what keeps a follower from
+   *                         ever observing a cleared mutable bucket beside a stale sealed store.
+   */
+  public void replicateSchema(final String dbName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
+      final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs,
+      final List<RaftLogEntryCodec.TsSealedChunk> sealedFileChunks) {
     final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(dbName, schemaJson,
-        filesToAdd, filesToRemove, walEntries, bucketDeltas, sealedFileBlobs);
+        filesToAdd, filesToRemove, walEntries, bucketDeltas, sealedFileBlobs, false, sealedFileChunks);
 
     final long cap = groupCommitter.maxEntrySize();
     if (entry.size() <= cap) {
@@ -121,8 +137,38 @@ public class RaftTransactionBroker {
     }
 
     for (final ByteString chunk : splitSchemaEntry(dbName, schemaJson, filesToAdd, filesToRemove, walEntries,
-        bucketDeltas, sealedFileBlobs, cap, entry.size()))
+        bucketDeltas, sealedFileBlobs, sealedFileChunks, cap, entry.size(), false))
       groupCommitter.submitAndWait(chunk.toByteArray());
+  }
+
+  /**
+   * Ships ONE delivery-only slice of a sealed store that does not fit a single Raft entry (issue #4416).
+   * <p>
+   * Marked {@code moreChunksFollow} and carrying nothing else - no schema JSON, no file maps, no WAL - so the
+   * follower stages the bytes and does nothing that publishes: same ordered-prefix contract as
+   * {@link #replicateSchemaInstalment}, applied to a payload that is a file rather than a WAL stream. The slice is
+   * sized by the producer against {@code GlobalConfiguration.replicatedSealedChunkBudget}, so it fits by
+   * construction; the check below is the guard that says so out loud rather than toppling the leader when the
+   * arithmetic and the transport ever disagree (#4743).
+   *
+   * @throws ReplicatedEntryTooLargeException when the encoded slice still exceeds the entry cap
+   */
+  public void replicateSealedChunk(final String dbName, final RaftLogEntryCodec.TsSealedChunk chunk) {
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(dbName, "", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), true,
+        List.of(chunk));
+
+    final long cap = groupCommitter.maxEntrySize();
+    if (entry.size() > cap)
+      throw new ReplicatedEntryTooLargeException(String.format(
+          """
+          Sealed TimeSeries store slice for '%s' of database '%s' at offset %d is %d bytes encoded, above the \
+          maximum replicated entry size of %d bytes. Lower arcadedb.ha.tsMaxSealedInlineSize, or raise \
+          arcadedb.ha.appendBufferSize - and with it arcadedb.ha.writeBufferSize, which must stay >= \
+          appendBufferSize + 8 bytes.""",
+          chunk.fileName(), dbName, chunk.offset(), entry.size(), cap));
+
+    groupCommitter.submitAndWait(entry.toByteArray());
   }
 
   /**
@@ -206,13 +252,31 @@ public class RaftTransactionBroker {
       final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
       final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs, final long cap, final int singleEntrySize,
       final boolean moreAfterLast) {
+    return splitSchemaEntry(dbName, schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas,
+        sealedFileBlobs, Collections.emptyList(), cap, singleEntrySize, moreAfterLast);
+  }
+
+  /**
+   * @param sealedFileChunks the final sealed-store slices (issue #4416). They publish, exactly like the sealed
+   *                         blobs and {@code filesToRemove} beside them, so they ride the LAST chunk and are
+   *                         measured into its header budget.
+   */
+  // @VisibleForTesting
+  static List<ByteString> splitSchemaEntry(final String dbName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
+      final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs,
+      final List<RaftLogEntryCodec.TsSealedChunk> sealedFileChunks, final long cap, final int singleEntrySize,
+      final boolean moreAfterLast) {
 
     // Worst-case non-WAL payload: the first entry carries filesToAdd, the last one the schema JSON,
-    // filesToRemove and the sealed blobs. Measured by encoding both headers with no WAL at all.
+    // filesToRemove, the sealed blobs and the final sealed slices. Measured by encoding both headers with no
+    // WAL at all.
     final int firstHeaderSize = RaftLogEntryCodec.encodeSchemaEntry(dbName, "", filesToAdd,
         Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList()).size();
     final int lastHeaderSize = RaftLogEntryCodec.encodeSchemaEntry(dbName, schemaJson, Collections.emptyMap(),
-        filesToRemove, Collections.emptyList(), Collections.emptyList(), sealedFileBlobs).size();
+        filesToRemove, Collections.emptyList(), Collections.emptyList(), sealedFileBlobs, moreAfterLast,
+        sealedFileChunks).size();
     final long walBudget = cap - Math.max(firstHeaderSize, lastHeaderSize);
 
     if (walEntries == null || walEntries.isEmpty() || walBudget <= 0)
@@ -226,7 +290,8 @@ public class RaftTransactionBroker {
           dbName, singleEntrySize, cap, schemaJson != null ? schemaJson.length() : 0,
           filesToAdd != null ? filesToAdd.size() : 0, filesToRemove != null ? filesToRemove.size() : 0,
           walEntries != null ? walEntries.size() : 0,
-          sealedFileBlobs != null ? sealedFileBlobs.size() : 0));
+          (sealedFileBlobs != null ? sealedFileBlobs.size() : 0)
+              + (sealedFileChunks != null ? sealedFileChunks.size() : 0)));
 
     // Group the WAL entries by their RAW size: the codec compresses them, so a group that fits the
     // budget uncompressed always fits it encoded. Each group keeps its index-aligned bucket delta.
@@ -273,7 +338,8 @@ public class RaftTransactionBroker {
           last ? filesToRemove : Collections.emptyMap(),
           walGroups.get(g), deltaGroups.get(g),
           last ? sealedFileBlobs : Collections.emptyList(),
-          !last || moreAfterLast);
+          !last || moreAfterLast,
+          last ? sealedFileChunks : Collections.emptyList());
 
       if (chunk.size() > cap)
         // A single WAL entry (or the header plus one WAL entry) still does not fit. Fail loudly rather

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedApplyTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedApplyTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedBlob;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedChunk;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #4416, follower side: a sealed store too large for one Raft entry arrives as an ordered sequence of
+ * slices, and this is what the apply path does with them.
+ * <p>
+ * The mechanism is entirely inside {@code ArcadeStateMachine.applySealedChunks}, so it is driven against a real
+ * {@link LocalDatabase} and a real (unstarted) {@link ArcadeStateMachine} - the same harness
+ * {@code Issue6839TsSealedBlobRecoveryTest} uses. A 3-node IT proves the happy path end to end (see
+ * {@code Issue4416SlicedSealedStoreIT}) but cannot reach the arms that matter most here: a sequence that does not
+ * line up, and a reassembly that does not match what the leader hashed. Both must refuse to install and ask for a
+ * resync, because installing either would put this node on a sealed store no other node has.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue4416SlicedSealedApplyTest {
+
+  private static final String TYPE_NAME   = "Cpu";
+  private static final String SEALED_FILE = TYPE_NAME + "_shard_0.ts.sealed";
+  private static final int    LEADER_ROWS = 20_000;
+  private static final int    LOCAL_ROWS  = 500;
+
+  @TempDir
+  private Path          serverDir;
+  private LocalDatabase leader;
+  private LocalDatabase follower;
+  private String        followerPath;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    leader = (LocalDatabase) new DatabaseFactory(serverDir.resolve("db-leader").toString()).create();
+    build(leader, LEADER_ROWS, 0);
+
+    followerPath = serverDir.resolve("db-follower").toString();
+    follower = (LocalDatabase) new DatabaseFactory(followerPath).create();
+    build(follower, LOCAL_ROWS, 1_000_000);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (leader != null && leader.isOpen())
+      leader.close();
+    if (follower != null && follower.isOpen())
+      follower.close();
+  }
+
+  /**
+   * The whole feature in one arm: a sealed store that no single entry could carry is delivered in slices, staged
+   * on disk while it is incomplete, and installed - byte for byte the leader's file - when the last slice lands.
+   */
+  @Test
+  void aStoreTooLargeForOneEntryIsReassembledAndInstalled() throws Exception {
+    final byte[] leaderSealed = sealedBytesOf(leader);
+    final List<TsSealedChunk> slices = slice(leaderSealed, 4_096);
+    assertThat(slices).as("the fixture must actually exceed one slice, or this test proves nothing")
+        .hasSizeGreaterThan(2);
+
+    final ArcadeStateMachine stateMachine = new ArcadeStateMachine();
+    final File staging = new File(followerPath, SEALED_FILE + ArcadeStateMachine.SEALED_STAGING_SUFFIX);
+
+    // Every slice but the last is a delivery-only entry: it must stage bytes and change nothing a query can see.
+    final long sealedSamplesBefore = sealedSampleCountOf(follower);
+    for (int i = 0; i < slices.size() - 1; i++) {
+      stateMachine.applySealedChunks(follower, List.of(slices.get(i)));
+      assertThat(staging).as("slice %d must be staged on disk, not held in heap", i).exists();
+      assertThat(staging.length()).isEqualTo(slices.get(i).offset() + slices.get(i).bytes().length);
+      assertThat(sealedSampleCountOf(follower)).as("nothing may be published before the final slice")
+          .isEqualTo(sealedSamplesBefore);
+    }
+
+    stateMachine.applySealedChunks(follower, List.of(slices.getLast()));
+
+    assertThat(staging).as("the staging file is consumed by the install").doesNotExist();
+    assertThat(Files.readAllBytes(new File(followerPath, SEALED_FILE).toPath()))
+        .as("the installed file must be the leader's, byte for byte").isEqualTo(leaderSealed);
+    assertThat(sealedSampleCountOf(follower)).as("the leader's sealed samples are now readable here")
+        .isEqualTo(sealedSampleCountOf(leader));
+  }
+
+  /**
+   * The same store, shipped whole because it fits, still works: the two paths install the identical file, which is
+   * what makes the slicing decision purely a transport concern and not a semantic one.
+   */
+  @Test
+  void theSlicedInstallMatchesTheWholeFileInstall() throws Exception {
+    final byte[] leaderSealed = sealedBytesOf(leader);
+
+    new ArcadeStateMachine().applySealedBlobs(follower, List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealed)));
+    final long viaBlob = sealedSampleCountOf(follower);
+
+    new ArcadeStateMachine().applySealedChunks(follower, slice(leaderSealed, 4_096));
+
+    assertThat(sealedSampleCountOf(follower)).isEqualTo(viaBlob);
+    assertThat(Files.readAllBytes(new File(followerPath, SEALED_FILE).toPath())).isEqualTo(leaderSealed);
+  }
+
+  /**
+   * A slice that does not start where this node's staging file ends means the sequence being delivered is not the
+   * sequence this node holds - a leader change mid-shipment, a staging file removed underneath it. Local state
+   * cannot be trusted to complete it, so the apply asks for a resync instead of assembling a file nobody has.
+   */
+  @Test
+  void aSliceThatDoesNotLineUpAsksForAResync() throws Exception {
+    final List<TsSealedChunk> slices = slice(sealedBytesOf(leader), 4_096);
+
+    assertThatThrownBy(() -> new ArcadeStateMachine().applySealedChunks(follower, List.of(slices.get(1))))
+        .as("a mid-sequence slice with nothing staged cannot be assembled")
+        .isInstanceOf(ReplicationException.class)
+        .hasMessageContaining("slice sequence is broken");
+
+    assertThat(new File(followerPath, SEALED_FILE + ArcadeStateMachine.SEALED_STAGING_SUFFIX))
+        .as("nothing may be staged from a slice that was refused").doesNotExist();
+  }
+
+  /**
+   * The first slice TRUNCATES whatever was staged before it, which is what makes a sequence abandoned by a leader
+   * that died mid-shipment cost nothing: the next leader simply starts again.
+   */
+  @Test
+  void aRestartedSequenceDiscardsTheAbandonedStagingFile() throws Exception {
+    final byte[] leaderSealed = sealedBytesOf(leader);
+    final ArcadeStateMachine stateMachine = new ArcadeStateMachine();
+
+    // An abandoned sequence: two slices of a much finer cut, then nothing.
+    final List<TsSealedChunk> abandoned = slice(leaderSealed, 1_024);
+    stateMachine.applySealedChunks(follower, List.of(abandoned.get(0)));
+    stateMachine.applySealedChunks(follower, List.of(abandoned.get(1)));
+
+    // A fresh sequence at a different cut completes normally over it.
+    stateMachine.applySealedChunks(follower, slice(leaderSealed, 4_096));
+
+    assertThat(Files.readAllBytes(new File(followerPath, SEALED_FILE).toPath())).isEqualTo(leaderSealed);
+    assertThat(sealedSampleCountOf(follower)).isEqualTo(sealedSampleCountOf(leader));
+  }
+
+  /**
+   * The whole-file CRC is what per-slice CRCs cannot say: each slice survived the wire, but what this node
+   * ASSEMBLED is not what the leader hashed. Installing it would put this node on a sealed store no other node
+   * has, so it is refused, the staging file goes, and the database resyncs.
+   */
+  @Test
+  void areassemblyThatDoesNotMatchTheLeaderIsRefused() throws Exception {
+    final byte[] leaderSealed = sealedBytesOf(leader);
+    final List<TsSealedChunk> slices = slice(leaderSealed, 4_096);
+
+    // Corrupt one slice's payload while leaving the sequence's shape - offsets, lengths, flags - intact.
+    final TsSealedChunk original = slices.get(1);
+    final byte[] corrupted = original.bytes().clone();
+    corrupted[0] ^= 0x5A;
+    slices.set(1, new TsSealedChunk(original.typeName(), original.shardIndex(), original.fileName(),
+        original.fileLength(), original.fileCrc(), original.offset(), corrupted, original.last()));
+
+    final File installed = new File(followerPath, SEALED_FILE);
+    final byte[] before = Files.readAllBytes(installed.toPath());
+
+    assertThatThrownBy(() -> new ArcadeStateMachine().applySealedChunks(follower, slices))
+        .isInstanceOf(ReplicationException.class)
+        .hasMessageContaining("CRC");
+
+    assertThat(new File(followerPath, SEALED_FILE + ArcadeStateMachine.SEALED_STAGING_SUFFIX))
+        .as("a rejected reassembly must not be left behind for the next sequence to append to").doesNotExist();
+    assertThat(Files.readAllBytes(installed.toPath()))
+        .as("this node keeps the sealed store it had rather than installing one nobody has").isEqualTo(before);
+  }
+
+  /** A final slice whose reassembled length disagrees with the leader's is refused for the same reason. */
+  @Test
+  void areassemblyOfTheWrongLengthIsRefused() throws Exception {
+    final List<TsSealedChunk> slices = slice(sealedBytesOf(leader), 4_096);
+    final TsSealedChunk last = slices.getLast();
+    slices.set(slices.size() - 1, new TsSealedChunk(last.typeName(), last.shardIndex(), last.fileName(),
+        last.fileLength() + 4_096, last.fileCrc(), last.offset(), last.bytes(), true));
+
+    assertThatThrownBy(() -> new ArcadeStateMachine().applySealedChunks(follower, slices))
+        .isInstanceOf(ReplicationException.class)
+        .hasMessageContaining("reassembled to");
+  }
+
+  /** A slice naming a type that has no sealed store is logged away, never written: same rule as a whole blob. */
+  @Test
+  void aSliceForANonTimeSeriesTypeIsRefused() throws Exception {
+    follower.getSchema().createDocumentType("NotATimeSeries");
+
+    new ArcadeStateMachine().applySealedChunks(follower, List.of(
+        new TsSealedChunk("NotATimeSeries", 0, "NotATimeSeries_shard_0.ts.sealed", 3L, 0L, 0L,
+            new byte[] { 1, 2, 3 }, true)));
+
+    assertThat(new File(followerPath, "NotATimeSeries_shard_0.ts.sealed"))
+        .as("nothing may be written for a type that has no sealed store").doesNotExist();
+    assertThat(new File(followerPath, "NotATimeSeries_shard_0.ts.sealed" + ArcadeStateMachine.SEALED_STAGING_SUFFIX))
+        .doesNotExist();
+  }
+
+  // ---- Helpers ----
+
+  private static List<TsSealedChunk> slice(final byte[] sealed, final long budget) {
+    return new ArrayList<>(
+        RaftReplicatedDatabase.sliceSealedBlob(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, sealed), budget, "db"));
+  }
+
+  private byte[] sealedBytesOf(final LocalDatabase database) throws IOException {
+    return Files.readAllBytes(new File(database.getDatabasePath(), SEALED_FILE).toPath());
+  }
+
+  private static long sealedSampleCountOf(final LocalDatabase database) {
+    return ((LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME)).getEngine().getShard(0).getSealedStore()
+        .getTotalSampleCount();
+  }
+
+  private static void build(final LocalDatabase database, final int rows, final int from) throws IOException {
+    database.command("sql", "CREATE TIMESERIES TYPE " + TYPE_NAME
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME)).getEngine();
+
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + (from + i) * 1_000L;
+      columns[0][i] = "host_" + ((from + i) % 7);
+      columns[1][i] = Math.sin(from + i) * 1_000;
+    }
+    engine.appendBatch(timestamps, columns);
+    engine.compactAll();
+
+    assertThat(new File(database.getDatabasePath(), SEALED_FILE)).exists();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedApplyTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedApplyTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -169,6 +170,33 @@ class Issue4416SlicedSealedApplyTest {
     stateMachine.applySealedChunks(follower, slice(leaderSealed, 4_096));
 
     assertThat(Files.readAllBytes(new File(followerPath, SEALED_FILE).toPath())).isEqualTo(leaderSealed);
+    assertThat(sealedSampleCountOf(follower)).isEqualTo(sealedSampleCountOf(leader));
+  }
+
+  /**
+   * The first slice must discard a LONGER leftover, not write over its head. {@code RandomAccessFile.write} never
+   * shrinks a file, so a staging file left behind by a longer abandoned sequence would keep its tail underneath
+   * the new one and the reassembly would come out the wrong length.
+   * <p>
+   * It plants the leftover directly rather than producing one, because the leftover this guards against is the
+   * one a FAILED delete leaves - and a delete that fails is not something a test can arrange portably. What it
+   * pins is therefore the invariant rather than the mechanism: offset 0 discards whatever was staged, however
+   * that is implemented. Remove both the truncation and the delete and this fails.
+   */
+  @Test
+  void theFirstSliceDiscardsALongerLeftover() throws Exception {
+    final byte[] leaderSealed = sealedBytesOf(leader);
+    final File staging = new File(followerPath, SEALED_FILE + ArcadeStateMachine.SEALED_STAGING_SUFFIX);
+
+    try (final RandomAccessFile leftover = new RandomAccessFile(staging, "rw")) {
+      leftover.setLength(leaderSealed.length + 8_192L);
+    }
+
+    new ArcadeStateMachine().applySealedChunks(follower, slice(leaderSealed, 4_096));
+
+    assertThat(staging).doesNotExist();
+    assertThat(Files.readAllBytes(new File(followerPath, SEALED_FILE).toPath()))
+        .as("the leftover tail must not have survived under the new image").isEqualTo(leaderSealed);
     assertThat(sealedSampleCountOf(follower)).isEqualTo(sealedSampleCountOf(leader));
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreIT.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #4416, end to end: a TimeSeries shard whose sealed store does not fit one Raft entry must keep sealing.
+ * <p>
+ * Before this, {@code TimeSeriesShard.compactInternal} skipped such a shard outright and logged a warning. That
+ * kept the cluster correct - the samples stay in the fully replicated mutable bucket - but the skip was
+ * PERMANENT: the store it refused to ship only grows, so the projected size never came back under the cap and the
+ * shard never sealed again, never compressed, never retained, never downsampled. This test pins the behaviour
+ * that replaces it: the store is sliced across an ordered sequence of entries, and every node ends up with the
+ * leader's sealed file and an empty mutable bucket.
+ * <p>
+ * The cap is set just above the per-slice framing so a modest sealed store needs several slices. That is the
+ * whole point of driving it from configuration rather than from volume: the mechanism under test is the sequence,
+ * not the megabytes, and a test that had to write a real 48MB store on three in-process nodes would trade the
+ * evidence for runtime.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue4416SlicedSealedStoreIT extends BaseRaftHATest {
+
+  /**
+   * Just enough over the per-slice framing that a slice carries a useful payload, and little enough that a modest
+   * sealed store still needs several. It also sets the ceiling this shard must stay under - 512 slices of the
+   * budget below, comfortably above anything {@link #SAMPLES} can seal - because a store OVER the ceiling is
+   * still skipped, and a test that quietly crossed it would be asserting the old behaviour.
+   */
+  private static final long SEALED_ENTRY_CAP = GlobalConfiguration.REPLICATED_SEALED_CHUNK_FRAMING_BYTES + 256;
+  private static final int  SAMPLES          = 200;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void checkDatabasesAreIdentical() {
+    // Sealed stores use direct file I/O, not page-level replication; equality is asserted in-test instead.
+  }
+
+  @Test
+  @Tag("slow")
+  void aSealedStoreTooLargeForOneEntryIsStillSealedAndReplicated() throws Exception {
+    // The cap is read live from the configuration at compaction time, and a database's ContextConfiguration falls
+    // back to the global value for anything it does not override - so setting it here, before the first
+    // compaction, reaches every node in this JVM. Restored for the other test classes, exactly as
+    // RaftTimeSeriesOversizedSealedIT does it.
+    final Object previousCap = GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE.getValue();
+    GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE.setValue(SEALED_ENTRY_CAP);
+    try {
+      final int leaderIndex = findLeaderIndex();
+      assertThat(leaderIndex).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+
+      executeCommand(leaderIndex, "sql",
+          "CREATE TIMESERIES TYPE weather TIMESTAMP ts TAGS (location STRING) FIELDS (temperature DOUBLE) SHARDS 1");
+      waitForReplicationIsCompleted(leaderIndex);
+
+      insertSamples(0, SAMPLES);
+      awaitAllServersReportSamples(SAMPLES);
+
+      timeSeriesEngine(findLeaderIndex()).compactAll();
+
+      // The regression itself: compaction actually RAN. Under the old cap this shard would have been skipped, the
+      // mutable bucket would still hold every sample, and the sealed store would still be empty.
+      awaitCompactionLanded(SAMPLES);
+
+      final int leaderAfter = findLeaderIndex();
+      assertThat((long) readSealedFile(leaderAfter).length)
+          .as("the sealed store must be larger than one slice may carry, or nothing was sliced")
+          .isGreaterThan(sliceBudget());
+      assertThat((long) readSealedFile(leaderAfter).length)
+          .as("and it must stay under the ceiling, or the shard was skipped and this test proves the OLD behaviour")
+          .isLessThan(sealedStoreCeiling());
+      assertThat(totalSealedSlicesShipped())
+          .as("the store must have travelled as a SEQUENCE of slices, not inline: that is the path under test")
+          .isGreaterThan(1L);
+
+      // A second cycle over a store that is already large: the sequence has to work when the follower's staging
+      // file already existed and the leader's image is a rewrite rather than a first seal.
+      insertSamples(SAMPLES, SAMPLES * 2);
+      awaitAllServersReportSamples(SAMPLES * 2);
+      timeSeriesEngine(findLeaderIndex()).compactAll();
+      awaitCompactionLanded(SAMPLES * 2);
+    } finally {
+      GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE.setValue(previousCap);
+    }
+  }
+
+  /**
+   * Every node holds the leader's sealed file, no node still holds the samples in its mutable bucket, and every
+   * node answers the same count. Asserted together because a partial truth here is the failure mode: a follower
+   * that applied the clear WAL without installing the sealed slices would report a LOWER count, and one that
+   * installed without clearing would report a higher one.
+   */
+  private void awaitCompactionLanded(final long expectedSamples) {
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(250, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+      final int leader = findLeaderIndex();
+      final byte[] leaderSealed = readSealedFile(leader);
+      assertThat(leaderSealed.length).as("the leader must have sealed something").isGreaterThan(0);
+
+      for (int i = 0; i < getServerCount(); i++) {
+        assertThat(countSamples(i)).as("sample count on server %d", i).isEqualTo(expectedSamples);
+        assertThat(mutableSampleCount(i)).as("mutable bucket on server %d after compaction", i).isZero();
+        if (i != leader)
+          assertThat(readSealedFile(i)).as("sealed store on server %d must match leader %d", i, leader)
+              .isEqualTo(leaderSealed);
+      }
+    });
+  }
+
+  /** What one slice may carry under {@link #SEALED_ENTRY_CAP}, asked of the production arithmetic itself. */
+  private static long sliceBudget() {
+    return GlobalConfiguration.replicatedSealedChunkBudget(cappedConfiguration());
+  }
+
+  /** The largest sealed store this configuration will replicate at all; above it the shard is still skipped. */
+  private static long sealedStoreCeiling() {
+    return GlobalConfiguration.maxReplicatedSealedStoreSize(cappedConfiguration());
+  }
+
+  private static ContextConfiguration cappedConfiguration() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE, SEALED_ENTRY_CAP);
+    return configuration;
+  }
+
+  /** Only the node that compacted ships slices, and an election may have moved it; sum rather than guess. */
+  private long totalSealedSlicesShipped() {
+    long total = 0;
+    for (int i = 0; i < getServerCount(); i++) {
+      final DatabaseInternal wrapped =
+          ((DatabaseInternal) getServerDatabase(i, getDatabaseName())).getWrappedDatabaseInstance();
+      if (wrapped instanceof RaftReplicatedDatabase raft)
+        total += raft.getSealedStoreChunksShipped();
+    }
+    return total;
+  }
+
+  private void insertSamples(final int fromInclusive, final int toExclusive) throws Exception {
+    for (int i = fromInclusive; i < toExclusive; i++)
+      executeCommand(findLeaderIndex(), "sql",
+          "INSERT INTO weather SET ts = " + (1_000 + i) + ", location = 'loc-" + (i % 5) + "', temperature = "
+              + (20.0 + i));
+  }
+
+  private void awaitAllServersReportSamples(final long expected) {
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(250, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+      for (int i = 0; i < getServerCount(); i++)
+        assertThat(countSamples(i)).as("sample count on server %d", i).isEqualTo(expected);
+    });
+  }
+
+  private long countSamples(final int serverIndex) {
+    final Database db = getServer(serverIndex).getDatabase(getDatabaseName());
+    try (final ResultSet rs = db.query("sql", "SELECT count(*) AS cnt FROM weather")) {
+      return rs.hasNext() ? rs.next().<Number>getProperty("cnt").longValue() : 0L;
+    }
+  }
+
+  private TimeSeriesEngine timeSeriesEngine(final int serverIndex) {
+    final DatabaseInternal db = (DatabaseInternal) getServer(serverIndex).getDatabase(getDatabaseName());
+    return ((LocalTimeSeriesType) db.getSchema().getType("weather")).getEngine();
+  }
+
+  private long mutableSampleCount(final int serverIndex) throws IOException {
+    final TimeSeriesEngine engine = timeSeriesEngine(serverIndex);
+    long total = 0;
+    for (int s = 0; s < engine.getShardCount(); s++)
+      total += engine.getShard(s).getMutableBucket().getSampleCount();
+    return total;
+  }
+
+  private byte[] readSealedFile(final int serverIndex) throws IOException {
+    final File sealed = new File(getDatabasePath(serverIndex), "weather_shard_0.ts.sealed");
+    return sealed.exists() ? Files.readAllBytes(sealed.toPath()) : new byte[0];
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreTest.java
@@ -265,11 +265,6 @@ class Issue4416SlicedSealedStoreTest {
   }
 
   /**
-   * A cap so small that a slice cannot even carry its own framing leaves the ceiling AT the per-entry cap, which
-   * is what keeps the pre-existing behaviour intact: such a shard is still skipped and its samples still stay in
-   * the replicated mutable bucket, rather than being shipped as an unbounded run of payload-free entries.
-   */
-  /**
    * The reserve has to grow WITH the slice, because what it absorbs does: a slice of already-compressed sealed
    * blocks can come off the LZ4 encoder larger than it went in, by up to {@code n/255 + 16} bytes. A fixed reserve
    * is under water by the time the entry cap reaches a few megabytes, and an entry over the cap is not a slow
@@ -291,6 +286,11 @@ class Issue4416SlicedSealedStoreTest {
     }
   }
 
+  /**
+   * A cap so small that a slice cannot even carry its own framing leaves the ceiling AT the per-entry cap, which
+   * is what keeps the pre-existing behaviour intact: such a shard is still skipped and its samples still stay in
+   * the replicated mutable bucket, rather than being shipped as an unbounded run of payload-free entries.
+   */
   @Test
   void aCapTooSmallToSliceLeavesTheCeilingAtOneEntry() {
     final ContextConfiguration configuration = new ContextConfiguration();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreTest.java
@@ -292,9 +292,12 @@ class Issue4416SlicedSealedStoreTest {
   // ---- where the ceiling now sits --------------------------------------------------------------------------
 
   /**
-   * The ceiling with stock settings: the 4MB appender limit binds per ENTRY (#4743), and 512 slices of it put the
-   * per-shard sealed store far above the 48MB the inline cap used to impose. The comparison is against the
-   * configured inline cap itself, because that number IS what used to stop the shard sealing.
+   * The ceiling with stock settings: the 32MB append-buffer limit binds per ENTRY (#4743) rather than the 48MB
+   * inline cap, and slicing puts the per-shard sealed store far above the 48MB that cap used to impose. The
+   * comparison is against the configured inline cap itself, because that number IS what used to stop the shard
+   * sealing. Which of the two bounds actually SETS the ceiling is pinned separately by
+   * {@link #atStockSettingsTheCeilingComesFromTheClampNotFromTheSliceCount} - it is the Integer.MAX_VALUE clamp,
+   * not 512 times the budget.
    */
   @Test
   void theDefaultCeilingIsFarAboveTheInlineCap() {
@@ -355,6 +358,67 @@ class Issue4416SlicedSealedStoreTest {
     assertThat(GlobalConfiguration.maxReplicatedSealedEntrySize(configuration)).isEqualTo(1024L * 1024);
     assertThat(GlobalConfiguration.replicatedSealedChunkBudget(configuration))
         .isEqualTo(1024L * 1024 - GlobalConfiguration.REPLICATED_SEALED_CHUNK_FRAMING_BYTES - (1024L * 1024) / 128);
+  }
+
+  /**
+   * The branch nothing else pins: a store needing MORE than {@link GlobalConfiguration#MAX_REPLICATED_SEALED_CHUNKS}
+   * slices is still shipped, whole and intact, rather than refused.
+   * <p>
+   * Refusing here is the tempting alternative and it is WRONG: the leader has already rewritten and swapped its
+   * sealed file by the time the slicer runs, so withholding it leaves every follower on an image no node holds any
+   * more. That is divergence traded for a latency spike. This test is what stops a future "surely we should cap
+   * this" edit from making that trade silently - it fails the moment the slicer starts returning a truncated list
+   * or an empty one.
+   * <p>
+   * Only the maintenance path (retention, downsampling) can reach here: {@code TimeSeriesShard.compactInternal}
+   * has a pre-check that keeps compaction under the ceiling, and {@code runSealedMaintenanceReplicated}
+   * deliberately has none, for the same divergence reason.
+   */
+  @Test
+  void aStoreNeedingMoreSlicesThanExpectedIsShippedANYWAYRatherThanRefused() {
+    final int overTheBound = GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS + 137;
+    final byte[] sealed = randomBytes(overTheBound);
+
+    final List<TsSealedChunk> slices = RaftReplicatedDatabase.sliceSealedBlob(
+        new TsSealedBlob(TYPE, 0, FILE, sealed), 1, DB);
+
+    assertThat(slices).as("every byte must still ship - a short list here is silent follower divergence")
+        .hasSize(overTheBound);
+    assertThat(slices.stream().filter(TsSealedChunk::last).count()).as("exactly one slice publishes").isEqualTo(1);
+    assertThat(slices.getLast().last()).isTrue();
+
+    final ByteArrayOutputStream reassembled = new ByteArrayOutputStream();
+    long nextOffset = 0;
+    for (final TsSealedChunk slice : slices) {
+      assertThat(slice.offset()).isEqualTo(nextOffset);
+      assertThat(slice.fileLength()).isEqualTo(sealed.length);
+      reassembled.writeBytes(slice.bytes());
+      nextOffset += slice.bytes().length;
+    }
+    assertThat(reassembled.toByteArray()).as("an oversized sequence still reassembles exactly").isEqualTo(sealed);
+  }
+
+  /**
+   * The regime that made the skip warning's old "%d slices of %d bytes each" sentence arithmetically FALSE: at the
+   * stock settings the {@link Integer#MAX_VALUE} clamp - not
+   * {@link GlobalConfiguration#MAX_REPLICATED_SEALED_CHUNKS} times the budget - is what sets the ceiling, and the
+   * two differ by an order of magnitude. An operator who multiplies the two numbers printed in that message and
+   * does not get the ceiling printed beside them stops believing the message.
+   */
+  @Test
+  void atStockSettingsTheCeilingComesFromTheClampNotFromTheSliceCount() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+
+    final long budget = GlobalConfiguration.replicatedSealedChunkBudget(configuration);
+    final long ceiling = GlobalConfiguration.maxReplicatedSealedStoreSize(configuration);
+
+    assertThat(ceiling).as("the clamp is what binds").isEqualTo(Integer.MAX_VALUE);
+    assertThat(budget * GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS)
+        .as("so the product is NOT the ceiling, and a message asserting it is would be wrong")
+        .isGreaterThan(ceiling);
+    assertThat(ceiling / budget).as("the stock ceiling is reached in far fewer than %d slices",
+        GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS)
+        .isLessThan(GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS);
   }
 
   private static byte[] randomBytes(final int length) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedBlob;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedChunk;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.zip.CRC32;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #4416: a TimeSeries shard used to stop sealing FOREVER once its sealed store outgrew what one Raft entry
+ * could carry. The store only grows, so the projected size never came back under the cap, and the shard's samples
+ * stayed in the uncompressed mutable bucket for good - correct and fully replicated, but never compressed, never
+ * retained, never downsampled.
+ * <p>
+ * The ceiling is lifted by SLICING: a store above one entry is shipped as an ordered sequence of entries the
+ * follower stages and reassembles. This class pins the leader-side half of that - the arithmetic a follower's
+ * reassembly depends on, the wire section that carries it, and the configuration that decides where the remaining
+ * ceiling sits - without a cluster, because none of it needs one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue4416SlicedSealedStoreTest {
+
+  private static final String DB   = "graph";
+  private static final String TYPE = "weather";
+  private static final String FILE = "weather_shard_0.ts.sealed";
+
+  // ---- the slicer ------------------------------------------------------------------------------------------
+
+  /**
+   * A store that fits one entry keeps shipping the way it always did: as a whole-file blob. The empty list is the
+   * signal for that, and it is what keeps every cluster whose stores fit inline byte-for-byte on the old path.
+   */
+  @Test
+  void aStoreThatFitsOneEntryIsNotSliced() {
+    final TsSealedBlob blob = new TsSealedBlob(TYPE, 0, FILE, new byte[4096]);
+
+    assertThat(RaftReplicatedDatabase.sliceSealedBlob(blob, 4096, DB)).isEmpty();
+    assertThat(RaftReplicatedDatabase.sliceSealedBlob(blob, 8192, DB)).isEmpty();
+  }
+
+  /**
+   * A budget of zero is what a cap too small to hold even one slice's framing produces. Slicing is impossible
+   * there, and saying so with an empty list is what leaves {@code TimeSeriesShard}'s guard free to skip the shard
+   * exactly as it did before slicing existed - rather than emitting a sequence of entries that carry no payload.
+   */
+  @Test
+  void aNonPositiveBudgetDisablesSlicing() {
+    final TsSealedBlob blob = new TsSealedBlob(TYPE, 0, FILE, new byte[4096]);
+
+    assertThat(RaftReplicatedDatabase.sliceSealedBlob(blob, 0, DB)).isEmpty();
+    assertThat(RaftReplicatedDatabase.sliceSealedBlob(blob, -1, DB)).isEmpty();
+  }
+
+  /**
+   * The invariants a follower's reassembly is built on, asserted together because they only mean anything
+   * together: contiguous offsets starting at zero, no slice above the budget, exactly one slice flagged
+   * {@code last}, one whole-file length and CRC every slice agrees on, and bytes that concatenate back to the
+   * original image.
+   */
+  @Test
+  void slicesReassembleIntoTheOriginalImage() throws Exception {
+    final byte[] sealed = randomBytes(10_000);
+    final long budget = 3_000;
+
+    final List<TsSealedChunk> slices = RaftReplicatedDatabase.sliceSealedBlob(
+        new TsSealedBlob(TYPE, 3, FILE, sealed), budget, DB);
+
+    assertThat(slices).as("10000 bytes at 3000 per slice").hasSize(4);
+
+    final CRC32 expectedCrc = new CRC32();
+    expectedCrc.update(sealed);
+
+    long nextOffset = 0;
+    final ByteArrayOutputStream reassembled = new ByteArrayOutputStream();
+    for (int i = 0; i < slices.size(); i++) {
+      final TsSealedChunk slice = slices.get(i);
+      assertThat(slice.typeName()).isEqualTo(TYPE);
+      assertThat(slice.shardIndex()).isEqualTo(3);
+      assertThat(slice.fileName()).isEqualTo(FILE);
+      assertThat(slice.offset()).as("slice %d must start where slice %d ended", i, i - 1).isEqualTo(nextOffset);
+      assertThat(slice.bytes().length).as("no slice may exceed the budget").isLessThanOrEqualTo((int) budget);
+      assertThat(slice.fileLength()).as("every slice describes the WHOLE file").isEqualTo(sealed.length);
+      assertThat(slice.fileCrc()).as("every slice carries the WHOLE file's CRC").isEqualTo(expectedCrc.getValue());
+      assertThat(slice.last()).as("only the final slice publishes").isEqualTo(i == slices.size() - 1);
+      reassembled.write(slice.bytes());
+      nextOffset += slice.bytes().length;
+    }
+
+    assertThat(reassembled.toByteArray()).isEqualTo(sealed);
+  }
+
+  /** A file that divides exactly by the budget must not produce a trailing empty slice. */
+  @Test
+  void anExactMultipleOfTheBudgetProducesNoEmptyTrailingSlice() {
+    final List<TsSealedChunk> slices = RaftReplicatedDatabase.sliceSealedBlob(
+        new TsSealedBlob(TYPE, 0, FILE, randomBytes(9_000)), 3_000, DB);
+
+    assertThat(slices).hasSize(3);
+    assertThat(slices).allSatisfy(slice -> assertThat(slice.bytes()).isNotEmpty());
+    assertThat(slices.getLast().last()).isTrue();
+  }
+
+  // ---- the wire format -------------------------------------------------------------------------------------
+
+  /** Round trip of the slice section, including the flag that has to be readable BEFORE it. */
+  @Test
+  void schemaEntryCarriesSlicesThroughAnEncodeDecodeRoundTrip() {
+    final byte[] payload = randomBytes(2_048);
+    final TsSealedChunk slice = new TsSealedChunk(TYPE, 2, FILE, 9_999L, 1234567L, 4_096L, payload, true);
+
+    final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry(DB, "{\"x\":1}", Map.of(7, "a.dat"),
+        Collections.emptyMap(), List.of("wal".getBytes()), List.of(Map.of(1, 2)), Collections.emptyList(), false,
+        List.of(slice));
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(encoded);
+
+    assertThat(decoded.moreChunksFollow()).as("the flag before the new section must still decode").isFalse();
+    assertThat(decoded.schemaJson()).isEqualTo("{\"x\":1}");
+    assertThat(decoded.filesToAdd()).containsEntry(7, "a.dat");
+    assertThat(decoded.walEntries()).hasSize(1);
+    assertThat(decoded.sealedFileBlobs()).isEmpty();
+    assertThat(decoded.sealedFileChunks()).hasSize(1);
+
+    final TsSealedChunk back = decoded.sealedFileChunks().getFirst();
+    assertThat(back.typeName()).isEqualTo(TYPE);
+    assertThat(back.shardIndex()).isEqualTo(2);
+    assertThat(back.fileName()).isEqualTo(FILE);
+    assertThat(back.fileLength()).isEqualTo(9_999L);
+    assertThat(back.fileCrc()).isEqualTo(1234567L);
+    assertThat(back.offset()).isEqualTo(4_096L);
+    assertThat(back.last()).isTrue();
+    assertThat(back.bytes()).isEqualTo(payload);
+  }
+
+  /**
+   * A delivery-only slice entry - the shape every slice but the last travels in - must decode with the
+   * continuation flag SET, because that flag is what stops the follower reloading its schema over a state the
+   * sequence has not finished delivering (#5443).
+   */
+  @Test
+  void aDeliveryOnlySliceEntryKeepsTheContinuationFlag() {
+    final TsSealedChunk slice = new TsSealedChunk(TYPE, 0, FILE, 8_192L, 42L, 0L, randomBytes(4_096), false);
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(), Collections.emptyMap(),
+            Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), true, List.of(slice)));
+
+    assertThat(decoded.moreChunksFollow()).isTrue();
+    assertThat(decoded.sealedFileChunks()).hasSize(1);
+    assertThat(decoded.sealedFileChunks().getFirst().last()).isFalse();
+    assertThat(decoded.schemaJson()).isEmpty();
+    assertThat(decoded.walEntries()).isEmpty();
+  }
+
+  /**
+   * The compatibility claim, asserted on the BYTES rather than on the decode: an entry with nothing to slice must
+   * be byte-identical to what the previous codec produced, or the new trailing section is not trailing at all and
+   * every entry a mixed-version cluster exchanges changes shape.
+   */
+  @Test
+  void anEntryWithNoSlicesIsByteIdenticalToThePreviousFormat() {
+    final List<byte[]> wal = List.of("wal-one".getBytes(), "wal-two".getBytes());
+    final List<TsSealedBlob> blobs = List.of(new TsSealedBlob(TYPE, 0, FILE, randomBytes(512)));
+
+    final ByteString withoutTheParameter = RaftLogEntryCodec.encodeSchemaEntry(DB, "{}", Map.of(1, "f.dat"),
+        Map.of(2, "g.dat"), wal, List.of(Map.of(3, 4), Map.of(5, 6)), blobs);
+    final ByteString withAnEmptySection = RaftLogEntryCodec.encodeSchemaEntry(DB, "{}", Map.of(1, "f.dat"),
+        Map.of(2, "g.dat"), wal, List.of(Map.of(3, 4), Map.of(5, 6)), blobs, false, Collections.emptyList());
+
+    assertThat(withAnEmptySection.toByteArray()).isEqualTo(withoutTheParameter.toByteArray());
+    assertThat(RaftLogEntryCodec.decode(withoutTheParameter).sealedFileChunks()).isEmpty();
+  }
+
+  /** A slice corrupted on the wire is refused, not installed: the decoder checks a per-slice CRC. */
+  @Test
+  void aCorruptedSliceFailsItsCrc() {
+    final TsSealedChunk slice = new TsSealedChunk(TYPE, 0, FILE, 1_024L, 7L, 0L, randomBytes(1_024), true);
+    final byte[] encoded = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false,
+        List.of(slice)).toByteArray();
+
+    // Flip a byte inside the compressed slice payload, which is the tail of the entry.
+    encoded[encoded.length - 5] ^= 0x7F;
+
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(ByteString.copyFrom(encoded)))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  // ---- the splitter ----------------------------------------------------------------------------------------
+
+  /**
+   * A publishing entry that ALSO has to be split by WAL volume must keep its final slices on the LAST chunk, next
+   * to the schema JSON and {@code filesToRemove}: the slices publish, and publishing early is what #5443 showed to
+   * be sticky rather than merely wasteful.
+   */
+  @Test
+  void theFinalSlicesRideTheLastChunkOfASplitSchemaEntry() {
+    final List<byte[]> wal = List.of(new byte[3_000], new byte[3_000], new byte[3_000]);
+    final List<TsSealedChunk> finalSlices = List.of(
+        new TsSealedChunk(TYPE, 0, FILE, 12_000L, 99L, 9_000L, randomBytes(3_000), true));
+
+    final List<ByteString> chunks = RaftTransactionBroker.splitSchemaEntry(DB, "{\"schema\":1}",
+        Collections.emptyMap(), Collections.emptyMap(), wal, List.of(Map.of(), Map.of(), Map.of()),
+        Collections.emptyList(), finalSlices, 8_000, 20_000, false);
+
+    assertThat(chunks).as("three 3000-byte WAL entries cannot share one 8000-byte entry").hasSizeGreaterThan(1);
+
+    for (int i = 0; i < chunks.size(); i++) {
+      final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(chunks.get(i));
+      final boolean last = i == chunks.size() - 1;
+      assertThat(decoded.sealedFileChunks().isEmpty())
+          .as("only the publishing chunk may carry sealed slices (chunk %d/%d)", i + 1, chunks.size())
+          .isEqualTo(!last);
+      assertThat(decoded.moreChunksFollow()).isEqualTo(!last);
+    }
+  }
+
+  // ---- where the ceiling now sits --------------------------------------------------------------------------
+
+  /**
+   * The ceiling with stock settings: the 4MB appender limit binds per ENTRY (#4743), and 512 slices of it put the
+   * per-shard sealed store far above the 48MB the inline cap used to impose. The comparison is against the
+   * configured inline cap itself, because that number IS what used to stop the shard sealing.
+   */
+  @Test
+  void theDefaultCeilingIsFarAboveTheInlineCap() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+
+    final long ceiling = GlobalConfiguration.maxReplicatedSealedStoreSize(configuration);
+
+    assertThat(ceiling).isGreaterThan(configuration.getValueAsLong(GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE));
+    assertThat(ceiling).isGreaterThan(GlobalConfiguration.maxReplicatedRaftEntrySize(configuration));
+    assertThat(ceiling).as("the leader still materializes the file as one array before slicing it")
+        .isLessThanOrEqualTo(Integer.MAX_VALUE);
+  }
+
+  /**
+   * A cap so small that a slice cannot even carry its own framing leaves the ceiling AT the per-entry cap, which
+   * is what keeps the pre-existing behaviour intact: such a shard is still skipped and its samples still stay in
+   * the replicated mutable bucket, rather than being shipped as an unbounded run of payload-free entries.
+   */
+  /**
+   * The reserve has to grow WITH the slice, because what it absorbs does: a slice of already-compressed sealed
+   * blocks can come off the LZ4 encoder larger than it went in, by up to {@code n/255 + 16} bytes. A fixed reserve
+   * is under water by the time the entry cap reaches a few megabytes, and an entry over the cap is not a slow
+   * path - Ratis rejects it and the leader steps down, repeatedly (#4743).
+   */
+  @Test
+  void theBudgetReservesEnoughForASliceThatCompressionMakesBIGGER() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+
+    for (final long entryCap : new long[] { 64L * 1024, 1024L * 1024, 4L * 1024 * 1024, 32L * 1024 * 1024 }) {
+      configuration.setValue(GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE, entryCap);
+      configuration.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, Long.toString(entryCap));
+
+      final long budget = GlobalConfiguration.replicatedSealedChunkBudget(configuration);
+      final long worstCaseEncoded = budget + budget / 255 + 16;
+
+      assertThat(worstCaseEncoded).as("an incompressible %d-byte slice must still fit a %d-byte entry", budget,
+          entryCap).isLessThan(entryCap);
+    }
+  }
+
+  @Test
+  void aCapTooSmallToSliceLeavesTheCeilingAtOneEntry() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE, 10L);
+
+    assertThat(GlobalConfiguration.replicatedSealedChunkBudget(configuration)).isZero();
+    assertThat(GlobalConfiguration.maxReplicatedSealedStoreSize(configuration))
+        .as("a store of 11 bytes must still be refused, exactly as before").isEqualTo(10L);
+  }
+
+  /** The inline cap never wins over the transport: #4743's rule survives the new arithmetic. */
+  @Test
+  void theTransportStillClampsTheConfiguredCap() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE, 512L * 1024 * 1024);
+    configuration.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, "1048576");
+
+    assertThat(GlobalConfiguration.maxReplicatedSealedEntrySize(configuration)).isEqualTo(1024L * 1024);
+    assertThat(GlobalConfiguration.replicatedSealedChunkBudget(configuration))
+        .isEqualTo(1024L * 1024 - GlobalConfiguration.REPLICATED_SEALED_CHUNK_FRAMING_BYTES - (1024L * 1024) / 128);
+  }
+
+  private static byte[] randomBytes(final int length) {
+    final byte[] bytes = new byte[length];
+    new Random(length).nextBytes(bytes);
+    return bytes;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4416SlicedSealedStoreTest.java
@@ -136,7 +136,8 @@ class Issue4416SlicedSealedStoreTest {
   @Test
   void schemaEntryCarriesSlicesThroughAnEncodeDecodeRoundTrip() {
     final byte[] payload = randomBytes(2_048);
-    final TsSealedChunk slice = new TsSealedChunk(TYPE, 2, FILE, 9_999L, 1234567L, 4_096L, payload, true);
+    // Geometrically real, because the decoder now insists on it: a final slice ends exactly at the file length.
+    final TsSealedChunk slice = new TsSealedChunk(TYPE, 2, FILE, 6_144L, 1234567L, 4_096L, payload, true);
 
     final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry(DB, "{\"x\":1}", Map.of(7, "a.dat"),
         Collections.emptyMap(), List.of("wal".getBytes()), List.of(Map.of(1, 2)), Collections.emptyList(), false,
@@ -155,7 +156,7 @@ class Issue4416SlicedSealedStoreTest {
     assertThat(back.typeName()).isEqualTo(TYPE);
     assertThat(back.shardIndex()).isEqualTo(2);
     assertThat(back.fileName()).isEqualTo(FILE);
-    assertThat(back.fileLength()).isEqualTo(9_999L);
+    assertThat(back.fileLength()).isEqualTo(6_144L);
     assertThat(back.fileCrc()).isEqualTo(1234567L);
     assertThat(back.offset()).isEqualTo(4_096L);
     assertThat(back.last()).isTrue();
@@ -214,6 +215,49 @@ class Issue4416SlicedSealedStoreTest {
 
     assertThatThrownBy(() -> RaftLogEntryCodec.decode(ByteString.copyFrom(encoded)))
         .isInstanceOf(IllegalStateException.class);
+  }
+
+  /**
+   * Offsets and lengths that cannot describe a real file are refused by the DECODER, which is what keeps the
+   * applier's "a sequence that does not line up asks for a resync, it never crashes" rule true for a malformed
+   * field as well as for a missing slice: a negative offset reaches {@code RandomAccessFile.seek} and comes back
+   * as a raw IOException the apply path can only report as an unexpected error.
+   */
+  @Test
+  void aSliceWhoseGeometryCannotDescribeAFileIsRefused() {
+    final byte[] payload = randomBytes(512);
+
+    final List<TsSealedChunk> impossible = List.of(
+        new TsSealedChunk(TYPE, 0, FILE, 4_096L, 7L, -1L, payload, false),          // negative offset
+        new TsSealedChunk(TYPE, 0, FILE, -1L, 7L, 0L, payload, false),              // negative file length
+        new TsSealedChunk(TYPE, 0, FILE, 256L, 7L, 0L, payload, false),             // slice overruns the file
+        new TsSealedChunk(TYPE, 0, FILE, 4_096L, 7L, 4_000L, payload, false),       // slice overruns the end
+        new TsSealedChunk(TYPE, 0, FILE, 4_096L, 7L, 0L, payload, true));           // final slice stops short
+
+    for (final TsSealedChunk chunk : impossible) {
+      final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+          Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), true,
+          List.of(chunk));
+
+      assertThatThrownBy(() -> RaftLogEntryCodec.decode(encoded))
+          .as("offset %d + %d bytes of a %d-byte file, last=%s", chunk.offset(), chunk.bytes().length,
+              chunk.fileLength(), chunk.last())
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Invalid SCHEMA_ENTRY sealed slice");
+    }
+  }
+
+  /** The geometry the producer actually emits passes, so the guard above cannot be refusing everything. */
+  @Test
+  void everySliceTheSlicerProducesPassesTheGeometryCheck() {
+    for (final TsSealedChunk chunk : RaftReplicatedDatabase.sliceSealedBlob(
+        new TsSealedBlob(TYPE, 0, FILE, randomBytes(10_000)), 3_000, DB)) {
+      final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+          Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), true,
+          List.of(chunk));
+
+      assertThat(RaftLogEntryCodec.decode(encoded).sealedFileChunks()).hasSize(1);
+    }
   }
 
   // ---- the splitter ----------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4416

## The problem

A replicated TimeSeries compaction ships the rewritten `.ts.sealed` file to the followers inside the same Raft
entry as the mutable-bucket clear, so the two land atomically and a query never sees a cleared bucket beside a
stale sealed store. Because the whole file rode ONE entry, `arcadedb.ha.tsMaxSealedInlineSize` (clamped to
`min(arcadedb.ha.grpcMessageSizeMax, arcadedb.ha.appendBufferSize)`, per #4743) was a ceiling on the sealed STORE
rather than merely on the entry: `TimeSeriesShard.compactInternal` skipped a shard whose projected store crossed
it, and that skip was **permanent** - the store it refused to ship only grows, so the projection never came back
under the cap and the shard never sealed again. Correct and fully replicated (the samples stay in the mutable
bucket) but never compressed, never retained, never downsampled, and the bucket itself unbounded.

## The fix: option 3 from the issue, slicing

A sealed store above one entry is cut into ordered slices of at most one entry's worth. Every slice but the last
ships as a **delivery-only** entry (`moreChunksFollow`, no schema JSON, no file maps, no WAL) that the follower
merely STAGES on disk; the final slice rides the **publishing** entry, so the install still happens in the same
entry as the clear WAL and the atomicity that made the whole-file design safe is unchanged. This is the
ordered-prefix contract #4743 built for oversized schema entries and #6136 reused for schema-WAL instalments,
applied to a file rather than to a WAL stream, so followers need no new state beyond the staging file.

Why not the issue's other two options: incremental block shipping (option 1) needs an append-friendly sealed
layout, and compaction currently REWRITES the file (`writeTempCompactionFile` re-serializes every retained block
in minTimestamp order), so a delta is not well defined without changing the format. Out-of-band HTTP fetch
(option 2) puts a blocking download on the single Raft apply thread and needs versioned staging on the leader
because the file it points at can be replaced before the follower pulls it. Slicing is format-agnostic, needs no
new transport, and works for the retention/downsampling maintenance path too - which ships whole sealed files
today with no size guard at all.

### Where the ceiling now sits

`arcadedb.ha.tsMaxSealedInlineSize` keeps its name and its 48MB default but now bounds one ENTRY. The per-shard
sealed ceiling becomes `GlobalConfiguration.maxReplicatedSealedStoreSize` = that value (still transport-clamped)
x 512 slices, capped at `Integer.MAX_VALUE` because the leader still materializes the file as one array before
slicing it. With stock settings that moves the ceiling from **48MB to ~2GB per shard**.

Two deliberate continuities with the old behaviour:
- a shard above the NEW ceiling is still skipped, with a warning that now names what to raise;
- a cap configured so small that a slice cannot carry even its own framing leaves the ceiling exactly at the
  per-entry cap, so a deliberately tiny cap behaves as it always did. `RaftTimeSeriesOversizedSealedIT`, which
  pins the skip with a 10-byte cap, is unmodified and still passes for that reason.

### Slice budget

`replicatedSealedChunkBudget` = per-entry cap - 4KB framing - **cap/128**. The proportional term is the one that
matters: a slice of already-compressed sealed blocks can come off the LZ4 encoder LARGER than it went in, by up
to `n/255 + 16` bytes, and at a 4MB cap that expansion alone (~16KB) is four times a fixed framing reserve. An
entry over the cap is not a slow path - Ratis rejects it and the leader steps down, repeatedly (#4743).
`theBudgetReservesEnoughForASliceThatCompressionMakesBIGGER` pins it, and it FAILED against the fixed-reserve
version before the proportional term was added.

### Follower reassembly

Staging is a `<sealed file>.parts` file next to the target, not a buffer in the state machine: a follower
persists its applied index between entries, so one that restarts mid-sequence will never be sent the earlier
slices again - a file survives that restart, a field does not - and a multi-gigabyte store never has to fit in
heap on the way in. A slice at `offset == 0` TRUNCATES whatever is staged, which makes a sequence abandoned by a
leader that died mid-shipment cost nothing; any other slice must find the staging file exactly `offset` bytes
long. The reassembled file is verified against the length and CRC32 the leader recorded for the WHOLE image
before installing - per-slice CRCs (checked by the decoder) only prove each piece survived the wire. A sequence
that does not line up, or a reassembly that does not match, refuses to install and throws `ReplicationException`,
which `applyWithRetry` turns into a targeted snapshot resync rather than putting this node on a sealed store no
other node has. The target path is derived from THIS node's schema, never from the file name in the payload.

### Wire format

`TsSealedChunk` travels in a new trailing section written AFTER the `moreChunksFollow` flag (which this encoder
always emits, so the flag can never be confused with the section's first byte). An entry with nothing to slice is
**byte-identical** to what the previous codec produced - asserted on the bytes, not on the decode.

**Rolling-upgrade note:** a node on an older codec stops right after the flag, so it installs nothing for a
SLICED store while still applying the mutable-bucket clear, and serves that shard from its previous sealed image
until it is upgraded and resynced. That is the same exposure the sealed-blob section itself has had since #4382,
for the same reason (a trailing section an old decoder cannot see). A leader only produces slices once a store
outgrows one entry, so a cluster whose stores fit inline is not exposed at all. Upgrade the followers first.
This is stated in the codec javadoc and in the release notes.

## Test plan

- [ ] `Issue4416SlicedSealedStoreTest` (13 tests, ha-raft): slicer invariants (contiguous offsets, one `last`,
      whole-file CRC, reassembly equals the original, no empty trailing slice), codec round trip, delivery-only
      slice keeps the continuation flag, **byte-identity with the previous format when nothing is sliced**,
      per-slice CRC corruption refused, `splitSchemaEntry` keeps the final slices on the LAST chunk, and the
      configuration arithmetic including the compression headroom and the too-small-cap fallback.
- [ ] `Issue4416SlicedSealedApplyTest` (7 tests, ha-raft): follower apply against a real `LocalDatabase` -
      staged-then-installed byte for byte, sliced install == whole-file install, a slice that does not line up
      asks for a resync, a restarted sequence discards the abandoned staging file, a reassembly with the wrong
      CRC or the wrong length is refused and the node keeps the store it had.
- [ ] `Issue4416SlicedSealedStoreIT` (3-node, `@Tag("slow")`): with the cap set just above the framing, a shard
      that would previously have been skipped seals, the store travels as a SEQUENCE (asserted on the new
      `getSealedStoreChunksShipped()` counter, `> 1`), every node ends with the leader's sealed file and an empty
      mutable bucket, and a second compaction cycle repeats it over a store that already has content.
- [ ] Unmodified and green: `RaftTimeSeriesOversizedSealedIT` (the skip still fires on a tiny cap),
      `RaftTimeSeriesReplication3NodesIT`, `Issue4458TsWalVersionGapIT`, `Issue5443SplitCompactionEntryIT`,
      `RaftLogEntryCodecTest`, `RaftTransactionBrokerTest`, `Issue4743OversizedRaftEntryTest`,
      `Issue6136SchemaWalInstalmentTest`, `Issue6839TsSealedBlobRecoveryTest`, `TimeSeriesSealedStoreTest`.
- [ ] Full `ha-raft` unit lane: 1001 tests, 0 failures attributable to this change (one `SnapshotSymlinkTest`
      flake under a concurrent run, green in isolation).
- [ ] Full `engine` timeseries suite: 394 tests, 0 failures.

## Known limits, deliberately left

- The leader still reads the whole sealed file into one `byte[]` before slicing it, which is why the ceiling is
  clamped to 2GB. Streaming the file into slices is a separate change and is stated as such in the javadoc.
- Every slice is a quorum round trip taken inside the compaction's replication session, so a very large store
  trades a permanent skip for a burst of entries. `MAX_REPLICATED_SEALED_CHUNKS` (512) bounds that burst, and a
  store needing more slices than that is shipped anyway - withholding it would diverge the followers - but
  reported at WARNING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TimeSeries sealed stores larger than a single Raft entry can now replicate through ordered slices.
  * Slices are validated and installed atomically, with automatic resynchronization when integrity checks fail.
  * Sealed stores up to 2 GB are supported, subject to configured slice limits.
  * Older followers retain their existing sealed data until upgraded and resynced.

* **Documentation**
  * Added release notes describing sliced sealed-store replication and compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->