### PR TITLE
fix(#6926): fullySorted() dereferenced a null ORDER BY alias, so ORDER BY @rid on a composite index threw NPE at plan time

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3495,7 +3495,16 @@ public class SelectExecutionPlanner {
       } else if (!order.equals(item.getType())) {
         return false;
       }
-      orderItems.add(item.getAlias());
+
+      // getAlias() is null for a record attribute (ORDER BY @rid) and for a complex expression (ORDER BY CASE WHEN ...),
+      // so ask for the name the item is actually known by. A modifier (ORDER BY p.sub, ORDER BY p[0]) orders by something
+      // the index does not hold, so the item is not covered by the index order either. In both cases the planner cannot
+      // prove the index iteration already yields the requested order, so the ORDER BY step has to stay (issue #6926).
+      final String name = item.getModifier() == null ? item.getName() : null;
+      if (name == null)
+        return false;
+
+      orderItems.add(name);
     }
 
     final List<String> conditionItems = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3497,9 +3497,10 @@ public class SelectExecutionPlanner {
       }
 
       // getAlias() is null for a record attribute (ORDER BY @rid) and for a complex expression (ORDER BY CASE WHEN ...),
-      // so ask for the name the item is actually known by. A modifier (ORDER BY p.sub, ORDER BY p[0]) orders by something
-      // the index does not hold, so the item is not covered by the index order either. In both cases the planner cannot
-      // prove the index iteration already yields the requested order, so the ORDER BY step has to stay (issue #6926).
+      // so ask for the name the item is actually known by. A modifier orders by a value derived from the property rather
+      // than by the property itself (ORDER BY s.right(1), ORDER BY s[0]), which the index does not hold. In both cases
+      // the planner cannot prove the index iteration already yields the requested order, so the ORDER BY step has to
+      // stay (issue #6926).
       final String name = item.getModifier() == null ? item.getName() : null;
       if (name == null)
         return false;

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue6926OrderByRecordAttributeWithIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue6926OrderByRecordAttributeWithIndexTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.arcadedb.query.sql;
 
 import com.arcadedb.TestHelper;
@@ -103,11 +121,18 @@ class Issue6926OrderByRecordAttributeWithIndexTest extends TestHelper {
   void orderByIndexedPropertiesIsStillSatisfiedByTheIndexOrder() {
     assertThat(intsOf("q", "SELECT FROM I WHERE p = 1 ORDER BY p, q")).containsExactly(1, 2, 3, 4, 5);
     assertThat(intsOf("q", "SELECT FROM I WHERE p = 1 ORDER BY q")).containsExactly(1, 2, 3, 4, 5);
+
+    // the rows would come out in this order anyway if the ORDER BY step were kept, so assert on the plan too:
+    // without it, this test would still pass if fullySorted() had simply been made to always answer false
+    assertThat(explain("SELECT FROM I WHERE p = 1 ORDER BY p, q")).doesNotContain("ORDER BY");
+    assertThat(explain("SELECT FROM I WHERE p = 1 ORDER BY q")).doesNotContain("ORDER BY");
   }
 
   @Test
-  void indexedEqualityStillUsesTheIndex() {
-    assertThat(explain("SELECT FROM I WHERE p = 1 ORDER BY @rid")).contains("FETCH FROM INDEX");
+  void indexedEqualityStillUsesTheIndexWhileTheOrderByStepIsKept() {
+    final String plan = explain("SELECT FROM I WHERE p = 1 ORDER BY @rid");
+    assertThat(plan).contains("FETCH FROM INDEX");
+    assertThat(plan).contains("ORDER BY");
   }
 
   private String explain(final String query) {

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue6926OrderByRecordAttributeWithIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue6926OrderByRecordAttributeWithIndexTest.java
@@ -1,0 +1,139 @@
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for <a href="https://github.com/ArcadeData/arcadedb/issues/6926">#6926</a>.
+ * <p>
+ * {@code SelectExecutionPlanner.fullySorted()} collected the ORDER BY items with {@code OrderByItem.getAlias()},
+ * which is null for a record attribute (such as {@code @rid}) and for a complex expression (such as
+ * {@code CASE WHEN}). With a composite index the size guard on the index property list did not stop the null from
+ * reaching the {@code equals()} comparison, so the query blew up with an NPE at plan time instead of returning its
+ * rows.
+ * <p>
+ * The same method also accepted an item carrying a modifier ({@code ORDER BY s.right(1)}) as if the index order on
+ * {@code s} already satisfied it, which silently returned the rows in the wrong order.
+ */
+class Issue6926OrderByRecordAttributeWithIndexTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE I");
+      database.command("sql", "CREATE PROPERTY I.p INTEGER");
+      database.command("sql", "CREATE PROPERTY I.q INTEGER");
+      database.command("sql", "CREATE INDEX ON I (p, q) NOTUNIQUE");
+
+      // insert the p=1 rows with descending q, so the index order (p, q ASC) is the reverse of the RID order
+      for (int q = 5; q >= 1; q--)
+        database.command("sql", "INSERT INTO I SET p = 1, q = " + q);
+
+      database.command("sql", "INSERT INTO I SET p = 2, q = 9");
+
+      database.command("sql", "CREATE DOCUMENT TYPE J");
+      database.command("sql", "CREATE PROPERTY J.p INTEGER");
+      database.command("sql", "CREATE PROPERTY J.s STRING");
+      database.command("sql", "CREATE INDEX ON J (p, s) NOTUNIQUE");
+
+      // the index order on s (a5, b4, c3, d2, e1) is the reverse of the order on the last character
+      database.command("sql", "INSERT INTO J SET p = 1, s = 'a5'");
+      database.command("sql", "INSERT INTO J SET p = 1, s = 'b4'");
+      database.command("sql", "INSERT INTO J SET p = 1, s = 'c3'");
+      database.command("sql", "INSERT INTO J SET p = 1, s = 'd2'");
+      database.command("sql", "INSERT INTO J SET p = 1, s = 'e1'");
+    });
+  }
+
+  @Test
+  void orderByRidWithIndexedEqualityOnCompositeIndex() {
+    final List<RID> rids = ridsOf("SELECT FROM I WHERE p = 1 ORDER BY @rid");
+
+    assertThat(rids).hasSize(5);
+    for (int i = 0; i < rids.size() - 1; i++)
+      assertThat(rids.get(i).getPosition()).isLessThan(rids.get(i + 1).getPosition());
+  }
+
+  @Test
+  void orderByRidDescWithIndexedEqualityOnCompositeIndex() {
+    final List<RID> rids = ridsOf("SELECT FROM I WHERE p = 1 ORDER BY @rid DESC");
+
+    assertThat(rids).hasSize(5);
+    for (int i = 0; i < rids.size() - 1; i++)
+      assertThat(rids.get(i).getPosition()).isGreaterThan(rids.get(i + 1).getPosition());
+  }
+
+  @Test
+  void orderByIndexedPropertyThenRidWithIndexedEqualityOnCompositeIndex() {
+    final List<RID> rids = ridsOf("SELECT FROM I WHERE p = 1 ORDER BY p, @rid");
+
+    assertThat(rids).hasSize(5);
+    for (int i = 0; i < rids.size() - 1; i++)
+      assertThat(rids.get(i).getPosition()).isLessThan(rids.get(i + 1).getPosition());
+  }
+
+  @Test
+  void orderByCaseExpressionWithIndexedEqualityOnCompositeIndex() {
+    final List<Integer> qs = intsOf("q", "SELECT FROM I WHERE p = 1 ORDER BY CASE WHEN q > 3 THEN 0 ELSE 1 END");
+
+    assertThat(qs).hasSize(5);
+    assertThat(qs.subList(0, 2)).containsExactlyInAnyOrder(4, 5);
+    assertThat(qs.subList(2, 5)).containsExactlyInAnyOrder(1, 2, 3);
+  }
+
+  @Test
+  void orderByIndexedPropertyWithModifierIsNotSatisfiedByTheIndexOrder() {
+    final List<String> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", "SELECT FROM J WHERE p = 1 ORDER BY s.right(1)")) {
+      while (rs.hasNext())
+        values.add(rs.next().getProperty("s"));
+    }
+
+    assertThat(values).containsExactly("e1", "d2", "c3", "b4", "a5");
+  }
+
+  @Test
+  void orderByIndexedPropertiesIsStillSatisfiedByTheIndexOrder() {
+    assertThat(intsOf("q", "SELECT FROM I WHERE p = 1 ORDER BY p, q")).containsExactly(1, 2, 3, 4, 5);
+    assertThat(intsOf("q", "SELECT FROM I WHERE p = 1 ORDER BY q")).containsExactly(1, 2, 3, 4, 5);
+  }
+
+  @Test
+  void indexedEqualityStillUsesTheIndex() {
+    assertThat(explain("SELECT FROM I WHERE p = 1 ORDER BY @rid")).contains("FETCH FROM INDEX");
+  }
+
+  private String explain(final String query) {
+    final StringBuilder plan = new StringBuilder();
+    try (final ResultSet rs = database.query("sql", "EXPLAIN " + query)) {
+      while (rs.hasNext())
+        plan.append(rs.next().toJSON());
+    }
+    return plan.toString();
+  }
+
+  private List<Integer> intsOf(final String property, final String query) {
+    final List<Integer> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        values.add(rs.next().getProperty(property));
+    }
+    return values;
+  }
+
+  private List<RID> ridsOf(final String query) {
+    final List<RID> rids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        rs.next().getIdentity().ifPresent(rids::add);
+    }
+    return rids;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue6926OrderByRecordAttributeWithIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue6926OrderByRecordAttributeWithIndexTest.java
@@ -67,6 +67,15 @@ class Issue6926OrderByRecordAttributeWithIndexTest extends TestHelper {
       database.command("sql", "INSERT INTO J SET p = 1, s = 'c3'");
       database.command("sql", "INSERT INTO J SET p = 1, s = 'd2'");
       database.command("sql", "INSERT INTO J SET p = 1, s = 'e1'");
+
+      // single-property index: the fields.size() < orderedFields.size() guard already stopped the NPE here, so this
+      // type pins that pre-existing rescue in place
+      database.command("sql", "CREATE DOCUMENT TYPE K");
+      database.command("sql", "CREATE PROPERTY K.p INTEGER");
+      database.command("sql", "CREATE INDEX ON K (p) NOTUNIQUE");
+
+      for (int i = 0; i < 5; i++)
+        database.command("sql", "INSERT INTO K SET p = 1, i = " + i);
     });
   }
 
@@ -115,6 +124,30 @@ class Issue6926OrderByRecordAttributeWithIndexTest extends TestHelper {
     }
 
     assertThat(values).containsExactly("e1", "d2", "c3", "b4", "a5");
+  }
+
+  @Test
+  void orderByIndexedPropertyWithModifierDescIsNotSatisfiedByTheIndexOrder() {
+    final List<String> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", "SELECT FROM J WHERE p = 1 ORDER BY s.right(1) DESC")) {
+      while (rs.hasNext())
+        values.add(rs.next().getProperty("s"));
+    }
+
+    assertThat(values).containsExactly("a5", "b4", "c3", "d2", "e1");
+  }
+
+  @Test
+  void orderByRidWithIndexedEqualityOnSinglePropertyIndex() {
+    final List<RID> rids = ridsOf("SELECT FROM K WHERE p = 1 ORDER BY @rid");
+
+    assertThat(rids).hasSize(5);
+    for (int i = 0; i < rids.size() - 1; i++)
+      assertThat(rids.get(i).getPosition()).isLessThan(rids.get(i + 1).getPosition());
+
+    final String plan = explain("SELECT FROM K WHERE p = 1 ORDER BY @rid");
+    assertThat(plan).contains("FETCH FROM INDEX");
+    assertThat(plan).contains("ORDER BY");
   }
 
   @Test


### PR DESCRIPTION
Closes #6926

## Problem

`SelectExecutionPlanner.fullySorted()` decides whether an index iteration already yields the order the query asked for. If it says yes, the planner sets `info.orderApplied = true` and drops the `ORDER BY` step from the plan.

It collected the ORDER BY item names with `OrderByItem.getAlias()`. That field is populated only for the plain identifier form, so it is **null** for a record attribute (`ORDER BY @rid`) and for a complex expression (`ORDER BY CASE WHEN ...`). The nulls were carried into `orderedFields` and dereferenced a few lines later:

```java
final String orderFieldName = orderedFields.get(i);
final String indexFieldName = fields.get(i);
if (!orderFieldName.equals(indexFieldName))   // NPE when orderFieldName is null
```

The `fields.size() < orderedFields.size()` guard above only rescues single-property indexes. With a **composite** index the list is long enough to reach the comparison, so the query failed at plan time:

```sql
CREATE INDEX ON I (p, q) NOTUNIQUE;
SELECT FROM I WHERE p = 1 ORDER BY @rid
-- java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "orderFieldName" is null
```

The existing `ORDER BY @rid` coverage (`OrderByRidTest`, `SelectStatementExecutionTest`) has no `WHERE` clause, so the index path was never entered.

A second, quieter defect lives in the same loop: an item carrying a **modifier** (`ORDER BY s.right(1)`, `ORDER BY s[0]`) has a non-null alias (`s`), so the method matched it against the index property `s` and declared the order satisfied. The `ORDER BY` step was then dropped and the rows came back in index order rather than in the requested order - no exception, just wrong results.

## Fix

`engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java` - ask the item for the name it is actually known by (`getName()`, which falls back to `recordAttr`), and bail out of `fullySorted()` as soon as the item cannot be named or carries a modifier:

```java
final String name = item.getModifier() == null ? item.getName() : null;
if (name == null)
  return false;
```

Returning `false` is the conservative answer: the planner keeps the `ORDER BY` step and the index is still used for the fetch, so nothing is lost beyond an optimization that was never sound for these item shapes. An ORDER BY the planner cannot name, or one that orders by something derived from a property rather than by the property itself, can never be proven covered by the index iteration order.

## Test

New `engine/src/test/java/com/arcadedb/query/sql/Issue6926OrderByRecordAttributeWithIndexTest.java`. The fixture inserts the `p = 1` rows with *descending* `q`, so the index order `(p, q ASC)` is the reverse of the RID order - an assertion on RID order therefore fails if the ORDER BY step is wrongly dropped, rather than passing by accident.

Against unpatched `main` the class runs 9 tests: **5 errors** (NPE) and **2 failures** (wrong order from the modifier cases). All 9 pass with the fix.

| test | before the fix |
|---|---|
| `orderByRidWithIndexedEqualityOnCompositeIndex` | NPE |
| `orderByRidDescWithIndexedEqualityOnCompositeIndex` | NPE |
| `orderByIndexedPropertyThenRidWithIndexedEqualityOnCompositeIndex` | NPE |
| `orderByCaseExpressionWithIndexedEqualityOnCompositeIndex` | NPE |
| `indexedEqualityStillUsesTheIndexWhileTheOrderByStepIsKept` (EXPLAIN) | NPE |
| `orderByIndexedPropertyWithModifierIsNotSatisfiedByTheIndexOrder` | wrong order |
| `orderByIndexedPropertyWithModifierDescIsNotSatisfiedByTheIndexOrder` | wrong order |
| `orderByIndexedPropertiesIsStillSatisfiedByTheIndexOrder` | passes - guard, see below |
| `orderByRidWithIndexedEqualityOnSinglePropertyIndex` | passes - pins the pre-existing size-guard rescue |

The guard test asserts through `EXPLAIN` that the eligible `ORDER BY p, q` / `ORDER BY q` plans still carry **no** `ORDER BY` step, so the fix cannot be "achieved" by disabling the optimization outright. Verified armed: with `if (true) return false;` injected at the head of `fullySorted()` that test fails.

## Test plan

- [x] `mvn -o -pl engine test -Dtest=Issue6926OrderByRecordAttributeWithIndexTest` - 9/9 green with the fix; 5 errors + 2 failures with the planner reverted to `main`.
- [x] `mvn -o -pl engine test -DexcludedGroups=benchmark,vector,slow` - **13969 tests, 0 failures, 0 errors, 23 skipped** (re-run on the final head).
- [x] `mvn -o verify -pl gremlin,graphql,postgresw,bolt,grpcw` - the query-language and wire-protocol modules that execute through the same SQL plan: **1074 tests, 0 failures**.
- [x] `mvn -o -pl engine license:check` - clean (the new test carries the Apache 2.0 header).
