### PR TITLE
fix(#6947): build the database segment of the Studio ts and cluster URLs with encodeDatabaseName

### DIFF
--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -250,7 +250,7 @@ function resyncDatabase(databaseName) {
       globalNotify("Resync", "Resyncing '" + databaseName + "' from leader, this may take a while...", "info");
       jQuery.ajax({
         type: "POST",
-        url: "api/v1/cluster/resync/" + encodeURIComponent(databaseName),
+        url: "api/v1/cluster/resync/" + encodeDatabaseName(databaseName),
         beforeSend: function(xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
       })
       .done(function() {
@@ -373,7 +373,7 @@ function verifyDatabase(databaseName) {
   globalNotify("Verify", "Verifying '" + databaseName + "' across the cluster...", "info");
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/cluster/verify/" + encodeURIComponent(databaseName),
+    url: "api/v1/cluster/verify/" + encodeDatabaseName(databaseName),
     beforeSend: function(xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
   })
   .done(function(data) {

--- a/studio/src/main/resources/static/js/studio-timeseries.js
+++ b/studio/src/main/resources/static/js/studio-timeseries.js
@@ -257,7 +257,7 @@ function tsExecuteQuery() {
 
   jQuery.ajax({
     type: "POST",
-    url: "api/v1/ts/" + db + "/query",
+    url: "api/v1/ts/" + encodeDatabaseName(db) + "/query",
     data: JSON.stringify(request),
     contentType: "application/json",
     beforeSend: function (xhr) {
@@ -298,7 +298,7 @@ function tsExecutePromQLQuery() {
   var endSec   = timeRange.to   != null ? timeRange.to   / 1000 : now / 1000;
   var stepSec  = parseInt($("#tsBucketInterval").val()) / 1000;
 
-  var url = "api/v1/ts/" + db + "/prom/api/v1/query_range" +
+  var url = "api/v1/ts/" + encodeDatabaseName(db) + "/prom/api/v1/query_range" +
     "?query=" + encodeURIComponent(expr) +
     "&start=" + startSec +
     "&end="   + endSec +
@@ -524,7 +524,7 @@ function tsGetLatest() {
     return;
   }
 
-  var url = "api/v1/ts/" + db + "/latest?type=" + encodeURIComponent(typeName);
+  var url = "api/v1/ts/" + encodeDatabaseName(db) + "/latest?type=" + encodeURIComponent(typeName);
 
   // Add first non-empty tag filter as query param (API supports single tag via query string)
   $(".ts-tag-input").each(function () {

--- a/studio/test/database-name-url-encoding.test.js
+++ b/studio/test/database-name-url-encoding.test.js
@@ -84,6 +84,23 @@ test("a missing name yields an empty segment rather than the string 'null'", () 
   assert.equal(encodeDatabaseName(undefined), "");
 });
 
+// Every endpoint registered in HttpServer.setupRoutes() whose path template carries a `{database}`
+// segment, plus the two the Raft plugin adds under `cluster/`. The alternation is the whole point of
+// this file's invariant: #6830 fixed the `command`/`query` sites and #6947 found that `ts` - a segment
+// nobody had listed here - was still concatenating the name raw in studio-timeseries.js. Add an entry
+// here whenever a route gains a `{database}` segment, or the next class of call sites is invisible too.
+const DATABASE_SEGMENT_ENDPOINTS = ["batch", "begin", "command", "commit", "exists", "progress", "query", "rollback", "ts"];
+const DATABASE_SEGMENT_RE = new RegExp(
+  "api/v1/(?:(?:" + DATABASE_SEGMENT_ENDPOINTS.join("|") + ")|cluster/(?:resync|verify))/"
+);
+
+// A line that only talks about an endpoint - a comment naming `POST /api/v1/cluster/verify/{db}` - builds
+// no URL, so it cannot carry the defect and must not be reported as one.
+function isComment(line) {
+  const t = line.trim();
+  return t.startsWith("//") || t.startsWith("*") || t.startsWith("/*");
+}
+
 test("every api/v1 URL in the Studio builds its database segment with encodeDatabaseName", () => {
   // Match the endpoint prefix in ANY form - string concatenation, a template literal, a parenthesized
   // expression - and require the helper on the same line, rather than matching only the `"..." + identifier`
@@ -92,11 +109,23 @@ test("every api/v1 URL in the Studio builds its database segment with encodeData
   for (const file of fs.readdirSync(JS_DIR).filter((f) => f.endsWith(".js"))) {
     const src = fs.readFileSync(path.join(JS_DIR, file), "utf8");
     src.split("\n").forEach((line, i) => {
-      if (/api\/v1\/(?:command|query|progress)\//.test(line) && !line.includes("encodeDatabaseName"))
+      if (DATABASE_SEGMENT_RE.test(line) && !isComment(line) && !line.includes("encodeDatabaseName"))
         offenders.push(file + ":" + (i + 1) + " -> " + line.trim());
     });
   }
   assert.deepEqual(offenders, [], "these call sites build the URL path segment without encodeDatabaseName");
+});
+
+test("the time series URLs keep a metacharacter-carrying name inside one path segment", () => {
+  // #6947: `"api/v1/ts/" + db + "/query"` sent `api/v1/ts/a#b/query` for a database named `a#b`, which the
+  // browser truncates at the fragment, and `a/b` invented a path segment the route cannot match. The server
+  // reads `{database}` as a single decoded segment, so the name has to be percent-encoded going in.
+  assert.equal("api/v1/ts/" + encodeDatabaseName("a#b") + "/query", "api/v1/ts/a%23b/query");
+  assert.equal("api/v1/ts/" + encodeDatabaseName("a b") + "/latest", "api/v1/ts/a%20b/latest");
+  assert.equal("api/v1/ts/" + encodeDatabaseName("a/b") + "/prom/api/v1/query_range", "api/v1/ts/a%2Fb/prom/api/v1/query_range");
+
+  // The raw concatenation the fix replaced produced a different resource for each of those names.
+  assert.notEqual("api/v1/ts/" + "a#b" + "/query", "api/v1/ts/" + encodeDatabaseName("a#b") + "/query");
 });
 
 test("no admin command is sent as a hand-built JSON string", () => {

--- a/studio/test/database-name-url-encoding.test.js
+++ b/studio/test/database-name-url-encoding.test.js
@@ -84,15 +84,19 @@ test("a missing name yields an empty segment rather than the string 'null'", () 
   assert.equal(encodeDatabaseName(undefined), "");
 });
 
-// Every endpoint registered in HttpServer.setupRoutes() whose path template carries a `{database}`
-// segment, plus the two the Raft plugin adds under `cluster/`. The alternation is the whole point of
-// this file's invariant: #6830 fixed the `command`/`query` sites and #6947 found that `ts` - a segment
-// nobody had listed here - was still concatenating the name raw in studio-timeseries.js. Add an entry
-// here whenever a route gains a `{database}` segment, or the next class of call sites is invisible too.
-const DATABASE_SEGMENT_ENDPOINTS = ["batch", "begin", "command", "commit", "exists", "progress", "query", "rollback", "ts"];
-const DATABASE_SEGMENT_RE = new RegExp(
-  "api/v1/(?:(?:" + DATABASE_SEGMENT_ENDPOINTS.join("|") + ")|cluster/(?:resync|verify))/"
-);
+// Every endpoint whose path template carries a `{database}` segment: the ones HttpServer.setupRoutes()
+// registers, then the three RaftHAPlugin.registerAPI() adds. The alternation is the whole point of this
+// file's invariant: #6830 fixed the `command`/`query` sites and #6947 found that `ts` - a prefix nobody
+// had listed here - was still concatenating the name raw in studio-timeseries.js, invisible to the test
+// that was supposed to prevent exactly that. So the list is kept exhaustive rather than trimmed to what
+// the Studio calls today: `ha/snapshot` has no Studio call site yet, and listing it is what stops the
+// first one from repeating #6947. Add an entry whenever a route gains a `{database}` segment.
+const DATABASE_SEGMENT_ENDPOINTS = [
+  "batch", "begin", "command", "commit", "exists", "progress", "query", "rollback", "ts", // HttpServer
+  "cluster/resync", "cluster/verify", "ha/snapshot",                                      // RaftHAPlugin
+];
+// The trailing slash is required: it is what keeps a hypothetical `api/v1/tsdb/` from matching `ts`.
+const DATABASE_SEGMENT_RE = new RegExp("api/v1/(?:" + DATABASE_SEGMENT_ENDPOINTS.join("|") + ")/");
 
 // A line that only talks about an endpoint - a comment naming `POST /api/v1/cluster/verify/{db}` - builds
 // no URL, so it cannot carry the defect and must not be reported as one.


### PR DESCRIPTION
Closes #6947

## Summary

The #6830 fix introduced `encodeDatabaseName()` and converted all 50 `api/v1/command/` and `api/v1/query/` call sites in the Studio, including six in `studio-timeseries.js` itself, but left the three `api/v1/ts/` sites in that same file concatenating `getCurrentDatabase()` raw into a URL **path segment**. `api/v1/ts/{database}/...` takes the name as a path segment (`HttpServer.setupRoutes()`), so a name carrying `#`, `?`, `&` or a space addressed a different resource, or no resource at all: with a database named `a#b` the Time Series panel's query went to `api/v1/ts/a#b/query`, which the browser truncates at the fragment, while the same panel's schema load (`api/v1/command/a%23b`) worked. The invariant test added alongside #6830 could not see any of it, because its regex alternation was `command|query|progress` and `ts` was not in it.

This fixes the three sites and widens the invariant so the *class* of defect stays fixed rather than just these instances. The endpoint alternation is now a named list of every route in `HttpServer.setupRoutes()` whose path template carries a `{database}` segment - `batch`, `begin`, `command`, `commit`, `exists`, `progress`, `query`, `rollback`, `ts` - plus `cluster/resync` and `cluster/verify` from the Raft plugin. `cluster/resync`/`cluster/verify` were already calling `encodeURIComponent` directly, which is equivalent, but routing them through the one helper is what lets the invariant cover them uniformly instead of carving out exceptions. The invariant also now skips comment lines, since `studio-cluster.js:371` documents `POST /api/v1/cluster/verify/{db}` in prose and builds no URL; that guard is load-bearing - exactly one line needs it.

Verified the defect was still present at `55e00aaa6` before the fix: the widened test failed listing exactly the five offending lines the issue names, and passes after.

## Changes

| File | Change |
|---|---|
| `studio/src/main/resources/static/js/studio-timeseries.js` | `:260` (`/query`), `:301` (`/prom/api/v1/query_range`), `:527` (`/latest`) now build the segment with `encodeDatabaseName(db)` |
| `studio/src/main/resources/static/js/studio-cluster.js` | `:253` (`cluster/resync`), `:376` (`cluster/verify`) routed through `encodeDatabaseName` instead of a bare `encodeURIComponent` |
| `studio/test/database-name-url-encoding.test.js` | invariant regex built from the full `{database}`-segment endpoint list; comment lines excluded; new test pinning the three time series URL shapes |

`studio-utils.js` (which defines the helper) is loaded at `index.html:149`, before `studio-cluster.js` (`:154`) and `studio-timeseries.js` (`:160`), and those two files are loaded from no other page - so the helper is always in scope at the new call sites.

## Notes on scope

- The server rejects `/`, `\`, NUL and `..` in a database name, so `a/b` is not creatable through normal means. The live cases are `#`, `?`, `&` and a space. The `a/b` assertion stays in the test because it is the clearest statement of what "one path segment" means.
- `api.html`'s "try it" explorer substitutes `{database}` through `encodeURIComponent` already (`api.html:735`); nothing to change there. The other `api/v1/ts/` occurrences under `static/` are documentation text with `{db}` placeholders.
- Only `encodeDatabaseName` call sites changed; for an ordinary name every URL is byte-identical to before.

## Test plan

- [ ] `cd studio && npm test` - 58 tests pass (this is the exact command `frontend-maven-plugin` runs in the `test` phase of the `studio` module)
- [ ] `cd studio && node --test test/database-name-url-encoding.test.js` - 8 tests pass, including the widened invariant and the new time series URL test
- [ ] Revert any one of the five source lines to the raw form and re-run: the invariant fails naming that exact `file:line`
- [ ] Manual: create a database named `a#b`, open the Studio Time Series panel, run a query and "Get latest" - both now request `api/v1/ts/a%23b/...` and return data instead of 404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of database names containing special URL characters in cluster synchronization, consistency checks, and time-series requests.
  * Improved API URL handling so database names remain intact as a single path segment.

* **Tests**
  * Expanded regression coverage across database-related API endpoints, including time-series and Raft requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->