### PR TITLE
fix(#6937): size the bucketed TimeSeries aggregation window from the mutable bucket too

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/timeseries/AggregationMetrics.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/AggregationMetrics.java
@@ -40,6 +40,7 @@ public final class AggregationMetrics {
   private int  scannedPages;
   private int  skippedPages;
   private long materializedRows;
+  private int  overflowBuckets;
 
   public void addIo(final long nanos) {
     ioNanos += nanos;
@@ -90,6 +91,16 @@ public final class AggregationMetrics {
     materializedRows += rows;
   }
 
+  /**
+   * Buckets the flat-mode result had to park in its overflow map because they fell outside the
+   * pre-allocated window (issue #6937). Correct output either way - the overflow map keeps the numbers
+   * right - but a non-zero value means the sizing estimate in {@code aggregateMulti()} came up short,
+   * which is the thing that used to lose samples silently. Worth watching in a profile.
+   */
+  public void addOverflowBuckets(final int buckets) {
+    overflowBuckets += buckets;
+  }
+
   public long getIoNanos() {
     return ioNanos;
   }
@@ -130,6 +141,10 @@ public final class AggregationMetrics {
     return materializedRows;
   }
 
+  public int getOverflowBuckets() {
+    return overflowBuckets;
+  }
+
   /**
    * Merges counters from another instance (used to aggregate across shards).
    */
@@ -144,6 +159,7 @@ public final class AggregationMetrics {
     scannedPages += other.scannedPages;
     skippedPages += other.skippedPages;
     materializedRows += other.materializedRows;
+    overflowBuckets += other.overflowBuckets;
   }
 
   @Override
@@ -151,9 +167,9 @@ public final class AggregationMetrics {
     final long totalNanos = ioNanos + decompTsNanos + decompValNanos + accumNanos;
     return String.format(
         "AggMetrics[io=%dms decompTs=%dms decompVal=%dms accum=%dms total=%dms | blocks: fast=%d slow=%d skipped=%d"
-            + " | pages: scanned=%d skipped=%d | rows: materialized=%d]",
+            + " | pages: scanned=%d skipped=%d | rows: materialized=%d | buckets: overflow=%d]",
         ioNanos / 1_000_000, decompTsNanos / 1_000_000, decompValNanos / 1_000_000,
         accumNanos / 1_000_000, totalNanos / 1_000_000,
-        fastPathBlocks, slowPathBlocks, skippedBlocks, scannedPages, skippedPages, materializedRows);
+        fastPathBlocks, slowPathBlocks, skippedBlocks, scannedPages, skippedPages, materializedRows, overflowBuckets);
   }
 }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
@@ -433,9 +433,12 @@ public final class MultiColumnAggregationResult {
 
   /**
    * Number of buckets that had to be parked in the flat-mode overflow map because they fell outside
-   * the pre-allocated window. Always 0 in map mode. Exposed for tests that assert the caller sized
-   * the flat window correctly, so a sizing regression is visible even though the overflow map keeps
-   * the numbers right (issue #6937).
+   * the pre-allocated window (issue #6937). The results are correct either way; a non-zero value means
+   * the caller's range estimate came up short, which is what used to lose samples silently. Read by
+   * {@code TimeSeriesEngine.aggregateMulti()} into {@link AggregationMetrics#addOverflowBuckets(int)},
+   * and by the tests that assert the sizing itself is right rather than merely rescued.
+   *
+   * @return the overflow bucket count, always 0 in map mode
    */
   int getOverflowBucketCount() {
     return overflowValues != null ? overflowValues.size() : 0;

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
@@ -408,8 +408,9 @@ public final class MultiColumnAggregationResult {
         }
       }
       // Buckets the other result had to park in its overflow map (issue #6937) still belong in the
-      // merged total; route them through the by-timestamp accumulator so they land in this result's
-      // flat window when it happens to be wide enough, and in its own overflow map otherwise.
+      // merged total. Both sides share firstBucketTs/bucketIntervalMs/maxBuckets (asserted above), so
+      // flatIndex() gives the same answer here and they necessarily re-overflow into this result's own
+      // map; going through the by-timestamp accumulator is what puts them there and merges duplicates.
       if (other.overflowValues != null)
         for (final Map.Entry<Long, double[]> entry : other.overflowValues.entrySet()) {
           final long bucketTs = entry.getKey();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
@@ -19,6 +19,7 @@
 package com.arcadedb.engine.timeseries;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,9 @@ import java.util.Map;
  *       Zero HashMap overhead per sample. Used when bucket interval and data range are known.</li>
  *   <li><b>Map mode</b>: HashMap-based fallback for unknown ranges or zero-interval queries.</li>
  * </ul>
+ * In flat mode the pre-allocated window is only as good as the caller's range estimate, so a bucket
+ * that falls outside it is parked in a lazily created overflow map rather than discarded: an
+ * under-sized window then costs a little speed, never a sample (issue #6937).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -56,6 +60,14 @@ public final class MultiColumnAggregationResult {
   private       long[][]   flatCounts;   // [bucketIdx][requestIdx]
   private       boolean[]  bucketUsed;   // whether this bucket has been touched
   private       List<Long> cachedBucketTimestamps; // cached result for flat mode
+
+  // --- Flat-mode overflow (issue #6937) ---
+  // Sizing the flat array is a caller-side estimate of the data range. When it comes up short - the
+  // mutable bucket growing past the sealed maximum while the aggregation runs, for instance - the
+  // samples that fall outside the pre-allocated window land here instead of being silently dropped.
+  // Lazily allocated, so a correctly sized flat result pays nothing.
+  private Map<Long, double[]> overflowValues;
+  private Map<Long, long[]>   overflowCounts;
 
   /**
    * Map-mode constructor (original behavior).
@@ -129,8 +141,10 @@ public final class MultiColumnAggregationResult {
   public void accumulate(final long bucketTs, final int requestIndex, final double value) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);
-      if (!ensureFlatBucket(idx))
+      if (!ensureFlatBucket(idx)) {
+        accumulateInPlace(overflowValuesFor(bucketTs), overflowCounts.get(bucketTs), requestIndex, value);
         return;
+      }
       accumulateInPlace(flatValues[idx], flatCounts[idx], requestIndex, value);
     } else {
       double[] vals = valuesByBucket.get(bucketTs);
@@ -151,10 +165,15 @@ public final class MultiColumnAggregationResult {
   public void accumulateRow(final long bucketTs, final double[] values) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);
-      if (!ensureFlatBucket(idx))
-        return;
-      final double[] vals = flatValues[idx];
-      final long[] counts = flatCounts[idx];
+      final double[] vals;
+      final long[] counts;
+      if (ensureFlatBucket(idx)) {
+        vals = flatValues[idx];
+        counts = flatCounts[idx];
+      } else {
+        vals = overflowValuesFor(bucketTs);
+        counts = overflowCounts.get(bucketTs);
+      }
       for (int i = 0; i < requestCount; i++)
         accumulateInPlace(vals, counts, i, values[i]);
     } else {
@@ -180,8 +199,10 @@ public final class MultiColumnAggregationResult {
   public void accumulateBlockStats(final long bucketTs, final double[] values, final int sampleCount) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);
-      if (!ensureFlatBucket(idx))
+      if (!ensureFlatBucket(idx)) {
+        accumulateBlockStatsInPlace(overflowValuesFor(bucketTs), overflowCounts.get(bucketTs), values, sampleCount);
         return;
+      }
       accumulateBlockStatsInPlace(flatValues[idx], flatCounts[idx], values, sampleCount);
     } else {
       double[] vals = valuesByBucket.get(bucketTs);
@@ -213,8 +234,10 @@ public final class MultiColumnAggregationResult {
       final double value, final long count) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);
-      if (!ensureFlatBucket(idx))
+      if (!ensureFlatBucket(idx)) {
+        accumulateStatInPlace(overflowValuesFor(bucketTs), overflowCounts.get(bucketTs), requestIndex, value, count);
         return;
+      }
       accumulateStatInPlace(flatValues[idx], flatCounts[idx], requestIndex, value, count);
     } else {
       double[] vals = valuesByBucket.get(bucketTs);
@@ -245,6 +268,12 @@ public final class MultiColumnAggregationResult {
             if (bucketUsed[b] && flatCounts[b][i] > 0)
               flatValues[b][i] = flatValues[b][i] / flatCounts[b][i];
           }
+          if (overflowValues != null)
+            for (final Map.Entry<Long, double[]> entry : overflowValues.entrySet()) {
+              final long[] counts = overflowCounts.get(entry.getKey());
+              if (counts[i] > 0)
+                entry.getValue()[i] = entry.getValue()[i] / counts[i];
+            }
         }
       }
     } else {
@@ -270,6 +299,12 @@ public final class MultiColumnAggregationResult {
         for (int b = 0; b < maxBuckets; b++)
           if (bucketUsed[b])
             result.add(firstBucketTs + (long) b * bucketIntervalMs);
+        if (overflowValues != null && !overflowValues.isEmpty()) {
+          // Overflow buckets sit outside the pre-allocated window on either side, so the merged list
+          // has to be re-sorted to keep the ascending-timestamp contract callers rely on.
+          result.addAll(overflowValues.keySet());
+          Collections.sort(result);
+        }
         cachedBucketTimestamps = result;
       }
       return cachedBucketTimestamps;
@@ -284,6 +319,12 @@ public final class MultiColumnAggregationResult {
         if (isUnusedMinMax(flatCounts[idx], requestIndex))
           return Double.NaN;
         return flatValues[idx][requestIndex];
+      }
+      final double[] overflow = overflowValues != null ? overflowValues.get(bucketTs) : null;
+      if (overflow != null) {
+        if (isUnusedMinMax(overflowCounts.get(bucketTs), requestIndex))
+          return Double.NaN;
+        return overflow[requestIndex];
       }
       return 0.0;
     }
@@ -310,7 +351,8 @@ public final class MultiColumnAggregationResult {
       final int idx = flatIndex(bucketTs);
       if (idx >= 0 && idx < maxBuckets && bucketUsed[idx])
         return flatCounts[idx][requestIndex];
-      return 0;
+      final long[] overflow = overflowCounts != null ? overflowCounts.get(bucketTs) : null;
+      return overflow != null ? overflow[requestIndex] : 0;
     }
     final long[] counts = countsByBucket.get(bucketTs);
     return counts != null ? counts[requestIndex] : 0;
@@ -318,7 +360,7 @@ public final class MultiColumnAggregationResult {
 
   public int size() {
     if (flatMode) {
-      int count = 0;
+      int count = overflowValues != null ? overflowValues.size() : 0;
       for (int b = 0; b < maxBuckets; b++)
         if (bucketUsed[b])
           count++;
@@ -365,6 +407,17 @@ public final class MultiColumnAggregationResult {
           tCounts[i] += oCounts[i];
         }
       }
+      // Buckets the other result had to park in its overflow map (issue #6937) still belong in the
+      // merged total; route them through the by-timestamp accumulator so they land in this result's
+      // flat window when it happens to be wide enough, and in its own overflow map otherwise.
+      if (other.overflowValues != null)
+        for (final Map.Entry<Long, double[]> entry : other.overflowValues.entrySet()) {
+          final long bucketTs = entry.getKey();
+          final double[] oVals = entry.getValue();
+          final long[] oCounts = other.overflowCounts.get(bucketTs);
+          for (int i = 0; i < requestCount; i++)
+            accumulateStatInPlaceByTs(bucketTs, i, oVals[i], oCounts[i]);
+        }
     } else {
       // Fallback: merge map-mode results
       for (final long bucketTs : other.getBucketTimestamps()) {
@@ -377,6 +430,16 @@ public final class MultiColumnAggregationResult {
     }
   }
 
+  /**
+   * Number of buckets that had to be parked in the flat-mode overflow map because they fell outside
+   * the pre-allocated window. Always 0 in map mode. Exposed for tests that assert the caller sized
+   * the flat window correctly, so a sizing regression is visible even though the overflow map keeps
+   * the numbers right (issue #6937).
+   */
+  int getOverflowBucketCount() {
+    return overflowValues != null ? overflowValues.size() : 0;
+  }
+
   // ---- Internal helpers ----
 
   int getRequestCount() {
@@ -385,6 +448,26 @@ public final class MultiColumnAggregationResult {
 
   AggregationType[] getTypes() {
     return types;
+  }
+
+  /**
+   * Returns (creating on first use) the overflow value array for a bucket that falls outside the
+   * pre-allocated flat window. The matching {@link #overflowCounts} entry is created alongside it,
+   * so callers can read it straight after this call.
+   */
+  private double[] overflowValuesFor(final long bucketTs) {
+    if (overflowValues == null) {
+      overflowValues = new HashMap<>();
+      overflowCounts = new HashMap<>();
+    }
+    double[] vals = overflowValues.get(bucketTs);
+    if (vals == null) {
+      vals = newInitializedValues();
+      overflowValues.put(bucketTs, vals);
+      overflowCounts.put(bucketTs, new long[requestCount]);
+      cachedBucketTimestamps = null; // invalidate cache
+    }
+    return vals;
   }
 
   private int flatIndex(final long bucketTs) {
@@ -495,8 +578,10 @@ public final class MultiColumnAggregationResult {
       final double value, final long count) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);
-      if (!ensureFlatBucket(idx))
+      if (!ensureFlatBucket(idx)) {
+        accumulateStatInPlace(overflowValuesFor(bucketTs), overflowCounts.get(bucketTs), requestIndex, value, count);
         return;
+      }
       accumulateStatInPlace(flatValues[idx], flatCounts[idx], requestIndex, value, count);
     } else {
       double[] vals = valuesByBucket.get(bucketTs);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
@@ -792,6 +792,20 @@ public class TimeSeriesBucket extends PaginatedComponent {
   }
 
   /**
+   * Returns {@code {min, max}} timestamps from a SINGLE header-page read, so the pair is a consistent
+   * snapshot rather than two independently-timed reads, and callers that need both - the flat-window
+   * sizing scan in {@code TimeSeriesEngine.aggregateMulti} - pay one page lookup instead of two.
+   * An empty bucket answers with the same markers {@link #getMinTimestamp()} and {@link #getMaxTimestamp()}
+   * return on their own, i.e. {@code {Long.MAX_VALUE, Long.MIN_VALUE}}.
+   */
+  public long[] getMinMaxTimestamps() throws IOException {
+    final BasePage headerPage = readHeaderPage();
+    if (headerPage == null)
+      return new long[] { Long.MAX_VALUE, Long.MIN_VALUE };
+    return new long[] { headerPage.readLong(HEADER_MIN_TS_OFFSET), headerPage.readLong(HEADER_MAX_TS_OFFSET) };
+  }
+
+  /**
    * Returns the number of data pages (excluding header page), or 0 when the file carries no header page.
    */
   public int getDataPageCount() throws IOException {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -422,7 +422,14 @@ public class TimeSeriesEngine implements AutoCloseable {
       final TagFilter tagFilter, final AggregationMetrics metrics) throws IOException {
     final int reqCount = requests.size();
 
-    // Determine actual data range to size flat arrays correctly
+    // Determine actual data range to size flat arrays correctly.
+    //
+    // This scan runs WITHOUT the per-shard compaction read locks on purpose - they are acquired further
+    // down, around the reads that actually produce the numbers. A compaction, or a fresh append, can
+    // therefore slip in between the estimate and the reads. That is deliberate and safe: the estimate
+    // only decides how wide the flat window is, and MultiColumnAggregationResult parks anything landing
+    // outside it in its overflow map rather than dropping it (issue #6937). Taking the locks here would
+    // hold them across the whole aggregation for no correctness gain, just contention with the writers.
     long actualMin = Long.MAX_VALUE;
     long actualMax = Long.MIN_VALUE;
     final boolean useFlatMode = bucketIntervalMs > 0;

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -563,6 +563,8 @@ public class TimeSeriesEngine implements AutoCloseable {
         }
 
         result.finalizeAvg();
+        if (metrics != null)
+          metrics.addOverflowBuckets(result.getOverflowBucketCount());
         return result;
       } finally {
         for (int s = 0; s < shardCount; s++)
@@ -611,6 +613,8 @@ public class TimeSeriesEngine implements AutoCloseable {
       }
 
       result.finalizeAvg();
+      if (metrics != null)
+        metrics.addOverflowBuckets(result.getOverflowBucketCount());
       return result;
     }
   }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -435,6 +435,22 @@ public class TimeSeriesEngine implements AutoCloseable {
           if (ss.getGlobalMaxTimestamp() > actualMax)
             actualMax = ss.getGlobalMaxTimestamp();
         }
+
+        // The mutable bucket carries everything appended since the last compaction and is NOT bounded
+        // by the sealed range - compaction is driven by the maintenance scheduler, not by sample
+        // timestamps, so the un-sealed tail can span an arbitrary number of buckets. Sizing the flat
+        // array from the sealed stores alone made every sample past that range resolve to an
+        // out-of-range index and vanish without an error (issue #6937).
+        final TimeSeriesBucket mutable = shard.getMutableBucket();
+        final long mutableMin = mutable.getMinTimestamp();
+        final long mutableMax = mutable.getMaxTimestamp();
+        // Empty markers are Long.MAX_VALUE / Long.MIN_VALUE, so an empty bucket never widens anything.
+        if (mutableMin <= mutableMax) {
+          if (mutableMin < actualMin)
+            actualMin = mutableMin;
+          if (mutableMax > actualMax)
+            actualMax = mutableMax;
+        }
       }
       // Clamp to query range
       if (fromTs != Long.MIN_VALUE && fromTs > actualMin)

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -448,15 +448,14 @@ public class TimeSeriesEngine implements AutoCloseable {
         // timestamps, so the un-sealed tail can span an arbitrary number of buckets. Sizing the flat
         // array from the sealed stores alone made every sample past that range resolve to an
         // out-of-range index and vanish without an error (issue #6937).
-        final TimeSeriesBucket mutable = shard.getMutableBucket();
-        final long mutableMin = mutable.getMinTimestamp();
-        final long mutableMax = mutable.getMaxTimestamp();
+        // One header-page read for the pair, so the two bounds are a consistent snapshot.
+        final long[] mutableRange = shard.getMutableBucket().getMinMaxTimestamps();
         // Empty markers are Long.MAX_VALUE / Long.MIN_VALUE, so an empty bucket never widens anything.
-        if (mutableMin <= mutableMax) {
-          if (mutableMin < actualMin)
-            actualMin = mutableMin;
-          if (mutableMax > actualMax)
-            actualMax = mutableMax;
+        if (mutableRange[0] <= mutableRange[1]) {
+          if (mutableRange[0] < actualMin)
+            actualMin = mutableRange[0];
+          if (mutableRange[1] > actualMax)
+            actualMax = mutableRange[1];
         }
       }
       // Clamp to query range

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6283BucketHeaderAccessorsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6283BucketHeaderAccessorsTest.java
@@ -123,6 +123,41 @@ class Issue6283BucketHeaderAccessorsTest extends TestHelper {
   }
 
   /**
+   * Issue #6937 added {@code getMinMaxTimestamps()}, which answers both bounds from ONE header read so the pair
+   * is a consistent snapshot. It has to agree with the two single-value readers in every state, empty included.
+   */
+  @Test
+  void combinedMinMaxReaderAgreesWithTheSingleValueReaders() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    database.begin();
+    final TimeSeriesBucket bucket = new TimeSeriesBucket(db, "issue6937_minmax",
+        db.getDatabasePath() + "/issue6937_minmax", columns());
+    ((LocalSchema) db.getSchema()).registerFile(bucket);
+
+    // No header page yet.
+    assertThat(bucket.getMinMaxTimestamps()).containsExactly(Long.MAX_VALUE, Long.MIN_VALUE);
+
+    // Header page written, still no samples.
+    bucket.initHeaderPage();
+    assertThat(bucket.getMinMaxTimestamps()).containsExactly(Long.MAX_VALUE, Long.MIN_VALUE);
+    assertThat(bucket.getMinMaxTimestamps()).containsExactly(bucket.getMinTimestamp(), bucket.getMaxTimestamp());
+
+    bucket.appendSamples(new long[] { -5_000L, 1000L, 3000L }, new Object[] { 19.0, 20.0, 22.0 });
+    assertThat(bucket.getMinMaxTimestamps()).containsExactly(-5_000L, 3000L);
+    assertThat(bucket.getMinMaxTimestamps()).containsExactly(bucket.getMinTimestamp(), bucket.getMaxTimestamp());
+    database.commit();
+
+    // ...and once committed, when the reader resolves the page through the page manager instead.
+    database.begin();
+    assertThat(bucket.getMinMaxTimestamps()).containsExactly(bucket.getMinTimestamp(), bucket.getMaxTimestamp());
+    assertThat(bucket.getMinMaxTimestamps()).containsExactly(-5_000L, 3000L);
+    database.commit();
+
+    dropBucket(db, bucket);
+  }
+
+  /**
    * The buckets built here are registered by hand and belong to no TimeSeries type, so they have to be removed
    * before the integrity check that closes the test, which reports any file the schema does not claim.
    */

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMutableTailAggregationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMutableTailAggregationTest.java
@@ -213,6 +213,78 @@ class TimeSeriesMutableTailAggregationTest {
     assertThat(result.getValue(0L, 0)).isEqualTo(10.0);
   }
 
+  /**
+   * The overflow path has its own branches in {@code finalizeAvg()} and in the untouched-MIN/MAX ->
+   * NaN check, so drive AVG/MIN/MAX through it as well and not just the SUM/COUNT accumulators.
+   */
+  @Test
+  void flatModeOverflowFinalizesAvgAndMinMaxLikeTheFlatArray() {
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(2, AggregationType.AVG, "avg_val"),
+        new MultiColumnAggregationRequest(2, AggregationType.MIN, "min_val"),
+        new MultiColumnAggregationRequest(2, AggregationType.MAX, "max_val"));
+
+    // Room for exactly 2 buckets: [0, 60_000) and [60_000, 120_000).
+    final MultiColumnAggregationResult result = new MultiColumnAggregationResult(requests, 0L, MINUTE_MS, 2);
+
+    // In-window bucket, as the reference.
+    result.accumulateRow(0L, new double[] { 4.0, 4.0, 4.0 });
+    result.accumulateRow(0L, new double[] { 8.0, 8.0, 8.0 });
+
+    // Overflow bucket, same data.
+    result.accumulateRow(300_000L, new double[] { 4.0, 4.0, 4.0 });
+    result.accumulateRow(300_000L, new double[] { 8.0, 8.0, 8.0 });
+
+    // Overflow bucket touched only by AVG, so MIN/MAX there never saw a sample.
+    result.accumulate(600_000L, 0, 10.0);
+
+    result.finalizeAvg();
+
+    assertThat(result.getOverflowBucketCount()).isEqualTo(2);
+
+    assertThat(result.getValue(0L, 0)).isEqualTo(6.0);
+    assertThat(result.getValue(300_000L, 0)).as("AVG must be divided by its count in the overflow map too").isEqualTo(6.0);
+    assertThat(result.getValue(300_000L, 1)).isEqualTo(4.0);
+    assertThat(result.getValue(300_000L, 2)).isEqualTo(8.0);
+    assertThat(result.getCount(300_000L, 0)).isEqualTo(2);
+
+    assertThat(result.getValue(600_000L, 0)).isEqualTo(10.0);
+    assertThat(result.getValue(600_000L, 1)).as("untouched MIN must surface as NaN, not the sentinel").isNaN();
+    assertThat(result.getValue(600_000L, 2)).as("untouched MAX must surface as NaN, not the sentinel").isNaN();
+
+    assertThat(result.getBucketTimestamps()).containsExactly(0L, 300_000L, 600_000L);
+  }
+
+  /**
+   * The parallel branch merges per-shard results; an overflow bucket on either side must survive that
+   * merge with its AVG denominator and MIN/MAX intact.
+   */
+  @Test
+  void mergeFromCarriesOverflowBucketsAcross() {
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(2, AggregationType.AVG, "avg_val"),
+        new MultiColumnAggregationRequest(2, AggregationType.MIN, "min_val"),
+        new MultiColumnAggregationRequest(2, AggregationType.MAX, "max_val"));
+
+    final MultiColumnAggregationResult left = new MultiColumnAggregationResult(requests, 0L, MINUTE_MS, 2);
+    final MultiColumnAggregationResult right = new MultiColumnAggregationResult(requests, 0L, MINUTE_MS, 2);
+
+    left.accumulateRow(300_000L, new double[] { 4.0, 4.0, 4.0 });
+    right.accumulateRow(300_000L, new double[] { 8.0, 8.0, 8.0 });
+    right.accumulateRow(0L, new double[] { 2.0, 2.0, 2.0 });
+
+    left.mergeFrom(right);
+    left.finalizeAvg();
+
+    assertThat(left.getOverflowBucketCount()).isEqualTo(1);
+    assertThat(left.getCount(300_000L, 0)).isEqualTo(2);
+    assertThat(left.getValue(300_000L, 0)).isEqualTo(6.0);
+    assertThat(left.getValue(300_000L, 1)).isEqualTo(4.0);
+    assertThat(left.getValue(300_000L, 2)).isEqualTo(8.0);
+    assertThat(left.getValue(0L, 0)).isEqualTo(2.0);
+    assertThat(left.getBucketTimestamps()).containsExactly(0L, 300_000L);
+  }
+
   // ---- helpers ----
 
   private TimeSeriesEngine createSealedPlusMutableTail() throws Exception {

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMutableTailAggregationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMutableTailAggregationTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Regression test for issue #6937: bucketed {@code aggregateMulti()} used to size its flat bucket
+ * array from the sealed stores only, so every sample in the un-sealed mutable bucket that fell past
+ * the sealed maximum resolved to an out-of-range flat index and was silently discarded.
+ * <p>
+ * The shape that triggers it: run a compaction (so the sealed store is non-empty and drives the
+ * sizing), then append a tail that spans more than two bucket intervals without compacting again.
+ */
+class TimeSeriesMutableTailAggregationTest {
+
+  private static final String DB_PATH = "target/databases/TimeSeriesMutableTailAggregationTest";
+
+  /** Sealed part: 50,000 samples, 10 ms apart -> [0 .. 499_990] ms, i.e. ~8.3 minutes. */
+  private static final int  SEALED_SAMPLES     = 50_000;
+  private static final long SEALED_INTERVAL_MS = 10L;
+
+  /** Mutable tail: 600 samples, 1 s apart, starting right after the sealed part -> 10 more minutes. */
+  private static final int  TAIL_SAMPLES     = 600;
+  private static final long TAIL_INTERVAL_MS = 1_000L;
+  private static final long TAIL_START_MS    = SEALED_SAMPLES * SEALED_INTERVAL_MS;
+
+  private static final long MINUTE_MS = 60_000L;
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.close();
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void bucketedAggregationKeepsMutableSamplesPastTheSealedMaximum() throws Exception {
+    final TimeSeriesEngine engine = createSealedPlusMutableTail();
+
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(2, AggregationType.SUM, "sum_val"),
+        new MultiColumnAggregationRequest(2, AggregationType.MIN, "min_val"),
+        new MultiColumnAggregationRequest(2, AggregationType.MAX, "max_val"),
+        new MultiColumnAggregationRequest(-1, AggregationType.COUNT, "cnt"));
+
+    // Flat mode: 1-minute buckets, so the 10-minute mutable tail spans far more than the
+    // two spare buckets the sealed-only sizing used to allocate.
+    final MultiColumnAggregationResult flat = engine.aggregateMulti(
+        Long.MIN_VALUE, Long.MAX_VALUE, requests, MINUTE_MS, null);
+
+    long totalCount = 0;
+    double totalSum = 0;
+    double min = Double.MAX_VALUE;
+    double max = -Double.MAX_VALUE;
+    for (final long bucketTs : flat.getBucketTimestamps()) {
+      totalCount += (long) flat.getValue(bucketTs, 3);
+      totalSum += flat.getValue(bucketTs, 0);
+      min = Math.min(min, flat.getValue(bucketTs, 1));
+      max = Math.max(max, flat.getValue(bucketTs, 2));
+    }
+
+    assertThat(totalCount)
+        .as("every sample must be accounted for, mutable tail included")
+        .isEqualTo(SEALED_SAMPLES + TAIL_SAMPLES);
+    assertThat(totalSum).isCloseTo(expectedTotalSum(), within(1.0));
+    assertThat(min).isEqualTo(1.0);
+    assertThat(max).isEqualTo(SEALED_SAMPLES + TAIL_SAMPLES);
+
+    // The last bucket of the tail must actually be present in the result.
+    final long lastTailBucket = Math.floorDiv(TAIL_START_MS + (TAIL_SAMPLES - 1) * TAIL_INTERVAL_MS, MINUTE_MS) * MINUTE_MS;
+    assertThat(flat.getBucketTimestamps()).contains(lastTailBucket);
+    assertThat(flat.getCount(lastTailBucket, 3)).isPositive();
+
+    // The overflow map is the safety net, not the fix: the engine must size the flat window from the
+    // mutable range too, so nothing needs parking in the first place.
+    assertThat(flat.getOverflowBucketCount())
+        .as("flat window must be sized to cover the mutable tail, not backfilled by the overflow map")
+        .isZero();
+    assertThat(flat.getBucketTimestamps()).isSorted();
+  }
+
+  @Test
+  void bucketedAggregationMatchesTheUnbucketedTotal() throws Exception {
+    final TimeSeriesEngine engine = createSealedPlusMutableTail();
+
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(2, AggregationType.SUM, "sum_val"),
+        new MultiColumnAggregationRequest(-1, AggregationType.COUNT, "cnt"));
+
+    // bucketIntervalMs = 0 -> map mode, which never had the sizing problem: use it as the oracle.
+    final MultiColumnAggregationResult mapMode = engine.aggregateMulti(
+        Long.MIN_VALUE, Long.MAX_VALUE, requests, 0L, null);
+    final long mapBucket = mapMode.getBucketTimestamps().getFirst();
+
+    final MultiColumnAggregationResult flat = engine.aggregateMulti(
+        Long.MIN_VALUE, Long.MAX_VALUE, requests, MINUTE_MS, null);
+
+    long flatCount = 0;
+    double flatSum = 0;
+    for (final long bucketTs : flat.getBucketTimestamps()) {
+      flatCount += (long) flat.getValue(bucketTs, 1);
+      flatSum += flat.getValue(bucketTs, 0);
+    }
+
+    assertThat(flatCount).isEqualTo((long) mapMode.getValue(mapBucket, 1));
+    assertThat(flatSum).isCloseTo(mapMode.getValue(mapBucket, 0), within(1.0));
+    assertThat(flatCount).isEqualTo(engine.countSamples());
+  }
+
+  /**
+   * Same shape on a sharded type, which takes the parallel branch of {@code aggregateMulti()}:
+   * the per-shard results are built independently and merged, so the tail has to survive the merge too.
+   */
+  @Test
+  void shardedBucketedAggregationKeepsMutableSamplesPastTheSealedMaximum() throws Exception {
+    database.command("sql",
+        """
+        CREATE TIMESERIES TYPE Metric TIMESTAMP ts TAGS (sensor STRING) FIELDS (value DOUBLE) \
+        SHARDS 4 COMPACTION_INTERVAL 1 HOURS""");
+
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType("Metric")).getEngine();
+    assertThat(engine.getShardCount()).isEqualTo(4);
+
+    appendBatch(engine, SEALED_SAMPLES, 0, 0L, SEALED_INTERVAL_MS);
+    engine.compactAll();
+    appendBatch(engine, TAIL_SAMPLES, SEALED_SAMPLES, TAIL_START_MS, TAIL_INTERVAL_MS);
+
+    final MultiColumnAggregationResult flat = engine.aggregateMulti(
+        Long.MIN_VALUE, Long.MAX_VALUE,
+        List.of(
+            new MultiColumnAggregationRequest(2, AggregationType.SUM, "sum_val"),
+            new MultiColumnAggregationRequest(-1, AggregationType.COUNT, "cnt")),
+        MINUTE_MS, null);
+
+    long totalCount = 0;
+    double totalSum = 0;
+    for (final long bucketTs : flat.getBucketTimestamps()) {
+      totalCount += (long) flat.getValue(bucketTs, 1);
+      totalSum += flat.getValue(bucketTs, 0);
+    }
+
+    assertThat(totalCount).isEqualTo(SEALED_SAMPLES + TAIL_SAMPLES);
+    assertThat(totalSum).isCloseTo(expectedTotalSum(), within(1.0));
+    assertThat(flat.getOverflowBucketCount())
+        .as("flat window must be sized to cover the mutable tail, not backfilled by the overflow map")
+        .isZero();
+    assertThat(flat.getBucketTimestamps()).isSorted();
+  }
+
+  /**
+   * Out-of-range buckets must never be dropped on the floor: even when the caller sizes the flat
+   * array too small, the samples have to land somewhere. Exercises the overflow path directly.
+   */
+  @Test
+  void flatModeResultDoesNotDiscardBucketsPastTheAllocatedRange() {
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(2, AggregationType.SUM, "sum_val"),
+        new MultiColumnAggregationRequest(-1, AggregationType.COUNT, "cnt"));
+
+    // Room for exactly 2 buckets: [0, 60_000) and [60_000, 120_000).
+    final MultiColumnAggregationResult result = new MultiColumnAggregationResult(requests, 0L, MINUTE_MS, 2);
+    assertThat(result.isFlatMode()).isTrue();
+
+    result.accumulateRow(0L, new double[] { 10.0, 1.0 });
+    result.accumulateRow(60_000L, new double[] { 20.0, 1.0 });
+    result.accumulateRow(180_000L, new double[] { 30.0, 1.0 });  // past the end
+    result.accumulateRow(180_000L, new double[] { 40.0, 1.0 });
+    result.accumulateRow(-60_000L, new double[] { 5.0, 1.0 });   // before the start
+
+    assertThat(result.getBucketTimestamps()).containsExactly(-60_000L, 0L, 60_000L, 180_000L);
+    assertThat(result.size()).isEqualTo(4);
+    assertThat(result.getOverflowBucketCount()).isEqualTo(2);
+    assertThat(result.getValue(180_000L, 0)).isEqualTo(70.0);
+    assertThat(result.getCount(180_000L, 0)).isEqualTo(2);
+    assertThat(result.getValue(-60_000L, 0)).isEqualTo(5.0);
+    assertThat(result.getValue(0L, 0)).isEqualTo(10.0);
+  }
+
+  // ---- helpers ----
+
+  private TimeSeriesEngine createSealedPlusMutableTail() throws Exception {
+    database.command("sql",
+        """
+        CREATE TIMESERIES TYPE Sensor TIMESTAMP ts TAGS (sensor STRING) FIELDS (value DOUBLE) \
+        SHARDS 1 COMPACTION_INTERVAL 1 HOURS""");
+
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType("Sensor")).getEngine();
+
+    appendBatch(engine, SEALED_SAMPLES, 0, 0L, SEALED_INTERVAL_MS);
+
+    engine.compactAll();
+
+    // Sanity: the sealed store must be non-empty, otherwise the buggy sizing path is not reached.
+    long sealedBlocks = 0;
+    for (int s = 0; s < engine.getShardCount(); s++)
+      sealedBlocks += engine.getShard(s).getSealedStore().getBlockCount();
+    assertThat(sealedBlocks).as("compaction must have sealed at least one block").isPositive();
+
+    // Tail appended AFTER compaction: it lives only in the mutable bucket.
+    appendBatch(engine, TAIL_SAMPLES, SEALED_SAMPLES, TAIL_START_MS, TAIL_INTERVAL_MS);
+
+    return engine;
+  }
+
+  private void appendBatch(final TimeSeriesEngine engine, final int count, final int valueOffset,
+      final long startTs, final long intervalMs) throws Exception {
+    final long[] timestamps = new long[count];
+    final Object[] sensors = new Object[count];
+    final Object[] values = new Object[count];
+    for (int i = 0; i < count; i++) {
+      timestamps[i] = startTs + i * intervalMs;
+      sensors[i] = "s1";
+      values[i] = (double) (valueOffset + i + 1);
+    }
+
+    database.begin();
+    engine.appendSamples(timestamps, sensors, values);
+    database.commit();
+  }
+
+  private double expectedTotalSum() {
+    final long n = SEALED_SAMPLES + TAIL_SAMPLES;
+    return n * (n + 1) / 2.0;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMutableTailAggregationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMutableTailAggregationTest.java
@@ -116,6 +116,23 @@ class TimeSeriesMutableTailAggregationTest {
     assertThat(flat.getBucketTimestamps()).isSorted();
   }
 
+  /**
+   * The overflow count is reported through {@link AggregationMetrics} so a future sizing regression is
+   * observable in a profile instead of only in this test class.
+   */
+  @Test
+  void aggregationMetricsReportTheOverflowBucketCount() throws Exception {
+    final TimeSeriesEngine engine = createSealedPlusMutableTail();
+
+    final AggregationMetrics metrics = new AggregationMetrics();
+    engine.aggregateMulti(Long.MIN_VALUE, Long.MAX_VALUE,
+        List.of(new MultiColumnAggregationRequest(-1, AggregationType.COUNT, "cnt")),
+        MINUTE_MS, null, metrics);
+
+    assertThat(metrics.getOverflowBuckets()).isZero();
+    assertThat(metrics.toString()).contains("overflow=0");
+  }
+
   @Test
   void bucketedAggregationMatchesTheUnbucketedTotal() throws Exception {
     final TimeSeriesEngine engine = createSealedPlusMutableTail();


### PR DESCRIPTION
Closes #6937

## Summary

Bucketed `aggregateMulti()` sized its flat bucket array by scanning **only** the sealed stores of each shard, so `actualMax` could never exceed the sealed maximum and `maxBuckets` came out as "the bucket holding the sealed max, plus one spare". The mutable bucket - everything appended since the last compaction, whose span is unbounded because compaction is driven by the maintenance scheduler rather than by sample timestamps - is iterated afterwards, and every row past the array resolved to `flatIndex() == -1`, `ensureFlatBucket(-1) == false`, and an early `return` that accumulated nothing. No error, no log, no metric: the samples simply were not in the answer.

This lands two changes:

1. **The fix** (`TimeSeriesEngine.aggregateMulti`): the range scan now folds each shard's mutable bucket `getMinTimestamp()`/`getMaxTimestamp()` into `actualMin`/`actualMax` alongside the sealed globals. Those accessors return `Long.MAX_VALUE`/`Long.MIN_VALUE` as their empty markers, so an empty mutable bucket widens nothing and the all-sealed and fresh-database shapes are unchanged. The query-range clamp is untouched.

2. **The safety net** (`MultiColumnAggregationResult`): the flat window is only ever as good as the caller's range estimate, so a bucket that lands outside it is now parked in a lazily allocated overflow map instead of being discarded. `accumulate`, `accumulateRow`, `accumulateBlockStats`, `accumulateSingleStat` and `accumulateStatInPlaceByTs` route there on an out-of-range index; `getValue`, `getCount`, `size`, `finalizeAvg`, `mergeFrom` and `getBucketTimestamps` read it back (the last one re-sorts, since overflow buckets can sit on either side of the window). Nothing is allocated when the window is sized correctly, which after change 1 is the normal case - a dropped sample should never be the quiet outcome.

Verified on `d91b06e1f6`: with 50,000 sealed samples plus a 600-sample / 10-minute mutable tail and a 1-minute bucket interval, the aggregation returned 50,100 of 50,600 samples - exactly the 100 that fit the two spare buckets, with the remaining 500 gone. Map mode (`bucketIntervalMs = 0`) returned the full total, matching the report.

Reachable from every `aggregateMulti` caller: SQL push-down (`AggregateFromTimeSeriesStep`), Cypher (`GroupByAggregationStep`), `POST /api/v1/timeseries/query`, and the Grafana handler.

### Arming the tests

Each half is independently armed, because either one alone makes the totals correct:

| | with both | sizing fix reverted | both reverted |
|---|---|---|---|
| total sample count | correct | correct (overflow map catches it) | **500 samples missing** |
| `getOverflowBucketCount()` | 0 | **9** | 0 (nothing to overflow into) |

So the totals assertions catch a regression of the safety net, and the `getOverflowBucketCount() == 0` assertions catch a regression of the sizing. Both were observed failing against the reverted code, not assumed.

## Test plan

New `engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMutableTailAggregationTest.java`:

- [x] `bucketedAggregationKeepsMutableSamplesPastTheSealedMaximum` - 50k sealed samples, `compactAll()`, then a 600-sample 10-minute mutable tail; 1-minute buckets. Asserts COUNT/SUM/MIN/MAX over every returned bucket, that the last tail bucket is present, that the buckets come back sorted, and that nothing had to overflow. Fails on `main` with `expected 50600 but was 50100`.
- [x] `bucketedAggregationMatchesTheUnbucketedTotal` - cross-checks flat mode against map mode (`bucketIntervalMs = 0`, the path that never had the bug) and against `engine.countSamples()`.
- [x] `shardedBucketedAggregationKeepsMutableSamplesPastTheSealedMaximum` - same shape on `SHARDS 4`, which takes the parallel branch where per-shard results are built independently and merged, so the tail has to survive `mergeFrom` too.
- [x] `flatModeResultDoesNotDiscardBucketsPastTheAllocatedRange` - direct unit test of the overflow path: a deliberately 2-bucket window fed rows before the start and past the end, asserting ordering, `size()`, values and counts.
- [x] Sanity guard in the fixture asserts the sealed store is non-empty, so the test cannot silently stop reaching the buggy path.

Regression runs (`-Dmaven.repo.local` isolated, `-DexcludedGroups=benchmark,slow,vector`):

- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.engine.timeseries.**'` - 546 tests, 0 failures
- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.query.sql.executor.**,com.arcadedb.query.opencypher.**'` - 0 failures
- [x] `Issue6824TimeBucketPreEpochTest`, `PerTypeAclIndexAndTimeSeriesTest`, `GraphAnalyticalViewTest` - 170 tests, 0 failures

Not run: the `server` timeseries ITs (`TimeSeriesQueryHandlerIT`, `GrafanaTimeSeriesHandlerIT`, `PromQLHttpHandlerIT`, ...). Port 2480 is held by a long-running local ArcadeDB instance on this machine, so those bind-fixed-port suites fail as authentication errors rather than as anything to do with this change. CI covers them.

---

## Review follow-ups applied

Four review cycles ran; the fifth review came back with nothing blocking. Everything actionable was applied:

- **Cycle 1** - documented at the call site *why* the flat-window sizing scan deliberately runs outside the per-shard compaction read locks (it only decides the window width; the overflow map absorbs any race, and taking the locks there would just add contention). Without the note, a future refactor reads it as a bug and "fixes" it by widening the lock scope.
- **Cycle 2** - added `TimeSeriesBucket.getMinMaxTimestamps()`, which answers both bounds from a **single** `readHeaderPage()`: one page lookup per shard instead of two, and the pair is a consistent snapshot rather than two independently-timed reads. Also tightened the `mergeFrom` comment: both sides share `firstBucketTs`/`bucketIntervalMs`/`maxBuckets` (asserted at the top of the method), so a bucket that overflowed in `other` *always* re-overflows here rather than sometimes landing in the flat window. New test method in `Issue6283BucketHeaderAccessorsTest` cross-checks the combined accessor against the two single-value readers across all three bucket states (no header page, empty header, populated) and across a commit.
- **Cycle 3** - `finalizeAvg()` and the untouched-MIN/MAX-to-NaN check both grew overflow-specific branches that only SUM/COUNT were driving. Added `flatModeOverflowFinalizesAvgAndMinMaxLikeTheFlatArray` (AVG denominator, MIN/MAX values, and NaN for a MIN/MAX request that never saw a sample, all through the overflow map) and `mergeFromCarriesOverflowBucketsAcross`.
- **Cycle 4** - threaded the overflow count into `AggregationMetrics` (`addOverflowBuckets`/`getOverflowBuckets`, plus `overflow=N` in `toString()`). The failure mode this PR fixes was silent precisely because there was no error, no log and no metric; if the sizing estimate ever comes up short again the overflow map keeps the answer correct, and now a profile says so.

**Not applied (non-blocking, explicitly optional in review):** backing the overflow maps with a `TreeMap` to avoid the `Collections.sort()` in `getBucketTimestamps()`. Overflow is the exceptional path after the sizing fix - the `getOverflowBucketCount() == 0` assertions and the new metric exist to keep it that way - so a `HashMap` plus a one-off sort is the cheaper trade for the common case, where neither is allocated at all.

### Extra regression runs after the follow-ups

- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.engine.timeseries.**'` - 550 tests, 0 failures
- [x] `mvn -o -pl engine,server -am -DskipTests install` - clean (`AggregationMetrics` is read by the HTTP timeseries and Grafana handlers)
