### PR TITLE
fix(pagerank): honor IN direction in OLTP and CSR paths

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -310,13 +310,19 @@ public final class GraphAlgorithms {
    * via CSR arrays. Each thread writes to a disjoint range of the next[] array,
    * requiring zero synchronization.
    * <p>
-   * When direction is OUT (directed), out-degree uses forward CSR and pull reads backward CSR.
-   * When direction is BOTH (undirected), out-degree uses forward+backward CSR and pull reads both.
+   * The direction names the edges rank is pushed ALONG, so it selects which CSR array plays each role.
+   * OUT pushes along stored edges: out-degree comes from the forward CSR and the pull reads the backward one.
+   * IN pushes along reversed edges, which is the mirror image: out-degree comes from the backward CSR and the
+   * pull reads the forward one. BOTH treats the graph as undirected and uses both arrays for both roles.
+   * <p>
+   * IN is not a decoration on OUT - it is the only way to ask for rank flowing backwards without materializing a
+   * reversed copy of the graph, and until PR #6956 this kernel silently ignored it and answered OUT, so a
+   * covered {@code algo.pagerank({direction: 'IN'})} disagreed with the same call on an uncovered graph.
    *
    * @param view       the analytical view (must be built)
    * @param damping    damping factor, typically 0.85
    * @param iterations number of power-iteration steps
-   * @param direction  edge direction: OUT for directed, BOTH for undirected
+   * @param direction  edge direction rank is pushed along: OUT, IN, or BOTH (undirected)
    * @param edgeTypes  edge types to traverse (null or empty = all)
    * @return double[] of ranks indexed by dense node ID
    */
@@ -347,7 +353,11 @@ public final class GraphAlgorithms {
     if (n == 0)
       return new double[0];
 
-    final boolean undirected = direction == DIRECTION.BOTH;
+    // Rank is pushed along `direction`, so each CSR array's role follows from it: `pushForward` means stored
+    // edges carry rank (out-degree from the forward CSR, pull from the backward one) and `pushBackward` means
+    // reversed edges do. BOTH sets both, which is what makes it undirected.
+    final boolean pushForward = direction != DIRECTION.IN;
+    final boolean pushBackward = direction != DIRECTION.OUT;
 
     double[] rank = new double[n];
     double[] next = new double[n];
@@ -375,12 +385,12 @@ public final class GraphAlgorithms {
     // Precompute outDegree array across all edge types (once, outside iteration loop)
     final int[] outDeg = new int[n];
     for (int t = 0; t < typeCount; t++) {
-      if (allFwdOffsets[t] != null) {
+      if (pushForward && allFwdOffsets[t] != null) {
         final int[] fwdOffsets = allFwdOffsets[t];
         for (int u = 0; u < n; u++)
           outDeg[u] += fwdOffsets[u + 1] - fwdOffsets[u];
       }
-      if (undirected && allBwdOffsets[t] != null) {
+      if (pushBackward && allBwdOffsets[t] != null) {
         final int[] bwdOffsets = allBwdOffsets[t];
         for (int u = 0; u < n; u++)
           outDeg[u] += bwdOffsets[u + 1] - bwdOffsets[u];
@@ -422,13 +432,15 @@ public final class GraphAlgorithms {
         for (int u = start; u < end; u++) {
           double sum = 0;
           for (int t = 0; t < typeCount; t++) {
-            if (allBwdOffsets[t] != null) {
+            // u receives from every node that pushes to it: pushing forward along v -> u means v is one of u's
+            // backward neighbors, pushing backward along u -> v means v is one of u's forward neighbors.
+            if (pushForward && allBwdOffsets[t] != null) {
               final int[] bwdOffsets = allBwdOffsets[t];
               final int[] bwdNeighbors = allBwdNeighbors[t];
               for (int j = bwdOffsets[u]; j < bwdOffsets[u + 1]; j++)
                 sum += contrib[bwdNeighbors[j]];
             }
-            if (undirected && allFwdOffsets[t] != null) {
+            if (pushBackward && allFwdOffsets[t] != null) {
               final int[] fwdOffsets = allFwdOffsets[t];
               final int[] fwdNeighbors = allFwdNeighbors[t];
               for (int j = fwdOffsets[u]; j < fwdOffsets[u + 1]; j++)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -52,7 +52,8 @@ import java.util.stream.Stream;
  *   <li>maxIterations (int, default 20): maximum number of iterations</li>
  *   <li>tolerance (double, default 0.0001): convergence threshold</li>
  *   <li>weightProperty (string, default null): edge property to use as weight</li>
- *   <li>direction (string, default "OUT"): edge direction for push - "OUT", "IN", or "BOTH"</li>
+ *   <li>direction (string, default "OUT"): edges rank is pushed along - "OUT", "IN", or "BOTH".
+ *       Anything else is rejected rather than coerced, since the three answer different questions</li>
  * </ul>
  * </p>
  * <p>
@@ -110,9 +111,7 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
     final double tolerance = config != null && config.get("tolerance") instanceof Number n ?
         n.doubleValue() : 0.0001;
     final String weightProperty = config != null ? (String) config.get("weightProperty") : null;
-    final String dirStr = config != null && config.get("direction") instanceof String s ? s : "OUT";
-    final Vertex.DIRECTION direction = "BOTH".equalsIgnoreCase(dirStr) ? Vertex.DIRECTION.BOTH :
-        "IN".equalsIgnoreCase(dirStr) ? Vertex.DIRECTION.IN : Vertex.DIRECTION.OUT;
+    final Vertex.DIRECTION direction = extractDirection(config != null ? config.get("direction") : null);
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
@@ -129,6 +128,40 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
 
     // Fall back to OLTP path
     return executeWithOLTP(db, dampingFactor, maxIterations, tolerance, weightProperty, direction, guard);
+  }
+
+  /**
+   * Resolves the {@code direction} config value, rejecting anything that is neither absent nor one of the three
+   * supported values.
+   * <p>
+   * The three directions answer genuinely different questions - OUT pushes rank along stored edges, IN along
+   * their reverse, BOTH along both - so coercing an unrecognised value to OUT, as this did before, answers a
+   * question the caller did not ask and returns a plausible-looking result rather than an error. {@code
+   * 'INCOMING'} is the case that matters: it is what someone reaching for {@code IN} types, and it used to
+   * silently produce OUT's scores. That was harmless only while IN was broken anyway (see the direction fix in
+   * PR #6956); now that IN works, the silence is the bug.
+   * <p>
+   * Absent and explicitly null both mean "use the default", which is OUT - not BOTH, whatever the shared
+   * {@code direction} note in the docs says about most algorithms.
+   * <p>
+   * Deliberately local rather than routed through {@link com.arcadedb.graph.GraphEngine#parseDirection}: that
+   * helper coerces unknown values to BOTH and is shared by around twenty other {@code algo.*} procedures, so
+   * tightening it is a far wider behaviour change than this procedure's own bug fix should carry.
+   */
+  private Vertex.DIRECTION extractDirection(final Object value) {
+    if (value == null)
+      return Vertex.DIRECTION.OUT;
+    if (!(value instanceof String s))
+      throw new IllegalArgumentException(
+          getName() + "(): direction must be a string, one of OUT, IN or BOTH, got " + value);
+    if ("OUT".equalsIgnoreCase(s))
+      return Vertex.DIRECTION.OUT;
+    if ("IN".equalsIgnoreCase(s))
+      return Vertex.DIRECTION.IN;
+    if ("BOTH".equalsIgnoreCase(s))
+      return Vertex.DIRECTION.BOTH;
+    throw new IllegalArgumentException(
+        getName() + "(): unknown direction '" + s + "', expected one of OUT, IN or BOTH");
   }
 
   private Stream<Result> executeWithCSR(final CommandContext context, final GraphAnalyticalView gav,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -32,7 +32,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.WorkGuard;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -68,6 +68,9 @@ import java.util.stream.Stream;
  */
 public class AlgoPageRank extends AbstractAlgoProcedure {
   public static final String NAME = "algo.pagerank";
+
+  /** Starting size of the per-node adjacency buffer the OLTP fallback reuses; it doubles on demand. */
+  private static final int INITIAL_ADJACENCY_CAPACITY = 16;
 
   @Override
   public String getName() {
@@ -159,59 +162,53 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
     final int n = vertices.size();
     final Map<RID, Integer> ridToIdx = buildRidIndex(vertices);
 
-    // Build adjacency once: for each node, store (neighborIdx, weight) pairs.
-    // When direction is BOTH, edges are treated as bidirectional (undirected graphs).
+    // Build adjacency once: for each node, the dense ids it pushes rank to, and the matching weights.
+    //
+    // `direction` names the edges rank travels ALONG, so it selects which stored directions to walk rather than
+    // which to report: OUT pushes along stored edges, IN pushes along their reverse, and BOTH pushes both ways,
+    // which is what makes it undirected. Before PR #6956 the OUT walk was unconditional and only BOTH added
+    // the reverse one, so an IN request was answered with OUT's adjacency.
     final int[][] outNeighbors = new int[n][];
     final double[][] outWeights = weightProperty != null ? new double[n][] : null;
+    final Vertex.DIRECTION[] walks = direction == Vertex.DIRECTION.BOTH ?
+        new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN } :
+        new Vertex.DIRECTION[] { direction };
+    // One growable primitive buffer, reused across every node and copied out at its exact size, rather than a
+    // List<int[]> whose every entry was a one-element array and a List<Double> that boxed every weight: that is
+    // two allocations per EDGE on a path that walks the whole graph.
+    int[] nbrBuf = new int[INITIAL_ADJACENCY_CAPACITY];
+    double[] wtBuf = weightProperty != null ? new double[INITIAL_ADJACENCY_CAPACITY] : null;
     for (int i = 0; i < n; i++) {
       final Vertex v = vertices.get(i);
-      final List<int[]> nbrs = new ArrayList<>();
-      final List<Double> wts = weightProperty != null ? new ArrayList<>() : null;
+      int count = 0;
 
-      // OUT and BOTH traverse edges in their stored direction.
-      if (direction != Vertex.DIRECTION.IN) {
-        for (final Edge edge : v.getEdges(Vertex.DIRECTION.OUT)) {
+      for (final Vertex.DIRECTION walk : walks) {
+        for (final Edge edge : v.getEdges(walk)) {
           try {
-            final Integer neighborIdx = ridToIdx.get(edge.getInVertex().getIdentity());
+            final Integer neighborIdx = ridToIdx.get(
+                walk == Vertex.DIRECTION.OUT ? edge.getInVertex().getIdentity() : edge.getOutVertex().getIdentity());
             if (neighborIdx == null)
               continue;
-            nbrs.add(new int[]{ neighborIdx });
-            if (wts != null) {
-              final Object w = edge.get(weightProperty);
-              wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
+            if (count == nbrBuf.length) {
+              nbrBuf = Arrays.copyOf(nbrBuf, count << 1);
+              if (wtBuf != null)
+                wtBuf = Arrays.copyOf(wtBuf, count << 1);
             }
+            nbrBuf[count] = neighborIdx;
+            if (wtBuf != null) {
+              final Object w = edge.get(weightProperty);
+              wtBuf[count] = w instanceof Number num ? num.doubleValue() : 1.0;
+            }
+            count++;
           } catch (final RecordNotFoundException e) {
             GhostEdgeReporter.reportSkipped(e);
           }
         }
       }
 
-      // IN reverses every edge; BOTH also traverses the reverse direction to treat the graph as undirected.
-      if (direction != Vertex.DIRECTION.OUT) {
-        for (final Edge edge : v.getEdges(Vertex.DIRECTION.IN)) {
-          try {
-            final Integer neighborIdx = ridToIdx.get(edge.getOutVertex().getIdentity());
-            if (neighborIdx == null)
-              continue;
-            nbrs.add(new int[]{ neighborIdx });
-            if (wts != null) {
-              final Object w = edge.get(weightProperty);
-              wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
-            }
-          } catch (final RecordNotFoundException e) {
-            GhostEdgeReporter.reportSkipped(e);
-          }
-        }
-      }
-
-      outNeighbors[i] = new int[nbrs.size()];
-      for (int j = 0; j < nbrs.size(); j++)
-        outNeighbors[i][j] = nbrs.get(j)[0];
-      if (outWeights != null) {
-        outWeights[i] = new double[wts.size()];
-        for (int j = 0; j < wts.size(); j++)
-          outWeights[i][j] = wts.get(j);
-      }
+      outNeighbors[i] = Arrays.copyOf(nbrBuf, count);
+      if (outWeights != null)
+        outWeights[i] = Arrays.copyOf(wtBuf, count);
     }
 
     // Iterate purely in-memory

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -52,7 +52,7 @@ import java.util.stream.Stream;
  *   <li>maxIterations (int, default 20): maximum number of iterations</li>
  *   <li>tolerance (double, default 0.0001): convergence threshold</li>
  *   <li>weightProperty (string, default null): edge property to use as weight</li>
- *   <li>direction (string, default "OUT"): edge direction for push — "OUT" for directed graphs, "BOTH" for undirected</li>
+ *   <li>direction (string, default "OUT"): edge direction for push - "OUT", "IN", or "BOTH"</li>
  * </ul>
  * </p>
  * <p>
@@ -168,24 +168,26 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
       final List<int[]> nbrs = new ArrayList<>();
       final List<Double> wts = weightProperty != null ? new ArrayList<>() : null;
 
-      // Always traverse OUT edges
-      for (final Edge edge : v.getEdges(Vertex.DIRECTION.OUT)) {
-        try {
-          final Integer neighborIdx = ridToIdx.get(edge.getInVertex().getIdentity());
-          if (neighborIdx == null)
-            continue;
-          nbrs.add(new int[]{ neighborIdx });
-          if (wts != null) {
-            final Object w = edge.get(weightProperty);
-            wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
+      // OUT and BOTH traverse edges in their stored direction.
+      if (direction != Vertex.DIRECTION.IN) {
+        for (final Edge edge : v.getEdges(Vertex.DIRECTION.OUT)) {
+          try {
+            final Integer neighborIdx = ridToIdx.get(edge.getInVertex().getIdentity());
+            if (neighborIdx == null)
+              continue;
+            nbrs.add(new int[]{ neighborIdx });
+            if (wts != null) {
+              final Object w = edge.get(weightProperty);
+              wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
+            }
+          } catch (final RecordNotFoundException e) {
+            GhostEdgeReporter.reportSkipped(e);
           }
-        } catch (final RecordNotFoundException e) {
-          GhostEdgeReporter.reportSkipped(e);
         }
       }
 
-      // For BOTH direction, also traverse IN edges (treat undirected edges as bidirectional)
-      if (direction == Vertex.DIRECTION.BOTH) {
+      // IN reverses every edge; BOTH also traverses the reverse direction to treat the graph as undirected.
+      if (direction != Vertex.DIRECTION.OUT) {
         for (final Edge edge : v.getEdges(Vertex.DIRECTION.IN)) {
           try {
             final Integer neighborIdx = ridToIdx.get(edge.getOutVertex().getIdentity());

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -178,12 +178,19 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
     // two allocations per EDGE on a path that walks the whole graph.
     int[] nbrBuf = new int[INITIAL_ADJACENCY_CAPACITY];
     double[] wtBuf = weightProperty != null ? new double[INITIAL_ADJACENCY_CAPACITY] : null;
+    int edgeStep = 0;
     for (int i = 0; i < n; i++) {
       final Vertex v = vertices.get(i);
       int count = 0;
 
       for (final Vertex.DIRECTION walk : walks) {
         for (final Edge edge : v.getEdges(walk)) {
+          // This build walks and deserialises every edge in the graph and had no checkpoint at all: the first
+          // one a call reached was the iteration loop below, so a deadline could not be seen until the whole
+          // adjacency was already materialised. Throttled by EDGE rather than by vertex for the reason
+          // AbstractAlgoProcedure.RecordRowReader gives for the same walk - one supernode can hold millions of
+          // them, and a per-vertex checkpoint would leave that whole node unabortable.
+          guard.checkPeriodically(edgeStep++);
           try {
             final Integer neighborIdx = ridToIdx.get(
                 walk == Vertex.DIRECTION.OUT ? edge.getInVertex().getIdentity() : edge.getOutVertex().getIdentity());

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
@@ -145,6 +145,38 @@ class AlgoPageRankTest {
   }
 
   @Test
+  void pageRankRejectsAnUnrecognisedDirection() {
+    // The three directions genuinely answer different questions (see the parity tests above), so silently
+    // coercing an unrecognised one to OUT answers a question the caller did not ask and looks like a working
+    // result. 'INCOMING' is the shape that matters: it is what someone reaching for IN actually types.
+    for (final String bad : new String[] { "INCOMING", "OUTGOING", "in ", "" })
+      assertThatThrownBy(() -> drainPageRank("CALL algo.pagerank({direction: '" + bad + "'}) YIELD node RETURN node"))
+          .as("direction '%s' must be rejected, not coerced to OUT", bad)
+          .hasStackTraceContaining("direction")
+          .hasStackTraceContaining("OUT, IN or BOTH");
+
+    // A present-but-not-a-string direction was silently coerced the same way.
+    assertThatThrownBy(() -> drainPageRank("CALL algo.pagerank({direction: 42}) YIELD node RETURN node"))
+        .hasStackTraceContaining("direction");
+
+    // The three valid values, in both cases, still work - and an absent or explicitly null direction still
+    // defaults to OUT rather than being rejected.
+    for (final String good : new String[] { "OUT", "IN", "BOTH", "out", "in", "both" })
+      assertThat(drainPageRank("CALL algo.pagerank({direction: '" + good + "'}) YIELD node RETURN node")).hasSize(3);
+    assertThat(drainPageRank("CALL algo.pagerank() YIELD node RETURN node")).hasSize(3);
+    assertThat(drainPageRank("CALL algo.pagerank({direction: null}) YIELD node RETURN node")).hasSize(3);
+  }
+
+  private List<Result> drainPageRank(final String query) {
+    final List<Result> rows = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+    return rows;
+  }
+
+  @Test
   void weightedPageRankHonoursInDirection() {
     // Weighted PageRank never takes the CSR path, so the OLTP fallback's weight arrays are only exercised here,
     // and only through Cypher - which also covers the 'IN' and 'OUT' config strings end to end.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
@@ -144,108 +144,32 @@ class AlgoPageRankTest {
 
   @Test
   void pageRankCSRAndOLTPProduceIdenticalResults() {
-    // Step 1: Run PageRank without GAV → OLTP path
-    final Map<String, Double> oltpScores = new HashMap<>();
-    try (final ResultSet rs = database.query("opencypher",
-        """
-        CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 20, tolerance: 0.0001}) \
-        YIELD node, score RETURN node.name AS name, score""")) {
-      while (rs.hasNext()) {
-        final Result r = rs.next();
-        oltpScores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
-      }
-    }
+    final Map<RID, Double> oltpScores = pageRankScores(newContext(), null, 0.0001);
     assertThat(oltpScores).hasSize(3);
 
-    // Step 2: Build a GAV so the CSR path is used
-    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
-        .withName("pagerank-csr")
-        .withVertexTypes("Page")
-        .withEdgeTypes("LINKS")
-        .build();
-    gav.awaitReady(10, TimeUnit.SECONDS);
-
-    // Step 3: Run PageRank with GAV → CSR path
-    final Map<String, Double> csrScores = new HashMap<>();
-    try (final ResultSet rs = database.query("opencypher",
-        """
-        CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 20, tolerance: 0.0001}) \
-        YIELD node, score RETURN node.name AS name, score""")) {
-      while (rs.hasNext()) {
-        final Result r = rs.next();
-        csrScores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
-      }
-    }
-    assertThat(csrScores).hasSize(3);
-
-    // Step 4: Compare — CSR and OLTP paths accumulate floating-point differences
-    // due to different iteration order and convergence behavior, so use 1e-4 tolerance
-    for (final Map.Entry<String, Double> entry : oltpScores.entrySet()) {
-      final String name = entry.getKey();
-      assertThat(csrScores).containsKey(name);
-      assertThat(csrScores.get(name)).isCloseTo(entry.getValue(), Offset.offset(1e-4));
-    }
-
-    gav.shutdown();
-  }
-
-  @Test
-  void weightedPageRankHonoursInDirection() {
-    // Weighted PageRank never takes the CSR path, so the OLTP fallback's weight arrays are only exercised here.
-    database.transaction(() -> {
-      try (final ResultSet rs = database.command("sql", "UPDATE LINKS SET weight = 1")) {
-        rs.close();
-      }
-      try (final ResultSet rs = database.command("sql",
-          "UPDATE LINKS SET weight = 9 WHERE out.name = 'A' AND in.name = 'C'")) {
-        rs.close();
-      }
-    });
-
-    // A -> B, A -> C (weight 9), B -> C, C -> A. Following the stored direction concentrates rank on C.
-    assertThat(topRankedName("OUT", "weight")).isEqualTo("C");
-    // Reversing it concentrates rank on A instead: A is where both B's and 90% of C's rank now flows.
-    assertThat(topRankedName("IN", "weight")).isEqualTo("A");
-  }
-
-  private String topRankedName(final String direction, final String weightProperty) {
-    try (final ResultSet rs = database.query("opencypher",
-        "CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 40, tolerance: 0.0, direction: '" + direction
-            + "', weightProperty: '" + weightProperty + "'}) YIELD node, score RETURN node.name AS name, score "
-            + "ORDER BY score DESC")) {
-      return (String) rs.next().getProperty("name");
+    final GraphAnalyticalView gav = readyView("pagerank-csr");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Map<RID, Double> csrScores = pageRankScores(csrContext, null, 0.0001);
+      assertCSRAccelerated(csrContext);
+      assertScoresMatch(oltpScores, csrScores);
+    } finally {
+      gav.shutdown();
     }
   }
 
   @Test
   void pageRankInDirectionCSRAndOLTPProduceIdenticalResults() {
-    // Invoked through the procedure rather than the query engine so the call's CommandContext is observable:
-    // awaitReady() returning true would not be enough on its own, because AlgoPageRank also drops to OLTP when
-    // the view reports pending changes and when findProvider() does not reach it at all - and a parity test
-    // served by OLTP twice pins the OLTP path against itself and can never fail. CSR_ACCELERATED_VAR is the
-    // only signal that says which path actually ran. The 'IN' config string itself is covered end-to-end by
-    // weightedPageRankHonoursInDirection.
-    final Map<RID, Double> oltpScores = pageRankScores(newContext(), Vertex.DIRECTION.IN);
+    // The 'IN' config string itself is covered end-to-end through Cypher by weightedPageRankHonoursInDirection.
+    final Map<RID, Double> oltpScores = pageRankScores(newContext(), Vertex.DIRECTION.IN, 0.0);
     assertThat(oltpScores).hasSize(3);
 
-    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
-        .withName("pagerank-in-csr")
-        .withVertexTypes("Page")
-        .withEdgeTypes("LINKS")
-        .build();
+    final GraphAnalyticalView gav = readyView("pagerank-in-csr");
     try {
-      assertThat(gav.awaitReady(10, TimeUnit.SECONDS)).isTrue();
-
       final BasicCommandContext csrContext = newContext();
-      final Map<RID, Double> csrScores = pageRankScores(csrContext, Vertex.DIRECTION.IN);
-      assertThat(csrContext.getVariable(CommandContext.CSR_ACCELERATED_VAR))
-          .as("the view must actually back the call, or this comparison pins the OLTP path against itself")
-          .isEqualTo(true);
-
-      assertThat(csrScores.keySet()).isEqualTo(oltpScores.keySet());
-      for (final Map.Entry<RID, Double> entry : oltpScores.entrySet())
-        assertThat(csrScores.get(entry.getKey())).as("score for " + entry.getKey())
-            .isCloseTo(entry.getValue(), Offset.offset(1e-4));
+      final Map<RID, Double> csrScores = pageRankScores(csrContext, Vertex.DIRECTION.IN, 0.0);
+      assertCSRAccelerated(csrContext);
+      assertScoresMatch(oltpScores, csrScores);
 
       // A -> B, A -> C, B -> C, C -> A. Reversed, A is where both B's and C's rank flows, so A must top both.
       final Map<String, Double> byName = new HashMap<>();
@@ -263,12 +187,20 @@ class AlgoPageRankTest {
     return context;
   }
 
-  private Map<RID, Double> pageRankScores(final CommandContext context, final Vertex.DIRECTION direction) {
+  /**
+   * Runs {@code algo.pagerank} through the procedure rather than the query engine, so the call's
+   * {@link CommandContext} stays observable and {@link #assertCSRAccelerated} can say which path served it.
+   *
+   * @param direction the {@code direction} config value, or null to leave the key out and take the default
+   */
+  private Map<RID, Double> pageRankScores(final CommandContext context, final Vertex.DIRECTION direction,
+      final double tolerance) {
     final Map<String, Object> config = new HashMap<>();
     config.put("dampingFactor", 0.85);
     config.put("maxIterations", 20);
-    config.put("tolerance", 0.0);
-    config.put("direction", direction.name());
+    config.put("tolerance", tolerance);
+    if (direction != null)
+      config.put("direction", direction.name());
 
     final Map<RID, Double> scores = new HashMap<>();
     for (final Iterator<Result> it = new AlgoPageRank().execute(new Object[] { config }, null, context).iterator();
@@ -279,57 +211,57 @@ class AlgoPageRankTest {
     return scores;
   }
 
-  @Test
-  void pageRankBothDirectionCSRAndOLTPProduceIdenticalResults() {
-    // Step 1: Run PageRank with direction=BOTH without GAV → OLTP path
-    final Map<String, Double> oltpScores = new HashMap<>();
-    try (final ResultSet rs = database.query("opencypher",
-        """
-        CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 20, tolerance: 0.0, direction: 'BOTH'}) \
-        YIELD node, score RETURN node.name AS name, score""")) {
-      while (rs.hasNext()) {
-        final Result r = rs.next();
-        oltpScores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
-      }
-    }
-    assertThat(oltpScores).hasSize(3);
+  /**
+   * A CSR/OLTP parity test whose CSR half quietly fell back to OLTP compares the OLTP path with itself and can
+   * never fail, whatever the CSR kernel does. {@code awaitReady()} returning true does not rule that out on its
+   * own either: {@link AlgoPageRank} also falls back when the view reports pending changes and when
+   * {@code findProvider()} does not reach it. This variable is what the procedure sets on the CSR path, so it is
+   * the only signal that says which one actually ran.
+   */
+  private void assertCSRAccelerated(final CommandContext context) {
+    assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+        .as("the view must actually back the call, or this comparison pins the OLTP path against itself")
+        .isEqualTo(true);
+  }
 
-    // Step 2: Build a GAV so the CSR path is used
+  /** Asserts every OLTP score has a CSR counterpart within the tolerance the two paths' iteration orders need. */
+  private void assertScoresMatch(final Map<RID, Double> oltpScores, final Map<RID, Double> csrScores) {
+    assertThat(csrScores.keySet()).isEqualTo(oltpScores.keySet());
+    for (final Map.Entry<RID, Double> entry : oltpScores.entrySet())
+      assertThat(csrScores.get(entry.getKey())).as("score for " + entry.getKey())
+          .isCloseTo(entry.getValue(), Offset.offset(1e-4));
+  }
+
+  private GraphAnalyticalView readyView(final String name) {
     final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
-        .withName("pagerank-both-csr")
+        .withName(name)
         .withVertexTypes("Page")
         .withEdgeTypes("LINKS")
         .build();
-    // Without this the CSR half can silently fall back to OLTP and the comparison pins OLTP against itself.
     assertThat(gav.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    return gav;
+  }
 
-    // Step 3: Run PageRank with direction=BOTH with GAV → CSR path
-    final Map<String, Double> csrScores = new HashMap<>();
-    try (final ResultSet rs = database.query("opencypher",
-        """
-        CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 20, tolerance: 0.0, direction: 'BOTH'}) \
-        YIELD node, score RETURN node.name AS name, score""")) {
-      while (rs.hasNext()) {
-        final Result r = rs.next();
-        csrScores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
-      }
+  @Test
+  void pageRankBothDirectionCSRAndOLTPProduceIdenticalResults() {
+    final Map<RID, Double> oltpScores = pageRankScores(newContext(), Vertex.DIRECTION.BOTH, 0.0);
+    assertThat(oltpScores).hasSize(3);
+
+    final GraphAnalyticalView gav = readyView("pagerank-both-csr");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Map<RID, Double> csrScores = pageRankScores(csrContext, Vertex.DIRECTION.BOTH, 0.0);
+      assertCSRAccelerated(csrContext);
+      assertScoresMatch(oltpScores, csrScores);
+
+      // Treating the graph as undirected redistributes rank but must not create or destroy any of it.
+      double sum = 0;
+      for (final double score : csrScores.values())
+        sum += score;
+      assertThat(sum).isBetween(0.9, 1.1);
+    } finally {
+      gav.shutdown();
     }
-    assertThat(csrScores).hasSize(3);
-
-    // Step 4: Compare — CSR and OLTP paths should match closely
-    for (final Map.Entry<String, Double> entry : oltpScores.entrySet()) {
-      final String name = entry.getKey();
-      assertThat(csrScores).containsKey(name);
-      assertThat(csrScores.get(name)).isCloseTo(entry.getValue(), Offset.offset(1e-4));
-    }
-
-    // Step 5: For undirected graph, scores should be more evenly distributed than directed
-    double sum = 0;
-    for (final double s : csrScores.values())
-      sum += s;
-    assertThat(sum).isBetween(0.9, 1.1);
-
-    gav.shutdown();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
@@ -20,7 +20,11 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -34,6 +38,7 @@ import com.arcadedb.graph.olap.GraphAnalyticalViewRegistry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -214,50 +219,64 @@ class AlgoPageRankTest {
 
   @Test
   void pageRankInDirectionCSRAndOLTPProduceIdenticalResults() {
-    // Step 1: Run PageRank with direction=IN without GAV -> OLTP path
-    final Map<String, Double> oltpScores = new HashMap<>();
-    try (final ResultSet rs = database.query("opencypher",
-        """
-        CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 20, tolerance: 0.0, direction: 'IN'}) \
-        YIELD node, score RETURN node.name AS name, score""")) {
-      while (rs.hasNext()) {
-        final Result r = rs.next();
-        oltpScores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
-      }
-    }
+    // Invoked through the procedure rather than the query engine so the call's CommandContext is observable:
+    // awaitReady() returning true would not be enough on its own, because AlgoPageRank also drops to OLTP when
+    // the view reports pending changes and when findProvider() does not reach it at all - and a parity test
+    // served by OLTP twice pins the OLTP path against itself and can never fail. CSR_ACCELERATED_VAR is the
+    // only signal that says which path actually ran. The 'IN' config string itself is covered end-to-end by
+    // weightedPageRankHonoursInDirection.
+    final Map<RID, Double> oltpScores = pageRankScores(newContext(), Vertex.DIRECTION.IN);
     assertThat(oltpScores).hasSize(3);
 
-    // Step 2: Build a GAV so the CSR path is used
     final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
         .withName("pagerank-in-csr")
         .withVertexTypes("Page")
         .withEdgeTypes("LINKS")
         .build();
-    gav.awaitReady(10, TimeUnit.SECONDS);
+    try {
+      assertThat(gav.awaitReady(10, TimeUnit.SECONDS)).isTrue();
 
-    // Step 3: Run PageRank with direction=IN with GAV -> CSR path
-    final Map<String, Double> csrScores = new HashMap<>();
-    try (final ResultSet rs = database.query("opencypher",
-        """
-        CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 20, tolerance: 0.0, direction: 'IN'}) \
-        YIELD node, score RETURN node.name AS name, score""")) {
-      while (rs.hasNext()) {
-        final Result r = rs.next();
-        csrScores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
-      }
+      final BasicCommandContext csrContext = newContext();
+      final Map<RID, Double> csrScores = pageRankScores(csrContext, Vertex.DIRECTION.IN);
+      assertThat(csrContext.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+          .as("the view must actually back the call, or this comparison pins the OLTP path against itself")
+          .isEqualTo(true);
+
+      assertThat(csrScores.keySet()).isEqualTo(oltpScores.keySet());
+      for (final Map.Entry<RID, Double> entry : oltpScores.entrySet())
+        assertThat(csrScores.get(entry.getKey())).as("score for " + entry.getKey())
+            .isCloseTo(entry.getValue(), Offset.offset(1e-4));
+
+      // A -> B, A -> C, B -> C, C -> A. Reversed, A is where both B's and C's rank flows, so A must top both.
+      final Map<String, Double> byName = new HashMap<>();
+      csrScores.forEach((rid, score) -> byName.put(rid.asVertex().getString("name"), score));
+      assertThat(byName.get("A")).isGreaterThan(byName.get("B"));
+      assertThat(byName.get("A")).isGreaterThan(byName.get("C"));
+    } finally {
+      gav.shutdown();
     }
-    assertThat(csrScores).hasSize(3);
+  }
 
-    for (final Map.Entry<String, Double> entry : oltpScores.entrySet()) {
-      assertThat(csrScores).containsKey(entry.getKey());
-      assertThat(csrScores.get(entry.getKey())).isCloseTo(entry.getValue(), Offset.offset(1e-4));
+  private BasicCommandContext newContext() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    return context;
+  }
+
+  private Map<RID, Double> pageRankScores(final CommandContext context, final Vertex.DIRECTION direction) {
+    final Map<String, Object> config = new HashMap<>();
+    config.put("dampingFactor", 0.85);
+    config.put("maxIterations", 20);
+    config.put("tolerance", 0.0);
+    config.put("direction", direction.name());
+
+    final Map<RID, Double> scores = new HashMap<>();
+    for (final Iterator<Result> it = new AlgoPageRank().execute(new Object[] { config }, null, context).iterator();
+        it.hasNext(); ) {
+      final Result row = it.next();
+      scores.put(row.getProperty("node"), ((Number) row.getProperty("score")).doubleValue());
     }
-
-    // A -> B, A -> C, B -> C, C -> A. Reversed, A is the only sink of two edges, so A must top the ranking.
-    assertThat(csrScores.get("A")).isGreaterThan(csrScores.get("B"));
-    assertThat(csrScores.get("A")).isGreaterThan(csrScores.get("C"));
-
-    gav.shutdown();
+    return scores;
   }
 
   @Test
@@ -281,7 +300,8 @@ class AlgoPageRankTest {
         .withVertexTypes("Page")
         .withEdgeTypes("LINKS")
         .build();
-    gav.awaitReady(10, TimeUnit.SECONDS);
+    // Without this the CSR half can silently fall back to OLTP and the comparison pins OLTP against itself.
+    assertThat(gav.awaitReady(10, TimeUnit.SECONDS)).isTrue();
 
     // Step 3: Run PageRank with direction=BOTH with GAV → CSR path
     final Map<String, Double> csrScores = new HashMap<>();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
@@ -185,6 +185,82 @@ class AlgoPageRankTest {
   }
 
   @Test
+  void weightedPageRankHonoursInDirection() {
+    // Weighted PageRank never takes the CSR path, so the OLTP fallback's weight arrays are only exercised here.
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("sql", "UPDATE LINKS SET weight = 1")) {
+        rs.close();
+      }
+      try (final ResultSet rs = database.command("sql",
+          "UPDATE LINKS SET weight = 9 WHERE out.name = 'A' AND in.name = 'C'")) {
+        rs.close();
+      }
+    });
+
+    // A -> B, A -> C (weight 9), B -> C, C -> A. Following the stored direction concentrates rank on C.
+    assertThat(topRankedName("OUT", "weight")).isEqualTo("C");
+    // Reversing it concentrates rank on A instead: A is where both B's and 90% of C's rank now flows.
+    assertThat(topRankedName("IN", "weight")).isEqualTo("A");
+  }
+
+  private String topRankedName(final String direction, final String weightProperty) {
+    try (final ResultSet rs = database.query("opencypher",
+        "CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 40, tolerance: 0.0, direction: '" + direction
+            + "', weightProperty: '" + weightProperty + "'}) YIELD node, score RETURN node.name AS name, score "
+            + "ORDER BY score DESC")) {
+      return (String) rs.next().getProperty("name");
+    }
+  }
+
+  @Test
+  void pageRankInDirectionCSRAndOLTPProduceIdenticalResults() {
+    // Step 1: Run PageRank with direction=IN without GAV -> OLTP path
+    final Map<String, Double> oltpScores = new HashMap<>();
+    try (final ResultSet rs = database.query("opencypher",
+        """
+        CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 20, tolerance: 0.0, direction: 'IN'}) \
+        YIELD node, score RETURN node.name AS name, score""")) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        oltpScores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
+      }
+    }
+    assertThat(oltpScores).hasSize(3);
+
+    // Step 2: Build a GAV so the CSR path is used
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("pagerank-in-csr")
+        .withVertexTypes("Page")
+        .withEdgeTypes("LINKS")
+        .build();
+    gav.awaitReady(10, TimeUnit.SECONDS);
+
+    // Step 3: Run PageRank with direction=IN with GAV -> CSR path
+    final Map<String, Double> csrScores = new HashMap<>();
+    try (final ResultSet rs = database.query("opencypher",
+        """
+        CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 20, tolerance: 0.0, direction: 'IN'}) \
+        YIELD node, score RETURN node.name AS name, score""")) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        csrScores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
+      }
+    }
+    assertThat(csrScores).hasSize(3);
+
+    for (final Map.Entry<String, Double> entry : oltpScores.entrySet()) {
+      assertThat(csrScores).containsKey(entry.getKey());
+      assertThat(csrScores.get(entry.getKey())).isCloseTo(entry.getValue(), Offset.offset(1e-4));
+    }
+
+    // A -> B, A -> C, B -> C, C -> A. Reversed, A is the only sink of two edges, so A must top the ranking.
+    assertThat(csrScores.get("A")).isGreaterThan(csrScores.get("B"));
+    assertThat(csrScores.get("A")).isGreaterThan(csrScores.get("C"));
+
+    gav.shutdown();
+  }
+
+  @Test
   void pageRankBothDirectionCSRAndOLTPProduceIdenticalResults() {
     // Step 1: Run PageRank with direction=BOTH without GAV → OLTP path
     final Map<String, Double> oltpScores = new HashMap<>();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
@@ -149,6 +149,7 @@ class AlgoPageRankTest {
     // Weighted PageRank never takes the CSR path, so the OLTP fallback's weight arrays are only exercised here,
     // and only through Cypher - which also covers the 'IN' and 'OUT' config strings end to end.
     final Map<String, Double> unweightedIn = pageRankByName("IN", null);
+    final Map<String, Double> unweightedOut = pageRankByName("OUT", null);
 
     // Weights are set through the graph API on purpose. `UPDATE LINKS SET weight = 9 WHERE out.name = 'A'` looks
     // like it would work and matches zero rows: `out`/`in` do not dereference to the endpoint vertex on an edge
@@ -170,12 +171,18 @@ class AlgoPageRankTest {
 
     // A -> B, A -> C (weight 9), B -> C, C -> A. Following the stored direction concentrates rank on C;
     // reversing it concentrates rank on A, where both B's rank and 90% of C's now flows.
-    assertThat(topRanked(pageRankByName("OUT", "weight"))).isEqualTo("C");
+    final Map<String, Double> weightedOut = pageRankByName("OUT", "weight");
+    assertThat(topRanked(weightedOut)).isEqualTo("C");
     final Map<String, Double> weightedIn = pageRankByName("IN", "weight");
     assertThat(topRanked(weightedIn)).isEqualTo("A");
 
-    // The split has to reach the SCORES too, or this test would pass identically with the weight arrays ignored:
-    // unweighted IN splits C's rank evenly between A and B, weighted IN sends 90% of it to A.
+    // Both top-ranked checks above are only orientation: C already wins OUT and A already wins IN at uniform
+    // weights, so neither can tell a consumed weight array from an ignored one. These two can. In each direction
+    // the 9:1 split diverts rank that an even split would have sent to B, so B must end up strictly poorer:
+    // under OUT it is A's rank being split 90/10 towards C, under IN it is C's being split 90/10 towards A.
+    assertThat(weightedOut.get("B"))
+        .as("weighted OUT must leave B less of A's rank than an even split would")
+        .isLessThan(unweightedOut.get("B") - 1e-6);
     assertThat(weightedIn.get("B"))
         .as("weighted IN must leave B less of C's rank than an even split would")
         .isLessThan(unweightedIn.get("B") - 1e-6);
@@ -215,6 +222,39 @@ class AlgoPageRankTest {
       csrScores.forEach((rid, score) -> byName.put(rid.asVertex().getString("name"), score));
       assertThat(byName.get("A")).isGreaterThan(byName.get("B"));
       assertThat(byName.get("A")).isGreaterThan(byName.get("C"));
+    } finally {
+      gav.shutdown();
+    }
+  }
+
+  @Test
+  void pageRankInDirectionAgreesOnDanglingNodesToo() {
+    // Reversing the direction also reverses which nodes are DANGLING, and dangling rank is redistributed by
+    // separate code in each kernel (the CSR one precomputes a dangling-node list from out-degree once; the OLTP
+    // one re-sums it every iteration). The A/B/C fixture cannot cover that under IN: every node there has an
+    // incoming edge, so nothing is dangling. D is a pure source - no incoming edges at all - so it pushes
+    // nothing under IN and its rank has to be redistributed rather than lost.
+    database.transaction(() -> {
+      final MutableVertex d = database.newVertex("Page").set("name", "D").save();
+      d.newEdge("LINKS", database.select().fromType("Page").where().property("name").eq().value("A").vertices().next(),
+          true, (Object[]) null).save();
+    });
+
+    final Map<RID, Double> oltpScores = pageRankScores(newContext(), Vertex.DIRECTION.IN, 0.0);
+    assertThat(oltpScores).hasSize(4);
+
+    final GraphAnalyticalView gav = readyView("pagerank-in-dangling-csr");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Map<RID, Double> csrScores = pageRankScores(csrContext, Vertex.DIRECTION.IN, 0.0);
+      assertCSRAccelerated(csrContext);
+      assertScoresMatch(oltpScores, csrScores);
+
+      // Rank must be conserved: a dangling node's share is redistributed, not dropped on the floor.
+      double sum = 0;
+      for (final double score : csrScores.values())
+        sum += score;
+      assertThat(sum).as("dangling rank under IN must be redistributed, not lost").isBetween(0.9, 1.1);
     } finally {
       gav.shutdown();
     }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
@@ -21,6 +21,8 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
@@ -143,6 +145,43 @@ class AlgoPageRankTest {
   }
 
   @Test
+  void weightedPageRankHonoursInDirection() {
+    // Weighted PageRank never takes the CSR path, so the OLTP fallback's weight arrays are only exercised here,
+    // and only through Cypher - which also covers the 'IN' and 'OUT' config strings end to end.
+    final Map<String, Double> unweightedIn = pageRankByName("IN", null);
+
+    // Weights are set through the graph API on purpose. `UPDATE LINKS SET weight = 9 WHERE out.name = 'A'` looks
+    // like it would work and matches zero rows: `out`/`in` do not dereference to the endpoint vertex on an edge
+    // type, so the whole fixture silently no-ops and every weight stays 1 - which is indistinguishable from an
+    // algorithm that ignores weights entirely.
+    database.transaction(() -> {
+      for (final Iterator<Vertex> vertices = database.select().fromType("Page").vertices(); vertices.hasNext(); ) {
+        final Vertex v = vertices.next();
+        for (final Edge edge : v.getEdges(Vertex.DIRECTION.OUT)) {
+          final MutableEdge weighted = edge.modify();
+          weighted.set("weight", "A".equals(v.getString("name")) && "C".equals(edge.getInVertex().getString("name"))
+              ? 9.0 : 1.0);
+          weighted.save();
+        }
+      }
+    });
+    assertThat(edgeWeights()).as("the 9:1 split must actually reach the edges").containsExactlyInAnyOrder(
+        1.0, 1.0, 1.0, 9.0);
+
+    // A -> B, A -> C (weight 9), B -> C, C -> A. Following the stored direction concentrates rank on C;
+    // reversing it concentrates rank on A, where both B's rank and 90% of C's now flows.
+    assertThat(topRanked(pageRankByName("OUT", "weight"))).isEqualTo("C");
+    final Map<String, Double> weightedIn = pageRankByName("IN", "weight");
+    assertThat(topRanked(weightedIn)).isEqualTo("A");
+
+    // The split has to reach the SCORES too, or this test would pass identically with the weight arrays ignored:
+    // unweighted IN splits C's rank evenly between A and B, weighted IN sends 90% of it to A.
+    assertThat(weightedIn.get("B"))
+        .as("weighted IN must leave B less of C's rank than an even split would")
+        .isLessThan(unweightedIn.get("B") - 1e-6);
+  }
+
+  @Test
   void pageRankCSRAndOLTPProduceIdenticalResults() {
     final Map<RID, Double> oltpScores = pageRankScores(newContext(), null, 0.0001);
     assertThat(oltpScores).hasSize(3);
@@ -180,6 +219,59 @@ class AlgoPageRankTest {
       gav.shutdown();
     }
   }
+
+  @Test
+  void pageRankBothDirectionCSRAndOLTPProduceIdenticalResults() {
+    final Map<RID, Double> oltpScores = pageRankScores(newContext(), Vertex.DIRECTION.BOTH, 0.0);
+    assertThat(oltpScores).hasSize(3);
+
+    final GraphAnalyticalView gav = readyView("pagerank-both-csr");
+    try {
+      final BasicCommandContext csrContext = newContext();
+      final Map<RID, Double> csrScores = pageRankScores(csrContext, Vertex.DIRECTION.BOTH, 0.0);
+      assertCSRAccelerated(csrContext);
+      assertScoresMatch(oltpScores, csrScores);
+
+      // Treating the graph as undirected redistributes rank but must not create or destroy any of it.
+      double sum = 0;
+      for (final double score : csrScores.values())
+        sum += score;
+      assertThat(sum).isBetween(0.9, 1.1);
+    } finally {
+      gav.shutdown();
+    }
+  }
+
+  private List<Double> edgeWeights() {
+    final List<Double> weights = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", "SELECT weight FROM LINKS")) {
+      while (rs.hasNext())
+        weights.add(((Number) rs.next().getProperty("weight")).doubleValue());
+    }
+    return weights;
+  }
+
+  /** Runs algo.pagerank through Cypher, so the config-map literal and the direction string are covered too. */
+  private Map<String, Double> pageRankByName(final String direction, final String weightProperty) {
+    final Map<String, Double> scores = new HashMap<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "CALL algo.pagerank({dampingFactor: 0.85, maxIterations: 40, tolerance: 0.0, direction: '" + direction + "'"
+            + (weightProperty != null ? ", weightProperty: '" + weightProperty + "'" : "")
+            + "}) YIELD node, score RETURN node.name AS name, score")) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        scores.put((String) r.getProperty("name"), ((Number) r.getProperty("score")).doubleValue());
+      }
+    }
+    assertThat(scores).hasSize(3);
+    return scores;
+  }
+
+  private static String topRanked(final Map<String, Double> scores) {
+    return scores.entrySet().stream().max(Map.Entry.comparingByValue()).orElseThrow().getKey();
+  }
+
+  // ── CSR/OLTP parity fixtures ────────────────────────────────────────
 
   private BasicCommandContext newContext() {
     final BasicCommandContext context = new BasicCommandContext();
@@ -240,28 +332,6 @@ class AlgoPageRankTest {
         .build();
     assertThat(gav.awaitReady(10, TimeUnit.SECONDS)).isTrue();
     return gav;
-  }
-
-  @Test
-  void pageRankBothDirectionCSRAndOLTPProduceIdenticalResults() {
-    final Map<RID, Double> oltpScores = pageRankScores(newContext(), Vertex.DIRECTION.BOTH, 0.0);
-    assertThat(oltpScores).hasSize(3);
-
-    final GraphAnalyticalView gav = readyView("pagerank-both-csr");
-    try {
-      final BasicCommandContext csrContext = newContext();
-      final Map<RID, Double> csrScores = pageRankScores(csrContext, Vertex.DIRECTION.BOTH, 0.0);
-      assertCSRAccelerated(csrContext);
-      assertScoresMatch(oltpScores, csrScores);
-
-      // Treating the graph as undirected redistributes rank but must not create or destroy any of it.
-      double sum = 0;
-      for (final double score : csrScores.values())
-        sum += score;
-      assertThat(sum).isBetween(0.9, 1.1);
-    } finally {
-      gav.shutdown();
-    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6792AddedVertexIdSpaceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6792AddedVertexIdSpaceTest.java
@@ -154,4 +154,23 @@ class Issue6792AddedVertexIdSpaceTest {
     assertThat(components.get(c)).isEqualTo(components.get(fresh));
     assertThat(components.get(a)).isNotEqualTo(components.get(c));
   }
+
+  @Test
+  void pageRankInDirectionFollowsIncomingEdgesWhileTheViewHasPendingChanges() {
+    assertThat(view.hasPendingChanges()).isTrue();
+
+    final Map<RID, Double> scores = new HashMap<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "CALL algo.pagerank({direction: 'IN', maxIterations: 20, tolerance: 0.0}) YIELD node, score RETURN node, score")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        scores.put(row.getProperty("node"), ((Number) row.getProperty("score")).doubleValue());
+      }
+    }
+
+    assertThat(scores).hasSize(4);
+    // A -> B and C -> FRESH. Reversing the traversal must therefore rank A above B and C above FRESH.
+    assertThat(scores.get(a)).isGreaterThan(scores.get(b));
+    assertThat(scores.get(c)).isGreaterThan(scores.get(fresh));
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Makes `algo.pagerank` honor the configured edge direction consistently in both execution paths:

- the OLTP fallback follows stored edges for `OUT`, reversed edges for `IN`, and both for `BOTH`
- the CSR kernel mirrors its forward/backward degree and pull arrays for `IN`, while preserving the existing `OUT` and `BOTH` paths
- weighted PageRank uses the matching edge weights when traversing incoming adjacency
- the OLTP adjacency build reuses primitive buffers and checks the query work guard while scanning edges
- the procedure documentation now lists all three supported directions

Regression coverage now includes query-level weighted `IN`, CSR/OLTP parity for `OUT`, `IN`, and `BOTH` with an explicit `CSR_ACCELERATED_VAR` assertion, and `IN` traversal while a synchronous Graph Analytical View has pending changes.

## Motivation

PR #6887 correctly routes PageRank away from the base CSR while a view has pending changes. That exposed an existing OLTP fallback bug: the fallback always built outgoing adjacency and added incoming adjacency only for `BOTH`, so `direction: 'IN'` returned outbound PageRank scores.

Review then found the same gap in the CSR kernel: `IN` fell through to the `OUT` arrangement there too. Consequently, the same `algo.pagerank({direction: 'IN'})` call could return different answers depending on whether a ready Graph Analytical View covered the graph. Both paths must be corrected together.

## Related issues

- Follow-up to #6887
- Addresses https://github.com/ArcadeData/arcadedb/pull/6887#discussion_r3885579124

## Additional Notes

The pending-view regression was added first. On the original `main` base, it failed with `A = 0.1754385992` and `B = 0.3245614008`, proving that an `IN` request followed the stored `A -> B` direction. It passes after the fix.

The weighted regression sets and verifies a real 9:1 edge-weight split, then asserts that the split changes the scores; it fails if weight reads are replaced by uniform weights. The CSR parity tests assert `CommandContext.CSR_ACCELERATED_VAR`, so they cannot pass by silently comparing the OLTP fallback with itself.

An existing lack of `MemoryBudget` reservations for the OLTP adjacency arrays is intentionally left for a separate, shared change; it also affects sibling algorithms and is not introduced by this fix. Validation of unrecognized direction strings is likewise unchanged because that behavior is shared across the procedure package.

Focused validation on current head `c22b1eeca`:

```text
./mvnw -pl engine -DskipITs -Dtest=AlgoPageRankTest,Issue6792AddedVertexIdSpaceTest,Issue6792GraphDataNodeIdBoundTest test

Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Current CI also has `unit-tests`, `opencypher-tck-tests`, `integration-tests`, `build-and-package`, lint/static analysis, and all five client/studio e2e suites green. The isolated `vector-unit-tests` failure is triaged in https://github.com/ArcadeData/arcadedb/pull/6956#issuecomment-5485494451 and has no PageRank code-path overlap.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PageRank calculations for incoming-edge traversal.
  * Ensured `OUT`, `IN`, and `BOTH` direction modes behave consistently.
  * Improved weighted PageRank accuracy when recent graph changes are pending.
  * Aligned results between analytical and transactional graph processing.

* **Documentation**
  * Clarified supported PageRank direction options and incoming-flow semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
