### PR TITLE
fix(#6936,#6859): sparse groupBy wrong-group selection, async vector rebuild ignores persisted prefix

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -176,6 +177,20 @@ public final class BmwScorer {
    * essential/non-essential split and the block-max skip can prune against it. The threshold is
    * conservative (a candidate above it may still be rejected because its specific group has a higher
    * worst), which is fine: pruning is correct, just slightly less aggressive than non-grouped top-K.
+   * <p>
+   * <b>Group admission is not first-come-first-served (issue #6936).</b> Candidates reach this
+   * traversal in ascending RID order, not score order, so the first {@code limit} distinct group
+   * keys encountered are not necessarily the highest-scoring groups - a much later (higher-RID)
+   * document could hold the single best-scoring group in the corpus. Once all {@code limit} slots
+   * are taken, a genuinely new group key is admitted anyway if its score beats the weakest currently
+   * open group's <i>best</i> member, evicting that group entirely to make room; a key that loses
+   * that comparison is rejected exactly as before. This makes the selected {@code limit} groups
+   * exactly the {@code limit} highest-peaking groups seen, mirroring how #5761 redefined "best
+   * group" for the dense (HNSW) grouped search. One trade-off remains: once the threshold above has
+   * risen, the traversal may already have skipped documents on the assumption that the group set was
+   * settled; a group evicted-then-later-reinstated after that point can end up with fewer than
+   * {@code groupSize} members even if the corpus holds more for it. Which {@code limit} groups win is
+   * always exact; a reinstated group's composition is best-effort from the point of reinstatement.
    * <p>
    * <b>{@code allowedRIDs} filter.</b> Applied inline in the scoring branch: a candidate RID outside
    * the whitelist is dropped before the non-essential probe walk even starts (cursors still advance
@@ -809,14 +824,20 @@ public final class BmwScorer {
     }
   }
 
-  /** Grouped top-K: one min-heap per group key, threshold = min across per-group worst scores. */
+  /**
+   * Grouped top-K: one min-heap per group key, threshold = min across per-group worst scores.
+   * <p>
+   * Admission of a brand-new group key once {@code limit} slots are taken is a comparison against
+   * the weakest currently open group's <i>peak</i> (its own best member) - see {@link #topKGrouped}
+   * for why (issue #6936).
+   */
   private static final class GroupedCollector implements Collector {
     private final int                                        limit;
     private final int                                        groupSize;
     private final Function<RID, Object>                      groupKeyResolver;
     private final Set<RID>                                   allowedRIDs;
     private final boolean                                    filterActive;
-    private final HashMap<Object, RidScoreMinHeap>           groups;
+    private final HashMap<Object, GroupState>                groups;
     private int                                              filledGroups;
     private float                                            threshold = Float.NEGATIVE_INFINITY;
 
@@ -843,47 +864,85 @@ public final class BmwScorer {
     @Override
     public void collect(final RID rid, final float score) {
       final Object groupKey = groupKeyResolver.apply(rid);
-      final RidScoreMinHeap group = groups.get(groupKey);
-      boolean stateChanged = false;
-      if (group == null) {
-        if (groups.size() < limit) {
-          final RidScoreMinHeap opened = new RidScoreMinHeap(groupSize);
-          opened.offer(rid, score);
-          groups.put(groupKey, opened);
-          if (opened.isFull())  // groupSize == 1: the group is already at capacity.
-            filledGroups++;
-          stateChanged = true;
-        }
-        // else: limit groups already open and this one is a new key - reject.
+      GroupState group = groups.get(groupKey);
+      boolean stateChanged;
+      if (group != null) {
+        stateChanged = admit(group, rid, score);
+      } else if (groups.size() < limit) {
+        group = new GroupState(groupSize);
+        groups.put(groupKey, group);
+        stateChanged = admit(group, rid, score);
       } else {
-        final boolean wasFull = group.isFull();
-        stateChanged = group.offer(rid, score);
-        if (!wasFull && group.isFull())
-          filledGroups++;
+        // All limit slots are taken by other keys. Find the weakest one - the lowest peak (best
+        // member) among the open groups - and only displace it if this candidate beats that peak;
+        // a linear scan is cheap here since limit is small and this branch only runs for a
+        // genuinely new key, far rarer than a plain collect() call.
+        Object weakestKey = null;
+        GroupState weakest = null;
+        for (final Map.Entry<Object, GroupState> e : groups.entrySet()) {
+          if (weakest == null || e.getValue().peak < weakest.peak) {
+            weakest = e.getValue();
+            weakestKey = e.getKey();
+          }
+        }
+        if (weakest != null && score > weakest.peak) {
+          if (weakest.heap.isFull())
+            filledGroups--;
+          groups.remove(weakestKey);
+          group = new GroupState(groupSize);
+          groups.put(groupKey, group);
+          stateChanged = admit(group, rid, score);
+        } else
+          stateChanged = false;
       }
       // Recompute the global threshold once every group has reached capacity. Until then it stays
-      // at NEGATIVE_INFINITY: a candidate could still open a new group or fill an empty slot inside
-      // an existing one, so pruning against a per-group watermark would be incorrect.
+      // at NEGATIVE_INFINITY: a candidate could still open a new group, evict a weaker one, or fill
+      // an empty slot inside an existing one, so pruning against a per-group watermark would be
+      // incorrect. Never lowered once raised: an eviction that drops filledGroups back under limit
+      // simply skips this block on the next call rather than walking the threshold back, since a
+      // DAAT traversal cannot un-skip documents it has already pruned past.
       if (stateChanged && filledGroups == limit && groups.size() == limit) {
         float min = Float.POSITIVE_INFINITY;
-        for (final RidScoreMinHeap pq : groups.values()) {
-          if (!pq.isEmpty() && pq.minScore() < min)
-            min = pq.minScore();
+        for (final GroupState g : groups.values()) {
+          if (!g.heap.isEmpty() && g.heap.minScore() < min)
+            min = g.heap.minScore();
         }
         if (min != Float.POSITIVE_INFINITY && min > threshold)
           threshold = min;
       }
     }
 
+    /** Offers {@code (rid, score)} into {@code group}'s heap and keeps its peak/fill bookkeeping current. */
+    private boolean admit(final GroupState group, final RID rid, final float score) {
+      final boolean wasFull = group.heap.isFull();
+      final boolean changed = group.heap.offer(rid, score);
+      if (score > group.peak)
+        group.peak = score;
+      if (!wasFull && group.heap.isFull())
+        filledGroups++;
+      return changed;
+    }
+
     List<RidScore> drain() {
       int total = 0;
-      for (final RidScoreMinHeap pq : groups.values())
-        total += pq.size();
+      for (final GroupState g : groups.values())
+        total += g.heap.size();
       final List<RidScore> out = new ArrayList<>(total);
-      for (final RidScoreMinHeap pq : groups.values())
-        pq.drainInto(out);
+      for (final GroupState g : groups.values())
+        g.heap.drainInto(out);
       out.sort(BY_SCORE_DESC);
       return out;
+    }
+  }
+
+  /** One open group's retained members plus its peak (best member ever admitted), tracked apart from
+   *  the min-heap since {@link RidScoreMinHeap} exposes only the current minimum. */
+  private static final class GroupState {
+    final RidScoreMinHeap heap;
+    float                 peak = Float.NEGATIVE_INFINITY;
+
+    GroupState(final int groupSize) {
+      this.heap = new RidScoreMinHeap(groupSize);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1593,224 +1593,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
       if (!graphNotYetMaterialised())
         return; // Another thread already resolved this while we waited for graphBuildLock
 
-      // Try to load persisted graph from disk
-      // IMPORTANT: If PRODUCT quantization is enabled but PQ file doesn't exist, we need to rebuild
-      // the graph from scratch so that ordinalToVectorId is consistent between graph and PQ.
-      // Loading graph from disk and then building PQ separately causes ordinal mismatch.
-      final boolean needsGraphRebuildForPQ = metadata.quantizationType == VectorQuantizationType.PRODUCT &&
-          pqFile != null && !pqFile.exists();
-      if (needsGraphRebuildForPQ) {
-        LogManager.instance().log(this, Level.INFO,
-            """
-                PRODUCT quantization enabled but PQ file missing - rebuilding graph from scratch for ordinal \
-                consistency: %s""",
-            indexName);
-      }
-
-      // CRITICAL FIX FOR #3135: Check if vectorIndex contains deleted entries
-      // If vectors were updated/deleted, the persisted graph's ordinal mappings are stale.
-      // The graph was built with ordinals based on the old vector set, but after filtering
-      // deleted vectors, the new ordinalToVectorId array will have different indices.
-      // This causes NPE when JVector tries to access vectors using stale ordinals.
-      // Solution: Rebuild graph from scratch if any deleted entries exist.
-      final boolean hasDeletedVectors = vectorIndex().getDeletedCount() > 0;
-      if (hasDeletedVectors) {
-        LogManager.instance().log(this, Level.INFO,
-            """
-                Deleted vectors detected in index %s - rebuilding graph from scratch to ensure ordinal consistency \
-                (fixes issue #3135: stale ordinal mappings after vector updates)""",
-            indexName);
-      }
-
-      final LSMVectorIndexGraphFile gf = graphFile;
-      if (gf != null && gf.hasPersistedGraph() && !needsGraphRebuildForPQ && !hasDeletedVectors) {
-        try {
-          final var loadedGraph = gf.loadGraph();
-
-          // Rebuild ordinalToVectorId from vectorIndex
-          // IMPORTANT: Must match the validation logic used during graph building
-          final String vectorProp =
-              metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ?
-                  metadata.propertyNames.getFirst() : "vector";
-
-          // One read of the location index for the whole walk, both because a per-element accessor call would
-          // re-check the materialisation flag on every live vector and because a compaction swaps the instance
-          // (issue #5568) - a filter that straddled the swap would mix two generations of offsets.
-          final VectorLocationIndex validationLocations = vectorIndex();
-          final int[] rebuiltOrdinalToVectorId = validationLocations.getAllVectorIds().filter(id -> {
-            final long offsetAndFlag = validationLocations.getOffsetAndFlag(id);
-            if (offsetAndFlag == VectorLocationIndex.ABSENT) {
-              return false;
-            }
-
-            // Re-validate vectors to match graph building logic
-            // NOTE: PRODUCT quantization does NOT store vectors in pages - must read from documents like NONE
-            final boolean hasInlineQuantization = metadata.quantizationType == VectorQuantizationType.INT8 ||
-                metadata.quantizationType == VectorQuantizationType.BINARY;
-            if (hasInlineQuantization) {
-              // With INT8/BINARY quantization: verify we can read the quantized vector from pages
-              try {
-                final float[] vector = readVectorFromOffset(VectorLocationIndex.offsetOf(offsetAndFlag),
-                    VectorLocationIndex.isCompactedOf(offsetAndFlag));
-                return vector != null && vector.length == metadata.dimensions && !VectorUtils.isZeroVector(vector);
-              } catch (final Exception e) {
-                return false;
-              }
-            } else {
-              // Without quantization: validate by reading from document.
-              try {
-                final RID rid = validationLocations.getRid(id);
-                if (rid == null)
-                  return false;
-                final Record record = getDatabase().lookupByRID(rid, false);
-                if (record == null)
-                  return false;
-                final Document doc = (Document) record;
-                final Object vectorObj = doc.get(vectorProp);
-                if (vectorObj == null)
-                  return false;
-                final float[] vector = VectorUtils.toFloatArray(vectorObj, metadata.encoding);
-                return vector.length == metadata.dimensions && !VectorUtils.isZeroVector(vector);
-              } catch (final Exception e) {
-                return false;
-              }
-            }
-          }).sorted().toArray();
-
-          final int graphSize = loadedGraph != null ? loadedGraph.size() : 0;
-          LogManager.instance().log(this, Level.INFO,
-              "Loaded graph from disk for index: %s, graphSize=%d, ordinalToVectorIdLength=%d, vectorIndexSize=%d",
-              indexName, graphSize, rebuiltOrdinalToVectorId.length, validationLocations.size());
-
-          // CRITICAL FIX FOR #3722: a persisted graph with fewer nodes than there are active vectors is stale -
-          // vectors were added after it was last built and persisted. On database restart deltaVectors (volatile)
-          // are lost and graphState is set to IMMUTABLE, so rebuildGraphBeforeSearch() never triggers and search
-          // can only find nodes in the stale graph.
-          //
-          // ISSUE #6106: that comparison is about how MANY vectors there are, and reusing the graph needs to know
-          // WHICH ones. The graph is addressed by ordinal, and ordinal i means a record only through the array
-          // rebuilt just above; pair a graph with an array from another generation of the live set and every node
-          // answers for a record it was never built from - a wrong-but-plausible result, not a failure. Counts
-          // cannot separate the two: since the renumbering compaction of issue #5870 every generation's ids are
-          // densely [0, N), so two generations holding different records routinely produce arrays of identical
-          // length. The manifest written next to the graph records the correspondence itself, and comparing
-          // against it is what makes the reuse safe rather than merely plausible.
-          final LSMVectorIndexGraphManifest.Content persistedManifest = gf.getManifest().read();
-
-          final String staleReason;
-          if (persistedManifest == null) {
-            // No manifest: a graph persisted by a version older than this check, or one whose persist was
-            // interrupted before it could write one. Judge it the historical way, by node count, rather than
-            // forcing every existing index to rebuild on the first open after an upgrade - but widen the
-            // comparison to ANY difference, because a graph larger than the live set lines its ordinals up no
-            // better than a smaller one: everything past the end of the rebuilt array is dropped as out of
-            // bounds, and everything before it can still address the wrong record.
-            staleReason = graphSize != rebuiltOrdinalToVectorId.length ?
-                "it has no manifest and holds %d nodes against %d active vectors".formatted(graphSize,
-                    rebuiltOrdinalToVectorId.length) :
-                null;
-            if (staleReason == null) {
-              // Also counted, not only logged: a WARNING is easy to miss, and "is this index still on the weaker
-              // comparison?" is a question an operator should be able to ask the stats rather than the log file.
-              metrics.incrementUnverifiedGraphReuses();
-              LogManager.instance().log(this, Level.WARNING,
-                  "Vector index %s is reusing a persisted graph that carries no manifest: its %d nodes match the "
-                      + "live vector count, but nothing on disk says they describe these records (issue #6106). "
-                      + "The next graph persist writes one; REBUILD INDEX forces it now",
-                  indexName, graphSize);
-            }
-          } else if (persistedManifest.vectorCount() != rebuiltOrdinalToVectorId.length
-              || persistedManifest.fingerprint() != LSMVectorIndexGraphManifest.fingerprintOf(
-              rebuiltOrdinalToVectorId, validationLocations::getRid)) {
-            staleReason = "it was built over %d records the manifest fingerprints as %s, not over the %d now live".formatted(
-                persistedManifest.vectorCount(), Long.toHexString(persistedManifest.fingerprint()),
-                rebuiltOrdinalToVectorId.length);
-          } else if (graphSize != rebuiltOrdinalToVectorId.length) {
-            // The manifest agrees with the live set but the pages do not: a truncated or otherwise damaged
-            // persist. Nothing here can repair it, so rebuild.
-            staleReason = "the pages hold %d nodes while its manifest and the live set both say %d".formatted(
-                graphSize, rebuiltOrdinalToVectorId.length);
-          } else
-            staleReason = null;
-
-          if (staleReason != null) {
-            // ISSUE #6655: a graph stale ONLY because more vectors were added since it was built - no deletions
-            // (guaranteed by the !hasDeletedVectors guard above) and, when a manifest is present, its fingerprint
-            // proves the graph's own ordinals [0, graphSize) still resolve to exactly the records they were built
-            // from - is not wrong, only behind. That is the identical staleness rebuildGraphBeforeSearch()'s async
-            // policy already tolerates mid-session (a graph missing the newest vectors, not one describing the
-            // wrong ones), so it is reused immediately instead of paying a synchronous full rebuild on the calling
-            // search thread for however large the WHOLE index has become - the reopen-time counterpart of #6067's
-            // close-time deferral, reached through the general stale-persisted-graph path rather than only the
-            // deferred-close one. A missing manifest cannot support this: the weak node-count comparison above
-            // proves nothing about WHICH records a same-sized graph describes, and a prefix of it proves even
-            // less. Below the async-rebuild threshold a synchronous rebuild is already cheap, so it is left alone.
-            // vectorIndex.size(), not graphIndex.size() as rebuildGraphBeforeSearch()'s analogous check uses:
-            // graphIndex is not yet set on this path (that is the whole point - the persisted graph has not been
-            // published to it yet), so the only live-vector count available here is the index's, which is also
-            // the more conservative of the two whenever they would differ (rebuiltOrdinalToVectorId.length can
-            // be smaller after validation filtering, never larger) - "is this worth deferring" errs towards yes.
-            final int[] prefix = persistedManifest != null && graphSize == persistedManifest.vectorCount()
-                && graphSize < rebuiltOrdinalToVectorId.length && graphSize > 0
-                && validationLocations.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE
-                && persistedManifest.fingerprint() == LSMVectorIndexGraphManifest.fingerprintOf(
-                Arrays.copyOf(rebuiltOrdinalToVectorId, graphSize), validationLocations::getRid) ?
-                rebuiltOrdinalToVectorId : null;
-
-            if (prefix != null) {
-              // Deliberately not done here: reuseStalePrefixGraph() does real I/O for the gap and must run
-              // unlocked (see the field javadoc above). Only the decision - not the read - belongs under this
-              // lock, same as every other branch in this method.
-              prefixReuseCandidate = new ReuseCandidate(loadedGraph, prefix, graphSize, vectorProp);
-            } else
-              LogManager.instance().log(this, Level.INFO,
-                  "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
-                  indexName, staleReason);
-            // Don't use the stale graph as IMMUTABLE — fall through to buildGraphFromScratch() below unless the
-            // prefix reuse above already queued a deferred reuse
-          } else {
-            // Graph is up to date — publish it under a brief write lock (issue #6713), then finish PQ
-            // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
-            lock.writeLock().lock();
-            try {
-              this.graphIndex = loadedGraph;
-              this.ordinalToVectorId = rebuiltOrdinalToVectorId;
-              if (graphState == GraphState.LOADING)
-                this.graphState = GraphState.IMMUTABLE;
-              // else: a concurrent put()/putBatch()/remove() already advanced graphState to MUTABLE while
-              // this validation ran unlocked. The freshly loaded graph is still a correct base for
-              // mergeWithDeltaScan() to merge against - it was built from a vectorIndex snapshot taken during
-              // that validation, and whatever changed since then is already in deltaVectors - but overwriting
-              // MUTABLE back to IMMUTABLE here would hide those pending deltas from search.
-            } finally {
-              lock.writeLock().unlock();
-            }
-
-            // Build PQ if PRODUCT quantization is enabled but PQ file doesn't exist
-            // This handles the case where graph was built before PRODUCT quantization was added
-            if (metadata.quantizationType == VectorQuantizationType.PRODUCT && pqFile != null && !pqFile.isPQReady()) {
-              LogManager.instance().log(this, Level.INFO,
-                  "PQ not available after graph load, building PQ for index: %s", indexName);
-              try {
-                // Create vector values from the loaded vectorIndex for PQ building
-                final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
-                    metadata.dimensions, vectorProp,
-                    snapshotOf(vectorIndex(), ordinalToVectorId), ordinalToVectorId, this,
-                    computeGraphBuildCacheCapacity(ordinalToVectorId.length, false));
-                buildAndPersistPQ(vectors);
-              } catch (final Exception e) {
-                LogManager.instance().log(this, Level.WARNING,
-                    "Failed to build PQ after graph load for index %s: %s", indexName, e.getMessage());
-              }
-            }
-
-            return;
-          }
-        } catch (final Exception e) {
-          LogManager.instance()
-              .log(this, Level.WARNING, "Failed to load graph for %s, will rebuild: %s", indexName, e.getMessage());
-        }
-      }
+      final PersistedGraphCheck check = loadPersistedGraphOrDecidePrefix();
+      if (check.fullyLoaded())
+        return;
+      prefixReuseCandidate = check.prefix();
 
       // No persisted graph, load failed, or it was stale with no usable prefix - build from scratch.
       // buildGraphFromScratch() acquires graphBuildLock itself; since it is reentrant this is safe to call
@@ -1849,6 +1635,252 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // where graphState stays LOADING across the same window, and it is bounded by a scan rather than by a
       // rebuild.
       reuseStalePrefixGraph(prefixReuseCandidate);
+    }
+  }
+
+  /**
+   * Outcome of {@link #loadPersistedGraphOrDecidePrefix()}: either the persisted graph was already fully
+   * up to date and has been published (nothing more for the caller to do), a stale-but-verified prefix is
+   * available for the caller to reuse via {@link #reuseStalePrefixGraph}, or neither and the caller must
+   * build from scratch.
+   */
+  private record PersistedGraphCheck(boolean fullyLoaded, ReuseCandidate prefix) {
+    private static final PersistedGraphCheck LOADED   = new PersistedGraphCheck(true, null);
+    private static final PersistedGraphCheck UNUSABLE = new PersistedGraphCheck(false, null);
+  }
+
+  /**
+   * The persisted-graph-on-disk decision shared by {@link #ensureGraphAvailable()} and the async-rebuild path
+   * (issue #6859): load it, validate it against the live vector set, and either publish it outright (up to
+   * date), hand back a {@link ReuseCandidate} for the caller to reuse as a prefix (stale only because more
+   * vectors were added - issue #6655), or say neither is possible.
+   * <p>
+   * Must be called while holding {@link #graphBuildLock} - it publishes {@link #graphIndex} directly in the
+   * "up to date" case, and both callers already serialize their own decision under that lock for exactly this
+   * reason. Does no I/O beyond the graph load and the live-set validation scan; the prefix reuse's own gap read
+   * happens later, unlocked, in {@link #reuseStalePrefixGraph}.
+   */
+  private PersistedGraphCheck loadPersistedGraphOrDecidePrefix() {
+    // Try to load persisted graph from disk
+    // IMPORTANT: If PRODUCT quantization is enabled but PQ file doesn't exist, we need to rebuild
+    // the graph from scratch so that ordinalToVectorId is consistent between graph and PQ.
+    // Loading graph from disk and then building PQ separately causes ordinal mismatch.
+    final boolean needsGraphRebuildForPQ = metadata.quantizationType == VectorQuantizationType.PRODUCT &&
+        pqFile != null && !pqFile.exists();
+    if (needsGraphRebuildForPQ) {
+      LogManager.instance().log(this, Level.INFO,
+          """
+              PRODUCT quantization enabled but PQ file missing - rebuilding graph from scratch for ordinal \
+              consistency: %s""",
+          indexName);
+    }
+
+    // CRITICAL FIX FOR #3135: Check if vectorIndex contains deleted entries
+    // If vectors were updated/deleted, the persisted graph's ordinal mappings are stale.
+    // The graph was built with ordinals based on the old vector set, but after filtering
+    // deleted vectors, the new ordinalToVectorId array will have different indices.
+    // This causes NPE when JVector tries to access vectors using stale ordinals.
+    // Solution: Rebuild graph from scratch if any deleted entries exist.
+    final boolean hasDeletedVectors = vectorIndex().getDeletedCount() > 0;
+    if (hasDeletedVectors) {
+      LogManager.instance().log(this, Level.INFO,
+          """
+              Deleted vectors detected in index %s - rebuilding graph from scratch to ensure ordinal consistency \
+              (fixes issue #3135: stale ordinal mappings after vector updates)""",
+          indexName);
+    }
+
+    final LSMVectorIndexGraphFile gf = graphFile;
+    if (gf == null || !gf.hasPersistedGraph() || needsGraphRebuildForPQ || hasDeletedVectors)
+      return PersistedGraphCheck.UNUSABLE;
+
+    try {
+      final var loadedGraph = gf.loadGraph();
+
+      // Rebuild ordinalToVectorId from vectorIndex
+      // IMPORTANT: Must match the validation logic used during graph building
+      final String vectorProp =
+          metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ?
+              metadata.propertyNames.getFirst() : "vector";
+
+      // One read of the location index for the whole walk, both because a per-element accessor call would
+      // re-check the materialisation flag on every live vector and because a compaction swaps the instance
+      // (issue #5568) - a filter that straddled the swap would mix two generations of offsets.
+      final VectorLocationIndex validationLocations = vectorIndex();
+      final int[] rebuiltOrdinalToVectorId = validationLocations.getAllVectorIds().filter(id -> {
+        final long offsetAndFlag = validationLocations.getOffsetAndFlag(id);
+        if (offsetAndFlag == VectorLocationIndex.ABSENT) {
+          return false;
+        }
+
+        // Re-validate vectors to match graph building logic
+        // NOTE: PRODUCT quantization does NOT store vectors in pages - must read from documents like NONE
+        final boolean hasInlineQuantization = metadata.quantizationType == VectorQuantizationType.INT8 ||
+            metadata.quantizationType == VectorQuantizationType.BINARY;
+        if (hasInlineQuantization) {
+          // With INT8/BINARY quantization: verify we can read the quantized vector from pages
+          try {
+            final float[] vector = readVectorFromOffset(VectorLocationIndex.offsetOf(offsetAndFlag),
+                VectorLocationIndex.isCompactedOf(offsetAndFlag));
+            return vector != null && vector.length == metadata.dimensions && !VectorUtils.isZeroVector(vector);
+          } catch (final Exception e) {
+            return false;
+          }
+        } else {
+          // Without quantization: validate by reading from document.
+          try {
+            final RID rid = validationLocations.getRid(id);
+            if (rid == null)
+              return false;
+            final Record record = getDatabase().lookupByRID(rid, false);
+            if (record == null)
+              return false;
+            final Document doc = (Document) record;
+            final Object vectorObj = doc.get(vectorProp);
+            if (vectorObj == null)
+              return false;
+            final float[] vector = VectorUtils.toFloatArray(vectorObj, metadata.encoding);
+            return vector.length == metadata.dimensions && !VectorUtils.isZeroVector(vector);
+          } catch (final Exception e) {
+            return false;
+          }
+        }
+      }).sorted().toArray();
+
+      final int graphSize = loadedGraph != null ? loadedGraph.size() : 0;
+      LogManager.instance().log(this, Level.INFO,
+          "Loaded graph from disk for index: %s, graphSize=%d, ordinalToVectorIdLength=%d, vectorIndexSize=%d",
+          indexName, graphSize, rebuiltOrdinalToVectorId.length, validationLocations.size());
+
+      // CRITICAL FIX FOR #3722: a persisted graph with fewer nodes than there are active vectors is stale -
+      // vectors were added after it was last built and persisted. On database restart deltaVectors (volatile)
+      // are lost and graphState is set to IMMUTABLE, so rebuildGraphBeforeSearch() never triggers and search
+      // can only find nodes in the stale graph.
+      //
+      // ISSUE #6106: that comparison is about how MANY vectors there are, and reusing the graph needs to know
+      // WHICH ones. The graph is addressed by ordinal, and ordinal i means a record only through the array
+      // rebuilt just above; pair a graph with an array from another generation of the live set and every node
+      // answers for a record it was never built from - a wrong-but-plausible result, not a failure. Counts
+      // cannot separate the two: since the renumbering compaction of issue #5870 every generation's ids are
+      // densely [0, N), so two generations holding different records routinely produce arrays of identical
+      // length. The manifest written next to the graph records the correspondence itself, and comparing
+      // against it is what makes the reuse safe rather than merely plausible.
+      final LSMVectorIndexGraphManifest.Content persistedManifest = gf.getManifest().read();
+
+      final String staleReason;
+      if (persistedManifest == null) {
+        // No manifest: a graph persisted by a version older than this check, or one whose persist was
+        // interrupted before it could write one. Judge it the historical way, by node count, rather than
+        // forcing every existing index to rebuild on the first open after an upgrade - but widen the
+        // comparison to ANY difference, because a graph larger than the live set lines its ordinals up no
+        // better than a smaller one: everything past the end of the rebuilt array is dropped as out of
+        // bounds, and everything before it can still address the wrong record.
+        staleReason = graphSize != rebuiltOrdinalToVectorId.length ?
+            "it has no manifest and holds %d nodes against %d active vectors".formatted(graphSize,
+                rebuiltOrdinalToVectorId.length) :
+            null;
+        if (staleReason == null) {
+          // Also counted, not only logged: a WARNING is easy to miss, and "is this index still on the weaker
+          // comparison?" is a question an operator should be able to ask the stats rather than the log file.
+          metrics.incrementUnverifiedGraphReuses();
+          LogManager.instance().log(this, Level.WARNING,
+              "Vector index %s is reusing a persisted graph that carries no manifest: its %d nodes match the "
+                  + "live vector count, but nothing on disk says they describe these records (issue #6106). "
+                  + "The next graph persist writes one; REBUILD INDEX forces it now",
+              indexName, graphSize);
+        }
+      } else if (persistedManifest.vectorCount() != rebuiltOrdinalToVectorId.length
+          || persistedManifest.fingerprint() != LSMVectorIndexGraphManifest.fingerprintOf(
+          rebuiltOrdinalToVectorId, validationLocations::getRid)) {
+        staleReason = "it was built over %d records the manifest fingerprints as %s, not over the %d now live".formatted(
+            persistedManifest.vectorCount(), Long.toHexString(persistedManifest.fingerprint()),
+            rebuiltOrdinalToVectorId.length);
+      } else if (graphSize != rebuiltOrdinalToVectorId.length) {
+        // The manifest agrees with the live set but the pages do not: a truncated or otherwise damaged
+        // persist. Nothing here can repair it, so rebuild.
+        staleReason = "the pages hold %d nodes while its manifest and the live set both say %d".formatted(
+            graphSize, rebuiltOrdinalToVectorId.length);
+      } else
+        staleReason = null;
+
+      if (staleReason != null) {
+        // ISSUE #6655: a graph stale ONLY because more vectors were added since it was built - no deletions
+        // (guaranteed by the !hasDeletedVectors guard above) and, when a manifest is present, its fingerprint
+        // proves the graph's own ordinals [0, graphSize) still resolve to exactly the records they were built
+        // from - is not wrong, only behind. That is the identical staleness rebuildGraphBeforeSearch()'s async
+        // policy already tolerates mid-session (a graph missing the newest vectors, not one describing the
+        // wrong ones), so it is reused immediately instead of paying a synchronous full rebuild on the calling
+        // search thread for however large the WHOLE index has become - the reopen-time counterpart of #6067's
+        // close-time deferral, reached through the general stale-persisted-graph path rather than only the
+        // deferred-close one. A missing manifest cannot support this: the weak node-count comparison above
+        // proves nothing about WHICH records a same-sized graph describes, and a prefix of it proves even
+        // less. Below the async-rebuild threshold a synchronous rebuild is already cheap, so it is left alone.
+        // vectorIndex.size(), not graphIndex.size() as rebuildGraphBeforeSearch()'s analogous check uses:
+        // graphIndex is not yet set on this path (that is the whole point - the persisted graph has not been
+        // published to it yet), so the only live-vector count available here is the index's, which is also
+        // the more conservative of the two whenever they would differ (rebuiltOrdinalToVectorId.length can
+        // be smaller after validation filtering, never larger) - "is this worth deferring" errs towards yes.
+        final int[] prefix = persistedManifest != null && graphSize == persistedManifest.vectorCount()
+            && graphSize < rebuiltOrdinalToVectorId.length && graphSize > 0
+            && validationLocations.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE
+            && persistedManifest.fingerprint() == LSMVectorIndexGraphManifest.fingerprintOf(
+            Arrays.copyOf(rebuiltOrdinalToVectorId, graphSize), validationLocations::getRid) ?
+            rebuiltOrdinalToVectorId : null;
+
+        if (prefix != null) {
+          // Deliberately not done here: reuseStalePrefixGraph() does real I/O for the gap and must run
+          // unlocked (see the field javadoc above). Only the decision - not the read - belongs under this
+          // lock, same as every other branch in this method.
+          return new PersistedGraphCheck(false, new ReuseCandidate(loadedGraph, prefix, graphSize, vectorProp));
+        }
+        LogManager.instance().log(this, Level.INFO,
+            "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
+            indexName, staleReason);
+        // Don't use the stale graph as IMMUTABLE — fall through to buildGraphFromScratch() below unless the
+        // prefix reuse above already queued a deferred reuse
+        return PersistedGraphCheck.UNUSABLE;
+      }
+
+      // Graph is up to date — publish it under a brief write lock (issue #6713), then finish PQ
+      // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
+      lock.writeLock().lock();
+      try {
+        this.graphIndex = loadedGraph;
+        this.ordinalToVectorId = rebuiltOrdinalToVectorId;
+        if (graphState == GraphState.LOADING)
+          this.graphState = GraphState.IMMUTABLE;
+        // else: a concurrent put()/putBatch()/remove() already advanced graphState to MUTABLE while
+        // this validation ran unlocked. The freshly loaded graph is still a correct base for
+        // mergeWithDeltaScan() to merge against - it was built from a vectorIndex snapshot taken during
+        // that validation, and whatever changed since then is already in deltaVectors - but overwriting
+        // MUTABLE back to IMMUTABLE here would hide those pending deltas from search.
+      } finally {
+        lock.writeLock().unlock();
+      }
+
+      // Build PQ if PRODUCT quantization is enabled but PQ file doesn't exist
+      // This handles the case where graph was built before PRODUCT quantization was added
+      if (metadata.quantizationType == VectorQuantizationType.PRODUCT && pqFile != null && !pqFile.isPQReady()) {
+        LogManager.instance().log(this, Level.INFO,
+            "PQ not available after graph load, building PQ for index: %s", indexName);
+        try {
+          // Create vector values from the loaded vectorIndex for PQ building
+          final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
+              metadata.dimensions, vectorProp,
+              snapshotOf(vectorIndex(), ordinalToVectorId), ordinalToVectorId, this,
+              computeGraphBuildCacheCapacity(ordinalToVectorId.length, false));
+          buildAndPersistPQ(vectors);
+        } catch (final Exception e) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Failed to build PQ after graph load for index %s: %s", indexName, e.getMessage());
+        }
+      }
+
+      return PersistedGraphCheck.LOADED;
+    } catch (final Exception e) {
+      LogManager.instance()
+          .log(this, Level.WARNING, "Failed to load graph for %s, will rebuild: %s", indexName, e.getMessage());
+      return PersistedGraphCheck.UNUSABLE;
     }
   }
 
@@ -3740,6 +3772,58 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * The build step of an async graph rebuild (issue #6859). {@link #startAsyncGraphRebuild}'s daemon thread
+   * calls this instead of {@link #buildGraphFromScratch()} directly.
+   * <p>
+   * When this session has never resolved what is on disk for this index ({@link #graphIndex} still {@code
+   * null} - the large-but-unloaded case {@link #inactivityRebuildScopeSize()} already recognises, issue
+   * #6798), the same persisted-graph decision {@link #ensureGraphAvailable()} makes on a search is made here
+   * first: a fully up-to-date persisted graph is published outright, with no rebuild needed at all, and a
+   * stale-but-verified prefix (issue #6655) is published and its gap queued into the delta buffer before the
+   * full rebuild below runs. Either way {@link #graphIndex} becomes non-null - and searchable via the ordinary
+   * delta-merge path - long before an O(current live set) {@code buildGraphFromScratch()} would otherwise
+   * finish. That is the gap this closes: with {@link #graphIndex} still null a concurrent search runs its own
+   * {@link #ensureGraphAvailable()}, which contends for {@link #graphBuildLock} - the same lock
+   * {@code buildGraphFromScratch()} holds for the whole rebuild - and blocks for the full O(N) duration instead
+   * of finding a graph already published and merging its delta scan against it, lock-free.
+   * <p>
+   * An already-resident session (a previous build or reuse already published a graph, or a racing thread just
+   * did while this one waited for {@link #graphBuildLock}) skips straight to {@code buildGraphFromScratch()},
+   * unchanged from before this issue: there is no persisted-graph decision left to make, and loading an older
+   * on-disk graph over a newer in-memory one would throw away progress.
+   * <p>
+   * Deliberately NOT implemented by calling {@link #ensureGraphAvailable()} itself: that method's own
+   * prefix-reuse branch calls {@link #startAsyncGraphRebuild()} at its tail to close the gap it just queued,
+   * and this method already runs from inside that very rebuild's daemon thread - the recursive call would find
+   * {@link #asyncRebuildInProgress} still {@code true} and no-op, leaving the gap queued but never folded into
+   * a real graph, and the next inactivity cycle would repeat the same reuse forever without ever finishing one.
+   * Calling {@link #loadPersistedGraphOrDecidePrefix()} and {@link #reuseStalePrefixGraph} directly, then
+   * falling through to {@code buildGraphFromScratch()} in this same invocation, folds the gap in exactly once,
+   * on this rebuild's own dime, the same way an async rebuild always has.
+   */
+  private void buildOrReuseGraphForAsyncRebuild() {
+    PersistedGraphCheck check = null;
+    if (this.graphIndex == null) {
+      graphBuildLock.lock();
+      try {
+        if (this.graphIndex == null)
+          check = loadPersistedGraphOrDecidePrefix();
+      } finally {
+        graphBuildLock.unlock();
+      }
+    }
+
+    if (check != null) {
+      if (check.fullyLoaded())
+        return; // Published outright; nothing left to build.
+      if (check.prefix() != null)
+        reuseStalePrefixGraph(check.prefix()); // Publishes the prefix and queues the gap; folded in below.
+    }
+
+    buildGraphFromScratch();
+  }
+
+  /**
    * Start an asynchronous graph rebuild in a background daemon thread (issue #3679).
    * The current graph remains available for searches while the rebuild is in progress.
    * When the rebuild completes, the new graph is hot-swapped atomically.
@@ -3805,7 +3889,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // actually about to be claimed, and any other index's rebuild has by now released whatever it held.
         if (!admitOnlineRebuild())
           return;
-        buildGraphFromScratch();
+        buildOrReuseGraphForAsyncRebuild();
         completed = true;
         LogManager.instance().log(this, Level.INFO,
             "Async graph rebuild completed for index: %s", indexName);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1836,12 +1836,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
         LogManager.instance().log(this, Level.INFO,
             "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
             indexName, staleReason);
-        // Don't use the stale graph as IMMUTABLE — fall through to buildGraphFromScratch() below unless the
+        // Don't use the stale graph as IMMUTABLE - fall through to buildGraphFromScratch() below unless the
         // prefix reuse above already queued a deferred reuse
         return PersistedGraphCheck.UNUSABLE;
       }
 
-      // Graph is up to date — publish it under a brief write lock (issue #6713), then finish PQ
+      // Graph is up to date - publish it under a brief write lock (issue #6713), then finish PQ
       // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
       lock.writeLock().lock();
       try {

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3814,8 +3814,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
     }
 
     if (check != null) {
-      if (check.fullyLoaded())
+      if (check.fullyLoaded()) {
+        // graphIndex is already published by loadPersistedGraphOrDecidePrefix() at this point, so clearing the
+        // latch here (unlike ensureGraphAvailable()'s prefix branch) cannot reopen the graphIndex-null-but-latch
+        // -false race window (issue #6772) - there is nothing left for graphNotYetMaterialised() to answer wrong.
+        persistedGraphUnresolved = false;
         return; // Published outright; nothing left to build.
+      }
       if (check.prefix() != null)
         reuseStalePrefixGraph(check.prefix()); // Publishes the prefix and queues the gap; folded in below.
     }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3822,7 +3822,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
         return; // Published outright; nothing left to build.
       }
       if (check.prefix() != null)
-        reuseStalePrefixGraph(check.prefix()); // Publishes the prefix and queues the gap; folded in below.
+        // Publishes the prefix and queues the gap. Its own tail call to startAsyncGraphRebuild() is expected to
+        // no-op here - this method runs from inside that very rebuild's daemon thread, so asyncRebuildInProgress
+        // is still true - not a bug: the fold-in happens via the explicit fall-through to buildGraphFromScratch()
+        // below instead.
+        reuseStalePrefixGraph(check.prefix());
     }
 
     buildGraphFromScratch();

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6936SparseGroupedTopKGroupChoiceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/Issue6936SparseGroupedTopKGroupChoiceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.sparsevector.SegmentFormat.WeightQuantization;
+import com.arcadedb.schema.LocalSchema;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for issue #6936: {@link BmwScorer#topKGrouped}'s group admission handed out its
+ * {@code limit} distinct-group slots to whichever keys the ascending-RID DAAT traversal reached
+ * first, and never revisited that choice once all slots were taken - the sparse index's own
+ * separate collector repeating the defect #5761 fixed for the dense (HNSW) grouped search.
+ * <p>
+ * Reproduces the issue's own repro shape: low-RID documents from groups A, B and C score near
+ * zero for the query, and a single much-later (higher-RID) document from group Z scores far above
+ * everything else. Before the fix, groups A/B/C fill the 3 available slots first and group Z -
+ * holding the single best-scoring document in the corpus - is rejected outright.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6936SparseGroupedTopKGroupChoiceTest extends TestHelper {
+
+  private static final SegmentParameters EXACT_PARAMS = SegmentParameters.builder()
+      .weightQuantization(WeightQuantization.FP32)
+      .build();
+
+  @Test
+  void bestScoringGroupWinsEvenAtTheHighestRid() throws Exception {
+    final Map<RID, Map<Integer, Float>> docs = new TreeMap<>();
+    final Map<RID, String> groupOf = new HashMap<>();
+
+    final int[]   queryDims    = { 0, 1, 2 };
+    final float[] queryWeights = { 1.0f, 1.0f, 1.0f };
+
+    // Groups A, B, C: two low-RID, near-zero-scoring documents each - they fill the 3 slots first.
+    addDoc(docs, groupOf, new RID(0, 1L), "A", Map.of(0, 0.01f));
+    addDoc(docs, groupOf, new RID(0, 2L), "A", Map.of(0, 0.01f));
+    addDoc(docs, groupOf, new RID(0, 3L), "B", Map.of(1, 0.01f));
+    addDoc(docs, groupOf, new RID(0, 4L), "B", Map.of(1, 0.01f));
+    addDoc(docs, groupOf, new RID(0, 5L), "C", Map.of(2, 0.01f));
+    addDoc(docs, groupOf, new RID(0, 6L), "C", Map.of(2, 0.01f));
+    // Group Z: a single, much-later (higher-RID) document that matches every term - the single
+    // best-scoring document in the corpus.
+    addDoc(docs, groupOf, new RID(0, 1_000L), "Z", Map.of(0, 1.0f, 1, 1.0f, 2, 1.0f));
+
+    final PaginatedSegmentReader[] readerHolder = new PaginatedSegmentReader[1];
+    inTx(() -> readerHolder[0] = buildSegment("seg-6936", 1L, docs));
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = readerHolder[0];
+      final DimCursor[] cursors = new DimCursor[queryDims.length];
+      try {
+        for (int i = 0; i < queryDims.length; i++)
+          cursors[i] = new DimCursor(queryDims[i], List.of(reader.openCursor(queryDims[i])));
+
+        final List<RidScore> got = BmwScorer.topKGrouped(queryDims, queryWeights, cursors, 3, 2,
+            rid -> groupOf.get(rid), null);
+
+        final List<String> groups = got.stream().map(rs -> groupOf.get(rs.rid())).distinct().toList();
+        assertThat(groups).as("groups returned for %s", got).contains("Z");
+        assertThat(got.getFirst().rid()).isEqualTo(new RID(0, 1_000L));
+      } finally {
+        for (final DimCursor c : cursors)
+          if (c != null)
+            c.close();
+      }
+    });
+  }
+
+  // ---------- helpers ----------
+
+  private static void addDoc(final Map<RID, Map<Integer, Float>> docs, final Map<RID, String> groupOf, final RID rid,
+      final String group, final Map<Integer, Float> weights) {
+    docs.put(rid, weights);
+    groupOf.put(rid, group);
+  }
+
+  @FunctionalInterface
+  private interface CheckedRunnable {
+    void run() throws Exception;
+  }
+
+  private void inTx(final CheckedRunnable r) {
+    database.transaction(() -> {
+      try {
+        r.run();
+      } catch (final RuntimeException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private SparseSegmentComponent newComponent(final String name) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    try {
+      final SparseSegmentComponent c = new SparseSegmentComponent(db, name, db.getDatabasePath() + "/" + name,
+          ComponentFile.MODE.READ_WRITE, SparseSegmentComponent.DEFAULT_PAGE_SIZE);
+      ((LocalSchema) db.getSchema().getEmbedded()).registerFile(c);
+      return c;
+    } catch (final IOException e) {
+      throw new RuntimeException("failed to create sparse segment component '" + name + "'", e);
+    }
+  }
+
+  private PaginatedSegmentReader buildSegment(final String name, final long segmentId,
+      final Map<RID, Map<Integer, Float>> docs) throws IOException {
+    final TreeMap<Integer, TreeMap<RID, Float>> byDim = new TreeMap<>();
+    for (final var doc : docs.entrySet()) {
+      for (final var dw : doc.getValue().entrySet())
+        byDim.computeIfAbsent(dw.getKey(), k -> new TreeMap<>()).put(doc.getKey(), dw.getValue());
+    }
+    final SparseSegmentComponent c = newComponent(name);
+    try (final SparseSegmentBuilder b = new SparseSegmentBuilder(c, EXACT_PARAMS)) {
+      b.setSegmentId(segmentId);
+      for (final var dim : byDim.entrySet()) {
+        b.startDim(dim.getKey());
+        for (final var p : dim.getValue().entrySet())
+          b.appendPosting(p.getKey(), p.getValue());
+        b.endDim();
+      }
+      b.finish();
+    }
+    return new PaginatedSegmentReader(c);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6859AsyncRebuildPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6859AsyncRebuildPrefixReuseTest.java
@@ -63,7 +63,9 @@ class Issue6859AsyncRebuildPrefixReuseTest {
   private static final int THRESHOLD  = 100;
   /** {@code inactivityRebuildIsWorthIt()}'s {@code Math.max(threshold / 10, 1)}. */
   private static final int FLOOR      = THRESHOLD / 10;
-  private static final int TIMEOUT_MS = 500;
+  // Wide enough that a stop-the-world pause between the last insert and the preconditions below cannot let the
+  // timer fire first and drain the counters those assertions read (a full-suite run shares one JVM).
+  private static final int TIMEOUT_MS = 5_000;
 
   private static final Duration REBUILD_SETTLE_TIMEOUT =
       Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsLong() + 60_000L);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6859AsyncRebuildPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6859AsyncRebuildPrefixReuseTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for issue #6859: a follow-up to #6798 (see {@link Issue6798InactivityTimerUnloadedGraphTest}).
+ * #6798 fixed the DECISION - the inactivity timer no longer reads a large-but-unloaded graph as small - but
+ * once the threshold-derived floor is legitimately reached on such an index, the async rebuild the timer
+ * starts still ran {@code buildGraphFromScratch()} over the whole live set instead of reusing the persisted
+ * graph already on disk as a prefix (issues #6655, #6772) the way a SEARCH-triggered rebuild would.
+ * <p>
+ * Reproduces the issue's own scenario: build and persist a large graph, reopen, write past the persisted
+ * graph without ever searching, and let the inactivity timer's async rebuild fire. Before the fix,
+ * {@code startAsyncGraphRebuild()}'s daemon thread called {@code buildGraphFromScratch()} directly and
+ * {@code stalePrefixGraphReuses} never moved - after it, the same daemon thread finds the on-disk prefix
+ * eligible, publishes it, and queues only the gap before folding it in with the same
+ * {@code buildGraphFromScratch()} call.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("vector")
+class Issue6859AsyncRebuildPrefixReuseTest {
+  private static final String DB_ROOT     = "target/test-databases/Issue6859AsyncRebuildPrefixReuseTest";
+  private static final int    DIMENSIONS  = 32;
+  /** Must exceed {@code LSMVectorIndex.ASYNC_REBUILD_MIN_GRAPH_SIZE} (1000), or the timer's cheap arm applies. */
+  private static final int    LARGE_COUNT = 1_500;
+
+  private static final int THRESHOLD  = 100;
+  /** {@code inactivityRebuildIsWorthIt()}'s {@code Math.max(threshold / 10, 1)}. */
+  private static final int FLOOR      = THRESHOLD / 10;
+  private static final int TIMEOUT_MS = 500;
+
+  private static final Duration REBUILD_SETTLE_TIMEOUT =
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsLong() + 60_000L);
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void inactivityTimerReusesThePersistedPrefixInsteadOfRebuildingFromScratch() {
+    buildAndPersistFixture(LARGE_COUNT);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        configure(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("precondition: nothing has loaded the graph in this session yet")
+            .isZero();
+        assertThat(index.getStats().get("persistedGraphNodeCount"))
+            .as("precondition: a complete graph over %d vectors is on disk", LARGE_COUNT)
+            .isEqualTo((long) LARGE_COUNT);
+        assertThat(index.getStats().get("stalePrefixGraphReuses"))
+            .as("precondition: no reuse has happened yet")
+            .isZero();
+
+        // Write past the persisted graph, and never search - the exact shape of a loader process that goes
+        // idle, and the one #6798's fix already guarantees will not skip the mutation threshold.
+        for (int i = LARGE_COUNT; i < LARGE_COUNT + FLOOR; i++)
+          insert(db, i, i + 1);
+
+        assertThat(index.getStats().get("mutationsSinceRebuild")).isEqualTo((long) FLOOR);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("no search happened, so nothing but the inactivity timer can have triggered anything yet")
+            .isZero();
+
+        // The inactivity timer fires, decides a rebuild is worth it, and its async rebuild reuses the
+        // persisted prefix instead of building from scratch (issue #6859) - the same reuse a search-triggered
+        // rebuild would perform via ensureGraphAvailable()/reuseStalePrefixGraph().
+        Awaitility.await("the inactivity timer's async rebuild reuses the persisted prefix")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("stalePrefixGraphReuses")).isPositive());
+
+        // The reuse alone must not silently under-report the graph: the gap it queued into the delta buffer
+        // has to be folded in by the same rebuild invocation for the final graph to cover every live vector.
+        Awaitility.await("the queued gap is folded into a complete graph by the same rebuild")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertThat(index.getStats().get("mutationsSinceRebuild")).isZero());
+
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("the rebuilt graph covers every live vector, prefix and gap alike")
+            .isEqualTo((long) (LARGE_COUNT + FLOOR));
+
+        Awaitility.await("the rebuild settles before the drop")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * Session 1: write {@code count} vectors, build and persist the graph, close cleanly. The reopening session
+   * then finds a complete, valid persisted graph that nothing in it has loaded.
+   */
+  private void buildAndPersistFixture(final int count) {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        insert(db, 0, count);
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: the graph must be built and IMMUTABLE before the close that persists it")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  /**
+   * Pinned per-database rather than globally: the absolute threshold with graph-size scaling disabled, so the
+   * floor is a known {@value #FLOOR}, and an inactivity window short enough to wait out.
+   */
+  private static void configure(final Database db) {
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, THRESHOLD);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, TIMEOUT_MS);
+  }
+
+  private static void insert(final Database db, final int fromInclusive, final int toExclusive) {
+    db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"EUCLIDEAN\" }");
+    });
+
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+      if ((i - fromInclusive) % 500 == 499) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  /** Deterministic per-id embedding, so a fixture is reproducible run to run. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x6859L * 31 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}


### PR DESCRIPTION
## Summary

- **#6936**: `BmwScorer.GroupedCollector` handed its `limit` distinct-group slots out first-come in ascending-RID traversal order and never reconsidered the choice, so a much later (higher-RID), best-scoring group could be rejected outright in favour of earlier, weaker groups - the same defect #5761 fixed for the dense (HNSW) grouped search, in the sparse index's own separate collector. Fixed by letting a new group key evict the weakest currently open group when it beats that group's peak (best member) score.
- **#6859**: `startAsyncGraphRebuild()`'s daemon thread always called `buildGraphFromScratch()` over the whole live set, even when this session had never resolved what was on disk (the large-but-unloaded case #6798 fixed the threshold-skip for) and a verified, reusable persisted graph prefix was available - the same prefix a search-triggered rebuild would reuse via `ensureGraphAvailable()`/`reuseStalePrefixGraph()` (issues #6655, #6772). Fixed by extracting that persisted-graph decision into a shared `loadPersistedGraphOrDecidePrefix()`, now also consulted by the async-rebuild thread. Deliberately run from inside the daemon thread's own body (which never holds the `this` monitor) rather than nested under `startAsyncGraphRebuild()`'s synchronized call, to avoid the lock-ordering edge PR #6784's review had declined to introduce.

## Test plan

- [x] New regression test `Issue6936SparseGroupedTopKGroupChoiceTest` reproduces the reporter's exact repro shape (low-RID groups A/B/C vs. a much-later, best-scoring group Z); fails on `main`, passes with the fix.
- [x] New regression test `Issue6859AsyncRebuildPrefixReuseTest` reproduces an ingest-only, never-searched session that reaches the inactivity timer's floor on a large-but-unloaded index; confirmed it hangs (never observes `stalePrefixGraphReuses`) without the fix, passes with it.
- [x] Full sparse-vector/`groupBy`-related test suite green (`MaxScorePruningTest`, `BmwBlockSkipPruningTest`, `BmwScorerCorrectnessTest`, `SQLFunctionVectorGroupByTest`, `SQLFunctionVectorNestedGroupByTest`, and the rest of `com.arcadedb.function.sql.vector`/`com.arcadedb.index.sparsevector` touching `topKGrouped`/`sparseNeighbors`).
- [x] Full `com.arcadedb.index.vector.*` package green (including `@Tag("vector")` lane), plus the targeted #6655/#6772/#6798/#6106/#6713 prefix-reuse and inactivity-timer regression tests.

Closes #6936, closes #6859.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved grouped vector search to prioritize higher-scoring groups and manage group replacement more effectively.
  * Improved asynchronous vector-index rebuilds by reusing valid persisted graph data and avoiding unnecessary full rebuilds.
  * Improved search availability and coverage while vector indexes are rebuilt in the background.

* **Bug Fixes**
  * Corrected sparse grouped top-K selection so the best-scoring groups are returned reliably.
  * Fixed cases where valid persisted vector-index data was not reused after reopening a database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->