### PR TITLE
Fix CountOps for sparse graph traversal provider node IDs

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/AntiJoinChainOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/AntiJoinChainOp.java
@@ -114,7 +114,7 @@ public final class AntiJoinChainOp implements CountOp {
 
   @Override
   public long execute(final GraphTraversalProvider provider, final Database db, final WorkGuard guard) {
-    final int nodeCount = provider.getNodeCount();
+    final int nodeIdUpperBound = provider.getNodeIdUpperBound();
     final int hops = edgeTypes.length;
 
     // Pre-compute valid bucket sets for type filtering. null = unlabelled, so no filter.
@@ -150,7 +150,7 @@ public final class AntiJoinChainOp implements CountOp {
         && antiJoinEdgeType.equals(edgeTypes[0])
         && inequalityIdxA >= 0 && inequalityIdxB >= 0
         && ineqMin == 0 && ineqMax == hops) {
-      final long result = executeEdgeScanAlgebraic(provider, nodeCount, validBuckets, guard);
+      final long result = executeEdgeScanAlgebraic(provider, nodeIdUpperBound, validBuckets, guard);
       if (result >= 0)
         return result;
     }
@@ -169,12 +169,15 @@ public final class AntiJoinChainOp implements CountOp {
 
     // Pre-compute bucket IDs for CSR-based anchor iteration and frontier filtering. A pattern that labels no
     // position needs none of them.
-    final int[] bucketIds = anyLabelled(validBuckets) ? precomputeBucketIds(provider, nodeCount, guard) : null;
+    final int[] bucketIds = anyLabelled(validBuckets)
+        ? precomputeBucketIds(provider, nodeIdUpperBound, guard) : null;
 
     long totalCount = 0;
 
-    for (int anchorId = 0; anchorId < nodeCount; anchorId++) {
+    for (int anchorId = 0; anchorId < nodeIdUpperBound; anchorId++) {
       guard.check();
+      if (!provider.isNodeLive(anchorId))
+        continue;
       if (anchorBuckets != null && !anchorBuckets.contains(bucketIds[anchorId]))
         continue;
 
@@ -207,7 +210,7 @@ public final class AntiJoinChainOp implements CountOp {
    * @return count, or -1 if NeighborViews unavailable (caller should fall back)
    */
   private long executeEdgeScanAlgebraic(final GraphTraversalProvider provider,
-      final int nodeCount, final IntHashSet[] validBuckets, final WorkGuard guard) {
+      final int nodeIdUpperBound, final IntHashSet[] validBuckets, final WorkGuard guard) {
     final Vertex.DIRECTION revDir0 = directions[0] == Vertex.DIRECTION.OUT ? Vertex.DIRECTION.IN
         : directions[0] == Vertex.DIRECTION.IN ? Vertex.DIRECTION.OUT : Vertex.DIRECTION.BOTH;
     final NeighborView viewA = provider.getNeighborView(revDir0, edgeTypes[0]);
@@ -227,13 +230,15 @@ public final class AntiJoinChainOp implements CountOp {
     if ((pos1Buckets != null && pos1Buckets.isEmpty()) || (pos2Buckets != null && pos2Buckets.isEmpty()))
       return 0;
     final int[] bucketIds = (pos1Buckets != null || pos2Buckets != null)
-        ? precomputeBucketIds(provider, nodeCount, guard) : null;
+        ? precomputeBucketIds(provider, nodeIdUpperBound, guard) : null;
 
     long total = 0;
 
     // Scan all E1 (middle) edges by iterating pos1 nodes
-    for (int b = 0; b < nodeCount; b++) {
+    for (int b = 0; b < nodeIdUpperBound; b++) {
       guard.check();
+      if (!provider.isNodeLive(b))
+        continue;
       if (pos1Buckets != null && !pos1Buckets.contains(bucketIds[b]))
         continue;
 
@@ -279,12 +284,14 @@ public final class AntiJoinChainOp implements CountOp {
     return false;
   }
 
-  /** Pre-computes bucket IDs for all CSR nodes. One-time O(nodeCount) cost, amortized across all anchors. */
-  private static int[] precomputeBucketIds(final GraphTraversalProvider provider, final int nodeCount,
+  /** Pre-computes bucket IDs for all live CSR nodes. One-time O(node ID space) cost. */
+  private static int[] precomputeBucketIds(final GraphTraversalProvider provider, final int nodeIdUpperBound,
       final WorkGuard guard) {
-    final int[] bucketIds = new int[nodeCount];
-    for (int v = 0; v < nodeCount; v++) {
+    final int[] bucketIds = new int[nodeIdUpperBound];
+    for (int v = 0; v < nodeIdUpperBound; v++) {
       guard.checkPeriodically(v);
+      if (!provider.isNodeLive(v))
+        continue;
       bucketIds[v] = provider.getRID(v).getBucketId();
     }
     return bucketIds;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOp.java
@@ -92,7 +92,7 @@ public final class DegreeProductOp implements CountOp {
     if (!hasMandatoryArm())
       return executeOLTP(db, guard);
 
-    final int nodeCount = provider.getNodeCount();
+    final int nodeIdUpperBound = provider.getNodeIdUpperBound();
 
     // Fast path: when all arms are single-hop, pre-fetch NeighborViews and scan
     // degree offset arrays directly. This is pure array arithmetic — no method dispatch,
@@ -114,10 +114,10 @@ public final class DegreeProductOp implements CountOp {
     }
 
     if (allSingleHopViews)
-      return executeFastScan(armViews, nodeCount, guard);
+      return executeFastScan(provider, armViews, nodeIdUpperBound, guard);
 
     // Slow path: per-node CSR lookup (fallback for multi-hop arms or missing views)
-    return executePerNode(provider, db, nodeCount, guard);
+    return executePerNode(provider, db, nodeIdUpperBound, guard);
   }
 
   /**
@@ -127,7 +127,8 @@ public final class DegreeProductOp implements CountOp {
    * For Q4/Q7 with ~5M CSR nodes and 4 arms: ~40M array reads at ~1ns = ~40ms.
    * Compared to per-node countEdges: ~20M method calls at ~150ns = ~3s (75x slower).
    */
-  private long executeFastScan(final NeighborView[] armViews, final int nodeCount, final WorkGuard guard) {
+  private long executeFastScan(final GraphTraversalProvider provider, final NeighborView[] armViews,
+      final int nodeIdUpperBound, final WorkGuard guard) {
     // Reorder: check mandatory arms first for early exit, optional arms last
     final int[] mandatoryIdx = new int[arms.length];
     final int[] optionalIdx = new int[arms.length];
@@ -140,8 +141,10 @@ public final class DegreeProductOp implements CountOp {
     }
 
     long total = 0;
-    for (int v = 0; v < nodeCount; v++) {
+    for (int v = 0; v < nodeIdUpperBound; v++) {
       guard.checkPeriodically(v);
+      if (!provider.isNodeLive(v))
+        continue;
       // Mandatory arms: skip if any degree is 0
       long product = 1;
       boolean skip = false;
@@ -175,17 +178,19 @@ public final class DegreeProductOp implements CountOp {
    * Per-node countEdges: 20M method calls × 150ns ≈ 3s.
    */
   private long executePerNode(final GraphTraversalProvider provider, final Database db,
-      final int nodeCount, final WorkGuard guard) {
+      final int nodeIdUpperBound, final WorkGuard guard) {
     // Pre-compute degree arrays: one int[] per arm, indexed by nodeId
     final int[][] armDegrees = new int[arms.length][];
     for (int a = 0; a < arms.length; a++) {
-      final int[] degrees = new int[nodeCount];
+      final int[] degrees = new int[nodeIdUpperBound];
       if (arms[a].edgeTypes.length == 1) {
         // Bulk degree computation — single pass over CSR offset arrays
         provider.getDegrees(degrees, arms[a].directions[0], arms[a].edgeTypes[0]);
       } else {
-        for (int v = 0; v < nodeCount; v++) {
+        for (int v = 0; v < nodeIdUpperBound; v++) {
           guard.checkPeriodically(v);
+          if (!provider.isNodeLive(v))
+            continue;
           degrees[v] = CSRCountUtils.walkArm(provider, v, arms[a].edgeTypes, arms[a].directions).length;
         }
       }
@@ -205,8 +210,10 @@ public final class DegreeProductOp implements CountOp {
 
     // Tight scan loop: pure array arithmetic, no method calls
     long total = 0;
-    for (int v = 0; v < nodeCount; v++) {
+    for (int v = 0; v < nodeIdUpperBound; v++) {
       guard.checkPeriodically(v);
+      if (!provider.isNodeLive(v))
+        continue;
       long product = 1;
       boolean skip = false;
       for (int i = 0; i < mandatoryCount; i++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOp.java
@@ -91,7 +91,7 @@ public final class PairHashJoinOp implements CountOp {
   @Override
   @SuppressWarnings("unchecked")
   public long execute(final GraphTraversalProvider provider, final Database db, final WorkGuard guard) {
-    final int nodeCount = provider.getNodeCount();
+    final int nodeIdUpperBound = provider.getNodeIdUpperBound();
 
     // Pre-compute intermediate label bucket sets ONCE (not per vertex!)
     final IntHashSet[] arm1Buckets = buildValidBucketSets(db, arm1IntermediateLabels);
@@ -120,9 +120,11 @@ public final class PairHashJoinOp implements CountOp {
     // because the table was owned by the arm2 branch (issue #6304).
     final int[] bucketIds;
     if (arm1View != null && (arm1Buckets != null || arm2Buckets != null)) {
-      bucketIds = new int[nodeCount];
-      for (int v = 0; v < nodeCount; v++) {
+      bucketIds = new int[nodeIdUpperBound];
+      for (int v = 0; v < nodeIdUpperBound; v++) {
         guard.checkPeriodically(v);
+        if (!provider.isNodeLive(v))
+          continue;
         bucketIds[v] = provider.getRID(v).getBucketId();
       }
     } else
@@ -148,19 +150,22 @@ public final class PairHashJoinOp implements CountOp {
       }
 
       if (allArm2Views) {
-        return buildAndProbeInline(arm1View, arm1Filter, arm2Views, arm2Buckets, probeView, nodeCount, bucketIds, guard);
+        return buildAndProbeInline(provider, arm1View, arm1Filter, arm2Views, arm2Buckets, probeView,
+            nodeIdUpperBound, bucketIds, guard);
       }
     }
 
     // FALLBACK: HashMap build + probe (for cases without full NeighborView coverage)
     if (arm1View != null && arm2View != null) {
-      buildWithViews(arm1View, arm1Filter, arm2View, arm2Buckets != null ? arm2Buckets[0] : null, pairCounts, nodeCount,
-          bucketIds, guard);
+      buildWithViews(provider, arm1View, arm1Filter, arm2View, arm2Buckets != null ? arm2Buckets[0] : null,
+          pairCounts, nodeIdUpperBound, bucketIds, guard);
     } else if (arm1View != null) {
-      buildWithArm1View(arm1View, arm1Filter, provider, arm2Buckets, pairCounts, nodeCount, bucketIds, guard);
+      buildWithArm1View(arm1View, arm1Filter, provider, arm2Buckets, pairCounts, nodeIdUpperBound, bucketIds, guard);
     } else {
-      for (int startId = 0; startId < nodeCount; startId++) {
+      for (int startId = 0; startId < nodeIdUpperBound; startId++) {
         guard.check();
+        if (!provider.isNodeLive(startId))
+          continue;
         final int[] ep1Ids = CSRCountUtils.walkArm(provider, startId, arm1EdgeTypes, arm1Directions, arm1Buckets);
         if (ep1Ids.length == 0)
           continue;
@@ -177,14 +182,18 @@ public final class PairHashJoinOp implements CountOp {
     long total = 0;
     if (probeViewFallback != null) {
       final int[] probeNbrs = probeViewFallback.neighbors();
-      for (int p1 = 0; p1 < nodeCount; p1++) {
+      for (int p1 = 0; p1 < nodeIdUpperBound; p1++) {
         guard.checkPeriodically(p1);
+        if (!provider.isNodeLive(p1))
+          continue;
         for (int j = probeViewFallback.offset(p1), end = probeViewFallback.offsetEnd(p1); j < end; j++)
           total += pairCounts.get(CSRCountUtils.packPair(p1, probeNbrs[j]), 0);
       }
     } else {
-      for (int p1 = 0; p1 < nodeCount; p1++) {
+      for (int p1 = 0; p1 < nodeIdUpperBound; p1++) {
         guard.checkPeriodically(p1);
+        if (!provider.isNodeLive(p1))
+          continue;
         final int[] neighbors = provider.getNeighborIds(p1, probeDirection, probeEdgeType);
         for (final int p2 : neighbors)
           total += pairCounts.get(CSRCountUtils.packPair(p1, p2), 0);
@@ -256,9 +265,10 @@ public final class PairHashJoinOp implements CountOp {
    * When arm2 has exactly 2 hops (the Q2 case), fuses the arm2 walk with the probe
    * check inline to avoid allocating an intermediate int[] per build node.
    */
-  private long buildAndProbeInline(final NeighborView arm1View, final IntHashSet arm1Filter,
+  private long buildAndProbeInline(final GraphTraversalProvider provider, final NeighborView arm1View,
+      final IntHashSet arm1Filter,
       final NeighborView[] arm2Views, final IntHashSet[] arm2Buckets, final NeighborView probeView,
-      final int nodeCount, final int[] bucketIds, final WorkGuard guard) {
+      final int nodeIdUpperBound, final int[] bucketIds, final WorkGuard guard) {
     final int[] arm1Nbrs = arm1View.neighbors();
     final int[] probeNbrs = probeView.neighbors();
     long total = 0;
@@ -270,9 +280,11 @@ public final class PairHashJoinOp implements CountOp {
       final IntHashSet arm2Filter0 = arm2Buckets != null ? arm2Buckets[0] : null;
       final IntHashSet arm2Filter1 = arm2Buckets != null ? arm2Buckets[1] : null;
 
-      for (int startId = 0; startId < nodeCount; startId++) {
+      for (int startId = 0; startId < nodeIdUpperBound; startId++) {
         // The build node's own cost is O(arm1 x arm2 x log d), so a per-anchor check is what bounds it.
         guard.check();
+        if (!provider.isNodeLive(startId))
+          continue;
         final int a1Start = arm1View.offset(startId);
         final int a1End = arm1View.offsetEnd(startId);
         if (a1Start == a1End) continue;
@@ -310,8 +322,10 @@ public final class PairHashJoinOp implements CountOp {
     }
 
     // GENERAL PATH: allocate arm2 endpoints array per build node
-    for (int startId = 0; startId < nodeCount; startId++) {
+    for (int startId = 0; startId < nodeIdUpperBound; startId++) {
       guard.check();
+      if (!provider.isNodeLive(startId))
+        continue;
       final int a1Start = arm1View.offset(startId);
       final int a1End = arm1View.offsetEnd(startId);
       if (a1Start == a1End) continue;
@@ -343,13 +357,16 @@ public final class PairHashJoinOp implements CountOp {
    * The two endpoint filters are the labels the pattern put on the shared variables; dropping one does not make
    * the join cheaper, it makes it count endpoints the pattern excluded (issue #6304).
    */
-  private void buildWithViews(final NeighborView arm1View, final IntHashSet arm1Filter,
+  private void buildWithViews(final GraphTraversalProvider provider, final NeighborView arm1View,
+      final IntHashSet arm1Filter,
       final NeighborView arm2View, final IntHashSet arm2Filter, final LongLongHashMap pairCounts,
-      final int nodeCount, final int[] bucketIds, final WorkGuard guard) {
+      final int nodeIdUpperBound, final int[] bucketIds, final WorkGuard guard) {
     final int[] arm1Nbrs = arm1View.neighbors();
     final int[] arm2Nbrs = arm2View.neighbors();
-    for (int startId = 0; startId < nodeCount; startId++) {
+    for (int startId = 0; startId < nodeIdUpperBound; startId++) {
       guard.check();
+      if (!provider.isNodeLive(startId))
+        continue;
       final int a1Start = arm1View.offset(startId);
       final int a1End = arm1View.offsetEnd(startId);
       if (a1Start == a1End) continue;
@@ -376,7 +393,7 @@ public final class PairHashJoinOp implements CountOp {
    */
   private void buildWithArm1View(final NeighborView arm1View, final IntHashSet arm1Filter,
       final GraphTraversalProvider provider, final IntHashSet[] arm2Buckets, final LongLongHashMap pairCounts,
-      final int nodeCount, final int[] bucketIds, final WorkGuard guard) {
+      final int nodeIdUpperBound, final int[] bucketIds, final WorkGuard guard) {
     final int[] arm1Nbrs = arm1View.neighbors();
 
     // Pre-fetch NeighborViews for arm2 hops
@@ -387,8 +404,10 @@ public final class PairHashJoinOp implements CountOp {
       if (arm2Views[h] == null) { allArm2Views = false; break; }
     }
 
-    for (int startId = 0; startId < nodeCount; startId++) {
+    for (int startId = 0; startId < nodeIdUpperBound; startId++) {
       guard.check();
+      if (!provider.isNodeLive(startId))
+        continue;
       final int a1Start = arm1View.offset(startId);
       final int a1End = arm1View.offsetEnd(startId);
       if (a1Start == a1End) continue;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
@@ -71,33 +71,33 @@ public final class PartitionedTriangleOp implements CountOp {
 
   @Override
   public long execute(final GraphTraversalProvider provider, final Database db, final WorkGuard guard) {
-    final int nodeCount = provider.getNodeCount();
-    final int[] personPartition = buildPartitionMapping(provider, nodeCount, guard);
+    final int nodeIdUpperBound = provider.getNodeIdUpperBound();
+    final int[] personPartition = buildPartitionMapping(provider, nodeIdUpperBound, guard);
 
     final NeighborView knowsView = provider.getNeighborView(Vertex.DIRECTION.BOTH, triangleEdgeType);
     if (knowsView == null)
-      return countTrianglesPerNode(provider, personPartition, nodeCount, guard);
+      return countTrianglesPerNode(provider, personPartition, nodeIdUpperBound, guard);
 
     final int[] nbrs = knowsView.neighbors();
 
     final int threadCount = Math.max(1, Runtime.getRuntime().availableProcessors());
     final long[] partialCounts = new long[threadCount];
 
-    if (nodeCount < 1000) {
-      partialCounts[0] = countRange(knowsView, nbrs, personPartition, 0, nodeCount, guard);
+    if (nodeIdUpperBound < 1000) {
+      partialCounts[0] = countRange(provider, knowsView, nbrs, personPartition, 0, nodeIdUpperBound, guard);
     } else {
       final ExecutorService executor = QueryEngineManager.getInstance().getExecutorService();
       final Future<?>[] futures = new Future<?>[threadCount - 1];
-      final int chunkSize = (nodeCount + threadCount - 1) / threadCount;
+      final int chunkSize = (nodeIdUpperBound + threadCount - 1) / threadCount;
       int launched = 0;
       for (int t = 1; t < threadCount; t++) {
         final int start = t * chunkSize;
-        final int end = Math.min(start + chunkSize, nodeCount);
-        if (start >= nodeCount)
+        final int end = Math.min(start + chunkSize, nodeIdUpperBound);
+        if (start >= nodeIdUpperBound)
           break;
         final int threadIdx = t;
         futures[launched++] = executor.submit(() ->
-            partialCounts[threadIdx] = countRange(knowsView, nbrs, personPartition, start, end, guard));
+            partialCounts[threadIdx] = countRange(provider, knowsView, nbrs, personPartition, start, end, guard));
       }
       // #4952: the calling thread runs chunk 0 itself (same discipline as GraphAlgorithms.parallelForRange)
       // instead of submitting ALL chunks and blocking. Submitting everything meant that, when this operator
@@ -111,7 +111,8 @@ public final class PartitionedTriangleOp implements CountOp {
       // into partialCounts (and holding pool threads) behind the caller's back.
       boolean chunk0Completed = false;
       try {
-        partialCounts[0] = countRange(knowsView, nbrs, personPartition, 0, Math.min(chunkSize, nodeCount), guard);
+        partialCounts[0] = countRange(provider, knowsView, nbrs, personPartition, 0,
+            Math.min(chunkSize, nodeIdUpperBound), guard);
         chunk0Completed = true;
       } finally {
         // #4951: awaitFutures throws on interrupt (cancelling the outstanding chunks) instead of returning,
@@ -134,13 +135,15 @@ public final class PartitionedTriangleOp implements CountOp {
     return total;
   }
 
-  private static long countRange(final NeighborView knowsView, final int[] nbrs,
+  private static long countRange(final GraphTraversalProvider provider, final NeighborView knowsView, final int[] nbrs,
       final int[] personPartition, final int start, final int end, final WorkGuard guard) {
     long count = 0;
     for (int u = start; u < end; u++) {
       // Triangle counting is superlinear in the degree, so the per-anchor check is what bounds the whole
       // range: one high-degree anchor already costs O(d^2) intersections (issue #6266).
       guard.check();
+      if (!provider.isNodeLive(u))
+        continue;
       final int country = personPartition[u];
       if (country < 0)
         continue;
@@ -174,9 +177,9 @@ public final class PartitionedTriangleOp implements CountOp {
     return count;
   }
 
-  private int[] buildPartitionMapping(final GraphTraversalProvider provider, final int nodeCount,
+  private int[] buildPartitionMapping(final GraphTraversalProvider provider, final int nodeIdUpperBound,
       final WorkGuard guard) {
-    final int[] partition = new int[nodeCount];
+    final int[] partition = new int[nodeIdUpperBound];
     Arrays.fill(partition, -1);
 
     final int chainLength = partitionEdgeTypes.length;
@@ -199,8 +202,10 @@ public final class PartitionedTriangleOp implements CountOp {
     // relies on when the triangle-edge view itself is missing. This keeps the mapping on the CSR node-id path -
     // no RID/Vertex materialization - even when the fast array-offset scan below cannot be used.
     if (!allViewsAvailable) {
-      for (int p = 0; p < nodeCount; p++) {
+      for (int p = 0; p < nodeIdUpperBound; p++) {
         guard.checkPeriodically(p);
+        if (!provider.isNodeLive(p))
+          continue;
         int current = p;
         boolean valid = true;
         for (int h = 0; h < chainLength; h++) {
@@ -220,8 +225,10 @@ public final class PartitionedTriangleOp implements CountOp {
     final NeighborView firstView = views[0];
     final int[] firstNbrs = firstView.neighbors();
 
-    for (int p = 0; p < nodeCount; p++) {
+    for (int p = 0; p < nodeIdUpperBound; p++) {
       guard.checkPeriodically(p);
+      if (!provider.isNodeLive(p))
+        continue;
       final int fStart = firstView.offset(p);
       final int fEnd = firstView.offsetEnd(p);
       if (fStart == fEnd)
@@ -245,10 +252,12 @@ public final class PartitionedTriangleOp implements CountOp {
   }
 
   private long countTrianglesPerNode(final GraphTraversalProvider provider,
-      final int[] personPartition, final int nodeCount, final WorkGuard guard) {
+      final int[] personPartition, final int nodeIdUpperBound, final WorkGuard guard) {
     long total = 0;
-    for (int u = 0; u < nodeCount; u++) {
+    for (int u = 0; u < nodeIdUpperBound; u++) {
       guard.check();
+      if (!provider.isNodeLive(u))
+        continue;
       final int country = personPartition[u];
       if (country < 0)
         continue;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOp.java
@@ -91,7 +91,7 @@ public final class PropagateChainOp implements CountOp {
     if (anchorRid != null)
       return executeFromSeededAnchor(provider, db, guard);
 
-    final int nodeCount = provider.getNodeCount();
+    final int nodeIdUpperBound = provider.getNodeIdUpperBound();
     final int hops = edgeTypes.length;
 
     // Pre-compute valid bucket sets for type filtering at each level. null = unlabelled, so no filter.
@@ -110,27 +110,26 @@ public final class PropagateChainOp implements CountOp {
     if (inequalityIdxA >= 0 && inequalityIdxB >= 0
         && Math.min(inequalityIdxA, inequalityIdxB) == 0
         && hops <= 2)
-      return executePerSourceInequality(provider, nodeCount, validBuckets, guard);
+      return executePerSourceInequality(provider, nodeIdUpperBound, validBuckets, guard);
 
     // Standard dense array propagation for chains without inequality
     // (or with inequality source not at position 0)
 
     // Pre-compute bucket IDs once for all filtering operations. A pattern that labels no position needs none of
     // them, and the scan costs one getRID per node.
-    final int[] bucketIds = anyLabelled(validBuckets) ? precomputeBucketIds(provider, nodeCount, guard) : null;
+    final int[] bucketIds = anyLabelled(validBuckets)
+        ? precomputeBucketIds(provider, nodeIdUpperBound, guard) : null;
 
     // Initialize anchor counts via bucket filtering (avoids OLTP iterateType). An unlabelled anchor accepts every
     // vertex, which is the whole node domain (issue #5757).
-    long[] current = new long[nodeCount];
+    long[] current = new long[nodeIdUpperBound];
     final IntHashSet anchorBuckets = validBuckets[0];
-    if (anchorBuckets == null)
-      Arrays.fill(current, 1L);
-    else {
-      for (int v = 0; v < nodeCount; v++) {
-        guard.checkPeriodically(v);
-        if (anchorBuckets.contains(bucketIds[v]))
-          current[v] = 1;
-      }
+    for (int v = 0; v < nodeIdUpperBound; v++) {
+      guard.checkPeriodically(v);
+      if (!provider.isNodeLive(v))
+        continue;
+      if (anchorBuckets == null || anchorBuckets.contains(bucketIds[v]))
+        current[v] = 1;
     }
 
     for (int hop = 0; hop < hops; hop++) {
@@ -142,8 +141,10 @@ public final class PropagateChainOp implements CountOp {
     }
 
     long total = 0;
-    for (int v = 0; v < nodeCount; v++) {
+    for (int v = 0; v < nodeIdUpperBound; v++) {
       guard.checkPeriodically(v);
+      if (!provider.isNodeLive(v))
+        continue;
       total += current[v];
     }
 
@@ -249,7 +250,7 @@ public final class PropagateChainOp implements CountOp {
    * For Q6 (10K persons × ~1.7K frontier nodes each): ~17M CSR ops (comparable to dense + self-loop).
    */
   private long executePerSourceInequality(final GraphTraversalProvider provider,
-      final int nodeCount, final IntHashSet[] validBuckets, final WorkGuard guard) {
+      final int nodeIdUpperBound, final IntHashSet[] validBuckets, final WorkGuard guard) {
     final int idxB = Math.max(inequalityIdxA, inequalityIdxB);
 
     // Pre-fetch NeighborViews for hops up to the inequality target
@@ -259,7 +260,8 @@ public final class PropagateChainOp implements CountOp {
 
     // Pre-compute bucket IDs for all nodes — eliminates per-node getRID calls during
     // frontier type filtering. One-time O(nodeCount) cost, amortized across all sources.
-    final int[] bucketIds = anyLabelled(validBuckets) ? precomputeBucketIds(provider, nodeCount, guard) : null;
+    final int[] bucketIds = anyLabelled(validBuckets)
+        ? precomputeBucketIds(provider, nodeIdUpperBound, guard) : null;
 
     // Identify anchor nodes via bucket filtering (avoids db.iterateType OLTP reads). null accepts every vertex,
     // empty accepts none (issue #5757).
@@ -269,8 +271,10 @@ public final class PropagateChainOp implements CountOp {
 
     long totalCount = 0;
 
-    for (int srcId = 0; srcId < nodeCount; srcId++) {
+    for (int srcId = 0; srcId < nodeIdUpperBound; srcId++) {
       guard.check();
+      if (!provider.isNodeLive(srcId))
+        continue;
       if (anchorBuckets != null && !anchorBuckets.contains(bucketIds[srcId]))
         continue;
 
@@ -311,7 +315,7 @@ public final class PropagateChainOp implements CountOp {
 
   private long countSelfLoopPaths(final GraphTraversalProvider provider,
       final IntHashSet[] validBuckets, final WorkGuard guard) {
-    final int nodeCount = provider.getNodeCount();
+    final int nodeIdUpperBound = provider.getNodeIdUpperBound();
     final int idxA = Math.min(inequalityIdxA, inequalityIdxB);
     final int idxB = Math.max(inequalityIdxA, inequalityIdxB);
     final int subChainLength = idxB - idxA;
@@ -321,7 +325,7 @@ public final class PropagateChainOp implements CountOp {
     // and compute |E0_reverse_nbrs(m) ∩ E2_nbrs(c)| for each middle edge (m,c).
     // For Q5: 2.6M REPLY_OF edges × ~2 merge ops = ~5M ops (vs 16K × 300 = ~14M per-anchor).
     if (subChainLength == 3 && idxA == 0 && idxB == edgeTypes.length) {
-      return countSelfLoop3HopEdgeScan(provider, nodeCount, validBuckets, guard);
+      return countSelfLoop3HopEdgeScan(provider, nodeIdUpperBound, validBuckets, guard);
     }
 
     // GENERAL PATH: per-anchor expansion
@@ -337,10 +341,13 @@ public final class PropagateChainOp implements CountOp {
     final IntHashSet anchorBuckets = validBuckets[idxA];
     if (anchorBuckets != null && anchorBuckets.isEmpty())
       return 0;
-    final int[] anchorBucketIds = anchorBuckets == null ? null : precomputeBucketIds(provider, nodeCount, guard);
+    final int[] anchorBucketIds = anchorBuckets == null ? null
+        : precomputeBucketIds(provider, nodeIdUpperBound, guard);
 
-    for (int vId = 0; vId < nodeCount; vId++) {
+    for (int vId = 0; vId < nodeIdUpperBound; vId++) {
       guard.check();
+      if (!provider.isNodeLive(vId))
+        continue;
       if (anchorBuckets != null && !anchorBuckets.contains(anchorBucketIds[vId]))
         continue;
 
@@ -390,7 +397,7 @@ public final class PropagateChainOp implements CountOp {
    * Avg ~2 merge comparisons per edge → ~5M ops total at ~3-5ns = ~15-25ms.
    */
   private long countSelfLoop3HopEdgeScan(final GraphTraversalProvider provider,
-      final int nodeCount, final IntHashSet[] validBuckets, final WorkGuard guard) {
+      final int nodeIdUpperBound, final IntHashSet[] validBuckets, final WorkGuard guard) {
     // E0: edge from pos0 to pos1, direction directions[0]
     // E1: edge from pos1 to pos2, direction directions[1] (middle, iterated)
     // E2: edge from pos2 to pos3, direction directions[2]
@@ -406,7 +413,7 @@ public final class PropagateChainOp implements CountOp {
 
     if (viewA == null || viewE1 == null || viewC == null) {
       // Fallback: can't get NeighborViews, use per-anchor approach
-      return countSelfLoopPerAnchorFallback(provider, nodeCount, validBuckets, guard);
+      return countSelfLoopPerAnchorFallback(provider, nodeIdUpperBound, validBuckets, guard);
     }
 
     final int[] aNbrs = viewA.neighbors();
@@ -420,13 +427,15 @@ public final class PropagateChainOp implements CountOp {
     if ((pos1Buckets != null && pos1Buckets.isEmpty()) || (pos2Buckets != null && pos2Buckets.isEmpty()))
       return 0;
     final int[] bucketIds = (pos1Buckets != null || pos2Buckets != null)
-        ? precomputeBucketIds(provider, nodeCount, guard) : null;
+        ? precomputeBucketIds(provider, nodeIdUpperBound, guard) : null;
 
     long selfLoop = 0;
 
     // Scan all E1 edges by iterating pos1 nodes
-    for (int b = 0; b < nodeCount; b++) {
+    for (int b = 0; b < nodeIdUpperBound; b++) {
       guard.check();
+      if (!provider.isNodeLive(b))
+        continue;
       // Check pos1 type filter
       if (pos1Buckets != null && !pos1Buckets.contains(bucketIds[b]))
         continue;
@@ -486,7 +495,7 @@ public final class PropagateChainOp implements CountOp {
    * Fallback per-anchor self-loop when NeighborViews are unavailable.
    */
   private long countSelfLoopPerAnchorFallback(final GraphTraversalProvider provider,
-      final int nodeCount, final IntHashSet[] validBuckets, final WorkGuard guard) {
+      final int nodeIdUpperBound, final IntHashSet[] validBuckets, final WorkGuard guard) {
     // Reuse existing per-anchor expansion logic
     final int subChainLength = Math.max(inequalityIdxA, inequalityIdxB);
     final NeighborView[] subViews = new NeighborView[subChainLength];
@@ -496,11 +505,14 @@ public final class PropagateChainOp implements CountOp {
     final IntHashSet anchorBuckets = validBuckets[0];
     if (anchorBuckets != null && anchorBuckets.isEmpty())
       return 0;
-    final int[] bucketIds = anchorBuckets == null ? null : precomputeBucketIds(provider, nodeCount, guard);
+    final int[] bucketIds = anchorBuckets == null ? null
+        : precomputeBucketIds(provider, nodeIdUpperBound, guard);
 
     long selfLoopTotal = 0;
-    for (int vId = 0; vId < nodeCount; vId++) {
+    for (int vId = 0; vId < nodeIdUpperBound; vId++) {
       guard.check();
+      if (!provider.isNodeLive(vId))
+        continue;
       if (anchorBuckets != null && !anchorBuckets.contains(bucketIds[vId]))
         continue;
       selfLoopTotal += countLoopsFromNode(provider, vId, subViews, 0, subChainLength, validBuckets);
@@ -660,15 +672,14 @@ public final class PropagateChainOp implements CountOp {
     return pos < next.length ? Arrays.copyOf(next, pos) : next;
   }
 
-  /**
-   * Pre-computes bucket IDs for all CSR nodes. One-time O(nodeCount) cost via bulk
-   * getDegrees-style scan, amortized across all per-source expansions.
-   */
-  private static int[] precomputeBucketIds(final GraphTraversalProvider provider, final int nodeCount,
+  /** Pre-computes bucket IDs for all live CSR nodes, amortized across all per-source expansions. */
+  private static int[] precomputeBucketIds(final GraphTraversalProvider provider, final int nodeIdUpperBound,
       final WorkGuard guard) {
-    final int[] bucketIds = new int[nodeCount];
-    for (int v = 0; v < nodeCount; v++) {
+    final int[] bucketIds = new int[nodeIdUpperBound];
+    for (int v = 0; v < nodeIdUpperBound; v++) {
       guard.checkPeriodically(v);
+      if (!provider.isNodeLive(v))
+        continue;
       bucketIds[v] = provider.getRID(v).getBucketId();
     }
     return bucketIds;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/AntiJoinChainOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/AntiJoinChainOpSparseNodeIdsTest.java
@@ -42,4 +42,23 @@ class AntiJoinChainOpSparseNodeIdsTest {
 
     assertThat(count).isEqualTo(2L);
   }
+
+  /**
+   * Same fixture as {@link #evaluatesLiveAnchorAboveLiveNodeCount()} but with NeighborViews exposed, so the
+   * scan runs through the {@code hopViews}-based expansion in {@code countWithAntiJoin} rather than the
+   * per-node {@code getNeighborIds} fallback - the path a real CSR-backed provider actually exposes.
+   */
+  @Test
+  void evaluatesLiveAnchorAboveLiveNodeCountWithViews() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider()
+        .withEdges("CHAIN", Vertex.DIRECTION.OUT, 0, 2)
+        .withEdges("CHAIN", Vertex.DIRECTION.OUT, HIGH_ID, 3);
+    final AntiJoinChainOp op = new AntiJoinChainOp(new String[] { null, null },
+        new String[] { "CHAIN" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT },
+        0, 1, "BLOCKS", Vertex.DIRECTION.OUT, -1, -1);
+
+    final long count = op.execute(provider, null, WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(2L);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/AntiJoinChainOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/AntiJoinChainOpSparseNodeIdsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.WorkGuard;
+
+import org.junit.jupiter.api.Test;
+
+import static com.arcadedb.query.opencypher.executor.steps.SparseNodeIdProvider.HIGH_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Regression coverage for issue #6967 in {@link AntiJoinChainOp}. */
+class AntiJoinChainOpSparseNodeIdsTest {
+
+  @Test
+  void evaluatesLiveAnchorAboveLiveNodeCount() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider().withoutViews()
+        .withEdges("CHAIN", Vertex.DIRECTION.OUT, 0, 2)
+        .withEdges("CHAIN", Vertex.DIRECTION.OUT, HIGH_ID, 3);
+    final AntiJoinChainOp op = new AntiJoinChainOp(new String[] { null, null },
+        new String[] { "CHAIN" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT },
+        0, 1, "BLOCKS", Vertex.DIRECTION.OUT, -1, -1);
+
+    final long count = op.execute(provider, null, WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(2L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOpSparseNodeIdsTest.java
@@ -42,4 +42,23 @@ class DegreeProductOpSparseNodeIdsTest {
 
     assertThat(count).isEqualTo(4L);
   }
+
+  /**
+   * Same fixture as {@link #includesLiveCentralNodeAboveLiveNodeCount()} but with NeighborViews exposed, so
+   * the scan runs through {@code executeFastScan} (the {@code NeighborView.degree()} array-arithmetic path
+   * production star-join queries actually hit) rather than the per-node {@code executePerNode} fallback.
+   */
+  @Test
+  void includesLiveCentralNodeAboveLiveNodeCountWithViews() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider()
+        .withEdges("ARM", Vertex.DIRECTION.OUT, 0, 2)
+        .withEdges("ARM", Vertex.DIRECTION.OUT, HIGH_ID, 2, 3, 4);
+    final DegreeProductOp op = new DegreeProductOp("Central", new DegreeProductOp.Arm[] {
+        new DegreeProductOp.Arm(new String[] { "ARM" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, false)
+    });
+
+    final long count = op.execute(provider, null, WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(4L);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOpSparseNodeIdsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.WorkGuard;
+
+import org.junit.jupiter.api.Test;
+
+import static com.arcadedb.query.opencypher.executor.steps.SparseNodeIdProvider.HIGH_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Regression coverage for issue #6967 in {@link DegreeProductOp}. */
+class DegreeProductOpSparseNodeIdsTest {
+
+  @Test
+  void includesLiveCentralNodeAboveLiveNodeCount() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider().withoutViews()
+        .withEdges("ARM", Vertex.DIRECTION.OUT, 0, 2)
+        .withEdges("ARM", Vertex.DIRECTION.OUT, HIGH_ID, 2, 3, 4);
+    final DegreeProductOp op = new DegreeProductOp("Central", new DegreeProductOp.Arm[] {
+        new DegreeProductOp.Arm(new String[] { "ARM" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, false)
+    });
+
+    final long count = op.execute(provider, null, WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(4L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOpSparseNodeIdsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.WorkGuard;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static com.arcadedb.query.opencypher.executor.steps.SparseNodeIdProvider.HIGH_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/** Regression coverage for issue #6967 in {@link PairHashJoinOp}. */
+class PairHashJoinOpSparseNodeIdsTest {
+
+  @Test
+  void buildsPairFromLiveNodeAboveLiveNodeCount() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider().withoutViews()
+        .withEdges("ARM_1", Vertex.DIRECTION.OUT, 0, 2)
+        .withEdges("ARM_2", Vertex.DIRECTION.OUT, 0, 3)
+        .withEdges("ARM_1", Vertex.DIRECTION.OUT, HIGH_ID, 2)
+        .withEdges("ARM_2", Vertex.DIRECTION.OUT, HIGH_ID, 3)
+        .withEdges("PROBE", Vertex.DIRECTION.OUT, 2, 3);
+    final PairHashJoinOp op = new PairHashJoinOp("Build",
+        new String[] { "ARM_1" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, null,
+        new String[] { "ARM_2" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, null,
+        "PROBE", Vertex.DIRECTION.OUT);
+
+    final long count = op.execute(provider, databaseWithBuildBucket(), WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(2L);
+  }
+
+  private static Database databaseWithBuildBucket() {
+    final Database db = Mockito.mock(Database.class);
+    final Schema schema = Mockito.mock(Schema.class);
+    final DocumentType buildType = Mockito.mock(DocumentType.class);
+    final Bucket buildBucket = Mockito.mock(Bucket.class);
+    when(db.getSchema()).thenReturn(schema);
+    when(schema.existsType("Build")).thenReturn(true);
+    when(schema.getType("Build")).thenReturn(buildType);
+    when(buildType.getBuckets(true)).thenReturn(List.of(buildBucket));
+    when(buildBucket.getFileId()).thenReturn(7);
+    return db;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOpSparseNodeIdsTest.java
@@ -55,6 +55,29 @@ class PairHashJoinOpSparseNodeIdsTest {
     assertThat(count).isEqualTo(2L);
   }
 
+  /**
+   * Same fixture as {@link #buildsPairFromLiveNodeAboveLiveNodeCount()} but with NeighborViews exposed, so
+   * the build phase runs through {@code buildAndProbeInline}'s NeighborView-backed walk - the path a real
+   * CSR-backed provider actually exposes - rather than the per-node {@code walkArm} fallback.
+   */
+  @Test
+  void buildsPairFromLiveNodeAboveLiveNodeCountWithViews() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider()
+        .withEdges("ARM_1", Vertex.DIRECTION.OUT, 0, 2)
+        .withEdges("ARM_2", Vertex.DIRECTION.OUT, 0, 3)
+        .withEdges("ARM_1", Vertex.DIRECTION.OUT, HIGH_ID, 2)
+        .withEdges("ARM_2", Vertex.DIRECTION.OUT, HIGH_ID, 3)
+        .withEdges("PROBE", Vertex.DIRECTION.OUT, 2, 3);
+    final PairHashJoinOp op = new PairHashJoinOp("Build",
+        new String[] { "ARM_1" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, null,
+        new String[] { "ARM_2" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, null,
+        "PROBE", Vertex.DIRECTION.OUT);
+
+    final long count = op.execute(provider, databaseWithBuildBucket(), WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(2L);
+  }
+
   private static Database databaseWithBuildBucket() {
     final Database db = Mockito.mock(Database.class);
     final Schema schema = Mockito.mock(Schema.class);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpSparseNodeIdsTest.java
@@ -45,4 +45,26 @@ class PartitionedTriangleOpSparseNodeIdsTest {
 
     assertThat(count).isEqualTo(6L);
   }
+
+  /**
+   * Same fixture as {@link #countsTriangleContainingLiveNodeAboveLiveNodeCount()} but with NeighborViews
+   * exposed, so partition mapping and triangle counting run through the CSR sorted-intersection
+   * {@code countRange} path rather than the per-node {@code countTrianglesPerNode} fallback.
+   */
+  @Test
+  void countsTriangleContainingLiveNodeAboveLiveNodeCountWithViews() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider()
+        .withEdges("IN_CITY", Vertex.DIRECTION.OUT, 2, 4)
+        .withEdges("IN_CITY", Vertex.DIRECTION.OUT, 3, 4)
+        .withEdges("IN_CITY", Vertex.DIRECTION.OUT, HIGH_ID, 4)
+        .withEdges("KNOWS", Vertex.DIRECTION.BOTH, 2, 3, HIGH_ID)
+        .withEdges("KNOWS", Vertex.DIRECTION.BOTH, 3, 2, HIGH_ID)
+        .withEdges("KNOWS", Vertex.DIRECTION.BOTH, HIGH_ID, 2, 3);
+    final PartitionedTriangleOp op = new PartitionedTriangleOp(new String[] { "IN_CITY" },
+        new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, "KNOWS");
+
+    final long count = op.execute(provider, null, WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(6L);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpSparseNodeIdsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.WorkGuard;
+
+import org.junit.jupiter.api.Test;
+
+import static com.arcadedb.query.opencypher.executor.steps.SparseNodeIdProvider.HIGH_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Regression coverage for issue #6967 in {@link PartitionedTriangleOp}. */
+class PartitionedTriangleOpSparseNodeIdsTest {
+
+  @Test
+  void countsTriangleContainingLiveNodeAboveLiveNodeCount() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider().withoutViews()
+        .withEdges("IN_CITY", Vertex.DIRECTION.OUT, 2, 4)
+        .withEdges("IN_CITY", Vertex.DIRECTION.OUT, 3, 4)
+        .withEdges("IN_CITY", Vertex.DIRECTION.OUT, HIGH_ID, 4)
+        .withEdges("KNOWS", Vertex.DIRECTION.BOTH, 2, 3, HIGH_ID)
+        .withEdges("KNOWS", Vertex.DIRECTION.BOTH, 3, 2, HIGH_ID)
+        .withEdges("KNOWS", Vertex.DIRECTION.BOTH, HIGH_ID, 2, 3);
+    final PartitionedTriangleOp op = new PartitionedTriangleOp(new String[] { "IN_CITY" },
+        new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, "KNOWS");
+
+    final long count = op.execute(provider, null, WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(6L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOpSparseNodeIdsTest.java
@@ -41,4 +41,22 @@ class PropagateChainOpSparseNodeIdsTest {
 
     assertThat(count).isEqualTo(2L);
   }
+
+  /**
+   * Same fixture as {@link #propagatesFromLiveAnchorAboveLiveNodeCount()} but with NeighborViews exposed, so
+   * the dense propagation runs through {@link CSRCountUtils#propagateOneHop}'s NeighborView-backed branch
+   * rather than its per-node {@code getNeighborIds} fallback.
+   */
+  @Test
+  void propagatesFromLiveAnchorAboveLiveNodeCountWithViews() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider()
+        .withEdges("CHAIN", Vertex.DIRECTION.OUT, 0, 2)
+        .withEdges("CHAIN", Vertex.DIRECTION.OUT, HIGH_ID, 3);
+    final PropagateChainOp op = new PropagateChainOp(new String[] { null, null },
+        new String[] { "CHAIN" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, -1, -1);
+
+    final long count = op.execute(provider, null, WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(2L);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOpSparseNodeIdsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOpSparseNodeIdsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.WorkGuard;
+
+import org.junit.jupiter.api.Test;
+
+import static com.arcadedb.query.opencypher.executor.steps.SparseNodeIdProvider.HIGH_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Regression coverage for issue #6967 in {@link PropagateChainOp}. */
+class PropagateChainOpSparseNodeIdsTest {
+
+  @Test
+  void propagatesFromLiveAnchorAboveLiveNodeCount() {
+    final SparseNodeIdProvider provider = new SparseNodeIdProvider().withoutViews()
+        .withEdges("CHAIN", Vertex.DIRECTION.OUT, 0, 2)
+        .withEdges("CHAIN", Vertex.DIRECTION.OUT, HIGH_ID, 3);
+    final PropagateChainOp op = new PropagateChainOp(new String[] { null, null },
+        new String[] { "CHAIN" }, new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, -1, -1);
+
+    final long count = op.execute(provider, null, WorkGuard.forCommandDeadline(null));
+
+    assertThat(count).isEqualTo(2L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/SparseNodeIdProvider.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/SparseNodeIdProvider.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.NeighborView;
+import com.arcadedb.graph.Vertex;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test provider whose node ID space contains one deleted slot and one live ID above the live-node count.
+ * Per-node access fails on the deleted slot so a whole-ID-space scan must honor {@link #isNodeLive(int)}.
+ */
+final class SparseNodeIdProvider implements GraphTraversalProvider {
+  static final int HOLE = 1;
+  static final int HIGH_ID = 5;
+  static final int UPPER_BOUND = 6;
+
+  private final Map<String, int[][]> adjacency = new HashMap<>();
+  private boolean exposeViews = true;
+
+  SparseNodeIdProvider withEdges(final String edgeType, final Vertex.DIRECTION direction,
+      final int nodeId, final int... neighbors) {
+    adjacency.computeIfAbsent(key(direction, edgeType), ignored -> emptyAdjacency())[nodeId] = neighbors;
+    return this;
+  }
+
+  SparseNodeIdProvider withoutViews() {
+    exposeViews = false;
+    return this;
+  }
+
+  @Override
+  public int getNodeCount() {
+    return UPPER_BOUND - 1;
+  }
+
+  @Override
+  public int getNodeIdUpperBound() {
+    return UPPER_BOUND;
+  }
+
+  @Override
+  public boolean isNodeLive(final int nodeId) {
+    return nodeId >= 0 && nodeId < UPPER_BOUND && nodeId != HOLE;
+  }
+
+  @Override
+  public boolean isReady() {
+    return true;
+  }
+
+  @Override
+  public String getName() {
+    return "sparse-node-id-test-provider";
+  }
+
+  @Override
+  public boolean coversVertexType(final String typeName) {
+    return true;
+  }
+
+  @Override
+  public boolean coversEdgeType(final String edgeTypeName) {
+    return true;
+  }
+
+  @Override
+  public int getNodeId(final RID rid) {
+    return (int) rid.getPosition();
+  }
+
+  @Override
+  public RID getRID(final int nodeId) {
+    assertLive(nodeId);
+    return new RID(7, nodeId);
+  }
+
+  @Override
+  public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+    assertLive(nodeId);
+    final int[][] rows = adjacency.get(key(direction, edgeTypes));
+    return rows != null ? rows[nodeId] : new int[0];
+  }
+
+  @Override
+  public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+    return getNeighborIds(nodeId, direction, edgeTypes).length;
+  }
+
+  @Override
+  public void getDegrees(final int[] degrees, final Vertex.DIRECTION direction, final String edgeType) {
+    Arrays.fill(degrees, 0);
+    for (int nodeId = 0; nodeId < degrees.length; nodeId++)
+      if (isNodeLive(nodeId))
+        degrees[nodeId] = (int) countEdges(nodeId, direction, edgeType);
+  }
+
+  @Override
+  public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+      final String... edgeTypes) {
+    return Arrays.binarySearch(getNeighborIds(nodeA, direction, edgeTypes), nodeB) >= 0;
+  }
+
+  @Override
+  public Object getProperty(final int nodeId, final String propertyName) {
+    return null;
+  }
+
+  @Override
+  public NeighborView getNeighborView(final Vertex.DIRECTION direction, final String... edgeTypes) {
+    if (!exposeViews)
+      return null;
+    final int[][] rows = adjacency.get(key(direction, edgeTypes));
+    return rows != null ? toView(rows) : null;
+  }
+
+  private static String key(final Vertex.DIRECTION direction, final String... edgeTypes) {
+    return direction + ":" + String.join(",", edgeTypes);
+  }
+
+  private void assertLive(final int nodeId) {
+    if (!isNodeLive(nodeId))
+      throw new AssertionError("attempted per-node access for deleted node ID " + nodeId);
+  }
+
+  private static int[][] emptyAdjacency() {
+    final int[][] rows = new int[UPPER_BOUND][];
+    Arrays.setAll(rows, ignored -> new int[0]);
+    return rows;
+  }
+
+  private static NeighborView toView(final int[][] rows) {
+    final int[] offsets = new int[UPPER_BOUND + 1];
+    int edgeCount = 0;
+    for (int nodeId = 0; nodeId < UPPER_BOUND; nodeId++) {
+      offsets[nodeId] = edgeCount;
+      edgeCount += rows[nodeId].length;
+    }
+    offsets[UPPER_BOUND] = edgeCount;
+    final int[] neighbors = new int[edgeCount];
+    int position = 0;
+    for (final int[] row : rows) {
+      System.arraycopy(row, 0, neighbors, position, row.length);
+      position += row.length;
+    }
+    return new NeighborView(UPPER_BOUND, offsets, neighbors);
+  }
+}


### PR DESCRIPTION
## Summary

- size CountOp node-indexed arrays from getNodeIdUpperBound()
- skip non-live IDs while enumerating sparse provider node ID spaces
- cover all five affected CountOps with separate sparse-ID regression tests

## Testing

- 5 sparse node ID regression tests
- 62 related OpenCypher and CountOp tests

Fixes #6967

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph query accuracy for datasets with sparse or deleted node IDs.
  * Ensured live nodes with high IDs are included in joins, traversals, degree calculations, triangle counting, and chain propagation.
  * Prevented invalid node slots from affecting query results.

* **Tests**
  * Added regression coverage for sparse node-ID scenarios across key graph query operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->