### PR TITLE
fix(#6927): subtract the tx-overlay REMOVE entries from an index range scan

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -170,6 +170,9 @@ public class HashIndex implements IndexInternal {
       Set<IndexCursorEntry> txChanges = null;
       Set<RID> removedRids = null;
       boolean hasRemoves = false;
+      // #6927: a remove(keys) carrying no RID kills EVERY disk RID at this key. It used to allocate an EMPTY
+      // removedRids set, which then filtered nothing at all, so the disk entries survived a whole-key removal.
+      boolean keyWideRemove = false;
 
       final Map<TransactionIndexContext.ComparableKey, Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey>> indexChanges =
           getDatabase().getTransaction().getIndexChanges().getIndexKeys(getName());
@@ -184,11 +187,25 @@ public class HashIndex implements IndexInternal {
                   return EMPTY_CURSOR;
 
                 hasRemoves = true;
+                if (value.rid == null)
+                  keyWideRemove = true;
+                else {
+                  if (removedRids == null)
+                    removedRids = new HashSet<>();
+                  removedRids.add(value.rid);
+                }
+                continue;
+              }
+
+              if (value.operation == TransactionIndexContext.IndexKey.IndexKeyOperation.REPLACE && value.oldRid != null) {
+                // #6927: on a unique index a same-key REMOVE + ADD is merged into ONE entry whose oldRid is the RID
+                // being replaced - the REMOVE no longer exists on its own. Commit replays that removal
+                // (TransactionIndexContext.commit), so the lookup must not hand the old RID back either; without this
+                // the caller saw BOTH RIDs under a key that is supposed to hold one.
+                hasRemoves = true;
                 if (removedRids == null)
                   removedRids = new HashSet<>();
-                if (value.rid != null)
-                  removedRids.add(value.rid);
-                continue;
+                removedRids.add(value.oldRid);
               }
 
               if (txChanges == null)
@@ -211,8 +228,9 @@ public class HashIndex implements IndexInternal {
 
         while (result.hasNext()) {
           final Identifiable next = result.next();
-          if (removedRids == null || !removedRids.contains(next.getIdentity()))
-            txChanges.add(new IndexCursorEntry(convertedKeys, next, 1));
+          if (keyWideRemove || (removedRids != null && removedRids.contains(next.getIdentity())))
+            continue;
+          txChanges.add(new IndexCursorEntry(convertedKeys, next, 1));
         }
         return new TempIndexCursor(txChanges);
       }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -562,6 +562,9 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
       Set<IndexCursorEntry> txChanges = null;
       Set<RID> removedRids = null;
       boolean hasRemoves = false;
+      // #6927: a remove(keys) carrying no RID kills EVERY disk RID at this key. It used to allocate an EMPTY
+      // removedRids set, which then filtered nothing at all, so the disk entries survived a whole-key removal.
+      boolean keyWideRemove = false;
 
       final Map<TransactionIndexContext.ComparableKey, Map<TransactionIndexContext.IndexKey,
           TransactionIndexContext.IndexKey>> indexChanges = getDatabase().getTransaction()
@@ -578,11 +581,25 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
                   return EMPTY_CURSOR;
 
                 hasRemoves = true;
+                if (value.rid == null)
+                  keyWideRemove = true;
+                else {
+                  if (removedRids == null)
+                    removedRids = new HashSet<>();
+                  removedRids.add(value.rid);
+                }
+                continue;
+              }
+
+              if (value.operation == TransactionIndexContext.IndexKey.IndexKeyOperation.REPLACE && value.oldRid != null) {
+                // #6927: on a unique index a same-key REMOVE + ADD is merged into ONE entry whose oldRid is the RID
+                // being replaced - the REMOVE no longer exists on its own. Commit replays that removal
+                // (TransactionIndexContext.commit), so the lookup must not hand the old RID back either; without this
+                // the caller saw BOTH RIDs under a key that is supposed to hold one.
+                hasRemoves = true;
                 if (removedRids == null)
                   removedRids = new HashSet<>();
-                if (value.rid != null)
-                  removedRids.add(value.rid);
-                continue;
+                removedRids.add(value.oldRid);
               }
 
               if (txChanges == null)
@@ -607,8 +624,9 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
         // MERGE WITH DISK RESULTS, FILTERING OUT REMOVED RIDS
         while (result.hasNext()) {
           final Identifiable next = result.next();
-          if (removedRids == null || !removedRids.contains(next.getIdentity()))
-            txChanges.add(new IndexCursorEntry(convertedKeys, next, 1));
+          if (keyWideRemove || (removedRids != null && removedRids.contains(next.getIdentity())))
+            continue;
+          txChanges.add(new IndexCursorEntry(convertedKeys, next, 1));
         }
         return new TempIndexCursor(txChanges);
       }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -75,7 +75,14 @@ public class LSMTreeIndexCursor implements IndexCursor {
   private       RID[]                                  currentValues;
   private       int                                    currentValueIndex = 0;
   private       TempIndexCursor                        txCursor;
+  /** Key of the in-tx overlay batch currently held: non-null exactly while a batch is pending, whether it carries
+   *  live ADDs ({@link #txCursor}), pending REMOVEs (#6927), or both. */
   private       Object[]                               txCursorKeys;
+  /** #6927: RIDs the pending overlay batch DELETES from the disk entry at {@link #txCursorKeys}. */
+  private       Set<RID>                               txRemovedRIDs;
+  /** #6927: the pending batch removes the WHOLE key - a {@code remove(keys)} carrying no RID, or any REMOVE on a
+   *  unique index, where the key can hold at most one RID. */
+  private       boolean                                txKeyWideRemove;
   /** Dead (tombstone-resolved) keys skipped by this scan; flushed to the main index stats at scan end. */
   private       long                                   deadEntriesSkipped = 0;
   /** Prefetched entry (#5635): produced by {@link #fetchNext()}, drained by {@link #next()}. Never a tombstone. */
@@ -398,7 +405,9 @@ public class LSMTreeIndexCursor implements IndexCursor {
    * by data, so this walk is short and bounded - it runs once per merge round, not once per row.
    */
   private boolean hasMoreSources() {
-    if ((currentValues != null && currentValueIndex < currentValues.length) || txCursor != null)
+    // #6927: txCursorKeys, not txCursor: a pending batch made only of REMOVEs carries no TempIndexCursor, yet the
+    // overlay walk must still reach the live keys sitting behind it.
+    if ((currentValues != null && currentValueIndex < currentValues.length) || txCursorKeys != null)
       return true;
     for (final LSMTreeIndexUnderlyingAbstractCursor pageCursor : pageCursors)
       if (pageCursor != null)
@@ -472,7 +481,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
       // record sharing the same non-unique key), and so a tx key strictly greater than the disk minor key is
       // left for a later round instead of being consumed and dropped.
       boolean includeTx = false;
-      if (txCursor != null && txCursor.hasNext() && txCursorKeys != null) {
+      if (txCursorKeys != null) {
         if (minorKey == null) {
           minorKey = txCursorKeys;
           includeTx = true;
@@ -573,10 +582,29 @@ public class LSMTreeIndexCursor implements IndexCursor {
         }
       }
 
-      // #5055: drain ALL overlay RIDs sharing this key (the whole txCursor batch) and merge them in.
-      if (includeTx)
-        while (txCursor.hasNext())
-          mergedRIDs.add((RID) txCursor.next());
+      if (includeTx) {
+        // #6927: SUBTRACT the overlay's pending REMOVEs from the disk RIDs before the overlay ADDs are merged in.
+        // This is the range-scan half of the filter LSMTreeIndex.get() has always applied to a point lookup
+        // (its removedRids set): without it a key deleted - or re-keyed by an UPDATE, which DocumentIndexer turns
+        // into REMOVE(oldKey,rid) + ADD(newKey,rid) - is still read straight off the page, because the removal
+        // only reaches the pages at commit time. Subtracting BEFORE the ADDs keeps a re-insert at the same key
+        // winning over the removal that preceded it.
+        if (txKeyWideRemove)
+          mergedRIDs.clear();
+        else if (txRemovedRIDs != null)
+          mergedRIDs.removeAll(txRemovedRIDs);
+
+        // #5055: drain ALL overlay RIDs sharing this key (the whole txCursor batch) and merge them in.
+        if (txCursor != null)
+          while (txCursor.hasNext())
+            mergedRIDs.add((RID) txCursor.next());
+
+        // BATCH CONSUMED: drop it so the tail below navigates to the NEXT overlay key
+        txCursor = null;
+        txCursorKeys = null;
+        txRemovedRIDs = null;
+        txKeyWideRemove = false;
+      }
 
       // a consumed key with no surviving RID is pure skip work caused by tombstone build-up:
       // account it so operators can see when a delete-heavy index needs a full compaction
@@ -585,7 +613,8 @@ public class LSMTreeIndexCursor implements IndexCursor {
 
       currentValues = mergedRIDs.isEmpty() ? null : mergedRIDs.toArray(new RID[0]);
 
-      if (txCursor == null || !txCursor.hasNext())
+      // A batch left pending (its key sorts after this round's) must survive to the round that consumes it.
+      if (txCursorKeys == null)
         getClosestEntryInTx(currentKeys != null ? currentKeys : typedFromKeys, false);
     }
   }
@@ -638,6 +667,8 @@ public class LSMTreeIndexCursor implements IndexCursor {
   private void getClosestEntryInTx(final Object[] keys, final boolean inclusive) {
     txCursor = null;
     txCursorKeys = null;
+    txRemovedRIDs = null;
+    txKeyWideRemove = false;
     if (index.getDatabase().getTransaction().getStatus() == TransactionContext.STATUS.BEGUN) {
       Set<IndexCursorEntry> txChanges = null;
 
@@ -691,29 +722,57 @@ public class LSMTreeIndexCursor implements IndexCursor {
           }
 
           final Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey> values = entry.getValue();
+          // #6927: a key whose only pending changes are REMOVEs is NOT nothing - it still has to suppress the
+          // matching disk RIDs downstream in fetchNext(), so it counts as a contributing candidate just like a
+          // live ADD does. Skipping it here (the previous behaviour) is what let a deleted or re-keyed row be
+          // emitted straight off the page.
+          boolean keyContributes = false;
           if (values != null) {
             for (final TransactionIndexContext.IndexKey value : values.values()) {
-              if (value == null || value.operation == TransactionIndexContext.IndexKey.IndexKeyOperation.REMOVE)
-                // REMOVED: A NON-UNIQUE KEY CAN STILL HOLD OTHER LIVE VALUES, SO SKIP JUST THIS ONE RATHER THAN
-                // THE WHOLE KEY
+              if (value == null)
                 continue;
 
-              if (txChanges == null) {
-                txChanges = new HashSet<>();
-                // All entries of this batch share the single overlay key just navigated to; cache it so
-                // next() can peek the batch key without consuming an entry (#5055).
-                txCursorKeys = tmpKeys;
+              if (value.operation == TransactionIndexContext.IndexKey.IndexKeyOperation.REMOVE) {
+                keyContributes = true;
+                if (value.rid == null || index.isUnique())
+                  // remove(keys) carries no RID and kills the whole key. On a unique index every REMOVE does:
+                  // the key holds at most one RID, which is exactly why LSMTreeIndex.get() answers a pending
+                  // REMOVE with EMPTY_CURSOR there.
+                  txKeyWideRemove = true;
+                else {
+                  // NON-UNIQUE: A KEY CAN STILL HOLD OTHER LIVE VALUES, SO REMOVE JUST THIS RID
+                  if (txRemovedRIDs == null)
+                    txRemovedRIDs = new HashSet<>();
+                  txRemovedRIDs.add(value.rid);
+                }
+                continue;
               }
 
+              if (value.operation == TransactionIndexContext.IndexKey.IndexKeyOperation.REPLACE && value.oldRid != null) {
+                // REPLACE is a same-key REMOVE(oldRid) + ADD(rid) merged into one entry, and commit does replay
+                // the removal of oldRid (TransactionIndexContext.commit): the scan must not emit it either.
+                if (txRemovedRIDs == null)
+                  txRemovedRIDs = new HashSet<>();
+                txRemovedRIDs.add(value.oldRid);
+              }
+
+              if (txChanges == null)
+                txChanges = new HashSet<>();
+
+              keyContributes = true;
               txChanges.add(new IndexCursorEntry(tmpKeys, value.rid, 1));
             }
           }
 
-          if (txChanges != null)
-            // FOUND A LIVE CANDIDATE
+          if (keyContributes) {
+            // FOUND A CANDIDATE (LIVE ADDS, PENDING REMOVES, OR BOTH). All entries of this batch share the single
+            // overlay key just navigated to; cache it so fetchNext() can peek the batch key without consuming an
+            // entry (#5055), and so a REMOVE-only batch is still visible to it at all (#6927).
+            txCursorKeys = tmpKeys;
             break;
+          }
 
-          // THIS KEY HAD NOTHING LIVE: TRY THE NEXT ONE IN THE SAME DIRECTION
+          // THIS KEY HAD NOTHING AT ALL: TRY THE NEXT ONE IN THE SAME DIRECTION
           entry = ascendingOrder ? indexChanges.higherEntry(entry.getKey()) : indexChanges.lowerEntry(entry.getKey());
         }
       }
@@ -747,6 +806,8 @@ public class LSMTreeIndexCursor implements IndexCursor {
     // a closed cursor is exhausted: drop the prefetched entry and the merge state so hasNext() cannot resurrect it
     txCursor = null;
     txCursorKeys = null;
+    txRemovedRIDs = null;
+    txKeyWideRemove = false;
     currentValues = null;
     currentValueIndex = 0;
     nextValue = null;

--- a/engine/src/test/java/com/arcadedb/index/Issue6927RangeScanTxRemovesTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6927RangeScanTxRemovesTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #6927: an index RANGE scan run inside a transaction ignored the transaction overlay's REMOVE entries, so it
+ * emitted rows that the same transaction had already deleted or re-keyed. The point-lookup path
+ * ({@link com.arcadedb.index.lsm.LSMTreeIndex#get(Object[], int)}) subtracts the pending removals from the disk
+ * result via its {@code removedRids} filter; {@code LSMTreeIndexCursor} collected only the overlay's ADD entries
+ * and dropped the REMOVEs on the floor, so the still-present disk entry was emitted unchanged.
+ * <p>
+ * The user-visible symptom is a row that does not satisfy the WHERE clause at all: {@code UPDATE ... SET age = 99
+ * WHERE age = 20} becomes {@code REMOVE(20, rid) + ADD(99, rid)} in the overlay, and the following
+ * {@code SELECT ... WHERE age &lt; 30} resolved the stale disk entry for key 20 back to the (now age=99) record.
+ * Nothing re-checks the predicate downstream, because the index consumed it entirely.
+ * <p>
+ * The pure-delete variant was wrong in a noisier way: the dead RIDs reached
+ * {@code GetValueFromIndexEntryStep}, which swallows the {@code RecordNotFoundException} with a WARNING per row,
+ * so SQL looked right by accident. Any direct {@link RangeIndex#range} / {@link RangeIndex#iterator} caller had
+ * no such net and received the dead RIDs.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6927RangeScanTxRemovesTest extends TestHelper {
+
+  private static final String TYPE_NAME = "Person";
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      final var type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("name", Type.STRING);
+      type.createProperty("age", Type.INTEGER);
+      type.createProperty("code", Type.INTEGER);
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "age" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "code" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+    });
+
+    database.transaction(() -> {
+      database.newDocument(TYPE_NAME).set("name", "a").set("age", 20).set("code", 1).save();
+      database.newDocument(TYPE_NAME).set("name", "b").set("age", 25).set("code", 2).save();
+    });
+  }
+
+  /**
+   * The reporter's exact shape: an in-transaction UPDATE that re-keys an indexed property, followed by a range
+   * scan whose predicate the index consumes entirely. Before the fix the scan returned the re-keyed row too,
+   * with {@code age=99}, i.e. a row violating the WHERE clause it was selected by.
+   */
+  @Test
+  void rangeScanDoesNotReturnRowReKeyedInTheSameTransaction() {
+    database.begin();
+    try {
+      database.command("sql", "UPDATE " + TYPE_NAME + " SET age = 99 WHERE age = 20");
+
+      final List<String> names = new ArrayList<>();
+      final ResultSet rs = database.query("sql", "SELECT name, age FROM " + TYPE_NAME + " WHERE age < 30");
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        assertThat(r.<Integer>getProperty("age")).isLessThan(30);
+        names.add(r.getProperty("name"));
+      }
+
+      assertThat(names).containsExactly("b");
+
+      // the point-lookup path has always been right: keep both paths pinned to the same answer
+      assertThat(database.lookupByKey(TYPE_NAME, "age", 20).hasNext()).isFalse();
+
+      // ...and the new key must be visible to the range scan
+      final List<String> reKeyed = new ArrayList<>();
+      final ResultSet rs2 = database.query("sql", "SELECT name FROM " + TYPE_NAME + " WHERE age > 30");
+      while (rs2.hasNext())
+        reKeyed.add(rs2.next().getProperty("name"));
+      assertThat(reKeyed).containsExactly("a");
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * The same asymmetry seen from the raw {@link RangeIndex} API, which has no {@code RecordNotFoundException}
+   * net downstream: a record deleted in this transaction must not be handed back by an ordered scan.
+   */
+  @Test
+  void rangeCursorSkipsRecordDeletedInTheSameTransaction() {
+    database.begin();
+    try {
+      final RID deleted = lookupRid("age", 20);
+      database.lookupByRID(deleted, true).asDocument().delete();
+
+      assertThat(collectRange("age", 0, 30, true)).doesNotContain(deleted).hasSize(1);
+      assertThat(collectRange("age", 0, 30, false)).doesNotContain(deleted).hasSize(1);
+      assertThat(collectIterator("age", true)).doesNotContain(deleted).hasSize(1);
+      assertThat(collectIterator("age", false)).doesNotContain(deleted).hasSize(1);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * A non-unique key holding two RIDs where only one is deleted in the transaction: the per-RID REMOVE must
+   * suppress exactly that RID and leave the sibling alone. This is the case a "the whole key is gone" shortcut
+   * would get wrong in the opposite direction.
+   */
+  @Test
+  void rangeCursorSuppressesOnlyTheRemovedRidOfASharedKey() {
+    database.transaction(() -> database.newDocument(TYPE_NAME).set("name", "c").set("age", 20).set("code", 3).save());
+
+    database.begin();
+    try {
+      final List<RID> sharing = collectRange("age", 20, 20, true);
+      assertThat(sharing).hasSize(2);
+
+      final RID victim = sharing.getFirst();
+      final RID survivor = sharing.get(1);
+      database.lookupByRID(victim, true).asDocument().delete();
+
+      assertThat(collectRange("age", 0, 30, true)).contains(survivor).doesNotContain(victim);
+      assertThat(collectRange("age", 0, 30, false)).contains(survivor).doesNotContain(victim);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * On a UNIQUE index a pending REMOVE means the key is gone, exactly as {@code LSMTreeIndex.get()} already
+   * decided by returning an empty cursor; the range scan has to agree.
+   */
+  @Test
+  void rangeCursorHonoursPendingRemoveOnAUniqueIndex() {
+    database.begin();
+    try {
+      final RID deleted = lookupRid("code", 1);
+      database.lookupByRID(deleted, true).asDocument().delete();
+
+      assertThat(database.lookupByKey(TYPE_NAME, "code", 1).hasNext()).isFalse();
+      assertThat(collectRange("code", 0, 10, true)).doesNotContain(deleted).hasSize(1);
+      assertThat(collectRange("code", 0, 10, false)).doesNotContain(deleted).hasSize(1);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * A record deleted AND a fresh one inserted at the same key in the same transaction: the ADD has to resurrect
+   * the key even though a REMOVE is pending on it, so the scan sees the new RID and only the new RID.
+   */
+  @Test
+  void rangeCursorResurrectsAKeyReInsertedAfterTheRemove() {
+    database.begin();
+    try {
+      final RID deleted = lookupRid("age", 20);
+      database.lookupByRID(deleted, true).asDocument().delete();
+      final RID inserted = database.newDocument(TYPE_NAME).set("name", "a2").set("age", 20).set("code", 4).save()
+          .getIdentity();
+
+      final List<RID> rids = collectRange("age", 0, 30, true);
+      assertThat(rids).contains(inserted).doesNotContain(deleted).hasSize(2);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * Every entry of the scanned range removed in the transaction: the cursor must report exhaustion instead of
+   * emitting dead RIDs, and must not resurrect them on a descending pass either.
+   */
+  @Test
+  void rangeCursorIsEmptyWhenEveryEntryWasRemovedInTheTransaction() {
+    database.begin();
+    try {
+      for (final RID rid : collectRange("age", 0, 100, true))
+        database.lookupByRID(rid, true).asDocument().delete();
+
+      assertThat(collectRange("age", 0, 100, true)).isEmpty();
+      assertThat(collectRange("age", 0, 100, false)).isEmpty();
+      assertThat(collectIterator("age", true)).isEmpty();
+
+      final ResultSet rs = database.query("sql", "SELECT FROM " + TYPE_NAME + " WHERE age < 100");
+      assertThat(rs.hasNext()).isFalse();
+    } finally {
+      database.rollback();
+    }
+  }
+
+  private RID lookupRid(final String property, final Object key) {
+    final IndexCursor cursor = database.lookupByKey(TYPE_NAME, property, key);
+    assertThat(cursor.hasNext()).isTrue();
+    return cursor.next().getIdentity();
+  }
+
+  private RangeIndex rangeIndex(final String property) {
+    return (RangeIndex) database.getSchema().getType(TYPE_NAME).getPolymorphicIndexByProperties(property);
+  }
+
+  private List<RID> collectRange(final String property, final int from, final int to, final boolean ascending) {
+    final IndexCursor cursor = rangeIndex(property).range(ascending, new Object[] { ascending ? from : to }, true,
+        new Object[] { ascending ? to : from }, true);
+    return drain(cursor);
+  }
+
+  private List<RID> collectIterator(final String property, final boolean ascending) {
+    return drain(rangeIndex(property).iterator(ascending));
+  }
+
+  private List<RID> drain(final IndexCursor cursor) {
+    final List<RID> rids = new ArrayList<>();
+    while (cursor.hasNext()) {
+      final Identifiable next = cursor.next();
+      assertThat(next).isNotNull();
+      rids.add(next.getIdentity());
+      // a RID handed out by an in-tx scan must resolve: a dead one is exactly the defect this test guards
+      final Document doc = database.lookupByRID(next.getIdentity(), true).asDocument();
+      assertThat(doc).isNotNull();
+    }
+    return rids;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue6927RangeScanTxRemovesTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6927RangeScanTxRemovesTest.java
@@ -216,6 +216,114 @@ class Issue6927RangeScanTxRemovesTest extends TestHelper {
     }
   }
 
+  /**
+   * The {@code REPLACE} shape, which only a UNIQUE index can produce: within one transaction the record holding key
+   * {@code K} is deleted and a DIFFERENT record is inserted at the same {@code K}. Because a unique index's overlay
+   * map is keyed by key value alone (not by RID), {@code TransactionIndexContext.addIndexKeyLock} collapses the pair
+   * into a single {@code REPLACE(rid=new, oldRid=old)} entry - so the pending removal of the old RID survives ONLY
+   * as {@code oldRid}, which commit does replay ({@code index.removeReplay(keyValues, oldRid)}). A scan that reads
+   * only {@code rid} therefore re-emits the old RID straight off the page.
+   * <p>
+   * The type is created with a single bucket on purpose: each bucket owns its own sub-index and therefore its own
+   * transaction lane, so a delete and an insert landing in different buckets stay two independent entries and never
+   * merge into a REPLACE.
+   */
+  @Test
+  void rangeScanAndLookupAgreeOnAUniqueKeyReplacedInTheSameTransaction() {
+    database.transaction(() -> {
+      final var type = database.getSchema().createDocumentType("Registration", 1);
+      type.createProperty("code", Type.INTEGER);
+      database.getSchema().buildTypeIndex("Registration", new String[] { "code" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+    });
+    database.transaction(() -> database.newDocument("Registration").set("code", 7).save());
+
+    database.begin();
+    try {
+      final IndexCursor before = database.lookupByKey("Registration", "code", 7);
+      assertThat(before.hasNext()).isTrue();
+      final RID replaced = before.next().getIdentity();
+
+      database.lookupByRID(replaced, true).asDocument().delete();
+      final RID replacement = database.newDocument("Registration").set("code", 7).save().getIdentity();
+
+      final RangeIndex index = (RangeIndex) database.getSchema().getType("Registration")
+          .getPolymorphicIndexByProperties("code");
+
+      final List<RID> ranged = drain(index.range(true, new Object[] { 0 }, true, new Object[] { 10 }, true));
+      assertThat(ranged).containsExactly(replacement);
+      assertThat(drain(index.range(false, new Object[] { 10 }, true, new Object[] { 0 }, true)))
+          .containsExactly(replacement);
+
+      // the point lookup on a UNIQUE key must agree: exactly one RID, the replacement. Asserted on the RAW
+      // sub-index too: TypeIndex.get() asks a unique index for limit=1 and returns whichever entry comes out
+      // first, so it would MASK a two-RID answer behind HashSet iteration order rather than fail on it.
+      for (final IndexInternal sub : ((TypeIndex) database.getSchema().getType("Registration")
+          .getPolymorphicIndexByProperties("code")).getSubIndexes())
+        assertThat(drain(sub.get(new Object[] { 7 }))).containsExactly(replacement);
+
+      assertThat(drain(database.lookupByKey("Registration", "code", 7))).containsExactly(replacement);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * A key-wide {@code remove(keys)} - the manual-index API form that carries no RID - on a NON-unique index. Both the
+   * range scan and the point lookup have to drop every disk RID at that key. {@code get()} used to allocate an EMPTY
+   * {@code removedRids} set for this shape and then filter nothing with it, so the removal was silently a no-op.
+   */
+  @Test
+  void bothPathsHonourAKeyWideRemoveOnANonUniqueIndex() {
+    database.transaction(() -> database.newDocument(TYPE_NAME).set("name", "c").set("age", 20).set("code", 3).save());
+
+    database.begin();
+    try {
+      final RangeIndex index = rangeIndex("age");
+      assertThat(drain(index.get(new Object[] { 20 }))).hasSize(2);
+
+      // no RID: the whole key goes, both RIDs with it
+      ((com.arcadedb.index.IndexInternal) index).remove(new Object[] { 20 });
+
+      assertThat(index.get(new Object[] { 20 }).hasNext()).isFalse();
+      assertThat(collectRange("age", 0, 30, true)).hasSize(1);
+      assertThat(collectRange("age", 0, 30, false)).hasSize(1);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * The same REPLACE shape as {@link #rangeScanAndLookupAgreeOnAUniqueKeyReplacedInTheSameTransaction} on a HASH
+   * index, whose {@code get()} carries a copy of the very same overlay-merge code. A hash index has no range scan,
+   * so the point lookup is the only path there - and it has to answer with one RID, not two.
+   */
+  @Test
+  void hashIndexLookupHonoursAUniqueKeyReplacedInTheSameTransaction() {
+    database.transaction(() -> {
+      final var type = database.getSchema().createDocumentType("Badge", 1);
+      type.createProperty("serial", Type.INTEGER);
+      database.getSchema().buildTypeIndex("Badge", new String[] { "serial" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+    });
+    database.transaction(() -> database.newDocument("Badge").set("serial", 11).save());
+
+    database.begin();
+    try {
+      final RID replaced = database.lookupByKey("Badge", "serial", 11).next().getIdentity();
+      database.lookupByRID(replaced, true).asDocument().delete();
+      final RID replacement = database.newDocument("Badge").set("serial", 11).save().getIdentity();
+
+      for (final IndexInternal sub : ((TypeIndex) database.getSchema().getType("Badge")
+          .getPolymorphicIndexByProperties("serial")).getSubIndexes())
+        assertThat(drain(sub.get(new Object[] { 11 }))).containsExactly(replacement);
+
+      assertThat(drain(database.lookupByKey("Badge", "serial", 11))).containsExactly(replacement);
+    } finally {
+      database.rollback();
+    }
+  }
+
   private RID lookupRid(final String property, final Object key) {
     final IndexCursor cursor = database.lookupByKey(TYPE_NAME, property, key);
     assertThat(cursor.hasNext()).isTrue();

--- a/engine/src/test/java/com/arcadedb/index/Issue6927RangeScanTxRemovesTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6927RangeScanTxRemovesTest.java
@@ -283,7 +283,7 @@ class Issue6927RangeScanTxRemovesTest extends TestHelper {
       assertThat(drain(index.get(new Object[] { 20 }))).hasSize(2);
 
       // no RID: the whole key goes, both RIDs with it
-      ((com.arcadedb.index.IndexInternal) index).remove(new Object[] { 20 });
+      ((IndexInternal) index).remove(new Object[] { 20 });
 
       assertThat(index.get(new Object[] { 20 }).hasNext()).isFalse();
       assertThat(collectRange("age", 0, 30, true)).hasSize(1);


### PR DESCRIPTION
Closes #6927

## Summary

An index **range** scan run inside a transaction ignored the transaction overlay's `REMOVE` entries, so it kept emitting rows the same transaction had already deleted or re-keyed. The **point-lookup** path has always been right: `LSMTreeIndex.get()` collects the pending removals into a `removedRids` set and subtracts them from the disk result (and short-circuits to `EMPTY_CURSOR` on a unique index). `LSMTreeIndexCursor.getClosestEntryInTx()` walked the very same `getIndexChanges().getIndexKeys()` map but collected only the ADDs, `continue`-ing past every REMOVE without recording it anywhere. `fetchNext()` then built the emitted set from page bytes plus overlay ADDs only, and a key whose sole pending change was a REMOVE came straight off the page unchanged - the removal does not reach the pages until commit.

The clean symptom is a row that does not satisfy the WHERE clause at all. `UPDATE Person SET age = 99 WHERE age = 20` becomes `REMOVE(20, rid) + ADD(99, rid)` in the overlay (`DocumentIndexer`), so the following `SELECT ... WHERE age < 30` resolved the stale disk entry for key `20` back to the record - which now has `age = 99`. Nothing re-checks the predicate downstream, because `SelectExecutionPlanner.needsFilterStep()` only chains a `FilterStep` for a *remaining* condition and the index consumed `age < 30` entirely. The pure-delete variant looked right by accident and was noisy about it: the dead RIDs reached `GetValueFromIndexEntryStep`, which swallows the `RecordNotFoundException` with a WARNING per row. Any direct `RangeIndex.range(...)` / `iterator(...)` caller has no such net and simply received dead RIDs.

## The fix (`LSMTreeIndexCursor`)

Mirror `get()`'s filter on the ordered path, in three connected pieces:

1. **`getClosestEntryInTx()` now records the REMOVEs** instead of skipping them: per-RID removals into `txRemovedRIDs`, a whole-key removal into `txKeyWideRemove` (a `remove(keys)` carrying no RID, or *any* REMOVE on a unique index - the key holds at most one RID there, which is exactly why `get()` answers `EMPTY_CURSOR`). A `REPLACE` carrying an `oldRid` - the same-key `REMOVE(oldRid) + ADD(rid)` merge - also contributes `oldRid`, since `TransactionIndexContext.commit()` does replay that removal.
2. **A REMOVE-only key is now a contributing candidate.** The walk used to stop only at a key with a live ADD, so a key that only *deletes* was skipped and its information lost. It now breaks on "live ADDs, pending REMOVEs, or both", which is what makes the suppression reachable at all. The issue flagged this explicitly.
3. **`fetchNext()` subtracts before it unions.** The overlay's removals are applied to the disk RIDs first, then the overlay ADDs are merged in - so a re-insert at the same key still wins over the REMOVE that preceded it.

Two bookkeeping consequences of (2), both necessary:

- `txCursorKeys` (not `txCursor`) is now the "a batch is pending" signal, in `hasMoreSources()` and in the `includeTx` guard: a REMOVE-only batch carries no `TempIndexCursor`, and if `hasMoreSources()` still keyed off `txCursor` the scan would report itself exhausted at the first REMOVE-only overlay key, hiding every live key behind it.
- The batch is explicitly cleared where it is consumed, and the tail re-navigation is gated on `txCursorKeys == null`, so a batch whose key sorts *after* this round's minor key survives to the round that actually consumes it rather than being navigated past.

Termination is unchanged: every round still either advances a page cursor or consumes (and clears) the overlay batch, whose successor is strictly greater/lesser in scan direction.

No new work on the happy path: `txRemovedRIDs` is allocated only when the transaction actually has a pending removal on the key being visited, and `hasMoreSources()` swaps one null-check for another.

## Test plan

New `engine/src/test/java/com/arcadedb/index/Issue6927RangeScanTxRemovesTest.java` - **6 tests, all 6 fail on `main`, all 6 pass with the fix**. `drain()` resolves every RID the cursor hands out, so a dead RID fails the test instead of being logged away:

- [x] `rangeScanDoesNotReturnRowReKeyedInTheSameTransaction` - the reporter's exact shape end to end. Asserts `age < 30` on every returned row (fails on `main` with `99 to be less than 30`), pins the point lookup to the same answer, and checks the *new* key is visible to the range scan.
- [x] `rangeCursorSkipsRecordDeletedInTheSameTransaction` - raw `RangeIndex.range()` and `.iterator()`, ascending and descending.
- [x] `rangeCursorSuppressesOnlyTheRemovedRidOfASharedKey` - non-unique key holding two RIDs, one deleted: the sibling must survive (the case a "whole key is gone" shortcut gets wrong in the other direction).
- [x] `rangeCursorHonoursPendingRemoveOnAUniqueIndex` - unique index, pending REMOVE suppresses the key, agreeing with `get()`.
- [x] `rangeCursorResurrectsAKeyReInsertedAfterTheRemove` - delete + re-insert at the same key in one transaction: the new RID and only the new RID.
- [x] `rangeCursorIsEmptyWhenEveryEntryWasRemovedInTheTransaction` - every entry of the range removed: exhaustion, both directions, plus the SQL view.

Regression runs (worktree, isolated `-Dmaven.repo.local`):

- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.index.**.*Test' -DexcludedGroups=benchmark,vector,slow` - **1247/1247 green**
- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.query.**.*Test,com.arcadedb.database.**.*Test,com.arcadedb.*Test' -DexcludedGroups=benchmark,vector,slow` - **8710 run, 0 failures** (covers SQL, `select`, and the openCypher engine, which read through this cursor)
- [x] `mvn -o -pl engine test -DexcludedGroups=benchmark,vector,slow` - **full engine module BUILD SUCCESS**, including the neighbouring cursor regression suites `Issue5662IndexCursorFollowUpsTest`, `Issue5683LSMTreeIndexCursorTest`, `Issue6592ClosestEntryInTxSkipsTombstonedKeyTest`, `LSMTreeIndexCursorContractTest`, `LSMTreeIndexCursorTombstoneRunTest`, `TransactionIndexKeyCollisionTest`
- One run of the index package showed `Issue6559ApproximateDeltaScoringScaleTest` red; it passes alone and on a clean re-run of the same selection, and it is a jvector PQ/delta-buffer timing fixture with no path through `LSMTreeIndexCursor`. Flake, not a regression.

## Review round 1: the point-lookup path had the same gap after all

The first review flagged the new `REPLACE`/`oldRid` branch as untested and questioned the PR's claim that "the point-lookup path has always been right". Both points were correct, and the second one was worse than it looked:

- `LSMTreeIndex.get()` never reads `oldRid`, so on a unique index it returned **both** the replaced and the replacement RID for a key that holds one. Confirmed by probing the raw sub-index in a running transaction: `subIndex.get([7]) -> #1:1, #1:0`.
- That did **not** show up through `lookupByKey`, because `TypeIndex.get()` asks a unique sub-index for `limit=1` and returns whichever entry the `HashSet` yields first. It masks the two-RID answer behind iteration order rather than failing on it - so the correct-looking answer was luck, not filtering.
- `get()` also allocated an **empty** `removedRids` set for a non-unique key-wide `remove(keys)` (RID `null`) and then filtered nothing with it, so a whole-key removal was a silent no-op. That is the gap the first revision disclosed as "adjacent, deliberately not changed".

Leaving those would have made the two paths disagree on exactly the case this PR exists to make them agree on, and would have left the requested `REPLACE` regression test pinned to `HashSet` order. So `get()` now applies the same three rules the cursor does: per-RID REMOVE subtracts that RID, a RID-less REMOVE drops the whole key, and a `REPLACE` subtracts its `oldRid`. `HashIndex.get()` carries a copy of the same overlay-merge block and got the identical correction - a hash index has no range scan, so its point lookup is the only path there.

### Tests added in this round (3 more, 9 total)

All three fail without the `get()` change (`Tests run: 9, Failures: 1, Errors: 2`) and pass with it:

- [x] `rangeScanAndLookupAgreeOnAUniqueKeyReplacedInTheSameTransaction` - the real `REPLACE` shape: unique index on a **single-bucket** type (each bucket owns its own sub-index and therefore its own tx lane, so a cross-bucket delete/insert never merges into a REPLACE). Asserts the ascending range, the descending range, **the raw sub-index `get()`** - not just `lookupByKey`, precisely because `TypeIndex` would mask it - and `lookupByKey`.
- [x] `hashIndexLookupHonoursAUniqueKeyReplacedInTheSameTransaction` - the same shape on a HASH unique index, asserted on every sub-index.
- [x] `bothPathsHonourAKeyWideRemoveOnANonUniqueIndex` - `remove(keys)` with no RID on a non-unique index: `get()` empty, and the range scan drops both RIDs at that key.

Verified the `REPLACE` branch is actually reached rather than assumed: a throwaway probe dumped the overlay for this exact fixture and printed `op=REPLACE rid=#1:1 oldRid=#1:0`.

- [x] Re-ran the full engine module after the change: `mvn -o -pl engine test -DexcludedGroups=benchmark,vector,slow` -> **Tests run: 13928, Failures: 0, Errors: 0, Skipped: 23, BUILD SUCCESS**

Nothing is left disclosed-but-unfixed now; the "adjacent, deliberately NOT changed" carve-out from the first revision is gone because it was fixed.

## Review round 2

- Applied: the fully-qualified `com.arcadedb.index.IndexInternal` cast in the test is now a plain `IndexInternal` (the test class already lives in that package, so no import is needed either). 9/9 still green.
- **Not applied, by the reviewer's own recommendation:** extracting the overlay REMOVE/REPLACE filtering into a shared static helper so `LSMTreeIndex.get()`, `HashIndex.get()` and `LSMTreeIndexCursor.getClosestEntryInTx()` stop carrying three near-identical copies. The duplication is real and this PR is itself the evidence for it - round 1 fixed one site and round 2 had to catch up two more. But the two `get()` methods have no common base class holding an index-specific `get()`, so a helper means touching three hot read paths for a refactor the reported defect does not need, and the reviewer explicitly rated it "might not be worth the churn in this PR". Filed as #6970 so a fourth call site cannot reintroduce the gap independently.
- On the flaky `Issue6559ApproximateDeltaScoringScaleTest`: agreed that PR CI is the right arbiter. It has no path through `LSMTreeIndexCursor` or either `get()`, passes in isolation, and passed on a clean re-run of the same 1247-test selection.

## Review round 3

No correctness findings. The reviewer independently cross-checked every branch against `TransactionIndexContext.commit()`'s replay and confirmed the read-side filter and the write-side replay agree on what a `REPLACE` means, including that the one `REPLACE` shape with a null `oldRid` (the cross-bucket duplicate check at `TransactionIndexContext.java:546`) is correctly *not* treated as a removal - that RID belongs to another sub-index's lane, which supplies its own REMOVE.

The one action asked for was filing the deduplication follow-up rather than doing it here: **#6970**.

Per #6927's comment thread, this lands before #6944 (the per-key-group allocations in `fetchNext()`), since it changes what state that loop has to keep.
