### PR TITLE
fix(#6924): increment the GROUP BY synthetic-alias counter so multi-key GROUP BY keeps every key

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -1044,7 +1044,7 @@ public class SelectExecutionPlanner {
       return;
     }
     final GroupBy newGroupBy = new GroupBy();
-    final int i = 0;
+    int nextAliasCount = 0;
     for (final Expression exp : info.groupBy.getItems()) {
       if (exp.isAggregate(context)) {
         throw new CommandExecutionException("Cannot group by an aggregate function");
@@ -1064,7 +1064,7 @@ public class SelectExecutionPlanner {
       if (!found) {
         final ProjectionItem newItem = new ProjectionItem();
         newItem.setExpression(exp);
-        final Identifier groupByAlias = new Identifier("_$$$GROUP_BY_ALIAS$$$_" + i);
+        final Identifier groupByAlias = new Identifier("_$$$GROUP_BY_ALIAS$$$_" + (nextAliasCount++));
         newItem.setAlias(groupByAlias);
         if (info.preAggregateProjection == null) {
           info.preAggregateProjection = new Projection();
@@ -1075,10 +1075,9 @@ public class SelectExecutionPlanner {
         info.preAggregateProjection.getItems().add(newItem);
         newGroupBy.getItems().add(new Expression(groupByAlias));
       }
-
-      info.groupBy = newGroupBy;
     }
 
+    info.groupBy = newGroupBy;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6924GroupByMultiKeyAliasTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6924GroupByMultiKeyAliasTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces issue #6924: {@code SelectExecutionPlanner.addGroupByExpressionsToProjections} synthesized the
+ * {@code _$$$GROUP_BY_ALIAS$$$_} name from a counter that was declared {@code final int i = 0} outside the loop and
+ * never incremented. Every GROUP BY key that was not already a plain projected identifier was therefore appended to the
+ * pre-aggregate projection under the very same alias, so the later values overwrote the earlier ones and the query
+ * silently grouped on the last key alone.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue6924GroupByMultiKeyAliasTest extends TestHelper {
+
+  @Test
+  void multiKeyGroupByOnNonProjectedIdentifiersKeepsEveryKey() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE G");
+      database.command("SQL", "INSERT INTO G SET a = 1, b = 1, v = 10");
+      database.command("SQL", "INSERT INTO G SET a = 1, b = 2, v = 20");
+      database.command("SQL", "INSERT INTO G SET a = 2, b = 1, v = 30");
+
+      final List<Long> counts = collectLongs("SELECT count(*) AS c FROM G GROUP BY a, b", "c");
+
+      // (1,1) (1,2) (2,1) are three distinct groups of one record each.
+      // Before the fix the plan grouped on `b` alone and returned two rows: 2 and 1.
+      assertThat(counts).hasSize(3);
+      assertThat(counts).containsExactly(1L, 1L, 1L);
+    });
+  }
+
+  @Test
+  void multiKeyGroupByExposesEachSyntheticAliasSeparately() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE G2");
+      database.command("SQL", "INSERT INTO G2 SET a = 1, b = 1, v = 10");
+      database.command("SQL", "INSERT INTO G2 SET a = 1, b = 2, v = 20");
+      database.command("SQL", "INSERT INTO G2 SET a = 2, b = 1, v = 30");
+
+      // The GROUP BY keys are projected too, so the grouping must be observable in the output rows.
+      final ResultSet rs = database.query("SQL", "SELECT a, b, sum(v) AS s FROM G2 GROUP BY a, b ORDER BY a, b");
+
+      final List<String> rows = new ArrayList<>();
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        rows.add(r.getProperty("a") + "/" + r.getProperty("b") + "/" + ((Number) r.getProperty("s")).longValue());
+      }
+
+      assertThat(rows).containsExactly("1/1/10", "1/2/20", "2/1/30");
+    });
+  }
+
+  @Test
+  void multiKeyGroupByOnComputedExpressionsKeepsEveryKey() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE G3");
+      database.command("SQL", "INSERT INTO G3 SET a = 1, b = 1, v = 10");
+      database.command("SQL", "INSERT INTO G3 SET a = 1, b = 2, v = 20");
+      database.command("SQL", "INSERT INTO G3 SET a = 2, b = 1, v = 30");
+
+      // `a + 0` / `b + 0` are not base identifiers, so both keys take the synthetic-alias branch.
+      final ResultSet rs = database.query("SQL", "SELECT count(*) AS c FROM G3 GROUP BY a + 0, b + 0");
+
+      final List<Long> counts = new ArrayList<>();
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        counts.add(((Number) r.getProperty("c")).longValue());
+        // the synthetic pre-aggregate aliases must never reach the caller
+        assertThat(r.getPropertyNames()).allSatisfy(name -> assertThat(name).doesNotContain("_$$$GROUP_BY_ALIAS$$$_"));
+      }
+
+      assertThat(counts).hasSize(3);
+      assertThat(counts).containsExactly(1L, 1L, 1L);
+    });
+  }
+
+  @Test
+  void threeKeyGroupByWithOneProjectedKeyKeepsTheOtherTwo() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE G4");
+      database.command("SQL", "INSERT INTO G4 SET a = 1, b = 1, c = 1, v = 10");
+      database.command("SQL", "INSERT INTO G4 SET a = 1, b = 1, c = 2, v = 20");
+      database.command("SQL", "INSERT INTO G4 SET a = 1, b = 2, c = 1, v = 30");
+
+      // `a` is a plain projected identifier and reuses its own projection; `b` and `c` both need a synthetic alias.
+      final List<Long> counts = collectLongs("SELECT a, count(*) AS c FROM G4 GROUP BY a, b, c", "c");
+
+      assertThat(counts).hasSize(3);
+      assertThat(counts).containsExactly(1L, 1L, 1L);
+    });
+  }
+
+  @Test
+  void singleComputedGroupByKeyStillWorks() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE G5");
+      database.command("SQL", "INSERT INTO G5 SET a = 1, v = 10");
+      database.command("SQL", "INSERT INTO G5 SET a = 1, v = 20");
+      database.command("SQL", "INSERT INTO G5 SET a = 2, v = 30");
+
+      final List<Long> sums = collectLongs("SELECT sum(v) AS c FROM G5 GROUP BY a", "c");
+
+      assertThat(sums).hasSize(2);
+      assertThat(sums).containsExactlyInAnyOrder(30L, 30L);
+    });
+  }
+
+  private List<Long> collectLongs(final String query, final String property) {
+    final ResultSet rs = database.query("SQL", query);
+    final List<Long> values = new ArrayList<>();
+    while (rs.hasNext())
+      values.add(((Number) rs.next().getProperty(property)).longValue());
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6924GroupByMultiKeyAliasTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6924GroupByMultiKeyAliasTest.java
@@ -121,12 +121,13 @@ class Issue6924GroupByMultiKeyAliasTest extends TestHelper {
       database.command("SQL", "CREATE DOCUMENT TYPE G5");
       database.command("SQL", "INSERT INTO G5 SET a = 1, v = 10");
       database.command("SQL", "INSERT INTO G5 SET a = 1, v = 20");
-      database.command("SQL", "INSERT INTO G5 SET a = 2, v = 30");
+      database.command("SQL", "INSERT INTO G5 SET a = 2, v = 50");
 
+      // distinct per-group sums, so the assertion pins which records landed in which group
       final List<Long> sums = collectLongs("SELECT sum(v) AS c FROM G5 GROUP BY a", "c");
 
       assertThat(sums).hasSize(2);
-      assertThat(sums).containsExactlyInAnyOrder(30L, 30L);
+      assertThat(sums).containsExactlyInAnyOrder(30L, 50L);
     });
   }
 


### PR DESCRIPTION
Closes #6924

## Summary

`SelectExecutionPlanner.addGroupByExpressionsToProjections` synthesizes a pre-aggregate projection for every GROUP BY key that is not already a plain projected identifier, naming it `_$$$GROUP_BY_ALIAS$$$_<n>`. The counter `n` was declared `final int i = 0;` *outside* the loop and never incremented, so every synthesized key was appended under the **same** alias. `Projection.calculateSingle` writes each item with `result.setProperty(alias, ...)`, so the second value overwrote the first, and `newGroupBy` ended up holding N copies of one alias expression. `AggregateProjectionCalculationStep.aggregate` then built the grouping key from those items and produced `[v, v, ...]` where `v` is the **last** GROUP BY expression only - a multi-key GROUP BY silently collapsed to grouping on its last key.

The fix mirrors what the sibling `calculateAdditionalOrderByProjections` already does correctly: make the counter mutable and post-increment it per synthesized alias. The stray `info.groupBy = newGroupBy;` assignment inside the loop body is also hoisted out (it was harmless - the same object reassigned N times - but misleading).

Because the `found` short-circuit requires both an alias match **and** `exp.isBaseIdentifier()`, the defect hit any GROUP BY key that was not a plain projected identifier: keys absent from the projection list, and dotted or computed keys even when projected.

### Repro

```sql
-- G: (a,b,v) = (1,1,10), (1,2,20), (2,1,30)
SELECT count(*) AS c FROM G GROUP BY a, b
```

Before: 2 rows (`c=2`, `c=1`) - grouped on `b` alone. After: 3 rows, each `c=1`.

### Why existing tests missed it

Every existing GROUP BY test uses either plain projected identifiers (`GroupByStepTest`, `MemoryOptimizationTest`), which take the `found` branch and never synthesize an alias, or a single computed key (`SelectStatementExecutionTest`), where one alias is enough. A multi-key GROUP BY with no aggregate function takes the `handleGroupByNoSplit` path and never reaches this method at all.

## Test plan

New regression test `engine/src/test/java/com/arcadedb/query/sql/executor/Issue6924GroupByMultiKeyAliasTest.java` - 3 of its 5 cases fail on `main` and pass with the fix:

- [x] `multiKeyGroupByOnNonProjectedIdentifiersKeepsEveryKey` - `GROUP BY a, b` with neither key projected. **Failed pre-fix** (2 groups, expected 3).
- [x] `multiKeyGroupByOnComputedExpressionsKeepsEveryKey` - `GROUP BY a + 0, b + 0`; non-base-identifier keys, so both take the synthetic-alias branch. **Failed pre-fix.** Also asserts the synthetic alias never leaks into `getPropertyNames()`.
- [x] `threeKeyGroupByWithOneProjectedKeyKeepsTheOtherTwo` - `GROUP BY a, b, c` with only `a` projected, so two keys need distinct aliases. **Failed pre-fix.**
- [x] `multiKeyGroupByExposesEachSyntheticAliasSeparately` - both keys projected (the `found` path); guards against regressing the branch that already worked.
- [x] `singleComputedGroupByKeyStillWorks` - one synthesized alias; guards the single-key case.

Suites run (all green, `-DexcludedGroups=benchmark,vector,slow`):

- [x] `engine` full unit suite - **13,970 tests, 0 failures, 23 skipped** (covers SQL, openCypher and the whole planner)
- [x] `gremlin` + `graphql` (`mvn verify`) - 101 tests, 0 failures
- [x] Wire protocols reading results through the shared planner: `postgresw` 428, `bolt` 344, `grpcw` 201 - 0 failures

`server` module tests were not run locally: port 2480 on this machine is held by an unrelated long-running ArcadeDB instance, which turns those fixed-port tests into spurious 403s. Nothing in this change touches server code; CI covers that lane.

## Review history

| Cycle | Head SHA | Outcome |
|---|---|---|
| 1 | `c2689d6` | LGTM. One non-blocking readability nit: `singleComputedGroupByKeyStillWorks` used two groups that both summed to 30, so the assertion could not distinguish which records landed in which group. **Addressed** in `c7c3ade` - the second group now sums to 50. |
| 2 | `c7c3ade` | LGTM, no actionable items. |

### Noted, not changed

Cycle 2 raised that the `found` scan matches against `preAggregateProjection.getAllAliases()`, which by then also contains aliases synthesized earlier in the same loop - so a GROUP BY key that is a base identifier named exactly `_$$$GROUP_BY_ALIAS$$$_<n>` would short-circuit as `found`. The reviewer scoped this out as pre-existing and extreme, and that holds: `IDENTIFIER` in `SQLLexer.g4` is `(DOLLAR | LETTER) PART_LETTER*` with `PART_LETTER: [0-9A-Z_a-z]`, so a `$` cannot appear after the first character of a bare identifier. Reaching the collision requires a backtick-quoted column literally named with the sentinel prefix. Left as-is; this diff does not widen it beyond the single alias that already existed by more than the extra suffixes.
