### PR TITLE
fix(#6938): PromQL - keep the left sample for a matched `or`, apply absent-label rules to unknown columns, step-align range points

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -183,7 +183,13 @@ public class PromQLEvaluator {
       if (result instanceof InstantVector iv) {
         for (final VectorSample sample : iv.samples()) {
           final String key = labelKey(sample.labels());
-          seriesMap.computeIfAbsent(key, k -> new ArrayList<>()).add(new double[] { sample.timestampMs(), sample.value() });
+          // Stamped with the evaluation step `t`, not with the sample's own timestamp (issue #6938):
+          // Prometheus guarantees one matrix point per step at exactly start + n*step, while the sample
+          // timestamp is wherever the lookback window happened to resolve. A series sparser than the step
+          // resolved to the same sample on several consecutive steps and repeated its timestamp, so any
+          // consumer indexing the matrix by timestamp (Grafana included) saw duplicate keys and jitter
+          // instead of a regular grid. The raw timestamp still drives staleness/lookback inside evaluate().
+          seriesMap.computeIfAbsent(key, k -> new ArrayList<>()).add(new double[] { t, sample.value() });
           labelsMap.putIfAbsent(key, sample.labels());
         }
       } else if (result instanceof ScalarResult sr) {
@@ -229,6 +235,9 @@ public class PromQLEvaluator {
     final List<ColumnDefinition> columns = tsType.getTsColumns();
 
     warnIfMultipleFields(columns, vs.metricName());
+
+    if (excludesEverySeries(vs.matchers(), columns, regexDeadline()))
+      return new InstantVector(List.of());
 
     final TagFilter tagFilter = buildTagFilter(vs.matchers(), columns);
     final long offset = vs.offsetMs();
@@ -279,6 +288,9 @@ public class PromQLEvaluator {
     final List<ColumnDefinition> columns = tsType.getTsColumns();
 
     warnIfMultipleFields(columns, vs.metricName());
+
+    if (excludesEverySeries(vs.matchers(), columns, regexDeadline()))
+      return new RangeVector(List.of());
 
     final TagFilter tagFilter = buildTagFilter(vs.matchers(), columns);
     final long offset = vs.offsetMs();
@@ -532,6 +544,43 @@ public class PromQLEvaluator {
     return filter;
   }
 
+  /**
+   * Returns {@code true} when a matcher naming a column the type does not declare rules out every series of
+   * that type (issue #6938).
+   * <p>
+   * A label the schema has no column for is absent from every series, so Prometheus' absent-label rules decide
+   * the whole type in one go: {@code =} with a non-empty value and {@code !=""} select nothing, while
+   * {@code !=} with a non-empty value, {@code =""} and any regex the empty string satisfies select everything.
+   * The evaluator used to get both directions backwards - {@link #buildTagFilter} silently dropped an unknown
+   * {@code =} matcher (so a typo like {@code up{jobb="api"}} widened the query to every series instead of
+   * narrowing it to none) and {@link #matchesPostFilters} rejected every row for an unknown {@code !=}/{@code !~}.
+   * Deciding it here, before the scan, also means the query never runs when the answer is already known.
+   */
+  private boolean excludesEverySeries(final List<LabelMatcher> matchers, final List<ColumnDefinition> columns,
+      final long regexDeadline) {
+    for (final LabelMatcher m : matchers) {
+      if ("__name__".equals(m.name()))
+        continue;
+      if (findNonTsRowIndex(m.name(), columns) >= 0)
+        continue;
+      if (!matchesAbsentLabel(m, regexDeadline))
+        return true;
+    }
+    return false;
+  }
+
+  /**
+   * Applies a matcher to a label that no series carries, which Prometheus treats as the empty string.
+   */
+  private boolean matchesAbsentLabel(final LabelMatcher m, final long regexDeadline) {
+    return switch (m.op()) {
+      case EQ -> m.value().isEmpty();
+      case NEQ -> !m.value().isEmpty();
+      case RE -> TimeBoundRegex.matchesUntil(compilePattern(m.value()), "", regexDeadline);
+      case NRE -> !TimeBoundRegex.matchesUntil(compilePattern(m.value()), "", regexDeadline);
+    };
+  }
+
   private boolean matchesPostFilters(final Object[] row, final List<LabelMatcher> matchers,
       final List<ColumnDefinition> columns, final long regexDeadline) {
     for (final LabelMatcher m : matchers) {
@@ -539,7 +588,10 @@ public class PromQLEvaluator {
         continue;
       final int rowIdx = findNonTsRowIndex(m.name(), columns);
       if (rowIdx < 0)
-        return false;
+        // The column is absent from the schema, so the label is absent from every series. excludesEverySeries()
+        // already settled such a matcher for the whole type before the scan started: reaching a row at all
+        // means it selected everything, so it cannot reject this one (issue #6938).
+        continue;
       final Object val = rowIdx < row.length ? row[rowIdx] : null;
       final String strVal = val != null ? val.toString() : "";
       switch (m.op()) {
@@ -711,7 +763,11 @@ public class PromQLEvaluator {
     for (final VectorSample ls : left.samples()) {
       final VectorSample rs = rightMap.get(labelKey(ls.labels()));
       if (rs != null) {
-        if (op == BinaryOp.AND) {
+        if (op == BinaryOp.AND || op == BinaryOp.OR) {
+          // For a matched label set both AND and OR are the left-hand sample by definition. OR used to fall
+          // into the arithmetic branch below, where applyBinaryOp() maps the set operators to NaN (issue
+          // #6938) - and since aggregation collapses labels to the empty set, the canonical
+          // `sum(a) or sum(b)` fallback always matched and always produced that NaN.
           result.add(ls);
         } else if (op == BinaryOp.UNLESS) {
           // skip — matched, so excluded

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -555,6 +555,11 @@ public class PromQLEvaluator {
    * {@code =} matcher (so a typo like {@code up{jobb="api"}} widened the query to every series instead of
    * narrowing it to none) and {@link #matchesPostFilters} rejected every row for an unknown {@code !=}/{@code !~}.
    * Deciding it here, before the scan, also means the query never runs when the answer is already known.
+   * <p>
+   * Deliberately outside the {@code try/catch} that turns an {@code iterateQuery()} failure into an empty
+   * result: the {@code IllegalArgumentException}/{@code TimeoutException} a bad or ReDoS-shaped {@code =~} can
+   * raise from here propagates to the caller, exactly as the same pattern already does from
+   * {@link #matchesPostFilters}, which runs outside that {@code try} too. A rejected query is not an empty one.
    */
   private boolean excludesEverySeries(final List<LabelMatcher> matchers, final List<ColumnDefinition> columns,
       final long regexDeadline) {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -571,6 +571,14 @@ public class PromQLEvaluator {
 
   /**
    * Applies a matcher to a label that no series carries, which Prometheus treats as the empty string.
+   * <p>
+   * Deliberate change of error behaviour for {@code =~}/{@code !~} on an unknown column: the pattern is now
+   * compiled - and therefore validated by {@link #compilePattern}, syntax and ReDoS guard alike - where
+   * {@link #matchesPostFilters} used to bail out on {@code rowIdx < 0} before ever reaching the switch, so a
+   * malformed or ReDoS-shaped regex against a nonexistent label silently produced an empty vector instead of
+   * the {@code IllegalArgumentException} the same pattern raises against a label that does exist. Prometheus
+   * validates the regex regardless of whether any series carries the label, and a typo'd label name is exactly
+   * the case where the query author most needs to be told rather than handed a plausible empty result.
    */
   private boolean matchesAbsentLabel(final LabelMatcher m, final long regexDeadline) {
     return switch (m.op()) {

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/promql/Issue6938PromQLSemanticsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/promql/Issue6938PromQLSemanticsTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression tests for issue #6938 - three PromQL semantics/presentation defects in {@link PromQLEvaluator}:
@@ -165,6 +166,23 @@ class Issue6938PromQLSemanticsTest extends TestHelper {
     // Same rule on the matrix-selector path (rate() over a range vector), not just the instant one.
     assertThat(evaluateInstant("count_over_time(promql6938_absent_matrix{jobb=\"api\"}[5m])").samples()).isEmpty();
     assertThat(evaluateInstant("count_over_time(promql6938_absent_matrix{jobb!=\"api\"}[5m])").samples()).hasSize(2);
+  }
+
+  @Test
+  void aRegexMatcherOnAnAbsentColumnIsStillValidatedRatherThanSilentlySkipped() {
+    // Deliberate change of error behaviour, called out in review: the absent-column path now compiles the
+    // pattern, so a malformed or ReDoS-shaped regex is rejected exactly as it is against a label the type does
+    // declare. It used to be dropped before compilePattern() was ever reached, handing the author a plausible
+    // empty result for a query that is simply invalid - and a typo'd label name is the case where being told
+    // matters most.
+    createTaggedType("promql6938_absent_badre", 10.0, 20.0);
+
+    assertThatThrownBy(() -> evaluateInstant("promql6938_absent_badre{jobb=~\"(a+)+\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ReDoS");
+    assertThatThrownBy(() -> evaluateInstant("promql6938_absent_badre{jobb!~\"[\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid regex pattern");
   }
 
   // --- 3. step-aligned matrix points --------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/promql/Issue6938PromQLSemanticsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/promql/Issue6938PromQLSemanticsTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries.promql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.timeseries.promql.PromQLResult.InstantVector;
+import com.arcadedb.engine.timeseries.promql.PromQLResult.MatrixResult;
+import com.arcadedb.engine.timeseries.promql.PromQLResult.MatrixSeries;
+import com.arcadedb.engine.timeseries.promql.PromQLResult.VectorSample;
+import com.arcadedb.engine.timeseries.promql.ast.PromQLExpr;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6938 - three PromQL semantics/presentation defects in {@link PromQLEvaluator}:
+ *
+ * <ol>
+ *   <li>{@code or} produced {@code NaN} whenever the two sides shared a label set, because the matched branch of
+ *       {@code applyVectorVector()} fell through to {@code applyBinaryOp()}, which maps AND/OR/UNLESS to
+ *       {@code Double.NaN}. The canonical {@code sum(a) or sum(b)} fallback was the worst case: aggregation
+ *       collapses labels to the empty set, so both sides always matched.</li>
+ *   <li>A label matcher naming a column the type does not declare matched backwards in every direction:
+ *       {@code =} silently matched every series (a typo widened the query instead of narrowing it) and
+ *       {@code !=}/{@code !~} matched none.</li>
+ *   <li>{@code evaluateRange()} stamped each matrix point with the raw sample timestamp instead of the
+ *       evaluation step, so a series sparser than the step repeated timestamps rather than producing the
+ *       regular {@code start + n*step} grid Prometheus guarantees.</li>
+ * </ol>
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6938PromQLSemanticsTest extends TestHelper {
+
+  private static final long EVAL_TIME_MS = 6_000L;
+
+  // --- 1. `or` on a matched label set -------------------------------------------------------------------
+
+  @Test
+  void orKeepsTheLeftHandSampleWhenBothSidesCollapseToTheEmptyLabelSet() {
+    createTaggedType("promql6938_or_a", 10.0, 20.0);
+    createTaggedType("promql6938_or_b", 100.0, 300.0);
+
+    // sum() collapses labels to {} on both sides, so the two samples always match: the matched branch used to
+    // fall through to applyBinaryOp(OR, ...) = NaN.
+    final InstantVector iv = evaluateInstant("sum(promql6938_or_a) or sum(promql6938_or_b)");
+
+    assertThat(iv.samples()).hasSize(1);
+    final VectorSample sample = iv.samples().getFirst();
+    assertThat(sample.value()).isNotNaN();
+    assertThat(sample.value()).isEqualTo(30.0); // 10 + 20 from the left side, never the right side's 400
+    assertThat(sample.labels()).isEmpty();
+  }
+
+  @Test
+  void orKeepsTheLeftHandSampleForEveryGroupSharedByBothSides() {
+    // left  -> host=h1:10, host=h2:20
+    // right -> host=h1:100, host=h3:300
+    createTaggedType("promql6938_orby_a", 10.0, 20.0);
+    createTaggedTypeWithHosts("promql6938_orby_b", "h1", 100.0, "h3", 300.0);
+
+    final InstantVector iv = evaluateInstant(
+        "sum by (host) (promql6938_orby_a) or sum by (host) (promql6938_orby_b)");
+
+    final Map<String, Double> byHost = byHost(iv);
+    // h1 is on both sides: OR must yield the LEFT value, not NaN and not the right one.
+    assertThat(byHost).containsEntry("h1", 10.0).containsEntry("h2", 20.0).containsEntry("h3", 300.0);
+    assertThat(byHost).hasSize(3);
+    for (final VectorSample s : iv.samples())
+      assertThat(s.value()).isNotNaN();
+  }
+
+  @Test
+  void andAndUnlessKeepTheirEstablishedSemanticsOnAMatchedLabelSet() {
+    createTaggedType("promql6938_and_a", 10.0, 20.0);
+    createTaggedTypeWithHosts("promql6938_and_b", "h1", 100.0, "h3", 300.0);
+
+    // Guard against the OR fix leaking into the sibling set operators.
+    final Map<String, Double> and = byHost(
+        evaluateInstant("sum by (host) (promql6938_and_a) and sum by (host) (promql6938_and_b)"));
+    assertThat(and).containsExactlyEntriesOf(Map.of("h1", 10.0));
+
+    final Map<String, Double> unless = byHost(
+        evaluateInstant("sum by (host) (promql6938_and_a) unless sum by (host) (promql6938_and_b)"));
+    assertThat(unless).containsExactlyEntriesOf(Map.of("h2", 20.0));
+  }
+
+  // --- 2. label matchers on a column absent from the schema ---------------------------------------------
+
+  @Test
+  void anEqualityMatcherOnAnAbsentColumnMatchesNoSeries() {
+    createTaggedType("promql6938_absent_eq", 10.0, 20.0);
+
+    // "jobb" is a typo for a label this type does not declare: Prometheus matches nothing, the old code
+    // dropped the matcher entirely and returned every series.
+    assertThat(evaluateInstant("promql6938_absent_eq{jobb=\"api\"}").samples()).isEmpty();
+  }
+
+  @Test
+  void anInequalityMatcherOnAnAbsentColumnMatchesEverySeries() {
+    createTaggedType("promql6938_absent_neq", 10.0, 20.0);
+
+    // An absent label reads as "" for every series, so != with a non-empty value matches all of them.
+    assertThat(evaluateInstant("promql6938_absent_neq{jobb!=\"api\"}").samples()).hasSize(2);
+  }
+
+  @Test
+  void anEmptyValueMatcherOnAnAbsentColumnFollowsPrometheusAbsentLabelRules() {
+    createTaggedType("promql6938_absent_empty", 10.0, 20.0);
+
+    // ="" selects series that do not have the label -> all of them.
+    assertThat(evaluateInstant("promql6938_absent_empty{jobb=\"\"}").samples()).hasSize(2);
+    // !="" selects series that DO have the label -> none of them.
+    assertThat(evaluateInstant("promql6938_absent_empty{jobb!=\"\"}").samples()).isEmpty();
+  }
+
+  @Test
+  void regexMatchersOnAnAbsentColumnAreEvaluatedAgainstTheEmptyString() {
+    createTaggedType("promql6938_absent_re", 10.0, 20.0);
+
+    // =~".*" matches "" -> every series; =~"api" does not -> none.
+    assertThat(evaluateInstant("promql6938_absent_re{jobb=~\".*\"}").samples()).hasSize(2);
+    assertThat(evaluateInstant("promql6938_absent_re{jobb=~\"api\"}").samples()).isEmpty();
+    // !~ is the exact negation of the two above.
+    assertThat(evaluateInstant("promql6938_absent_re{jobb!~\".*\"}").samples()).isEmpty();
+    assertThat(evaluateInstant("promql6938_absent_re{jobb!~\"api\"}").samples()).hasSize(2);
+  }
+
+  @Test
+  void matchersOnAColumnTheTypeDoesDeclareAreUnaffected() {
+    createTaggedType("promql6938_present", 10.0, 20.0);
+
+    assertThat(byHost(evaluateInstant("promql6938_present{host=\"h1\"}"))).containsOnlyKeys("h1");
+    assertThat(byHost(evaluateInstant("promql6938_present{host!=\"h1\"}"))).containsOnlyKeys("h2");
+    assertThat(byHost(evaluateInstant("promql6938_present{host=~\"h.*\"}"))).containsOnlyKeys("h1", "h2");
+    assertThat(evaluateInstant("promql6938_present{host!~\"h.*\"}").samples()).isEmpty();
+  }
+
+  @Test
+  void anAbsentColumnMatcherAlsoGovernsARangeSelector() {
+    createTaggedType("promql6938_absent_matrix", 10.0, 20.0);
+
+    // Same rule on the matrix-selector path (rate() over a range vector), not just the instant one.
+    assertThat(evaluateInstant("count_over_time(promql6938_absent_matrix{jobb=\"api\"}[5m])").samples()).isEmpty();
+    assertThat(evaluateInstant("count_over_time(promql6938_absent_matrix{jobb!=\"api\"}[5m])").samples()).hasSize(2);
+  }
+
+  // --- 3. step-aligned matrix points --------------------------------------------------------------------
+
+  @Test
+  void rangePointsAreStampedWithTheEvaluationStepNotTheRawSampleTimestamp() {
+    // Two samples 4 seconds apart, queried on a 1-second step: every step between them resolves to the same
+    // ts=1000 sample through the lookback window, so the raw sample timestamp repeated four times instead of
+    // producing the regular start + n*step grid.
+    database.command("sql", "CREATE TIMESERIES TYPE promql6938_grid TIMESTAMP ts FIELDS (value DOUBLE)");
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO promql6938_grid SET ts = 1000, value = 1.0");
+      database.command("sql", "INSERT INTO promql6938_grid SET ts = 5000, value = 5.0");
+    });
+
+    final PromQLResult result = new PromQLEvaluator(getDatabaseInternal())
+        .evaluateRange(new PromQLParser("promql6938_grid").parse(), 1000L, 5000L, 1000L);
+
+    assertThat(result).isInstanceOf(MatrixResult.class);
+    final List<MatrixSeries> series = ((MatrixResult) result).series();
+    assertThat(series).hasSize(1);
+
+    final List<double[]> points = series.getFirst().values();
+    assertThat(points).hasSize(5);
+    for (int i = 0; i < points.size(); i++)
+      assertThat(points.get(i)[0]).as("point %d must sit on the step grid", i).isEqualTo(1000.0 + i * 1000.0);
+
+    // The values still come from the lookback resolution: 1.0 carried forward until ts=5000 lands.
+    assertThat(points.get(0)[1]).isEqualTo(1.0);
+    assertThat(points.get(3)[1]).isEqualTo(1.0);
+    assertThat(points.get(4)[1]).isEqualTo(5.0);
+  }
+
+  @Test
+  void rangePointsOfAnAggregationAreAlsoStepAligned() {
+    createTaggedType("promql6938_grid_agg", 10.0, 20.0);
+
+    final PromQLResult result = new PromQLEvaluator(getDatabaseInternal())
+        .evaluateRange(new PromQLParser("sum(promql6938_grid_agg)").parse(), 2000L, 6000L, 2000L);
+
+    final List<MatrixSeries> series = ((MatrixResult) result).series();
+    assertThat(series).hasSize(1);
+    final List<double[]> points = series.getFirst().values();
+    assertThat(points).hasSize(3);
+    assertThat(points.get(0)[0]).isEqualTo(2000.0);
+    assertThat(points.get(1)[0]).isEqualTo(4000.0);
+    assertThat(points.get(2)[0]).isEqualTo(6000.0);
+  }
+
+  // --- helpers ------------------------------------------------------------------------------------------
+
+  private DatabaseInternal getDatabaseInternal() {
+    return (DatabaseInternal) database;
+  }
+
+  private InstantVector evaluateInstant(final String promql) {
+    final PromQLExpr expr = new PromQLParser(promql).parse();
+    final PromQLResult result = new PromQLEvaluator(getDatabaseInternal()).evaluateInstant(expr, EVAL_TIME_MS);
+    assertThat(result).isInstanceOf(InstantVector.class);
+    return (InstantVector) result;
+  }
+
+  private static Map<String, Double> byHost(final InstantVector iv) {
+    final Map<String, Double> result = new LinkedHashMap<>();
+    for (final VectorSample s : iv.samples())
+      result.put(s.labels().get("host"), s.value());
+    return result;
+  }
+
+  private void createTaggedType(final String typeName, final double firstValue, final double secondValue) {
+    createTaggedTypeWithHosts(typeName, "h1", firstValue, "h2", secondValue);
+  }
+
+  private void createTaggedTypeWithHosts(final String typeName, final String firstHost, final double firstValue,
+      final String secondHost, final double secondValue) {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE)");
+    database.transaction(() -> {
+      database.command("sql",
+          "INSERT INTO " + typeName + " SET ts = 1000, host = '" + firstHost + "', value = " + firstValue);
+      database.command("sql",
+          "INSERT INTO " + typeName + " SET ts = 1000, host = '" + secondHost + "', value = " + secondValue);
+    });
+  }
+}


### PR DESCRIPTION
Closes #6938

Three self-contained defects in `PromQLEvaluator`, all reproduced on `main` before the fix (8 of the 12 tests in the new `Issue6938PromQLSemanticsTest` fail without it; the other 4 are guards against the fix leaking into behaviour that was already correct).

## 1. `or` returned `NaN` for a matched label set (bug-high)

`applyVectorVector()` special-cased only `AND` and `UNLESS` in the matched-label-set branch. `OR` fell into the arithmetic `else`, where `applyBinaryOp()` maps `AND, OR, UNLESS -> Double.NaN` ("handled at vector level"), and since `OR` is not a comparison op the `NaN` was added to the result verbatim. The unmatched branches were already right, so only the overlap was broken - which is the worst possible case, because aggregation collapses labels to the empty set (`computeGroupLabels` returns `Map.of()`), so the canonical `sum(a) or sum(b)` fallback idiom *always* matched and *always* returned a single `NaN` instead of `sum(a)`.

Fix: `AND` and `OR` share the arm. For a matched label set both are the left-hand sample by definition.

## 2. A label matcher on a column absent from the schema matched backwards (bug-medium)

Both directions were inverted, which is the dangerous polarity for an alerting expression - a typo in a label name silently *widened* the query:

| matcher on an unknown column | before | Prometheus / now |
|---|---|---|
| `{jobb="api"}` | every series (`buildTagFilter` skipped the matcher entirely) | no series |
| `{jobb!="api"}` | no series (`matchesPostFilters` returned `false` on `rowIdx < 0`) | every series |
| `{jobb=~"api"}` | no series | no series |
| `{jobb=~".*"}` | no series | every series |
| `{jobb!~"api"}` | no series | every series |

Fix: a new `excludesEverySeries()` resolves each matcher's column against the type's schema before the scan. An unresolvable column means the label is absent from every series of that type, so Prometheus' absent-label rules (`matchesAbsentLabel()`, matching against `""`) settle the matcher for the whole type in one go: either it selects everything (the scan proceeds unchanged) or nothing (an empty vector is returned without ever running the query). `matchesPostFilters()`'s `rowIdx < 0` branch consequently becomes `continue` instead of `return false`. The two already-correct cases - `=""` matches everything, `!=""` matches nothing - are pinned by tests so the fix cannot regress them.

Applied on both selector paths, instant and matrix, and the regex forms go through the same `TimeBoundRegex`/`compilePattern` pair as the row-level filters, so the ReDoS guard and the shared regex deadline still apply.

**Deliberate change of error behaviour, raised in review:** because `=~`/`!~` on an unknown column now reach `compilePattern()`, a malformed or ReDoS-shaped regex against a nonexistent label raises `IllegalArgumentException` where it used to be dropped on `rowIdx < 0` before compilation and silently produce an empty vector. Prometheus validates the regex whether or not any series carries the label, and a typo'd label name is precisely the case where the author needs to be told rather than handed a plausible empty result. Documented on `matchesAbsentLabel()` and pinned by `aRegexMatcherOnAnAbsentColumnIsStillValidatedRatherThanSilentlySkipped`. That exception is deliberately *not* wrapped by the `try/catch` that turns an `iterateQuery()` failure into an empty result - it propagates to the caller, exactly as the same pattern already does from `matchesPostFilters()`, which runs outside that `try` too. A rejected query is not an empty one.

## 3. `evaluateRange()` stamped matrix points with the raw sample timestamp (bug-medium)

Prometheus guarantees one point per step at exactly `start + n*step`. The loop already computes that `t` and used it for the `ScalarResult` branch, but the `InstantVector` branch wrote `sample.timestampMs()` - wherever the lookback window happened to resolve. A series sparser than the step therefore repeated a timestamp across consecutive steps: two samples at `ts=1000` and `ts=5000` queried at `start=1000,end=5000,step=1000` produced `[1000, 1000, 1000, 1000, 5000]` instead of `[1000, 2000, 3000, 4000, 5000]`. Any consumer indexing a matrix by timestamp (Grafana included) sees duplicate keys and jitter rather than a regular grid.

Fix: emit each point at `t`. The sample's own timestamp still drives the staleness/lookback decision inside `evaluate()`; only the presentation changes.

## Test plan

- [x] `mvn -pl engine -am test -Dtest=Issue6938PromQLSemanticsTest` - 12 tests. On `main` 8 of them fail (both `or` cases, four absent-column cases, both step-grid cases); all 11 pass with the fix.
- [x] `mvn -pl engine -am test -Dtest='PromQL*Test,Issue6807*Test,Issue6938*Test,*TimeSeries*Test,Issue68*Test,Issue69*Test'` - 430 tests, 0 failures. Covers the existing `PromQLEvaluatorIntegrationTest` (including the `#5886` regex-deadline tests, whose budget-sharing assertions the new pre-scan gate could have disturbed) and `Issue6807RangeStepGuardTest`.
- [x] `mvn -pl server test -Dtest='Issue6807PromQL*Test,PrometheusApiSpecTest'` - 22 tests, 0 failures.
- [ ] `PromQLHttpHandlerIT` was NOT run locally: port 2480 is held by another ArcadeDB instance on this machine, which turns server ITs into a wall of spurious auth failures. Its `rangeQuery` / `rangeQueryWithRate` assertions only check `resultType` and the presence of a `values` array, so the timestamp change is not visible to them; CI covers it.

Guard tests worth calling out: `andAndUnlessKeepTheirEstablishedSemanticsOnAMatchedLabelSet` (the `OR` arm must not leak into its siblings), `matchersOnAColumnTheTypeDoesDeclareAreUnaffected` (the pre-scan gate must not touch resolvable columns), and `anAbsentColumnMatcherAlsoGovernsARangeSelector` (the matrix path, not just the instant one).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PromQL range-query timestamps to align with evaluation steps.
  * Improved `OR` and `AND` results for matching label sets.
  * Fixed filtering behavior for labels that are not present in the data.
  * Added validation for invalid or potentially unsafe label-matching regular expressions.
  * Improved handling of queries that cannot match any available series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->