### PR TITLE
fix: null-filter IS NULL translation and upsert ObjectId _id normalization (#6952, #6953)

### DIFF
--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -643,12 +643,17 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     if (isReplacement(u)) {
       for (final Map.Entry<String, Object> entry : u.entrySet()) {
         final Object value = entry.getValue();
-        if ("_id".equals(entry.getKey()) && value instanceof ObjectId)
-          idIsObjectId = true;
+        // Last write wins, matching record.set() itself: a replacement re-specifying "_id" overrides whatever type
+        // the filter seeded, rather than only ever promoting it to true and leaking a stale ObjectId flag if the
+        // replacement's own _id is some other type.
+        if ("_id".equals(entry.getKey()))
+          idIsObjectId = value instanceof ObjectId;
         record.set(entry.getKey(), normalizeIdValue(value));
       }
     } else {
-      idIsObjectId |= applyOperatorsToDocument(record, u);
+      final Boolean setIdIsObjectId = applyOperatorsToDocument(record, u);
+      if (setIdIsObjectId != null)
+        idIsObjectId = setIdIsObjectId;
     }
 
     // has(), not get() == null: an explicit "_id": null in the filter/update is a legal (if unusual) BSON _id and
@@ -676,10 +681,13 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
    * Applies the update operators to the record being upserted, returning whether an ObjectId-typed {@code _id} was
    * seeded through {@code $set} - mirroring the same tracking the filter-seeding loop and the replacement branch in
    * {@link #executeUpsert} already do, so the response reports {@code _id} back as an ObjectId regardless of which
-   * branch supplied it.
+   * branch supplied it. {@code null} means {@code $set} never touched {@code _id} at all, so the caller should keep
+   * whatever the filter-seeding loop already determined instead of overriding it - unlike a plain {@code boolean}
+   * OR, this lets a non-{@code ObjectId} {@code $set}-supplied {@code _id} correctly override (rather than leak
+   * through) a {@code true} the filter already seeded.
    */
-  private boolean applyOperatorsToDocument(final MutableDocument record, final Document u) {
-    boolean idIsObjectId = false;
+  private Boolean applyOperatorsToDocument(final MutableDocument record, final Document u) {
+    Boolean idIsObjectId = null;
     for (final Map.Entry<String, Object> entry : u.entrySet()) {
       final String op = entry.getKey();
       final Document operand = (Document) entry.getValue();
@@ -687,8 +695,8 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
       case "$set" -> {
         for (final Map.Entry<String, Object> f : operand.entrySet()) {
           final Object value = f.getValue();
-          if ("_id".equals(f.getKey()) && value instanceof ObjectId)
-            idIsObjectId = true;
+          if ("_id".equals(f.getKey()))
+            idIsObjectId = value instanceof ObjectId;
           record.set(f.getKey(), normalizeIdValue(value));
         }
       }

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -641,10 +641,14 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
       }
 
     if (isReplacement(u)) {
-      for (final Map.Entry<String, Object> entry : u.entrySet())
-        record.set(entry.getKey(), entry.getValue());
+      for (final Map.Entry<String, Object> entry : u.entrySet()) {
+        final Object value = entry.getValue();
+        if ("_id".equals(entry.getKey()) && value instanceof ObjectId)
+          idIsObjectId = true;
+        record.set(entry.getKey(), normalizeIdValue(value));
+      }
     } else {
-      applyOperatorsToDocument(record, u);
+      idIsObjectId |= applyOperatorsToDocument(record, u);
     }
 
     // has(), not get() == null: an explicit "_id": null in the filter/update is a legal (if unusual) BSON _id and
@@ -668,14 +672,25 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     return value instanceof ObjectId oid ? oid.getHexData() : value;
   }
 
-  private void applyOperatorsToDocument(final MutableDocument record, final Document u) {
+  /**
+   * Applies the update operators to the record being upserted, returning whether an ObjectId-typed {@code _id} was
+   * seeded through {@code $set} - mirroring the same tracking the filter-seeding loop and the replacement branch in
+   * {@link #executeUpsert} already do, so the response reports {@code _id} back as an ObjectId regardless of which
+   * branch supplied it.
+   */
+  private boolean applyOperatorsToDocument(final MutableDocument record, final Document u) {
+    boolean idIsObjectId = false;
     for (final Map.Entry<String, Object> entry : u.entrySet()) {
       final String op = entry.getKey();
       final Document operand = (Document) entry.getValue();
       switch (op) {
       case "$set" -> {
-        for (final Map.Entry<String, Object> f : operand.entrySet())
-          record.set(f.getKey(), f.getValue());
+        for (final Map.Entry<String, Object> f : operand.entrySet()) {
+          final Object value = f.getValue();
+          if ("_id".equals(f.getKey()) && value instanceof ObjectId)
+            idIsObjectId = true;
+          record.set(f.getKey(), normalizeIdValue(value));
+        }
       }
       case "$unset" -> {
         for (final String f : operand.keySet())
@@ -691,6 +706,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
       default -> throw new UnsupportedOperationException("Unsupported update operator '" + op + "'");
       }
     }
+    return idIsObjectId;
   }
 
   /**

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
@@ -54,8 +54,7 @@ public class MongoDBToSqlTranslator {
           throw new IllegalArgumentException("Invalid operator " + key);
       } else {
         buffer.append(quoteFieldPath(entry.getKey()));
-        buffer.append(" = ");
-        buildValue(buffer, params, value);
+        buildEquality(buffer, params, true, value);
       }
     }
   }
@@ -131,11 +130,9 @@ public class MongoDBToSqlTranslator {
       } else
         throw new IllegalArgumentException("Operator $nin was expecting a collection");
     } else if ("$eq".equals(key)) {
-      sql.append(" = ");
-      buildValue(sql, params, value);
+      buildEquality(sql, params, true, value);
     } else if ("$ne".equals(key)) {
-      sql.append(" <> ");
-      buildValue(sql, params, value);
+      buildEquality(sql, params, false, value);
     } else if ("$lt".equals(key)) {
       sql.append(" < ");
       buildValue(sql, params, value);
@@ -213,6 +210,23 @@ public class MongoDBToSqlTranslator {
     buffer.append('(');
     buildValue(buffer, params, normalized);
     buffer.append(')');
+  }
+
+  /**
+   * Emits an (in)equality comparison, special-casing a {@code null} operand as {@code IS [NOT] NULL} rather than a
+   * bound {@code = null} / {@code <> null} parameter. SQL equality against a bound {@code null} never matches a
+   * stored {@code null} (or absent) property, whereas MongoDB's {@code {field: null}} / {@code {field: {$ne: null}}}
+   * do - both match a missing field as well as a stored {@code null} - so binding it as an ordinary parameter would
+   * silently match nothing.
+   */
+  protected static void buildEquality(final StringBuilder buffer, final Map<String, Object> params, final boolean positive,
+      final Object value) {
+    if (value == null)
+      buffer.append(positive ? " IS NULL" : " IS NOT NULL");
+    else {
+      buffer.append(positive ? " = " : " <> ");
+      buildValue(buffer, params, value);
+    }
   }
 
   /**
@@ -298,6 +312,15 @@ public class MongoDBToSqlTranslator {
    * MongoDB allows any BSON scalar as {@code _id}, not just an ObjectId. Only a value that actually looks like a
    * 24-char hex ObjectId string is decoded as one; anything else (an integer, an odd-length or non-hex string, ...)
    * is passed through unchanged instead of corrupting or throwing.
+   * <p>
+   * Known limitation (#6955): a client-supplied {@code String _id} that happens to be exactly 24 hex characters is,
+   * once stored, indistinguishable from a real {@code ObjectId}'s hex encoding - both are the same bare hex string
+   * on disk. A plain {@code insertOne} followed by {@code find} therefore round-trips such a {@code String _id} back
+   * as an {@code ObjectId}. Unlike the upsert path (see {@code executeUpsert}'s {@code idIsObjectId} tracking), there
+   * is no in-memory flag to bridge insert and a later, possibly separate, {@code find} call - fixing this for real
+   * would mean persisting the original BSON type alongside {@code _id} (a marker byte/prefix, a side property, or a
+   * schema-level type tag), a storage-format decision affecting every document with a hex-looking String {@code _id}
+   * rather than a narrow code fix. Left as a documented limitation rather than guessed at unilaterally.
    */
   private static Object convertIdToMongoDB(final Object value) {
     if (value instanceof String s && isObjectIdHex(s))

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
@@ -215,9 +215,13 @@ public class MongoDBToSqlTranslator {
   /**
    * Emits an (in)equality comparison, special-casing a {@code null} operand as {@code IS [NOT] NULL} rather than a
    * bound {@code = null} / {@code <> null} parameter. SQL equality against a bound {@code null} never matches a
-   * stored {@code null} (or absent) property, whereas MongoDB's {@code {field: null}} / {@code {field: {$ne: null}}}
-   * do - both match a missing field as well as a stored {@code null} - so binding it as an ordinary parameter would
-   * silently match nothing.
+   * stored {@code null} (or absent) property, whereas MongoDB's {@code {field: null}} does - it matches a missing
+   * field as well as a stored {@code null} - so binding it as an ordinary parameter would silently match nothing.
+   * <p>
+   * {@code {field: {$ne: null}}} is not the exact negation of that: per MongoDB's own semantics it matches only a
+   * field that exists and is not null, excluding a missing field too (rather than including it, the way negating
+   * {@code {field: null}} might suggest). {@code IS NOT NULL} matches that: ArcadeDB also evaluates a missing
+   * property as {@code null}, so it is excluded here exactly as MongoDB excludes it.
    */
   protected static void buildEquality(final StringBuilder buffer, final Map<String, Object> params, final boolean positive,
       final Object value) {

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBHexStringIdAmbiguityTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBHexStringIdAmbiguityTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Documents a known limitation flagged by issue #6955, deliberately left as a documented limitation rather than
+ * fixed (see the maintainer's decision on the issue): a client-supplied {@code String _id} that happens to be
+ * exactly 24 hex characters is, once stored, indistinguishable from a real {@code ObjectId}'s hex encoding - both
+ * end up as the same bare hex string on disk. A plain {@code insertOne} followed by a separate {@code find} call
+ * therefore round-trips such a {@code String _id} back as an {@code ObjectId} rather than the original {@code
+ * String}.
+ * <p>
+ * This is different from - and not fixed by - issue #6941/#6951's upsert fix: {@code executeUpsert} can track the
+ * original BSON type in memory because the filter and the seeded record are handled within the same method call.
+ * {@code insertOne} and the later {@code find} are separate wire calls, potentially on separate connections, so
+ * there is no equivalent in-memory flag to bridge them. Fixing this for real requires a storage-format decision
+ * (persisting the original BSON type alongside {@code _id}), not a narrow code change - see
+ * {@link MongoDBToSqlTranslator#convertIdToMongoDB} for the full rationale.
+ * <p>
+ * This test pins today's actual (documented-limitation) behavior so a future storage-format change updates it
+ * deliberately instead of it silently starting to pass or fail.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class MongoDBHexStringIdAmbiguityTest extends BaseGraphServerTest {
+
+  private static final int                       DEF_PORT = 27017;
+  private              MongoClient               client;
+  private              MongoCollection<Document> collection;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin");
+  }
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+    getDatabase(0);
+    client = new MongoClient(new ServerAddress("localhost", DEF_PORT),
+        MongoCredential.createPlainCredential("root", getDatabaseName(), DEFAULT_PASSWORD_FOR_TESTS.toCharArray()),
+        MongoClientOptions.builder().serverSelectionTimeout(5000).build());
+    client.getDatabase(getDatabaseName()).createCollection("doc");
+    collection = client.getDatabase(getDatabaseName()).getCollection("doc");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    if (client != null)
+      client.close();
+    super.endTest();
+  }
+
+  @Test
+  void hexLookingStringIdInsertedPlainRoundTripsAsAnObjectIdOnFind() {
+    final String hexLookingId = "abcdef0123456789abcdef01";
+    collection.insertOne(new Document("_id", hexLookingId).append("name", "x"));
+
+    final Document found = collection.find().first();
+
+    assertThat(found).isNotNull();
+    // Documented limitation (#6955): the client sent a String, but it comes back as an ObjectId because the stored
+    // hex form is indistinguishable from a real ObjectId's. Contrast with MongoDBNonObjectIdTest, which covers an
+    // odd-length or non-hex-looking String _id: those are not ambiguous and correctly round-trip as a String.
+    assertThat(found.get("_id")).isInstanceOf(org.bson.types.ObjectId.class);
+    assertThat(found.get("_id").toString()).isEqualTo(hexLookingId);
+  }
+}

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBHexStringIdAmbiguityTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBHexStringIdAmbiguityTest.java
@@ -26,6 +26,7 @@ import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCollection;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,7 +97,7 @@ public class MongoDBHexStringIdAmbiguityTest extends BaseGraphServerTest {
     // Documented limitation (#6955): the client sent a String, but it comes back as an ObjectId because the stored
     // hex form is indistinguishable from a real ObjectId's. Contrast with MongoDBNonObjectIdTest, which covers an
     // odd-length or non-hex-looking String _id: those are not ambiguous and correctly round-trip as a String.
-    assertThat(found.get("_id")).isInstanceOf(org.bson.types.ObjectId.class);
+    assertThat(found.get("_id")).isInstanceOf(ObjectId.class);
     assertThat(found.get("_id").toString()).isEqualTo(hexLookingId);
   }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBToSqlTranslatorParamsTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBToSqlTranslatorParamsTest.java
@@ -112,8 +112,14 @@ class MongoDBToSqlTranslatorParamsTest {
     assertThat(sql.toString()).doesNotContain("E10");
   }
 
+  /**
+   * Regression test for issue #6952: an equality comparison against a bound {@code null} parameter does not match a
+   * stored {@code null} (or absent) property the way SQL's {@code IS NULL} does, so a Mongo filter of the shape
+   * {@code {field: null}} - legal, since MongoDB's null-equality also matches a missing field - used to compile to
+   * {@code `missing` = :p0} with {@code p0} bound to {@code null} and match nothing.
+   */
   @Test
-  void aNullValueIsBoundRatherThanSpelled() {
+  void aNullValueEmitsIsNullInsteadOfBoundEquality() {
     final StringBuilder sql = new StringBuilder();
     final Map<String, Object> params = new HashMap<>();
 
@@ -121,9 +127,39 @@ class MongoDBToSqlTranslatorParamsTest {
     query.put("missing", null);
     MongoDBToSqlTranslator.buildExpression(sql, params, query);
 
-    assertThat(sql.toString()).isEqualTo("`missing` = :p0");
-    assertThat(params).containsKey("p0");
-    assertThat(params.get("p0")).isNull();
+    assertThat(sql.toString()).isEqualTo("`missing` IS NULL");
+    assertThat(params).isEmpty();
+  }
+
+  /**
+   * Follow-up to #6952: {@code $eq} shares the same {@code buildValue} call as the plain-equality shape above, so it
+   * carries the identical gap for {@code {field: {$eq: null}}}.
+   */
+  @Test
+  void eqNullEmitsIsNull() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    MongoDBToSqlTranslator.buildExpression(sql, params, new Document("missing", new Document("$eq", null)));
+
+    assertThat(sql.toString()).isEqualTo("(`missing` IS NULL)");
+    assertThat(params).isEmpty();
+  }
+
+  /**
+   * Follow-up to #6952: {@code $ne} is the negated counterpart of {@code $eq} and shares the same root cause - a
+   * bound {@code null} parameter compiled with {@code <>} never matches a stored {@code null}/missing property
+   * either, so {@code {field: {$ne: null}}} must emit {@code IS NOT NULL} instead.
+   */
+  @Test
+  void neNullEmitsIsNotNull() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    MongoDBToSqlTranslator.buildExpression(sql, params, new Document("missing", new Document("$ne", null)));
+
+    assertThat(sql.toString()).isEqualTo("(`missing` IS NOT NULL)");
+    assertThat(params).isEmpty();
   }
 
   @Test

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
@@ -257,12 +257,36 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
   }
 
   /**
-   * Follow-up to #6952: {@code $ne} shares the same root cause as plain equality and {@code $eq}, so a filter of
-   * {@code {field: {$ne: null}}} must exclude a document whose field is stored as {@code null}.
+   * Follow-up to #6952, flagged by review: MongoDB's {@code {field: null}} matches both a stored {@code null} and a
+   * document where the field is simply absent - {@code findByNullValuedFieldMatchesTheStoredNull} only pins the
+   * first half of that claim (routing around the second half by using a dedicated collection). This closes the loop
+   * by asserting the second half directly: a document that never set {@code tag} at all is still matched.
    */
   @Test
-  void neNullExcludesTheStoredNullButMatchesEverythingElse() {
+  void findByNullValuedFieldAlsoMatchesADocumentWhereTheFieldIsAbsent() {
+    client.getDatabase(getDatabaseName()).createCollection("nullFilterAbsent");
+    final MongoCollection<Document> nullDocs = client.getDatabase(getDatabaseName()).getCollection("nullFilterAbsent");
+    nullDocs.insertOne(new Document("test", "absent-field"));
+
+    final Document found = nullDocs.find(eq("tag", null)).first();
+
+    assertThat(found).isNotNull();
+    assertThat(found.getString("test")).isEqualTo("absent-field");
+  }
+
+  /**
+   * Follow-up to #6952: {@code $ne} shares the same root cause as plain equality and {@code $eq}, so a filter of
+   * {@code {field: {$ne: null}}} must exclude a document whose field is stored as {@code null}.
+   * <p>
+   * Unlike plain {@code {field: null}} equality, {@code {field: {$ne: null}}} is not its exact negation: per
+   * MongoDB's own documentation it matches only a field that exists and is not null, excluding a document where the
+   * field is missing too (rather than including it). A document with no {@code tag} field at all is included here
+   * to pin that half of the contract as well.
+   */
+  @Test
+  void neNullExcludesTheStoredNullAndAnAbsentFieldButMatchesEverythingElse() {
     collection.insertOne(new Document("test", "null-field").append("tag", null));
+    collection.insertOne(new Document("test", "absent-field"));
     collection.insertOne(new Document("test", "set-field").append("tag", "x"));
 
     final Document found = collection.find(new Document("tag", new Document("$ne", null))).first();
@@ -277,18 +301,22 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
    * <p>
    * A dedicated collection is used for the same reason as {@link #findByNullValuedFieldMatchesTheStoredNull}: the
    * null filter also matches a document where the field is absent, so the shared {@code collection}'s ten unrelated
-   * documents (no {@code tag} field) would be swept up by {@code deleteMany} too.
+   * documents (no {@code tag} field) would be swept up by {@code deleteMany} too. This is exercised directly by
+   * inserting an absent-field document alongside the explicit-null one and asserting {@code deleteMany} removes
+   * both, closing the same missing-field half of the contract for the delete path.
    */
   @Test
-  void deleteManyByNullValuedFieldRemovesTheStoredNull() {
+  void deleteManyByNullValuedFieldRemovesBothTheStoredNullAndAnAbsentField() {
     client.getDatabase(getDatabaseName()).createCollection("nullFilterDelete");
     final MongoCollection<Document> nullDocs = client.getDatabase(getDatabaseName()).getCollection("nullFilterDelete");
     nullDocs.insertOne(new Document("test", "null-field").append("tag", null));
+    nullDocs.insertOne(new Document("test", "absent-field"));
 
     final DeleteResult result = nullDocs.deleteMany(new Document("tag", null));
 
-    assertThat(result.getDeletedCount()).isEqualTo(1);
+    assertThat(result.getDeletedCount()).isEqualTo(2);
     assertThat(nullDocs.find(eq("test", "null-field")).first()).isNull();
+    assertThat(nullDocs.find(eq("test", "absent-field")).first()).isNull();
   }
 
   /**
@@ -333,5 +361,25 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
     final Document found = collection.find(eq("_id", id)).first();
     assertThat(found).isNotNull();
     assertThat(found.get("v")).isEqualTo(42);
+  }
+
+  /**
+   * Follow-up to #6953, flagged by review: the replacement branch's fix normalizes every field's value the same way
+   * the pre-existing filter-seeding loop already does, not just {@code _id} - ArcadeDB has no native ObjectId type,
+   * so an ObjectId-valued non-{@code _id} field would otherwise be stored as the raw driver object too, and later
+   * fail to match a filter on that field the same way an un-normalized {@code _id} did.
+   */
+  @Test
+  void replaceOneUpsertNormalizesANonIdObjectIdFieldToo() {
+    final ObjectId ref = new ObjectId();
+
+    final UpdateResult result = collection.replaceOne(eq("test", "no-such-value-3"),
+        new Document("ref", ref).append("replaced", true), new UpdateOptions().upsert(true));
+
+    assertThat(result.getUpsertedId()).isNotNull();
+
+    final Document found = collection.find(eq("ref", ref)).first();
+    assertThat(found).isNotNull();
+    assertThat(found.get("replaced")).isEqualTo(true);
   }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
@@ -207,18 +207,18 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
    * {@code executeUpsert} must tell that apart from a genuinely absent {@code _id} and preserve it, rather than
    * discarding it for a freshly generated one the way the original #6941 bug discarded a seeded ObjectId.
    * <p>
-   * This does not assert that a second {@code eq("_id", null)} upsert is idempotent: matching a stored {@code null}
-   * by equality is a separate, pre-existing gap in the filter-to-SQL translation (an "=" comparison against a bound
-   * null parameter, rather than "IS NULL") that affects every {@code null}-valued filter, not just this upsert path
-   * - tracked separately rather than fixed here.
+   * The upsert is now repeated with the same {@code eq("_id", null)} filter to confirm it is idempotent: before
+   * #6952 was fixed, matching a stored {@code null} by equality compiled to {@code "_id" = :p0} with {@code p0}
+   * bound to {@code null}, which never matches a stored null the way SQL's {@code IS NULL} does, so this second
+   * call would have inserted a duplicate instead of updating in place.
    */
   @Test
   void upsertFilteredOnNullIdPreservesTheNullId() {
-    final UpdateResult result = collection.updateOne(eq("_id", null), new Document("$set", new Document("v", 1)),
+    final UpdateResult first = collection.updateOne(eq("_id", null), new Document("$set", new Document("v", 1)),
         new UpdateOptions().upsert(true));
 
-    assertThat(result.getUpsertedId()).isNotNull();
-    assertThat(result.getUpsertedId().isNull()).isTrue();
+    assertThat(first.getUpsertedId()).isNotNull();
+    assertThat(first.getUpsertedId().isNull()).isTrue();
 
     final Document inserted = collection.find(eq("v", 1)).first();
     assertThat(inserted).isNotNull();
@@ -226,5 +226,112 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
     // wire response actually carries an "_id" field rather than having dropped it.
     assertThat(inserted.containsKey("_id")).isTrue();
     assertThat(inserted.get("_id")).isNull();
+
+    final UpdateResult second = collection.updateOne(eq("_id", null), new Document("$set", new Document("v", 2)),
+        new UpdateOptions().upsert(true));
+    assertThat(second.getUpsertedId()).isNull();
+    assertThat(second.getModifiedCount()).isEqualTo(1);
+    assertThat(collection.countDocuments(eq("_id", null))).isEqualTo(1);
+    assertThat(collection.find(eq("_id", null)).first().get("v")).isEqualTo(2);
+  }
+
+  /**
+   * Regression test for issue #6952: a filter on a null-valued field must match a document that actually stores
+   * that field as {@code null}, the same way MongoDB's null-equality does. Before the fix, {@code {field: null}}
+   * compiled to {@code "field" = :param} with {@code param} bound to {@code null}, which never matches.
+   * <p>
+   * A dedicated collection is used because MongoDB's null-equality also matches a document where the field is
+   * simply absent, which is exactly the semantics being fixed here - the shared {@code collection} already holds
+   * ten unrelated documents with no {@code tag} field at all, and those would match too.
+   */
+  @Test
+  void findByNullValuedFieldMatchesTheStoredNull() {
+    client.getDatabase(getDatabaseName()).createCollection("nullFilterDoc");
+    final MongoCollection<Document> nullDocs = client.getDatabase(getDatabaseName()).getCollection("nullFilterDoc");
+    nullDocs.insertOne(new Document("test", "null-field").append("tag", null));
+
+    final Document found = nullDocs.find(eq("tag", null)).first();
+
+    assertThat(found).isNotNull();
+    assertThat(found.getString("test")).isEqualTo("null-field");
+  }
+
+  /**
+   * Follow-up to #6952: {@code $ne} shares the same root cause as plain equality and {@code $eq}, so a filter of
+   * {@code {field: {$ne: null}}} must exclude a document whose field is stored as {@code null}.
+   */
+  @Test
+  void neNullExcludesTheStoredNullButMatchesEverythingElse() {
+    collection.insertOne(new Document("test", "null-field").append("tag", null));
+    collection.insertOne(new Document("test", "set-field").append("tag", "x"));
+
+    final Document found = collection.find(new Document("tag", new Document("$ne", null))).first();
+
+    assertThat(found).isNotNull();
+    assertThat(found.getString("test")).isEqualTo("set-field");
+  }
+
+  /**
+   * Regression test for issue #6952: {@code deleteMany} on a null-valued filter must remove the document whose
+   * field is actually stored as {@code null}, not silently delete nothing.
+   * <p>
+   * A dedicated collection is used for the same reason as {@link #findByNullValuedFieldMatchesTheStoredNull}: the
+   * null filter also matches a document where the field is absent, so the shared {@code collection}'s ten unrelated
+   * documents (no {@code tag} field) would be swept up by {@code deleteMany} too.
+   */
+  @Test
+  void deleteManyByNullValuedFieldRemovesTheStoredNull() {
+    client.getDatabase(getDatabaseName()).createCollection("nullFilterDelete");
+    final MongoCollection<Document> nullDocs = client.getDatabase(getDatabaseName()).getCollection("nullFilterDelete");
+    nullDocs.insertOne(new Document("test", "null-field").append("tag", null));
+
+    final DeleteResult result = nullDocs.deleteMany(new Document("tag", null));
+
+    assertThat(result.getDeletedCount()).isEqualTo(1);
+    assertThat(nullDocs.find(eq("test", "null-field")).first()).isNull();
+  }
+
+  /**
+   * Regression test for issue #6953: {@code executeUpsert}'s replacement branch (a full {@code replaceOne} upsert)
+   * used to copy the update document's values verbatim, so a client-supplied {@code _id} that is an actual
+   * {@code ObjectId} was stored as that raw driver object rather than the hex-string convention every other
+   * {@code _id} write path in this class follows. That would make the stored {@code _id} fail to match a later
+   * {@code eq("_id", ...)} filter, which binds the ObjectId as its hex string.
+   */
+  @Test
+  void replaceOneUpsertNormalizesAReplacementObjectIdIdToItsHexString() {
+    final ObjectId id = new ObjectId();
+
+    final UpdateResult result = collection.replaceOne(eq("test", "no-such-value"),
+        new Document("_id", id).append("replaced", true), new UpdateOptions().upsert(true));
+
+    assertThat(result.getUpsertedId()).isNotNull();
+    assertThat(result.getUpsertedId().isObjectId()).isTrue();
+    assertThat(result.getUpsertedId().asObjectId().getValue()).isEqualTo(id);
+
+    final Document found = collection.find(eq("_id", id)).first();
+    assertThat(found).isNotNull();
+    assertThat(found.get("replaced")).isEqualTo(true);
+  }
+
+  /**
+   * Regression test for issue #6953: the same gap as above, reached through the {@code $set} branch of an upsert
+   * (rather than a full replacement) - {@code applyOperatorsToDocument} stored a {@code $set}-supplied {@code _id}
+   * verbatim too.
+   */
+  @Test
+  void setUpsertNormalizesAnObjectIdIdToItsHexString() {
+    final ObjectId id = new ObjectId();
+
+    final UpdateResult result = collection.updateOne(eq("test", "no-such-value-2"),
+        new Document("$set", new Document("_id", id).append("v", 42)), new UpdateOptions().upsert(true));
+
+    assertThat(result.getUpsertedId()).isNotNull();
+    assertThat(result.getUpsertedId().isObjectId()).isTrue();
+    assertThat(result.getUpsertedId().asObjectId().getValue()).isEqualTo(id);
+
+    final Document found = collection.find(eq("_id", id)).first();
+    assertThat(found).isNotNull();
+    assertThat(found.get("v")).isEqualTo(42);
   }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
@@ -413,4 +413,25 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
     assertThat(found).isNotNull();
     assertThat(found.get("v")).isEqualTo(1);
   }
+
+  /**
+   * Follow-up to #6953, flagged by review: the same last-write-wins tracking above is exercised through the
+   * replacement branch, not just {@code $set} - a {@code replaceOne} upsert whose filter seeds an ObjectId
+   * {@code _id} but whose replacement document supplies a plain string must report the string back too.
+   */
+  @Test
+  void replaceOneUpsertOverridingAFilterSeededObjectIdWithAPlainStringReportsTheStringNotTheObjectId() {
+    final ObjectId filterId = new ObjectId();
+
+    final UpdateResult result = collection.replaceOne(eq("_id", filterId),
+        new Document("_id", "plain-string-id-2").append("replaced", true), new UpdateOptions().upsert(true));
+
+    assertThat(result.getUpsertedId()).isNotNull();
+    assertThat(result.getUpsertedId().isString()).isTrue();
+    assertThat(result.getUpsertedId().asString().getValue()).isEqualTo("plain-string-id-2");
+
+    final Document found = collection.find(eq("_id", "plain-string-id-2")).first();
+    assertThat(found).isNotNull();
+    assertThat(found.get("replaced")).isEqualTo(true);
+  }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
@@ -289,8 +289,13 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
     collection.insertOne(new Document("test", "absent-field"));
     collection.insertOne(new Document("test", "set-field").append("tag", "x"));
 
-    final Document found = collection.find(new Document("tag", new Document("$ne", null))).first();
+    final Document nePredicate = new Document("tag", new Document("$ne", null));
 
+    // countDocuments, not just .first(): pins exclusivity rather than relying on result ordering - if the
+    // translation regressed to also match the null/absent documents, .first() could still return "set-field" and
+    // hide the regression.
+    assertThat(collection.countDocuments(nePredicate)).isEqualTo(1);
+    final Document found = collection.find(nePredicate).first();
     assertThat(found).isNotNull();
     assertThat(found.getString("test")).isEqualTo("set-field");
   }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateDeleteTest.java
@@ -386,5 +386,31 @@ public class MongoDBUpdateDeleteTest extends BaseGraphServerTest {
     final Document found = collection.find(eq("ref", ref)).first();
     assertThat(found).isNotNull();
     assertThat(found.get("replaced")).isEqualTo(true);
+    // Asserts on the stored value directly, not just that the filter round-trip happens to work: "ref" is not
+    // "_id", so it is never promoted back to an ObjectId on read (only "_id" gets that treatment in
+    // convertMapToMongoDB) - it must come back as the plain hex string it was normalized to on write.
+    assertThat(found.get("ref")).isEqualTo(ref.toHexString());
+  }
+
+  /**
+   * Follow-up to #6953, flagged by review: {@code idIsObjectId} must reflect whichever site last set {@code _id},
+   * not just OR together every site that ever saw an ObjectId - otherwise a filter seeding an ObjectId {@code _id}
+   * followed by a {@code $set} that overwrites it with a plain string would still report the response {@code _id}
+   * as an ObjectId, even though the client's own {@code $set} explicitly chose a {@code String}.
+   */
+  @Test
+  void setUpsertOverridingAFilterSeededObjectIdWithAPlainStringReportsTheStringNotTheObjectId() {
+    final ObjectId filterId = new ObjectId();
+
+    final UpdateResult result = collection.updateOne(eq("_id", filterId),
+        new Document("$set", new Document("_id", "plain-string-id").append("v", 1)), new UpdateOptions().upsert(true));
+
+    assertThat(result.getUpsertedId()).isNotNull();
+    assertThat(result.getUpsertedId().isString()).isTrue();
+    assertThat(result.getUpsertedId().asString().getValue()).isEqualTo("plain-string-id");
+
+    final Document found = collection.find(eq("_id", "plain-string-id")).first();
+    assertThat(found).isNotNull();
+    assertThat(found.get("v")).isEqualTo(1);
   }
 }


### PR DESCRIPTION
## Summary
Follow-ups from PR #6951's review (#6939/#6940/#6941 batch):

- Fixes #6952: a Mongo filter of the shape `{field: null}` (or `{field: {$eq: null}}`) compiled to `"field" = :param` bound to `null`, which never matches a stored `null` or absent property the way SQL's `IS NULL` does. `buildExpression`/`$eq`/`$ne` now special-case a `null` operand as `IS [NOT] NULL` through a shared `buildEquality` helper.
- Fixes #6953: `executeUpsert`'s replacement and `$set` branches stored a client-supplied `ObjectId _id` verbatim instead of normalizing it to the hex string every other `_id` write path in the class uses, and didn't track its original BSON type for the response. Both branches now route through `normalizeIdValue` and track `idIsObjectId` the same way the filter-seeding loop already does.
- Addresses #6955 by documenting it as a known limitation rather than a code fix: a plain `insertOne` with a 24-hex-char String `_id` is indistinguishable from a real `ObjectId` once stored (both end up as the same bare hex string), and `insertOne`/`find` are separate wire calls with no in-memory flag to bridge them the way the upsert path can. Fixing it for real needs a storage-format decision (persisting the original BSON type alongside `_id`), so it's left documented (Javadoc on `convertIdToMongoDB`) with a regression test pinning today's actual behavior, rather than guessed at unilaterally.

## Test plan
- [x] `MongoDBToSqlTranslatorParamsTest`: updated the existing null-equality test (was pinning the buggy `= :param` shape) and added `$eq`/`$ne` null coverage
- [x] `MongoDBUpdateDeleteTest`: added `find`/`$ne`/`deleteMany` null-filter coverage, extended the existing null-id upsert test to prove idempotency, and added replacement/`$set` ObjectId-normalization coverage for #6953
- [x] New `MongoDBHexStringIdAmbiguityTest` pins #6955's documented-limitation behavior
- [x] `mvn -o -pl mongodbw -am test -DexcludedGroups=benchmark,slow,vector` - 129 tests, 0 failures

https://claude.ai/code/session_012iQgBExjxMBrXTZzXFRi2Y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MongoDB upsert handling so `_id` types follow the most recent update, including replacement and `$set` operations.
  * Corrected `null` equality and inequality filtering, including missing-field behavior.
  * Fixed repeated upserts with `null` identifiers to update existing records instead of creating duplicates.
  * Improved `deleteMany` behavior for null-valued filters.
  * Improved ObjectId normalization and documented conversion behavior for 24-character hexadecimal string identifiers.

* **Tests**
  * Added regression coverage for ObjectId round-tripping, null filters, deletion, and upsert scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->