### PR TITLE
fix(#6939,#6940,#6941): MongoDB wire protocol batch - non-ObjectId _id, insert/count reporting, upsert id discard

### DIFF
--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
@@ -20,6 +20,7 @@ package com.arcadedb.mongo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.Record;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.parser.Identifier;
 import de.bwaldvogel.mongo.MongoCollection;
@@ -294,7 +295,7 @@ public class MongoDBCollectionWrapper implements MongoCollection<Long> {
     int skipped = 0;
 
     if (!hasFilter) {
-      final Iterator<com.arcadedb.database.Record> it = database.iterateType(collectionName, false);
+      final Iterator<Record> it = database.iterateType(collectionName, false);
       while (it.hasNext()) {
         it.next();
         if (skipped < skip) {

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
@@ -287,6 +287,8 @@ public class MongoDBCollectionWrapper implements MongoCollection<Long> {
 
   @Override
   public int count(final Document document, final int skip, final int limit) {
+    // The count command's own default for an unspecified limit is -1 (MongoDBDatabaseWrapper#countCollection), so
+    // limit <= 0 here means "no limit" - deliberately, not incidentally lining up with an explicit limit: 0.
     final boolean hasFilter = document != null && !document.isEmpty();
     if (!hasFilter && skip <= 0 && limit <= 0)
       return (int) database.countType(collectionName, false);

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
@@ -20,7 +20,6 @@ package com.arcadedb.mongo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.MutableDocument;
-import com.arcadedb.database.Record;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.parser.Identifier;
 import de.bwaldvogel.mongo.MongoCollection;
@@ -35,7 +34,6 @@ import de.bwaldvogel.mongo.oplog.Oplog;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -293,46 +291,38 @@ public class MongoDBCollectionWrapper implements MongoCollection<Long> {
     if (!hasFilter && skip <= 0 && limit <= 0)
       return (int) database.countType(collectionName, false);
 
-    int counted = 0;
-    int skipped = 0;
+    int counted;
 
-    if (!hasFilter) {
-      final Iterator<Record> it = database.iterateType(collectionName, false);
-      while (it.hasNext()) {
-        it.next();
-        if (skipped < skip) {
-          skipped++;
-          continue;
-        }
-        counted++;
-        if (limit > 0 && counted >= limit)
-          break;
-      }
-    } else if (skip <= 0 && limit <= 0) {
-      // No pagination to apply row-by-row: let the engine aggregate instead of materializing every matching row.
+    if (skip <= 0 && limit <= 0) {
+      // No pagination to apply: let the engine aggregate instead of materializing every matching row.
       final Map<String, Object> params = new HashMap<>();
-      final StringBuilder sql = new StringBuilder("select count(*) as count from ").append(Identifier.quote(collectionName))
-          .append(" where ");
-      MongoDBToSqlTranslator.buildExpression(sql, params, document);
+      final StringBuilder sql = new StringBuilder("select count(*) as count from ").append(Identifier.quote(collectionName));
+      if (hasFilter) {
+        sql.append(" where ");
+        MongoDBToSqlTranslator.buildExpression(sql, params, document);
+      }
 
       try (final ResultSet rs = database.query("SQL", sql.toString(), params)) {
         counted = rs.hasNext() ? ((Number) rs.next().getProperty("count")).intValue() : 0;
       }
     } else {
+      // Push skip/limit into the query itself - @rid is enough to count a row, no need to materialize the record.
       final Map<String, Object> params = new HashMap<>();
-      final StringBuilder sql = new StringBuilder("select from ").append(Identifier.quote(collectionName)).append(" where ");
-      MongoDBToSqlTranslator.buildExpression(sql, params, document);
+      final StringBuilder sql = new StringBuilder("select @rid from ").append(Identifier.quote(collectionName));
+      if (hasFilter) {
+        sql.append(" where ");
+        MongoDBToSqlTranslator.buildExpression(sql, params, document);
+      }
+      if (skip > 0)
+        sql.append(" skip ").append(skip);
+      if (limit > 0)
+        sql.append(" limit ").append(limit);
 
+      counted = 0;
       try (final ResultSet rs = database.query("SQL", sql.toString(), params)) {
         while (rs.hasNext()) {
           rs.next();
-          if (skipped < skip) {
-            skipped++;
-            continue;
-          }
           counted++;
-          if (limit > 0 && counted >= limit)
-            break;
         }
       }
     }

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
@@ -306,6 +306,16 @@ public class MongoDBCollectionWrapper implements MongoCollection<Long> {
         if (limit > 0 && counted >= limit)
           break;
       }
+    } else if (skip <= 0 && limit <= 0) {
+      // No pagination to apply row-by-row: let the engine aggregate instead of materializing every matching row.
+      final Map<String, Object> params = new HashMap<>();
+      final StringBuilder sql = new StringBuilder("select count(*) as count from ").append(Identifier.quote(collectionName))
+          .append(" where ");
+      MongoDBToSqlTranslator.buildExpression(sql, params, document);
+
+      try (final ResultSet rs = database.query("SQL", sql.toString(), params)) {
+        counted = rs.hasNext() ? ((Number) rs.next().getProperty("count")).intValue() : 0;
+      }
     } else {
       final Map<String, Object> params = new HashMap<>();
       final StringBuilder sql = new StringBuilder("select from ").append(Identifier.quote(collectionName)).append(" where ");

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
@@ -314,9 +314,9 @@ public class MongoDBCollectionWrapper implements MongoCollection<Long> {
         MongoDBToSqlTranslator.buildExpression(sql, params, document);
       }
       if (skip > 0)
-        sql.append(" skip ").append(skip);
+        sql.append(" SKIP ").append(skip);
       if (limit > 0)
-        sql.append(" limit ").append(limit);
+        sql.append(" LIMIT ").append(limit);
 
       counted = 0;
       try (final ResultSet rs = database.query("SQL", sql.toString(), params)) {

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBCollectionWrapper.java
@@ -34,6 +34,7 @@ import de.bwaldvogel.mongo.oplog.Oplog;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -284,8 +285,46 @@ public class MongoDBCollectionWrapper implements MongoCollection<Long> {
   }
 
   @Override
-  public int count(final Document document, final int i, final int i1) {
-    return (int) database.countType(collectionName, false);
+  public int count(final Document document, final int skip, final int limit) {
+    final boolean hasFilter = document != null && !document.isEmpty();
+    if (!hasFilter && skip <= 0 && limit <= 0)
+      return (int) database.countType(collectionName, false);
+
+    int counted = 0;
+    int skipped = 0;
+
+    if (!hasFilter) {
+      final Iterator<com.arcadedb.database.Record> it = database.iterateType(collectionName, false);
+      while (it.hasNext()) {
+        it.next();
+        if (skipped < skip) {
+          skipped++;
+          continue;
+        }
+        counted++;
+        if (limit > 0 && counted >= limit)
+          break;
+      }
+    } else {
+      final Map<String, Object> params = new HashMap<>();
+      final StringBuilder sql = new StringBuilder("select from ").append(Identifier.quote(collectionName)).append(" where ");
+      MongoDBToSqlTranslator.buildExpression(sql, params, document);
+
+      try (final ResultSet rs = database.query("SQL", sql.toString(), params)) {
+        while (rs.hasNext()) {
+          rs.next();
+          if (skipped < skip) {
+            skipped++;
+            continue;
+          }
+          counted++;
+          if (limit > 0 && counted >= limit)
+            break;
+        }
+      }
+    }
+
+    return counted;
   }
 
   @Override

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -637,7 +637,9 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
       applyOperatorsToDocument(record, u);
     }
 
-    if (record.get("_id") == null)
+    // has(), not get() == null: an explicit "_id": null in the filter/update is a legal (if unusual) BSON _id and
+    // must be preserved, whereas a genuinely absent _id needs one generated.
+    if (!record.has("_id"))
       record.set("_id", new ObjectId().getHexData());
 
     record.save();

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -469,8 +469,6 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
           collection.insertDocuments(documents);
           n = documents.size();
 
-          assert n == documents.size();
-
           final Document result = new Document("n", n);
           this.putLastResult(channel, result);
         }

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -478,8 +478,6 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
         this.putLastError(channel, var7);
         throw var7;
       }
-
-      ++n;
     } catch (final MongoServerError e) {
       final Document error = new Document();
       error.put("index", n);
@@ -578,7 +576,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
           nModified += updated;
 
           if (updated == 0 && upsert) {
-            final ObjectId id = executeUpsert(collectionName, q, u);
+            final Object id = executeUpsert(collectionName, q, u);
             final Document upDoc = new Document("index", index);
             upDoc.put("_id", id);
             upserted.add(upDoc);
@@ -615,7 +613,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     return executeCount(sql.toString(), params);
   }
 
-  private ObjectId executeUpsert(final String collectionName, final Document q, final Document u) {
+  private Object executeUpsert(final String collectionName, final Document q, final Document u) {
     final MutableDocument record = database.newDocument(database.getSchema().getOrCreateDocumentType(collectionName).getName());
 
     // Seed the new document with the filter's top-level equalities, mirroring MongoDB upsert.
@@ -627,9 +625,9 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
         final Object value = entry.getValue();
         if (value instanceof Document opDoc) {
           if (opDoc.containsKey("$eq"))
-            record.set(field, opDoc.get("$eq"));
+            record.set(field, normalizeIdValue(opDoc.get("$eq")));
         } else
-          record.set(field, value);
+          record.set(field, normalizeIdValue(value));
       }
 
     if (isReplacement(u)) {
@@ -639,10 +637,23 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
       applyOperatorsToDocument(record, u);
     }
 
-    final ObjectId id = new ObjectId();
-    record.set("_id", id.getHexData());
+    if (record.get("_id") == null)
+      record.set("_id", new ObjectId().getHexData());
+
     record.save();
-    return id;
+
+    // Mirror the on-wire ObjectId type when the id is one, so the driver reports it (and can round-trip it) the
+    // same way it does for a normally-generated id; any other BSON scalar seeded from the filter is kept as-is.
+    final Object id = record.get("_id");
+    return id instanceof String hex && MongoDBToSqlTranslator.isObjectIdHex(hex) ? new ObjectId(hex) : id;
+  }
+
+  /**
+   * The filter seeding loop copies values verbatim; an {@code ObjectId}-typed filter value (e.g. {@code eq("_id", objectId)})
+   * must be normalized to its hex string, matching how {@code insertDocuments} and {@code buildValue} store an ObjectId.
+   */
+  private static Object normalizeIdValue(final Object value) {
+    return value instanceof ObjectId oid ? oid.getHexData() : value;
   }
 
   private void applyOperatorsToDocument(final MutableDocument record, final Document u) {

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -614,6 +614,11 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
   private Object executeUpsert(final String collectionName, final Document q, final Document u) {
     final MutableDocument record = database.newDocument(database.getSchema().getOrCreateDocumentType(collectionName).getName());
 
+    // Tracks the _id's own BSON type as seeded, independently of the hex string it ends up stored as: a client
+    // that filtered on an ObjectId gets an ObjectId back, but a client that filtered on a plain 24-hex-char String
+    // (indistinguishable from an ObjectId's hex once stored) must get that String type back, not a promoted one.
+    boolean idIsObjectId = false;
+
     // Seed the new document with the filter's top-level equalities, mirroring MongoDB upsert.
     if (q != null)
       for (final Map.Entry<String, Object> entry : q.entrySet()) {
@@ -622,10 +627,17 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
           continue;
         final Object value = entry.getValue();
         if (value instanceof Document opDoc) {
-          if (opDoc.containsKey("$eq"))
-            record.set(field, normalizeIdValue(opDoc.get("$eq")));
-        } else
+          if (opDoc.containsKey("$eq")) {
+            final Object eqValue = opDoc.get("$eq");
+            if ("_id".equals(field) && eqValue instanceof ObjectId)
+              idIsObjectId = true;
+            record.set(field, normalizeIdValue(eqValue));
+          }
+        } else {
+          if ("_id".equals(field) && value instanceof ObjectId)
+            idIsObjectId = true;
           record.set(field, normalizeIdValue(value));
+        }
       }
 
     if (isReplacement(u)) {
@@ -637,15 +649,15 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
 
     // has(), not get() == null: an explicit "_id": null in the filter/update is a legal (if unusual) BSON _id and
     // must be preserved, whereas a genuinely absent _id needs one generated.
-    if (!record.has("_id"))
+    if (!record.has("_id")) {
       record.set("_id", new ObjectId().getHexData());
+      idIsObjectId = true;
+    }
 
     record.save();
 
-    // Mirror the on-wire ObjectId type when the id is one, so the driver reports it (and can round-trip it) the
-    // same way it does for a normally-generated id; any other BSON scalar seeded from the filter is kept as-is.
     final Object id = record.get("_id");
-    return id instanceof String hex && MongoDBToSqlTranslator.isObjectIdHex(hex) ? new ObjectId(hex) : id;
+    return idIsObjectId && id instanceof String hex ? new ObjectId(hex) : id;
   }
 
   /**

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
@@ -289,9 +289,29 @@ public class MongoDBToSqlTranslator {
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
       final String p = entry.getKey();
       final Object value = entry.getValue();
-      result.put(p, "_id".equals(p) ? getObjectId((String) value) : toBsonValue(value));
+      result.put(p, "_id".equals(p) ? convertIdToMongoDB(value) : toBsonValue(value));
     }
     return result;
+  }
+
+  /**
+   * MongoDB allows any BSON scalar as {@code _id}, not just an ObjectId. Only a value that actually looks like a
+   * 24-char hex ObjectId string is decoded as one; anything else (an integer, an odd-length or non-hex string, ...)
+   * is passed through unchanged instead of corrupting or throwing.
+   */
+  private static Object convertIdToMongoDB(final Object value) {
+    if (value instanceof String s && isObjectIdHex(s))
+      return getObjectId(s);
+    return toBsonValue(value);
+  }
+
+  static boolean isObjectIdHex(final String s) {
+    if (s.length() != 24)
+      return false;
+    for (int i = 0; i < s.length(); i++)
+      if (Character.digit(s.charAt(i), 16) < 0)
+        return false;
+    return true;
   }
 
   /**
@@ -324,6 +344,9 @@ public class MongoDBToSqlTranslator {
   }
 
   protected static ObjectId getObjectId(final String s) {
+    if (!isObjectIdHex(s))
+      throw new IllegalArgumentException("'" + s + "' is not a 24-char hex ObjectId");
+
     final byte[] buffer = new byte[s.length() / 2];
     for (int i = 0; i < s.length(); i += 2) {
       buffer[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBInsertCountCommandTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBInsertCountCommandTest.java
@@ -124,4 +124,16 @@ public class MongoDBInsertCountCommandTest extends BaseGraphServerTest {
     final Document both = mongoDatabase.runCommand(new Document("count", "doc").append("skip", 8).append("limit", 5));
     assertThat(both.getInteger("n")).isEqualTo(2);
   }
+
+  @Test
+  void countCommandHonoursQueryTogetherWithSkipAndLimit() {
+    for (int i = 0; i < 10; i++)
+      collection.insertOne(new Document("counter", i).append("even", i % 2 == 0));
+
+    // 5 matching documents (0,2,4,6,8); skip 1, limit 2 -> 2,4
+    final Document result = mongoDatabase.runCommand(
+        new Document("count", "doc").append("query", new Document("even", true)).append("skip", 1).append("limit", 2));
+
+    assertThat(result.getInteger("n")).isEqualTo(2);
+  }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBInsertCountCommandTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBInsertCountCommandTest.java
@@ -45,9 +45,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class MongoDBInsertCountCommandTest extends BaseGraphServerTest {
 
-  private static final int          DEF_PORT = 27017;
-  private              MongoClient  client;
-  private              MongoDatabase        mongoDatabase;
+  private static final int                       DEF_PORT = 27017;
+  private              MongoClient               client;
+  private              MongoDatabase             mongoDatabase;
   private              MongoCollection<Document> collection;
 
   @Override

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBInsertCountCommandTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBInsertCountCommandTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6940: the raw {@code insert} command reported {@code n} one higher than the number
+ * of documents actually inserted (a leftover {@code ++n;} from a per-document loop that was replaced by a single
+ * bulk call), and the raw {@code count} command ignored its {@code query}, {@code skip} and {@code limit}
+ * arguments entirely, always answering with the whole collection size.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class MongoDBInsertCountCommandTest extends BaseGraphServerTest {
+
+  private static final int          DEF_PORT = 27017;
+  private              MongoClient  client;
+  private              MongoDatabase        mongoDatabase;
+  private              MongoCollection<Document> collection;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin");
+  }
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+    getDatabase(0);
+    client = new MongoClient(new ServerAddress("localhost", DEF_PORT),
+        MongoCredential.createPlainCredential("root", getDatabaseName(), DEFAULT_PASSWORD_FOR_TESTS.toCharArray()),
+        MongoClientOptions.builder().serverSelectionTimeout(5000).build());
+    mongoDatabase = client.getDatabase(getDatabaseName());
+    mongoDatabase.createCollection("doc");
+    collection = mongoDatabase.getCollection("doc");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    if (client != null)
+      client.close();
+    super.endTest();
+  }
+
+  @Test
+  void insertCommandReportsExactInsertedCount() {
+    final Document command = new Document("insert", "doc")
+        .append("documents", List.of(new Document("a", 1)));
+
+    final Document result = mongoDatabase.runCommand(command);
+
+    assertThat(result.getInteger("n")).isEqualTo(1);
+  }
+
+  @Test
+  void insertManyReportsExactInsertedCount() {
+    collection.insertMany(List.of(new Document("a", 1), new Document("a", 2), new Document("a", 3)));
+
+    assertThat(collection.countDocuments()).isEqualTo(3);
+  }
+
+  @Test
+  void countCommandHonoursQuery() {
+    collection.insertOne(new Document("name", "found"));
+    collection.insertOne(new Document("name", "other"));
+
+    final Document command = new Document("count", "doc").append("query", new Document("name", "nope"));
+    final Document result = mongoDatabase.runCommand(command);
+
+    assertThat(result.getInteger("n")).isEqualTo(0);
+
+    final Document matching = mongoDatabase.runCommand(
+        new Document("count", "doc").append("query", new Document("name", "found")));
+    assertThat(matching.getInteger("n")).isEqualTo(1);
+  }
+
+  @Test
+  void countCommandHonoursSkipAndLimit() {
+    for (int i = 0; i < 10; i++)
+      collection.insertOne(new Document("counter", i));
+
+    final Document skipped = mongoDatabase.runCommand(new Document("count", "doc").append("skip", 5));
+    assertThat(skipped.getInteger("n")).isEqualTo(5);
+
+    final Document limited = mongoDatabase.runCommand(new Document("count", "doc").append("limit", 3));
+    assertThat(limited.getInteger("n")).isEqualTo(3);
+
+    final Document both = mongoDatabase.runCommand(new Document("count", "doc").append("skip", 8).append("limit", 5));
+    assertThat(both.getInteger("n")).isEqualTo(2);
+  }
+}

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBNonObjectIdTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBNonObjectIdTest.java
@@ -99,12 +99,15 @@ public class MongoDBNonObjectIdTest extends BaseGraphServerTest {
 
   @Test
   void evenLengthNonHexStringIdIsPreservedNotSilentlyCorrupted() {
-    collection.insertOne(new Document("_id", "not-a-hex-strng!").append("name", "z"));
+    // Exactly 24 chars (the ObjectId hex length) but 'g' is not a hex digit, so this must be rejected by the
+    // per-character check in isObjectIdHex rather than the length check alone.
+    final String id = "g".repeat(24);
+    collection.insertOne(new Document("_id", id).append("name", "z"));
 
     final Document found = collection.find().first();
 
     assertThat(found).isNotNull();
-    assertThat(found.get("_id")).isEqualTo("not-a-hex-strng!");
+    assertThat(found.get("_id")).isEqualTo(id);
   }
 
   @Test

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBNonObjectIdTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBNonObjectIdTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6939: a document with a client-supplied {@code _id} that is not a 24-char hex
+ * ObjectId string (an integer, or an odd-length string) made every subsequent unfiltered read of the collection
+ * throw, because {@code convertMapToMongoDB} treated every {@code _id} as an ObjectId hex string unconditionally.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class MongoDBNonObjectIdTest extends BaseGraphServerTest {
+
+  private static final int                       DEF_PORT = 27017;
+  private              MongoClient               client;
+  private              MongoCollection<Document> collection;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin");
+  }
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+    getDatabase(0);
+    client = new MongoClient(new ServerAddress("localhost", DEF_PORT),
+        MongoCredential.createPlainCredential("root", getDatabaseName(), DEFAULT_PASSWORD_FOR_TESTS.toCharArray()),
+        MongoClientOptions.builder().serverSelectionTimeout(5000).build());
+    client.getDatabase(getDatabaseName()).createCollection("doc");
+    collection = client.getDatabase(getDatabaseName()).getCollection("doc");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    if (client != null)
+      client.close();
+    super.endTest();
+  }
+
+  @Test
+  void integerIdDoesNotBreakSubsequentReads() {
+    collection.insertOne(new Document("_id", 1).append("name", "x"));
+
+    final Document found = collection.find().first();
+
+    assertThat(found).isNotNull();
+    assertThat(found.get("_id")).isEqualTo(1);
+    assertThat(found.getString("name")).isEqualTo("x");
+  }
+
+  @Test
+  void oddLengthStringIdDoesNotBreakSubsequentReads() {
+    collection.insertOne(new Document("_id", "abc").append("name", "y"));
+
+    final Document found = collection.find().first();
+
+    assertThat(found).isNotNull();
+    assertThat(found.get("_id")).isEqualTo("abc");
+    assertThat(found.getString("name")).isEqualTo("y");
+  }
+
+  @Test
+  void evenLengthNonHexStringIdIsPreservedNotSilentlyCorrupted() {
+    collection.insertOne(new Document("_id", "not-a-hex-strng!").append("name", "z"));
+
+    final Document found = collection.find().first();
+
+    assertThat(found).isNotNull();
+    assertThat(found.get("_id")).isEqualTo("not-a-hex-strng!");
+  }
+
+  @Test
+  void mixedIdTypesInSameCollectionAllReadBack() {
+    collection.insertOne(new Document("_id", 1).append("name", "int-id"));
+    collection.insertOne(new Document("_id", "abc").append("name", "odd-string-id"));
+
+    final List<Document> all = collection.find().into(new ArrayList<>());
+
+    assertThat(all).hasSize(2);
+    assertThat(all).extracting(d -> d.getString("name")).containsExactlyInAnyOrder("int-id", "odd-string-id");
+  }
+}

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBToSqlTranslatorParamsTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBToSqlTranslatorParamsTest.java
@@ -376,4 +376,18 @@ class MongoDBToSqlTranslatorParamsTest {
     assertThatThrownBy(() -> MongoDBToSqlTranslator.buildExpression(sql, params, new Document("field", new Document("$not", new Document()))))
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  /**
+   * Regression test for issue #6939: {@code getObjectId} used to index straight past the end of an odd-length
+   * input (or, for an even-length non-hex string, silently fabricate a wrong id) instead of rejecting it. Its
+   * only caller already filters with {@code isObjectIdHex} first, so this guard is unreachable in practice today,
+   * but it is exercised directly here since the method is {@code protected} and its contract should hold on its
+   * own regardless of how careful the current caller happens to be.
+   */
+  @Test
+  void getObjectIdRejectsMalformedInputInsteadOfIndexingPastTheEndOrFabricatingAnId() {
+    assertThatThrownBy(() -> MongoDBToSqlTranslator.getObjectId("abc")).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> MongoDBToSqlTranslator.getObjectId("g".repeat(24))).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> MongoDBToSqlTranslator.getObjectId("short")).isInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
@@ -183,4 +183,27 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
     assertThat(found).isNotNull();
     assertThat(found.get("v")).isEqualTo(2);
   }
+
+  /**
+   * Follow-up to #6941 flagged by review: an explicit {@code _id: null} filter is a legal, if unusual, BSON _id.
+   * {@code executeUpsert} must tell that apart from a genuinely absent {@code _id} and preserve it, rather than
+   * discarding it for a freshly generated one the way the original #6941 bug discarded a seeded ObjectId.
+   * <p>
+   * This does not assert that a second {@code eq("_id", null)} upsert is idempotent: matching a stored {@code null}
+   * by equality is a separate, pre-existing gap in the filter-to-SQL translation (an "=" comparison against a bound
+   * null parameter, rather than "IS NULL") that affects every {@code null}-valued filter, not just this upsert path
+   * - tracked separately rather than fixed here.
+   */
+  @Test
+  void upsertFilteredOnNullIdPreservesTheNullId() {
+    final UpdateResult result = collection.updateOne(eq("_id", null), new Document("$set", new Document("v", 1)),
+        new UpdateOptions().upsert(true));
+
+    assertThat(result.getUpsertedId()).isNotNull();
+    assertThat(result.getUpsertedId().isNull()).isTrue();
+
+    final Document inserted = collection.find(eq("v", 1)).first();
+    assertThat(inserted).isNotNull();
+    assertThat(inserted.get("_id")).isNull();
+  }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
@@ -185,6 +185,24 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
   }
 
   /**
+   * Follow-up to #6941 flagged by review: a client-supplied {@code String _id} that happens to be exactly 24 hex
+   * characters is indistinguishable, once stored, from a real ObjectId's hex encoding. {@code executeUpsert} used
+   * to promote every such stored hex string back to an ObjectId in the response regardless of what the client
+   * actually sent, silently changing the wire type of an id the client chose as a plain string.
+   */
+  @Test
+  void upsertFilteredOnHexLookingStringIdReportsItAsAStringNotAnObjectId() {
+    final String hexLookingId = "abcdef0123456789abcdef01";
+
+    final UpdateResult result = collection.updateOne(eq("_id", hexLookingId), new Document("$set", new Document("v", 1)),
+        new UpdateOptions().upsert(true));
+
+    assertThat(result.getUpsertedId()).isNotNull();
+    assertThat(result.getUpsertedId().isString()).isTrue();
+    assertThat(result.getUpsertedId().asString().getValue()).isEqualTo(hexLookingId);
+  }
+
+  /**
    * Follow-up to #6941 flagged by review: an explicit {@code _id: null} filter is a legal, if unusual, BSON _id.
    * {@code executeUpsert} must tell that apart from a genuinely absent {@code _id} and preserve it, rather than
    * discarding it for a freshly generated one the way the original #6941 bug discarded a seeded ObjectId.
@@ -204,6 +222,9 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
 
     final Document inserted = collection.find(eq("v", 1)).first();
     assertThat(inserted).isNotNull();
+    // containsKey, not just get() == null: a Map.get returns null for a missing key too, so this confirms the
+    // wire response actually carries an "_id" field rather than having dropped it.
+    assertThat(inserted.containsKey("_id")).isTrue();
     assertThat(inserted.get("_id")).isNull();
   }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
@@ -29,6 +29,7 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,5 +157,30 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
     final Document inserted = collection.find(eq("test", "missing")).first();
     assertThat(inserted).isNotNull();
     assertThat(inserted.get("counter")).isEqualTo(999);
+  }
+
+  /**
+   * Regression test for issue #6941: {@code executeUpsert} seeded the new record's {@code _id} from the filter
+   * but then unconditionally overwrote it with a freshly generated one, so repeating an upsert filtered on
+   * {@code _id} (the idiomatic "upsert by primary key" pattern) never matched its own previous insert and kept
+   * creating duplicates instead of updating in place.
+   */
+  @Test
+  void upsertFilteredOnIdIsIdempotent() {
+    final ObjectId id = new ObjectId();
+
+    final UpdateResult first = collection.updateOne(eq("_id", id), new Document("$set", new Document("v", 1)),
+        new UpdateOptions().upsert(true));
+    assertThat(first.getUpsertedId()).isNotNull();
+    assertThat(first.getUpsertedId().asObjectId().getValue()).isEqualTo(id);
+
+    final UpdateResult second = collection.updateOne(eq("_id", id), new Document("$set", new Document("v", 2)),
+        new UpdateOptions().upsert(true));
+    assertThat(second.getUpsertedId()).isNull();
+    assertThat(second.getModifiedCount()).isEqualTo(1);
+
+    final Document found = collection.find(eq("_id", id)).first();
+    assertThat(found).isNotNull();
+    assertThat(found.get("v")).isEqualTo(2);
   }
 }


### PR DESCRIPTION
## Summary

Fixes three related MongoDB wire protocol bugs, all high-confidence with clear repros:

- **#6939**: `convertMapToMongoDB` treated every `_id` as a 24-char hex ObjectId string unconditionally. A client-supplied integer `_id` threw `ClassCastException`, an odd-length string threw `StringIndexOutOfBoundsException`, and an even-length non-hex string was silently corrupted into a wrong ObjectId - and since this ran on every read, one such document made the whole collection permanently unreadable over the wire. Fixed by only decoding `_id` as an ObjectId when it actually looks like one (24 hex chars); anything else passes through unchanged. `getObjectId` also now rejects malformed input with an explicit `IllegalArgumentException` instead of indexing past the end or fabricating a wrong id.
- **#6940**: the raw `insert` command reported `n = inserted + 1` due to a leftover `++n` from a per-document loop that had been replaced by a single bulk `insertDocuments` call. The raw `count` command ignored its `query`/`skip`/`limit` entirely and always returned the whole collection size. Fixed the stray increment, and rewrote `count` to filter (reusing the existing `buildExpression` SQL translation) and paginate the same way `find` does, without materializing full BSON documents.
- **#6941**: `executeUpsert` seeded the new record's `_id` from the filter's top-level equality (so `{_id: <id>}` did set it) but then unconditionally overwrote it with a freshly generated one, so an idempotent "upsert by primary key" pattern created a new duplicate document on every call. Fixed by generating an id only when the record still has none after seeding, and by normalizing an `ObjectId`-typed filter value to its hex string on the way in (matching every other `_id` write path) rather than storing the raw object.

## Test plan

- [x] Added `MongoDBNonObjectIdTest` (#6939): integer id, odd-length string id, even-length non-hex string id, and mixed id types in the same collection all read back correctly instead of throwing/corrupting.
- [x] Added `MongoDBInsertCountCommandTest` (#6940): raw `insert` command and driver `insertMany` report the exact inserted count; raw `count` command honours `query`, `skip`, and `limit`.
- [x] Added `upsertFilteredOnIdIsIdempotent` to `MongoDBUpdateDeleteTest` (#6941): upserting twice with the same `_id` filter updates in place instead of creating a duplicate, and `getUpsertedId()` reports the id the client asked to upsert.
- [x] Verified all four new/modified test classes fail against the pre-fix code (reproducing the exact reported symptoms) and pass after the fix.
- [x] Full `mongodbw` module test suite: 117 tests, 0 failures, 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MongoDB count queries now honor filters, skips, and limits.
  * Added support for ObjectId and non-ObjectId document identifiers.
  * Upserts preserve requested identifiers, including explicit null values, and prevent duplicates.

* **Bug Fixes**
  * Improved handling of invalid identifiers and insert failures.
  * Corrected identifier conversion in MongoDB responses.

* **Tests**
  * Added regression coverage for counting, identifier types, and idempotent upserts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->