### PR TITLE
fix(#6948): re-schedule TimeSeries maintenance after an HA sealed-store repair

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceScheduler.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceScheduler.java
@@ -145,6 +145,20 @@ public class TimeSeriesMaintenanceScheduler {
   }
 
   /**
+   * Whether a maintenance task is currently registered and live for the given type name.
+   * <p>
+   * Exists because "this type is maintained" has no other observable: the recurring task logs nothing when it
+   * finds nothing to do, and its three effects - {@code compactAll()}, {@code applyRetention()} and
+   * {@code applyDownsampling()} - are invisible until enough data has accumulated for one of them to change
+   * something. A caller that has just made a type usable again (issue #6948: the HA sealed-store repair) needs to
+   * be able to assert that it also made it maintained.
+   */
+  public boolean isScheduled(final String typeName) {
+    final ScheduledFuture<?> future = tasks.get(typeName);
+    return future != null && !future.isCancelled() && !future.isDone();
+  }
+
+  /**
    * Cancels the maintenance task for a specific type.
    */
   public void cancel(final String typeName) {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceScheduler.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceScheduler.java
@@ -105,8 +105,18 @@ public class TimeSeriesMaintenanceScheduler {
     // result to followers. Followers running it independently would diverge. The individual
     // engine operations also self-gate via runWithCompactionReplication, but skipping here avoids
     // the wasted DatabaseContext init + transaction churn on every follower tick.
+    //
+    // The two flags MUST be read off getWrappedDatabaseInstance() and not off the scheduled reference
+    // (issue #6948). Every schedule() call site hands over the instance LocalSchema was built with, and
+    // LocalSchema's `database` field is final and captured inside LocalDatabase.openInternal() - before the
+    // server has wrapped the database for HA, and never updated afterwards. So the scheduled reference is the
+    // raw LocalDatabase, whose isReplicated() is the DatabaseInternal default `false`, and this skip could
+    // never fire for anyone. getWrappedDatabaseInstance() resolves the CURRENT wrapper on every tick, which is
+    // the same idiom the operations below already use to reach runWithCompactionReplication - which is why the
+    // consequence was wasted work on every follower tick rather than divergence.
     final DatabaseInternal dbInternal = (DatabaseInternal) db;
-    if (dbInternal.isReplicated() && !dbInternal.isLeader())
+    final DatabaseInternal replicationView = dbInternal.getWrappedDatabaseInstance();
+    if (replicationView != null && replicationView.isReplicated() && !replicationView.isLeader())
       return;
 
     // The maintenance thread is created by a ScheduledExecutorService and does not

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6948FollowerSkipResolvesWrapperTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6948FollowerSkipResolvesWrapperTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6948: {@code runMaintenance}'s leader-only skip has to read {@code isReplicated()}/{@code isLeader()} off
+ * the CURRENT wrapper, not off the reference the task was scheduled with.
+ * <p>
+ * Every {@code schedule()} call site hands over the instance {@code LocalSchema} was built with, and that field is
+ * {@code final}, captured inside {@code LocalDatabase.openInternal()} - which runs before the server wraps the
+ * database for HA, and is never updated afterwards. So the scheduled reference is the raw {@code LocalDatabase},
+ * whose {@code isReplicated()} is the {@code DatabaseInternal} default {@code false}, and the skip could not fire
+ * for anybody. The cost was wasted work rather than divergence, because the three operations underneath already
+ * resolve the wrapper per call to reach {@code runWithCompactionReplication} - but the skip exists precisely to
+ * avoid that wasted work, and it was doing nothing.
+ * <p>
+ * The wrapper here is installed exactly the way the HA server installs {@code RaftReplicatedDatabase}: through
+ * {@code LocalDatabase.setWrappedDatabaseInstance()}, with the wrapper answering itself for
+ * {@code getWrappedDatabaseInstance()} and delegating everything else to the real database. The two flags are the
+ * only behaviour it invents, because they are the only ones the engine module cannot get from a real Raft node.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6948FollowerSkipResolvesWrapperTest extends TestHelper {
+
+  private static final String TYPE_NAME = "Reading";
+
+  /**
+   * Runs BEFORE {@code TestHelper.afterTest()} (JUnit runs a subclass's {@code @AfterEach} first), which matters:
+   * the harness's closing integrity check reports a warning for a database that says it is replicated, and this
+   * test's whole point is a database that says exactly that.
+   */
+  @AfterEach
+  void removeWrapper() {
+    if (database != null && database.isOpen())
+      ((LocalDatabase) database).setWrappedDatabaseInstance((LocalDatabase) database);
+  }
+
+  /**
+   * A follower does no maintenance at all. Observed through compaction: the mutable rows are still in the mutable
+   * bucket afterwards, because nothing sealed them.
+   */
+  @Test
+  void aFollowerSkipsMaintenanceEvenThoughItWasScheduledWithTheRawInstance() throws Exception {
+    final LocalTimeSeriesType tsType = createTypeWithMutableRows();
+    installWrapper(true, false);
+
+    TimeSeriesMaintenanceScheduler.runMaintenance(database, tsType, TYPE_NAME);
+
+    assertThat(tsType.getEngine().getShard(0).getSealedStore().getBlockCount())
+        .as("a follower must not compact: the leader ships the sealed store").isZero();
+  }
+
+  /**
+   * The arm that proves the one above is not passing because maintenance is broken outright: the same call on a
+   * leader does compact. Also covers the standalone case indirectly - {@code isReplicated() == false} takes the
+   * same branch as a leader.
+   */
+  @Test
+  void aLeaderStillRunsMaintenance() throws Exception {
+    final LocalTimeSeriesType tsType = createTypeWithMutableRows();
+    installWrapper(true, true);
+
+    TimeSeriesMaintenanceScheduler.runMaintenance(database, tsType, TYPE_NAME);
+
+    assertThat(tsType.getEngine().getShard(0).getSealedStore().getBlockCount())
+        .as("a leader compacts, and ships the result").isGreaterThan(0);
+  }
+
+  /** A standalone database has no wrapper at all and must keep maintaining itself. */
+  @Test
+  void aStandaloneDatabaseStillRunsMaintenance() throws Exception {
+    final LocalTimeSeriesType tsType = createTypeWithMutableRows();
+
+    TimeSeriesMaintenanceScheduler.runMaintenance(database, tsType, TYPE_NAME);
+
+    assertThat(tsType.getEngine().getShard(0).getSealedStore().getBlockCount()).isGreaterThan(0);
+  }
+
+  // ---- Helpers ----
+
+  private LocalTimeSeriesType createTypeWithMutableRows() throws IOException {
+    database.command("sql", "CREATE TIMESERIES TYPE " + TYPE_NAME
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+    final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+
+    final int rows = 3_000;
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + i * 1_000L;
+      columns[0][i] = "host_" + (i % 7);
+      columns[1][i] = (double) i;
+    }
+    tsType.getEngine().appendBatch(timestamps, columns);
+
+    assertThat(tsType.getEngine().getShard(0).getSealedStore().getBlockCount())
+        .as("nothing is sealed yet, so the assertions below measure this call alone").isZero();
+    return tsType;
+  }
+
+  /**
+   * Installs a wrapper the way the HA server does, so "raw instance" and "wrapped instance" are two different
+   * objects with two different answers to the replication flags.
+   */
+  private void installWrapper(final boolean replicated, final boolean leader) {
+    final LocalDatabase real = (LocalDatabase) database;
+    final DatabaseInternal wrapper = (DatabaseInternal) Proxy.newProxyInstance(
+        DatabaseInternal.class.getClassLoader(), new Class<?>[] { DatabaseInternal.class },
+        (proxy, method, args) -> {
+          switch (method.getName()) {
+          // Mirrors RaftReplicatedDatabase: the wrapper is its own wrapped instance.
+          case "getWrappedDatabaseInstance":
+            if (method.getParameterCount() == 0)
+              return proxy;
+            break;
+          case "isReplicated":
+            return replicated;
+          case "isLeader":
+            return leader;
+          default:
+            break;
+          }
+          try {
+            return method.invoke(real, args);
+          } catch (final InvocationTargetException e) {
+            throw e.getCause();
+          }
+        });
+    real.setWrappedDatabaseInstance(wrapper);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceSchedulerIsScheduledTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceSchedulerIsScheduledTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6948, engine half: {@code isScheduled()} is the observable the HA repair path's regression test asserts
+ * on, so it has to be able to tell the two states apart on its own. Whether a type is maintained has no other
+ * outward sign - the recurring task logs nothing when it finds nothing to do, and its three effects only become
+ * visible once enough data has piled up for one of them to change something - so an accessor that answered
+ * {@code true} (or {@code false}) unconditionally would leave that test passing for no reason.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class TimeSeriesMaintenanceSchedulerIsScheduledTest extends TestHelper {
+
+  @Test
+  void isScheduledDistinguishesScheduledFromUnscheduledAndCancelled() {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE Probe TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS 1");
+    final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType("Probe");
+
+    final TimeSeriesMaintenanceScheduler scheduler = new TimeSeriesMaintenanceScheduler();
+    try {
+      assertThat(scheduler.isScheduled("Probe")).as("a fresh scheduler maintains nothing").isFalse();
+      assertThat(scheduler.isScheduled("NeverSeen")).isFalse();
+
+      scheduler.schedule(database, tsType);
+      assertThat(scheduler.isScheduled("Probe")).as("schedule() must be observable").isTrue();
+
+      // Idempotent: schedule() cancels and replaces the task for the same name, and the type stays maintained.
+      scheduler.schedule(database, tsType);
+      assertThat(scheduler.isScheduled("Probe")).as("a repeated schedule() leaves the type maintained").isTrue();
+
+      scheduler.cancel("Probe");
+      assertThat(scheduler.isScheduled("Probe")).as("a cancelled task is no longer maintenance").isFalse();
+    } finally {
+      scheduler.shutdown();
+    }
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2405,6 +2405,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * <p>
    * Shared with the sliced path (issue #4416), which reassembles the leader's copy on disk rather than in heap and
    * so arrives here with a path instead of an array. {@code source} is CONSUMED on success.
+   * <p>
+   * A repaired type is also re-scheduled for maintenance (issue #6948). The only other place that schedules an
+   * existing type is {@code LocalSchema.readConfiguration()}, and it skips precisely the types this method
+   * repairs: at schema load their engine was unavailable, so the gate there never fired for them. Without this
+   * call the type comes back readable and writable yet permanently unmaintained for the life of the process -
+   * {@code compactAll()}, {@code applyRetention()} and {@code applyDownsampling()} have no other caller, so the
+   * mutable bucket grows unbounded and configured retention and downsampling silently stop being applied. The
+   * leader-only skip that makes this harmless on a follower lives INSIDE the recurring task, not in
+   * {@code schedule()}, so a healthy follower keeps a ticking task ready for the moment it is elected; a repaired
+   * one would have none. {@code schedule()} replaces any existing task for the type name, so a repeated repair is
+   * safe.
    */
   private boolean repairEngineWithSealedFile(final DatabaseInternal db, final LocalTimeSeriesType tsType,
       final int shardIndex, final File source) {
@@ -2427,7 +2438,29 @@ public class ArcadeStateMachine extends BaseStateMachine {
               + "for shard %d; skipping", null, tsType.getName(), decodedDbName(db), shardIndex);
       return false;
     }
+
+    scheduleMaintenanceAfterRepair(db, tsType);
     return true;
+  }
+
+  /**
+   * Re-arms automatic compaction, retention and downsampling for a type that has just been repaired (issue #6948).
+   * <p>
+   * Kept off the success path's error handling on purpose: the repair itself has already succeeded and the type is
+   * usable again, so a scheduler that refuses the task - the executor rejecting it mid-shutdown - must be logged
+   * and swallowed rather than turned into "the repair failed". That is the same split
+   * {@code LocalSchema.readConfiguration()} makes at its own {@code schedule()} call site.
+   */
+  private void scheduleMaintenanceAfterRepair(final DatabaseInternal db, final LocalTimeSeriesType tsType) {
+    try {
+      final LocalSchema schema = db.getSchema().getEmbedded();
+      schema.getTimeSeriesMaintenanceScheduler().schedule(schema.getDatabase(), tsType);
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Repaired TimeSeries type '%s' (db=%s) but could not re-schedule its automatic maintenance; compaction, "
+              + "retention and downsampling stay off for it until the database is reopened: %s", e, tsType.getName(),
+          decodedDbName(db), e.getMessage());
+    }
   }
 
   private static String decodedDbName(final DatabaseInternal db) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2447,9 +2447,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * Re-arms automatic compaction, retention and downsampling for a type that has just been repaired (issue #6948).
    * <p>
    * Kept off the success path's error handling on purpose: the repair itself has already succeeded and the type is
-   * usable again, so a scheduler that refuses the task - the executor rejecting it mid-shutdown - must be logged
-   * and swallowed rather than turned into "the repair failed". That is the same split
-   * {@code LocalSchema.readConfiguration()} makes at its own {@code schedule()} call site.
+   * usable again, so failing to ALSO schedule it must be logged and swallowed rather than turned into "the repair
+   * failed" - the data is in place either way, and the state a thrown exception would leave is strictly worse than
+   * the one it would be reporting.
+   * <p>
+   * The catch is deliberately wider than the {@code RejectedExecutionException} that
+   * {@code LocalSchema.readConfiguration()} catches at its own {@code schedule()} call site, and the difference is
+   * the caller, not the callee. That one runs during a database open, where an escaping runtime exception fails the
+   * open and says so. This one runs inside the Raft apply path, whose whole contract here is that one type must not
+   * abort the apply of an entry that may carry blobs for others - the same reason
+   * {@link #repairEngineWithSealedBlob} reports failure rather than throwing. So nothing may escape, including a
+   * programming error. It is logged WITH its stack trace and names the consequence precisely, so it does not
+   * disappear: it reads as the bug it is rather than as a benign mid-shutdown rejection.
    */
   private void scheduleMaintenanceAfterRepair(final DatabaseInternal db, final LocalTimeSeriesType tsType) {
     try {
@@ -2458,8 +2467,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING,
           "Repaired TimeSeries type '%s' (db=%s) but could not re-schedule its automatic maintenance; compaction, "
-              + "retention and downsampling stay off for it until the database is reopened: %s", e, tsType.getName(),
-          decodedDbName(db), e.getMessage());
+              + "retention and downsampling stay off for it until the database is reopened: %s: %s", e,
+          tsType.getName(), decodedDbName(db), e.getClass().getSimpleName(), e.getMessage());
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2446,6 +2446,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
   /**
    * Re-arms automatic compaction, retention and downsampling for a type that has just been repaired (issue #6948).
    * <p>
+   * Scheduled with {@code schema.getDatabase()} rather than the {@code db} parameter, so this task holds the same
+   * instance the two pre-existing {@code schedule()} call sites hold: the one {@code LocalSchema} was built with,
+   * which lives exactly as long as the schema does. {@code db} here is the server's wrapper, and wrappers are
+   * replaceable - a task holding a superseded one through the scheduler's {@code WeakReference} would cancel
+   * itself the moment that wrapper became garbage, which is this very bug again by another route. The replication
+   * flags the recurring task needs are NOT taken from this reference: {@code runMaintenance} resolves
+   * {@code getWrappedDatabaseInstance()} on every tick, for the same reason the compaction path underneath it
+   * does.
+   * <p>
    * Kept off the success path's error handling on purpose: the repair itself has already succeeded and the type is
    * usable again, so failing to ALSO schedule it must be logged and swallowed rather than turned into "the repair
    * failed" - the data is in place either way, and the state a thrown exception would leave is strictly worse than

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2457,15 +2457,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * open and says so. This one runs inside the Raft apply path, whose whole contract here is that one type must not
    * abort the apply of an entry that may carry blobs for others - the same reason
    * {@link #repairEngineWithSealedBlob} reports failure rather than throwing. So nothing may escape, including a
-   * programming error. It is logged WITH its stack trace and names the consequence precisely, so it does not
-   * disappear: it reads as the bug it is rather than as a benign mid-shutdown rejection.
+   * programming error. It is logged at SEVERE, WITH its stack trace and its exception class, and names the
+   * consequence precisely, so it does not disappear: swallowing it here must not also hide it, and what it leaves
+   * behind - a type maintained by nothing - is the very defect this method exists to prevent.
    */
   private void scheduleMaintenanceAfterRepair(final DatabaseInternal db, final LocalTimeSeriesType tsType) {
     try {
       final LocalSchema schema = db.getSchema().getEmbedded();
       schema.getTimeSeriesMaintenanceScheduler().schedule(schema.getDatabase(), tsType);
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING,
+      LogManager.instance().log(this, Level.SEVERE,
           "Repaired TimeSeries type '%s' (db=%s) but could not re-schedule its automatic maintenance; compaction, "
               + "retention and downsampling stay off for it until the database is reopened: %s: %s", e,
           tsType.getName(), decodedDbName(db), e.getClass().getSimpleName(), e.getMessage());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2456,10 +2456,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * the caller, not the callee. That one runs during a database open, where an escaping runtime exception fails the
    * open and says so. This one runs inside the Raft apply path, whose whole contract here is that one type must not
    * abort the apply of an entry that may carry blobs for others - the same reason
-   * {@link #repairEngineWithSealedBlob} reports failure rather than throwing. So nothing may escape, including a
-   * programming error. It is logged at SEVERE, WITH its stack trace and its exception class, and names the
-   * consequence precisely, so it does not disappear: swallowing it here must not also hide it, and what it leaves
-   * behind - a type maintained by nothing - is the very defect this method exists to prevent.
+   * {@link #repairEngineWithSealedBlob} reports failure rather than throwing. So no <em>exception</em> may escape,
+   * a programming error included.
+   * <p>
+   * {@code Exception} and not {@code Throwable}, deliberately: an {@code Error} says the JVM itself is no longer in
+   * a state this node can reason about, and the apply path's "do not let one type abort the entry" contract is not
+   * a licence to keep applying Raft entries through one. Errors still propagate.
+   * <p>
+   * What IS swallowed is logged at SEVERE, with its stack trace and its exception class, and names the consequence
+   * precisely, so it does not disappear: swallowing it here must not also hide it, and what it leaves behind - a
+   * type maintained by nothing - is the very defect this method exists to prevent. That is louder than the sibling
+   * catch in {@code LocalSchema.readConfiguration()} on purpose, and for the same reason the catch is wider: there
+   * the alternative was the open failing loudly on its own, here nothing else will ever say a word.
    */
   private void scheduleMaintenanceAfterRepair(final DatabaseInternal db, final LocalTimeSeriesType tsType) {
     try {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6948MaintenanceAfterRepairTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6948MaintenanceAfterRepairTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.engine.timeseries.TimeSeriesMaintenanceScheduler;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedBlob;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6948, the remainder of #6839: a TimeSeries type that recovers through the HA sealed-store repair came back
+ * readable and writable yet permanently UNMAINTAINED.
+ * <p>
+ * {@code schedule()} has exactly two call sites in main code - type creation, and
+ * {@code LocalSchema.readConfiguration()} behind an {@code isEngineAvailable()} gate. The gate is skipped for
+ * precisely the types this path repairs, because at schema load their engine is the thing that failed. So the
+ * repair handed back a usable type with no maintenance task, and nothing downstream ever created one:
+ * {@code compactAll()}, {@code applyRetention()} and {@code applyDownsampling()} have no caller outside the
+ * recurring task, which means the mutable bucket grew unbounded ("Compaction is always scheduled to prevent
+ * unbounded mutable-bucket growth", says the scheduler's own javadoc) and configured retention and downsampling
+ * silently stopped being applied for that type on that node until the database was closed and reopened.
+ * <p>
+ * "It is a follower, it would skip the work anyway" does not cover it: the leader-only skip lives INSIDE the
+ * recurring task, not in {@code schedule()}. A healthy follower keeps a ticking task that takes over the instant it
+ * is elected; a repaired one had none, and never would. {@link #aHealthyTypeIsMaintainedAfterAPlainReopen()} is the
+ * control that pins that asymmetry - it is what the repaired type has to be restored to parity with.
+ * <p>
+ * Same harness as {@code Issue6839TsSealedBlobRecoveryTest}: a real {@link LocalDatabase} and a real (unstarted)
+ * {@link ArcadeStateMachine}, no mocking. The cluster adds nothing here - the defect is entirely in the apply path.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6948MaintenanceAfterRepairTest {
+
+  private static final String TYPE_NAME   = "Cpu";
+  private static final String SEALED_FILE = sealedFileName(0);
+  private static final int    ROWS        = 3_000;
+
+  @TempDir
+  private Path          serverDir;
+  private LocalDatabase database;
+  private String        databasePath;
+
+  @BeforeEach
+  void setUp() {
+    databasePath = serverDir.resolve("db-ts").toString();
+    database = (LocalDatabase) new DatabaseFactory(databasePath).create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.close();
+  }
+
+  /**
+   * The regression itself. Before the fix every assertion up to the repair passed and the last one failed: the
+   * type was available again and maintained by nothing.
+   */
+  @Test
+  void aRepairedTypeIsScheduledForMaintenanceAgain() throws Exception {
+    final byte[] leaderSealedBytes = buildTypeAndCaptureItsSealedFile();
+
+    breakTheSealedFileAndReopen();
+
+    final LocalTimeSeriesType broken = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(broken.isEngineAvailable()).as("the #6356 state this test starts from").isFalse();
+    assertThat(scheduler().isScheduled(TYPE_NAME))
+        .as("the schema-load gate skips an engine-unavailable type, so nothing is maintaining it yet").isFalse();
+
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
+
+    assertThat(broken.isEngineAvailable()).as("the #6839 repair still works").isTrue();
+    assertThat(scheduler().isScheduled(TYPE_NAME))
+        .as("a repaired type must be maintained again: compaction, retention and downsampling have no other caller")
+        .isTrue();
+  }
+
+  /**
+   * The parity the arm above is measured against, and the reason "it is only a follower" is not an answer: a type
+   * whose files are intact is maintained from the moment the schema loads, whether or not this node leads. The
+   * leader-only decision is taken per tick, inside the task.
+   */
+  @Test
+  void aHealthyTypeIsMaintainedAfterAPlainReopen() throws Exception {
+    buildTypeAndCaptureItsSealedFile();
+
+    database.close();
+    database = (LocalDatabase) new DatabaseFactory(databasePath).open();
+
+    final LocalTimeSeriesType healthy = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(healthy.isEngineAvailable()).isTrue();
+    assertThat(scheduler().isScheduled(TYPE_NAME)).isTrue();
+  }
+
+  /**
+   * A repair that did not repair anything must not claim the type is maintained. The blob here is bytes the sealed
+   * store cannot open, so {@code initEngine()} fails again and the method returns before the new scheduling call -
+   * which matters, because a task for a type whose engine is null would tick forever doing nothing while reporting
+   * that the type is looked after.
+   */
+  @Test
+  void aFailedRepairSchedulesNothing() throws Exception {
+    buildTypeAndCaptureItsSealedFile();
+
+    breakTheSealedFileAndReopen();
+
+    final LocalTimeSeriesType broken = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(broken.isEngineAvailable()).isFalse();
+
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, new byte[512])));
+
+    assertThat(broken.isEngineAvailable()).isFalse();
+    assertThat(scheduler().isScheduled(TYPE_NAME))
+        .as("nothing was repaired, so nothing may be scheduled").isFalse();
+  }
+
+  /**
+   * A Raft entry can be applied more than once across a restart, and a type can be repaired again after a second
+   * corruption. {@code schedule()} cancels and replaces the task for the type name, so the type ends up maintained
+   * by exactly one task either way - the repair path must not need to know whether it is the first.
+   */
+  @Test
+  void aRepeatedRepairLeavesTheTypeMaintained() throws Exception {
+    final byte[] leaderSealedBytes = buildTypeAndCaptureItsSealedFile();
+
+    breakTheSealedFileAndReopen();
+
+    final ArcadeStateMachine stateMachine = new ArcadeStateMachine();
+    stateMachine.applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
+    stateMachine.applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
+
+    final LocalTimeSeriesType repaired = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(repaired.isEngineAvailable()).isTrue();
+    assertThat(scheduler().isScheduled(TYPE_NAME)).isTrue();
+  }
+
+  // ---- Helpers ----
+
+  private TimeSeriesMaintenanceScheduler scheduler() {
+    return database.getSchema().getEmbedded().getTimeSeriesMaintenanceScheduler();
+  }
+
+  private byte[] buildTypeAndCaptureItsSealedFile() throws IOException {
+    database.command("sql", "CREATE TIMESERIES TYPE " + TYPE_NAME
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME)).getEngine();
+    appendRows(engine, 0, ROWS);
+    engine.compactAll();
+
+    final File sealed = new File(databasePath, SEALED_FILE);
+    assertThat(sealed).exists();
+    return Files.readAllBytes(sealed.toPath());
+  }
+
+  private static String sealedFileName(final int shardIndex) {
+    return TYPE_NAME + "_shard_" + shardIndex + ".ts.sealed";
+  }
+
+  /**
+   * Flips byte 0 of the sealed file - part of its MAGIC_VALUE, so the store can never open - and reopens the
+   * database, which is the state {@code LocalSchema.readConfiguration()} registers rather than dropping (#6356).
+   */
+  private void breakTheSealedFileAndReopen() throws IOException {
+    database.close();
+    final File sealed = new File(databasePath, SEALED_FILE);
+    try (final RandomAccessFile raf = new RandomAccessFile(sealed, "rw")) {
+      raf.seek(0);
+      final int b = raf.read();
+      raf.seek(0);
+      raf.write(b ^ 0x01);
+    }
+    database = (LocalDatabase) new DatabaseFactory(databasePath).open();
+  }
+
+  private void appendRows(final TimeSeriesEngine engine, final int from, final int rows) throws IOException {
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + (from + i) * 1_000L;
+      columns[0][i] = "host_" + ((from + i) % 7);
+      columns[1][i] = (double) (from + i);
+    }
+    engine.appendBatch(timestamps, columns);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6948MaintenanceAfterRepairTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6948MaintenanceAfterRepairTest.java
@@ -149,12 +149,49 @@ class Issue6948MaintenanceAfterRepairTest {
   }
 
   /**
-   * A Raft entry can be applied more than once across a restart, and a type can be repaired again after a second
-   * corruption. {@code schedule()} cancels and replaces the task for the type name, so the type ends up maintained
-   * by exactly one task either way - the repair path must not need to know whether it is the first.
+   * Recovery is not one-shot: a type that is corrupted, repaired, and then corrupted AGAIN comes back maintained
+   * the second time too.
+   * <p>
+   * The second corruption and reopen are what make this a genuine second repair rather than a repeat of the first.
+   * {@code applySealedBlobs} only takes the repair branch when {@code tsType.getEngine() == null}; once the first
+   * repair has succeeded the type has an engine, and a further blob for it is simply installed through the live
+   * sealed store - see {@link #aRedundantBlobAfterARepairLeavesTheTaskInPlace()}, which pins that other branch. So
+   * driving the type back to engine-unavailable is the only way to reach {@code scheduleMaintenanceAfterRepair}
+   * twice, and the reopen is the only way to do it without reaching into the type's internals: {@code initEngine()}
+   * returns immediately once the engine is non-null.
    */
   @Test
-  void aRepeatedRepairLeavesTheTypeMaintained() throws Exception {
+  void aSecondCorruptionIsRepairedAndScheduledAgain() throws Exception {
+    final byte[] leaderSealedBytes = buildTypeAndCaptureItsSealedFile();
+
+    breakTheSealedFileAndReopen();
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
+    assertThat(scheduler().isScheduled(TYPE_NAME)).as("the first repair schedules").isTrue();
+
+    // Corrupt the file the first repair put in place, and come back up on it.
+    breakTheSealedFileAndReopen();
+    final LocalTimeSeriesType brokenAgain = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
+    assertThat(brokenAgain.isEngineAvailable()).isFalse();
+    assertThat(scheduler().isScheduled(TYPE_NAME))
+        .as("the reopened schema skips the gate again, so nothing is maintaining it").isFalse();
+
+    new ArcadeStateMachine().applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
+
+    assertThat(brokenAgain.isEngineAvailable()).isTrue();
+    assertThat(scheduler().isScheduled(TYPE_NAME)).as("and so does the second").isTrue();
+  }
+
+  /**
+   * The other branch. A blob that arrives for a type whose engine is already healthy - a Raft entry replayed after
+   * a restart, the leader re-shipping a store - never reaches {@code repairEngineWithSealedFile} at all: it is
+   * installed through the live sealed store. What this pins is that the maintenance task the earlier repair
+   * installed survives it, since a type losing its task on a routine install would be the same defect by another
+   * route.
+   */
+  @Test
+  void aRedundantBlobAfterARepairLeavesTheTaskInPlace() throws Exception {
     final byte[] leaderSealedBytes = buildTypeAndCaptureItsSealedFile();
 
     breakTheSealedFileAndReopen();
@@ -162,12 +199,16 @@ class Issue6948MaintenanceAfterRepairTest {
     final ArcadeStateMachine stateMachine = new ArcadeStateMachine();
     stateMachine.applySealedBlobs(database,
         List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
-    stateMachine.applySealedBlobs(database,
-        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
 
     final LocalTimeSeriesType repaired = (LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME);
     assertThat(repaired.isEngineAvailable()).isTrue();
     assertThat(scheduler().isScheduled(TYPE_NAME)).isTrue();
+
+    stateMachine.applySealedBlobs(database,
+        List.of(new TsSealedBlob(TYPE_NAME, 0, SEALED_FILE, leaderSealedBytes)));
+
+    assertThat(repaired.isEngineAvailable()).isTrue();
+    assertThat(scheduler().isScheduled(TYPE_NAME)).as("a routine install must not unschedule the type").isTrue();
   }
 
   // ---- Helpers ----


### PR DESCRIPTION
Closes #6948

## Summary

The #6839 fix gave the "registered but engine-unavailable" TimeSeries state a real way out, but a type that recovers through the Raft repair came back readable and writable yet **permanently unmaintained**: compaction, retention and downsampling never ran for it again for the life of the process.

`schedule()` has exactly two call sites in main code - type creation (`TimeSeriesTypeBuilder`), and `LocalSchema.readConfiguration()` behind an `isEngineAvailable()` gate. That gate is skipped for precisely the types this path repairs, because at schema load their engine is the thing that failed. `ArcadeStateMachine.repairEngineWithSealedFile()` called `initEngine()` and re-checked `isEngineAvailable()`, but scheduled nothing, and nothing downstream did either. Since `engine.compactAll()`, `engine.applyRetention()` and `engine.applyDownsampling()` have no caller outside the recurring maintenance task, the mutable bucket grew unbounded ("Compaction is always scheduled to prevent unbounded mutable-bucket growth", says the scheduler's own javadoc) and configured retention/downsampling policies silently stopped being applied for that type on that node until the database was closed and reopened.

"It is a follower, it would skip the work anyway" does not cover it: the leader-only skip lives **inside** the recurring task (`TimeSeriesMaintenanceScheduler.runMaintenance`), not in `schedule()`. A healthy follower keeps a ticking task that takes over the instant it is elected; a repaired one had none, and never would.

## Change

- `ArcadeStateMachine.repairEngineWithSealedFile()` now calls a new private `scheduleMaintenanceAfterRepair()` once the repair has actually succeeded (after the `isEngineAvailable()` re-check, so a failed repair still schedules nothing). It resolves the scheduler through `db.getSchema().getEmbedded()` and passes `LocalSchema.getDatabase()` - the same `Database` reference `LocalSchema` itself hands to `schedule()`, so the scheduler's `WeakReference` targets the object whose lifetime it is meant to track. Both repair entry points - the inline `TsSealedBlob` path and the sliced path from #4416 - funnel through this method, so both are covered.
- Scheduling failure is logged at WARNING (with stack trace and exception class) and swallowed: the repair has already succeeded and the type is usable again, so failing to *also* schedule it must not be reported as "the repair failed".
  The catch is deliberately wider than the `RejectedExecutionException` that `LocalSchema.readConfiguration()` catches at its own `schedule()` call site, and the difference is the caller rather than the callee: that one runs during a database open, where an escaping runtime exception fails the open and says so; this one runs inside the Raft apply path, whose contract here is that one type must not abort the apply of an entry that may carry blobs for others - the same reason `repairEngineWithSealedBlob` reports failure rather than throwing. So nothing may escape, a programming error included, and the log line names the exception class and the exact consequence so it reads as the bug it is rather than as a benign mid-shutdown rejection. Spelled out in the method javadoc.
- `schedule()` is idempotent (it cancels and replaces any existing task for the type name), so a repeated repair is safe and needs no first-time bookkeeping.
- New `TimeSeriesMaintenanceScheduler.isScheduled(String)` accessor. "This type is maintained" had no outward sign at all - the recurring task logs nothing when it finds nothing to do, and its three effects are invisible until enough data has accumulated for one of them to change something - so without it the regression test would have had nothing to assert on.

The `:1911` gate in `LocalSchema` is deliberately left alone. `runMaintenance` already returns early on `engine == null`, so it is belt-and-braces rather than load-bearing, and removing it is not what this bug is about.

## Test plan

- [x] `ha-raft`: new `Issue6948MaintenanceAfterRepairTest` (5 cases), same harness as `Issue6839TsSealedBlobRecoveryTest` - a real `LocalDatabase` plus a real unstarted `ArcadeStateMachine`, no mocking, no cluster (the defect is entirely inside the apply path):
  - `aRepairedTypeIsScheduledForMaintenanceAgain` - the regression: break the sealed file, reopen, assert engine-unavailable **and** not scheduled, apply the leader's blob, assert available **and** scheduled.
  - `aHealthyTypeIsMaintainedAfterAPlainReopen` - the control that pins the asymmetry a repaired type has to be restored to parity with, and the concrete reason the follower-only argument does not hold.
  - `aFailedRepairSchedulesNothing` - a garbage blob leaves the type unavailable and unscheduled; a task for an engine-less type would tick forever reporting that the type is looked after.
  - `aSecondCorruptionIsRepairedAndScheduledAgain` - recovery is not one-shot: corrupt, repair, corrupt again, repair again, scheduled both times. The second corruption + reopen is what makes it a *genuine* second repair; `applySealedBlobs` only takes the repair branch when `getEngine() == null`.
  - `aRedundantBlobAfterARepairLeavesTheTaskInPlace` - the other branch: a blob for a type whose engine is already healthy is installed through the live sealed store and never reaches the repair path; what it pins is that the task the earlier repair installed survives a routine install.
- [x] Negative control: with the `scheduleMaintenanceAfterRepair()` call commented out, `aRepairedTypeIsScheduledForMaintenanceAgain`, `aSecondCorruptionIsRepairedAndScheduledAgain` and `aRedundantBlobAfterARepairLeavesTheTaskInPlace` all fail, while the two control arms (`aHealthyTypeIsMaintainedAfterAPlainReopen`, `aFailedRepairSchedulesNothing`) still pass. Restored, all 5 pass.
- [x] `engine`: new `TimeSeriesMaintenanceSchedulerIsScheduledTest` proves the new accessor actually discriminates (fresh / unknown name / scheduled / re-scheduled / cancelled), so the ha-raft assertions cannot pass vacuously.
- [x] `mvn -o -pl ha-raft test -Dtest='ArcadeStateMachine*Test,Issue6839TsSealedBlobRecoveryTest,Issue4416SlicedSealedApplyTest,Issue4416SlicedSealedStoreTest,Issue6948MaintenanceAfterRepairTest'` - 131 tests, 0 failures.
- [x] `mvn -o -pl engine test -Dtest='TimeSeries*Test,Issue6839InitEngineRetryableTest'` - 213 tests, 0 failures.

Not covered by an automated test: the end-to-end 3-node repro (corrupt a follower's sealed file, let the leader compact, transfer leadership to the repaired follower). A cluster IT would add flakiness without adding evidence - the scheduling decision is entirely inside the apply path, and the leader check that the transfer exercises is already unit-covered inside `runMaintenance`.

## Review round 2

- **`aRepeatedRepairLeavesTheTypeMaintained` did not exercise a second repair.** Correct, and confirmed: `applySealedBlobs` only takes the repair branch when `tsType.getEngine() == null`, so after the first successful repair the second `applySealedBlobs` fell through to `installSealedFileBytes` and never reached `scheduleMaintenanceAfterRepair` again. Split into two tests that each say what they do: `aSecondCorruptionIsRepairedAndScheduledAgain` corrupts and reopens a second time so the repair branch is genuinely re-entered, and `aRedundantBlobAfterARepairLeavesTheTaskInPlace` names the healthy-install branch it actually covers. Both fail with the fix disabled.
- **WARNING vs SEVERE.** Agreed and raised to SEVERE. The javadoc frames the catch as also covering a programming error, and what it leaves behind - a type maintained by nothing - is the exact defect this method exists to prevent, so swallowing it must not also hide it.
- **`isScheduled()`'s `!future.isDone()` is unreachable today.** Accurate: `runMaintenance` catches `Throwable`, so only cancellation makes a fixed-rate future done. Left as is - it is the correct predicate for "live task" and costs nothing, and relying on `runMaintenance`'s catch-all from another class would be the more fragile of the two.
- The `schema.getDatabase()` / wrapped-instance and catch-`Exception` points were confirmations, no change needed.

## Review round 3

All three items were non-blocking observations; one produced a change.

- **The javadoc said "nothing may escape" while the catch is `Exception`, not `Throwable`.** Real inconsistency, fixed in the doc rather than the code: catching `Exception` is intentional. An `Error` means the JVM is no longer in a state this node can reason about, and the apply path's "one type must not abort the entry" contract is not a licence to keep applying Raft entries through one. The javadoc now says so explicitly and scopes the claim to exceptions.
- **SEVERE diverges from the sibling `RejectedExecutionException` catch's severity.** Kept, now with the reason written down next to it: the sibling catch runs during a database open, which fails loudly on its own if anything worse is wrong; here nothing else will ever say a word, and what is left behind is exactly the defect this method exists to prevent.
- **`!future.isCancelled()` is redundant with `!future.isDone()`.** Left as is - it states the two conditions the predicate means independently of `ScheduledFuture`'s current relationship between them, and costs nothing.

## Review round 4 - a real finding, fixed at a different place than suggested

The reviewer was right about the fact and I was wrong to have waved it away in round 2. Verified independently:

- `LocalSchema.database` is `final`, and `LocalDatabase.openInternal()` constructs the schema at `LocalDatabase.java:2862` with `wrappedDatabaseInstance`, which at that instant is still `this` - `RaftReplicatedDatabase`'s constructor calls `setWrappedDatabaseInstance(this)` on an already-open `LocalDatabase`, long after. So `schema.getDatabase()` is the raw `LocalDatabase`, whose `isReplicated()` is the `DatabaseInternal` default `false`.
- Consequence: `runMaintenance`'s `if (dbInternal.isReplicated() && !dbInternal.isLeader()) return;` **never fired for any TimeSeries type on any node** - not just repaired ones. Both pre-existing call sites (`LocalSchema.readConfiguration()` and `TimeSeriesTypeBuilder`) pass the same field.

Where I disagree is the severity and therefore the fix. The three operations do **not** run independently on followers today: `TimeSeriesShard.compactInternal` and `TimeSeriesEngine.runSealedMaintenanceReplicated` both reach `runWithCompactionReplication` through `database.getWrappedDatabaseInstance()`, resolved **at call time**, so they already decline on a follower. `runMaintenance`'s own comment says as much - the skip is there to avoid the wasted `DatabaseContext` init and transaction churn, not to prevent divergence. So this was dead optimization, not a correctness hole.

That also rules out the suggested fix of passing `db`. `db` is the server's *wrapper*, and wrappers are replaceable; the scheduler holds a `WeakReference`, so a task pinned to a superseded wrapper would cancel itself the moment that wrapper became garbage - i.e. the very bug this PR fixes, by another route. The instance that must be held is the stable one.

**Fix**: `runMaintenance` now resolves the replication view per tick, the same idiom the operations underneath it already use:

```java
final DatabaseInternal replicationView = dbInternal.getWrappedDatabaseInstance();
if (replicationView != null && replicationView.isReplicated() && !replicationView.isLeader())
  return;
```

This makes the skip work for the new call site *and* both pre-existing ones, keeps the scheduled reference stable, and needs no follow-up issue. The choice of `schema.getDatabase()` in `scheduleMaintenanceAfterRepair` is now documented in its javadoc with this reasoning rather than left implicit.

**New test** (engine): `Issue6948FollowerSkipResolvesWrapperTest` installs a wrapper through `LocalDatabase.setWrappedDatabaseInstance()` exactly as the HA server installs `RaftReplicatedDatabase` - answering itself for `getWrappedDatabaseInstance()` and delegating everything else to the real database, inventing only the two replication flags the engine module cannot get from a real Raft node. Three arms: follower does not compact, leader does, standalone does. Negative control: with the per-tick resolution reverted to the scheduled reference, the follower arm fails and the other two pass.

- [x] `mvn -o -pl engine test -Dtest='TimeSeries*Test,Issue6839InitEngineRetryableTest,Issue6948*Test'` - 216 tests, 0 failures.
- [x] `mvn -o -pl ha-raft test -Dtest='ArcadeStateMachine*Test,Issue6839TsSealedBlobRecoveryTest,Issue4416Sliced*Test,Issue6948MaintenanceAfterRepairTest'` - 131 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a way to check whether time-series maintenance is currently scheduled for a type.

- **Bug Fixes**
  - Prevented maintenance from running on replicas when the database is not the active leader.
  - Automatically rescheduled maintenance after successful time-series repair and engine recovery.
  - Preserved correct scheduling behavior across repeated repairs, reopenings, and redundant data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->