### PR TITLE
fix(#5756): remove the unreachable column projection push-down from the filtered scan

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClusterExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClusterExecutionStep.java
@@ -27,7 +27,6 @@ import com.arcadedb.log.LogManager;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -39,7 +38,6 @@ public class FetchFromClusterExecutionStep extends AbstractExecutionStep {
   public static final Object            ORDER_DESC   = "DESC";
   private final       QueryPlanningInfo queryPlanning;
   private final       int               bucketId;
-  private final       Set<String>       projectedProperties;
   private             Object            order;
   private             long              totalFetched = 0L;
   private             boolean           warnedAboutSkippedRecords;
@@ -55,7 +53,6 @@ public class FetchFromClusterExecutionStep extends AbstractExecutionStep {
     super(context);
     this.bucketId = bucketId;
     this.queryPlanning = queryPlanning;
-    this.projectedProperties = queryPlanning != null ? queryPlanning.projectedProperties : null;
     this.order = order;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeWithFilterStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeWithFilterStep.java
@@ -39,7 +39,6 @@ public class FetchFromTypeWithFilterStep extends AbstractExecutionStep {
 
   private       String      typeName;
   private       WhereClause whereClause;
-  private       Set<String> projectedProperties;
   private       boolean     orderByRidAsc  = false;
   private       boolean     orderByRidDesc = false;
   private       List<ExecutionStep> subSteps = new ArrayList<>();
@@ -51,13 +50,11 @@ public class FetchFromTypeWithFilterStep extends AbstractExecutionStep {
     super(context);
   }
 
-  public FetchFromTypeWithFilterStep(final String typeName, final Set<String> clusters,
-      final WhereClause whereClause, final Set<String> projectedProperties,
+  public FetchFromTypeWithFilterStep(final String typeName, final Set<String> clusters, final WhereClause whereClause,
       final CommandContext context, final Boolean ridOrder) {
     super(context);
     this.typeName = typeName;
     this.whereClause = whereClause;
-    this.projectedProperties = projectedProperties;
 
     if (Boolean.TRUE.equals(ridOrder))
       orderByRidAsc = true;
@@ -92,7 +89,7 @@ public class FetchFromTypeWithFilterStep extends AbstractExecutionStep {
 
     for (final int bucketId : bucketIds) {
       if (bucketId > 0) {
-        final ScanWithFilterStep step = new ScanWithFilterStep(bucketId, whereClause, projectedProperties, context);
+        final ScanWithFilterStep step = new ScanWithFilterStep(bucketId, whereClause, context);
         if (orderByRidAsc)
           step.setOrder(FetchFromClusterExecutionStep.ORDER_ASC);
         else if (orderByRidDesc)
@@ -180,8 +177,6 @@ public class FetchFromTypeWithFilterStep extends AbstractExecutionStep {
     final String ind = ExecutionStepInternal.getIndent(depth, indent);
     builder.append(ind);
     builder.append("+ FETCH FROM TYPE ").append(typeName).append(" WITH FILTER");
-    if (projectedProperties != null)
-      builder.append(" [projected: ").append(String.join(", ", projectedProperties)).append("]");
     if (context.isProfiling())
       builder.append(" (").append(getCostFormatted()).append(")");
     builder.append("\n");
@@ -217,7 +212,6 @@ public class FetchFromTypeWithFilterStep extends AbstractExecutionStep {
     result.whereClause = this.whereClause;
     result.orderByRidAsc = this.orderByRidAsc;
     result.orderByRidDesc = this.orderByRidDesc;
-    result.projectedProperties = this.projectedProperties;
     result.subSteps = this.subSteps.stream().map(x -> ((ExecutionStepInternal) x).copy(context)).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryPlanningInfo.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryPlanningInfo.java
@@ -75,13 +75,6 @@ public class QueryPlanningInfo {
   boolean        projectionsCalculated = false;
   AndBlock       ridRangeConditions;
 
-  /**
-   * Set of property names required by this query (from SELECT, WHERE, GROUP BY, ORDER BY).
-   * When null, all properties are needed (e.g., SELECT *).
-   * Used for column projection pushdown to avoid deserializing unused properties.
-   */
-  Set<String> projectedProperties;
-
   public QueryPlanningInfo copy() {
     //TODO check what has to be copied and what can be just referenced as it is
     final QueryPlanningInfo result = new QueryPlanningInfo();
@@ -109,7 +102,6 @@ public class QueryPlanningInfo {
     result.orderApplied = this.orderApplied;
     result.projectionsCalculated = this.projectionsCalculated;
     result.ridRangeConditions = this.ridRangeConditions;
-    result.projectedProperties = this.projectedProperties;
 
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScanWithFilterStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScanWithFilterStep.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.query.sql.executor;
 
-import com.arcadedb.database.ImmutableDocument;
 import com.arcadedb.database.Record;
 import com.arcadedb.engine.BucketIterator;
 import com.arcadedb.exception.TimeoutException;
@@ -26,28 +25,23 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.parser.WhereClause;
 
 import java.util.Iterator;
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.logging.Level;
 
 /**
  * A combined scan + filter step that evaluates the WHERE predicate immediately after loading each record,
  * avoiding the overhead of creating ResultInternal wrappers for records that don't match the filter.
  * <p>
- * When {@code projectedProperties} is set, matching records are returned with only the projected properties
- * deserialized, using a two-phase approach:
- * <ol>
- *   <li>Filter phase: WHERE predicate accesses only the fields it references (lazy deserialization)</li>
- *   <li>Projection phase: only the SELECT-listed properties are deserialized from the binary buffer</li>
- * </ol>
- * Fields that appear in both WHERE and SELECT are deserialized only once (the lazy cache in ImmutableDocument).
+ * A surviving record is handed downstream as a plain wrapper around the {@link com.arcadedb.database.ImmutableDocument}
+ * it was read from, so every column is still deserialized one at a time, on demand, and only if something actually asks
+ * for it. This step used to carry a second "column projection push-down" phase that pre-extracted the SELECT-listed
+ * columns into the row instead; it was unreachable by construction and has been removed - see issue #5756 and the note
+ * on {@code SelectExecutionPlanner#handleTypeAsTarget}.
  */
 public class ScanWithFilterStep extends AbstractExecutionStep {
 
   private final int         bucketId;
   private final WhereClause whereClause;
-  private final Set<String> projectedProperties;
   private       Object      order;
   private       long        totalFetched  = 0L;
   private       long        totalFiltered = 0L;
@@ -55,16 +49,10 @@ public class ScanWithFilterStep extends AbstractExecutionStep {
 
   private Iterator<Record> iterator;
 
-  public ScanWithFilterStep(final int bucketId, final WhereClause whereClause, final Set<String> projectedProperties,
-      final CommandContext context) {
+  public ScanWithFilterStep(final int bucketId, final WhereClause whereClause, final CommandContext context) {
     super(context);
     this.bucketId = bucketId;
     this.whereClause = whereClause;
-    this.projectedProperties = projectedProperties;
-  }
-
-  public ScanWithFilterStep(final int bucketId, final WhereClause whereClause, final CommandContext context) {
-    this(bucketId, whereClause, null, context);
   }
 
   public void setOrder(final Object order) {
@@ -96,7 +84,7 @@ public class ScanWithFilterStep extends AbstractExecutionStep {
             final Record record = iterator.next();
             totalFetched++;
 
-            // Phase 1: Evaluate WHERE on the full document (uses lazy per-field deserialization)
+            // Evaluate WHERE on the document itself: every field access is lazily deserialized on demand
             final ResultInternal candidate = new ResultInternal(record);
 
             // Set $current before WHERE evaluation so method calls (e.g. split()) resolve correctly
@@ -105,18 +93,7 @@ public class ScanWithFilterStep extends AbstractExecutionStep {
             final long filterBegin = context.isProfiling() ? System.nanoTime() : 0;
             try {
               if (whereClause.matchesFilters(candidate, context)) {
-                // Phase 2: If projectedProperties is set, extract only needed columns
-                if (projectedProperties != null && record instanceof ImmutableDocument immutableDoc) {
-                  final String[] fieldNames = projectedProperties.toArray(new String[0]);
-                  final Map<String, Object> props = immutableDoc.propertiesAsMap(fieldNames);
-                  final ResultInternal projected = new ResultInternal(context.getDatabase());
-                  projected.setElement(immutableDoc);
-                  for (final Map.Entry<String, Object> entry : props.entrySet())
-                    projected.setProperty(entry.getKey(), entry.getValue());
-                  nextItem = projected;
-                } else
-                  nextItem = candidate;
-
+                nextItem = candidate;
                 context.setVariable("current", nextItem);
                 return;
               }
@@ -181,8 +158,6 @@ public class ScanWithFilterStep extends AbstractExecutionStep {
   public String prettyPrint(final int depth, final int indent) {
     String result = ExecutionStepInternal.getIndent(depth, indent) + "+ SCAN WITH FILTER BUCKET " + bucketId
         + " (" + context.getDatabase().getSchema().getBucketById(bucketId).getName() + ")";
-    if (projectedProperties != null)
-      result += " [projected: " + String.join(", ", projectedProperties) + "]";
     if (context.isProfiling())
       result += " (" + getCostFormatted() + ")";
     result += "\n" + ExecutionStepInternal.getIndent(depth, indent) + "  " + whereClause;
@@ -196,8 +171,7 @@ public class ScanWithFilterStep extends AbstractExecutionStep {
 
   @Override
   public ExecutionStep copy(final CommandContext context) {
-    final ScanWithFilterStep copy = new ScanWithFilterStep(this.bucketId, this.whereClause.copy(), this.projectedProperties,
-        context);
+    final ScanWithFilterStep copy = new ScanWithFilterStep(this.bucketId, this.whereClause.copy(), context);
     copy.setOrder(this.order);
     return copy;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScanWithFilterStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScanWithFilterStep.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.database.ImmutableDocument;
 import com.arcadedb.database.Record;
 import com.arcadedb.engine.BucketIterator;
 import com.arcadedb.exception.TimeoutException;
@@ -32,7 +33,7 @@ import java.util.logging.Level;
  * A combined scan + filter step that evaluates the WHERE predicate immediately after loading each record,
  * avoiding the overhead of creating ResultInternal wrappers for records that don't match the filter.
  * <p>
- * A surviving record is handed downstream as a plain wrapper around the {@link com.arcadedb.database.ImmutableDocument}
+ * A surviving record is handed downstream as a plain wrapper around the {@link ImmutableDocument}
  * it was read from, so every column is still deserialized one at a time, on demand, and only if something actually asks
  * for it. This step used to carry a second "column projection push-down" phase that pre-extracted the SELECT-listed
  * columns into the row instead; it was unreachable by construction and has been removed - see issue #5756 and the note

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -167,66 +167,6 @@ public class SelectExecutionPlanner {
     // literal-only comparisons, so the verdict holds for every execution that reuses the cached plan.
     if (info.whereClause != null && info.whereClause.isAlwaysTrue(context))
       info.whereClause = null;
-
-    info.projectedProperties = computeProjectedProperties(info);
-  }
-
-  /**
-   * Computes the set of property names required by this query for column projection pushdown.
-   * Analyzes SELECT projections, WHERE clause, GROUP BY, and ORDER BY to determine the minimal
-   * set of properties that need to be deserialized from storage.
-   *
-   * @return the set of required property names, or null if all properties are needed (e.g., SELECT *)
-   */
-  private static Set<String> computeProjectedProperties(final QueryPlanningInfo info) {
-    // If there's no projection or it contains *, we need all properties
-    if (info.projection == null)
-      return null;
-
-    for (final ProjectionItem item : info.projection.getItems())
-      if (item.isAll())
-        return null;
-
-    final Set<String> result = new HashSet<>();
-
-    // Extract from SELECT projections
-    for (final ProjectionItem item : info.projection.getItems()) {
-      if (item.getExpression() != null && item.getExpression().isBaseIdentifier())
-        result.add(item.getExpression().getDefaultAlias().getStringValue());
-      else if (item.getExpression() != null)
-        // Complex expression: we can't determine the exact fields needed, need all
-        return null;
-    }
-
-    // Extract from WHERE clause
-    if (info.whereClause != null) {
-      // WHERE can reference arbitrary fields, so we need all properties if we can't analyze it
-      // For safety, return null to indicate all properties needed
-      return null;
-    }
-
-    // Extract from GROUP BY
-    if (info.groupBy != null) {
-      for (final Expression expr : info.groupBy.getItems()) {
-        if (expr.isBaseIdentifier())
-          result.add(expr.getDefaultAlias().getStringValue());
-        else
-          return null;
-      }
-    }
-
-    // Extract from ORDER BY
-    if (info.orderBy != null) {
-      for (final OrderByItem item : info.orderBy.getItems()) {
-        final String alias = item.getAlias();
-        if (alias != null)
-          result.add(alias);
-        else
-          return null;
-      }
-    }
-
-    return result.isEmpty() ? null : result;
   }
 
   public InternalExecutionPlan createExecutionPlan(final CommandContext context, final boolean useCache) {
@@ -1983,14 +1923,21 @@ public class SelectExecutionPlanner {
 
     // Predicate pushdown: if there's a WHERE clause and no index was used, integrate the filter
     // directly into the scan step to avoid separate FilterStep overhead.
-    // Also passes projectedProperties so that only SELECT-listed fields are deserialized
-    // for matching records (two-phase deserialization optimization).
+    // Only the predicate is pushed down, never the column list. A column projection push-down used to ride along
+    // here, and it was unreachable by construction: it was computed only when the statement had no WHERE clause,
+    // while this step exists only because it has one (issue #5756). Reviving it is not just a matter of widening
+    // that computation - the row it built carried the projected columns as content AND the record as element, and
+    // ResultInternal reads those two stores with different precedences, so any column left out of the projected
+    // set answered null to getProperty() while hasProperty() still said true. Every downstream consumer of a
+    // column the SELECT does not name - a per-record LET, an ORDER BY alias, a subquery - would have read that
+    // null as the stored value. Deserialization is already per-column and on demand (ImmutableDocument.get()),
+    // so there is no "materialize everything then discard it" cost here to reclaim.
     // Skip pushdown when WHERE references LET variables ($), since LET is evaluated after fetch.
     final boolean whereRefersToLet = info.perRecordLetClause != null && info.whereClause != null
         && info.whereClause.toString().contains("$");
     if (info.whereClause != null && info.whereClause.baseExpression != null && !whereRefersToLet) {
       final FetchFromTypeWithFilterStep fetcher = new FetchFromTypeWithFilterStep(identifier.getStringValue(), effectiveClusters,
-          info.whereClause, info.projectedProperties, context, orderByRidAsc);
+          info.whereClause, context, orderByRidAsc);
       if (orderByRidAsc != null)
         info.orderApplied = true;
       plan.chain(fetcher);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue5756FilteredScanColumnPushdownTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue5756FilteredScanColumnPushdownTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5756 - the column projection push-down that {@code ScanWithFilterStep} used to carry was unreachable by
+ * construction: the planner computed the projected column set only for a statement with no WHERE clause, while the
+ * filtered scan exists only because the statement has one. It has been removed.
+ * <p>
+ * These tests pin the contract a future column push-down would have to honour, because the removed one did not:
+ * it emitted a row carrying the projected columns as content <em>and</em> the record as element, and
+ * {@link ResultInternal} reads those two stores with different precedences. A column left out of the projected set
+ * therefore answered {@code null} to {@code getProperty()} while {@code hasProperty()} still reported {@code true} -
+ * so every downstream reader of a column the SELECT does not name (a per-record LET, an ORDER BY alias, a subquery)
+ * would have silently read {@code null} instead of the stored value.
+ */
+class Issue5756FilteredScanColumnPushdownTest extends TestHelper {
+
+  private static final int RECORD_COUNT = 40;
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Wide");
+      for (int i = 0; i < RECORD_COUNT; i++) {
+        final MutableDocument doc = database.newDocument("Wide");
+        doc.set("id", i);
+        doc.set("name", "n" + i);
+        doc.set("status", i % 2 == 0 ? "active" : "closed");
+        doc.set("amount", i * 1.5);
+        doc.set("note", "note_" + i);
+        doc.save();
+      }
+    });
+  }
+
+  /**
+   * The filtered scan is chosen exactly when there is a WHERE clause, so no plan can ever advertise a column
+   * push-down on it. Before the fix the marker was emitted by dead code that no query shape could reach; after it,
+   * the concept is gone. Either way the plan must never claim to project columns at the scan.
+   */
+  @Test
+  void noFilteredScanPlanAdvertisesAColumnPushdown() {
+    final List<String> queries = List.of(
+        "SELECT name, amount FROM Wide WHERE status = 'closed'",
+        "SELECT name FROM Wide WHERE id > 30",
+        "SELECT name FROM Wide WHERE id > 30 ORDER BY amount DESC",
+        "SELECT name, amount FROM Wide WHERE name IS NOT NULL AND id > 30",
+        "SELECT status FROM Wide WHERE id > 2 GROUP BY status",
+        "SELECT name, $a AS a FROM Wide LET $a = amount WHERE id > 30");
+
+    for (final String query : queries) {
+      final String plan = explain(query);
+      assertThat(plan).as("filtered scan expected for: %s", query).contains("SCAN WITH FILTER");
+      assertThat(plan).as("no column push-down may be advertised for: %s", query).doesNotContain("[projected:");
+    }
+  }
+
+  /**
+   * A narrow SELECT over a filtered scan returns exactly the requested columns, and the column the filter ran on is
+   * not smuggled into the row through any accessor - not {@code getPropertyNames()}, not {@code hasProperty()}, and
+   * not the defaulting {@code getProperty(name, default)} overload that reads the backing element.
+   */
+  @Test
+  void narrowProjectionOverAFilteredScanReturnsExactlyTheSelectedColumns() {
+    final ResultSet rs = database.query("SQL", "SELECT name, amount FROM Wide WHERE status = 'closed'");
+
+    int count = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      assertThat(row.getPropertyNames()).containsExactlyInAnyOrder("name", "amount");
+      assertThat(row.<String>getProperty("name")).startsWith("n");
+      assertThat(row.<Double>getProperty("amount")).isNotNull();
+
+      assertThat(row.hasProperty("status")).isFalse();
+      assertThat(row.<Object>getProperty("status")).isNull();
+      assertThat(row.<Object>getProperty("status", "RESURRECTED")).isEqualTo("RESURRECTED");
+      assertThat(row.toMap()).doesNotContainKeys("status", "note");
+      count++;
+    }
+    assertThat(count).isEqualTo(RECORD_COUNT / 2);
+  }
+
+  /**
+   * The decisive guard. {@code amount} is read by a per-record LET, downstream of the filtered scan and outside the
+   * SELECT list. Under the removed push-down the scan would have emitted a row whose content held only
+   * {@code name}, and {@code $a} would have evaluated to null on every row while the query still looked healthy.
+   */
+  @Test
+  void aColumnOutsideTheSelectListIsStillReadableDownstreamOfAFilteredScan() {
+    final ResultSet rs = database.query("SQL", "SELECT name, $a AS a FROM Wide LET $a = amount WHERE id > 30");
+
+    final List<Double> amounts = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      final Double a = row.getProperty("a");
+      assertThat(a).as("LET over a filtered scan must read the stored value, not null").isNotNull();
+      amounts.add(a);
+    }
+    assertThat(amounts).hasSize(RECORD_COUNT - 31);
+    assertThat(amounts).containsExactly(31 * 1.5, 32 * 1.5, 33 * 1.5, 34 * 1.5, 35 * 1.5, 36 * 1.5, 37 * 1.5, 38 * 1.5,
+        39 * 1.5);
+  }
+
+  /**
+   * Same guard on the sort path: {@code note} is neither selected nor filtered on, and the ORDER BY has to see its
+   * real values on rows coming out of the filtered scan.
+   */
+  @Test
+  void orderByAColumnOutsideTheSelectListOverAFilteredScan() {
+    final ResultSet rs = database.query("SQL", "SELECT name FROM Wide WHERE status = 'active' ORDER BY amount DESC LIMIT 3");
+
+    final List<String> names = new ArrayList<>();
+    while (rs.hasNext())
+      names.add(rs.next().getProperty("name"));
+
+    assertThat(names).containsExactly("n38", "n36", "n34");
+  }
+
+  /**
+   * A record missing one of the projected columns still survives the filter and reports the column as absent rather
+   * than as a value borrowed from another record.
+   */
+  @Test
+  void aRecordMissingAProjectedColumnIsReportedAsAbsent() {
+    database.transaction(() -> {
+      final MutableDocument sparse = database.newDocument("Wide");
+      sparse.set("id", 100);
+      sparse.set("status", "closed");
+      sparse.save();
+    });
+
+    final ResultSet rs = database.query("SQL", "SELECT name, amount FROM Wide WHERE id = 100");
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Object>getProperty("name")).isNull();
+    assertThat(row.<Object>getProperty("amount")).isNull();
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  private String explain(final String query) {
+    final ResultSet rs = database.query("SQL", "EXPLAIN " + query);
+    assertThat(rs.hasNext()).isTrue();
+    return rs.next().getProperty("executionPlanAsString");
+  }
+}


### PR DESCRIPTION
Closes #5756

## Summary

The column projection push-down that `ScanWithFilterStep` carried was unreachable by construction, and it is removed here rather than revived. `SelectExecutionPlanner.computeProjectedProperties()` bailed out to `null` the moment the statement had a WHERE clause, while the filtered scan exists *only* because the statement has one - so `projectedProperties != null` and `whereClause != null` were mutually exclusive in that step. The same set was also handed to `FetchFromClusterExecutionStep`, which stored it in a field it never read. With the last consumer gone, `QueryPlanningInfo.projectedProperties` and `computeProjectedProperties()` (a `HashSet` allocation plus a projection/GROUP BY/ORDER BY walk, run on every uncached SELECT) go with it.

The issue offered two resolutions - make it work, or delete it. Two findings settled it for deletion:

**The premise of "make it work" does not hold.** There is no "deserialise every column and throw most away" cost to reclaim. `ImmutableDocument.get()` deserialises one named property at a time, `ResultInternal` wrapping a record reads through to it lazily, and `Projection.calculateSingle()` evaluates only the expressions the SELECT names. A filtered scan already touches just the columns WHERE and SELECT mention. The push-down's residual win was one header pass instead of *k*, paid for with a second `ResultInternal` plus a `LinkedHashMap` allocated per surviving row.

**Reviving it would have returned silently wrong data.** The row the dead branch built carried the projected columns as `content` *and* the record as `element`, and `ResultInternal` reads those two stores with different precedences. Measured on a record `{id:1, name:"n1", status:"closed", amount:1.5}` with the branch's own construction and a projected set of `{name, amount}`:

```
getPropertyNames()        = [name, amount]
hasProperty("status")     = true
getProperty("status")     = null          <-- but the record holds "closed"
getProperty("status","D") = closed
toMap()                   = {id=1, name=n1, status=closed, amount=1.5, ...}
```

`SuffixIdentifier.execute(Result, ctx)` resolves a field as `hasProperty(name) ? getProperty(name) : ...`, so any downstream reader of a column the SELECT does not name - a per-record LET, an ORDER BY alias, a subquery - would have read `null` as the stored value, with no error anywhere. Widening `computeProjectedProperties()` to union the WHERE-referenced fields does not fix that; it only moves the boundary, and the failure mode past the new boundary is still a silent wrong answer rather than a missed optimisation. That is exactly what the original bail-out comment ("WHERE can reference arbitrary fields") was warning about.

Confirmed empirically before the change that no query shape reaches the branch - narrow SELECT with WHERE, with ORDER BY, with GROUP BY, with a per-record LET, and `WHERE 1 = 1` (folded away by #6266's always-true handling, which then drops the filtered scan entirely). None emitted the `[projected: ...]` marker.

## Changes

- `ScanWithFilterStep` - drop the `projectedProperties` field, the 4-argument constructor, the dead phase-2 branch and the plan marker; the class Javadoc now describes what the step actually does.
- `FetchFromTypeWithFilterStep` - drop the parameter it only forwarded, its field, plan marker and `copy()` line.
- `FetchFromClusterExecutionStep` - drop the write-only `projectedProperties` field.
- `SelectExecutionPlanner` - drop `computeProjectedProperties()` and its call; the surviving comment at the predicate-push-down site records why the column half is not coming back.
- `QueryPlanningInfo` - drop the now-unreferenced field.

Predicate push-down itself is untouched: `SELECT ... WHERE` still fetches through `FETCH FROM TYPE ... WITH FILTER` / `SCAN WITH FILTER`, and no plan shape changes.

## Test plan

New `engine/src/test/java/com/arcadedb/query/sql/executor/Issue5756FilteredScanColumnPushdownTest.java` pins the contract any future column push-down has to honour:

- [ ] `noFilteredScanPlanAdvertisesAColumnPushdown` - six query shapes all plan a `SCAN WITH FILTER` and none advertises `[projected:`.
- [ ] `narrowProjectionOverAFilteredScanReturnsExactlyTheSelectedColumns` - the row lists exactly the selected columns, and the filter column is not smuggled back through `hasProperty()`, `getProperty(name, default)` or `toMap()`.
- [ ] `aColumnOutsideTheSelectListIsStillReadableDownstreamOfAFilteredScan` - `SELECT name, $a AS a FROM Wide LET $a = amount WHERE id > 30` reads the stored `amount`, not `null`.
- [ ] `orderByAColumnOutsideTheSelectListOverAFilteredScan` - ORDER BY on an unselected column sorts on real values.
- [ ] `aRecordMissingAProjectedColumnIsReportedAsAbsent` - a record without a projected column still survives the filter and reports it absent.

The tests were proven able to fail: with a naive push-down temporarily wired back into `ScanWithFilterStep`, 3 of the 5 go red (the LET, the ORDER BY and the exact-columns assertions), which is precisely the silent-wrong-data failure described above.

Also run green: `OLAPOptimizationsTest` (the existing "two-phase deserialization" coverage), `ExplainStatementExecutionTest`, `QueryTest`, `ConstantFalseFilterFoldingTest`, `BucketIteratorSkippedRecordWarningTest`, `Issue6465PlainScanSourcesHonourCommandDeadlineTest`, `Issue5966BetweenUsesIndexTest`, `Issue6033BetweenToLowerCaseCiIndexTest`, `Issue6037InToLowerCaseCiIndexTest`, plus the full `arcadedb-engine` suite excluding the `benchmark`/`slow`/`vector` lanes.

## Note

`ImmutableDocument.propertiesAsMap(String...)` is deliberately kept. It was the branch's only production caller, but it is public API, it was fixed on its own merits in #5734, and it has direct test coverage in `ImmutableDocumentLazyLoadingInconsistencyTest`.

## Review cycles

| Cycle | Head | Change | Bot outcome |
|---|---|---|---|
| 1 | `e88a2e8` | Initial removal + regression test | `claude`: "No functional concerns. This looks safe to merge as-is." `coderabbitai`: one trivial nitpick - a fully qualified Javadoc link. |
| 2 | `d87fc89` | Import `ImmutableDocument` and use its simple name in the Javadoc link (the repo guideline CodeRabbit cited) | `claude`: clean, "Nothing here blocks merge." No new actionable items. |

No deferred items. One observation was raised and deliberately not acted on: `claude` noted that `FetchFromClusterExecutionStep` still keeps a `queryPlanning` field whose only other consumer (`ridRangeConditions`) has been commented out since before this PR. It flagged it itself as pre-existing and out of scope here, so it is left for a future cleanup pass rather than widened into this diff.
