### PR TITLE
feat(#3890): add optional mTLS to the Raft gRPC transport

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2118,7 +2118,10 @@ public enum GlobalConfiguration {
       arcadedb.ha.tls.trustCertCollectionFile, binding peer identity to the certificate rather than to a \
       source IP address. Set to false for server-only TLS, \
       which encrypts the traffic but leaves the Raft port open to any client that trusts the cluster CA - the \
-      back door this setting exists to close. Only meaningful when arcadedb.ha.tls.enabled is true.""",
+      back door this setting exists to close. Turning it off does NOT make \
+      arcadedb.ha.tls.trustCertCollectionFile optional: the dialling node still needs the cluster CA to \
+      validate the certificate presented by the node it dials. Only meaningful when arcadedb.ha.tls.enabled \
+      is true.""",
       Boolean.class, true),
 
   // POSTGRES

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2074,6 +2074,48 @@ public enum GlobalConfiguration {
       stickiness (drop a host from the allowlist as soon as it stops resolving).""",
       Long.class, 300_000L),
 
+  HA_TLS_ENABLED("arcadedb.ha.tls.enabled", SCOPE.SERVER,
+      """
+      Negotiate TLS on the Raft gRPC transport, which carries AppendEntries, RequestVote and the Ratis \
+      admin/client calls between the nodes of a cluster. When true, arcadedb.ha.tls.certChainFile, \
+      arcadedb.ha.tls.privateKeyFile and arcadedb.ha.tls.trustCertCollectionFile must all name a readable PEM \
+      file or the node refuses to start. Default is false so a development or test cluster still starts with \
+      no configuration at all; the peer-address allowlist (arcadedb.ha.peerAllowlist.enabled) is IP-based and \
+      is defeated by a spoofed source address or a compromised peer, so it is a best-effort default rather \
+      than a substitute for TLS on an untrusted network. TLS on the gRPC port does not replace the \
+      X-ArcadeDB-Cluster-Token check on the HTTP side channels (snapshot download, database verify).""",
+      Boolean.class, false),
+
+  HA_TLS_CERT_CHAIN_FILE("arcadedb.ha.tls.certChainFile", SCOPE.SERVER,
+      """
+      PEM file holding this node's Raft gRPC certificate followed by any intermediate CA certificates. The \
+      certificate must carry a subject alternative name matching the address the other nodes use to dial this \
+      node in arcadedb.ha.serverList (on Kubernetes, the pod's stable headless-service DNS name). Required \
+      when arcadedb.ha.tls.enabled is true.""",
+      String.class, ""),
+
+  HA_TLS_PRIVATE_KEY_FILE("arcadedb.ha.tls.privateKeyFile", SCOPE.SERVER,
+      """
+      PEM file holding the PKCS#8 private key that matches arcadedb.ha.tls.certChainFile. Required when \
+      arcadedb.ha.tls.enabled is true.""",
+      String.class, ""),
+
+  HA_TLS_TRUST_CERT_COLLECTION_FILE("arcadedb.ha.tls.trustCertCollectionFile", SCOPE.SERVER,
+      """
+      PEM file holding the cluster CA certificate(s) that sign every node certificate. A peer presenting a \
+      certificate this collection does not chain to is rejected during the TLS handshake, before any Raft \
+      message is read. Required when arcadedb.ha.tls.enabled is true.""",
+      String.class, ""),
+
+  HA_TLS_MUTUAL_AUTH("arcadedb.ha.tls.mutualAuth", SCOPE.SERVER,
+      """
+      Require the dialling peer to present a client certificate signed by the CA collection in \
+      arcadedb.ha.tls.trustCertCollectionFile, binding peer identity to the certificate rather than to a \
+      source IP address. Set to false for server-only TLS, \
+      which encrypts the traffic but leaves the Raft port open to any client that trusts the cluster CA - the \
+      back door this setting exists to close. Only meaningful when arcadedb.ha.tls.enabled is true.""",
+      Boolean.class, true),
+
   // POSTGRES
   POSTGRES_PORT("arcadedb.postgres.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for Postgres plugin. Default is 5432", Integer.class, 5432),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2090,8 +2090,13 @@ public enum GlobalConfiguration {
       """
       PEM file holding this node's Raft gRPC certificate followed by any intermediate CA certificates. The \
       certificate must carry a subject alternative name matching the address the other nodes use to dial this \
-      node in arcadedb.ha.serverList (on Kubernetes, the pod's stable headless-service DNS name). Required \
-      when arcadedb.ha.tls.enabled is true.""",
+      node in arcadedb.ha.serverList (on Kubernetes, the pod's stable headless-service DNS name). Every node \
+      both accepts and initiates Raft connections, so with arcadedb.ha.tls.mutualAuth=true this one \
+      certificate is presented as the TLS server certificate AND as the client certificate: it needs BOTH the \
+      serverAuth and clientAuth extended key usages. A CA that issues single-purpose certificates will \
+      otherwise produce a handshake failure that the startup file checks cannot catch, because the file is \
+      perfectly readable and merely the wrong kind of certificate. Required when arcadedb.ha.tls.enabled is \
+      true.""",
       String.class, ""),
 
   HA_TLS_PRIVATE_KEY_FILE("arcadedb.ha.tls.privateKeyFile", SCOPE.SERVER,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/KubernetesAutoJoin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/KubernetesAutoJoin.java
@@ -21,6 +21,7 @@ package com.arcadedb.server.ha.raft;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftGroup;
@@ -52,9 +53,11 @@ import java.util.logging.Level;
  * {@code Mode.ADD} is atomic, so concurrent joins from different pods are safe even without
  * additional coordination.
  * <p>
- * <b>Security note:</b> Peer discovery uses DNS resolution of the headless service hostname.
- * The Raft gRPC transport does not enforce cluster-token authentication. In production Kubernetes
- * deployments, restrict gRPC port access to only ArcadeDB StatefulSet pods via a NetworkPolicy.
+ * <b>Security note:</b> Peer discovery uses DNS resolution of the headless service hostname, and the
+ * Raft gRPC transport does not enforce cluster-token authentication. Secure the port with mTLS
+ * ({@code arcadedb.ha.tls.*}, issue #3890) and restrict access to the StatefulSet pods with a
+ * NetworkPolicy. The probe client below inherits the server's transport configuration, so it speaks TLS
+ * exactly when the cluster does.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -112,14 +115,30 @@ public class KubernetesAutoJoin {
   private final RaftGroup      raftGroup;
   private final RaftPeerId     localPeerId;
   private final RaftProperties raftProperties;
+  // Ratis transport parameters of the local server. Ratis carries the gRPC TLS configuration on
+  // Parameters, NOT on RaftProperties, so the probe client below has to be handed these to reach a peer
+  // whose Raft port requires TLS (issue #3890). Never null.
+  private final Parameters     raftParameters;
   private       Sleeper        sleeper = Thread::sleep;
 
+  /**
+   * Builds an auto-join with no transport parameters, so its probe client dials in plaintext. Only
+   * correct for a cluster with {@code arcadedb.ha.tls.enabled=false}; production wiring goes through
+   * {@link #KubernetesAutoJoin(ArcadeDBServer, RaftGroup, RaftPeerId, RaftProperties, Parameters)} with the
+   * same {@link Parameters} the local Ratis server was built from.
+   */
   public KubernetesAutoJoin(final ArcadeDBServer server, final RaftGroup raftGroup,
       final RaftPeerId localPeerId, final RaftProperties raftProperties) {
+    this(server, raftGroup, localPeerId, raftProperties, null);
+  }
+
+  public KubernetesAutoJoin(final ArcadeDBServer server, final RaftGroup raftGroup,
+      final RaftPeerId localPeerId, final RaftProperties raftProperties, final Parameters raftParameters) {
     this.server = server;
     this.raftGroup = raftGroup;
     this.localPeerId = localPeerId;
     this.raftProperties = raftProperties;
+    this.raftParameters = raftParameters != null ? raftParameters : new Parameters();
   }
 
   /** Package-private test hook: replaces the real sleeps so retry tests run instantly. */
@@ -195,6 +214,7 @@ public class KubernetesAutoJoin {
         try (final RaftClient tempClient = RaftClient.newBuilder()
             .setRaftGroup(targetGroup)
             .setProperties(tempProps)
+            .setParameters(raftParameters)
             .setRetryPolicy(PROBE_RETRY_POLICY)
             .build()) {
 
@@ -310,13 +330,16 @@ public class KubernetesAutoJoin {
     return buildProbeProperties();
   }
 
+  /** Package-private for unit testing that the probe client inherits the server's transport configuration. */
+  Parameters probeParametersForTest() {
+    return raftParameters;
+  }
+
   private RaftProperties buildProbeProperties() {
-    // Clone the main server's RaftProperties so TLS, gRPC flow-control, authentication and any
-    // other operator-set security knobs carry over into the short-lived probe client. Starting
-    // from a bare RaftProperties() would silently build a plaintext client that cannot talk to
-    // a TLS-only peer (handshake failure) and - more dangerously - could downgrade a deployment
-    // to plaintext if Ratis ever allowed an unencrypted fallback. Only the probe-specific
-    // timeouts are then overridden.
+    // Clone the main server's RaftProperties so gRPC flow-control, message sizing, authentication and
+    // any other operator-set knobs carry over into the short-lived probe client; only the probe-specific
+    // timeouts are then overridden. Note that the gRPC TLS configuration is NOT among them - Ratis keeps
+    // it on Parameters, which is why raftParameters is threaded in separately and set on the client.
     final RaftProperties props = new RaftProperties(raftProperties);
     props.set("raft.server.rpc.type", "GRPC");
     RaftServerConfigKeys.Rpc.setTimeoutMin(props,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -228,9 +228,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // buildParameters() on each Ratis (re)start. Kept so refreshRaftClient() can rebuild the leader's
   // self-client with the SAME transport configuration: a client built with an empty Parameters would
   // dial the Raft port in plaintext and fail every handshake once TLS is on (issue #3890).
-  // Only meaningful once buildParameters() has RETURNED: it is assigned after the TLS configuration has
-  // been validated and installed, never before, so a ConfigurationException from a bad cert/key/trust path
-  // cannot leave this field pointing at a half-built, TLS-less transport configuration.
+  // Published by buildParameters() only on its LAST line, once the TLS configuration and the inbound-peer
+  // allowlist customizer are both installed. Two things depend on that: a ConfigurationException from a bad
+  // cert/key/trust path leaves the previous, working value in place rather than a TLS-less one, and a
+  // concurrent reader (refreshRaftClient() from a leader-change callback) never sees a half-built transport
+  // configuration.
   private volatile Parameters                 raftParameters        = new Parameters();
   private final    Object                    leaderChangeNotifier  = new Object();
   private final    Object                    applyNotifier         = new Object();
@@ -3663,21 +3665,31 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * The customizer adds a {@link PeerAddressAllowlistFilter} that rejects inbound Raft gRPC
    * connections from IPs not listed in {@code arcadedb.ha.serverList}.
    */
-  private Parameters buildParameters(final ContextConfiguration configuration) {
+  // Package-private rather than private so Issue3890RaftParametersPublicationTest can pin when
+  // raftParameters becomes visible - the property this method exists to get right.
+  Parameters buildParameters(final ContextConfiguration configuration) {
     this.allowlistFilter = null;
     final Parameters parameters = new Parameters();
 
     // mTLS first: it is the cryptographic peer identity the allowlist below cannot provide. Throws a
     // ConfigurationException at startup when enabled with an unusable cert/key/trust path (issue #3890),
-    // which is why raftParameters is published only after this line rather than before it.
+    // which is one of the two reasons raftParameters is published only on the way out of this method.
     final GrpcTlsConfig tlsConfig = RaftPropertiesBuilder.applyTls(configuration, parameters);
-    this.raftParameters = parameters;
     if (tlsConfig != null)
       LogManager.instance().log(this, Level.INFO,
           "Raft gRPC transport secured with TLS (mutual authentication: %s)", tlsConfig.getMtlsEnabled());
 
+    installPeerAllowlist(configuration, parameters);
+
+    // Last line on every path: see the field's comment. Nothing above may publish a partially-configured
+    // Parameters, and nothing below may add to it.
+    this.raftParameters = parameters;
+    return parameters;
+  }
+
+  private void installPeerAllowlist(final ContextConfiguration configuration, final Parameters parameters) {
     if (!configuration.getValueAsBoolean(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED))
-      return parameters;
+      return;
 
     final String serverList = configuration.getValueAsString(GlobalConfiguration.HA_SERVER_LIST);
     final long refreshMs = configuration.getValueAsLong(GlobalConfiguration.HA_GRPC_ALLOWLIST_REFRESH_MS);
@@ -3687,13 +3699,17 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (peerHosts.isEmpty()) {
       LogManager.instance().log(this, Level.WARNING,
           "arcadedb.ha.peerAllowlist.enabled=true but arcadedb.ha.serverList is empty; allowlist not installed");
-      return parameters;
+      return;
     }
     final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(peerHosts, refreshMs, startupGraceMs,
         stickyTtlMs);
     this.allowlistFilter = filter;
     GrpcConfigKeys.Server.setServicesCustomizer(parameters, new RaftGrpcServicesCustomizer(filter));
-    return parameters;
+  }
+
+  /** Package-private test hook: the transport configuration the Raft client builders read. */
+  Parameters raftParametersForTest() {
+    return raftParameters;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -213,6 +213,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // Inbound Raft gRPC peer allowlist, recreated on each Ratis (re)start. Periodically refreshed by the
   // health monitor tick so a returned peer's new pod IP is admitted proactively (issue #4696).
   private volatile PeerAddressAllowlistFilter allowlistFilter;
+  // Ratis transport parameters (gRPC TLS conf and the inbound-allowlist services customizer) built by
+  // buildParameters() on each Ratis (re)start. Kept so refreshRaftClient() can rebuild the leader's
+  // self-client with the SAME transport configuration: a client built with an empty Parameters would
+  // dial the Raft port in plaintext and fail every handshake once TLS is on (issue #3890).
+  private volatile Parameters                 raftParameters        = new Parameters();
   private final    Object                    leaderChangeNotifier  = new Object();
   private final    Object                    applyNotifier         = new Object();
   // Upper bound on a single applyNotifier.wait(...) call before the loop re-checks the apply-index
@@ -953,7 +958,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
 
     this.raftProperties = properties;
 
-    raftClient = buildRaftClient(raftGroup, properties);
+    raftClient = buildRaftClient(raftGroup, properties, parameters);
 
     LogManager.instance()
         .log(this, Level.INFO, "Raft cluster joined: %d nodes %s", peerDisplayNames.size(), peerDisplayNames.values());
@@ -1395,17 +1400,19 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         } else
           startupOption = RaftStorage.StartupOption.RECOVER;
 
+        final Parameters recoveryParameters = buildParameters(configuration);
+
         this.raftServer = RaftServer.newBuilder()
             .setServerId(localPeerId)
             .setGroup(raftGroup)
             .setStateMachine(stateMachine)
             .setProperties(properties)
-            .setParameters(buildParameters(configuration))
+            .setParameters(recoveryParameters)
             .setOption(startupOption)
             .build();
         this.raftServer.start();
         this.raftProperties = properties;
-        this.raftClient = buildRaftClient(raftGroup, properties);
+        this.raftClient = buildRaftClient(raftGroup, properties, recoveryParameters);
 
         final int batchSize = configuration.getValueAsInteger(GlobalConfiguration.HA_GROUP_COMMIT_BATCH_SIZE);
         final int queueSize = configuration.getValueAsInteger(GlobalConfiguration.HA_GROUP_COMMIT_QUEUE_SIZE);
@@ -1638,7 +1645,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     // no broker is available to concurrent callers (the field is volatile).
     final RaftClient oldClient = raftClient;
 
-    raftClient = buildRaftClient(raftGroup, raftProperties, knownLeaderId);
+    raftClient = buildRaftClient(raftGroup, raftProperties, raftParameters, knownLeaderId);
 
     if (transactionBroker != null) {
       final int batchSize = configuration.getValueAsInteger(GlobalConfiguration.HA_GROUP_COMMIT_BATCH_SIZE);
@@ -2557,24 +2564,28 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * This uses a bounded retry so a single call returns within a reasonable time, allowing
    * our own retry loop in setConfigurationWithRetry to control the overall timeout.
    */
-  private static RaftClient buildRaftClient(final RaftGroup group, final RaftProperties properties) {
-    return buildRaftClient(group, properties, null);
+  private static RaftClient buildRaftClient(final RaftGroup group, final RaftProperties properties,
+      final Parameters parameters) {
+    return buildRaftClient(group, properties, parameters, null);
   }
 
   /**
-   * Like {@link #buildRaftClient(RaftGroup, RaftProperties)}, but seeds the new client with a
+   * Like {@link #buildRaftClient(RaftGroup, RaftProperties, Parameters)}, but seeds the new client with a
    * known leader peer ID so the first write request routes directly to the leader without a
    * probe round-trip.
+   *
+   * @param parameters the same transport {@link Parameters} the local Ratis server was built with, so the
+   *                   self-client speaks TLS whenever the transport does (issue #3890).
    */
   private static RaftClient buildRaftClient(final RaftGroup group, final RaftProperties properties,
-      final RaftPeerId knownLeaderId) {
+      final Parameters parameters, final RaftPeerId knownLeaderId) {
     // Set the client-side RPC timeout to match the quorum timeout so a slow leader response
     // does not trigger a premature TimeoutIOException before the commit completes.
     RaftClientConfigKeys.Rpc.setRequestTimeout(properties, TimeDuration.valueOf(10, TimeUnit.SECONDS));
     final RaftClient.Builder builder = RaftClient.newBuilder()
         .setRaftGroup(group)
         .setProperties(properties)
-        .setParameters(new Parameters())
+        .setParameters(parameters != null ? parameters : new Parameters())
         .setRetryPolicy(RetryPolicies.retryUpToMaximumCountWithFixedSleep(60, TimeDuration.valueOf(1, TimeUnit.SECONDS)));
     if (knownLeaderId != null)
       builder.setLeaderId(knownLeaderId);
@@ -3640,6 +3651,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private Parameters buildParameters(final ContextConfiguration configuration) {
     this.allowlistFilter = null;
     final Parameters parameters = new Parameters();
+    this.raftParameters = parameters;
+
+    // mTLS first: it is the cryptographic peer identity the allowlist below cannot provide. Throws a
+    // ConfigurationException at startup when enabled with an unusable cert/key/trust path (issue #3890).
+    if (RaftPropertiesBuilder.applyTls(configuration, parameters) != null)
+      LogManager.instance().log(this, Level.INFO,
+          "Raft gRPC transport secured with TLS (mutual authentication: %s)",
+          configuration.getValueAsBoolean(GlobalConfiguration.HA_TLS_MUTUAL_AUTH));
+
     if (!configuration.getValueAsBoolean(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED))
       return parameters;
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -31,6 +31,7 @@ import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.metrics.MetricRegistries;
 import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
@@ -217,6 +218,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // buildParameters() on each Ratis (re)start. Kept so refreshRaftClient() can rebuild the leader's
   // self-client with the SAME transport configuration: a client built with an empty Parameters would
   // dial the Raft port in plaintext and fail every handshake once TLS is on (issue #3890).
+  // Only meaningful once buildParameters() has RETURNED: it is assigned after the TLS configuration has
+  // been validated and installed, never before, so a ConfigurationException from a bad cert/key/trust path
+  // cannot leave this field pointing at a half-built, TLS-less transport configuration.
   private volatile Parameters                 raftParameters        = new Parameters();
   private final    Object                    leaderChangeNotifier  = new Object();
   private final    Object                    applyNotifier         = new Object();
@@ -3652,14 +3656,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private Parameters buildParameters(final ContextConfiguration configuration) {
     this.allowlistFilter = null;
     final Parameters parameters = new Parameters();
-    this.raftParameters = parameters;
 
     // mTLS first: it is the cryptographic peer identity the allowlist below cannot provide. Throws a
-    // ConfigurationException at startup when enabled with an unusable cert/key/trust path (issue #3890).
-    if (RaftPropertiesBuilder.applyTls(configuration, parameters) != null)
+    // ConfigurationException at startup when enabled with an unusable cert/key/trust path (issue #3890),
+    // which is why raftParameters is published only after this line rather than before it.
+    final GrpcTlsConfig tlsConfig = RaftPropertiesBuilder.applyTls(configuration, parameters);
+    this.raftParameters = parameters;
+    if (tlsConfig != null)
       LogManager.instance().log(this, Level.INFO,
-          "Raft gRPC transport secured with TLS (mutual authentication: %s)",
-          configuration.getValueAsBoolean(GlobalConfiguration.HA_TLS_MUTUAL_AUTH));
+          "Raft gRPC transport secured with TLS (mutual authentication: %s)", tlsConfig.getMtlsEnabled());
 
     if (!configuration.getValueAsBoolean(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED))
       return parameters;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -989,7 +989,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     // as soon as a leader is visible - at that point this node is either a functioning member or a
     // cold-start election completed - or on shutdown.
     if (configuration.getValueAsBoolean(GlobalConfiguration.HA_K8S)) {
-      final KubernetesAutoJoin autoJoin = new KubernetesAutoJoin(arcadeServer, raftGroup, localPeerId, raftProperties);
+      final KubernetesAutoJoin autoJoin = new KubernetesAutoJoin(arcadeServer, raftGroup, localPeerId, raftProperties,
+          parameters);
       final Thread joinThread = new Thread(
           () -> autoJoin.tryAutoJoinWithRetry(() -> !shutdownRequested && getLeaderId() == null),
           "arcadedb-k8s-auto-join");

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -111,10 +111,20 @@ import java.util.logging.Logger;
  * {@link #shutdownRequested} volatile flag prevents recovery during shutdown.
  * <p>
  * <b>Security note (K8s mode):</b> When {@code HA_K8S} is enabled and gRPC is bound
- * to {@code 0.0.0.0}, any pod in the Kubernetes cluster can connect to the Raft port
- * and inject Raft log entries. Authentication for inter-node traffic relies on
- * Kubernetes NetworkPolicy. Operators should restrict access to the Raft port via
- * NetworkPolicy rules in production.
+ * to {@code 0.0.0.0}, any host that can reach the Raft port can connect to it and inject Raft log
+ * entries. Three mitigations, in decreasing order of strength:
+ * <ul>
+ *   <li>{@code arcadedb.ha.tls.*} (issue #3890) - mutual TLS, the only one that binds peer identity to a
+ *       certificate rather than to a spoofable source address, and the only one that also encrypts the
+ *       traffic. Off by default; this is the supported way to secure the Raft port in production.</li>
+ *   <li>{@code arcadedb.ha.peerAllowlist.enabled} - rejects inbound connections whose address does not
+ *       resolve to a host in {@code HA_SERVER_LIST}. On by default, but IP-based: defeated by spoofing on a
+ *       flat L2 network or by a compromised peer. A best-effort default, not a substitute for mTLS.</li>
+ *   <li>A Kubernetes NetworkPolicy restricting the port to the StatefulSet pods - network-level isolation,
+ *       and worth having alongside either of the above.</li>
+ * </ul>
+ * None of these replaces the {@code X-ArcadeDB-Cluster-Token} check on the HTTP side channels (snapshot
+ * download, database verify), which is a separate control on a separate port.
  */
 public class RaftHAServer implements HealthMonitor.HealthTarget {
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
@@ -24,12 +24,15 @@ import com.arcadedb.exception.ConfigurationException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ha.raft.ratis.FixedGrpcRpcType;
 import org.apache.ratis.RaftConfigKeys;
+import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 
+import java.io.File;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -66,6 +69,69 @@ class RaftPropertiesBuilder {
    */
   static long maxReplicatedEntrySize(final ContextConfiguration configuration) {
     return GlobalConfiguration.maxReplicatedRaftEntrySize(configuration);
+  }
+
+  /**
+   * Builds the TLS configuration for the Raft gRPC transport, or returns {@code null} when
+   * {@link GlobalConfiguration#HA_TLS_ENABLED} is false - in which case the transport stays plaintext,
+   * exactly as before this setting existed.
+   * <p>
+   * The three PEM paths are validated here rather than left to Netty, so a typo or an unmounted secret
+   * volume fails the node at startup with the offending setting named, instead of surfacing later as an
+   * opaque handshake failure on every peer connection.
+   *
+   * @throws ConfigurationException if TLS is enabled and any of the cert/key/trust paths is unset, missing,
+   *                                not a regular file, or unreadable
+   */
+  static GrpcTlsConfig buildTlsConfig(final ContextConfiguration configuration) {
+    if (!configuration.getValueAsBoolean(GlobalConfiguration.HA_TLS_ENABLED))
+      return null;
+
+    final File certChain = requireReadableFile(configuration, GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE);
+    final File privateKey = requireReadableFile(configuration, GlobalConfiguration.HA_TLS_PRIVATE_KEY_FILE);
+    final File trustCerts = requireReadableFile(configuration, GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE);
+    final boolean mutualAuth = configuration.getValueAsBoolean(GlobalConfiguration.HA_TLS_MUTUAL_AUTH);
+
+    if (!mutualAuth)
+      LogManager.instance().log(RaftPropertiesBuilder.class, Level.WARNING,
+          "Raft gRPC TLS is enabled with %s=false: the transport is encrypted but the dialling peer is NOT "
+              + "authenticated, so any client trusting the cluster CA can still open a Raft stream",
+          GlobalConfiguration.HA_TLS_MUTUAL_AUTH.getKey());
+
+    return new GrpcTlsConfig(privateKey, certChain, trustCerts, mutualAuth);
+  }
+
+  /**
+   * Installs the TLS configuration built by {@link #buildTlsConfig(ContextConfiguration)} on the
+   * {@link Parameters} handed to both {@code RaftServer.Builder} and {@code RaftClient.Builder}.
+   * <p>
+   * A single {@code GrpcConfigKeys.TLS} entry is enough: Ratis's {@code GrpcFactory} reads it as the default
+   * for all three gRPC endpoints (admin, client and server-to-server), so AppendEntries, InstallSnapshot and
+   * RequestVote traffic are all covered by this one call. No-op when TLS is disabled, which leaves
+   * {@code Parameters} exactly as Ratis's plaintext default expects it.
+   *
+   * @return the TLS configuration that was installed, or {@code null} when TLS is disabled
+   */
+  static GrpcTlsConfig applyTls(final ContextConfiguration configuration, final Parameters parameters) {
+    final GrpcTlsConfig tlsConfig = buildTlsConfig(configuration);
+    if (tlsConfig == null)
+      return null;
+    GrpcConfigKeys.TLS.setConf(parameters, tlsConfig);
+    return tlsConfig;
+  }
+
+  private static File requireReadableFile(final ContextConfiguration configuration,
+      final GlobalConfiguration setting) {
+    final String path = configuration.getValueAsString(setting);
+    if (path == null || path.isBlank())
+      throw new ConfigurationException(
+          setting.getKey() + " must be set when " + GlobalConfiguration.HA_TLS_ENABLED.getKey() + " is true");
+
+    final File file = new File(path);
+    if (!file.isFile() || !file.canRead())
+      throw new ConfigurationException(
+          setting.getKey() + " (" + path + ") is not a readable file: Raft gRPC TLS cannot be initialized");
+    return file;
   }
 
   static RaftProperties build(final ContextConfiguration configuration) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
@@ -33,6 +33,9 @@ import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -92,6 +95,8 @@ class RaftPropertiesBuilder {
     final File trustCerts = requireReadableFile(configuration, GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE);
     final boolean mutualAuth = configuration.getValueAsBoolean(GlobalConfiguration.HA_TLS_MUTUAL_AUTH);
 
+    warnIfPrivateKeyIsReadableByOthers(privateKey);
+
     if (!mutualAuth)
       LogManager.instance().log(RaftPropertiesBuilder.class, Level.WARNING,
           "Raft gRPC TLS is enabled with %s=false: the transport is encrypted but the dialling peer is NOT "
@@ -109,6 +114,14 @@ class RaftPropertiesBuilder {
    * for all three gRPC endpoints (admin, client and server-to-server), so AppendEntries, InstallSnapshot and
    * RequestVote traffic are all covered by this one call. No-op when TLS is disabled, which leaves
    * {@code Parameters} exactly as Ratis's plaintext default expects it.
+   * <p>
+   * <b>That defaulting is a Ratis implementation detail, not a documented contract</b>, verified against
+   * <b>Ratis 3.3.0</b>: {@code GrpcFactory(Parameters)} reads {@code TLS.conf} plus the three per-endpoint
+   * keys, and its {@code SslContexts} constructor builds the {@code TLS.conf} context first and passes it as
+   * the fallback for admin, client and server. If a Ratis upgrade changes that, this one entry stops reaching
+   * the endpoints that do not set their own, and the symptom is the bug this method exists to prevent - a
+   * client dialling the Raft port in plaintext against a TLS server. On any Ratis version bump, re-read
+   * {@code GrpcFactory} and run {@code Issue3890RaftMtlsIT}, which is the test that would catch it.
    *
    * @return the TLS configuration that was installed, or {@code null} when TLS is disabled
    */
@@ -118,6 +131,32 @@ class RaftPropertiesBuilder {
       return null;
     GrpcConfigKeys.TLS.setConf(parameters, tlsConfig);
     return tlsConfig;
+  }
+
+  /**
+   * Warns when the private key is readable by the group or by everyone. Deliberately a warning and not a
+   * refusal: file ownership is the deployment's business, a container image or a mounted secret may legitimately
+   * arrive with permissions this node cannot change, and refusing to start would be a worse outcome than a
+   * noisy log. Silently accepting it would be worse still - a world-readable Raft key hands anyone on the host
+   * a cluster identity, which is precisely what this setting exists to prevent.
+   * <p>
+   * No-op on a file system with no POSIX view (Windows), where the question has no answer in these terms.
+   */
+  private static void warnIfPrivateKeyIsReadableByOthers(final File privateKey) {
+    final Set<PosixFilePermission> permissions;
+    try {
+      permissions = Files.getPosixFilePermissions(privateKey.toPath());
+    } catch (final Exception e) {
+      // UnsupportedOperationException on a non-POSIX file system, IOException on a file that vanished
+      // between the readability check and here. Neither is worth failing a startup over.
+      return;
+    }
+
+    if (permissions.contains(PosixFilePermission.GROUP_READ) || permissions.contains(PosixFilePermission.OTHERS_READ))
+      LogManager.instance().log(RaftPropertiesBuilder.class, Level.WARNING,
+          "The Raft gRPC private key %s (%s) is readable beyond its owner: any local account that can read it "
+              + "can present this node's identity to the cluster. Restrict it to owner-only (chmod 600)",
+          GlobalConfiguration.HA_TLS_PRIVATE_KEY_FILE.getKey(), privateKey.getAbsolutePath());
   }
 
   private static File requireReadableFile(final ContextConfiguration configuration,

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftMtlsIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftMtlsIT.java
@@ -46,16 +46,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *   <li>a peer holding a certificate signed by a <em>different</em> CA, and an anonymous peer holding none,
  *       are both rejected during the TLS handshake, before any Raft message is read.</li>
  * </ul>
- * The negative handshakes pin TLS 1.2 deliberately: under TLS 1.3 the client finishes the handshake before
- * the server has verified its certificate, so the rejection would surface asynchronously on a later read
- * rather than out of {@code startHandshake()}, and the assertion would be racy.
+ * The negative handshakes pin TLS 1.2 (see {@code RaftTestPki.connect}): under TLS 1.3 the client finishes
+ * the handshake before the server has verified its certificate, so the rejection would surface
+ * asynchronously on a later read rather than out of {@code startHandshake()}, and the assertion would be racy.
+ * <p>
+ * The complementary {@code arcadedb.ha.tls.mutualAuth=false} configuration - where the same anonymous client
+ * is accepted - is covered by {@link Issue3890RaftServerOnlyTlsIT}.
  */
 class Issue3890RaftMtlsIT extends BaseRaftHATest {
 
-  private static final String  VERTEX_TYPE   = "MtlsReplicated";
-  private static final int     RECORD_COUNT  = 200;
-  private static final String  TLS_1_2       = "TLSv1.2";
-  private static final int     HANDSHAKE_TIMEOUT_MS = 15_000;
+  private static final String VERTEX_TYPE  = "MtlsReplicated";
+  private static final int    RECORD_COUNT = 200;
 
   private static RaftTestPki clusterPki;
   private static RaftTestPki foreignPki;
@@ -158,10 +159,7 @@ class Issue3890RaftMtlsIT extends BaseRaftHATest {
   }
 
   private SSLSocket connect(final SSLContext context) throws IOException {
-    final SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket("localhost", raftPortOf(0));
-    socket.setEnabledProtocols(new String[] { TLS_1_2 });
-    socket.setSoTimeout(HANDSHAKE_TIMEOUT_MS);
-    return socket;
+    return RaftTestPki.connect(context, "localhost", raftPortOf(0));
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftMtlsIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftMtlsIT.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.graph.MutableVertex;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #3890: the Raft gRPC port used for log replication, leader election and snapshot chunk transfer had
+ * no peer authentication and no in-transit encryption, so any host able to reach it could open a stream to
+ * the Ratis server and inject log entries. The peer-address allowlist added earlier is IP-based, and an IP
+ * is not an identity.
+ * <p>
+ * This test boots a three-node cluster with {@code arcadedb.ha.tls.enabled=true} against a throwaway cluster
+ * CA and asserts both halves of the fix:
+ * <ul>
+ *   <li>the cluster still elects a leader, commits transactions and catches followers up - over TLS;</li>
+ *   <li>a peer holding a certificate signed by a <em>different</em> CA, and an anonymous peer holding none,
+ *       are both rejected during the TLS handshake, before any Raft message is read.</li>
+ * </ul>
+ * The negative handshakes pin TLS 1.2 deliberately: under TLS 1.3 the client finishes the handshake before
+ * the server has verified its certificate, so the rejection would surface asynchronously on a later read
+ * rather than out of {@code startHandshake()}, and the assertion would be racy.
+ */
+class Issue3890RaftMtlsIT extends BaseRaftHATest {
+
+  private static final String  VERTEX_TYPE   = "MtlsReplicated";
+  private static final int     RECORD_COUNT  = 200;
+  private static final String  TLS_1_2       = "TLSv1.2";
+  private static final int     HANDSHAKE_TIMEOUT_MS = 15_000;
+
+  private static RaftTestPki clusterPki;
+  private static RaftTestPki foreignPki;
+
+  @BeforeAll
+  static void generateCertificates() throws Exception {
+    final Path pkiDirectory = Path.of("target", "issue3890-mtls-pki");
+    clusterPki = RaftTestPki.create(pkiDirectory, "cluster");
+    foreignPki = RaftTestPki.create(pkiDirectory, "foreign");
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+    config.setValue(GlobalConfiguration.HA_TLS_ENABLED, true);
+    config.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE, clusterPki.nodeCertificate().toString());
+    config.setValue(GlobalConfiguration.HA_TLS_PRIVATE_KEY_FILE, clusterPki.nodePrivateKey().toString());
+    config.setValue(GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE, clusterPki.caCertificate().toString());
+    config.setValue(GlobalConfiguration.HA_TLS_MUTUAL_AUTH, true);
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  /**
+   * The whole replication round-trip over the TLS transport: an elected leader, a committed transaction, and
+   * every follower holding the same records. Without the {@code Parameters} wiring on both the Ratis server
+   * and the leader's self-client, this never gets past the first AppendEntries.
+   */
+  @Test
+  void clusterReplicatesOverMutualTls() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a Raft leader must be elected over the TLS transport").isGreaterThanOrEqualTo(0);
+
+    final var db = getServerDatabase(leaderIndex, getDatabaseName());
+    db.transaction(() -> {
+      if (!db.getSchema().existsType(VERTEX_TYPE))
+        db.getSchema().createVertexType(VERTEX_TYPE);
+    });
+
+    db.transaction(() -> {
+      for (int i = 0; i < RECORD_COUNT; i++) {
+        final MutableVertex vertex = db.newVertex(VERTEX_TYPE);
+        vertex.set("idx", i);
+        vertex.save();
+      }
+    });
+
+    assertClusterConsistency();
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
+          .as("server %d must have caught up over TLS", i)
+          .isEqualTo(RECORD_COUNT);
+  }
+
+  /**
+   * Positive control for the two rejection tests below: the port really is speaking TLS, and a peer holding
+   * a cluster-CA certificate completes the handshake and is served the node's certificate.
+   */
+  @Test
+  void raftPortCompletesHandshakeWithClusterCertificate() throws Exception {
+    try (final SSLSocket socket = connect(RaftTestPki.clientContext(clusterPki, clusterPki))) {
+      socket.startHandshake();
+
+      final var peerCertificates = socket.getSession().getPeerCertificates();
+      assertThat(peerCertificates).isNotEmpty();
+      assertThat(((X509Certificate) peerCertificates[0]).getSubjectX500Principal().getName())
+          .contains("CN=localhost");
+    }
+  }
+
+  /**
+   * The attack the issue describes: a host that can reach the Raft port, presenting an identity the cluster
+   * CA never signed. It must not get as far as a gRPC stream.
+   */
+  @Test
+  void raftPortRejectsPeerSignedByAForeignCa() throws Exception {
+    assertThatThrownBy(() -> handshake(RaftTestPki.clientContext(foreignPki, clusterPki)))
+        .isInstanceOf(IOException.class);
+  }
+
+  /**
+   * The weaker version of the same attack, and the one the peer-address allowlist alone could not stop: a
+   * host that merely knows the port and offers no certificate at all.
+   */
+  @Test
+  void raftPortRejectsPeerWithoutCertificate() throws Exception {
+    assertThatThrownBy(() -> handshake(RaftTestPki.anonymousClientContext(clusterPki)))
+        .isInstanceOf(IOException.class);
+  }
+
+  private void handshake(final SSLContext context) throws IOException {
+    try (final SSLSocket socket = connect(context)) {
+      socket.startHandshake();
+    }
+  }
+
+  private SSLSocket connect(final SSLContext context) throws IOException {
+    final SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket("localhost", raftPortOf(0));
+    socket.setEnabledProtocols(new String[] { TLS_1_2 });
+    socket.setSoTimeout(HANDSHAKE_TIMEOUT_MS);
+    return socket;
+  }
+
+  /**
+   * Derives the Raft port from the peer id ({@code localhost_<raftPort>}) rather than duplicating the base
+   * port constant, so this test cannot drift away from what the cluster actually bound.
+   */
+  private int raftPortOf(final int serverIndex) {
+    final String peerId = peerIdForIndex(serverIndex);
+    return Integer.parseInt(peerId.substring(peerId.lastIndexOf('_') + 1));
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftParametersPublicationTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftParametersPublicationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.ConfigurationException;
+import com.arcadedb.server.ArcadeDBServer;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code RaftHAServer.raftParameters} is what the Raft client builders read to speak the same transport the
+ * local Ratis server speaks, and {@code refreshRaftClient()} can read it from a leader-change callback on
+ * another thread while {@code restartRatis()} is rebuilding it. So WHEN it becomes visible is a property in
+ * its own right, and one that has already been got wrong twice while issue #3890 was in review:
+ * <ul>
+ *   <li>publishing before the TLS configuration was validated left a plaintext {@link Parameters} in the
+ *       field whenever a cert/key/trust path was unusable;</li>
+ *   <li>publishing between the TLS install and the peer-allowlist install left a window in which the
+ *       customizer was missing from the object a reader could already see.</li>
+ * </ul>
+ * Both are closed by publishing on the method's last line, and this test is what keeps it there: it is
+ * deliberately about the field rather than about the returned value, because the returned value was never
+ * the part that was wrong.
+ */
+class Issue3890RaftParametersPublicationTest {
+
+  private static final String SERVER_LIST = "localhost:2434:2480,localhost:2435:2481";
+
+  @TempDir
+  private Path tempDir;
+  private Path certChain;
+  private Path privateKey;
+  private Path trustCerts;
+
+  @BeforeEach
+  void createCertificateFiles() throws Exception {
+    certChain = Files.writeString(tempDir.resolve("node-cert.pem"), "cert");
+    privateKey = Files.writeString(tempDir.resolve("node-key.pem"), "key");
+    trustCerts = Files.writeString(tempDir.resolve("ca.pem"), "ca");
+  }
+
+  @Test
+  void publishedParametersCarryBothTheTlsConfigAndTheAllowlistCustomizer() {
+    final RaftHAServer server = detachedServer();
+    final Parameters returned = server.buildParameters(tlsConfiguration());
+
+    final Parameters published = server.raftParametersForTest();
+    assertThat(published).isSameAs(returned);
+    assertThat(GrpcConfigKeys.TLS.conf(published)).isNotNull();
+    assertThat(GrpcConfigKeys.Server.servicesCustomizer(published))
+        .as("the inbound-peer allowlist customizer must be installed before the object is published")
+        .isNotNull();
+  }
+
+  /**
+   * The restart case: a cert file that has become unreadable since the last successful start. The previous,
+   * working transport configuration has to survive, because a client built from a bare {@link Parameters}
+   * would silently dial the Raft port in plaintext.
+   */
+  @Test
+  void aFailedRebuildLeavesThePreviouslyPublishedParametersInPlace() {
+    final RaftHAServer server = detachedServer();
+    final Parameters good = server.buildParameters(tlsConfiguration());
+
+    final ContextConfiguration broken = tlsConfiguration();
+    broken.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE, tempDir.resolve("vanished.pem").toString());
+
+    assertThatThrownBy(() -> server.buildParameters(broken))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.tls.certChainFile");
+
+    assertThat(server.raftParametersForTest()).isSameAs(good);
+    assertThat(GrpcConfigKeys.TLS.conf(server.raftParametersForTest())).isNotNull();
+  }
+
+  @Test
+  void aPlaintextClusterPublishesUsableParametersWithNoTlsConfig() {
+    final RaftHAServer server = detachedServer();
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, SERVER_LIST);
+
+    server.buildParameters(config);
+
+    final Parameters published = server.raftParametersForTest();
+    assertThat(published).isNotNull();
+    assertThat(GrpcConfigKeys.TLS.conf(published)).isNull();
+    assertThat(GrpcConfigKeys.Server.servicesCustomizer(published)).isNotNull();
+  }
+
+  private ContextConfiguration tlsConfiguration() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, SERVER_LIST);
+    config.setValue(GlobalConfiguration.HA_TLS_ENABLED, true);
+    config.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE, certChain.toString());
+    config.setValue(GlobalConfiguration.HA_TLS_PRIVATE_KEY_FILE, privateKey.toString());
+    config.setValue(GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE, trustCerts.toString());
+    return config;
+  }
+
+  /**
+   * A {@link RaftHAServer} whose constructor has run but whose Ratis server was never started: the peer group
+   * is all {@code buildParameters} reads, so nothing has to be bound or written to disk.
+   */
+  private static RaftHAServer detachedServer() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, SERVER_LIST);
+
+    final ArcadeDBServer arcadeServer = mock(ArcadeDBServer.class);
+    when(arcadeServer.getServerName()).thenReturn("ArcadeDB_0");
+
+    return new RaftHAServer(arcadeServer, config);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftServerOnlyTlsIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftServerOnlyTlsIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.graph.MutableVertex;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLSocket;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The other half of {@code arcadedb.ha.tls.mutualAuth}, and the reason the setting logs a WARNING when it is
+ * turned off: with {@code mutualAuth=false} the Raft port is encrypted but NOT authenticated, so the very
+ * client {@link Issue3890RaftMtlsIT} shows being rejected - one holding no certificate at all - completes the
+ * handshake here.
+ * <p>
+ * Asserting that positively matters more than it looks. Without it, the only evidence that {@code mutualAuth}
+ * does anything is that turning it off makes the rejection tests go red, which is a claim someone has to
+ * re-establish by hand. This pins it in the suite, so a regression that quietly stopped requesting a client
+ * certificate would turn {@link Issue3890RaftMtlsIT} red while this class stayed green, and the pair of
+ * results would say which of the two settings had broken.
+ */
+class Issue3890RaftServerOnlyTlsIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE  = "ServerOnlyTlsReplicated";
+  private static final int    RECORD_COUNT = 50;
+
+  private static RaftTestPki clusterPki;
+
+  @BeforeAll
+  static void generateCertificates() throws Exception {
+    clusterPki = RaftTestPki.create(Path.of("target", "issue3890-server-only-tls-pki"), "cluster");
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_TLS_ENABLED, true);
+    config.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE, clusterPki.nodeCertificate().toString());
+    config.setValue(GlobalConfiguration.HA_TLS_PRIVATE_KEY_FILE, clusterPki.nodePrivateKey().toString());
+    config.setValue(GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE, clusterPki.caCertificate().toString());
+    config.setValue(GlobalConfiguration.HA_TLS_MUTUAL_AUTH, false);
+  }
+
+  @Test
+  void serverOnlyTlsAcceptsAPeerWithoutAClientCertificate() throws Exception {
+    try (final SSLSocket socket = RaftTestPki.connect(RaftTestPki.anonymousClientContext(clusterPki),
+        "localhost", raftPortOf(0))) {
+      socket.startHandshake();
+      assertThat(socket.getSession().isValid())
+          .as("with mutualAuth=false the Raft port must not demand a client certificate")
+          .isTrue();
+    }
+  }
+
+  /** Server-only TLS still has to be a working transport, not merely a reachable one. */
+  @Test
+  void clusterReplicatesOverServerOnlyTls() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a Raft leader must be elected over the TLS transport").isGreaterThanOrEqualTo(0);
+
+    final var db = getServerDatabase(leaderIndex, getDatabaseName());
+    db.transaction(() -> {
+      if (!db.getSchema().existsType(VERTEX_TYPE))
+        db.getSchema().createVertexType(VERTEX_TYPE);
+    });
+
+    db.transaction(() -> {
+      for (int i = 0; i < RECORD_COUNT; i++) {
+        final MutableVertex vertex = db.newVertex(VERTEX_TYPE);
+        vertex.set("idx", i);
+        vertex.save();
+      }
+    });
+
+    assertClusterConsistency();
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
+          .as("server %d must have caught up over server-only TLS", i)
+          .isEqualTo(RECORD_COUNT);
+  }
+
+  private int raftPortOf(final int serverIndex) {
+    final String peerId = peerIdForIndex(serverIndex);
+    return Integer.parseInt(peerId.substring(peerId.lastIndexOf('_') + 1));
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinTlsInheritanceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinTlsInheritanceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.grpc.GrpcTlsConfig;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The Kubernetes auto-join probe opens its own short-lived {@code RaftClient} against a peer's Raft port.
+ * Ratis carries the gRPC TLS configuration on {@link Parameters}, not on {@link RaftProperties}, so cloning
+ * the server's properties - which is all the probe used to do - leaves that client speaking plaintext. On a
+ * cluster with {@code arcadedb.ha.tls.enabled=true} every probe would then fail its handshake, and because
+ * the probe swallows per-peer failures the node would simply report "no existing cluster found" and never
+ * join (issue #3890).
+ */
+class KubernetesAutoJoinTlsInheritanceTest {
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  void probeClientInheritsTheServerTlsConfiguration() throws Exception {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_ENABLED, true);
+    config.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE,
+        Files.writeString(tempDir.resolve("node-cert.pem"), "cert").toString());
+    config.setValue(GlobalConfiguration.HA_TLS_PRIVATE_KEY_FILE,
+        Files.writeString(tempDir.resolve("node-key.pem"), "key").toString());
+    config.setValue(GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE,
+        Files.writeString(tempDir.resolve("ca.pem"), "ca").toString());
+
+    final Parameters serverParameters = new Parameters();
+    final GrpcTlsConfig tlsConfig = RaftPropertiesBuilder.applyTls(config, serverParameters);
+    assertThat(tlsConfig).isNotNull();
+
+    final KubernetesAutoJoin autoJoin = new KubernetesAutoJoin(null, singlePeerGroup(),
+        RaftPeerId.valueOf("localhost_2434"), new RaftProperties(), serverParameters);
+
+    assertThat(GrpcConfigKeys.TLS.conf(autoJoin.probeParametersForTest())).isSameAs(tlsConfig);
+  }
+
+  /**
+   * The legacy constructor still has to produce a usable, plaintext-dialling probe rather than a
+   * {@link NullPointerException} the first time a peer is contacted.
+   */
+  @Test
+  void probeClientWithoutTransportParametersStaysPlaintext() {
+    final KubernetesAutoJoin autoJoin = new KubernetesAutoJoin(null, singlePeerGroup(),
+        RaftPeerId.valueOf("localhost_2434"), new RaftProperties());
+
+    assertThat(autoJoin.probeParametersForTest()).isNotNull();
+    assertThat(GrpcConfigKeys.TLS.conf(autoJoin.probeParametersForTest())).isNull();
+  }
+
+  private static RaftGroup singlePeerGroup() {
+    return RaftGroup.valueOf(RaftGroupId.randomId(),
+        List.of(RaftPeer.newBuilder().setId("localhost_2434").setAddress("localhost:2434").build()));
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGrpcTlsConfigTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGrpcTlsConfigTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.ConfigurationException;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.grpc.GrpcTlsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies the {@code arcadedb.ha.tls.*} settings introduced by issue #3890: the Raft gRPC transport must
+ * stay plaintext by default, must carry a {@link GrpcTlsConfig} on the Ratis {@link Parameters} once
+ * enabled, and must refuse to start - naming the offending setting - when enabled with a cert, key or trust
+ * path that cannot be read.
+ * <p>
+ * The PEM contents are irrelevant here; only the plumbing and the validation are under test, so ordinary
+ * files stand in for certificates. {@link Issue3890RaftMtlsIT} covers the handshake itself with a real CA.
+ */
+class RaftGrpcTlsConfigTest {
+
+  @TempDir
+  private Path   tempDir;
+  private Path   certChain;
+  private Path   privateKey;
+  private Path   trustCerts;
+
+  @BeforeEach
+  void createFiles() throws Exception {
+    certChain = Files.writeString(tempDir.resolve("node-cert.pem"), "cert");
+    privateKey = Files.writeString(tempDir.resolve("node-key.pem"), "key");
+    trustCerts = Files.writeString(tempDir.resolve("ca.pem"), "ca");
+  }
+
+  @Test
+  void transportStaysPlaintextByDefault() {
+    final Parameters parameters = new Parameters();
+    assertThat(RaftPropertiesBuilder.applyTls(new ContextConfiguration(), parameters)).isNull();
+    assertThat(GrpcConfigKeys.TLS.conf(parameters)).isNull();
+  }
+
+  /**
+   * The paths are only read when TLS is on, so a stale or templated path left behind in a configuration
+   * file must not stop a plaintext node from starting.
+   */
+  @Test
+  void disabledTlsIgnoresUnusablePaths() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE, tempDir.resolve("nope.pem").toString());
+
+    final Parameters parameters = new Parameters();
+    assertThatCode(() -> RaftPropertiesBuilder.applyTls(config, parameters)).doesNotThrowAnyException();
+    assertThat(GrpcConfigKeys.TLS.conf(parameters)).isNull();
+  }
+
+  @Test
+  void enabledTlsAttachesFileBasedConfigToParameters() {
+    final Parameters parameters = new Parameters();
+    final GrpcTlsConfig returned = RaftPropertiesBuilder.applyTls(enabledConfiguration(), parameters);
+
+    // The single TLS entry is what Ratis's GrpcFactory reads as the default for the admin, client and
+    // server-to-server endpoints alike, so this one assertion covers all three.
+    final GrpcTlsConfig attached = GrpcConfigKeys.TLS.conf(parameters);
+    assertThat(attached).isNotNull().isSameAs(returned);
+    assertThat(attached.isFileBasedConfig()).isTrue();
+    assertThat(attached.getCertChainFile()).isEqualTo(certChain.toFile());
+    assertThat(attached.getPrivateKeyFile()).isEqualTo(privateKey.toFile());
+    assertThat(attached.getTrustStoreFile()).isEqualTo(trustCerts.toFile());
+    assertThat(attached.getMtlsEnabled()).isTrue();
+  }
+
+  @Test
+  void mutualAuthenticationCanBeTurnedOff() {
+    final ContextConfiguration config = enabledConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_MUTUAL_AUTH, false);
+
+    final GrpcTlsConfig tlsConfig = RaftPropertiesBuilder.buildTlsConfig(config);
+    assertThat(tlsConfig).isNotNull();
+    assertThat(tlsConfig.getMtlsEnabled()).isFalse();
+  }
+
+  @Test
+  void unsetCertChainFileFailsFast() {
+    final ContextConfiguration config = enabledConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE, "");
+
+    assertThatThrownBy(() -> RaftPropertiesBuilder.buildTlsConfig(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.tls.certChainFile")
+        .hasMessageContaining("arcadedb.ha.tls.enabled");
+  }
+
+  @Test
+  void unsetPrivateKeyFileFailsFast() {
+    final ContextConfiguration config = enabledConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_PRIVATE_KEY_FILE, "");
+
+    assertThatThrownBy(() -> RaftPropertiesBuilder.buildTlsConfig(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.tls.privateKeyFile");
+  }
+
+  @Test
+  void unsetTrustCertCollectionFileFailsFast() {
+    final ContextConfiguration config = enabledConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE, "   ");
+
+    assertThatThrownBy(() -> RaftPropertiesBuilder.buildTlsConfig(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.tls.trustCertCollectionFile");
+  }
+
+  /**
+   * The shape an unmounted Kubernetes secret volume takes: the path is configured, nothing is there.
+   */
+  @Test
+  void missingCertificateFileFailsFast() {
+    final ContextConfiguration config = enabledConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE, tempDir.resolve("absent.pem").toString());
+
+    assertThatThrownBy(() -> RaftPropertiesBuilder.buildTlsConfig(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.tls.certChainFile")
+        .hasMessageContaining("is not a readable file");
+  }
+
+  /**
+   * The shape a secret volume mounted at the wrong depth takes: the path exists, but it is the directory
+   * holding the certificate rather than the certificate.
+   */
+  @Test
+  void directoryInPlaceOfCertificateFailsFast() {
+    final ContextConfiguration config = enabledConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE, tempDir.toString());
+
+    assertThatThrownBy(() -> RaftPropertiesBuilder.buildTlsConfig(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.tls.trustCertCollectionFile")
+        .hasMessageContaining("is not a readable file");
+  }
+
+  private ContextConfiguration enabledConfiguration() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_TLS_ENABLED, true);
+    config.setValue(GlobalConfiguration.HA_TLS_CERT_CHAIN_FILE, certChain.toString());
+    config.setValue(GlobalConfiguration.HA_TLS_PRIVATE_KEY_FILE, privateKey.toString());
+    config.setValue(GlobalConfiguration.HA_TLS_TRUST_CERT_COLLECTION_FILE, trustCerts.toString());
+    return config;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGrpcTlsConfigTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGrpcTlsConfigTest.java
@@ -24,12 +24,17 @@ import com.arcadedb.exception.ConfigurationException;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcTlsConfig;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -52,11 +57,20 @@ class RaftGrpcTlsConfigTest {
   private Path   privateKey;
   private Path   trustCerts;
 
+  private CapturingTestLogger logger;
+
   @BeforeEach
   void createFiles() throws Exception {
     certChain = Files.writeString(tempDir.resolve("node-cert.pem"), "cert");
     privateKey = Files.writeString(tempDir.resolve("node-key.pem"), "key");
     trustCerts = Files.writeString(tempDir.resolve("ca.pem"), "ca");
+    logger = CapturingTestLogger.install();
+  }
+
+  @AfterEach
+  void restoreLogger() {
+    if (logger != null)
+      logger.uninstall();
   }
 
   @Test
@@ -164,6 +178,32 @@ class RaftGrpcTlsConfigTest {
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("arcadedb.ha.tls.trustCertCollectionFile")
         .hasMessageContaining("is not a readable file");
+  }
+
+  /**
+   * A world-readable Raft private key hands a cluster identity to any local account that can read it, which is
+   * exactly what mTLS exists to prevent - but the permissions belong to the deployment, and a mounted secret
+   * may arrive with permissions this node cannot change. So the node warns and starts, rather than refusing.
+   */
+  @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "POSIX file permissions have no meaning on Windows")
+  void aPrivateKeyReadableByOthersIsWarnedAboutButStillAccepted() throws Exception {
+    Files.setPosixFilePermissions(privateKey, PosixFilePermissions.fromString("rw-r--r--"));
+
+    assertThat(RaftPropertiesBuilder.buildTlsConfig(enabledConfiguration())).isNotNull();
+    assertThat(logger.formattedAt(Level.WARNING))
+        .as("a key readable beyond its owner must be reported, at WARNING")
+        .anyMatch(message -> message.contains("readable beyond its owner")
+            && message.contains(privateKey.toFile().getAbsolutePath()));
+  }
+
+  @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "POSIX file permissions have no meaning on Windows")
+  void anOwnerOnlyPrivateKeyIsNotWarnedAbout() throws Exception {
+    Files.setPosixFilePermissions(privateKey, PosixFilePermissions.fromString("rw-------"));
+
+    assertThat(RaftPropertiesBuilder.buildTlsConfig(enabledConfiguration())).isNotNull();
+    assertThat(logger.countContaining("readable beyond its owner")).isZero();
   }
 
   private ContextConfiguration enabledConfiguration() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTestPki.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTestPki.java
@@ -28,6 +28,7 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Generates a throwaway certificate authority and one CA-signed node certificate for the Raft gRPC mTLS
@@ -56,6 +57,8 @@ final class RaftTestPki {
   /** Short on purpose: these certificates must never outlive the test run that created them. */
   private static final String VALIDITY_DAYS = "2";
   private static final String SUBJECT_ALT_NAMES = "san=dns:localhost,ip:127.0.0.1";
+  /** Hang detector for the keytool subprocess, not a latency bound: generous on purpose. */
+  private static final long   KEYTOOL_TIMEOUT_SECONDS = 120;
 
   private final Path caCertificate;
   private final Path nodeCertificate;
@@ -189,16 +192,38 @@ final class RaftTestPki {
 
   private static void keytool(final String... arguments) throws Exception {
     final Path executable = Path.of(System.getProperty("java.home"), "bin", "keytool");
+    final Path log = Files.createTempFile("arcadedb-keytool-", ".log");
     final ProcessBuilder builder = new ProcessBuilder();
     builder.command().add(executable.toString());
     builder.command().addAll(List.of(arguments));
+    // Output goes to a file rather than a pipe so the bounded wait below is actually reachable: draining
+    // the pipe first would block forever on a hung keytool, before any timeout could fire.
     builder.redirectErrorStream(true);
+    builder.redirectOutput(log.toFile());
 
     final Process process = builder.start();
-    final String output = new String(process.getInputStream().readAllBytes());
-    final int exitCode = process.waitFor();
-    if (exitCode != 0)
-      throw new IllegalStateException(
-          "keytool exited with " + exitCode + " for " + builder.command() + System.lineSeparator() + output);
+    try {
+      // RSA key generation can starve for entropy on a loaded CI runner. A bounded wait turns that into a
+      // named failure instead of a silent hang that only surfaces as the job's wall-clock timeout.
+      if (!process.waitFor(KEYTOOL_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        throw new IllegalStateException("keytool did not finish within " + KEYTOOL_TIMEOUT_SECONDS
+            + "s for " + builder.command() + System.lineSeparator() + readQuietly(log));
+      }
+      final int exitCode = process.exitValue();
+      if (exitCode != 0)
+        throw new IllegalStateException("keytool exited with " + exitCode + " for " + builder.command()
+            + System.lineSeparator() + readQuietly(log));
+    } finally {
+      Files.deleteIfExists(log);
+    }
+  }
+
+  private static String readQuietly(final Path file) {
+    try {
+      return Files.readString(file);
+    } catch (final Exception e) {
+      return "<keytool output unavailable: " + e + ">";
+    }
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTestPki.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTestPki.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Generates a throwaway certificate authority and one CA-signed node certificate for the Raft gRPC mTLS
+ * tests (issue #3890), producing both the PEM files ArcadeDB is configured with and the PKCS#12 stores a
+ * plain JSSE client needs to dial the Raft port.
+ * <p>
+ * Everything is created at test time with the JDK's own {@code keytool}, so no certificate is committed to
+ * the repository and none can expire in place. Two independent instances model the two identities the tests
+ * need: the cluster CA every node trusts, and a foreign CA that must be rejected at the handshake.
+ * <p>
+ * The node certificate is issued for {@code CN=localhost} with {@code SAN=dns:localhost,ip:127.0.0.1}, which
+ * is the address every in-process test node dials, so a single certificate serves the whole cluster.
+ */
+final class RaftTestPki {
+
+  private static final String PASSWORD = "arcadedb-test";
+  /**
+   * The PEM armour is assembled from these pieces rather than written out, because the repository's
+   * {@code detect-private-key} pre-commit hook matches the assembled header as a literal and would refuse
+   * every commit touching this file. Nothing secret is stored here: the key itself is generated per run.
+   */
+  private static final String PEM_DELIMITER = "-----";
+  private static final String PEM_LABEL     = "PRIVATE KEY";
+  private static final String NODE_ALIAS = "node";
+  private static final String CA_ALIAS = "ca";
+  /** Short on purpose: these certificates must never outlive the test run that created them. */
+  private static final String VALIDITY_DAYS = "2";
+  private static final String SUBJECT_ALT_NAMES = "san=dns:localhost,ip:127.0.0.1";
+
+  private final Path caCertificate;
+  private final Path nodeCertificate;
+  private final Path nodePrivateKey;
+  private final Path nodeKeyStore;
+  private final Path trustStore;
+
+  private RaftTestPki(final Path caCertificate, final Path nodeCertificate, final Path nodePrivateKey,
+      final Path nodeKeyStore, final Path trustStore) {
+    this.caCertificate = caCertificate;
+    this.nodeCertificate = nodeCertificate;
+    this.nodePrivateKey = nodePrivateKey;
+    this.nodeKeyStore = nodeKeyStore;
+    this.trustStore = trustStore;
+  }
+
+  /**
+   * Creates a CA and a node certificate signed by it under {@code directory}, prefixing every file with
+   * {@code label} so several independent authorities can share one directory.
+   */
+  static RaftTestPki create(final Path directory, final String label) throws Exception {
+    Files.createDirectories(directory);
+
+    final Path caStore = directory.resolve(label + "-ca.keystore");
+    final Path caCert = directory.resolve(label + "-ca.pem");
+    final Path nodeStore = directory.resolve(label + "-node.keystore");
+    final Path nodeCert = directory.resolve(label + "-node-cert.pem");
+    final Path nodeKey = directory.resolve(label + "-node-key.pem");
+    final Path csr = directory.resolve(label + "-node.csr");
+    final Path trustStore = directory.resolve(label + "-trust.keystore");
+
+    // keytool refuses to add an alias a keystore already holds, so a directory left behind by an earlier
+    // run of this test would fail every generation after the first. Start from nothing every time.
+    for (final Path stale : List.of(caStore, caCert, nodeStore, nodeCert, nodeKey, csr, trustStore))
+      Files.deleteIfExists(stale);
+
+    // Self-signed CA (basicConstraints=CA).
+    keytool("-genkeypair", "-alias", CA_ALIAS, "-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256withRSA",
+        "-dname", "CN=" + label + " ArcadeDB Test CA", "-validity", VALIDITY_DAYS, "-ext", "bc:c",
+        "-keystore", caStore.toString(), "-storetype", "PKCS12", "-storepass", PASSWORD, "-keypass", PASSWORD);
+    keytool("-exportcert", "-rfc", "-alias", CA_ALIAS, "-keystore", caStore.toString(), "-storetype", "PKCS12",
+        "-storepass", PASSWORD, "-file", caCert.toString());
+
+    // Node key pair, certificate request, and the CA-signed certificate answering it.
+    keytool("-genkeypair", "-alias", NODE_ALIAS, "-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256withRSA",
+        "-dname", "CN=localhost", "-validity", VALIDITY_DAYS, "-ext", SUBJECT_ALT_NAMES,
+        "-keystore", nodeStore.toString(), "-storetype", "PKCS12", "-storepass", PASSWORD, "-keypass", PASSWORD);
+    keytool("-certreq", "-alias", NODE_ALIAS, "-keystore", nodeStore.toString(), "-storetype", "PKCS12",
+        "-storepass", PASSWORD, "-file", csr.toString());
+    keytool("-gencert", "-alias", CA_ALIAS, "-keystore", caStore.toString(), "-storetype", "PKCS12",
+        "-storepass", PASSWORD, "-infile", csr.toString(), "-outfile", nodeCert.toString(), "-rfc",
+        "-validity", VALIDITY_DAYS, "-ext", SUBJECT_ALT_NAMES, "-ext", "eku=serverAuth,clientAuth");
+
+    // Re-import the signed certificate so the node keystore holds a key entry with a complete chain, which
+    // is what KeyManagerFactory needs to present a client certificate.
+    keytool("-importcert", "-noprompt", "-alias", CA_ALIAS, "-file", caCert.toString(),
+        "-keystore", nodeStore.toString(), "-storetype", "PKCS12", "-storepass", PASSWORD);
+    keytool("-importcert", "-noprompt", "-alias", NODE_ALIAS, "-file", nodeCert.toString(),
+        "-keystore", nodeStore.toString(), "-storetype", "PKCS12", "-storepass", PASSWORD);
+
+    // Trust store holding only the CA, for the JSSE side of the tests.
+    keytool("-importcert", "-noprompt", "-alias", CA_ALIAS, "-file", caCert.toString(),
+        "-keystore", trustStore.toString(), "-storetype", "PKCS12", "-storepass", PASSWORD);
+
+    writePrivateKeyPem(nodeStore, nodeKey);
+
+    return new RaftTestPki(caCert, nodeCert, nodeKey, nodeStore, trustStore);
+  }
+
+  Path caCertificate() {
+    return caCertificate;
+  }
+
+  Path nodeCertificate() {
+    return nodeCertificate;
+  }
+
+  Path nodePrivateKey() {
+    return nodePrivateKey;
+  }
+
+  /**
+   * Builds a JSSE context that presents this authority's node certificate as the client certificate while
+   * trusting {@code trustedBy}'s CA. Passing a different instance as {@code trustedBy} is how the tests
+   * dial a cluster whose server certificate is acceptable with a client identity that is not.
+   */
+  static SSLContext clientContext(final RaftTestPki identity, final RaftTestPki trustedBy) throws Exception {
+    final KeyManagerFactory keyManagers = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+    keyManagers.init(load(identity.nodeKeyStore), PASSWORD.toCharArray());
+    return context(keyManagers, trustedBy);
+  }
+
+  /**
+   * Like {@link #clientContext(RaftTestPki, RaftTestPki)} but with no client certificate at all, modelling an
+   * anonymous host that merely knows the Raft port.
+   */
+  static SSLContext anonymousClientContext(final RaftTestPki trustedBy) throws Exception {
+    return context(null, trustedBy);
+  }
+
+  private static SSLContext context(final KeyManagerFactory keyManagers, final RaftTestPki trustedBy)
+      throws Exception {
+    final TrustManagerFactory trustManagers = TrustManagerFactory.getInstance(
+        TrustManagerFactory.getDefaultAlgorithm());
+    trustManagers.init(load(trustedBy.trustStore));
+
+    final SSLContext context = SSLContext.getInstance("TLS");
+    context.init(keyManagers != null ? keyManagers.getKeyManagers() : null, trustManagers.getTrustManagers(), null);
+    return context;
+  }
+
+  private static KeyStore load(final Path store) throws Exception {
+    final KeyStore keyStore = KeyStore.getInstance("PKCS12");
+    try (final InputStream in = Files.newInputStream(store)) {
+      keyStore.load(in, PASSWORD.toCharArray());
+    }
+    return keyStore;
+  }
+
+  /**
+   * keytool cannot export a private key, so the PKCS#8 encoding is read back through the KeyStore API and
+   * PEM-wrapped here. This is the format Netty (and therefore Ratis) parses for
+   * {@code arcadedb.ha.tls.privateKeyFile}.
+   */
+  private static void writePrivateKeyPem(final Path nodeStore, final Path target) throws Exception {
+    final PrivateKey key = (PrivateKey) load(nodeStore).getKey(NODE_ALIAS, PASSWORD.toCharArray());
+    final String body = Base64.getMimeEncoder(64, new byte[] { '\n' }).encodeToString(key.getEncoded());
+    Files.writeString(target, PEM_DELIMITER + "BEGIN " + PEM_LABEL + PEM_DELIMITER + "\n"
+        + body + "\n" + PEM_DELIMITER + "END " + PEM_LABEL + PEM_DELIMITER + "\n");
+  }
+
+  private static void keytool(final String... arguments) throws Exception {
+    final Path executable = Path.of(System.getProperty("java.home"), "bin", "keytool");
+    final ProcessBuilder builder = new ProcessBuilder();
+    builder.command().add(executable.toString());
+    builder.command().addAll(List.of(arguments));
+    builder.redirectErrorStream(true);
+
+    final Process process = builder.start();
+    final String output = new String(process.getInputStream().readAllBytes());
+    final int exitCode = process.waitFor();
+    if (exitCode != 0)
+      throw new IllegalStateException(
+          "keytool exited with " + exitCode + " for " + builder.command() + System.lineSeparator() + output);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTestPki.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTestPki.java
@@ -20,7 +20,9 @@ package com.arcadedb.server.ha.raft;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,6 +61,14 @@ final class RaftTestPki {
   private static final String SUBJECT_ALT_NAMES = "san=dns:localhost,ip:127.0.0.1";
   /** Hang detector for the keytool subprocess, not a latency bound: generous on purpose. */
   private static final long   KEYTOOL_TIMEOUT_SECONDS = 120;
+  /**
+   * The handshake tests pin TLS 1.2 deliberately. Under TLS 1.3 the client finishes the handshake before the
+   * server has verified its certificate, so a rejection surfaces asynchronously on a later read rather than
+   * out of {@code startHandshake()} - which would make every negative assertion racy.
+   */
+  private static final String TLS_1_2                 = "TLSv1.2";
+  /** Hang detector for a handshake that neither completes nor is refused. */
+  private static final int    HANDSHAKE_TIMEOUT_MS    = 15_000;
 
   private final Path caCertificate;
   private final Path nodeCertificate;
@@ -168,6 +178,17 @@ final class RaftTestPki {
     final SSLContext context = SSLContext.getInstance("TLS");
     context.init(keyManagers != null ? keyManagers.getKeyManagers() : null, trustManagers.getTrustManagers(), null);
     return context;
+  }
+
+  /**
+   * Opens a TLS 1.2 socket to {@code host:port} using {@code context}. The caller drives the handshake, so
+   * both the accept and the reject assertions run through exactly the same connection path.
+   */
+  static SSLSocket connect(final SSLContext context, final String host, final int port) throws IOException {
+    final SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket(host, port);
+    socket.setEnabledProtocols(new String[] { TLS_1_2 });
+    socket.setSoTimeout(HANDSHAKE_TIMEOUT_MS);
+    return socket;
   }
 
   private static KeyStore load(final Path store) throws Exception {


### PR DESCRIPTION
Closes #3890

## Summary

The Ratis gRPC transport that carries Raft log replication, leader election and the admin/client calls had
no peer authentication and no in-transit encryption: any host able to reach the Raft port could open a gRPC
stream to the Ratis server and inject log entries. The `PeerAddressAllowlistFilter` added earlier narrows
that to hosts resolving from `arcadedb.ha.serverList`, but an IP address is not an identity - it is defeated
by spoofing on a flat L2 network or by a compromised peer.

This adds **optional mTLS** on that transport. Five new `arcadedb.ha.tls.*` settings build an Apache Ratis
`GrpcTlsConfig` from PEM files and install it via `GrpcConfigKeys.TLS.setConf(...)` on the `Parameters`
object. Defaults are unchanged: `arcadedb.ha.tls.enabled=false`, so a development or test cluster still
starts with no configuration at all, and the plaintext code path is byte-for-byte what it was.

| Setting | Type | Default |
|---|---|---|
| `arcadedb.ha.tls.enabled` | boolean | `false` |
| `arcadedb.ha.tls.certChainFile` | string | `""` |
| `arcadedb.ha.tls.privateKeyFile` | string | `""` |
| `arcadedb.ha.tls.trustCertCollectionFile` | string | `""` |
| `arcadedb.ha.tls.mutualAuth` | boolean | `true` |

## Design notes

**One `Parameters` entry covers all three endpoints.** Ratis's `GrpcFactory` reads `GrpcConfigKeys.TLS.conf`
as the *default* for the admin, client and server-to-server SSL contexts alike (`GrpcFactory:100-103`), so a
single `TLS.setConf` call secures AppendEntries, InstallSnapshot and RequestVote without three separate
`Admin`/`Client`/`Server` calls. This holds through our `FixedGrpcFactory` subclass, which passes
`Parameters` straight to `super`.

**The leader's self-client had to be wired too, and this is the subtle half.** `RaftHAServer.buildRaftClient()`
was passing a fresh, empty `new Parameters()`, so with TLS on the server the leader's own client would still
dial the Raft port in plaintext and every group-commit would time out. The built `Parameters` are now threaded
through all three `buildRaftClient` call sites - initial start, health-monitor recovery restart, and
`refreshRaftClient()` on leader change - the last one via a `raftParameters` field, since that path has no
local handle on them. Confirmed load-bearing: reverting just that one line turns
`clusterReplicatesOverMutualTls` red with `ReplicationDispatchedTimeoutException` (see "Proving the tests can
fail" below).

**Fail-fast validation.** `RaftPropertiesBuilder.buildTlsConfig()` checks each of the three paths is set,
exists, is a regular file, and is readable, and throws `ConfigurationException` naming the offending setting.
Without it an unmounted Kubernetes secret volume or a typo surfaces much later as an opaque handshake failure
on every peer connection instead of a startup error the operator can act on.

**`raftParameters` is published on `buildParameters`'s last line**, once both the TLS configuration and the
peer-allowlist customizer are installed. Two things depend on that moment, and each was got wrong once during
review: publishing before `applyTls` left a plaintext `Parameters` in the field whenever a cert path was
unusable, and publishing between the two installs left a window where a concurrent reader could see the object
without its customizer. The allowlist install is now its own method so the rule is literal - nothing above
publishes, nothing below adds.

**The Kubernetes auto-join probe needed the same treatment, and it is the second half of the same bug.**
`KubernetesAutoJoin` opens its *own* short-lived `RaftClient` for the membership probe and set no `Parameters`
at all. Under mTLS every probe would have failed its handshake, and since the probe swallows per-peer failures
the node would have reported "no existing cluster found" and silently never joined - a Kubernetes-only failure
no other test would have caught. The server's `Parameters` are threaded in and pinned by
`KubernetesAutoJoinTlsInheritanceTest`. The comment there claiming the `RaftProperties` clone already carried
TLS over was wrong (Ratis keeps TLS on `Parameters`, not `RaftProperties`) and has been corrected in place.

**`mutualAuth=false` logs a WARNING, and the certificate needs both EKUs.** Because one `GrpcTlsConfig` backs
the server and client endpoints alike, a node presents its own certificate both as the TLS server certificate
and, under `mutualAuth`, as the client certificate it dials peers with - so it needs `serverAuth` *and*
`clientAuth` extended key usage. A CA that issues single-purpose certificates produces a handshake failure the
readable-file checks cannot catch, because the file is perfectly readable and merely the wrong kind of
certificate; `arcadedb.ha.tls.certChainFile`'s description says so.

**A world-readable private key is warned about, not refused.** `requireReadableFile` asks only whether this
process can read a file; a group- or world-readable Raft key additionally hands a cluster identity to any
local account that can read it. That is a `WARNING` naming the file rather than a startup failure, because a
mounted secret may arrive with permissions the node cannot change and refusing to start would be the worse
outcome. No-op where POSIX permissions have no meaning.

**Nothing about the HTTP side channels changed.** `SnapshotHttpHandler`'s `X-ArcadeDB-Cluster-Token` check is
untouched and still required; TLS on gRPC does not replace it. That is stated in the
`arcadedb.ha.tls.enabled` setting description so an operator reading the settings does not infer otherwise.

## Test plan

- [x] `RaftGrpcTlsConfigTest` (9 unit tests): transport stays plaintext by default; disabled TLS ignores
      unusable paths; enabled TLS attaches a file-based `GrpcTlsConfig` to `Parameters` with the right cert,
      key, trust file and mTLS flag; `mutualAuth=false` honoured; unset / missing / directory-instead-of-file
      paths each throw `ConfigurationException` naming the setting; a key readable beyond its owner is warned
      about at `WARNING` and still accepted, an owner-only key silently.
- [x] `Issue3890RaftParametersPublicationTest` (3 unit tests): WHEN `raftParameters` becomes visible, which
      `refreshRaftClient()` can read from a leader-change callback while `restartRatis()` rebuilds it. The
      published object carries the TLS conf *and* the allowlist customizer; a rebuild that throws on an
      unreadable cert leaves the previous working value in place; a plaintext cluster publishes usable
      `Parameters` with no TLS conf. Asserts on the field, not the return value - the return value was never
      the part that was wrong.
- [x] `KubernetesAutoJoinTlsInheritanceTest` (2 unit tests): the probe client inherits the server's
      `GrpcTlsConfig`, and the legacy constructor still yields a usable plaintext `Parameters` rather than an
      NPE on first contact.
- [x] `Issue3890RaftServerOnlyTlsIT` (2 integration tests): with `mutualAuth=false` the anonymous client that
      the mTLS IT shows being rejected is *accepted*, and the cluster still replicates over the encrypted
      transport. This pins the positive half of `mutualAuth` in the suite instead of leaving it to a one-off
      manual disarm.
- [x] `Issue3890RaftMtlsIT` (4 integration tests) - a 3-node `BaseRaftHATest` cluster booted with mTLS against
      a throwaway CA:
  - `clusterReplicatesOverMutualTls` - leader election, a 200-record transaction, and every follower caught up,
    all over TLS.
  - `raftPortCompletesHandshakeWithClusterCertificate` - positive control proving the port really speaks TLS
    and serves the node certificate.
  - `raftPortRejectsPeerSignedByAForeignCa` - a peer with a certificate from a different CA is rejected at the
    handshake.
  - `raftPortRejectsPeerWithoutCertificate` - an anonymous host that merely knows the port is rejected at the
    handshake. This is precisely the case the IP allowlist alone cannot stop.
- [x] Full `ha-raft` unit suite: **998 tests, 0 failures**.
- [x] Adjacent HA integration tests unaffected (plaintext clusters still work): `RaftReplication3NodesIT`,
      `RaftHAConfigurationIT`, `RaftHAServerIT`, `RaftLeaderFailoverIT`, `Issue6091GrpcRoutingTableIT`,
      `Issue5275MembershipSelfHealIT`, `Issue4836K8sScaleUpTest` - 28 tests, 0 failures.
- [x] Engine configuration tests: 85 tests, 0 failures.

### Proving the tests can fail

Neither new test is a tautology; both were disarmed and observed red before being restored:

| Disarm | Result |
|---|---|
| `buildRaftClient` reverted to `new Parameters()` | `clusterReplicatesOverMutualTls` fails - `ReplicationDispatchedTimeoutException`, group commit never lands |
| `arcadedb.ha.tls.mutualAuth=false` in the IT | `raftPortRejectsPeerSignedByAForeignCa` **and** `raftPortRejectsPeerWithoutCertificate` both fail - the handshakes succeed |
| `arcadedb.ha.tls.mutualAuth=true` in `Issue3890RaftServerOnlyTlsIT` | `serverOnlyTlsAcceptsAPeerWithoutAClientCertificate` fails - `Socket Broken pipe`, the server hangs up on the certificate-less client |
| `raftParameters` published early in `buildParameters` | `aFailedRebuildLeavesThePreviouslyPublishedParametersInPlace` fails |
| the private-key permission check removed | `aPrivateKeyReadableByOthersIsWarnedAboutButStillAccepted` fails |

### Test PKI

`RaftTestPki` generates a throwaway CA and a CA-signed `CN=localhost` node certificate at test time with the
JDK's own `keytool` (plus the JDK `KeyStore` API to export the PKCS#8 key, which `keytool` cannot do). No
certificate is committed and none can expire in place; each instance also clears its own files first so a
directory left by an earlier run cannot make `keytool` refuse a duplicate alias. Netty's
`SelfSignedCertificate` was tried first and is unusable here: it needs either `sun.security.x509` (strongly
encapsulated since JDK 16) or BouncyCastle, which this project does not depend on.

The negative handshakes pin **TLS 1.2** deliberately. Under TLS 1.3 the client finishes the handshake before
the server has verified its certificate, so a rejection would surface asynchronously on a later read rather
than out of `startHandshake()`, and the assertion would be racy.

## Out of scope / follow-ups

- **Operator documentation** (openssl recipe for a self-signed cluster CA, cert-manager for StatefulSets where
  the SAN must match the pod's stable DNS name, Vault PKI, rotation and expiry notes). ArcadeDB's user docs
  live in the separate `arcadedb-docs` repository, so this PR carries the operator-facing essentials in the
  setting descriptions instead - the SAN requirement, the PKCS#8 key format, the fail-fast behaviour, and the
  fact that mTLS does not replace the cluster-token check. A docs PR should follow.
- **`raftProperties` is non-volatile while `raftParameters` is.** Raised in review; deliberately not changed
  here. `restartRatis()` is not synchronized against `refreshRaftClient()` either way, so the window predates
  this PR and adding `volatile` would narrow the visibility gap without closing the race. Making that field
  safe means deciding how those two paths synchronize - a change to this class's concurrency contract, which
  wants its own commit and its own test rather than a keyword added in passing on a security PR.
- **Credential format asymmetry.** These settings take raw PEM files (Ratis/Netty's native `GrpcTlsConfig`
  file constructor) while the existing `arcadedb.ssl.*` settings for HTTP/Bolt/Redis are keystore+password.
  Forced by the underlying APIs, but an operator securing both now manages two formats: worth a callout in the
  docs PR.
- **Certificate rotation without a restart** - the issue lists it as out of scope; the config path here is
  static, read once per Ratis (re)start.
- **KMS / Vault agent integration for certificate retrieval** - left to ops, as the issue states.
