### PR TITLE
fix(#6933): size the sealed-slice budget per session and cut slices on demand

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -666,7 +666,7 @@ public class TimeSeriesEngine implements AutoCloseable {
    * ALREADY rewritten, which would leave the followers on an image no node has any more - divergence, in place of
    * a burst of entries. A store that is over the ceiling when it gets here arrived that way (a database that was
    * standalone when it sealed, then joined a cluster), and the honest handling is the one
-   * {@code RaftReplicatedDatabase.sliceSealedBlob} applies: ship it, and report the oversized slice count.
+   * {@code RaftReplicatedDatabase.planSealedSlices} applies: ship it, and report the oversized slice count.
    */
   private void runSealedMaintenanceReplicated(final SealedMaintenance work) throws IOException {
     final DatabaseInternal db = database.getWrappedDatabaseInstance();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -542,7 +542,7 @@ public class TimeSeriesShard implements AutoCloseable {
           // Raft entry", which made HA_TS_MAX_SEALED_INLINE_SIZE the ceiling on the sealed store itself: a
           // shard that once crossed it never sealed again, because the store it would have to ship only ever
           // grows. A sealed store above one entry is now SLICED across an ordered sequence of entries
-          // (RaftReplicatedDatabase.sliceSealedBlob), so the ceiling is what that sequence can carry - see
+          // (RaftReplicatedDatabase.planSealedSlices), so the ceiling is what that sequence can carry - see
           // GlobalConfiguration.maxReplicatedSealedStoreSize, which still folds in the #4743 rule that the
           // real per-entry ceiling is min(grpcMessageSizeMax, appendBufferSize) and NOT the configured cap
           // alone: shipping an entry above it makes Ratis reject it and the leader step down, over and over.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2336,8 +2336,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       return plans;
     }
 
-    // Every store beyond the first also pays for its own slice framing - the budget reserves for exactly one.
-    long extraFraming = 0;
+    // Every store beyond the first pays for its own slice framing outright; the FIRST one pays only for whatever
+    // it costs ABOVE the flat reserve already held back inside publishingSealedCapacity. Charging it in full would
+    // reserve twice for the same slice and shrink the tail of every single-shard cluster for nothing, and not
+    // charging it at all would leave the flat reserve as the last unmeasured assumption here - a type name of a
+    // few thousand characters really does outgrow it, and nothing caps type-name length.
+    long extraFraming = Math.max(0L,
+        sealedSliceFraming(blobs.getFirst()) - GlobalConfiguration.REPLICATED_SEALED_CHUNK_FRAMING_BYTES);
     for (int i = 1; i < blobs.size(); i++)
       extraFraming += sealedSliceFraming(blobs.get(i));
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -75,6 +75,7 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.network.binary.ReplicatedEntryTooLargeException;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.query.QueryEngine;
 import com.arcadedb.query.opencypher.optimizer.statistics.GraphStatisticsCache;
@@ -2186,35 +2187,212 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   /**
-   * Cuts a sealed-store image into the ordered slices that will carry it (issue #4416), or returns EMPTY when it
-   * fits one entry and must ship inline as a {@link RaftLogEntryCodec.TsSealedBlob} exactly as before.
+   * How ONE sealed store will be shipped: metadata only, no bytes (issues #4416, #6933).
+   * <p>
+   * The slices are described here and CUT ON DEMAND by {@link #slice}, because materializing them all up front
+   * doubled leader heap for the whole shipping loop - the source image stays strongly reachable throughout, so a
+   * 600MB sealed store cost 1.2GB, and #6917 raised the per-shard ceiling from one 32MB entry to the
+   * {@code Integer.MAX_VALUE} clamp in {@link GlobalConfiguration#maxReplicatedSealedStoreSize}. Cutting one
+   * slice at a time bounds the extra copy by one slice.
+   * <p>
+   * A plan has a BODY of up to {@code count - 1} slices of {@code bodySliceSize} bytes and a final slice of
+   * {@code tailSize} bytes. The two sizes differ because they are spent in different places: every body slice
+   * gets a delivery-only entry to itself, so it may use the whole per-entry budget, while every store's final
+   * slice has to share ONE publishing entry with every other store of the same maintenance session (#6933).
+   *
+   * @param count         how many slices carry the store; {@code 0} when it ships whole as a
+   *                      {@link RaftLogEntryCodec.TsSealedBlob}
+   * @param bodySliceSize how many bytes each slice but the last carries
+   * @param tailSize      how many bytes the final - publishing - slice carries
+   * @param fileCrc       CRC32 of the whole image, carried on every slice so the follower validates what it
+   *                      reassembled against the leader's own copy
+   * @param fileLength    the whole image's length
+   */
+  // @VisibleForTesting
+  record SealedSlicePlan(int count, int bodySliceSize, int tailSize, long fileCrc, int fileLength) {
+
+    /** Whether the store needs slicing at all, or ships whole exactly as it did before #4416. */
+    boolean sliced() {
+      return count > 0;
+    }
+
+    /**
+     * Cuts slice {@code index} out of {@code blob}. The returned chunk is the ONLY copy this plan makes, and it
+     * is the caller's to drop as soon as it has been shipped.
+     */
+    RaftLogEntryCodec.TsSealedChunk slice(final RaftLogEntryCodec.TsSealedBlob blob, final int index) {
+      final boolean last = index == count - 1;
+      final int bodyLength = fileLength - tailSize;
+      final int from = last ? bodyLength : (int) Math.min(bodyLength, (long) index * bodySliceSize);
+      final int to = last ? fileLength : (int) Math.min(bodyLength, (long) from + bodySliceSize);
+      return new RaftLogEntryCodec.TsSealedChunk(blob.typeName(), blob.shardIndex(), blob.fileName(), fileLength,
+          fileCrc, from, Arrays.copyOfRange(blob.bytes(), from, to), last);
+    }
+  }
+
+  /** The plan of a store that ships whole. */
+  private static final SealedSlicePlan NOT_SLICED = new SealedSlicePlan(0, 0, 0, 0L, 0);
+
+  /**
+   * Fixed bytes the codec writes per sealed slice besides its payload: the type and file names, six numbers and a
+   * flag (issue #6933). {@link GlobalConfiguration#REPLICATED_SEALED_CHUNK_FRAMING_BYTES} already reserves for
+   * ONE slice, generously; this is what each ADDITIONAL slice sharing the publishing entry costs.
+   */
+  private static final int SEALED_SLICE_FRAMING_BYTES = 256;
+
+  /**
+   * What the publishing entry spends on everything that is NOT sealed payload, measured by encoding it (issue
+   * #6933). Both file maps are measured even though {@code splitSchemaEntry} may move {@code filesToAdd} to the
+   * FIRST chunk of a split: overstating the header can only make the sealed payload smaller, understating it puts
+   * the entry over the cap.
+   */
+  private static int publishingHeaderSize(final String databaseName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove) {
+    return RaftLogEntryCodec.encodeSchemaEntry(databaseName, schemaJson, filesToAdd, filesToRemove,
+        Collections.emptyList(), Collections.emptyList(), Collections.emptyList()).size();
+  }
+
+  /**
+   * How many raw sealed bytes the PUBLISHING entry may carry in total (issue #6933) - all the whole blobs plus
+   * every sliced store's final slice.
+   * <p>
+   * Two different bounds meet here and both have to hold. {@code sealedEntryBudget} is the POLICY one,
+   * {@code arcadedb.ha.tsMaxSealedInlineSize} less its framing and compression reserve, and it says nothing about
+   * a schema JSON riding beside the payload because a delivery-only entry carries none. The transport one does:
+   * the publishing entry also carries the schema JSON and the file maps, and it is the WHOLE entry that must stay
+   * under the cap. Subtracting the header from the policy budget instead would be wrong in the direction that
+   * matters - with a deliberately small inline cap the header is larger than the whole budget, and a shard that
+   * used to seal would stop sealing.
+   *
+   * @param sealedEntryBudget    {@link GlobalConfiguration#replicatedSealedChunkBudget}; {@code <= 0} means
+   *                             slicing is off entirely
+   * @param entryCap             the transport's maximum replicated entry size
+   * @param publishingHeaderSize what {@link #publishingHeaderSize} measured for this session
+   */
+  // @VisibleForTesting
+  static long publishingSealedCapacity(final long sealedEntryBudget, final long entryCap,
+      final int publishingHeaderSize) {
+    if (sealedEntryBudget <= 0)
+      return 0;
+    final long transportRoom = entryCap - publishingHeaderSize
+        - GlobalConfiguration.REPLICATED_SEALED_CHUNK_FRAMING_BYTES - entryCap / 128;
+    return Math.min(sealedEntryBudget, transportRoom);
+  }
+
+  /**
+   * Plans how EVERY sealed store of one compaction/maintenance session is shipped (issue #6933), before a single
+   * entry is committed.
+   * <p>
+   * WHY THIS IS A SESSION-WIDE DECISION AND NOT A PER-STORE ONE. {@code TimeSeriesEngine.runSealedMaintenanceReplicated}
+   * runs retention and downsampling for every shard of a type inside ONE
+   * {@link #runWithCompactionReplication(Callable)} session, so {@code recordedSealed} routinely holds several
+   * stores. Everything that PUBLISHES rides one entry: the whole blobs, and the final slice of every sliced
+   * store. Sizing each store's final slice against the whole per-entry budget - which is what #6917 did - asks
+   * that one entry to carry N budgets, and {@code RaftTransactionBroker.splitSchemaEntry} cannot split it,
+   * because what blows the cap is the header rather than the WAL: it computes {@code walBudget <= 0} and throws.
+   * By then {@code replicateSealedChunk} has already committed every earlier slice of every store to the Raft
+   * log, leaving the followers staging sealed stores they will never install while the leader has swapped its own
+   * and cleared its mutable buckets.
+   * <p>
+   * So the publishing entry's sealed capacity is divided evenly among the stores: a store no larger than its
+   * share ships whole, a larger one is sliced with a final slice capped at that share. The body slices keep the
+   * full per-entry budget, because each of them travels alone. The resulting publishing payload is at most
+   * {@code stores x share}, which is the capacity itself - it fits by construction, at any shard count.
+   *
+   * @param sealedEntryBudget  raw sealed bytes one DELIVERY-ONLY entry may carry, from
+   *                           {@link GlobalConfiguration#replicatedSealedChunkBudget}; {@code <= 0} means a cap
+   *                           too small to slice at all, where every store keeps shipping whole exactly as it did
+   *                           before #4416 and {@code TimeSeriesShard}'s own guard is what bounds it
+   * @param publishingCapacity raw sealed bytes the PUBLISHING entry may carry in total, from
+   *                           {@link #publishingSealedCapacity}
+   *
+   * @throws ReplicatedEntryTooLargeException when the publishing entry cannot carry even one slice per store.
+   *                                          Thrown HERE, where nothing has been shipped yet, rather than from
+   *                                          the splitter after the delivery-only slices are already committed.
+   */
+  // @VisibleForTesting
+  static List<SealedSlicePlan> planSealedShipping(final List<RaftLogEntryCodec.TsSealedBlob> blobs,
+      final long sealedEntryBudget, final long publishingCapacity, final String databaseName) {
+    final List<SealedSlicePlan> plans = new ArrayList<>(blobs.size());
+    if (blobs.isEmpty())
+      return plans;
+
+    if (sealedEntryBudget <= 0) {
+      // A cap too small to hold even one slice's framing. Slicing is impossible, so this is the pre-#4416 world:
+      // ship whole and let TimeSeriesShard's guard keep the stores under one entry.
+      for (int i = 0; i < blobs.size(); i++)
+        plans.add(NOT_SLICED);
+      return plans;
+    }
+
+    // Every store beyond the first also pays for its own slice framing - the budget reserves for exactly one.
+    final long share = (publishingCapacity - (long) SEALED_SLICE_FRAMING_BYTES * (blobs.size() - 1)) / blobs.size();
+    if (share <= 0)
+      throw new ReplicatedEntryTooLargeException(String.format(
+          """
+          Schema change for database '%s' publishes %d TimeSeries sealed store(s) but only %d bytes of one Raft \
+          entry are left for them once the schema JSON and the file maps are on it. Raise \
+          arcadedb.ha.appendBufferSize - and with it arcadedb.ha.writeBufferSize, which must stay >= \
+          appendBufferSize + 8 bytes.""",
+          databaseName, blobs.size(), Math.max(0L, publishingCapacity)));
+
+    for (final RaftLogEntryCodec.TsSealedBlob blob : blobs)
+      plans.add(planSealedSlices(blob, sealedEntryBudget, share, databaseName));
+    return plans;
+  }
+
+  /**
+   * Plans the slices of ONE sealed-store image (issue #4416), or returns a plan that is not
+   * {@link SealedSlicePlan#sliced()} when it fits its share of the publishing entry and must ship inline as a
+   * {@link RaftLogEntryCodec.TsSealedBlob} exactly as before.
    * <p>
    * Static and side-effect-free so the arithmetic that a follower's reassembly depends on - contiguous offsets, a
    * whole-file CRC every slice agrees on, exactly one slice flagged {@code last} - can be pinned without a cluster.
    * <p>
-   * Slices are cut against {@code budget} rather than against the entry cap directly: the codec compresses each
-   * one, so a slice that fits uncompressed always fits encoded, and the framing the budget already subtracts
-   * covers the rest. A store needing more than {@code MAX_REPLICATED_SEALED_CHUNKS} slices is still shipped -
-   * refusing here would leave the follower holding a stale sealed file the leader has already replaced, which is
+   * Slices are cut against the budgets rather than against the entry cap directly: the codec compresses each one,
+   * so a slice that fits uncompressed always fits encoded, and the framing the budget already subtracts covers
+   * the rest. A store needing more than {@code MAX_REPLICATED_SEALED_CHUNKS} slices is still shipped - refusing
+   * here would leave the follower holding a stale sealed file the leader has already replaced, which is
    * divergence - but it is reported, because the shard guard in {@code TimeSeriesShard.compactInternal} is
    * supposed to have kept it from ever getting this far and the maintenance path (retention, downsampling) has no
    * such guard.
+   * <p>
+   * When the tail fits without shrinking anything the slicing is UNIFORM, byte for byte what #4416 shipped: that
+   * is the single-store case, which is every cluster whose types have one shard.
    *
-   * @param budget how many raw bytes of sealed content one entry may carry; {@code <= 0} disables slicing
+   * @param bodyBudget how many raw bytes of sealed content one delivery-only entry may carry; {@code <= 0}
+   *                   disables slicing
+   * @param tailBudget how many of those this store may spend on the shared publishing entry; {@code <= 0}
+   *                   disables slicing
    */
   // @VisibleForTesting
-  static List<RaftLogEntryCodec.TsSealedChunk> sliceSealedBlob(final RaftLogEntryCodec.TsSealedBlob blob,
-      final long budget, final String databaseName) {
+  static SealedSlicePlan planSealedSlices(final RaftLogEntryCodec.TsSealedBlob blob, final long bodyBudget,
+      final long tailBudget, final String databaseName) {
     final byte[] bytes = blob.bytes() != null ? blob.bytes() : new byte[0];
-    if (budget <= 0 || bytes.length <= budget)
-      return Collections.emptyList();
+    if (bodyBudget <= 0 || tailBudget <= 0 || bytes.length <= tailBudget)
+      return NOT_SLICED;
 
     final CRC32 crc = new CRC32();
     crc.update(bytes);
-    final long fileCrc = crc.getValue();
 
-    final int sliceSize = (int) Math.min(budget, Integer.MAX_VALUE);
-    final int count = (int) (((long) bytes.length + sliceSize - 1) / sliceSize);
+    final int length = bytes.length;
+    final int bodySliceSize = (int) Math.min(bodyBudget, Integer.MAX_VALUE);
+
+    // The uniform shape first, because it is the one #4416 pinned and the one a single-shard type always gets.
+    final int uniformCount = (int) (((long) length + bodySliceSize - 1) / bodySliceSize);
+    final long uniformTail = length - (long) (uniformCount - 1) * bodySliceSize;
+
+    final int count;
+    final int tailSize;
+    if (uniformTail <= tailBudget) {
+      count = uniformCount;
+      tailSize = (int) uniformTail;
+    } else {
+      // The tail would not fit this store's share of the publishing entry: cap it, and let the body absorb the
+      // difference. The body is at least one byte long here, because length > tailBudget >= tailSize.
+      tailSize = (int) Math.min(tailBudget, Integer.MAX_VALUE);
+      count = (int) (((long) length - tailSize + bodySliceSize - 1) / bodySliceSize) + 1;
+    }
 
     if (count > GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS)
       LogManager.instance().log(RaftReplicatedDatabase.class, Level.WARNING,
@@ -2223,16 +2401,29 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           above the %d one compaction is expected to produce. Shipping it anyway - withholding it would leave the \
           other nodes on a sealed store this one has already replaced - but raise arcadedb.ha.appendBufferSize, or \
           shorten the retention on this type, before the burst starts costing write latency.""",
-          null, blob.fileName(), databaseName, bytes.length, count, sliceSize,
+          null, blob.fileName(), databaseName, length, count, bodySliceSize,
           GlobalConfiguration.MAX_REPLICATED_SEALED_CHUNKS);
 
-    final List<RaftLogEntryCodec.TsSealedChunk> slices = new ArrayList<>(count);
-    for (int i = 0; i < count; i++) {
-      final int from = (int) ((long) i * sliceSize);
-      final int to = (int) Math.min(bytes.length, (long) from + sliceSize);
-      slices.add(new RaftLogEntryCodec.TsSealedChunk(blob.typeName(), blob.shardIndex(), blob.fileName(),
-          bytes.length, fileCrc, from, Arrays.copyOfRange(bytes, from, to), i == count - 1));
-    }
+    return new SealedSlicePlan(count, bodySliceSize, tailSize, crc.getValue(), length);
+  }
+
+  /**
+   * The eager form of {@link #planSealedSlices}, for the single-store case where the whole entry budget is this
+   * store's to spend. Kept because the #4416 tests pin the arithmetic through it; the shipping path uses the plan
+   * directly so it never holds more than one slice at a time.
+   *
+   * @param budget how many raw bytes of sealed content one entry may carry; {@code <= 0} disables slicing
+   */
+  // @VisibleForTesting
+  static List<RaftLogEntryCodec.TsSealedChunk> sliceSealedBlob(final RaftLogEntryCodec.TsSealedBlob blob,
+      final long budget, final String databaseName) {
+    final SealedSlicePlan plan = planSealedSlices(blob, budget, budget, databaseName);
+    if (!plan.sliced())
+      return Collections.emptyList();
+
+    final List<RaftLogEntryCodec.TsSealedChunk> slices = new ArrayList<>(plan.count());
+    for (int i = 0; i < plan.count(); i++)
+      slices.add(plan.slice(blob, i));
     return slices;
   }
 
@@ -2350,6 +2541,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         appendFilePagesAsWal(grown.getKey(), walChunkBudget, walEntries, bucketDeltas, grown.getValue());
 
       final List<RaftLogEntryCodec.TsSealedBlob> recordedSealed = new ArrayList<>(compactionSealedBuffer.get());
+      // Released here rather than only in the finally (#6933): the shipping loop below drops each sliced store's
+      // image as it goes, and a second list still holding it would make that release do nothing. Nothing can add
+      // to the buffer any more - the compaction callback has returned.
+      compactionSealedBuffer.get().clear();
 
       if (addFiles.isEmpty() && removeFiles.isEmpty() && walEntries.isEmpty() && recordedSealed.isEmpty())
         return result;
@@ -2370,27 +2565,42 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // escalates to a snapshot resync, and a follower's part-written staging file is truncated by the first
       // slice of the next sequence. Deliberately not retried here - a retry would re-ship a sealed image the next
       // compaction is about to rewrite anyway.
+      // #6933: the whole session is planned BEFORE anything ships, because the publishing entry has to carry the
+      // final slice of EVERY sliced store plus every whole blob, and a plan that cannot fit has to be refused
+      // here rather than by the splitter after the delivery-only slices are already in the Raft log. The schema
+      // JSON is serialized early for the same reason - its encoded size is part of what the sealed payload has
+      // to leave room for.
+      final String serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
       final long sealedChunkBudget = GlobalConfiguration.replicatedSealedChunkBudget(proxied.getConfiguration());
+      final List<SealedSlicePlan> sealedPlans = planSealedShipping(recordedSealed, sealedChunkBudget,
+          publishingSealedCapacity(sealedChunkBudget, broker.maxEntrySize(),
+              publishingHeaderSize(getName(), serializedSchema, addFiles, removeFiles)), getName());
+
       final List<RaftLogEntryCodec.TsSealedBlob> sealedBlobs = new ArrayList<>(recordedSealed.size());
       final List<RaftLogEntryCodec.TsSealedChunk> finalSealedChunks = new ArrayList<>();
       int sealedSlicesShipped = 0;
-      for (final RaftLogEntryCodec.TsSealedBlob blob : recordedSealed) {
-        final List<RaftLogEntryCodec.TsSealedChunk> slices = sliceSealedBlob(blob, sealedChunkBudget, getName());
-        if (slices.isEmpty()) {
+      for (int store = 0; store < recordedSealed.size(); store++) {
+        final RaftLogEntryCodec.TsSealedBlob blob = recordedSealed.get(store);
+        final SealedSlicePlan plan = sealedPlans.get(store);
+        if (!plan.sliced()) {
           sealedBlobs.add(blob);
           continue;
         }
-        for (int i = 0; i < slices.size() - 1; i++)
-          broker.replicateSealedChunk(getName(), slices.get(i));
-        finalSealedChunks.add(slices.getLast());
-        sealedSlicesShipped += slices.size();
+        // One slice materialized at a time (#6933): the source image is already one whole-file array on this
+        // thread, and cutting the sequence up front made it two.
+        for (int i = 0; i < plan.count() - 1; i++)
+          broker.replicateSealedChunk(getName(), plan.slice(blob, i));
+        finalSealedChunks.add(plan.slice(blob, plan.count() - 1));
+        sealedSlicesShipped += plan.count();
+        // Nothing needs this store's image any more - only its final slice publishes - so let an N-shard session
+        // stop holding N whole-file arrays at once.
+        recordedSealed.set(store, null);
         // Per-STORE, not per-session: the burst that costs latency is one store's sequence of round trips, and
         // summing across stores would hide a single pathological shard behind a busy-but-healthy cycle.
-        sealedChunksMaxSequence.accumulateAndGet(slices.size(), Math::max);
+        sealedChunksMaxSequence.accumulateAndGet(plan.count(), Math::max);
       }
       sealedChunksShipped.addAndGet(sealedSlicesShipped);
 
-      final String serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
       broker.replicateSchema(getName(), serializedSchema, addFiles, removeFiles, walEntries, bucketDeltas,
           sealedBlobs, finalSealedChunks);
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2178,7 +2178,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * The cumulative {@link #getSealedStoreChunksShipped()} cannot answer the question an operator actually has,
    * which is whether a SINGLE store is producing a burst: a thousand slices reads the same there whether it was
    * one pathological store or a thousand healthy one-slice ones. This is the burst gauge. Anything at or above
-   * {@link GlobalConfiguration#MAX_REPLICATED_SEALED_CHUNKS} means the WARNING in {@link #sliceSealedBlob} fired
+   * {@link GlobalConfiguration#MAX_REPLICATED_SEALED_CHUNKS} means the WARNING in {@link #planSealedSlices} fired
    * and the leader is holding a FileManager recording session open across that many sequential quorum round
    * trips, which shows up as leader commit latency (see that constant's javadoc for exactly what it blocks).
    */
@@ -2362,7 +2362,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           entry are left for them once the schema JSON and the file maps are on it, %d each after their framing. \
           Raise arcadedb.ha.appendBufferSize - and with it arcadedb.ha.writeBufferSize, which must stay >= \
           appendBufferSize + 8 bytes.""",
-          databaseName, blobs.size(), Math.max(0L, publishingCapacity), share));
+          databaseName, blobs.size(), Math.max(0L, publishingCapacity), Math.max(0L, share)));
 
     for (final RaftLogEntryCodec.TsSealedBlob blob : blobs)
       plans.add(planSealedSlices(blob, sealedEntryBudget, share, databaseName));

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2310,6 +2310,14 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * full per-entry budget, because each of them travels alone. The resulting publishing payload is at most
    * {@code stores x share}, which is the capacity itself - it fits by construction, at any shard count.
    *
+   * WHY THE CAPACITY IS DIVIDED EVENLY AND NOT BY SIZE. A size-weighted allocation would fit a session that an
+   * even one refuses - one tiny store beside one huge one, on a cap tight enough that the huge one's even share is
+   * smaller than the tiny store already is. Even division is chosen anyway because the property that matters here
+   * is the one a reader can check in a line: no store contributes more than its share, so the total cannot exceed
+   * the capacity, at any shard count and in any order. A weighted split has to be re-derived every time the
+   * publishing entry's contents change, and it buys headroom only in a regime an operator reaches by lowering
+   * {@code arcadedb.ha.tsMaxSealedInlineSize} far below the cap - which the refusal message tells them to undo.
+   *
    * @param sealedEntryBudget  raw sealed bytes one DELIVERY-ONLY entry may carry, from
    *                           {@link GlobalConfiguration#replicatedSealedChunkBudget}; {@code <= 0} means a cap
    *                           too small to slice at all, where every store keeps shipping whole exactly as it did

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2234,11 +2234,22 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private static final SealedSlicePlan NOT_SLICED = new SealedSlicePlan(0, 0, 0, 0L, 0);
 
   /**
-   * Fixed bytes the codec writes per sealed slice besides its payload: the type and file names, six numbers and a
-   * flag (issue #6933). {@link GlobalConfiguration#REPLICATED_SEALED_CHUNK_FRAMING_BYTES} already reserves for
-   * ONE slice, generously; this is what each ADDITIONAL slice sharing the publishing entry costs.
+   * What the codec writes for one sealed slice besides its payload, MEASURED rather than guessed (issue #6933):
+   * the type and file names are variable-length, and a long type name lengthens the derived
+   * {@code .ts.sealed} name with it, so a flat constant is a bound that a sufficiently verbose schema walks past.
+   * <p>
+   * Encoding a whole empty entry rather than the slice section alone overstates it by the entry header, which is
+   * the safe direction: {@link GlobalConfiguration#REPLICATED_SEALED_CHUNK_FRAMING_BYTES} already reserves for
+   * ONE slice, so this is only charged for the stores BEYOND the first.
    */
-  private static final int SEALED_SLICE_FRAMING_BYTES = 256;
+  private static int sealedSliceFraming(final RaftLogEntryCodec.TsSealedBlob blob) {
+    final RaftLogEntryCodec.TsSealedChunk empty = new RaftLogEntryCodec.TsSealedChunk(blob.typeName(),
+        blob.shardIndex(), blob.fileName(), 0L, 0L, 0L, EMPTY_SLICE_PAYLOAD, true);
+    return RaftLogEntryCodec.encodeSchemaEntry("", "", Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, List.of(empty)).size();
+  }
+
+  private static final byte[] EMPTY_SLICE_PAYLOAD = new byte[0];
 
   /**
    * What the publishing entry spends on everything that is NOT sealed payload, measured by encoding it (issue
@@ -2326,15 +2337,19 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     }
 
     // Every store beyond the first also pays for its own slice framing - the budget reserves for exactly one.
-    final long share = (publishingCapacity - (long) SEALED_SLICE_FRAMING_BYTES * (blobs.size() - 1)) / blobs.size();
+    long extraFraming = 0;
+    for (int i = 1; i < blobs.size(); i++)
+      extraFraming += sealedSliceFraming(blobs.get(i));
+
+    final long share = (publishingCapacity - extraFraming) / blobs.size();
     if (share <= 0)
       throw new ReplicatedEntryTooLargeException(String.format(
           """
           Schema change for database '%s' publishes %d TimeSeries sealed store(s) but only %d bytes of one Raft \
-          entry are left for them once the schema JSON and the file maps are on it. Raise \
-          arcadedb.ha.appendBufferSize - and with it arcadedb.ha.writeBufferSize, which must stay >= \
+          entry are left for them once the schema JSON and the file maps are on it, %d each after their framing. \
+          Raise arcadedb.ha.appendBufferSize - and with it arcadedb.ha.writeBufferSize, which must stay >= \
           appendBufferSize + 8 bytes.""",
-          databaseName, blobs.size(), Math.max(0L, publishingCapacity)));
+          databaseName, blobs.size(), Math.max(0L, publishingCapacity), share));
 
     for (final RaftLogEntryCodec.TsSealedBlob blob : blobs)
       plans.add(planSealedSlices(blob, sealedEntryBudget, share, databaseName));
@@ -2357,8 +2372,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * supposed to have kept it from ever getting this far and the maintenance path (retention, downsampling) has no
    * such guard.
    * <p>
-   * When the tail fits without shrinking anything the slicing is UNIFORM, byte for byte what #4416 shipped: that
-   * is the single-store case, which is every cluster whose types have one shard.
+   * When the tail fits without shrinking anything the slicing is UNIFORM - the shape #4416 shipped. That is not
+   * quite "every single-shard cluster keeps its old byte layout": a lone store owns the whole publishing capacity,
+   * but the capacity itself is now the entry cap less the measured schema JSON and file maps, so a store whose
+   * uniform tail was within a schema JSON of the budget gets one more, smaller, final slice than it used to. That
+   * IS the thin-margin half of #6933, not a side effect of it.
    *
    * @param bodyBudget how many raw bytes of sealed content one delivery-only entry may carry; {@code <= 0}
    *                   disables slicing

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6933MultiStoreSealedApplyTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6933MultiStoreSealedApplyTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedBlob;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedChunk;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6933, follower side: a maintenance session that seals SEVERAL shards at once ships several sliced stores
+ * and publishes all their final slices in ONE entry.
+ * <p>
+ * Nothing covered that before - every existing assertion is on a single store, and
+ * {@code Issue4416SlicedSealedStoreTest} pins {@code sealedFileChunks()).hasSize(1)} throughout - yet the
+ * multi-store session is the normal shape of {@code TimeSeriesEngine.runSealedMaintenanceReplicated}, which runs
+ * retention and downsampling for every shard of a type inside one replication session. This drives the whole
+ * leader-to-follower path for two shards against real databases: plan, ship every delivery-only slice, then apply
+ * both publishing slices together, the way the publishing entry delivers them.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6933MultiStoreSealedApplyTest {
+
+  private static final String TYPE_NAME   = "Cpu";
+  private static final int    SHARDS      = 2;
+  private static final int    LEADER_ROWS = 20_000;
+  private static final int    LOCAL_ROWS  = 500;
+
+  /** Small enough that a 20,000-row store needs many slices, and it is the whole entry's worth. */
+  private static final long ENTRY_BUDGET = 4_096;
+
+  @TempDir
+  private Path          serverDir;
+  private LocalDatabase leader;
+  private LocalDatabase follower;
+  private String        followerPath;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    leader = (LocalDatabase) new DatabaseFactory(serverDir.resolve("db-leader").toString()).create();
+    build(leader, LEADER_ROWS, 0);
+
+    followerPath = serverDir.resolve("db-follower").toString();
+    follower = (LocalDatabase) new DatabaseFactory(followerPath).create();
+    build(follower, LOCAL_ROWS, 1_000_000);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (leader != null && leader.isOpen())
+      leader.close();
+    if (follower != null && follower.isOpen())
+      follower.close();
+  }
+
+  /**
+   * Two shards sealed in one session: every store is delivered in slices, nothing publishes until the last entry,
+   * and that one entry installs BOTH files.
+   */
+  @Test
+  void twoSlicedStoresPublishTogetherAndBothAreInstalled() throws Exception {
+    final List<TsSealedBlob> stores = leaderStores();
+    assertThat(stores).as("the fixture needs both shards holding sealed data").hasSize(SHARDS);
+
+    // What the leader plans for the session, with the publishing entry's capacity split between the two stores.
+    final List<RaftReplicatedDatabase.SealedSlicePlan> plans =
+        RaftReplicatedDatabase.planSealedShipping(stores, ENTRY_BUDGET, ENTRY_BUDGET, "db");
+    assertThat(plans).as("both stores must need slicing, or this test proves nothing")
+        .allSatisfy(plan -> assertThat(plan.sliced()).isTrue());
+
+    final ArcadeStateMachine stateMachine = new ArcadeStateMachine();
+    final long[] sealedBefore = { sealedSampleCountOf(follower, 0), sealedSampleCountOf(follower, 1) };
+
+    // The delivery-only entries: one slice each, in the order the leader ships them, store after store.
+    final List<TsSealedChunk> publishing = new ArrayList<>();
+    for (int store = 0; store < stores.size(); store++) {
+      final RaftReplicatedDatabase.SealedSlicePlan plan = plans.get(store);
+      for (int i = 0; i < plan.count() - 1; i++)
+        stateMachine.applySealedChunks(follower, List.of(plan.slice(stores.get(store), i)));
+      publishing.add(plan.slice(stores.get(store), plan.count() - 1));
+    }
+
+    for (int shard = 0; shard < SHARDS; shard++)
+      assertThat(sealedSampleCountOf(follower, shard))
+          .as("shard %d must not publish before the publishing entry lands", shard).isEqualTo(sealedBefore[shard]);
+
+    // The publishing entry, carrying every store's final slice at once - the shape #6933 is about.
+    stateMachine.applySealedChunks(follower, publishing);
+
+    for (int shard = 0; shard < SHARDS; shard++) {
+      assertThat(stagingFileOf(shard)).as("shard %d's staging file is consumed by the install", shard)
+          .doesNotExist();
+      assertThat(Files.readAllBytes(sealedFileOf(followerPath, shard).toPath()))
+          .as("shard %d must hold the leader's file, byte for byte", shard)
+          .isEqualTo(Files.readAllBytes(sealedFileOf(leader.getDatabasePath(), shard).toPath()));
+      assertThat(sealedSampleCountOf(follower, shard)).as("shard %d's sealed samples are now readable here", shard)
+          .isEqualTo(sealedSampleCountOf(leader, shard));
+    }
+  }
+
+  /**
+   * The publishing entry the plan builds must actually FIT one entry - the defect this issue is about is that it
+   * did not, and the throw landed after every delivery-only slice was already committed to the Raft log.
+   */
+  @Test
+  void thePublishingEntryTheSessionBuildsFitsOneEntry() {
+    final List<TsSealedBlob> stores = leaderStores();
+    final long cap = 64L * 1024;
+    final int header = RaftLogEntryCodec.encodeSchemaEntry("db", "{\"schema\":1}", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+        Collections.emptyList()).size();
+
+    final List<RaftReplicatedDatabase.SealedSlicePlan> plans = RaftReplicatedDatabase.planSealedShipping(stores,
+        ENTRY_BUDGET, RaftReplicatedDatabase.publishingSealedCapacity(ENTRY_BUDGET, cap, header), "db");
+
+    final List<TsSealedChunk> publishing = new ArrayList<>();
+    for (int store = 0; store < stores.size(); store++)
+      publishing.add(plans.get(store).slice(stores.get(store), plans.get(store).count() - 1));
+
+    assertThat(RaftLogEntryCodec.encodeSchemaEntry("db", "{\"schema\":1}", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+        Collections.emptyList(), false, publishing).size()).isLessThanOrEqualTo((int) cap);
+  }
+
+  // ---- Helpers ----
+
+  private List<TsSealedBlob> leaderStores() {
+    final List<TsSealedBlob> stores = new ArrayList<>(SHARDS);
+    for (int shard = 0; shard < SHARDS; shard++) {
+      final File sealed = sealedFileOf(leader.getDatabasePath(), shard);
+      assertThat(sealed).as("shard %d must have sealed something", shard).exists();
+      try {
+        stores.add(new TsSealedBlob(TYPE_NAME, shard, sealed.getName(), Files.readAllBytes(sealed.toPath())));
+      } catch (final IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    return stores;
+  }
+
+  private File stagingFileOf(final int shard) {
+    return new File(sealedFileOf(followerPath, shard).getPath() + ArcadeStateMachine.SEALED_STAGING_SUFFIX);
+  }
+
+  private static File sealedFileOf(final String databasePath, final int shard) {
+    return new File(databasePath, TYPE_NAME + "_shard_" + shard + ".ts.sealed");
+  }
+
+  private static long sealedSampleCountOf(final LocalDatabase database, final int shard) {
+    return ((LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME)).getEngine().getShard(shard)
+        .getSealedStore().getTotalSampleCount();
+  }
+
+  private static void build(final LocalDatabase database, final int rows, final int from) throws IOException {
+    database.command("sql", "CREATE TIMESERIES TYPE " + TYPE_NAME
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS " + SHARDS);
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType(TYPE_NAME)).getEngine();
+
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + (from + i) * 1_000L;
+      columns[0][i] = "host_" + ((from + i) % 7);
+      columns[1][i] = Math.sin(from + i) * 1_000;
+    }
+    engine.appendBatch(timestamps, columns);
+    engine.compactAll();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6933MultiStoreSealedShippingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6933MultiStoreSealedShippingTest.java
@@ -152,6 +152,25 @@ class Issue6933MultiStoreSealedShippingTest {
     assertThat(plans).allSatisfy(plan -> assertThat(plan.sliced()).isFalse());
   }
 
+  /**
+   * The framing a slice costs besides its payload is not a constant: the type name and the file name derived from
+   * it are both written on EVERY slice, and nothing caps a type name's length. A session of stores whose names run
+   * to the hundreds of bytes must still build a publishing entry that fits, which it only does because the margin
+   * is measured rather than assumed.
+   */
+  @Test
+  void storesWithVeryLongNamesStillFitOnePublishingEntry() {
+    final String longType = "t".repeat(400);
+    final List<TsSealedBlob> stores = new ArrayList<>();
+    // Enough shards that the names' bulk outgrows the single-slice reserve the budget already holds back: with a
+    // flat 256-byte allowance per extra store this entry comes out over the cap.
+    for (int shard = 0; shard < 16; shard++)
+      stores.add(new TsSealedBlob(longType, shard, longType + "_shard_" + shard + ".ts.sealed",
+          randomBytes((int) (SEALED_BUDGET * 2))));
+
+    assertThat(encodedPublishingEntrySize(stores)).isLessThanOrEqualTo(ENTRY_CAP);
+  }
+
   // ---- the geometry a follower reassembles from ------------------------------------------------------------
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6933MultiStoreSealedShippingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6933MultiStoreSealedShippingTest.java
@@ -171,6 +171,21 @@ class Issue6933MultiStoreSealedShippingTest {
     assertThat(encodedPublishingEntrySize(stores)).isLessThanOrEqualTo(ENTRY_CAP);
   }
 
+  /**
+   * The last unmeasured assumption, on the store the flat reserve is supposed to cover: a LONE store whose names
+   * cost more per slice than {@link GlobalConfiguration#REPLICATED_SEALED_CHUNK_FRAMING_BYTES} still has to build
+   * an entry that fits, so the first store is charged for whatever it costs above that reserve rather than
+   * exempted from measurement.
+   */
+  @Test
+  void aLoneStoreWhoseNamesOutgrowTheFlatReserveStillFitsOnePublishingEntry() {
+    final String hugeType = "t".repeat(6_000);
+    final TsSealedBlob store = new TsSealedBlob(hugeType, 0, hugeType + "_shard_0.ts.sealed",
+        randomBytes((int) (SEALED_BUDGET * 2)));
+
+    assertThat(encodedPublishingEntrySize(List.of(store))).isLessThanOrEqualTo(ENTRY_CAP);
+  }
+
   // ---- the geometry a follower reassembles from ------------------------------------------------------------
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6933MultiStoreSealedShippingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6933MultiStoreSealedShippingTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.network.binary.ReplicatedEntryTooLargeException;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedBlob;
+import com.arcadedb.server.ha.raft.RaftLogEntryCodec.TsSealedChunk;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6933: the sliced-sealed-store path added by #6917 sized every slice as if its store were the only sealed
+ * payload of the session, and then folded the FINAL slice of EVERY store into one publishing entry.
+ * <p>
+ * {@code TimeSeriesEngine.runSealedMaintenanceReplicated} runs retention and downsampling for every shard of a
+ * type inside ONE {@code runWithCompactionReplication} session, so N shards over the per-entry budget produce N
+ * final slices of up to a full budget each on a single entry - which {@code splitSchemaEntry} cannot split,
+ * because the payload that blows the cap is the header rather than the WAL. It throws, and it throws AFTER every
+ * earlier slice of every store has already been committed to the Raft log.
+ * <p>
+ * This class pins the leader-side arithmetic that makes the publishing entry fit by construction, without a
+ * cluster, because none of it needs one.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6933MultiStoreSealedShippingTest {
+
+  private static final String DB   = "graph";
+  private static final String TYPE = "weather";
+
+  /** The transport cap, and the sealed payload one entry may carry under it. */
+  private static final long ENTRY_CAP     = 64L * 1024;
+  private static final long SEALED_BUDGET =
+      ENTRY_CAP - GlobalConfiguration.REPLICATED_SEALED_CHUNK_FRAMING_BYTES - ENTRY_CAP / 128;
+
+  /** A schema JSON of a realistic size for a database with a handful of types. */
+  private static final String SCHEMA_JSON = "{\"schema\":\"" + "x".repeat(4_000) + "\"}";
+
+  // ---- the defect ------------------------------------------------------------------------------------------
+
+  /**
+   * The state of the world before the fix, kept as the proof that the guard below is guarding something: three
+   * stores sliced as if each owned the whole entry hand {@code splitSchemaEntry} three full-budget final slices,
+   * and the splitter refuses them - after the delivery-only slices have already been committed.
+   */
+  @Test
+  void threeFullBudgetFinalSlicesCannotShareOnePublishingEntry() {
+    final List<TsSealedChunk> finalSlices = new ArrayList<>();
+    for (int shard = 0; shard < 3; shard++)
+      finalSlices.add(RaftReplicatedDatabase.sliceSealedBlob(storeOf(shard, 3), SEALED_BUDGET, DB).getLast());
+
+    assertThatThrownBy(() -> RaftTransactionBroker.splitSchemaEntry(DB, SCHEMA_JSON, Collections.emptyMap(),
+        Collections.emptyMap(), List.of(new byte[512]), List.of(Map.of()), Collections.emptyList(), finalSlices,
+        ENTRY_CAP, Integer.MAX_VALUE, false))
+        .as("three slices of ~%d bytes each cannot ride one %d-byte entry", SEALED_BUDGET, ENTRY_CAP)
+        .isInstanceOf(ReplicatedEntryTooLargeException.class);
+  }
+
+  // ---- the session-wide plan -------------------------------------------------------------------------------
+
+  /**
+   * The fix, asserted where it matters: whatever the session's shape, everything that has to ride the PUBLISHING
+   * entry - the whole blobs plus every store's final slice - fits it, together with the schema JSON and the file
+   * maps that publish beside them.
+   */
+  @Test
+  void everyStoresFinalSliceTogetherFitsOnePublishingEntry() {
+    final List<TsSealedBlob> stores = List.of(storeOf(0, 3), storeOf(1, 5), storeOf(2, 1));
+
+    assertThat(encodedPublishingEntrySize(stores)).isLessThanOrEqualTo(ENTRY_CAP);
+  }
+
+  /** The same, with more shards than a slice can be usefully divided among on a small entry cap. */
+  @Test
+  void aSessionWithManyShardsStillFitsOnePublishingEntry() {
+    final List<TsSealedBlob> stores = new ArrayList<>();
+    for (int shard = 0; shard < 8; shard++)
+      stores.add(storeOf(shard, 2 + shard));
+
+    assertThat(encodedPublishingEntrySize(stores)).isLessThanOrEqualTo(ENTRY_CAP);
+  }
+
+  /**
+   * A store small enough to ride whole still does - it becomes a {@code TsSealedBlob}, not a one-slice sequence -
+   * and it is charged against the SAME publishing budget as the sliced stores beside it, which is what stops a
+   * mixed session overflowing where an all-sliced one does not.
+   */
+  @Test
+  void aStoreThatFitsItsShareStillRidesWholeAndIsChargedAgainstTheSameBudget() {
+    final TsSealedBlob small = new TsSealedBlob(TYPE, 0, fileNameOf(0), randomBytes(600));
+    final TsSealedBlob big = storeOf(1, 4);
+
+    final List<RaftReplicatedDatabase.SealedSlicePlan> plans = RaftReplicatedDatabase.planSealedShipping(
+        List.of(small, big), SEALED_BUDGET, publishingCapacity(), DB);
+
+    assertThat(plans.getFirst().sliced()).as("a 600-byte store needs no slicing").isFalse();
+    assertThat(plans.getLast().sliced()).isTrue();
+    assertThat(encodedPublishingEntrySize(List.of(small, big))).isLessThanOrEqualTo(ENTRY_CAP);
+  }
+
+  /**
+   * The publishing entry has to fit BEFORE the first delivery-only slice is committed to the Raft log, because
+   * nothing rolls those back: a leader that discovers the entry is unbuildable at the end has already left every
+   * follower staging a sealed store it will never install.
+   */
+  @Test
+  void aPublishingEntryThatCannotBeBuiltIsRefusedBeforeAnythingIsShipped() {
+    assertThatThrownBy(() -> RaftReplicatedDatabase.planSealedShipping(List.of(storeOf(0, 3), storeOf(1, 3)),
+        SEALED_BUDGET, RaftReplicatedDatabase.publishingSealedCapacity(SEALED_BUDGET, ENTRY_CAP, (int) ENTRY_CAP), DB))
+        .as("a header that eats the whole entry leaves nothing for the final slices")
+        .isInstanceOf(ReplicatedEntryTooLargeException.class);
+  }
+
+  /**
+   * A cap too small to carry even one slice's framing disables slicing, and that has to keep meaning "ship whole,
+   * exactly as before #4416" rather than "refuse the session": {@code TimeSeriesShard}'s own guard is what keeps
+   * such a shard from sealing at all, and it is unchanged.
+   */
+  @Test
+  void aBudgetOfZeroLeavesEveryStoreShippingWhole() {
+    final List<RaftReplicatedDatabase.SealedSlicePlan> plans = RaftReplicatedDatabase.planSealedShipping(
+        List.of(storeOf(0, 3), storeOf(1, 3)), 0, publishingCapacity(), DB);
+
+    assertThat(plans).hasSize(2);
+    assertThat(plans).allSatisfy(plan -> assertThat(plan.sliced()).isFalse());
+  }
+
+  // ---- the geometry a follower reassembles from ------------------------------------------------------------
+
+  /**
+   * The invariants a follower's reassembly is built on, asserted for a plan whose final slice is deliberately
+   * SMALLER than its body slices - the shape the session-wide budget produces and the uniform slicer never did:
+   * contiguous offsets from zero, no body slice above the entry budget, a final slice within the share this store
+   * was given, exactly one slice flagged {@code last}, and bytes that concatenate back to the original image.
+   */
+  @Test
+  void slicesWithASmallFinalSliceStillReassembleIntoTheOriginalImage() throws Exception {
+    final TsSealedBlob blob = storeOf(2, 4);
+    final long tailBudget = 1_500;
+
+    final RaftReplicatedDatabase.SealedSlicePlan plan =
+        RaftReplicatedDatabase.planSealedSlices(blob, SEALED_BUDGET, tailBudget, DB);
+
+    assertThat(plan.sliced()).isTrue();
+
+    long nextOffset = 0;
+    final ByteArrayOutputStream reassembled = new ByteArrayOutputStream();
+    for (int i = 0; i < plan.count(); i++) {
+      final TsSealedChunk slice = plan.slice(blob, i);
+      final boolean last = i == plan.count() - 1;
+
+      assertThat(slice.offset()).as("slice %d must start where slice %d ended", i, i - 1).isEqualTo(nextOffset);
+      assertThat(slice.bytes()).as("no slice may be empty").isNotEmpty();
+      assertThat(slice.bytes().length).as("no slice may exceed the entry budget")
+          .isLessThanOrEqualTo((int) SEALED_BUDGET);
+      if (last)
+        assertThat(slice.bytes().length).as("the publishing slice may not exceed this store's share")
+            .isLessThanOrEqualTo((int) tailBudget);
+      assertThat(slice.fileLength()).isEqualTo(blob.bytes().length);
+      assertThat(slice.last()).as("only the final slice publishes").isEqualTo(last);
+
+      reassembled.write(slice.bytes());
+      nextOffset += slice.bytes().length;
+    }
+
+    assertThat(reassembled.toByteArray()).isEqualTo(blob.bytes());
+  }
+
+  /** Every slice the planner emits must still pass the decoder's geometry check. */
+  @Test
+  void everySlicePlannedWithASmallTailPassesTheGeometryCheck() {
+    final TsSealedBlob blob = storeOf(0, 3);
+    final RaftReplicatedDatabase.SealedSlicePlan plan =
+        RaftReplicatedDatabase.planSealedSlices(blob, SEALED_BUDGET, 900, DB);
+
+    for (int i = 0; i < plan.count(); i++) {
+      final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+          Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), true,
+          List.of(plan.slice(blob, i)));
+
+      assertThat(RaftLogEntryCodec.decode(encoded).sealedFileChunks()).hasSize(1);
+    }
+  }
+
+  /**
+   * When one store owns the whole budget the plan must reproduce the uniform slicer byte for byte, or the
+   * arithmetic #4416 pinned has quietly changed for every single-shard cluster.
+   */
+  @Test
+  void aStoreThatOwnsTheWholeBudgetIsSlicedExactlyAsBefore() {
+    final TsSealedBlob blob = storeOf(0, 4);
+
+    final List<TsSealedChunk> uniform = RaftReplicatedDatabase.sliceSealedBlob(blob, SEALED_BUDGET, DB);
+    final RaftReplicatedDatabase.SealedSlicePlan plan =
+        RaftReplicatedDatabase.planSealedSlices(blob, SEALED_BUDGET, SEALED_BUDGET, DB);
+
+    assertThat(plan.count()).isEqualTo(uniform.size());
+    for (int i = 0; i < uniform.size(); i++) {
+      assertThat(plan.slice(blob, i).offset()).isEqualTo(uniform.get(i).offset());
+      assertThat(plan.slice(blob, i).bytes()).isEqualTo(uniform.get(i).bytes());
+      assertThat(plan.slice(blob, i).last()).isEqualTo(uniform.get(i).last());
+    }
+  }
+
+  // ---- the heap contract -----------------------------------------------------------------------------------
+
+  /**
+   * The plan is METADATA. It must not hold the store's bytes, nor any slice cut from them: the leader already
+   * carries one whole-file image per sealed store, and the eager slice list #6917 built doubled that for stores
+   * the same commit allowed to reach ~2GB. A component of array type here is that doubling coming back.
+   */
+  @Test
+  void aPlanHoldsNoBytes() {
+    assertThat(RaftReplicatedDatabase.SealedSlicePlan.class.getRecordComponents())
+        .as("a plan describes slices, it does not hold them")
+        .allSatisfy(component -> assertThat(component.getType().isArray()).isFalse());
+  }
+
+  /** And a slice is cut on demand, so shipping one leaves nothing of it behind. */
+  @Test
+  void eachSliceIsCutFreshOnDemand() {
+    final TsSealedBlob blob = storeOf(0, 3);
+    final RaftReplicatedDatabase.SealedSlicePlan plan =
+        RaftReplicatedDatabase.planSealedSlices(blob, SEALED_BUDGET, SEALED_BUDGET, DB);
+
+    assertThat(plan.slice(blob, 0).bytes())
+        .isEqualTo(plan.slice(blob, 0).bytes())
+        .isNotSameAs(plan.slice(blob, 0).bytes());
+  }
+
+
+  /**
+   * The two bounds the capacity has to respect are different bounds, and only the transport one knows about the
+   * schema JSON: a deliberately small {@code tsMaxSealedInlineSize} beside a stock append buffer leaves the
+   * POLICY budget binding, and charging the header against THAT would stop a shard that used to seal.
+   */
+  @Test
+  void aSmallInlineCapIsNotChargedForTheSchemaJson() {
+    final long tinyPolicyBudget = 222;
+
+    assertThat(RaftReplicatedDatabase.publishingSealedCapacity(tinyPolicyBudget, 32L * 1024 * 1024, 1_867))
+        .as("the header comes off the transport cap, which has room to spare")
+        .isEqualTo(tinyPolicyBudget);
+  }
+
+  /** And when the two caps coincide the header does come off, because then it really is competing for the entry. */
+  @Test
+  void aStockCapIsChargedForTheSchemaJson() {
+    assertThat(RaftReplicatedDatabase.publishingSealedCapacity(SEALED_BUDGET, ENTRY_CAP, publishingHeaderSize()))
+        .isLessThan(SEALED_BUDGET);
+  }
+
+  // ---- helpers ---------------------------------------------------------------------------------------------
+
+  /** The publishing entry a session over {@code stores} would build, encoded exactly as the broker encodes it. */
+  private long encodedPublishingEntrySize(final List<TsSealedBlob> stores) {
+    final List<RaftReplicatedDatabase.SealedSlicePlan> plans =
+        RaftReplicatedDatabase.planSealedShipping(stores, SEALED_BUDGET, publishingCapacity(), DB);
+
+    final List<TsSealedBlob> wholeBlobs = new ArrayList<>();
+    final List<TsSealedChunk> finalSlices = new ArrayList<>();
+    for (int i = 0; i < stores.size(); i++) {
+      final RaftReplicatedDatabase.SealedSlicePlan plan = plans.get(i);
+      if (plan.sliced())
+        finalSlices.add(plan.slice(stores.get(i), plan.count() - 1));
+      else
+        wholeBlobs.add(stores.get(i));
+    }
+
+    return RaftLogEntryCodec.encodeSchemaEntry(DB, SCHEMA_JSON, Collections.emptyMap(), filesToRemove(),
+        Collections.emptyList(), Collections.emptyList(), wholeBlobs, false, finalSlices).size();
+  }
+
+  private static long publishingCapacity() {
+    return RaftReplicatedDatabase.publishingSealedCapacity(SEALED_BUDGET, ENTRY_CAP, publishingHeaderSize());
+  }
+
+  private static int publishingHeaderSize() {
+    return RaftLogEntryCodec.encodeSchemaEntry(DB, SCHEMA_JSON, Collections.emptyMap(), filesToRemove(),
+        Collections.emptyList(), Collections.emptyList(), Collections.emptyList()).size();
+  }
+
+  private static Map<Integer, String> filesToRemove() {
+    return Map.of(11, "weather_shard_0.ts.sealed.old", 12, "weather_shard_1.ts.sealed.old");
+  }
+
+  /**
+   * A sealed store of {@code bodySlices} full budgets plus an almost-full remainder, which is what makes the
+   * uniform slicer hand the publishing entry a nearly full-budget final slice - the shape that overflows.
+   */
+  private static TsSealedBlob storeOf(final int shard, final int bodySlices) {
+    return new TsSealedBlob(TYPE, shard, fileNameOf(shard),
+        randomBytes((int) (SEALED_BUDGET * bodySlices + SEALED_BUDGET - 137L * (shard + 1))));
+  }
+
+  private static String fileNameOf(final int shard) {
+    return TYPE + "_shard_" + shard + ".ts.sealed";
+  }
+
+  private static byte[] randomBytes(final int length) {
+    final byte[] bytes = new byte[length];
+    new Random(length).nextBytes(bytes);
+    return bytes;
+  }
+}


### PR DESCRIPTION
Closes #6933

Two follow-ups to the sliced-sealed-store path added by #6917 (`c1785ced6`), both in the new code.

## 1. Several sliced stores in one session overflowed the single publishing entry

`TimeSeriesEngine.runSealedMaintenanceReplicated` runs retention and downsampling for *every shard* of a type inside one `runWithCompactionReplication` session, so `recordedSealed` routinely holds several sealed stores. Everything that *publishes* rides one entry: the whole blobs, plus the final slice of every sliced store.

`runWithCompactionReplication` sized each slice with `GlobalConfiguration.replicatedSealedChunkBudget()` - the budget for a *whole* entry - and then folded the final slice of every store into one `finalSealedChunks` list handed to `replicateSchema`. N stores therefore asked one entry to carry N budgets. `splitSchemaEntry` measures that as `lastHeaderSize`, computes `walBudget = cap - lastHeaderSize <= 0` and throws `ReplicatedEntryTooLargeException` - **after** `replicateSealedChunk` has already committed every earlier slice of every store to the Raft log. Followers are left staging sealed stores they will never install while the leader has already swapped its own and cleared its mutable buckets.

The margin was thin even for a single store: a full-budget last slice left only the `perEntry/128` compression reserve for the schema JSON, `filesToRemove` and the entry header.

**Fix.** The whole session is planned before anything ships:

- `publishingSealedCapacity(sealedEntryBudget, entryCap, headerSize)` returns how many raw sealed bytes the publishing entry may carry. Two bounds meet there and both hold: the *policy* budget (`tsMaxSealedInlineSize` less framing and compression reserve), and the *transport* one (`cap` less the measured schema JSON + file maps + framing + expansion reserve). The header comes off the transport cap, never off the policy budget - subtracting it from the policy budget is what broke `Issue4416SlicedSealedStoreIT`, where a deliberately tiny inline cap sits beside a stock 32MB append buffer and a shard that used to seal would have stopped.
- `planSealedShipping(blobs, sealedEntryBudget, publishingCapacity, db)` divides that capacity evenly among the stores. A store no larger than its share still ships whole as a `TsSealedBlob`; a larger one is sliced with body slices at the full per-entry budget (each travels alone in a delivery-only entry) and a final slice capped at its share. The publishing payload is therefore at most `stores x share`, i.e. the capacity - it fits by construction, at any shard count.
- When the capacity cannot hold even one slice per store the plan throws `ReplicatedEntryTooLargeException` **there**, before the first delivery-only slice is committed.

Single-store sessions are unchanged where they can be: with one store the tail budget is the whole capacity, so the slicing stays the uniform shape #4416 pinned.

## 2. `sliceSealedBlob` doubled leader heap

It built the complete `List<TsSealedChunk>` up front, each slice an `Arrays.copyOfRange` of the source, while `blob.bytes()` stayed strongly reachable - peak heap 2x the sealed store. #6917 raised the per-shard ceiling from 32MB to the `Integer.MAX_VALUE` clamp, so the doubling now applies to stores up to ~2GB, and an N-shard session held N of them at once.

**Fix.** `SealedSlicePlan` is a metadata-only record (count, body slice size, tail size, CRC, file length - the test asserts it holds no array component). `plan.slice(blob, i)` cuts one slice on demand, so the extra copy is bounded by one slice. The shipping loop drops each sliced store's image as it goes, and the `compactionSealedBuffer` thread-local is released right after it is copied so that drop actually frees the array. `sliceSealedBlob` stays, delegating to the plan, so the #4416 arithmetic tests keep pinning it.

## Test plan

- [x] `Issue6933MultiStoreSealedShippingTest` (13 tests) - pins the session-wide arithmetic without a cluster: three full-budget final slices really do make `splitSchemaEntry` throw (the defect, kept as the proof the guard guards something); the planned publishing entry encodes under the cap for 3-store and 8-store sessions and for a mixed whole/sliced one; the plan is refused before anything ships when the header eats the entry; a zero budget still leaves every store shipping whole; the small-inline-cap case is not charged for the schema JSON while the stock case is; slices with a small final slice reassemble byte for byte with contiguous offsets and pass the decoder's geometry check; a store owning the whole budget is sliced exactly as before; the plan holds no bytes and cuts each slice fresh.
- [x] `Issue6933MultiStoreSealedApplyTest` (2 tests) - the coverage gap the issue names ("no test covers more than one sliced store"): two shards of a real `LocalDatabase`, every delivery-only slice applied one entry at a time, nothing published until the publishing entry, then both stores installed byte for byte from one `applySealedChunks` call.
- [x] `Issue4416SlicedSealedStoreTest` (17), `Issue4416SlicedSealedApplyTest` (8), `Issue4416SlicedSealedStoreIT` - unchanged and green.
- [x] Full `ha-raft` unit lane: 1050 tests, 0 failures.
- [x] TimeSeries HA ITs: `RaftTimeSeriesOversizedSealedIT`, `RaftTimeSeriesReplication3NodesIT`, `Issue4458TsWalVersionGapIT`, `TimeSeriesThreeNodeWalGapReproIT`, `Issue6839TsSealedBlobRecoveryTest` - 12 tests, 0 failures.

## Notes

- Wire format unchanged: slice sizes are a producer-side decision, and the follower validates offsets, total length and whole-file CRC rather than slice geometry.
- `SEALED_SLICE_FRAMING_BYTES = 256` charges each store beyond the first for its own slice framing; `REPLICATED_SEALED_CHUNK_FRAMING_BYTES` (4096) already reserves, generously, for one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of sealed data across multiple stores during replication.
  - Accounted for actual per-store framing overhead when allocating capacity.
  - Prevented publishing entries from exceeding available capacity, including long names and limited space.
  - Ensured delivery-only slices are applied and finalized without leaving staging artifacts.

- **Tests**
  - Added coverage for multi-store sealed shipping, slice reassembly, capacity limits, metadata planning, and zero-budget scenarios.
  - Verified replicated files, sample counts, and data integrity after application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->