### PR TITLE
fix(#6950): refuse an update computed from a record image a concurrent commit already replaced

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1422,6 +1422,17 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         null);
   }
 
+  /**
+   * Writes a record to its page immediately, without the read lock {@link #updateRecord(Record)} takes.
+   * <p>
+   * <b>The #6950 MVCC guard lives on the two paths INTO this method, not inside it.</b> A caller already holding a
+   * transaction gets it from {@code TransactionContext.addUpdatedRecord}, which pins the record's page and checks the
+   * image the moment the record is taken for update; a caller with no transaction gets it from the implicit-transaction
+   * branch below. Everything that reaches this method with a transaction someone ELSE opened - the edge-append rebase
+   * and the commit-time {@code updatedRecords} flush - is deliberately unguarded here, because the check already ran
+   * once for it. A NEW direct caller that opens its own transaction and then calls this is therefore the one shape
+   * that would slip through both: route it through {@link #updateRecord(Record)} instead of adding a third bypass.
+   */
   @Override
   public void updateRecordNoLock(final Record record, final boolean discardRecordAfter) {
     boolean success = false;

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1428,6 +1428,21 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     final boolean implicitTransaction = checkTransactionIsActive(autoTransaction);
 
     try {
+      if (implicitTransaction) {
+        // #6950: the transaction was opened by THIS call, so the record was read before it existed and nothing has
+        // put its page under the MVCC check yet. Pin it and verify it still holds the image this update is diffed
+        // against: a concurrent commit that landed in between would otherwise be overwritten silently, since the
+        // page loaded here is already the newer one and the commit-time version check has nothing to refuse. The
+        // transactional path does the same at the moment the record is taken for update (addUpdatedRecord).
+        final RID rid = record.getIdentity();
+        final LocalBucket bucket = (LocalBucket) schema.getBucketById(rid.getBucketId());
+        try {
+          TransactionContext.checkRecordIsStillTheOneRead(bucket, rid, bucket.fetchPageInTransaction(rid), record);
+        } catch (final IOException e) {
+          throw new DatabaseOperationException("Error on update the record " + rid, e);
+        }
+      }
+
       final List<IndexInternal> indexes = record instanceof Document d ? indexer.getInvolvedIndexes(d) :
           Collections.emptyList();
 

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -519,6 +519,39 @@ public class TransactionContext implements Transaction {
       throw new TransactionException("Transaction not begun");
   }
 
+  /**
+   * Refuses, with the retryable conflict the caller already knows how to handle, an update computed from a record
+   * image that is no longer the committed one (#6950).
+   * <p>
+   * A record's page is put under the commit-time MVCC check when the record is TAKEN for update - not when its
+   * content was read. Under the default READ_COMMITTED isolation a read caches no page in the transaction (see
+   * {@link #getPage(PageId, int)}), so a commit landing between the read and the pin hands the pin the NEWER
+   * version: the version check then has nothing left to refuse, and the read-modify-write is applied on top of a
+   * value it never saw. That is a SILENTLY lost update - no exception for either writer, so no retry loop can help -
+   * and it is what handed two writers the same range in the counter-document (hi-lo / sequence emulation) pattern.
+   * Comparing the image the update is diffed against with the slot the pin just loaded is what tells a stale
+   * read-modify-write from a good one, at RECORD granularity, so a concurrent write to another slot of the same page
+   * stays the false conflict it is.
+   * <p>
+   * Only for a {@link MutableDocument}: its buffer is the pre-update image by construction - properties are overlaid
+   * on a map and the buffer is left alone, which is exactly what {@code LocalDatabase.getOriginalDocument} relies on
+   * to diff the indexes. An edge segment, by contrast, is mutated IN PLACE before it is handed to
+   * {@code updateRecord}, so its buffer is the image being WRITTEN rather than the one that was read: comparing it
+   * would refuse every edge append. Concurrency on those chunks is owned by the commutative edge-append merge.
+   *
+   * @param recordPage the page just pinned for {@code rid}, or {@code null} when the RID could not name one.
+   */
+  public static void checkRecordIsStillTheOneRead(final LocalBucket bucket, final RID rid, final BasePage recordPage,
+      final Record record) {
+    if (recordPage == null || !(record instanceof MutableDocument))
+      return;
+
+    final Binary readImage = ((RecordInternal) record).getBuffer();
+    if (readImage != null && bucket.hasRecordChangedSinceRead(rid, recordPage, readImage))
+      throw new ConcurrentModificationException("Record " + rid + " was modified by a concurrent transaction between "
+          + "its read and its update. Please retry the operation");
+  }
+
   public void addUpdatedRecord(final Record record) throws IOException {
     final RID rid = record.getIdentity();
 
@@ -527,6 +560,14 @@ public class TransactionContext implements Transaction {
     if (updatedRecords.put(record.getIdentity(), record) == null) {
       final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
       final MutablePage recordPage = bucket.fetchPageInTransaction(rid);
+      try {
+        checkRecordIsStillTheOneRead(bucket, rid, recordPage, record);
+      } catch (final ConcurrentModificationException e) {
+        // The transaction is doomed either way, but a caller that swallows the conflict and commits anyway must not
+        // find this record still queued for a write it never got to make.
+        updatedRecords.remove(rid);
+        throw e;
+      }
       // #6129, #6141: same moment, and the same reason, as the page pinned right above - it is the view of the record
       // this update is based on. The pin covers the record's own slot and nothing else, so a record that keeps content
       // on another page (the chunk chain of a multi-page record past its head, the content record behind a placeholder

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1022,6 +1022,62 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     return database.getTransaction().getPageToModify(new PageId(database, file.getFileId(), pageId), pageSize, false);
   }
 
+  /**
+   * Whether the slot of {@code rid} on {@code page} no longer holds, byte for byte, the record image an update was
+   * computed from (#6950).
+   * <p>
+   * The page a deferred update is validated against is pinned when the record is TAKEN for update
+   * ({@code TransactionContext.addUpdatedRecord}), not when its content was read: under the default READ_COMMITTED
+   * isolation a plain read caches nothing in the transaction, so a commit landing in between hands the pin the NEWER
+   * version and the commit-time version check has nothing left to refuse. The read-modify-write is then applied on
+   * top of a value it never saw - a silently lost update rather than a retryable conflict. Comparing the image the
+   * update started from against the slot the pin just loaded is what tells the two apart, and it does so at RECORD
+   * granularity, so a concurrent write to another slot of the same page stays the false conflict it is.
+   * <p>
+   * Answers only for a plain record stored inside this very slot. A placeholder pointer, a multi-page record's head
+   * chunk and a placeholder's content keep their body elsewhere, so this page cannot see whether it changed: they
+   * return {@code false} here and stay covered by the off-page fingerprint
+   * ({@link #offPageContentFingerprint(RID, BasePage, boolean)}) exactly as before. A freed or deleted slot also
+   * returns {@code false}: the commit's own vanished-record check (#4959) is what reports that one.
+   * <p>
+   * Never throws. A page that cannot be read where a record was is not a reason to fail a write that would otherwise
+   * succeed, and the commit-time version check is still behind it.
+   *
+   * @param readImage the image the update is diffed against - the record's own buffer, the same one
+   *                  {@code LocalDatabase.getOriginalDocument} rebuilds the pre-update document from.
+   */
+  public boolean hasRecordChangedSinceRead(final RID rid, final BasePage page, final Binary readImage) {
+    try {
+      final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+      if (positionInPage >= page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET))
+        return false;
+
+      final int recordPositionInPage = getRecordPositionInPage(page, positionInPage);
+      if (recordPositionInPage == 0)
+        // FREE SLOT (NEVER USED OR DELETED)
+        return false;
+
+      final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
+      if (recordSize[0] <= 0)
+        // DELETED, OR A SHAPE WHOSE BODY IS NOT (ENTIRELY) IN THIS SLOT: SEE THE JAVADOC
+        return false;
+
+      final int size = (int) recordSize[0];
+      if (size != readImage.size())
+        return true;
+
+      // One intrinsified Arrays.equals over the two heap arrays, stopping at the first difference, rather than a
+      // byte loop through the page accessors: this runs on the write path, once per record taken for update.
+      return !page.isSameContentAs((int) (recordPositionInPage + recordSize[1]), readImage, 0, size);
+
+    } catch (final Exception e) {
+      LogManager.instance()
+          .log(this, Level.FINE, "Unable to re-read record %s on page %s while taking it for update", e, rid,
+              page.getPageId());
+      return false;
+    }
+  }
+
   @Override
   public Iterator<Record> iterator() {
     database.checkPermissionsOnFile(fileId, SecurityDatabaseUser.ACCESS.READ_RECORD);

--- a/engine/src/test/java/com/arcadedb/engine/Issue6950RecordImageGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6950RecordImageGuardTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.RecordInternal;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins {@link LocalBucket#hasRecordChangedSinceRead(RID, BasePage, Binary)} branch by branch (#6950).
+ * <p>
+ * The method is the guard that turns a read-modify-write computed from a replaced record image into a retryable
+ * conflict, and it deliberately FAILS OPEN: every shape it cannot compare - and any exception while reading the page -
+ * answers "unchanged", so that a write which would otherwise succeed is never refused by the guard itself. That is
+ * also what makes it worth pinning directly: a refactor that widened one of those "unchanged" answers would silently
+ * reopen the lost-update this test's sibling
+ * ({@code com.arcadedb.query.sql.executor.ConcurrentUpdateStatementLostUpdateTest}) exists to close, without failing
+ * anything.
+ */
+public class Issue6950RecordImageGuardTest extends TestHelper {
+  private static final String TYPE = "Guarded";
+
+  @Test
+  void anUnchangedPlainRecordIsNotReportedAsChanged() {
+    final RID rid = createRecord("aaa");
+    final Binary image = imageOf(rid);
+
+    database.transaction(() -> assertThat(guard(rid, image))
+        .as("the very image the record still holds")
+        .isFalse());
+  }
+
+  @Test
+  void aPlainRecordRewrittenWithTheSameLengthIsReportedAsChanged() {
+    final RID rid = createRecord("aaa");
+    final Binary image = imageOf(rid);
+
+    replaceValueWith(rid, "bbb");
+
+    database.transaction(() -> assertThat(guard(rid, image))
+        .as("same length, different bytes: a length check alone would miss this one")
+        .isTrue());
+  }
+
+  @Test
+  void aPlainRecordRewrittenWithADifferentLengthIsReportedAsChanged() {
+    final RID rid = createRecord("aaa");
+    final Binary image = imageOf(rid);
+
+    replaceValueWith(rid, "a much longer value than the one the image was taken from");
+
+    database.transaction(() -> assertThat(guard(rid, image)).isTrue());
+  }
+
+  @Test
+  void aDeletedRecordIsNotReportedAsChanged() {
+    final RID rid = createRecord("aaa");
+    final Binary image = imageOf(rid);
+
+    database.transaction(() -> database.lookupByRID(rid, true).delete());
+
+    database.transaction(() -> assertThat(guard(rid, image))
+        .as("a vanished record is reported by the commit's own check (#4959), not by this guard")
+        .isFalse());
+  }
+
+  @Test
+  void aNeverUsedSlotIsNotReportedAsChanged() {
+    final RID rid = createRecord("aaa");
+    final Binary image = imageOf(rid);
+    final RID unusedSlot = new RID(rid.getBucketId(), rid.getPosition() + 1);
+
+    database.transaction(() -> assertThat(guard(unusedSlot, image))
+        .as("a slot past the page's record count carries no record to compare")
+        .isFalse());
+  }
+
+  @Test
+  void aMultiPageRecordIsNotReportedAsChanged() {
+    final RID rid = createRecord("x".repeat(200_000));
+    final Binary image = imageOf(rid);
+
+    replaceValueWith(rid, "y".repeat(200_000));
+
+    database.transaction(() -> assertThat(guard(rid, image))
+        .as("a head chunk keeps its body off this page, so the slot cannot answer: the off-page fingerprint does")
+        .isFalse());
+  }
+
+  private boolean guard(final RID rid, final Binary image) {
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
+    try {
+      return bucket.hasRecordChangedSinceRead(rid, bucket.fetchPageInTransaction(rid), image);
+    } catch (final Exception e) {
+      throw new IllegalStateException("Unable to load the page of " + rid, e);
+    }
+  }
+
+  private RID createRecord(final String value) {
+    final RID[] rid = new RID[1];
+    database.transaction(() -> {
+      if (!database.getSchema().existsType(TYPE))
+        database.getSchema().createDocumentType(TYPE).createProperty("v", Type.STRING);
+      rid[0] = database.newDocument(TYPE).set("v", value).save().getIdentity();
+    });
+    return rid[0];
+  }
+
+  private void replaceValueWith(final RID rid, final String value) {
+    database.transaction(() -> {
+      final MutableDocument doc = database.lookupByRID(rid, true).asDocument().modify();
+      doc.set("v", value).save();
+    });
+  }
+
+  /** The committed image of {@code rid}, detached from the page it was read from. */
+  private Binary imageOf(final RID rid) {
+    final Binary[] image = new Binary[1];
+    database.transaction(
+        () -> image[0] = ((RecordInternal) database.lookupByRID(rid, true).asDocument().modify()).getBuffer().copyOfContent());
+    return image[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConcurrentUpdateStatementLostUpdateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConcurrentUpdateStatementLostUpdateTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6950: concurrent single-statement
+ * {@code UPDATE ... SET value = value + ? RETURN BEFORE} commands on the SAME document silently lost increments.
+ * <p>
+ * A record's page is put under the commit-time MVCC check when the record is TAKEN for update, not when its content
+ * was read; under the default READ_COMMITTED isolation a read caches no page in the transaction, so a commit landing
+ * in between handed the pin the newer version and the version check had nothing left to refuse. Both writers were
+ * told they had succeeded and one increment vanished, which no retry loop can repair.
+ * <p>
+ * The two racy methods are the reproducer from the issue: they fail within seconds without the fix. The two
+ * deterministic ones plant exactly the state the race leaves - a record replaced between the read and the update -
+ * so the contract is pinned without depending on a schedule, for both the transactional and the auto-committed path.
+ */
+public class ConcurrentUpdateStatementLostUpdateTest extends TestHelper {
+  private static final int  WRITERS               = 8;
+  private static final int  INCREMENTS_PER_WRITER = 500;
+  private static final long DELTA                 = 25;
+  private static final int  MAX_RETRIES           = 10_000;
+
+  @Test
+  void concurrentUpdateStatementsInExplicitTransactionsMustNotLoseIncrements() throws Exception {
+    createCounter("CounterTx");
+    runConcurrentIncrements("CounterTx", true);
+  }
+
+  @Test
+  void concurrentAutoCommittedUpdateStatementsMustNotLoseIncrements() throws Exception {
+    createCounter("CounterAutoCommit");
+    database.setAutoTransaction(true);
+    try {
+      runConcurrentIncrements("CounterAutoCommit", false);
+    } finally {
+      database.setAutoTransaction(false);
+    }
+  }
+
+  @Test
+  void anUpdateComputedFromAReplacedImageIsRefusedInsideATransaction() throws Exception {
+    createCounter("CounterStaleTx");
+    final RID rid = ridOfCounter("CounterStaleTx");
+
+    database.begin();
+    try {
+      final MutableDocument stale = database.lookupByRID(rid, true).asDocument().modify();
+      assertThat(stale.getLong("value")).isEqualTo(0L);
+
+      // ANOTHER TRANSACTION REPLACES THE RECORD WHILE THIS ONE HOLDS THE IMAGE IT READ
+      commitFromAnotherThread(rid, 25L);
+
+      assertThatThrownBy(() -> stale.set("value", stale.getLong("value") + 25L).save())
+          .as("an update computed from an image a concurrent transaction already replaced must be a retryable conflict")
+          .isInstanceOf(ConcurrentModificationException.class);
+    } finally {
+      if (database.isTransactionActive())
+        database.rollback();
+    }
+
+    assertThat(currentValue("CounterStaleTx")).as("the concurrent increment must survive").isEqualTo(25L);
+  }
+
+  @Test
+  void anUpdateComputedFromAReplacedImageIsRefusedOnTheAutoCommittedPath() throws Exception {
+    createCounter("CounterStaleAutoCommit");
+    final RID rid = ridOfCounter("CounterStaleAutoCommit");
+
+    database.setAutoTransaction(true);
+    try {
+      final MutableDocument stale = database.lookupByRID(rid, true).asDocument().modify();
+      assertThat(stale.getLong("value")).isEqualTo(0L);
+
+      commitFromAnotherThread(rid, 25L);
+
+      assertThatThrownBy(() -> stale.set("value", stale.getLong("value") + 25L).save())
+          .as("the auto-committed path opens its own transaction, so nothing had pinned the page before it either")
+          .isInstanceOf(ConcurrentModificationException.class);
+    } finally {
+      database.setAutoTransaction(false);
+    }
+
+    assertThat(currentValue("CounterStaleAutoCommit")).as("the concurrent increment must survive").isEqualTo(25L);
+  }
+
+  private RID ridOfCounter(final String typeName) {
+    try (final ResultSet rs = database.query("sql", "SELECT FROM " + typeName + " WHERE name = ?", "seq")) {
+      return rs.next().getElement().get().getIdentity();
+    }
+  }
+
+  /** Commits a real increment of {@code rid} from another thread, so it lands as a separate committed transaction. */
+  private void commitFromAnotherThread(final RID rid, final long delta) throws Exception {
+    final ExecutorService other = Executors.newSingleThreadExecutor();
+    try {
+      other.submit(() -> database.transaction(() -> {
+        final MutableDocument doc = database.lookupByRID(rid, true).asDocument().modify();
+        doc.set("value", doc.getLong("value") + delta).save();
+      })).get(60, TimeUnit.SECONDS);
+    } finally {
+      other.shutdownNow();
+    }
+  }
+
+  private void createCounter(final String typeName) {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(typeName);
+      type.createProperty("name", Type.STRING);
+      type.createProperty("value", Type.LONG);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+      database.newDocument(typeName).set("name", "seq").set("value", 0L).save();
+    });
+  }
+
+  private void runConcurrentIncrements(final String typeName, final boolean explicitTransaction) throws Exception {
+    final Set<Long> beforeValues = ConcurrentHashMap.newKeySet();
+    final List<Long> duplicates = new CopyOnWriteArrayList<>();
+    final AtomicLong surfacedConflicts = new AtomicLong();
+
+    final CountDownLatch start = new CountDownLatch(1);
+    final ExecutorService pool = Executors.newFixedThreadPool(WRITERS);
+    try {
+      final List<Future<?>> futures = new ArrayList<>();
+      for (int i = 0; i < WRITERS; i++)
+        futures.add(pool.submit(() -> {
+          start.await();
+          for (int n = 0; n < INCREMENTS_PER_WRITER; n++) {
+            final long before = incrementOnce(typeName, explicitTransaction, surfacedConflicts);
+            if (!beforeValues.add(before))
+              duplicates.add(before);
+          }
+          return null;
+        }));
+      start.countDown();
+      for (final Future<?> future : futures)
+        future.get(300, TimeUnit.SECONDS);
+    } finally {
+      pool.shutdownNow();
+    }
+
+    final long expected = (long) WRITERS * INCREMENTS_PER_WRITER * DELTA;
+    final long actual = currentValue(typeName);
+
+    assertThat(duplicates)
+        .as("Two concurrent UPDATE ... RETURN BEFORE statements returned the same before-value "
+            + "(both writers were handed the same counter range) without any conflict being raised. "
+            + "Conflicts surfaced as NeedRetryException (and retried): %d", surfacedConflicts.get())
+        .isEmpty();
+    assertThat(actual)
+        .as("The final counter must account for every acknowledged increment "
+            + "(%d writers x %d increments x %d), but %d increments were silently lost. "
+            + "Conflicts surfaced as NeedRetryException (and retried): %d",
+            WRITERS, INCREMENTS_PER_WRITER, DELTA, (expected - actual) / DELTA, surfacedConflicts.get())
+        .isEqualTo(expected);
+  }
+
+  private long incrementOnce(final String typeName, final boolean explicitTransaction,
+      final AtomicLong surfacedConflicts) {
+    for (int attempt = 0; ; attempt++) {
+      try {
+        final long[] before = new long[1];
+        if (explicitTransaction)
+          database.transaction(() -> before[0] = executeIncrement(typeName), false, 1);
+        else
+          before[0] = executeIncrement(typeName);
+        return before[0];
+      } catch (final NeedRetryException e) {
+        surfacedConflicts.incrementAndGet();
+        if (attempt >= MAX_RETRIES)
+          throw new IllegalStateException("Retry budget exceeded", e);
+      }
+    }
+  }
+
+  private long executeIncrement(final String typeName) {
+    try (final ResultSet rs = database.command("sql",
+        "UPDATE " + typeName + " SET value = value + ? RETURN BEFORE WHERE name = ?", DELTA, "seq")) {
+      return ((Number) rs.next().getProperty("value")).longValue();
+    }
+  }
+
+  private long currentValue(final String typeName) {
+    try (final ResultSet rs = database.query("sql",
+        "SELECT value FROM " + typeName + " WHERE name = ?", "seq")) {
+      return ((Number) rs.next().getProperty("value")).longValue();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConcurrentUpdateStatementLostUpdateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConcurrentUpdateStatementLostUpdateTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -52,9 +53,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * in between handed the pin the newer version and the version check had nothing left to refuse. Both writers were
  * told they had succeeded and one increment vanished, which no retry loop can repair.
  * <p>
- * The two racy methods are the reproducer from the issue: they fail within seconds without the fix. The two
- * deterministic ones plant exactly the state the race leaves - a record replaced between the read and the update -
- * so the contract is pinned without depending on a schedule, for both the transactional and the auto-committed path.
+ * The two racy methods are the reproducer from the issue: they fail within seconds without the fix. They are
+ * {@code @Tag("slow")} because each drives 4,000 contended SQL statements through tens of thousands of retries, which
+ * is the shape that lane exists for; the two deterministic ones are not, so the contract stays pinned in the default
+ * lane. Those plant exactly the state the race leaves - a record replaced between the read and the update - so it is
+ * pinned without depending on a schedule, for both the transactional and the auto-committed path.
  */
 public class ConcurrentUpdateStatementLostUpdateTest extends TestHelper {
   private static final int  WRITERS               = 8;
@@ -62,12 +65,14 @@ public class ConcurrentUpdateStatementLostUpdateTest extends TestHelper {
   private static final long DELTA                 = 25;
   private static final int  MAX_RETRIES           = 10_000;
 
+  @Tag("slow")
   @Test
   void concurrentUpdateStatementsInExplicitTransactionsMustNotLoseIncrements() throws Exception {
     createCounter("CounterTx");
     runConcurrentIncrements("CounterTx", true);
   }
 
+  @Tag("slow")
   @Test
   void concurrentAutoCommittedUpdateStatementsMustNotLoseIncrements() throws Exception {
     createCounter("CounterAutoCommit");


### PR DESCRIPTION
Closes #6950

## The defect

A record's page is put under the commit-time MVCC check when the record is **taken for update**, not when its content was **read**.

`TransactionContext.addUpdatedRecord()` pins the record's page (`LocalBucket.fetchPageInTransaction`) at `save()` time - the comment in `LocalDatabase.updateRecord` says so explicitly: *"THE PAGE IS EARLY LOADED IN TX CACHE TO USE THE PAGE MVCC IN CASE OF CONCURRENT OPERATIONS ON THE MODIFIED RECORD"*. But under the default `READ_COMMITTED` isolation a plain read caches **nothing** in the transaction (`TransactionContext.getPage()` only populates `immutablePages` under `REPEATABLE_READ`). So when a concurrent commit lands between the read and the pin, `getPageToModify` loads the **newer** page version, and the commit-time `checkPageVersion` has nothing left to refuse: the read-modify-write is applied on top of a value it never saw.

That is a **silently** lost update - both writers are told they succeeded, no exception is raised for either, so no retry loop can repair it. The window is small (read -> `save()`), which is why the issue's reproducer surfaces ~20,000 correctly-detected conflicts and only a handful of silent ones.

Confirmation that this is the mechanism and not something else: running the exact same reproducer under `REPEATABLE_READ` - where the read *does* pin the page - produces 0 duplicates and a correct final counter, with the same ~20,000 surfaced conflicts.

The auto-committed variant of the reproducer misses even the pin. With `setAutoTransaction(true)` and no caller transaction, `LocalDatabase.updateRecord` takes its `else` branch into `updateRecordNoLock`, which opens the transaction *itself* - so the record was read before that transaction existed and nothing put its page under any check at all.

## The fix

Verify, at the moment the record is taken for update, that the freshly pinned page still holds **byte for byte** the image this update is diffed against. If it does not, raise the retryable `ConcurrentModificationException` the caller already knows how to handle, instead of overwriting a value nobody saw.

- `LocalBucket.hasRecordChangedSinceRead(rid, page, readImage)` - the comparison, one intrinsified `Arrays.equals` through the existing `BasePage.isSameContentAs` (#6217), no copy and no byte loop. It answers only for a **plain record stored in this very slot**; a placeholder pointer, a multi-page record's head chunk and a placeholder's content keep their body elsewhere, so they return "unchanged" and stay covered by the off-page fingerprint (#6129) exactly as before. A freed/deleted slot likewise returns "unchanged" - the commit's own vanished-record check (#4959) is what reports that one. It never throws.
- `TransactionContext.checkRecordIsStillTheOneRead(...)` - the shared guard, called from `addUpdatedRecord()` (transactional path) and from `LocalDatabase.updateRecordNoLock()` when *that* call opened the implicit transaction (auto-commit path).

Two deliberate restrictions:

1. **Record granularity, not page granularity.** The comparison is against the record's own slot, so a concurrent write to *another* slot of the same page stays the false conflict it already is and keeps flowing through the disjoint-slot merge (#5381).
2. **`MutableDocument` only.** Its buffer is the pre-update image by construction - properties are overlaid on a map and the buffer is left alone, which is exactly what `LocalDatabase.getOriginalDocument()` relies on to diff the indexes. An edge segment, by contrast, is mutated **in place** before it is handed to `updateRecord`, so its buffer is the image being *written* rather than the one that was read; comparing it would refuse every edge append. Concurrency on those chunks is owned by the commutative edge-append merge instead.

## Test plan

New `engine/src/test/java/com/arcadedb/query/sql/executor/ConcurrentUpdateStatementLostUpdateTest`, 4 methods, all 4 fail on the base commit and pass with the fix:

- [x] `concurrentUpdateStatementsInExplicitTransactionsMustNotLoseIncrements` - the issue's reproducer, 8 writers x 500 increments of +25 inside `database.transaction(...)`: every `RETURN BEFORE` value unique and the final counter equal to the sum of the acknowledged increments.
- [x] `concurrentAutoCommittedUpdateStatementsMustNotLoseIncrements` - the same, with bare auto-committed commands.
- [x] `anUpdateComputedFromAReplacedImageIsRefusedInsideATransaction` - **deterministic**: plants the state the race leaves (another thread commits a real increment between this transaction's read and its `save()`) and asserts the `ConcurrentModificationException`, plus that the concurrent increment survived.
- [x] `anUpdateComputedFromAReplacedImageIsRefusedOnTheAutoCommittedPath` - the same, for the path that opens its own transaction.
- [x] Full `engine` suite (`-DexcludedGroups=benchmark,vector,slow`).
- [x] `graph`-heavy classes exercised by the engine suite cover the edge-segment exclusion (edge appends must not start conflicting).

Local runs, all green: `engine` default lane **13,968** tests, `engine` slow lane **261**, `graphql` **101**. (`gremlin` skips tests in its own module by configuration - its suite lives in `gremlin-it`.)

Also added `engine/src/test/java/com/arcadedb/engine/Issue6950RecordImageGuardTest` (6 methods), which pins `hasRecordChangedSinceRead` branch by branch. The method deliberately **fails open** - every shape it cannot compare, and any exception while reading the page, answers "unchanged" so the guard never refuses a write it cannot judge - which is exactly why it needs a direct test: a refactor that widened one of those answers would reopen this bug without failing anything. Both mutations of the method break it (forcing `return false` fails the two "changed" methods, forcing `return true` fails the four "unchanged" ones), so every branch is armed rather than incidentally traversed.

## Review cycles

| # | head | what changed | outcome |
|---|---|---|---|
| 1 | `7dfd1e7` | the fix + `ConcurrentUpdateStatementLostUpdateTest` | no correctness bug found; 4 minor suggestions |
| 2 | `091c269` | `@Tag("slow")` on the two contention reproducers only; new `Issue6950RecordImageGuardTest`; the fail-open catch and the double `fetchPageInTransaction` answered rather than changed (the second acquisition is `updateRecordInternal`'s own `getPageToModify`, a `modifiedPages` hit, no I/O) | no blocking issues; one suggestion |
| 3 | `3e51b89` | javadoc on `updateRecordNoLock` naming where the guard lives and the one shape that would slip past both paths | clean - no actionable items |

No deferred items.
