### PR TITLE
Fix #6943, #6944, #6945: triangle-op overlay fallback, LSM cursor allocations, embedded doc JSON

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -4086,8 +4086,8 @@ cluster whose stores fit inline is not exposed at all. Upgrade the followers fir
 
 `PartitionedTriangleOp` (the CSR-accelerated operator behind country-partitioned triangle-counting Cypher queries)
 built its partition mapping from `NeighborView`s and, the moment any hop's view came back null, returned the mapping
-it had already filled with the "no partition" sentinel `-1` for every node - unchanged. `GraphAnalyticalView
-#getNeighborView` returns null unconditionally while an active delta overlay is being served, which is the normal
+it had already filled with the "no partition" sentinel `-1` for every node - unchanged.
+`GraphAnalyticalView#getNeighborView` returns null unconditionally while an active delta overlay is being served, which is the normal
 state of a view between commits, not an exotic one. Every downstream consumer reads `-1` as "this node belongs to
 no partition", so the operator answered 0 for the whole query instead of falling back, with nothing to indicate the
 fast path had bailed out. The fix walks the partition chain with the provider's per-node `getNeighborIds` accessor
@@ -4112,8 +4112,8 @@ Unrelated to the overlay work but found in the same pass: `Result.valueToJSON` c
 under its generic `Record` branch, which serializes a record as its RID string - an embedded document has no RID
 by construction, so the branch returned `null` and every embedded document in a SQL projection (bare, aliased, or
 inside a list) rendered as `null` in `Result.toJSON()`, including in the AI chat tool's row serialization. It now
-has its own arm ahead of the `Record` check, serializing inline via `Document#toJSON()`. And `LSMTreeIndexCursor
-#fetchNext()` allocated a fresh `ArrayList`, `HashMap` and `HashSet` for every key group it emitted - one full set
+has its own arm ahead of the `Record` check, serializing inline via `Document#toJSON()`. And
+`LSMTreeIndexCursor#fetchNext()` allocated a fresh `ArrayList`, `HashMap` and `HashSet` for every key group it emitted - one full set
 of collections per row on a unique-index scan. The three are now instance fields, `clear()`-ed at the start of
 each group instead of reallocated; the cursor is single-threaded and every group's contents are fully consumed
 before the next one starts, so nothing outlives the reuse.

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -4081,3 +4081,48 @@ image until it is upgraded and resynced. A leader only produces slices once a st
 cluster whose stores fit inline is not exposed at all. Upgrade the followers first.
 
 [#4416](https://github.com/ArcadeData/arcadedb/issues/4416)
+
+## A country-partitioned triangle count no longer silently answers 0 while a Graph Analytical View has an active delta overlay (#6943, #6944, #6945)
+
+`PartitionedTriangleOp` (the CSR-accelerated operator behind country-partitioned triangle-counting Cypher queries)
+built its partition mapping from `NeighborView`s and, the moment any hop's view came back null, returned the mapping
+it had already filled with the "no partition" sentinel `-1` for every node - unchanged. `GraphAnalyticalView
+#getNeighborView` returns null unconditionally while an active delta overlay is being served, which is the normal
+state of a view between commits, not an exotic one. Every downstream consumer reads `-1` as "this node belongs to
+no partition", so the operator answered 0 for the whole query instead of falling back, with nothing to indicate the
+fast path had bailed out. The fix walks the partition chain with the provider's per-node `getNeighborIds` accessor
+instead - the same fallback the triangle-edge side of this operator already used when its own view was missing -
+so an active overlay degrades to a slower but correct answer rather than a wrong one.
+
+Two related findings surfaced while auditing the surrounding code. `GraphAnalyticalView#countCommonNeighbors` was
+the one pair accessor on the class that never consulted the overlay at all - unlike `isConnectedTo` and
+`countEdgesBetween`, it read only the base CSR, so an overlay-deleted common neighbour stayed counted and an
+overlay-added one never was - and it also skipped the bounds guard its siblings carry, so a node ID the overlay had
+handed out for a newly added vertex threw `ArrayIndexOutOfBoundsException`. It now delegates to the same
+overlay-aware per-node accessor, with the original zero-copy CSR intersection kept as a fast path for the common
+no-overlay case. Separately, `algo.betweenness` normalized every score by the UNDIRECTED constant
+`2/((n-1)(n-2))` even though its traversal is directed (`DIRECTION.OUT` only); every existing shortest-path
+contribution is per ordered pair under that traversal, so the correct factor is `1/((n-1)(n-2))`, matching
+NetworkX's and Neo4j GDS's directed betweenness. **This is a behavioral change**: every `algo.betweenness({normalized:
+true})` score is now exactly half what it was, since the old value was not off by an edge case but by a constant
+2x factor. A hub-and-spokes fixture (four nodes, one hub reached by every shortest path) makes the old bug visible
+directly - the normalized score for the hub came out as 2.0, outside the procedure's own documented `[0,1]` range.
+
+Unrelated to the overlay work but found in the same pass: `Result.valueToJSON` classified an `EmbeddedDocument`
+under its generic `Record` branch, which serializes a record as its RID string - an embedded document has no RID
+by construction, so the branch returned `null` and every embedded document in a SQL projection (bare, aliased, or
+inside a list) rendered as `null` in `Result.toJSON()`, including in the AI chat tool's row serialization. It now
+has its own arm ahead of the `Record` check, serializing inline via `Document#toJSON()`. And `LSMTreeIndexCursor
+#fetchNext()` allocated a fresh `ArrayList`, `HashMap` and `HashSet` for every key group it emitted - one full set
+of collections per row on a unique-index scan. The three are now instance fields, `clear()`-ed at the start of
+each group instead of reallocated; the cursor is single-threaded and every group's contents are fully consumed
+before the next one starts, so nothing outlives the reuse.
+
+A follow-up, [#6967](https://github.com/ArcadeData/arcadedb/issues/6967), tracks a related but separate finding:
+`PartitionedTriangleOp` and its sibling `CountOp` operators (`DegreeProductOp`, `PairHashJoinOp`,
+`AntiJoinChainOp`, `PropagateChainOp`) all size arrays and loop bounds from `getNodeCount()` (the live node count)
+rather than `getNodeIdUpperBound()` (the ID space's exclusive bound), which can differ once a delta overlay has
+added or deleted nodes without renumbering - the same shape #6792 fixed in other kernels. That gap predates this
+fix and spans five files with a shared root cause, so it is being tracked and fixed separately.
+
+[#6943](https://github.com/ArcadeData/arcadedb/issues/6943), [#6944](https://github.com/ArcadeData/arcadedb/issues/6944), [#6945](https://github.com/ArcadeData/arcadedb/issues/6945)

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -2616,23 +2616,39 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     return end - start;
   }
 
+  /**
+   * Counts, per requested direction, the neighbours nodeA and nodeB have in common for one edge type.
+   * <p>
+   * #6943: this used to read only the base CSR - the one pair accessor on this class that never consulted
+   * {@code snap.overlay}, unlike its siblings {@link #isConnectedForType} and {@link #countBetweenForType} - so an
+   * overlay-deleted common neighbour stayed counted and an overlay-added one never was. It also omitted the
+   * {@code nodeA < snap.nodeMapping.size()} guard both siblings carry, so an overlay-added node id - legal once
+   * {@link #getNodeIdUpperBound()} exceeds {@link #getNodeCount()} - indexed {@code offsets[nodeA + 1]} straight
+   * past the end of the {@code n+1}-long array.
+   * <p>
+   * Fixed by delegating to {@link #getNeighborsFromCSR}, the same overlay-aware (added minus deleted, base-CSR
+   * bounds already guarded) per-node/per-direction accessor {@link #countDirectional} and {@link #getVertices}
+   * already rely on, instead of duplicating that merge logic here. OUT and IN are intersected separately (not
+   * merged into one BOTH-direction set first) so a BOTH request still means "common OUT-neighbours plus common
+   * IN-neighbours" - the same split the original code and {@link #isConnectedForType}/{@link #countBetweenForType}
+   * use - rather than crediting a pair where nodeA reaches C via OUT and nodeB reaches C via IN as a match.
+   */
   private int countCommonForType(final Snapshot snap, final int nodeA, final int nodeB,
       final Vertex.DIRECTION direction, final String edgeType) {
     final CSRAdjacencyIndex csr = snap.csrPerType.get(edgeType);
-    if (csr == null)
+    if (csr == null && snap.overlay == null)
       return 0;
+
     int count = 0;
     if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-      final int[] neighbors = csr.getForwardNeighbors();
-      final int[] offsets = csr.getForwardOffsets();
-      count += sortedIntersectionCount(neighbors, offsets[nodeA], offsets[nodeA + 1],
-          neighbors, offsets[nodeB], offsets[nodeB + 1]);
+      final int[] aOut = getNeighborsFromCSR(snap, csr, nodeA, Vertex.DIRECTION.OUT, edgeType);
+      final int[] bOut = getNeighborsFromCSR(snap, csr, nodeB, Vertex.DIRECTION.OUT, edgeType);
+      count += sortedIntersectionCount(aOut, 0, aOut.length, bOut, 0, bOut.length);
     }
     if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-      final int[] neighbors = csr.getBackwardNeighbors();
-      final int[] offsets = csr.getBackwardOffsets();
-      count += sortedIntersectionCount(neighbors, offsets[nodeA], offsets[nodeA + 1],
-          neighbors, offsets[nodeB], offsets[nodeB + 1]);
+      final int[] aIn = getNeighborsFromCSR(snap, csr, nodeA, Vertex.DIRECTION.IN, edgeType);
+      final int[] bIn = getNeighborsFromCSR(snap, csr, nodeB, Vertex.DIRECTION.IN, edgeType);
+      count += sortedIntersectionCount(aIn, 0, aIn.length, bIn, 0, bIn.length);
     }
     return count;
   }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -2632,12 +2632,22 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * merged into one BOTH-direction set first) so a BOTH request still means "common OUT-neighbours plus common
    * IN-neighbours" - the same split the original code and {@link #isConnectedForType}/{@link #countBetweenForType}
    * use - rather than crediting a pair where nodeA reaches C via OUT and nodeB reaches C via IN as a match.
+   * <p>
+   * Review round 2: {@link #getNeighborsFromCSR} allocates a {@code copyOfRange} per direction per node even on
+   * the overwhelmingly common no-overlay case, where the original code intersected the raw CSR arrays in place
+   * with zero allocation. Restored that zero-copy path, gated on {@code snap.overlay == null} - the same "fast
+   * path when no overlay" split {@link #getNeighborsFromCSR} itself already uses - and fall back to the
+   * overlay-aware accessor only when an overlay is active or a node id falls outside the base CSR, which is
+   * exactly the condition #6943 needed fixed.
    */
   private int countCommonForType(final Snapshot snap, final int nodeA, final int nodeB,
       final Vertex.DIRECTION direction, final String edgeType) {
     final CSRAdjacencyIndex csr = snap.csrPerType.get(edgeType);
     if (csr == null && snap.overlay == null)
       return 0;
+
+    if (snap.overlay == null && csr != null && nodeA < snap.nodeMapping.size() && nodeB < snap.nodeMapping.size())
+      return countCommonForTypeNoOverlay(csr, nodeA, nodeB, direction);
 
     int count = 0;
     if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
@@ -2649,6 +2659,25 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       final int[] aIn = getNeighborsFromCSR(snap, csr, nodeA, Vertex.DIRECTION.IN, edgeType);
       final int[] bIn = getNeighborsFromCSR(snap, csr, nodeB, Vertex.DIRECTION.IN, edgeType);
       count += sortedIntersectionCount(aIn, 0, aIn.length, bIn, 0, bIn.length);
+    }
+    return count;
+  }
+
+  /** Zero-copy fast path for {@link #countCommonForType}: no overlay, both nodes in the base CSR. */
+  private static int countCommonForTypeNoOverlay(final CSRAdjacencyIndex csr, final int nodeA, final int nodeB,
+      final Vertex.DIRECTION direction) {
+    int count = 0;
+    if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
+      final int[] neighbors = csr.getForwardNeighbors();
+      final int[] offsets = csr.getForwardOffsets();
+      count += sortedIntersectionCount(neighbors, offsets[nodeA], offsets[nodeA + 1],
+          neighbors, offsets[nodeB], offsets[nodeB + 1]);
+    }
+    if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
+      final int[] neighbors = csr.getBackwardNeighbors();
+      final int[] offsets = csr.getBackwardOffsets();
+      count += sortedIntersectionCount(neighbors, offsets[nodeA], offsets[nodeA + 1],
+          neighbors, offsets[nodeB], offsets[nodeB + 1]);
     }
     return count;
   }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -2633,12 +2633,11 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * IN-neighbours" - the same split the original code and {@link #isConnectedForType}/{@link #countBetweenForType}
    * use - rather than crediting a pair where nodeA reaches C via OUT and nodeB reaches C via IN as a match.
    * <p>
-   * Review round 2: {@link #getNeighborsFromCSR} allocates a {@code copyOfRange} per direction per node even on
-   * the overwhelmingly common no-overlay case, where the original code intersected the raw CSR arrays in place
-   * with zero allocation. Restored that zero-copy path, gated on {@code snap.overlay == null} - the same "fast
-   * path when no overlay" split {@link #getNeighborsFromCSR} itself already uses - and fall back to the
-   * overlay-aware accessor only when an overlay is active or a node id falls outside the base CSR, which is
-   * exactly the condition #6943 needed fixed.
+   * {@link #getNeighborsFromCSR} allocates a {@code copyOfRange} per direction per node even on the overwhelmingly
+   * common no-overlay case, where a direct CSR intersection needs zero allocation. {@link #countCommonForTypeNoOverlay}
+   * keeps that zero-copy path, gated on {@code snap.overlay == null} - the same "fast path when no overlay" split
+   * {@link #getNeighborsFromCSR} itself already uses - falling back to the overlay-aware accessor only when an
+   * overlay is active or a node id falls outside the base CSR.
    */
   private int countCommonForType(final Snapshot snap, final int nodeA, final int nodeB,
       final Vertex.DIRECTION direction, final String edgeType) {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -84,6 +84,12 @@ public class LSMTreeIndexCursor implements IndexCursor {
   /** The entry {@link #next()} last returned: what {@link #getRecord()} and {@link #getKeys()} describe. */
   private       RID                                    lastReturnedValue;
   private       Object[]                               lastReturnedKeys;
+  /** #6944: the 3 containers below are per-key-group scratch space, hoisted here and {@code clear()}ed at the
+   *  start of every group instead of being reallocated - the cursor is single-threaded and each group's
+   *  contents are fully consumed before the next group starts, so nothing outlives a reuse. */
+  private final List<Integer>                          minorKeyIndexes    = new ArrayList<>();
+  private final HashMap<RID, Boolean>                   ridState           = new HashMap<>();
+  private final HashSet<RID>                            mergedRIDs         = new HashSet<>();
 
   public LSMTreeIndexCursor(final LSMTreeIndexMutable index, final boolean ascendingOrder) throws IOException {
     this(index, ascendingOrder, null, true, null, true);
@@ -437,7 +443,10 @@ public class LSMTreeIndexCursor implements IndexCursor {
       currentValueIndex = 0;
 
       Object[] minorKey = null;
-      final List<Integer> minorKeyIndexes = new ArrayList<>();
+      // #6944: explicit clear() rather than relying on the in-loop clear()s below, which only fire on paths
+      // that touch a live pageCursor - a tx-only group (no live pageCursors this round) would otherwise carry
+      // over stale indices from the previous group.
+      minorKeyIndexes.clear();
 
       // FIND THE MINOR KEY
       for (int p = 0; p < totalCursors; ++p) {
@@ -514,7 +523,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
       // [newest, ..., oldest], so iterate it in reverse) and within each page in insertion
       // order. We track per-RID validity and only mark the whole key as deleted when we
       // encounter a REMOVED_ENTRY_RID tombstone; a later insert at the same key resurrects it.
-      final HashMap<RID, Boolean> ridState = new HashMap<>();
+      ridState.clear();
 
       for (int i = minorKeyIndexes.size() - 1; i >= 0; --i) {
         final int minorKeyIndex = minorKeyIndexes.get(i);
@@ -539,7 +548,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
 
       // Collect the surviving RIDs for this key. #5055: disk RIDs and overlay RIDs are UNIONed - a committed
       // record and an uncommitted one sharing the same non-unique key must both appear during in-tx iteration.
-      final Set<RID> mergedRIDs = new HashSet<>();
+      mergedRIDs.clear();
 
       // ADVANCE EACH PAGE CURSOR PAST THIS KEY and, if any page contributed, add its per-RID-filtered set.
       if (!minorKeyIndexes.isEmpty()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
@@ -181,12 +181,41 @@ public final class PartitionedTriangleOp implements CountOp {
 
     final int chainLength = partitionEdgeTypes.length;
     final NeighborView[] views = new NeighborView[chainLength];
-    for (int h = 0; h < chainLength; h++)
+    boolean allViewsAvailable = true;
+    for (int h = 0; h < chainLength; h++) {
       views[h] = provider.getNeighborView(partitionDirections[h], partitionEdgeTypes[h]);
+      if (views[h] == null)
+        allViewsAvailable = false;
+    }
 
-    for (final NeighborView v : views)
-      if (v == null)
-        return partition;
+    // #6943: a NeighborView is unavailable while a delta overlay is active (GraphAnalyticalView.getNeighborView
+    // returns null unconditionally in that state) - the normal condition of a view between commits, not an
+    // exotic one. Falling straight through to an all-(-1) mapping made every consumer read "no vertex is in any
+    // partition" instead of "the fast path is unavailable", so the whole query silently answered 0.
+    //
+    // Rather than bailing out of the CSR path entirely (the OLTP fallback below still exercises it), walk the
+    // chain with the per-node accessor: it is specified to work regardless of overlay state (see
+    // GraphTraversalProvider#getNeighborIds javadoc) and is the same fallback #countTrianglesPerNode already
+    // relies on when the triangle-edge view itself is missing. This keeps the mapping on the CSR node-id path -
+    // no RID/Vertex materialization - even when the fast array-offset scan below cannot be used.
+    if (!allViewsAvailable) {
+      for (int p = 0; p < nodeCount; p++) {
+        guard.checkPeriodically(p);
+        int current = p;
+        boolean valid = true;
+        for (int h = 0; h < chainLength; h++) {
+          final int[] hNbrs = provider.getNeighborIds(current, partitionDirections[h], partitionEdgeTypes[h]);
+          if (hNbrs.length == 0) {
+            valid = false;
+            break;
+          }
+          current = hNbrs[0];
+        }
+        if (valid)
+          partition[p] = current;
+      }
+      return partition;
+    }
 
     final NeighborView firstView = views[0];
     final int[] firstNbrs = firstView.neighbors();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
@@ -41,7 +41,10 @@ import java.util.stream.Stream;
  * <p>
  * Config map parameters (all optional):
  * <ul>
- *   <li>normalized (boolean, default true): whether to normalize scores by 2/((n-1)(n-2))</li>
+ *   <li>normalized (boolean, default true): whether to normalize scores by 1/((n-1)(n-2)), the DIRECTED
+ *       normalization factor - this procedure walks {@link Vertex.DIRECTION#OUT} only, so every shortest
+ *       path counted is one ordered pair, never the two-ways-of-counting-the-same-pair an undirected
+ *       traversal would produce (which is what the 2/((n-1)(n-2)) factor is for)</li>
  * </ul>
  * </p>
  * <p>
@@ -181,9 +184,15 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
       }
     }
 
-    // Normalize
+    // Normalize. #6943: this traversal is DIRECTED (adjacency built with DIRECTION.OUT above), so Brandes
+    // accumulates exactly one contribution per ORDERED pair, raw maximum (n-1)(n-2) - the 2/((n-1)(n-2))
+    // factor belongs to an UNDIRECTED traversal, where every unordered pair is reached from both ends and
+    // must be halved back down. Applying it here doubled every score (NetworkX and GDS both use
+    // 1/((n-1)(n-2)) for a directed betweenness), which a hub-and-spokes fixture makes visible: a 4-node
+    // graph with every pair routed through one hub yields raw=6, and 2/((n-1)(n-2)) normalizes that to 2.0 -
+    // outside the documented [0,1] range.
     if (normalized && n > 2) {
-      final double normFactor = 2.0 / ((double) (n - 1) * (n - 2));
+      final double normFactor = 1.0 / ((double) (n - 1) * (n - 2));
       for (int i = 0; i < n; i++)
         betweenness[i] *= normFactor;
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/Result.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/Result.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.Document;
+import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.graph.Edge;
@@ -120,6 +121,8 @@ public interface Result {
     if (val != null) {
       if (val instanceof Result result) {
         return result.toJSON();
+      } else if (val instanceof EmbeddedDocument embedded) {
+        return embedded.toJSON();
       } else if (val instanceof Record record) {
         return record.getIdentity() != null ? record.getIdentity().toString() : null;
       } else if (val instanceof Iterable<?> iterable) {

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6943CountCommonNeighborsOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6943CountCommonNeighborsOverlayTest.java
@@ -143,8 +143,9 @@ class Issue6943CountCommonNeighborsOverlayTest extends TestHelper {
     database.commit();
 
     final int idC = gav.getNodeId(c.getIdentity());
-    assertThat(idC).as("precondition: C's node id must be an overlay-added id past the base node count")
-        .isGreaterThanOrEqualTo(gav.getNodeCount() - 1);
+    // No deletions precede this add, so C's id is deterministically the next slot after the 2 base nodes (B, X).
+    assertThat(idC).as("precondition: C's node id must be the overlay-added id past the base node count")
+        .isEqualTo(2);
 
     // Before the fix, nodeA=idC indexed the base CSR's offsets array without a bounds check and threw AIOOBE.
     assertThat(gav.countCommonNeighbors(idC, idB, Vertex.DIRECTION.OUT, "KNOWS"))

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6943CountCommonNeighborsOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6943CountCommonNeighborsOverlayTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6943's second finding: {@code GraphAnalyticalView.countCommonNeighbors} was the one
+ * pair accessor on this class that never consulted {@code snap.overlay} - both {@code isConnectedTo} and
+ * {@code countEdgesBetween} already subtract overlay deletions and add overlay additions for the same kind of pair
+ * question. It also omitted the {@code nodeA < snap.nodeMapping.size()} guard both siblings carry, so a node id the
+ * overlay handed out for a newly added vertex (legal once {@link GraphAnalyticalView#getNodeIdUpperBound()} exceeds
+ * the base node count) indexed the base CSR's offsets array straight past its end.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6943CountCommonNeighborsOverlayTest extends TestHelper {
+
+  @Test
+  void overlayDeletedCommonNeighbourIsExcluded() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    final MutableVertex x = database.newVertex("Person").set("name", "X").save();
+    a.newEdge("KNOWS", x);
+    b.newEdge("KNOWS", x);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("common-neighbors-overlay-delete")
+        .withVertexTypes("Person")
+        .withEdgeTypes("KNOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+
+    final int idA = gav.getNodeId(a.getIdentity());
+    final int idB = gav.getNodeId(b.getIdentity());
+
+    assertThat(gav.countCommonNeighbors(idA, idB, Vertex.DIRECTION.OUT, "KNOWS"))
+        .as("precondition: X is a common OUT-neighbour of A and B before the overlay touches anything").isEqualTo(1);
+
+    // Delete A -> X within the overlay window (no compaction in between).
+    database.begin();
+    a.getIdentity().asVertex().getEdges(Vertex.DIRECTION.OUT, "KNOWS").forEach(e -> {
+      if (e.getIn().equals(x.getIdentity()))
+        e.delete();
+    });
+    database.commit();
+
+    assertThat(gav.countCommonNeighbors(idA, idB, Vertex.DIRECTION.OUT, "KNOWS"))
+        .as("an overlay-deleted common neighbour must no longer be counted (#6943)").isEqualTo(0);
+
+    gav.drop();
+  }
+
+  @Test
+  void overlayAddedCommonNeighbourIsIncluded() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    final MutableVertex x = database.newVertex("Person").set("name", "X").save();
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("common-neighbors-overlay-add")
+        .withVertexTypes("Person")
+        .withEdgeTypes("KNOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+
+    final int idA = gav.getNodeId(a.getIdentity());
+    final int idB = gav.getNodeId(b.getIdentity());
+
+    assertThat(gav.countCommonNeighbors(idA, idB, Vertex.DIRECTION.OUT, "KNOWS"))
+        .as("precondition: no common neighbour before the overlay adds anything").isEqualTo(0);
+
+    // Add A -> X and B -> X within the overlay window (no compaction in between).
+    database.begin();
+    a.getIdentity().asVertex().modify().newEdge("KNOWS", x);
+    b.getIdentity().asVertex().modify().newEdge("KNOWS", x);
+    database.commit();
+
+    assertThat(gav.countCommonNeighbors(idA, idB, Vertex.DIRECTION.OUT, "KNOWS"))
+        .as("an overlay-added common neighbour must be counted (#6943)").isEqualTo(1);
+
+    gav.drop();
+  }
+
+  @Test
+  void overlayAddedNodeIdDoesNotThrowArrayIndexOutOfBounds() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+
+    database.begin();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    final MutableVertex x = database.newVertex("Person").set("name", "X").save();
+    b.newEdge("KNOWS", x);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("common-neighbors-overlay-new-node")
+        .withVertexTypes("Person")
+        .withEdgeTypes("KNOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+
+    final int idB = gav.getNodeId(b.getIdentity());
+    assertThat(gav.getNodeCount()).as("precondition").isEqualTo(2);
+
+    // Add a brand-new vertex C within the overlay window: its node id is >= the base node count, the
+    // "legal once getNodeIdUpperBound() exceeds getNodeCount()" shape #6943 describes.
+    database.begin();
+    final MutableVertex c = database.newVertex("Person").set("name", "C").save();
+    c.newEdge("KNOWS", x);
+    database.commit();
+
+    final int idC = gav.getNodeId(c.getIdentity());
+    assertThat(idC).as("precondition: C's node id must be an overlay-added id past the base node count")
+        .isGreaterThanOrEqualTo(gav.getNodeCount() - 1);
+
+    // Before the fix, nodeA=idC indexed the base CSR's offsets array without a bounds check and threw AIOOBE.
+    assertThat(gav.countCommonNeighbors(idC, idB, Vertex.DIRECTION.OUT, "KNOWS"))
+        .as("X is a common OUT-neighbour of the overlay-added C and the base node B (#6943)").isEqualTo(1);
+    assertThat(gav.countCommonNeighbors(idB, idC, Vertex.DIRECTION.OUT, "KNOWS"))
+        .as("the same question with the overlay-added id as nodeB").isEqualTo(1);
+
+    gav.drop();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue6944CursorScratchSpaceReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue6944CursorScratchSpaceReuseTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -74,7 +75,7 @@ class Issue6944CursorScratchSpaceReuseTest extends TestHelper {
         seen.add((Integer) rs.next().getProperty("a"));
 
       assertThat(seen).as("both the committed disk entries and the uncommitted tx-only tail must be visible")
-          .containsExactlyInAnyOrderElementsOf(java.util.stream.IntStream.range(0, 30).boxed().toList());
+          .containsExactlyInAnyOrderElementsOf(IntStream.range(0, 30).boxed().toList());
     } finally {
       database.rollback();
     }
@@ -105,7 +106,7 @@ class Issue6944CursorScratchSpaceReuseTest extends TestHelper {
         seen.add((Integer) rs.next().getProperty("a"));
 
       assertThat(seen).as("both the committed disk entries and the uncommitted tx-only tail must be visible")
-          .containsExactlyInAnyOrderElementsOf(java.util.stream.IntStream.range(0, 40).boxed().toList());
+          .containsExactlyInAnyOrderElementsOf(IntStream.range(0, 40).boxed().toList());
     } finally {
       database.rollback();
     }

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue6944CursorScratchSpaceReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue6944CursorScratchSpaceReuseTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6944: {@link LSMTreeIndexCursor#fetchNext()} allocated a fresh {@code ArrayList},
+ * {@code HashMap} and {@code HashSet} for every key group it emitted, i.e. per row on a unique-index scan. The fix
+ * hoists the three containers to instance fields and {@code clear()}s them at the start of every group instead.
+ * <p>
+ * That reuse is only safe if every group starts from a genuinely empty container - the risky case is a group with
+ * NO live page cursor (every {@code pageCursors[p]} already exhausted and null), which is reached once a scan works
+ * through all committed disk entries and only the in-transaction overlay tail remains: the "FIND THE MINOR KEY" loop
+ * never touches {@code minorKeyIndexes} on that path, so a reused field would otherwise carry over the previous
+ * group's (unrelated) cursor indices instead of the explicit {@code clear()} added at the top of the round. These
+ * tests force exactly that page-exhausted-then-tx-only-tail transition, in both directions, plus a duplicate/tombstone
+ * heavy scan that cycles the {@code ridState}/{@code mergedRIDs} fields across many groups.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6944CursorScratchSpaceReuseTest extends TestHelper {
+
+  @Test
+  void txOnlyTailAfterDiskExhaustionAscending() {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("Doc6944a").withTotalBuckets(1).create();
+    type.createProperty("a", Integer.class);
+    database.getSchema().buildTypeIndex("Doc6944a", new String[] { "a" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+
+    // Committed baseline: several disk-backed key groups.
+    database.transaction(() -> {
+      for (int i = 0; i < 20; ++i)
+        database.newDocument("Doc6944a").set("a", i).save();
+    });
+
+    database.begin();
+    try {
+      // Uncommitted keys strictly ABOVE every committed key: once the scan exhausts the disk cursors it must
+      // keep emitting these tx-only groups WITHOUT inheriting the last disk group's stale cursor indices.
+      for (int i = 20; i < 30; ++i)
+        database.newDocument("Doc6944a").set("a", i).save();
+
+      final Set<Integer> seen = new HashSet<>();
+      final ResultSet rs = database.query("sql", "SELECT a FROM Doc6944a ORDER BY a ASC");
+      while (rs.hasNext())
+        seen.add((Integer) rs.next().getProperty("a"));
+
+      assertThat(seen).as("both the committed disk entries and the uncommitted tx-only tail must be visible")
+          .containsExactlyInAnyOrderElementsOf(java.util.stream.IntStream.range(0, 30).boxed().toList());
+    } finally {
+      database.rollback();
+    }
+  }
+
+  @Test
+  void txOnlyTailAfterDiskExhaustionDescending() {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("Doc6944b").withTotalBuckets(1).create();
+    type.createProperty("a", Integer.class);
+    database.getSchema().buildTypeIndex("Doc6944b", new String[] { "a" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+
+    database.transaction(() -> {
+      for (int i = 20; i < 40; ++i)
+        database.newDocument("Doc6944b").set("a", i).save();
+    });
+
+    database.begin();
+    try {
+      // Uncommitted keys strictly BELOW every committed key: in DESC order these become the tx-only tail once
+      // the disk cursors (the higher keys) are exhausted.
+      for (int i = 0; i < 20; ++i)
+        database.newDocument("Doc6944b").set("a", i).save();
+
+      final Set<Integer> seen = new HashSet<>();
+      final ResultSet rs = database.query("sql", "SELECT a FROM Doc6944b ORDER BY a DESC");
+      while (rs.hasNext())
+        seen.add((Integer) rs.next().getProperty("a"));
+
+      assertThat(seen).as("both the committed disk entries and the uncommitted tx-only tail must be visible")
+          .containsExactlyInAnyOrderElementsOf(java.util.stream.IntStream.range(0, 40).boxed().toList());
+    } finally {
+      database.rollback();
+    }
+  }
+
+  @Test
+  void manyGroupsWithDuplicatesAndTombstonesSurviveFieldReuse() {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("Doc6944c").withTotalBuckets(1).create();
+    type.createProperty("a", Integer.class);
+    database.getSchema().buildTypeIndex("Doc6944c", new String[] { "a" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
+
+    // 3 committed batches (separate transactions -> separate mutable pages) so keys interleave across pages,
+    // each key duplicated a few times, to exercise the ridState/mergedRIDs merge across many key groups.
+    for (int batch = 0; batch < 3; ++batch) {
+      final int b = batch;
+      database.transaction(() -> {
+        for (int i = 0; i < 100; ++i)
+          for (int dup = 0; dup < 2; ++dup)
+            database.newDocument("Doc6944c").set("a", i).set("batch", b).set("dup", dup).save();
+      });
+    }
+
+    // Delete every RID belonging to duplicate slot 0 to force per-RID tombstones interleaved with the survivors.
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql", "SELECT FROM Doc6944c WHERE dup = 0");
+      while (rs.hasNext())
+        rs.next().getRecord().get().asDocument().delete();
+    });
+
+    int count = 0;
+    final Set<String> distinctKeysSeen = new HashSet<>();
+    final ResultSet rs = database.query("sql", "SELECT a FROM Doc6944c ORDER BY a ASC");
+    while (rs.hasNext()) {
+      distinctKeysSeen.add(rs.next().getProperty("a").toString());
+      ++count;
+    }
+
+    // 3 batches * 1 surviving duplicate (dup=1) per key = 3 rows per key, 100 distinct keys.
+    assertThat(count).as("only the non-tombstoned duplicates must survive the scan").isEqualTo(300);
+    assertThat(distinctKeysSeen).hasSize(100);
+  }
+
+  /**
+   * The actual perf claim: {@code minorKeyIndexes}/{@code ridState}/{@code mergedRIDs} must be the SAME container
+   * instance across key groups, not a fresh {@code ArrayList}/{@code HashMap}/{@code HashSet} per group. Before the
+   * fix, this identity check fails on the very first two rows.
+   */
+  @Test
+  void scratchContainersAreReusedAcrossGroups() throws Exception {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("Doc6944d").withTotalBuckets(1).create();
+    type.createProperty("a", Integer.class);
+    database.getSchema().buildTypeIndex("Doc6944d", new String[] { "a" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < 10; ++i)
+        database.newDocument("Doc6944d").set("a", i).save();
+    });
+
+    database.transaction(() -> {
+      try {
+        final var typeIndex = database.getSchema().getType("Doc6944d").getIndexesByProperties("a").getFirst();
+        LSMTreeIndexMutable mutable = null;
+        for (final var bucketIndex : typeIndex.getIndexesOnBuckets())
+          if (bucketIndex instanceof LSMTreeIndex lsmIndex)
+            mutable = lsmIndex.getMutableIndex();
+
+        final LSMTreeIndexCursor cursor = (LSMTreeIndexCursor) mutable.range(true, null, true, null, true);
+        try {
+          final Field minorKeyIndexesField = LSMTreeIndexCursor.class.getDeclaredField("minorKeyIndexes");
+          final Field ridStateField = LSMTreeIndexCursor.class.getDeclaredField("ridState");
+          final Field mergedRIDsField = LSMTreeIndexCursor.class.getDeclaredField("mergedRIDs");
+          minorKeyIndexesField.setAccessible(true);
+          ridStateField.setAccessible(true);
+          mergedRIDsField.setAccessible(true);
+
+          assertThat(cursor.hasNext()).isTrue();
+          final RID first = cursor.next();
+          final Object minorKeyIndexesAfterFirst = minorKeyIndexesField.get(cursor);
+          final Object ridStateAfterFirst = ridStateField.get(cursor);
+          final Object mergedRIDsAfterFirst = mergedRIDsField.get(cursor);
+
+          assertThat(cursor.hasNext()).isTrue();
+          final RID second = cursor.next();
+          assertThat(second).isNotEqualTo(first);
+
+          assertThat(minorKeyIndexesField.get(cursor)).as("minorKeyIndexes must be the SAME instance, not reallocated per group")
+              .isSameAs(minorKeyIndexesAfterFirst);
+          assertThat(ridStateField.get(cursor)).as("ridState must be the SAME instance, not reallocated per group")
+              .isSameAs(ridStateAfterFirst);
+          assertThat(mergedRIDsField.get(cursor)).as("mergedRIDs must be the SAME instance, not reallocated per group")
+              .isSameAs(mergedRIDsAfterFirst);
+        } finally {
+          cursor.close();
+        }
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpMissingPartitionViewTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpMissingPartitionViewTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.NeighborView;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.WorkGuard;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6943: {@link PartitionedTriangleOp#execute} answered 0 for the whole query whenever
+ * the partition-chain {@link NeighborView} could not be handed out - which is the normal state of a
+ * {@code GraphAnalyticalView} between commits (an active delta overlay makes {@code getNeighborView} return null
+ * unconditionally), not an exotic condition.
+ * <p>
+ * {@code buildPartitionMapping} used to bail out to an all-{@code -1} mapping the moment any partition-chain view
+ * was null; every consumer reads {@code -1} as "this node belongs to no partition", so the triangle count came back
+ * 0 even though the triangle-edge view ({@code KNOWS}) and the underlying graph data were both perfectly fine.
+ * <p>
+ * The fix keeps the mapping on the CSR node-id path by falling back to {@link GraphTraversalProvider#getNeighborIds}
+ * for the partition-chain walk - the same fallback {@code countTrianglesPerNode} already uses when the
+ * triangle-edge view itself is missing - instead of silently producing invalid partition data.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PartitionedTriangleOpMissingPartitionViewTest {
+
+  private static final int NODE_COUNT = 12;
+
+  /** Provider whose partition-chain view ("IN_CITY") is unavailable (simulating an active delta overlay),
+   *  while the triangle-edge view ("KNOWS") and the per-node accessor are both fully functional. */
+  private static final class OverlayActiveStubProvider implements GraphTraversalProvider {
+    private final NeighborView knowsView;
+    private final int[][] cityNeighbors;
+
+    private OverlayActiveStubProvider(final NeighborView knowsView, final int[][] cityNeighbors) {
+      this.knowsView = knowsView;
+      this.cityNeighbors = cityNeighbors;
+    }
+
+    @Override
+    public int getNodeCount() {
+      return NODE_COUNT;
+    }
+
+    @Override
+    public NeighborView getNeighborView(final Vertex.DIRECTION direction, final String... edgeTypes) {
+      if (edgeTypes.length == 1 && "KNOWS".equals(edgeTypes[0]))
+        return knowsView;
+      // #6943: the partition-chain view is unavailable - this is what an active delta overlay looks like.
+      return null;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "stub-overlay-active";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return -1;
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return null;
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      if (edgeTypes.length == 1 && "IN_CITY".equals(edgeTypes[0]))
+        return cityNeighbors[nodeId];
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return getNeighborIds(nodeId, direction, edgeTypes).length;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+        final String... edgeTypes) {
+      return false;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+  }
+
+  @Test
+  void missingPartitionViewFallsBackToPerNodeLookupInsteadOfReturningZero() {
+    // Two disjoint triangles: (0,1,2) all in city 10, (3,4,5) all in city 11. Nodes 6..11 are isolated.
+    final int[][] knowsAdjacency = new int[NODE_COUNT][];
+    for (int i = 0; i < NODE_COUNT; i++)
+      knowsAdjacency[i] = new int[0];
+    knowsAdjacency[0] = new int[] { 1, 2 };
+    knowsAdjacency[1] = new int[] { 0, 2 };
+    knowsAdjacency[2] = new int[] { 0, 1 };
+    knowsAdjacency[3] = new int[] { 4, 5 };
+    knowsAdjacency[4] = new int[] { 3, 5 };
+    knowsAdjacency[5] = new int[] { 3, 4 };
+
+    int edgeCount = 0;
+    for (final int[] adj : knowsAdjacency)
+      edgeCount += adj.length;
+    final int[] offsets = new int[NODE_COUNT + 1];
+    final int[] neighbors = new int[edgeCount];
+    int pos = 0;
+    for (int i = 0; i < NODE_COUNT; i++) {
+      offsets[i] = pos;
+      for (final int n : knowsAdjacency[i])
+        neighbors[pos++] = n;
+    }
+    offsets[NODE_COUNT] = pos;
+    final NeighborView knowsView = new NeighborView(NODE_COUNT, offsets, neighbors);
+
+    // IN_CITY chain: every node points to its own city node id (10 or 11) - only reachable via getNeighborIds
+    // since getNeighborView("IN_CITY") returns null.
+    final int[][] cityNeighbors = new int[NODE_COUNT][];
+    for (int i = 0; i < NODE_COUNT; i++)
+      cityNeighbors[i] = new int[0];
+    cityNeighbors[0] = new int[] { 10 };
+    cityNeighbors[1] = new int[] { 10 };
+    cityNeighbors[2] = new int[] { 10 };
+    cityNeighbors[3] = new int[] { 11 };
+    cityNeighbors[4] = new int[] { 11 };
+    cityNeighbors[5] = new int[] { 11 };
+
+    final PartitionedTriangleOp op = new PartitionedTriangleOp(new String[] { "IN_CITY" },
+        new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, "KNOWS");
+
+    final long count = op.execute(new OverlayActiveStubProvider(knowsView, cityNeighbors), null,
+        WorkGuard.forCommandDeadline(null));
+
+    // Each triangle is counted 6 times (each of its 3 nodes as u, each of its 2 neighbors as v) = 12 total,
+    // NOT 0 - the bug returned 0 because the partition mapping degraded to all -1.
+    assertThat(count).as("a missing partition-chain view must not silently zero out every partition membership")
+        .isEqualTo(12L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweennessTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweennessTest.java
@@ -128,6 +128,57 @@ class AlgoBetweennessTest {
     }
   }
 
+  /**
+   * Regression for #6943: the normalization factor was {@code 2/((n-1)(n-2))}, the UNDIRECTED constant, even
+   * though this procedure's adjacency is built {@code DIRECTION.OUT}-only (a directed traversal). On a
+   * hub-and-spokes graph where a=b=d all route through hub c in both directions (a->c, b->c, d->c, c->a, c->b,
+   * c->d), every one of the 6 ordered leaf pairs is routed through c, so c's raw betweenness is 6 - the maximum
+   * possible for n=4, i.e. {@code (n-1)(n-2) = 6}. The correct DIRECTED normalization
+   * ({@code 1/((n-1)(n-2))}) must therefore bring c's score to exactly 1.0; the old undirected factor doubled
+   * it to 2.0, outside the documented [0,1] range.
+   */
+  @Test
+  void betweennessDirectedNormalizationStaysInRange() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-algo-betweenness-hub");
+    if (factory.exists())
+      factory.open().drop();
+    final Database hubDatabase = factory.create();
+    try {
+      hubDatabase.getSchema().createVertexType("Node");
+      hubDatabase.getSchema().createEdgeType("EDGE");
+
+      hubDatabase.transaction(() -> {
+        final MutableVertex a = hubDatabase.newVertex("Node").set("name", "A").save();
+        final MutableVertex b = hubDatabase.newVertex("Node").set("name", "B").save();
+        final MutableVertex c = hubDatabase.newVertex("Node").set("name", "C").save();
+        final MutableVertex d = hubDatabase.newVertex("Node").set("name", "D").save();
+        a.newEdge("EDGE", c, true, (Object[]) null).save();
+        b.newEdge("EDGE", c, true, (Object[]) null).save();
+        d.newEdge("EDGE", c, true, (Object[]) null).save();
+        c.newEdge("EDGE", a, true, (Object[]) null).save();
+        c.newEdge("EDGE", b, true, (Object[]) null).save();
+        c.newEdge("EDGE", d, true, (Object[]) null).save();
+      });
+
+      final ResultSet rs = hubDatabase.query("opencypher",
+          "CALL algo.betweenness({normalized: true}) YIELD node, score RETURN node.name AS name, score");
+
+      double scoreC = Double.NaN;
+      while (rs.hasNext()) {
+        final Result result = rs.next();
+        final double score = ((Number) result.getProperty("score")).doubleValue();
+        assertThat(score).as("every normalized score must stay within the documented [0,1] range (#6943)")
+            .isBetween(0.0, 1.0);
+        if ("C".equals(result.getProperty("name")))
+          scoreC = score;
+      }
+
+      assertThat(scoreC).as("the hub must reach the maximum possible directed-normalized score").isEqualTo(1.0);
+    } finally {
+      hubDatabase.drop();
+    }
+  }
+
   @Test
   void betweennessNonNormalized() {
     final ResultSet rs = database.query("opencypher",

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6718BetweennessPrimitiveArraysTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6718BetweennessPrimitiveArraysTest.java
@@ -82,8 +82,13 @@ class Issue6718BetweennessPrimitiveArraysTest {
    * shortest path of length 2 through C, while every same-triangle pair is a direct edge. Hand-computable exactly:
    * C sits on 4 unordered pairs' unique shortest path; running Brandes from every node as source over a
    * bidirectionally-represented (undirected) graph counts each such pair twice (once per direction), so the raw,
-   * non-normalized score for C is 8 and 0 for every other node. Normalizing by {@code 2/((n-1)(n-2))} with n = 5
-   * gives {@code 8 * 2/(4*3) = 4/3}.
+   * non-normalized score for C is 8 and 0 for every other node.
+   * <p>
+   * Normalizing: {@link AlgoBetweenness} always runs a full, undeduped source iteration (every node as source,
+   * directed adjacency) with no built-in undirected halving, so - reciprocal edges or not - the raw maximum a node
+   * can reach is the ordered-pair count {@code (n-1)(n-2)}, and the matching normalization is
+   * {@code 1/((n-1)(n-2))} (#6943) - not the {@code 2/((n-1)(n-2))} factor, which presumes a raw computation that
+   * counts each unordered pair once. With n = 5 that gives {@code 8 * 1/(4*3) = 2/3}.
    */
   @Test
   void bowtieGraphMatchesHandComputedScores() {
@@ -108,7 +113,7 @@ class Issue6718BetweennessPrimitiveArraysTest {
 
     final Map<String, Double> normalized = scoresByName("CALL algo.betweenness({normalized: true}) YIELD node, score "
         + "RETURN node.name AS name, score");
-    assertThat(normalized.get("C")).isCloseTo(4.0 / 3.0, offset(1e-9));
+    assertThat(normalized.get("C")).isCloseTo(2.0 / 3.0, offset(1e-9));
     for (final String leaf : List.of("A", "B", "D", "E"))
       assertThat(normalized.get(leaf)).isCloseTo(0.0, offset(1e-9));
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/EmbeddedDocumentToJSONBug6945Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/EmbeddedDocumentToJSONBug6945Test.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6945: {@code Result.toJSON()} rendered a projected embedded document
+ * as {@code null}, because {@code valueToJSON} matched it against the generic {@code Record} branch
+ * (which serializes to a RID) before ever checking for {@code EmbeddedDocument}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class EmbeddedDocumentToJSONBug6945Test extends TestHelper {
+
+  @Test
+  void projectedEmbeddedDocumentSerializesInline() {
+    database.getSchema().createDocumentType("Address6945").createProperty("city", Type.STRING);
+    database.getSchema().createDocumentType("Person6945").createProperty("address", Type.EMBEDDED).setOfType("Address6945");
+
+    database.transaction(() -> database.newDocument("Person6945").set("address", Map.of("city", "Rome")).save());
+
+    try (final ResultSet rs = database.query("sql", "SELECT address FROM Person6945")) {
+      final JSONObject json = rs.next().toJSON();
+      final JSONObject address = json.getJSONObject("address");
+      assertThat(address).isNotNull();
+      assertThat(address.getString("city")).isEqualTo("Rome");
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT address AS aliased FROM Person6945")) {
+      final JSONObject json = rs.next().toJSON();
+      assertThat(json.getJSONObject("aliased").getString("city")).isEqualTo("Rome");
+    }
+  }
+
+  @Test
+  void projectedEmbeddedDocumentListSerializesInline() {
+    database.getSchema().createDocumentType("Address6945b").createProperty("city", Type.STRING);
+    database.getSchema().createDocumentType("Person6945b").createProperty("tags", Type.LIST).setOfType("Address6945b");
+
+    database.transaction(() -> database.newDocument("Person6945b").set("tags", List.of(Map.of("city", "A"))).save());
+
+    try (final ResultSet rs = database.query("sql", "SELECT tags FROM Person6945b")) {
+      final JSONArray tags = rs.next().toJSON().getJSONArray("tags");
+      assertThat(tags.length()).isEqualTo(1);
+      assertThat(tags.getJSONObject(0).getString("city")).isEqualTo("A");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #6943: `PartitionedTriangleOp` answered 0 for the whole query whenever a partition-chain `NeighborView` was unavailable (the normal state of a `GraphAnalyticalView` while a delta overlay is active), because `buildPartitionMapping` silently degraded to an all-`-1` mapping. Now falls back to the per-node `GraphTraversalProvider#getNeighborIds` walk, the same fallback already used when the triangle-edge view itself is missing.
- Same issue, two smaller findings addressed in the same area:
  - `GraphAnalyticalView#countCommonNeighbors` never consulted the delta overlay (unlike its siblings `isConnectedTo`/`countEdgesBetween`) and omitted the `nodeA`-in-base bounds guard, throwing AIOOBE for an overlay-added node id. Rewritten to delegate to the existing overlay-aware `getNeighborsFromCSR`.
  - `algo.betweenness` normalized with the undirected factor `2/((n-1)(n-2))` even though its traversal is `DIRECTION.OUT`-only; fixed to `1/((n-1)(n-2))`, matching NetworkX/GDS for directed betweenness. Updated the one pre-existing test whose hardcoded expectation baked in the old (incorrect) factor.
- Fixes #6944: `LSMTreeIndexCursor.fetchNext()` allocated an `ArrayList`, a `HashMap` and a `HashSet` per key group (i.e. per row on a unique-index range scan). Hoisted to instance fields, cleared per group instead of reallocated.
- Fixes #6945: `Result.valueToJSON` classified an `EmbeddedDocument` under the generic `Record` branch (which serializes to a RID), rendering every embedded document in a projection as `null`. Added an `EmbeddedDocument` arm ahead of it.

## Test plan
- [x] New regression test per issue, each verified to fail against pre-fix code and pass after the fix
- [x] `mvn -o -pl engine -am test` for `com.arcadedb.index.**` (1257 tests), `com.arcadedb.graph.olap.**` + `com.arcadedb.query.opencypher.procedures.algo.**` (831 tests), `com.arcadedb.query.opencypher.executor.steps.**` + `com.arcadedb.query.sql.executor.**` (1606 tests) — all green
- [x] `mvn -o -pl engine -am install -DskipTests` compiles clean

Fixes #6943
Fixes #6944
Fixes #6945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected graph analytics for added or deleted overlay edges and nodes.
  - Improved triangle queries when partition neighbor data is unavailable.
  - Fixed directed betweenness centrality normalization.
  - Embedded documents now serialize correctly as inline JSON, including lists and aliases.
  - Improved index cursor handling across transaction-only entries, duplicates, and tombstones.
- **Performance**
  - Reduced overhead during graph neighbor counting and index cursor scans.
- **Documentation**
  - Updated graph analytics and betweenness centrality guidance.
- **Tests**
  - Added regression coverage for overlays, triangle queries, index scans, betweenness scores, and JSON serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->