### PR TITLE
fix(#6930,#6928,#4918,#6929): Postgres wire pair, null-in-array NPE, JSON bind decoding, INSERT ON DUPLICATE KEY SKIP

### DIFF
--- a/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLLexer.g4
+++ b/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLLexer.g4
@@ -293,6 +293,9 @@ MATCHES: M A T C H E S;
 INSTANCEOF: I N S T A N C E O F;
 KEY: K E Y;
 ITEM: I T E M;
+// Issue #4918: INSERT ... ON DUPLICATE KEY SKIP. Also listed among the keywords usable as an identifier, so a
+// schema that already has a type or property called "duplicate" keeps parsing.
+DUPLICATE: D U P L I C A T E;
 
 // ============================================================================
 // SPECIAL ATTRIBUTE TOKENS

--- a/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4
+++ b/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4
@@ -336,11 +336,17 @@ nestedProjectionItem
 /**
  * INSERT statement
  * INSERT INTO target [(fields)] VALUES (values) | SET field=value | CONTENT {...} | FROM query
- * [RETURN projection] [UNSAFE]
+ * [ON DUPLICATE KEY SKIP] [RETURN projection] [UNSAFE]
+ *
+ * ON DUPLICATE KEY SKIP (issue #4918): a record whose unique-index key already exists is silently skipped
+ * instead of aborting the whole batch - useful for bulk-inserting a CONTENT array where some rows may already
+ * exist. Only unique-key conflicts are swallowed; every other error (a missing mandatory field, a type
+ * mismatch, ...) still aborts the command, since silently hiding those would mask real data problems.
  */
 insertStatement
     : INSERT INTO (identifier (BUCKET identifier)? | bucketIdentifier)
       insertBody?
+      (ON DUPLICATE KEY SKIP_KW)?
       (RETURN projection)?
       (FROM? (selectStatement | LPAREN selectStatement RPAREN))?
       UNSAFE?
@@ -1605,6 +1611,7 @@ identifier
     | TIMESTAMP
     | DEFAULT
     | KEY
+    | DUPLICATE
     | FORMAT
     | CUSTOM
     | SKIP_KW

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -4791,6 +4791,9 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // UNSAFE flag
     stmt.unsafe = insertCtx.UNSAFE() != null;
 
+    // ON DUPLICATE KEY SKIP (issue #4918)
+    stmt.onDuplicateKeySkip = insertCtx.DUPLICATE() != null;
+
     return stmt;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
@@ -42,6 +42,7 @@ public class InsertExecutionPlanner {
   protected InsertBody      insertBody;
   protected Projection      returnStatement;
   protected SelectStatement selectStatement;
+  protected boolean         onDuplicateKeySkip;
 
   public InsertExecutionPlanner() {
   }
@@ -53,6 +54,7 @@ public class InsertExecutionPlanner {
     this.insertBody = statement.getInsertBody() == null ? null : statement.getInsertBody().copy();
     this.returnStatement = statement.getReturnStatement() == null ? null : statement.getReturnStatement().copy();
     this.selectStatement = statement.getSelectStatement() == null ? null : statement.getSelectStatement().copy();
+    this.onDuplicateKeySkip = statement.isOnDuplicateKeySkip();
   }
 
   public InsertExecutionPlan createExecutionPlan(final CommandContext context) {
@@ -86,7 +88,7 @@ public class InsertExecutionPlanner {
   }
 
   private void handleSave(final InsertExecutionPlan result, final Identifier targetClusterName, final CommandContext context) {
-    result.chain(new SaveElementStep(context, targetClusterName, true));
+    result.chain(new SaveElementStep(context, targetClusterName, true, onDuplicateKeySkip));
   }
 
   private void handleReturn(final InsertExecutionPlan result, final Projection returnStatement, final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
@@ -152,12 +152,13 @@ public class SaveElementStep extends AbstractExecutionStep {
    * either a previously committed one or an earlier record in this same batch, since {@link TypeIndex#get} reads
    * through to this transaction's own staged-but-uncommitted index entries.
    * <p>
-   * A key is exempted from the check only when the index's own uniqueness enforcement would exempt it: that is
-   * {@link LSMTreeIndexAbstract#isKeyNull} (every component null, not just one) AND the index's
-   * {@code NULL_STRATEGY} is {@code SKIP} - the same two conditions {@code TransactionIndexContext} gates its own
-   * commit-time duplicate check on. A composite key with only SOME null components, or an all-null key on an
-   * index built with {@code NULL_STRATEGY.INDEX} (where nulls are indexed and compared like any other value), is
-   * still a real key that must be probed.
+   * A key is exempted from the check exactly when {@link LSMTreeIndexAbstract#isKeyNull} says so (every
+   * component null, not just one) - unconditionally, regardless of the index's {@code NULL_STRATEGY}, matching
+   * both call sites of the engine's own commit-time duplicate check ({@code TransactionIndexContext}'s
+   * {@code checkUniqueIndexKeys()} and {@code addIndexKeyLock()}). "Multiple NULLs allowed in a unique index" is
+   * deliberate SQL-standard behavior that holds under {@code NULL_STRATEGY.INDEX} too - that setting affects
+   * whether a null key gets a physical index entry, not whether an all-null key is exempt from uniqueness. A
+   * composite key with only SOME null components is not exempt: it is still a real key that must be probed.
    *
    * @return the conflicting index/RID, or {@code null} if no unique index on this type is violated
    */
@@ -172,7 +173,7 @@ public class SaveElementStep extends AbstractExecutionStep {
       for (int i = 0; i < keyProperties.size(); i++)
         keyValues[i] = doc.get(keyProperties.get(i));
 
-      if (index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.SKIP && LSMTreeIndexAbstract.isKeyNull(keyValues))
+      if (LSMTreeIndexAbstract.isKeyNull(keyValues))
         continue;
 
       try (final IndexCursor existing = index.get(keyValues, 1)) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
@@ -34,7 +34,6 @@ import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.schema.ContinuousAggregate;
 import com.arcadedb.schema.ContinuousAggregateImpl;
 import com.arcadedb.schema.ContinuousAggregateRefresher;
-import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.Type;
@@ -92,6 +91,11 @@ public class SaveElementStep extends AbstractExecutionStep {
   public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
     final ResultSet upstream = getPrev().syncPull(context, nRecords);
     return new ResultSet() {
+      // Every record pulled through one INSERT statement targets the same type, so the unique-index list is
+      // resolved once per distinct type name seen rather than on every single row of a CONTENT [...] batch.
+      private String          cachedTypeName;
+      private List<TypeIndex> cachedUniqueIndexes;
+
       @Override
       public boolean hasNext() {
         return upstream.hasNext();
@@ -127,7 +131,11 @@ public class SaveElementStep extends AbstractExecutionStep {
             return result;
 
           if (skipDuplicateKey) {
-            final DuplicateKeyConflict conflict = findDuplicateKeyConflict(modifiableDoc, context);
+            if (!docType.getName().equals(cachedTypeName)) {
+              cachedTypeName = docType.getName();
+              cachedUniqueIndexes = docType.getAllIndexes(true).stream().filter(TypeIndex::isUnique).toList();
+            }
+            final DuplicateKeyConflict conflict = findDuplicateKeyConflict(modifiableDoc, cachedUniqueIndexes);
             if (conflict != null)
               return skippedResult(modifiableDoc, conflict);
           }
@@ -148,9 +156,10 @@ public class SaveElementStep extends AbstractExecutionStep {
   }
 
   /**
-   * Probes every unique index on the document's type (issue #4918) for a key already claimed by another record -
-   * either a previously committed one or an earlier record in this same batch, since {@link TypeIndex#get} reads
-   * through to this transaction's own staged-but-uncommitted index entries.
+   * Probes the document type's unique indexes (issue #4918, already filtered to the unique ones and cached by
+   * the caller - see {@link #syncPull}) for a key already claimed by another record - either a previously
+   * committed one or an earlier record in this same batch, since {@link TypeIndex#get} reads through to this
+   * transaction's own staged-but-uncommitted index entries.
    * <p>
    * A key is exempted from the check exactly when {@link LSMTreeIndexAbstract#isKeyNull} says so (every
    * component null, not just one) - unconditionally, regardless of the index's {@code NULL_STRATEGY}, matching
@@ -162,12 +171,8 @@ public class SaveElementStep extends AbstractExecutionStep {
    *
    * @return the conflicting index/RID, or {@code null} if no unique index on this type is violated
    */
-  private static DuplicateKeyConflict findDuplicateKeyConflict(final MutableDocument doc, final CommandContext context) {
-    final DocumentType type = context.getDatabase().getSchema().getType(doc.getTypeName());
-    for (final TypeIndex index : type.getAllIndexes(true)) {
-      if (!index.isUnique())
-        continue;
-
+  private static DuplicateKeyConflict findDuplicateKeyConflict(final MutableDocument doc, final List<TypeIndex> uniqueIndexes) {
+    for (final TypeIndex index : uniqueIndexes) {
       final List<String> keyProperties = index.getPropertyNames();
       final Object[] keyValues = new Object[keyProperties.size()];
       for (int i = 0; i < keyProperties.size(); i++)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
@@ -28,6 +28,7 @@ import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.schema.ContinuousAggregate;
@@ -71,6 +72,13 @@ public class SaveElementStep extends AbstractExecutionStep {
    *                         a conflict against already-committed data is detected at commit time, by which
    *                         point the record's bucket write already happened and cannot be undone record-by-
    *                         record without a full compensating delete.
+   *                         <p>
+   *                         Known limitation: the probe only sees keys staged by THIS transaction plus already
+   *                         -committed data, so two concurrent transactions each inserting the same new key can
+   *                         both pass the probe: one of them still hits an uncaught {@code DuplicatedKeyException}
+   *                         at its own commit, aborting that whole batch rather than skipping just that row. This
+   *                         mirrors ArcadeDB's commit-time conflict model for every other write, not a gap
+   *                         specific to this clause.
    */
   public SaveElementStep(final CommandContext context, final Identifier bucket, final boolean createAlways,
       final boolean skipDuplicateKey) {
@@ -142,9 +150,14 @@ public class SaveElementStep extends AbstractExecutionStep {
   /**
    * Probes every unique index on the document's type (issue #4918) for a key already claimed by another record -
    * either a previously committed one or an earlier record in this same batch, since {@link TypeIndex#get} reads
-   * through to this transaction's own staged-but-uncommitted index entries. A composite key with any null
-   * component is skipped, matching SQL's own unique-index semantics: {@code NULL} never equals {@code NULL}, so
-   * it can never be "the same key" as an existing entry.
+   * through to this transaction's own staged-but-uncommitted index entries.
+   * <p>
+   * A key is exempted from the check only when the index's own uniqueness enforcement would exempt it: that is
+   * {@link LSMTreeIndexAbstract#isKeyNull} (every component null, not just one) AND the index's
+   * {@code NULL_STRATEGY} is {@code SKIP} - the same two conditions {@code TransactionIndexContext} gates its own
+   * commit-time duplicate check on. A composite key with only SOME null components, or an all-null key on an
+   * index built with {@code NULL_STRATEGY.INDEX} (where nulls are indexed and compared like any other value), is
+   * still a real key that must be probed.
    *
    * @return the conflicting index/RID, or {@code null} if no unique index on this type is violated
    */
@@ -156,16 +169,10 @@ public class SaveElementStep extends AbstractExecutionStep {
 
       final List<String> keyProperties = index.getPropertyNames();
       final Object[] keyValues = new Object[keyProperties.size()];
-      boolean hasNullComponent = false;
-      for (int i = 0; i < keyProperties.size(); i++) {
-        final Object value = doc.get(keyProperties.get(i));
-        if (value == null) {
-          hasNullComponent = true;
-          break;
-        }
-        keyValues[i] = value;
-      }
-      if (hasNullComponent)
+      for (int i = 0; i < keyProperties.size(); i++)
+        keyValues[i] = doc.get(keyProperties.get(i));
+
+      if (index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.SKIP && LSMTreeIndexAbstract.isKeyNull(keyValues))
         continue;
 
       try (final IndexCursor existing = index.get(keyValues, 1)) {
@@ -189,7 +196,7 @@ public class SaveElementStep extends AbstractExecutionStep {
     result.setProperty("@skipped", true);
     result.setProperty("@type", attemptedDoc.getTypeName());
     result.setProperty("@duplicateIndex", conflict.indexName());
-    result.setProperty("@duplicateKeys", Arrays.toString(conflict.keys()));
+    result.setProperty("@duplicateKeys", Arrays.asList(conflict.keys()));
     result.setProperty("@existingRID", conflict.existingRID());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
@@ -19,17 +19,22 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Document;
+import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
 import com.arcadedb.database.TransactionContext;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.TypeIndex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.schema.ContinuousAggregate;
 import com.arcadedb.schema.ContinuousAggregateImpl;
 import com.arcadedb.schema.ContinuousAggregateRefresher;
+import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.Type;
@@ -39,6 +44,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
@@ -49,11 +55,30 @@ import java.util.logging.Level;
 public class SaveElementStep extends AbstractExecutionStep {
   private final Identifier bucket;
   private final boolean    createAlways;
+  private final boolean    skipDuplicateKey;
 
   public SaveElementStep(final CommandContext context, final Identifier bucket, final boolean createAlways) {
+    this(context, bucket, createAlways, false);
+  }
+
+  /**
+   * @param skipDuplicateKey when true (issue #4918's {@code INSERT ... ON DUPLICATE KEY SKIP}), a record that
+   *                         would violate a unique index already carried by a previously committed record OR
+   *                         an earlier record in this same batch is never persisted at all, and is reported as
+   *                         a skipped row instead of aborting the whole statement. The conflict is detected by
+   *                         probing the unique indexes directly (see {@link #findDuplicateKeyConflict}) rather
+   *                         than by catching the save failure: {@code Index.put()} only throws synchronously
+   *                         for a conflict against another key staged earlier in the SAME open transaction -
+   *                         a conflict against already-committed data is detected at commit time, by which
+   *                         point the record's bucket write already happened and cannot be undone record-by-
+   *                         record without a full compensating delete.
+   */
+  public SaveElementStep(final CommandContext context, final Identifier bucket, final boolean createAlways,
+      final boolean skipDuplicateKey) {
     super(context);
     this.bucket = bucket;
     this.createAlways = createAlways;
+    this.skipDuplicateKey = skipDuplicateKey;
   }
 
   @Override
@@ -94,6 +119,12 @@ public class SaveElementStep extends AbstractExecutionStep {
           if (!createAlways && modifiableDoc.getIdentity() != null && !modifiableDoc.isDirty())
             return result;
 
+          if (skipDuplicateKey) {
+            final DuplicateKeyConflict conflict = findDuplicateKeyConflict(modifiableDoc, context);
+            if (conflict != null)
+              return skippedResult(modifiableDoc, conflict);
+          }
+
           if (bucket == null)
             modifiableDoc.save();
           else
@@ -107,6 +138,63 @@ public class SaveElementStep extends AbstractExecutionStep {
         upstream.close();
       }
     };
+  }
+
+  /**
+   * Probes every unique index on the document's type (issue #4918) for a key already claimed by another record -
+   * either a previously committed one or an earlier record in this same batch, since {@link TypeIndex#get} reads
+   * through to this transaction's own staged-but-uncommitted index entries. A composite key with any null
+   * component is skipped, matching SQL's own unique-index semantics: {@code NULL} never equals {@code NULL}, so
+   * it can never be "the same key" as an existing entry.
+   *
+   * @return the conflicting index/RID, or {@code null} if no unique index on this type is violated
+   */
+  private static DuplicateKeyConflict findDuplicateKeyConflict(final MutableDocument doc, final CommandContext context) {
+    final DocumentType type = context.getDatabase().getSchema().getType(doc.getTypeName());
+    for (final TypeIndex index : type.getAllIndexes(true)) {
+      if (!index.isUnique())
+        continue;
+
+      final List<String> keyProperties = index.getPropertyNames();
+      final Object[] keyValues = new Object[keyProperties.size()];
+      boolean hasNullComponent = false;
+      for (int i = 0; i < keyProperties.size(); i++) {
+        final Object value = doc.get(keyProperties.get(i));
+        if (value == null) {
+          hasNullComponent = true;
+          break;
+        }
+        keyValues[i] = value;
+      }
+      if (hasNullComponent)
+        continue;
+
+      try (final IndexCursor existing = index.get(keyValues, 1)) {
+        if (existing.hasNext()) {
+          final Identifiable conflictingRecord = existing.next();
+          return new DuplicateKeyConflict(index.getName(), keyValues, conflictingRecord.getIdentity());
+        }
+      }
+    }
+    return null;
+  }
+
+  private record DuplicateKeyConflict(String indexName, Object[] keys, RID existingRID) {
+  }
+
+  /**
+   * Builds the row reported for a record skipped by {@code ON DUPLICATE KEY SKIP} (issue #4918): the attempted
+   * properties are kept so a {@code RETURN} projection can still report on them, plus {@code @skipped} and the
+   * conflict details so the caller can tell a skipped row from an inserted one and knows why it was skipped.
+   */
+  private static Result skippedResult(final MutableDocument attemptedDoc, final DuplicateKeyConflict conflict) {
+    final ResultInternal result = new ResultInternal(attemptedDoc.toMap(false));
+    result.setProperty("@skipped", true);
+    result.setProperty("@type", attemptedDoc.getTypeName());
+    result.setProperty("@duplicateIndex", conflict.indexName());
+    result.setProperty("@duplicateKeys", Arrays.toString(conflict.keys()));
+    result.setProperty("@existingRID", conflict.existingRID());
+    return result;
   }
 
   private void saveToTimeSeries(final LocalTimeSeriesType tsType, final TimeSeriesEngine engine, final Document doc,
@@ -222,6 +310,6 @@ public class SaveElementStep extends AbstractExecutionStep {
 
   @Override
   public ExecutionStep copy(final CommandContext context) {
-    return new SaveElementStep(context, bucket == null ? null : bucket.copy(), createAlways);
+    return new SaveElementStep(context, bucket == null ? null : bucket.copy(), createAlways, skipDuplicateKey);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
@@ -19,7 +19,6 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Document;
-import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.TransactionContext;
@@ -170,10 +169,8 @@ public class SaveElementStep extends AbstractExecutionStep {
         continue;
 
       try (final IndexCursor existing = index.get(keyValues, 1)) {
-        if (existing.hasNext()) {
-          final Identifiable conflictingRecord = existing.next();
-          return new DuplicateKeyConflict(index.getName(), keyValues, conflictingRecord.getIdentity());
-        }
+        if (existing.hasNext())
+          return new DuplicateKeyConflict(index.getName(), keyValues, existing.next().getIdentity());
       }
     }
     return null;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InsertStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InsertStatement.java
@@ -45,6 +45,7 @@ public class InsertStatement extends Statement {
   public boolean         selectInParentheses = false;
   public boolean         selectWithFrom      = false;
   public boolean         unsafe              = false;
+  public boolean         onDuplicateKeySkip  = false;
 
   public InsertStatement() {
   }
@@ -64,6 +65,9 @@ public class InsertStatement extends Statement {
     if (insertBody != null) {
       builder.append(" ");
       insertBody.toString(params, builder);
+    }
+    if (onDuplicateKeySkip) {
+      builder.append(" ON DUPLICATE KEY SKIP");
     }
     if (returnStatement != null) {
       builder.append(" RETURN ");
@@ -105,6 +109,7 @@ public class InsertStatement extends Statement {
     result.selectInParentheses = selectInParentheses;
     result.selectWithFrom = selectWithFrom;
     result.unsafe = unsafe;
+    result.onDuplicateKeySkip = onDuplicateKeySkip;
     return result;
   }
 
@@ -154,6 +159,8 @@ public class InsertStatement extends Statement {
       return false;
     if (unsafe != that.unsafe)
       return false;
+    if (onDuplicateKeySkip != that.onDuplicateKeySkip)
+      return false;
     if (!Objects.equals(targetType, that.targetType))
       return false;
     if (!Objects.equals(targetBucketName, that.targetBucketName))
@@ -178,6 +185,7 @@ public class InsertStatement extends Statement {
     result = 31 * result + (selectInParentheses ? 1 : 0);
     result = 31 * result + (selectWithFrom ? 1 : 0);
     result = 31 * result + (unsafe ? 1 : 0);
+    result = 31 * result + (onDuplicateKeySkip ? 1 : 0);
     return result;
   }
 
@@ -215,6 +223,10 @@ public class InsertStatement extends Statement {
 
   public boolean isUnsafe() {
     return unsafe;
+  }
+
+  public boolean isOnDuplicateKeySkip() {
+    return onDuplicateKeySkip;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InsertStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InsertStatement.java
@@ -66,9 +66,8 @@ public class InsertStatement extends Statement {
       builder.append(" ");
       insertBody.toString(params, builder);
     }
-    if (onDuplicateKeySkip) {
+    if (onDuplicateKeySkip)
       builder.append(" ON DUPLICATE KEY SKIP");
-    }
     if (returnStatement != null) {
       builder.append(" RETURN ");
       returnStatement.toString(params, builder);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.exception.ValidationException;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Regression/feature tests for issue #4918: {@code INSERT INTO ... CONTENT [ ... ] ON DUPLICATE KEY SKIP} lets a
+ * bulk insert of a JSON array skip records that would violate a unique index instead of aborting the whole
+ * batch, as plain {@code INSERT ... CONTENT [...]} still does.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class InsertOnDuplicateKeySkipTest extends TestHelper {
+
+  public InsertOnDuplicateKeySkipTest() {
+    autoStartTx = true;
+  }
+
+  private void createProductTypeWithUniqueSku() {
+    database.getSchema().createDocumentType("Product").createProperty("sku", Type.STRING);
+    database.command("sql", "CREATE INDEX IF NOT EXISTS ON Product (sku) UNIQUE");
+  }
+
+  @Test
+  void withoutTheClauseADuplicateKeyStillAbortsTheRemainderOfTheBatch() {
+    createProductTypeWithUniqueSku();
+    database.command("sql", "INSERT INTO Product SET sku = 'A1', name = 'first'");
+
+    // Matches the documented baseline (issue #4918): the record BEFORE the clash is still inserted, the
+    // clashing record raises, and every record AFTER it never runs at all - the whole point of the new clause.
+    assertThatExceptionOfType(DuplicatedKeyException.class).isThrownBy(() -> database.command("sql",
+        "INSERT INTO Product CONTENT [ {\"sku\":\"A2\",\"name\":\"second\"}, {\"sku\":\"A1\",\"name\":\"clashes\"}, {\"sku\":\"A3\",\"name\":\"never runs\"} ]"));
+
+    assertThat(database.query("sql", "SELECT FROM Product WHERE sku = 'A3'").hasNext()).isFalse();
+  }
+
+  @Test
+  void skipsARecordClashingWithAPreviouslyCommittedRecord() {
+    createProductTypeWithUniqueSku();
+    database.command("sql", "INSERT INTO Product SET sku = 'A1', name = 'original'");
+
+    final ResultSet result = database.command("sql",
+        "INSERT INTO Product CONTENT [ {\"sku\":\"A2\",\"name\":\"second\"}, {\"sku\":\"A1\",\"name\":\"clashes\"} ] ON DUPLICATE KEY SKIP");
+
+    final Result first = result.next();
+    assertThat(first.<Boolean>getProperty("@skipped")).isNull();
+    assertThat(first.<String>getProperty("sku")).isEqualTo("A2");
+
+    final Result second = result.next();
+    assertThat(second.<Boolean>getProperty("@skipped")).isTrue();
+    assertThat(second.<String>getProperty("sku")).isEqualTo("A1");
+    assertThat(second.<String>getProperty("@duplicateIndex")).isEqualTo("Product[sku]");
+    assertThat(second.<Object>getProperty("@existingRID")).isNotNull();
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    // The pre-existing record was left untouched, not overwritten.
+    final Result existing = database.query("sql", "SELECT FROM Product WHERE sku = 'A1'").next();
+    assertThat(existing.<String>getProperty("name")).isEqualTo("original");
+
+    assertThat(database.query("sql", "SELECT FROM Product WHERE sku = 'A2'").hasNext()).isTrue();
+    assertThat(database.countType("Product", true)).isEqualTo(2);
+  }
+
+  @Test
+  void skipsARecordClashingWithAnEarlierRecordInTheSameBatch() {
+    createProductTypeWithUniqueSku();
+
+    final ResultSet result = database.command("sql",
+        "INSERT INTO Product CONTENT [ {\"sku\":\"B1\",\"name\":\"first\"}, {\"sku\":\"B1\",\"name\":\"dup-in-batch\"} ] ON DUPLICATE KEY SKIP");
+
+    final Result first = result.next();
+    assertThat(first.<Boolean>getProperty("@skipped")).isNull();
+
+    final Result second = result.next();
+    assertThat(second.<Boolean>getProperty("@skipped")).isTrue();
+    result.close();
+
+    assertThat(database.countType("Product", true)).isEqualTo(1);
+    assertThat(database.query("sql", "SELECT FROM Product WHERE sku = 'B1'").next().<String>getProperty("name")).isEqualTo("first");
+  }
+
+  @Test
+  void aNonDuplicateKeyErrorStillAbortsTheRemainderOfTheBatch() {
+    database.getSchema().createDocumentType("Strict").createProperty("code", Type.STRING).setMandatory(true);
+
+    // The mandatory-field violation is not a duplicate key: SKIP must not swallow it, so it still raises and
+    // still stops any record after it, exactly like the DuplicatedKeyException baseline above.
+    assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> database.command("sql",
+        "INSERT INTO Strict CONTENT [ {\"other\":\"missing mandatory code\"}, {\"code\":\"never runs\"} ] ON DUPLICATE KEY SKIP"));
+
+    assertThat(database.query("sql", "SELECT FROM Strict WHERE code = 'never runs'").hasNext()).isFalse();
+  }
+
+  @Test
+  void allRecordsInsertedWhenThereIsNoConflict() {
+    createProductTypeWithUniqueSku();
+
+    final ResultSet result = database.command("sql",
+        "INSERT INTO Product CONTENT [ {\"sku\":\"C1\"}, {\"sku\":\"C2\"}, {\"sku\":\"C3\"} ] ON DUPLICATE KEY SKIP");
+
+    int count = 0;
+    while (result.hasNext()) {
+      assertThat(result.next().<Boolean>getProperty("@skipped")).isNull();
+      count++;
+    }
+    result.close();
+    assertThat(count).isEqualTo(3);
+  }
+
+  @Test
+  void duplicateAsAPropertyNameStillParsesAsAnIdentifier() {
+    database.getSchema().createDocumentType("Labelled");
+
+    final ResultSet result = database.command("sql", "INSERT INTO Labelled SET duplicate = true, skip = 'no'");
+    final Result item = result.next();
+    assertThat(item.<Boolean>getProperty("duplicate")).isTrue();
+    assertThat(item.<String>getProperty("skip")).isEqualTo("no");
+    result.close();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
@@ -25,6 +25,8 @@ import com.arcadedb.schema.Type;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -76,6 +78,7 @@ public class InsertOnDuplicateKeySkipTest extends TestHelper {
     assertThat(second.<String>getProperty("sku")).isEqualTo("A1");
     assertThat(second.<String>getProperty("@duplicateIndex")).isEqualTo("Product[sku]");
     assertThat(second.<Object>getProperty("@existingRID")).isNotNull();
+    assertThat(second.<List<Object>>getProperty("@duplicateKeys")).containsExactly("A1");
     assertThat(result.hasNext()).isFalse();
     result.close();
 
@@ -131,6 +134,46 @@ public class InsertOnDuplicateKeySkipTest extends TestHelper {
     }
     result.close();
     assertThat(count).isEqualTo(3);
+  }
+
+  @Test
+  void skipsAPartiallyNullCompositeKeyClashingWithAnExistingRecord() {
+    // A composite unique index only exempts a key from the uniqueness check when EVERY component is null
+    // (LSMTreeIndexAbstract.isKeyNull); a key with just ONE null component, like (John, null) here, is still a
+    // real key the engine enforces uniqueness on - findDuplicateKeyConflict() must agree, or the clashing record
+    // slips past the probe and aborts the batch with an uncaught DuplicatedKeyException instead of being skipped.
+    database.getSchema().createDocumentType("Person").createProperty("firstName", Type.STRING);
+    database.getSchema().getType("Person").createProperty("lastName", Type.STRING);
+    database.command("sql", "CREATE INDEX IF NOT EXISTS ON Person (firstName, lastName) UNIQUE");
+    database.command("sql", "INSERT INTO Person SET firstName = 'John', lastName = null");
+
+    final ResultSet result = database.command("sql",
+        "INSERT INTO Person CONTENT [ {\"firstName\":\"John\",\"lastName\":null} ] ON DUPLICATE KEY SKIP");
+
+    final Result item = result.next();
+    assertThat(item.<Boolean>getProperty("@skipped")).isTrue();
+    assertThat(item.<String>getProperty("@duplicateIndex")).isEqualTo("Person[firstName,lastName]");
+    result.close();
+
+    assertThat(database.countType("Person", true)).isEqualTo(1);
+  }
+
+  @Test
+  void aFullyNullKeyIsStillCheckedUnderNullStrategyIndex() {
+    // NULL_STRATEGY.INDEX (as opposed to the default SKIP) indexes and compares null like any other value, so
+    // an all-null key is no longer exempt from the uniqueness check the way it is under SKIP.
+    database.getSchema().createDocumentType("Ticket").createProperty("code", Type.STRING);
+    database.command("sql", "CREATE INDEX IF NOT EXISTS ON Ticket (code) UNIQUE NULL_STRATEGY INDEX");
+    database.command("sql", "INSERT INTO Ticket SET code = null");
+
+    final ResultSet result = database.command("sql",
+        "INSERT INTO Ticket CONTENT [ {\"code\":null} ] ON DUPLICATE KEY SKIP");
+
+    final Result item = result.next();
+    assertThat(item.<Boolean>getProperty("@skipped")).isTrue();
+    result.close();
+
+    assertThat(database.countType("Ticket", true)).isEqualTo(1);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
@@ -159,9 +159,11 @@ public class InsertOnDuplicateKeySkipTest extends TestHelper {
   }
 
   @Test
-  void aFullyNullKeyIsStillCheckedUnderNullStrategyIndex() {
-    // NULL_STRATEGY.INDEX (as opposed to the default SKIP) indexes and compares null like any other value, so
-    // an all-null key is no longer exempt from the uniqueness check the way it is under SKIP.
+  void anAllNullKeyIsNeverADuplicateEvenUnderNullStrategyIndex() {
+    // SQL standard: NULL != NULL, so multiple all-null keys are allowed in a unique index regardless of
+    // NULL_STRATEGY (engine/src/test/java/com/arcadedb/index/NullValuesIndexTest#nullStrategyIndex_uniqueAllowsMultipleNulls
+    // proves this holds for a plain INSERT even under NULL_STRATEGY.INDEX). ON DUPLICATE KEY SKIP must not
+    // report a "duplicate" - and so must not silently drop the row - for something a plain INSERT would accept.
     database.getSchema().createDocumentType("Ticket").createProperty("code", Type.STRING);
     database.command("sql", "CREATE INDEX IF NOT EXISTS ON Ticket (code) UNIQUE NULL_STRATEGY INDEX");
     database.command("sql", "INSERT INTO Ticket SET code = null");
@@ -170,10 +172,10 @@ public class InsertOnDuplicateKeySkipTest extends TestHelper {
         "INSERT INTO Ticket CONTENT [ {\"code\":null} ] ON DUPLICATE KEY SKIP");
 
     final Result item = result.next();
-    assertThat(item.<Boolean>getProperty("@skipped")).isTrue();
+    assertThat(item.<Boolean>getProperty("@skipped")).isNull();
     result.close();
 
-    assertThat(database.countType("Ticket", true)).isEqualTo(1);
+    assertThat(database.countType("Ticket", true)).isEqualTo(2);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
@@ -128,6 +128,30 @@ public class InsertOnDuplicateKeySkipTest extends TestHelper {
   }
 
   @Test
+  void skipsARecordClashingOnANumericUniqueKey() {
+    // findDuplicateKeyConflict() reads the key straight off the document with doc.get(); this confirms the
+    // probe agrees with the real index write for a non-STRING key too (all other cases here use STRING skus).
+    database.getSchema().createDocumentType("Order").createProperty("orderNumber", Type.INTEGER);
+    database.command("sql", "CREATE INDEX IF NOT EXISTS ON Order (orderNumber) UNIQUE");
+    database.command("sql", "INSERT INTO Order SET orderNumber = 1001, status = 'original'");
+    database.commit();
+    database.begin();
+
+    final ResultSet result = database.command("sql",
+        "INSERT INTO Order CONTENT [ {\"orderNumber\":1002,\"status\":\"second\"}, {\"orderNumber\":1001,\"status\":\"clashes\"} ] ON DUPLICATE KEY SKIP");
+
+    final Result first = result.next();
+    assertThat(first.<Boolean>getProperty("@skipped")).isNull();
+
+    final Result second = result.next();
+    assertThat(second.<Boolean>getProperty("@skipped")).isTrue();
+    result.close();
+
+    assertThat(database.countType("Order", true)).isEqualTo(2);
+    assertThat(database.query("sql", "SELECT FROM Order WHERE orderNumber = 1001").next().<String>getProperty("status")).isEqualTo("original");
+  }
+
+  @Test
   void allRecordsInsertedWhenThereIsNoConflict() {
     createProductTypeWithUniqueSku();
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
@@ -66,6 +66,13 @@ public class InsertOnDuplicateKeySkipTest extends TestHelper {
     createProductTypeWithUniqueSku();
     database.command("sql", "INSERT INTO Product SET sku = 'A1', name = 'original'");
 
+    // Actually commit and start a new transaction here: TestHelper's autoStartTx keeps everything in one open
+    // transaction otherwise, which would only exercise the same-batch path (already covered by
+    // skipsARecordClashingWithAnEarlierRecordInTheSameBatch), not the cross-transaction/committed-data scenario
+    // that is the actual reason a naive catch-the-save-failure implementation doesn't work.
+    database.commit();
+    database.begin();
+
     final ResultSet result = database.command("sql",
         "INSERT INTO Product CONTENT [ {\"sku\":\"A2\",\"name\":\"second\"}, {\"sku\":\"A1\",\"name\":\"clashes\"} ] ON DUPLICATE KEY SKIP");
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertOnDuplicateKeySkipTest.java
@@ -137,6 +137,54 @@ public class InsertOnDuplicateKeySkipTest extends TestHelper {
   }
 
   @Test
+  void supportsTheSetInsertForm() {
+    // ON DUPLICATE KEY SKIP is wired into SaveElementStep, which every insert body form feeds through - not
+    // just CONTENT [...]. Pins that down for the SET form explicitly.
+    createProductTypeWithUniqueSku();
+    database.command("sql", "INSERT INTO Product SET sku = 'E1', name = 'original'");
+
+    final ResultSet result = database.command("sql",
+        "INSERT INTO Product SET sku = 'E1', name = 'clashes' ON DUPLICATE KEY SKIP");
+
+    final Result item = result.next();
+    assertThat(item.<Boolean>getProperty("@skipped")).isTrue();
+    result.close();
+
+    assertThat(database.countType("Product", true)).isEqualTo(1);
+    assertThat(database.query("sql", "SELECT FROM Product WHERE sku = 'E1'").next().<String>getProperty("name")).isEqualTo("original");
+  }
+
+  @Test
+  void supportsTheFromQueryInsertForm() {
+    // Same reasoning as supportsTheSetInsertForm(), for the INSERT ... FROM <query> form - selecting whole
+    // elements (not a column projection): CopyDocumentStep copies an element into an unsaved in-memory document
+    // and lets SaveElementStep do the one save, same as the CONTENT/SET forms. A projected SELECT is a
+    // different, pre-existing code path in CopyDocumentStep that saves eagerly and bypasses SaveElementStep
+    // entirely - out of scope for this clause, since fixing that is a CopyDocumentStep change unrelated to #4918.
+    createProductTypeWithUniqueSku();
+    database.command("sql", "INSERT INTO Product SET sku = 'D1', name = 'original'");
+    database.getSchema().createDocumentType("Staging").createProperty("sku", Type.STRING);
+    database.getSchema().getType("Staging").createProperty("name", Type.STRING);
+    database.command("sql",
+        "INSERT INTO Staging CONTENT [ {\"sku\":\"D1\",\"name\":\"clashes\"}, {\"sku\":\"D2\",\"name\":\"second\"} ]");
+
+    final ResultSet result = database.command("sql",
+        "INSERT INTO Product ON DUPLICATE KEY SKIP FROM (SELECT FROM Staging ORDER BY sku)");
+
+    final Result first = result.next();
+    assertThat(first.<Boolean>getProperty("@skipped")).isTrue();
+    assertThat(first.<String>getProperty("sku")).isEqualTo("D1");
+
+    final Result second = result.next();
+    assertThat(second.<Boolean>getProperty("@skipped")).isNull();
+    assertThat(second.<String>getProperty("sku")).isEqualTo("D2");
+    result.close();
+
+    assertThat(database.countType("Product", true)).isEqualTo(2);
+    assertThat(database.query("sql", "SELECT FROM Product WHERE sku = 'D1'").next().<String>getProperty("name")).isEqualTo("original");
+  }
+
+  @Test
   void skipsAPartiallyNullCompositeKeyClashingWithAnExistingRecord() {
     // A composite unique index only exempts a key from the uniqueness check when EVERY component is null
     // (LSMTreeIndexAbstract.isKeyNull); a key with just ONE null component, like (John, null) here, is still a

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -2685,7 +2685,7 @@ public class PostgresNetworkExecutor extends Thread {
       return "SAVEPOINT";
     } else if (upperCaseText.startsWith("RELEASE ")) {
       return "RELEASE";
-    } else if (upperCaseText.startsWith("SET ") || "SET".equals(upperCaseText)) {
+    } else if (upperCaseText.startsWith("SET ")) {
       return "SET";
     } else {
       return "";

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -431,7 +431,12 @@ public class PostgresNetworkExecutor extends Thread {
         if (portal.columns != null) {
           writeRowDescription(portal.columns, portal.resultFormats);
           portal.rowDescriptionSent = true;
-        }
+        } else if (portal.ignoreExecution)
+          // SAVEPOINT/RELEASE/ROLLBACK TO/SET: no statement AND no result ever coming, so Describe still owes
+          // exactly one reply (issue #6930). A non-"sql" language (e.g. cypher) also has no statement here, but
+          // unlike these it DOES expect a result once executed - its columns just are not known yet at Describe
+          // time, so it is deliberately left out of this branch rather than answered with a premature NoData.
+          writeNoData();
       }
     } else if (type == 'S') {
       // Describe Statement: send ParameterDescription followed by RowDescription/NoData
@@ -491,7 +496,9 @@ public class PostgresNetworkExecutor extends Thread {
                 Thread.currentThread().threadId());
 
       if (portal.ignoreExecution)
-        writeNoData();
+        // SAVEPOINT/RELEASE/ROLLBACK TO/SET never produce rows: Execute must answer CommandComplete, not
+        // NoData - NoData ('n') is a Describe-only reply and is never a legal answer to Execute (issue #6930).
+        writeCommandComplete(portal.query, 0);
       else {
         if (!portal.executed) {
           final long engineStart = System.nanoTime();
@@ -2672,6 +2679,14 @@ public class PostgresNetworkExecutor extends Thread {
       return "COMMIT";
     } else if (isRollbackStatement(upperCaseText)) {
       return "ROLLBACK";
+    } else if (upperCaseText.startsWith("ROLLBACK TO ")) {
+      return "ROLLBACK";
+    } else if (upperCaseText.startsWith("SAVEPOINT ")) {
+      return "SAVEPOINT";
+    } else if (upperCaseText.startsWith("RELEASE ")) {
+      return "RELEASE";
+    } else if (upperCaseText.startsWith("SET ") || "SET".equals(upperCaseText)) {
+      return "SET";
     } else {
       return "";
     }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -871,9 +871,13 @@ public enum PostgresType {
         sb.append(",");
       }
       first = false;
-      if (element instanceof Float || element.getClass() == float.class) {
+      if (element == null) {
+        sb.append("NULL");
+        continue;
+      }
+      if (element instanceof Float) {
         sb.append(((Number) element).floatValue());
-      } else if (element instanceof Double || element.getClass() == double.class) {
+      } else if (element instanceof Double) {
         sb.append(((Number) element).doubleValue());
       } else if (element instanceof Number || element instanceof Boolean) {
         sb.append(element);
@@ -908,7 +912,7 @@ public enum PostgresType {
       } else if (element instanceof String str) {
         appendQuoted(sb, str);
       } else {
-        sb.append(element == null ? "NULL" : element.toString());
+        sb.append(element.toString());
       }
     }
     sb.append("}");
@@ -1143,10 +1147,9 @@ public enum PostgresType {
       case CHAR -> (char) buffer.get();
       case BOOLEAN -> buffer.get() == 1;
       case JSON -> {
-        int length = buffer.getInt();
-        byte[] bytes = new byte[length];
-        buffer.get(bytes);
-        yield parseJsonText(new String(bytes));
+        // In PostgreSQL binary format, json is the raw UTF-8 text with no inner length prefix
+        // (json_send emits it verbatim); the length is already provided by the Bind message.
+        yield parseJsonText(new String(valueAsBytes, DatabaseFactory.getDefaultCharset()));
       }
       case ARRAY_INT, ARRAY_LONG, ARRAY_DOUBLE, ARRAY_REAL, ARRAY_TEXT, ARRAY_BOOLEAN, ARRAY_CHAR, ARRAY_JSON ->
           deserializeBinaryArray(buffer);

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6930DescribeExecuteSetSavepointIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6930DescribeExecuteSetSavepointIT.java
@@ -70,6 +70,13 @@ class Issue6930DescribeExecuteSetSavepointIT extends PostgresWireProtocolTestBas
     assertReplySequenceForIgnoredExecutionStatement("RELEASE test_savepoint2", "RELEASE");
   }
 
+  @Test
+  @DisplayName("[#6930] Describe(P)+Execute on a ROLLBACK TO portal answers NoData then CommandComplete 'ROLLBACK'")
+  void rollbackToPortalDescribeAndExecute() throws Exception {
+    assertReplySequenceForIgnoredExecutionStatement("SAVEPOINT test_savepoint3", "SAVEPOINT");
+    assertReplySequenceForIgnoredExecutionStatement("ROLLBACK TO test_savepoint3", "ROLLBACK");
+  }
+
   private void assertReplySequenceForIgnoredExecutionStatement(final String query, final String expectedTag) throws Exception {
     try (final Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6930DescribeExecuteSetSavepointIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6930DescribeExecuteSetSavepointIT.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression tests for issue #6930: a {@code Describe('P')} on a portal bound from {@code SET}/{@code SAVEPOINT}/
+ * {@code RELEASE}/{@code ROLLBACK TO} sent no reply at all (every {@code Describe} must be answered by exactly
+ * one of {@code RowDescription} or {@code NoData}), and the matching {@code Execute} answered {@code NoData}
+ * ({@code 'n'}, a Describe-only reply) instead of {@code CommandComplete} ({@code 'C'}).
+ * <p>
+ * These tests speak the wire protocol directly over a raw socket so the extended-query {@code Describe('P')}
+ * path is actually exercised, and so the exact reply sequence and the {@code CommandComplete} tag content can
+ * be inspected (a JDBC client that always describes the statement, rather than the portal, would never reach
+ * the first bug, and pgjdbc historically tolerated the second by accident - see the issue for why).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6930DescribeExecuteSetSavepointIT extends PostgresWireProtocolTestBase {
+
+  @Test
+  @DisplayName("[#6930] Describe(P)+Execute on a SET portal answers NoData then CommandComplete 'SET'")
+  void setPortalDescribeAndExecute() throws Exception {
+    assertReplySequenceForIgnoredExecutionStatement("SET datestyle = 'ISO'", "SET");
+  }
+
+  @Test
+  @DisplayName("[#6930] Describe(P)+Execute on a SAVEPOINT portal answers NoData then CommandComplete 'SAVEPOINT'")
+  void savepointPortalDescribeAndExecute() throws Exception {
+    assertReplySequenceForIgnoredExecutionStatement("SAVEPOINT test_savepoint", "SAVEPOINT");
+  }
+
+  @Test
+  @DisplayName("[#6930] Describe(P)+Execute on a RELEASE portal answers NoData then CommandComplete 'RELEASE'")
+  void releasePortalDescribeAndExecute() throws Exception {
+    assertReplySequenceForIgnoredExecutionStatement("SAVEPOINT test_savepoint2", "SAVEPOINT");
+    assertReplySequenceForIgnoredExecutionStatement("RELEASE test_savepoint2", "RELEASE");
+  }
+
+  private void assertReplySequenceForIgnoredExecutionStatement(final String query, final String expectedTag) throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        sendParse(out, query);
+        sendBind(out);
+        sendDescribePortal(out);
+        sendExecute(out);
+        sendSync(out);
+
+        final WireMessage parseComplete = readWireMessage(in);
+        assertThat(parseComplete.type()).isEqualTo('1');
+        final WireMessage bindComplete = readWireMessage(in);
+        assertThat(bindComplete.type()).isEqualTo('2');
+
+        // Exactly one Describe reply, and no rows since these statements never produce any.
+        final WireMessage describeReply = readWireMessage(in);
+        assertThat(describeReply.type()).as("Describe('P') on a %s portal must answer NoData, not silence", query)
+            .isEqualTo('n');
+
+        // Execute must answer CommandComplete with the real command tag, never NoData.
+        final WireMessage executeReply = readWireMessage(in);
+        assertThat(executeReply.type()).as("Execute on a %s portal must answer CommandComplete, not NoData", query)
+            .isEqualTo('C');
+        assertThat(tagOf(executeReply)).isEqualTo(expectedTag);
+
+        final WireMessage readyForQuery = readWireMessage(in);
+        assertThat(readyForQuery.type()).isEqualTo('Z');
+      });
+    }
+  }
+
+  private void authenticate(final DataOutputStream out, final DataInputStream in) throws Exception {
+    sendStartupMessage(out, "root", getDatabaseName());
+    readMessage(in); // AuthenticationCleartextPassword
+    sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+    readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // unnamed statement
+    writeCString(body, query);
+    body.write(0);
+    body.write(0); // int16 numParamDataTypes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('P');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendBind(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    writeCString(body, ""); // statement name
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0
+    body.write(0);
+    body.write(0); // int16 numParamValues = 0
+    body.write(0);
+    body.write(0); // int16 numResultFormatCodes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('B');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendDescribePortal(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    body.write('P'); // describe a portal, not a prepared statement
+    writeCString(body, ""); // unnamed portal
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('D');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendExecute(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0); // int32 limit = 0 (no limit)
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('E');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendSync(final DataOutputStream out) throws Exception {
+    out.writeByte('S');
+    out.writeInt(4);
+    out.flush();
+  }
+
+  /**
+   * A {@code CommandComplete} body is a single null-terminated tag string with no other fields.
+   */
+  private static String tagOf(final WireMessage message) {
+    final byte[] body = message.body();
+    return new String(body, 0, body.length - 1, StandardCharsets.UTF_8);
+  }
+
+  private record WireMessage(char type, byte[] body) {
+  }
+
+  private static WireMessage readWireMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] body = new byte[length - 4];
+    in.readFully(body);
+    return new WireMessage((char) type, body);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -995,12 +995,12 @@ class PostgresTypeTest {
 
   @Test
   void deserializeBinaryJson() {
+    // issue #6929: PostgreSQL's json_send emits the raw UTF-8 text with no inner length prefix,
+    // so the wire payload is just the text bytes (the Bind message carries the length separately).
     String jsonStr = "{\"key\":\"value\"}";
-    ByteBuffer buffer = ByteBuffer.allocate(4 + jsonStr.length()).order(ByteOrder.BIG_ENDIAN);
-    buffer.putInt(jsonStr.length());
-    buffer.put(jsonStr.getBytes());
-    Object result = PostgresType.deserialize(PostgresType.JSON.code, 1, buffer.array());
+    Object result = PostgresType.deserialize(PostgresType.JSON.code, 1, jsonStr.getBytes());
     assertThat(result).isInstanceOf(JSONObject.class);
+    assertThat(((JSONObject) result).getString("key")).isEqualTo("value");
   }
 
   @Test
@@ -1605,7 +1605,6 @@ class PostgresTypeTest {
 
   @Test
   void serializeAsTextCollectionAllNonNull() {
-    // Test with non-null values only (null handling in arrays has a known limitation)
     Binary buffer = new Binary();
     List<Object> list = new ArrayList<>();
     list.add(1);
@@ -1617,6 +1616,35 @@ class PostgresTypeTest {
     byte[] data = new byte[length];
     buffer.getByteBuffer().get(data);
     assertThat(new String(data)).isEqualTo("{1,2,3}");
+  }
+
+  @Test
+  void serializeAsTextCollectionWithNullElement() {
+    // issue #6928: a null element must not throw NPE, it must render as the Postgres NULL literal
+    Binary buffer = new Binary();
+    List<Object> list = new ArrayList<>();
+    list.add("a");
+    list.add(null);
+    PostgresType.ARRAY_TEXT.serializeAsText(PostgresType.ARRAY_TEXT, buffer, list);
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+    assertThat(new String(data)).isEqualTo("{\"a\",NULL}");
+  }
+
+  @Test
+  void serializeAsTextCollectionAllNullElements() {
+    // issue #6928: a list with only null elements falls back to ARRAY_TEXT and must not throw
+    Binary buffer = new Binary();
+    List<Object> list = new ArrayList<>();
+    list.add(null);
+    PostgresType.ARRAY_TEXT.serializeAsText(PostgresType.ARRAY_TEXT, buffer, list);
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+    assertThat(new String(data)).isEqualTo("{NULL}");
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -997,8 +997,8 @@ class PostgresTypeTest {
   void deserializeBinaryJson() {
     // issue #6929: PostgreSQL's json_send emits the raw UTF-8 text with no inner length prefix,
     // so the wire payload is just the text bytes (the Bind message carries the length separately).
-    String jsonStr = "{\"key\":\"value\"}";
-    Object result = PostgresType.deserialize(PostgresType.JSON.code, 1, jsonStr.getBytes());
+    final String jsonStr = "{\"key\":\"value\"}";
+    final Object result = PostgresType.deserialize(PostgresType.JSON.code, 1, jsonStr.getBytes());
     assertThat(result).isInstanceOf(JSONObject.class);
     assertThat(((JSONObject) result).getString("key")).isEqualTo("value");
   }


### PR DESCRIPTION
## Summary

Fixes four independent, small issues in one batch:

- **#6930** - `Describe('P')` on a portal bound from `SAVEPOINT`/`RELEASE`/`ROLLBACK TO`/`SET` sent no reply at all (every `Describe` must be answered by exactly one of `RowDescription` or `NoData`). The matching `Execute` answered `NoData` (a Describe-only reply) instead of `CommandComplete`. Both are fixed together as the issue requires, since fixing only one desynchronizes pgjdbc. A non-`"sql"`-language portal (e.g. cypher) is deliberately left out of the `Describe` fix - it has no statement here either, but it DOES expect a result once executed (columns just aren't known yet at Describe time), so answering it with a premature `NoData` would break it; verified this the hard way when the first version of the fix regressed `PostgresProtocolIT`'s cypher/sqlscript tests, which rely on that yet-unfixed pre-existing gap for cypher to accidentally get its `RowDescription` from `Execute` instead.
- **#6928** - `serializeArrayToString()` dereferenced a `LIST` element before null-checking it, so a null inside a `LIST` column threw `NPE` while writing the Postgres array literal. The null check is now first, matching the dead `NULL` arm that was already there.
- **#6929** - A binary-format `json` (OID 114) bind parameter was decoded by first reading a bogus 4-byte length prefix that PostgreSQL's `json_send` never sends, corrupting/crashing on any real client that binds JSON in binary format. Now decoded as the raw UTF-8 text, exactly like `VARCHAR`/`TEXT`/`BPCHAR`.
- **#4918** - New SQL clause: `INSERT INTO Type CONTENT [ {...}, {...} ] ON DUPLICATE KEY SKIP`. A record that would violate a unique index - either one already committed, or an earlier record in the same batch - is skipped instead of aborting the rest of the array, and reported back as a row with `@skipped: true`, `@duplicateIndex`, `@duplicateKeys` and `@existingRID` so the caller always knows what happened. All other errors (mandatory field, type mismatch, ...) still abort, matching the scope agreed in the issue thread.

  **Design note on #4918** (better alternative to a naive implementation): a duplicate is *never* detected by catching the save failure. `Index.put()` only throws synchronously for a conflict against another key already staged in the SAME open transaction; a conflict against already-committed data is only detected by ArcadeDB at `commit()` time - by which point the record's bucket write has already happened and cannot be undone record-by-record without a full compensating delete (and a real risk of leaving a partially-indexed orphan record). Instead, each candidate record's unique indexes are probed directly with `Index.get()` *before* ever writing it - which also transparently sees this transaction's own pending, uncommitted entries, so an in-batch duplicate is caught the same way as a pre-existing one.

#6659 (Postgres portal-suspension eager materialization) was in the original batch but is **not** touched here: it's explicitly deferred to milestone 26.10.1 by its own tracking comment (lvca, 2026-08-24), pending PR #6658 (now merged) landing first. Forcing it into this PR would contradict that already-recorded decision.

## Test plan
- [x] `PostgresTypeTest` (227 tests) - added 2 new tests for #6928, updated 1 stale test that hand-encoded the #6929 bug instead of the real wire format
- [x] New `Issue6930DescribeExecuteSetSavepointIT` (raw-socket wire-protocol test, 3 cases) - verified it fails without the fix, passes with it
- [x] Full `postgresw` module test suite green, including `PostgresProtocolIT`, `Issue6701SetSessionLocalIT`, `Issue6698PreparedStatementCloseIT`, `Issue6543RollbackExtendedProtocolIT`, `Issue6548AbortedTransactionRollbackExtendedProtocolIT` - no regressions
- [x] New `InsertOnDuplicateKeySkipTest` (6 cases: pre-existing-record clash, same-batch clash, non-duplicate-key error still aborts, no-conflict happy path, baseline without the clause, `duplicate`/`skip` still usable as identifiers) - verified all 4 feature-dependent cases fail without the change, pass with it
- [x] Full `com.arcadedb.query.sql.parser.*Test` package (391 tests) and `DDLTest`, plus all existing `Insert*Test` classes - green, no grammar regressions
- [x] `mvn -o compile`/`test-compile` clean on `engine` and `postgresw`

🔗 https://github.com/ArcadeData/arcadedb/pull/new/fix/6930-6928-4918-6929-postgres-insert-batch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `INSERT ... ON DUPLICATE KEY SKIP` to skip records that conflict with unique keys.
  * Skipped duplicates include metadata describing conflicting keys, while other validation errors remain reported.
  * The word `duplicate` remains available as an identifier.

* **Bug Fixes**
  * Improved PostgreSQL handling for `SET` and `ROLLBACK TO` command responses.
  * Corrected PostgreSQL array serialization for null values.
  * Corrected PostgreSQL JSON binary deserialization for raw JSON payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->