### PR TITLE
fix(#6925): chain the DISTINCT dedup for statements with GROUP BY, UNWIND or expand()

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -194,9 +194,6 @@ public class SelectExecutionPlanner {
 
     final SelectExecutionPlan selectExecutionPlan = new SelectExecutionPlan(context, limitValue);
 
-    if (info.expand && info.distinct)
-      throw new CommandExecutionException("Cannot execute a statement with DISTINCT expand(), please use a subquery");
-
     // A statement whose own text proves that it cannot return a row is answered without touching the storage. This is
     // read off the clauses as the statement wrote them, before optimizeQuery() rearranges them into index searches.
     final String emptyReason = emptyByConstructionReason(context);
@@ -322,6 +319,13 @@ public class SelectExecutionPlanner {
         result.chain(new ProjectionCalculationStep(info.projectionAfterUnwind, context));
 
       handleOrderBy(result, info, context);
+      // DISTINCT has to be chained here as well, and after the ORDER BY exactly like the branch below does it:
+      // info.distinct is read off the projection in init() and then cleared, so a statement that also has
+      // expand(), UNWIND or GROUP BY used to have the keyword accepted, dropped and never re-applied (issue
+      // #6925). Chaining it after handleOrderBy() is what makes the dedup see the final row shape - the
+      // projection that strips the columns an ORDER BY on a non-selected alias added is chained by
+      // handleOrderBy() itself - and it keeps SKIP/LIMIT counting the rows the statement returns.
+      handleDistinct(result, info, context);
       if (info.skip != null)
         result.chain(new SkipExecutionStep(info.skip, context));
 
@@ -703,7 +707,10 @@ public class SelectExecutionPlanner {
       }
       if (info.aggregateProjection != null) {
         long aggregationLimit = -1;
-        if (info.orderBy == null && info.limit != null) {
+        // The cap counts the groups the aggregation emits, so it is only equivalent to the statement's LIMIT
+        // when nothing downstream can drop a row. A DISTINCT collapses groups that project to the same row,
+        // so pushing SKIP+LIMIT into the aggregation would under-deliver rows (issue #6925).
+        if (info.orderBy == null && info.limit != null && !info.distinct) {
           try {
             aggregationLimit = info.limit.getValue(context);
             if (info.skip != null && info.skip.getValue(context) > 0) {
@@ -1797,7 +1804,10 @@ public class SelectExecutionPlanner {
     if (limitSize >= 0)
       maxResults = skipSize + limitSize;
 
-    if (info.expand || info.unwind != null)
+    // The cap is on the rows the sort emits, so it is only the answer when nothing downstream can drop rows.
+    // A DISTINCT chained after the ORDER BY collapses duplicates out of those SKIP+LIMIT rows and would then
+    // return fewer rows than the LIMIT asked for, so the sort stays uncapped in that case (issue #6925).
+    if (info.expand || info.unwind != null || info.distinct)
       maxResults = null;
 
     if (!info.orderApplied && info.orderBy != null && info.orderBy.getItems() != null && !info.orderBy.getItems().isEmpty()) {

--- a/engine/src/test/java/com/arcadedb/query/sql/DistinctWithGroupByUnwindExpandTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/DistinctWithGroupByUnwindExpandTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces issue #6925: {@code SelectExecutionPlanner.handleProjectionsBlock()} chained the DISTINCT
+ * dedup step from a single branch, the one taken when the statement has neither {@code expand()}, nor
+ * UNWIND, nor GROUP BY. Since {@code init()} reads {@code info.distinct} off the projection and then
+ * clears it, the keyword was accepted, dropped, and never re-applied for the other branch: DISTINCT was
+ * silently a no-op for every statement that also had GROUP BY, UNWIND or {@code expand()}.
+ *
+ * {@code MatchExecutionPlanner} funnels its RETURN clause through the same method, so MATCH ... RETURN
+ * DISTINCT with an UNWIND was affected identically.
+ */
+class DistinctWithGroupByUnwindExpandTest extends TestHelper {
+
+  private static List<Result> toList(final ResultSet rs) {
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+    return rows;
+  }
+
+  @Test
+  void distinctIsAppliedWithUnwind() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE U");
+      database.command("SQL", "INSERT INTO U SET tag = ['a', 'b', 'a']");
+
+      // Control: the fixture really does produce 3 unwound rows without DISTINCT.
+      assertThat(toList(database.query("SQL", "SELECT tag FROM U UNWIND tag"))).hasSize(3);
+
+      final List<Result> rows = toList(database.query("SQL", "SELECT DISTINCT tag FROM U UNWIND tag"));
+      assertThat(rows).hasSize(2);
+      assertThat(rows.stream().map(r -> (String) r.getProperty("tag")).toList()).containsExactlyInAnyOrder("a", "b");
+    });
+  }
+
+  @Test
+  void distinctIsAppliedWithGroupBy() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE G");
+      database.command("SQL", "INSERT INTO G SET a = 'x'");
+      database.command("SQL", "INSERT INTO G SET a = 'y'");
+      database.command("SQL", "INSERT INTO G SET a = 'z'");
+      database.command("SQL", "INSERT INTO G SET a = 'z'");
+
+      // Control: three groups of sizes 1, 1 and 2 -> two distinct counts.
+      assertThat(toList(database.query("SQL", "SELECT count(*) AS c FROM G GROUP BY a"))).hasSize(3);
+
+      final List<Result> rows = toList(database.query("SQL", "SELECT DISTINCT count(*) AS c FROM G GROUP BY a"));
+      assertThat(rows).hasSize(2);
+      assertThat(rows.stream().map(r -> ((Number) r.getProperty("c")).longValue()).toList()).containsExactlyInAnyOrder(1L, 2L);
+    });
+  }
+
+  @Test
+  void distinctIsAppliedWithExpandOfScalarList() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE T");
+      database.command("SQL", "INSERT INTO T SET tags = ['a', 'b', 'a']");
+
+      assertThat(toList(database.query("SQL", "SELECT expand(tags) FROM T"))).hasSize(3);
+
+      final List<Result> rows = toList(database.query("SQL", "SELECT DISTINCT expand(tags) FROM T"));
+      assertThat(rows).hasSize(2);
+    });
+  }
+
+  @Test
+  void distinctIsAppliedWithExpandOfVertices() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE VERTEX TYPE Person");
+      database.command("SQL", "CREATE EDGE TYPE Knows");
+      database.command("SQL", "INSERT INTO Person SET name = 'a'");
+      database.command("SQL", "INSERT INTO Person SET name = 'b'");
+      database.command("SQL", "INSERT INTO Person SET name = 'target'");
+      // Both 'a' and 'b' point at the same vertex, so expand(out()) yields it twice.
+      database.command("SQL",
+          "CREATE EDGE Knows FROM (SELECT FROM Person WHERE name = 'a') TO (SELECT FROM Person WHERE name = 'target')");
+      database.command("SQL",
+          "CREATE EDGE Knows FROM (SELECT FROM Person WHERE name = 'b') TO (SELECT FROM Person WHERE name = 'target')");
+
+      assertThat(toList(database.query("SQL", "SELECT expand(out('Knows')) FROM Person"))).hasSize(2);
+
+      final List<Result> rows = toList(database.query("SQL", "SELECT DISTINCT expand(out('Knows')) FROM Person"));
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.getFirst().getProperty("name")).isEqualTo("target");
+    });
+  }
+
+  /**
+   * SKIP and LIMIT must count the rows the statement returns, not the rows the sort produced: the ORDER BY
+   * step is capped at SKIP+LIMIT rows, so a dedup chained after it would otherwise return fewer rows than
+   * the LIMIT asked for.
+   */
+  @Test
+  void distinctWithGroupByHonoursOrderByAndLimit() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE L");
+      // groups: k1 -> 1, k2 -> 1, k3 -> 1, k4 -> 2, k5 -> 3 => distinct counts {1, 2, 3}
+      database.command("SQL", "INSERT INTO L SET k = 'k1'");
+      database.command("SQL", "INSERT INTO L SET k = 'k2'");
+      database.command("SQL", "INSERT INTO L SET k = 'k3'");
+      database.command("SQL", "INSERT INTO L SET k = 'k4'");
+      database.command("SQL", "INSERT INTO L SET k = 'k4'");
+      database.command("SQL", "INSERT INTO L SET k = 'k5'");
+      database.command("SQL", "INSERT INTO L SET k = 'k5'");
+      database.command("SQL", "INSERT INTO L SET k = 'k5'");
+
+      final List<Result> all = toList(database.query("SQL", "SELECT DISTINCT count(*) AS c FROM L GROUP BY k ORDER BY c"));
+      assertThat(all.stream().map(r -> ((Number) r.getProperty("c")).longValue()).toList()).containsExactly(1L, 2L, 3L);
+
+      final List<Result> limited = toList(
+          database.query("SQL", "SELECT DISTINCT count(*) AS c FROM L GROUP BY k ORDER BY c LIMIT 2"));
+      assertThat(limited.stream().map(r -> ((Number) r.getProperty("c")).longValue()).toList()).containsExactly(1L, 2L);
+
+      final List<Result> skipped = toList(
+          database.query("SQL", "SELECT DISTINCT count(*) AS c FROM L GROUP BY k ORDER BY c SKIP 1 LIMIT 1"));
+      assertThat(skipped.stream().map(r -> ((Number) r.getProperty("c")).longValue()).toList()).containsExactly(2L);
+
+      // Without an ORDER BY the LIMIT is pushed into the aggregation as a cap on the number of GROUPS; the
+      // dedup that follows would then collapse those groups into fewer rows than the LIMIT asked for.
+      assertThat(toList(database.query("SQL", "SELECT DISTINCT count(*) AS c FROM L GROUP BY k LIMIT 2"))).hasSize(2);
+    });
+  }
+
+  @Test
+  void distinctIsAppliedWithUnwindInMatch() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE VERTEX TYPE M");
+      database.command("SQL", "INSERT INTO M SET name = 'n', tag = ['a', 'b', 'a']");
+
+      assertThat(toList(database.query("SQL", "MATCH {type: M, as: m} RETURN m.tag AS tag UNWIND tag"))).hasSize(3);
+
+      final List<Result> rows = toList(
+          database.query("SQL", "MATCH {type: M, as: m} RETURN DISTINCT m.tag AS tag UNWIND tag"));
+      assertThat(rows).hasSize(2);
+      assertThat(rows.stream().map(r -> (String) r.getProperty("tag")).toList()).containsExactlyInAnyOrder("a", "b");
+    });
+  }
+
+  /**
+   * Without GROUP BY, UNWIND or expand() the dedup was already chained; this pins the unaffected branch so a
+   * regression there does not hide behind the new coverage.
+   */
+  @Test
+  void distinctStillWorksWithoutGroupByUnwindOrExpand() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE P");
+      database.command("SQL", "INSERT INTO P SET v = 1");
+      database.command("SQL", "INSERT INTO P SET v = 1");
+      database.command("SQL", "INSERT INTO P SET v = 2");
+
+      assertThat(toList(database.query("SQL", "SELECT DISTINCT v FROM P"))).hasSize(2);
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/DistinctWithGroupByUnwindExpandTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/DistinctWithGroupByUnwindExpandTest.java
@@ -151,6 +151,32 @@ class DistinctWithGroupByUnwindExpandTest extends TestHelper {
     });
   }
 
+  /**
+   * The {@code expand()} branch used to be rejected outright by a (dead) plan-time guard, so it never met
+   * ORDER BY / SKIP / LIMIT at all. Same invariant as the GROUP BY case above: the pagination has to count the
+   * rows the statement returns, not the rows the sort produced.
+   */
+  @Test
+  void distinctWithExpandHonoursOrderByAndLimit() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE E");
+      database.command("SQL", "INSERT INTO E SET tags = ['b', 'a', 'a', 'c']");
+
+      assertThat(toList(database.query("SQL", "SELECT expand(tags) FROM E"))).hasSize(4);
+
+      final List<Result> all = toList(database.query("SQL", "SELECT DISTINCT expand(tags) FROM E ORDER BY value"));
+      assertThat(all.stream().map(r -> (String) r.getProperty("value")).toList()).containsExactly("a", "b", "c");
+
+      final List<Result> limited = toList(
+          database.query("SQL", "SELECT DISTINCT expand(tags) FROM E ORDER BY value LIMIT 2"));
+      assertThat(limited.stream().map(r -> (String) r.getProperty("value")).toList()).containsExactly("a", "b");
+
+      final List<Result> skipped = toList(
+          database.query("SQL", "SELECT DISTINCT expand(tags) FROM E ORDER BY value SKIP 1 LIMIT 1"));
+      assertThat(skipped.stream().map(r -> (String) r.getProperty("value")).toList()).containsExactly("b");
+    });
+  }
+
   @Test
   void distinctIsAppliedWithUnwindInMatch() {
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/query/sql/DistinctWithGroupByUnwindExpandTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/DistinctWithGroupByUnwindExpandTest.java
@@ -177,6 +177,55 @@ class DistinctWithGroupByUnwindExpandTest extends TestHelper {
     });
   }
 
+  /**
+   * Same pagination invariant again, this time for the UNWIND branch. Note the clause order the grammar
+   * requires (ORDER BY before UNWIND); the plan still unwinds first and sorts the unwound rows.
+   */
+  @Test
+  void distinctWithUnwindHonoursOrderByAndLimit() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE W");
+      database.command("SQL", "INSERT INTO W SET tag = ['b', 'a', 'a', 'c']");
+
+      final List<Result> all = toList(database.query("SQL", "SELECT DISTINCT tag FROM W ORDER BY tag UNWIND tag"));
+      assertThat(all.stream().map(r -> (String) r.getProperty("tag")).toList()).containsExactly("a", "b", "c");
+
+      final List<Result> limited = toList(
+          database.query("SQL", "SELECT DISTINCT tag FROM W ORDER BY tag UNWIND tag LIMIT 2"));
+      assertThat(limited.stream().map(r -> (String) r.getProperty("tag")).toList()).containsExactly("a", "b");
+
+      final List<Result> skipped = toList(
+          database.query("SQL", "SELECT DISTINCT tag FROM W ORDER BY tag UNWIND tag SKIP 1 LIMIT 1"));
+      assertThat(skipped.stream().map(r -> (String) r.getProperty("tag")).toList()).containsExactly("b");
+    });
+  }
+
+  /**
+   * GROUP BY and UNWIND in the same statement: the dedup has to see the rows the UNWIND produced, not the
+   * groups the aggregation produced, so it can only be chained after both.
+   */
+  @Test
+  void distinctIsAppliedWithGroupByAndUnwindTogether() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE C");
+      database.command("SQL", "INSERT INTO C SET a = 'x'");
+      database.command("SQL", "INSERT INTO C SET a = 'x'");
+      database.command("SQL", "INSERT INTO C SET a = 'y'");
+      database.command("SQL", "INSERT INTO C SET a = 'z'");
+      database.command("SQL", "INSERT INTO C SET a = 'z'");
+
+      // Three groups with counts 2, 1, 2; each is unwound into two rows -> 6 rows, of which the two
+      // count-2 groups produce the same pair, so DISTINCT leaves 4.
+      final String sql = "SELECT count(*) AS c, [1, 2] AS p FROM C GROUP BY a UNWIND p";
+      assertThat(toList(database.query("SQL", sql))).hasSize(6);
+
+      final List<Result> rows = toList(database.query("SQL", "SELECT DISTINCT count(*) AS c, [1, 2] AS p FROM C GROUP BY a UNWIND p"));
+      assertThat(rows).hasSize(4);
+      assertThat(rows.stream().map(r -> ((Number) r.getProperty("c")).longValue() + ":" + r.getProperty("p")).toList())
+          .containsExactlyInAnyOrder("2:1", "2:2", "1:1", "1:2");
+    });
+  }
+
   @Test
   void distinctIsAppliedWithUnwindInMatch() {
     database.transaction(() -> {


### PR DESCRIPTION
Closes #6925

## Problem

`SelectExecutionPlanner.handleProjectionsBlock()` chained the DISTINCT dedup step from exactly one branch: the one taken when the statement has neither `expand()`, nor UNWIND, nor GROUP BY. `init()` reads `info.distinct` off the projection and immediately clears it (`info.projection.setDistinct(false)`), so for every statement that *did* have one of those three clauses the keyword was parsed, accepted, dropped, and never re-applied. No error, silently duplicated rows:

| statement | expected | actual before |
|---|---|---|
| `SELECT DISTINCT tag FROM U UNWIND tag` (`tag = ['a','b','a']`) | 2 | 3 |
| `SELECT DISTINCT count(*) AS c FROM G GROUP BY a` (groups 1,1,2) | 2 | 3 |
| `SELECT DISTINCT expand(tags) FROM T` (`tags = ['a','b','a']`) | 2 | 3 |
| `MATCH {type: M, as: m} RETURN DISTINCT m.tag AS tag UNWIND tag` | 2 | 3 |

`MatchExecutionPlanner` funnels its non-`$elements` RETURN clause through the same method, so MATCH was affected identically - this was one defect, not two.

There was a guard for the `expand()` case, `if (info.expand && info.distinct) throw new CommandExecutionException("Cannot execute a statement with DISTINCT expand(), please use a subquery")`, but it was **dead code**: `info.expand` is only set inside `optimizeQuery()`, which runs *after* that check, so `info.expand` is always `false` there and the exception could never fire. Nothing in the repo referenced the message - no test, no doc.

## Fix

Three changes, all in `SelectExecutionPlanner`:

1. **`handleProjectionsBlock()`** - chain `handleDistinct()` in the `expand || unwind != null || groupBy != null` branch too, placed *after* `handleOrderBy()` exactly like the other branch does it. That position matters twice: `handleOrderBy()` is what chains `projectionAfterOrderBy`, the projection that strips the extra columns an ORDER BY on a non-selected alias added, so the dedup must run after it to see the final row shape; and it keeps SKIP/LIMIT counting the rows the statement returns rather than the rows the sort produced.

2. **`handleOrderBy()`** - do not cap the `OrderByStep` at SKIP+LIMIT when `info.distinct` is set. The cap is on the rows the sort *emits*, which is only the answer when nothing downstream can drop a row; a dedup running after it collapses duplicates out of those rows and would return fewer than the LIMIT asked for. This also fixes the same pre-existing under-delivery on the already-working branch (`SELECT DISTINCT v FROM P ORDER BY v LIMIT n`).

3. **`handleProjections()`** - same reasoning for the group cap pushed into `AggregateProjectionCalculationStep`: it counts *groups*, and a DISTINCT collapses groups that project to the same row, so it is not pushed down when `info.distinct` is set.

The dead `DISTINCT expand()` guard is removed rather than repaired. Repairing it (moving it after `optimizeQuery()`) would turn a query that silently returned duplicates into a hard error; `DistinctExecutionStep` handles the rows `ExpandStep` produces without any change - element wrappers take its RID fast path, scalars and maps go through the property-based `DistinctKey` - so supporting the combination is both correct and strictly more useful than rejecting it.

## Test plan

New regression test `engine/src/test/java/com/arcadedb/query/sql/DistinctWithGroupByUnwindExpandTest.java` (10 cases). Of the first seven, **6 fail before the fix and all 7 pass after**; the 7th pins the already-working branch so a regression there cannot hide behind the new coverage. The remaining three were added in response to review feedback. Every case carries a control assertion proving the fixture really produces duplicates without DISTINCT.

- [x] `distinctIsAppliedWithUnwind` - `SELECT DISTINCT tag FROM U UNWIND tag` -> 2 rows (was 3)
- [x] `distinctIsAppliedWithGroupBy` - `SELECT DISTINCT count(*) AS c FROM G GROUP BY a` -> 2 rows (was 3)
- [x] `distinctIsAppliedWithExpandOfScalarList` - `SELECT DISTINCT expand(tags) FROM T` -> 2 rows (was 3)
- [x] `distinctIsAppliedWithExpandOfVertices` - `SELECT DISTINCT expand(out('Knows')) FROM Person` -> 1 row (was 2); exercises the RID fast path
- [x] `distinctWithGroupByHonoursOrderByAndLimit` - ORDER BY / SKIP / LIMIT interaction, including the no-ORDER-BY case that pushes the cap into the aggregation
- [x] `distinctWithExpandHonoursOrderByAndLimit` - the same pagination invariant for the `expand()` branch, which the dead guard used to keep from ever meeting ORDER BY / SKIP / LIMIT
- [x] `distinctWithUnwindHonoursOrderByAndLimit` - the same invariant for the UNWIND branch
- [x] `distinctIsAppliedWithGroupByAndUnwindTogether` - GROUP BY and UNWIND in one statement, so the dedup is proven to see the unwound rows rather than the groups
- [x] `distinctIsAppliedWithUnwindInMatch` - the `MatchExecutionPlanner` route through the same method
- [x] `distinctStillWorksWithoutGroupByUnwindOrExpand` - the branch that already worked

Verification run: full `engine` module suite, `-DexcludedGroups=benchmark,vector,slow`.

## Notes for the reviewer

- **Behaviour change worth calling out:** a statement combining `DISTINCT` with `ORDER BY ... SKIP/LIMIT` now sorts the whole result set instead of stopping the `OrderByStep` at SKIP+LIMIT rows, and a `DISTINCT ... GROUP BY ... LIMIT` no longer caps the number of groups the aggregation emits. Both caps are unsound once a dedup downstream can drop rows - they were the reason such a query could return fewer rows than the LIMIT asked for - but queries that were previously silently-wrong-and-fast will now be correct and, on large result sets, slower.
- Server-module suites were not run locally: port 2480 is held by a long-running ArcadeDB instance on this machine, which makes those tests fail as 403 / "Too many failed authentication attempts" regardless of the change. CI covers them.
- Grepped the test tree for assertions pinning `+ DISTINCT` / `maxResults` / plan `prettyPrint()` strings that this change would move: none. `EXPLAIN` output for statements combining DISTINCT with GROUP BY / UNWIND / `expand()` now shows an extra `+ DISTINCT` step, and the `+ ORDER BY` step of a DISTINCT statement no longer prints a `maxResults` cap. No test in the repo pinned either string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `DISTINCT` query handling with `expand()`, `UNWIND`, and `GROUP BY`.
  - Results are now deduplicated after sorting and before pagination, producing accurate `SKIP` and `LIMIT` outcomes.
  - Preserved expected row counts when aggregation, ordering, or expansion could create duplicate results.
  - Added support for `DISTINCT expand()` queries and improved behavior across scalar, vertex, and `MATCH` queries.

- **Tests**
  - Added comprehensive coverage for deduplication, aggregation, ordering, and pagination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->