### PR TITLE
fix(engine) #6921: CREATE INDEX <name> IF NOT EXISTS answers for the name it was given, not for any index on those properties

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -217,6 +217,35 @@ public abstract class IndexBuilder<T extends Index> {
                 + "cannot satisfy would leave the type with no index at all"));
   }
 
+  /**
+   * Builds the error reported when the request WROTE an index name that is not the name of the index already on
+   * those properties.
+   * <p>
+   * The name is part of the request rather than a label on it: an index is reachable only through its name -
+   * {@code SEARCH_INDEX('<name>', ...)}, {@code DROP INDEX <name>}, {@code REBUILD INDEX <name>} - so an index under
+   * another name does not provide what was asked for, whatever its definition. A type keeps one index per property
+   * set, so the requested name cannot be added alongside it either, and answering a guarded request with the other
+   * index left the name silently uncreated while the statement reported on it (issue #6921).
+   * <p>
+   * Separate from {@link #conflictWithExistingIndex} because it is a different refusal: there the definitions do not
+   * line up and the fix is to align them, here they may line up perfectly and the only thing in the way is that
+   * ArcadeDB cannot hold two indexes on one property set. Naming the existing index is the actionable part - it is
+   * what a caller has to search for, or drop.
+   * <p>
+   * {@link IllegalArgumentException} for the same reason as its sibling: the HTTP layer maps it to a 400.
+   */
+  public static IllegalArgumentException conflictWithExistingIndexName(final Index existing, final String requestedName,
+      final String requestedTypeName, final List<String> requestedProperties) {
+    final boolean inherited = !existing.getTypeName().equals(requestedTypeName);
+    return new IllegalArgumentException(
+        "Cannot create the index '" + requestedName + "' on type '" + requestedTypeName + "' properties "
+            + requestedProperties + " because those properties are already indexed by '" + existing.getName() + "'"
+            + (inherited ? " on the parent type '" + existing.getTypeName() + "'" : "")
+            + ". A type holds one index per property set, so the requested name cannot be added next to it: use '"
+            + existing.getName() + "' to address the existing index, or drop it first to create the index under the "
+            + "requested name");
+  }
+
   private static String describeDefinition(final Schema.INDEX_TYPE indexType, final boolean unique) {
     return indexType + " (unique=" + unique + ")";
   }

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -297,6 +297,24 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
         satisfied = settingMismatches.isEmpty();
       }
 
+      // Third half, once the definition lines up: the NAME the caller wrote. A name is not a label on the request -
+      // an index is reachable only through it (SEARCH_INDEX('<name>', ...), DROP INDEX, REBUILD INDEX) - so an index
+      // already on these properties under a different name does not provide what was asked for either, and a type
+      // holds one index per property set so the requested name cannot be added next to it. Answering the guard with
+      // the other index left the requested name uncreated while the statement reported on the request, and every
+      // later lookup through that name failed (issue #6921).
+      //
+      // Last of the three on purpose: a definition mismatch is the harder problem and stays the reported one, so a
+      // named request over an index of the wrong kind or configuration still names the kind or the settings rather
+      // than the name. And only a name the caller WROTE reaches this - {@link CreateIndexStatement} forwards the
+      // manual name alone and leaves the auto-derived typeName[properties] form out - which keeps a guarded request
+      // that named nothing the plain no-op it has always been.
+      //
+      // Applied on the unguarded path too: a name conflict is not something IF NOT EXISTS makes idempotent, so the
+      // "use IF NOT EXISTS" hint the unguarded message below ends with would be the wrong advice here.
+      if (satisfied && indexName != null && !indexName.isEmpty() && !indexName.equals(existingTypeIndex.getName()))
+        throw conflictWithExistingIndexName(existingTypeIndex, indexName, metadata.typeName, metadata.propertyNames);
+
       if (satisfied && ignoreIfExists)
         return existingTypeIndex;
 

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -312,6 +312,13 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
       //
       // Applied on the unguarded path too: a name conflict is not something IF NOT EXISTS makes idempotent, so the
       // "use IF NOT EXISTS" hint the unguarded message below ends with would be the wrong advice here.
+      //
+      // The other production caller that sets a name on a TYPE index is {@code RebuildIndexStatement}, which carries
+      // the logical index's own name across the rebuild (issue #5791). It never meets this check: it drops the index
+      // first, inside the same {@code executeLockingFiles} closure, so the lookup above finds nothing on those
+      // properties by the time create() runs. The one shape that still reaches here - a type whose OWN index was just
+      // dropped while a parent type indexes the same properties - was already refused before this check existed, by
+      // the unguarded branch further down; only the message it is refused with changes.
       if (satisfied && indexName != null && !indexName.isEmpty() && !indexName.equals(existingTypeIndex.getName()))
         throw conflictWithExistingIndexName(existingTypeIndex, indexName, metadata.typeName, metadata.propertyNames);
 

--- a/engine/src/test/java/com/arcadedb/index/Issue5765IndexSettingsIfNotExistsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5765IndexSettingsIfNotExistsTest.java
@@ -213,15 +213,21 @@ public class Issue5765IndexSettingsIfNotExistsTest extends TestHelper {
 
   /**
    * The other direction of the builder half: settings that match make the guarded statement the no-op it asks to be.
-   * The answer names the index that actually satisfied the request - not the name the statement asked for, which
-   * nothing was created under - and reports {@code created: false} so a caller cannot read success as "my name is
-   * now on an index".
+   * The answer names the index that actually satisfied the request and reports {@code created: false}, so a caller
+   * cannot read success as "my name is now on an index".
+   * <p>
+   * The vehicle used to be an explicit index name, which is what got the statement past {@code CreateIndexStatement}'s
+   * {@code existsIndex(name)} shortcut and into the builder. A name the statement WROTE is now part of the request
+   * (issue #6921) - it cannot be satisfied by an index carrying another one - so the no-op is reached here through a
+   * SUBTYPE instead: {@code SubDoc[embedding]} does not exist either, and the builder finds the parent's index by
+   * properties exactly the same way. The named form of this very statement is asserted right below.
    */
   @Test
-  void namedGuardedMatchingSettingsStayANoOp() {
+  void guardedMatchingSettingsStayANoOpInTheBuilder() {
     createVectorIndex(384, "COSINE");
+    database.command("sql", "CREATE DOCUMENT TYPE SubDoc EXTENDS Doc");
 
-    final ResultSet rs = database.command("sql", "CREATE INDEX myVectorIdx IF NOT EXISTS ON Doc (embedding) LSM_VECTOR "
+    final ResultSet rs = database.command("sql", "CREATE INDEX IF NOT EXISTS ON SubDoc (embedding) LSM_VECTOR "
         + "METADATA {\"dimensions\": 384, \"similarity\": \"COSINE\"}");
     final Result result = rs.next();
     assertThat(result.<Boolean>getProperty("created")).isFalse();
@@ -229,23 +235,61 @@ public class Issue5765IndexSettingsIfNotExistsTest extends TestHelper {
     assertThat(result.<Long>getProperty("totalIndexed")).isEqualTo(0L);
 
     assertThat(dimensionsOf("Doc[embedding]")).isEqualTo(384);
+    assertThat(database.getSchema().existsIndex("SubDoc[embedding]")).isFalse();
+  }
+
+  /**
+   * The named form of the statement above. Its settings match, so nothing in the definition is in the way and the
+   * message carries no settings mismatch - the only thing that cannot be granted is the NAME, because a type holds
+   * one index per property set and {@code Doc[embedding]} already occupies it (issue #6921).
+   */
+  @Test
+  void namedGuardedMatchingSettingsReportTheNameConflict() {
+    createVectorIndex(384, "COSINE");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX myVectorIdx IF NOT EXISTS ON Doc (embedding) "
+        + "LSM_VECTOR METADATA {\"dimensions\": 384, \"similarity\": \"COSINE\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("myVectorIdx")
+        .hasMessageContaining("Doc[embedding]")
+        .hasMessageNotContaining("dimensions=");
+
+    assertThat(dimensionsOf("Doc[embedding]")).isEqualTo(384);
     assertThat(database.getSchema().existsIndex("myVectorIdx")).isFalse();
   }
 
   /**
-   * Same no-op, on the non-vector builder: a named guarded full-text create whose analyzer matches leaves the existing
-   * index alone and reports it under its own name.
+   * Same no-op, on the non-vector builder: a guarded full-text create whose analyzer matches leaves the existing index
+   * alone and reports it under its own name.
    */
   @Test
-  void namedGuardedMatchingFullTextSettingsStayANoOp() {
+  void guardedMatchingFullTextSettingsStayANoOpInTheBuilder() {
     database.command("sql", "CREATE INDEX ON Doc (title) FULL_TEXT METADATA "
         + "{\"analyzer\": \"org.apache.lucene.analysis.core.KeywordAnalyzer\"}");
+    database.command("sql", "CREATE DOCUMENT TYPE SubDoc EXTENDS Doc");
 
-    final ResultSet rs = database.command("sql", "CREATE INDEX myTitleIdx IF NOT EXISTS ON Doc (title) FULL_TEXT "
+    final ResultSet rs = database.command("sql", "CREATE INDEX IF NOT EXISTS ON SubDoc (title) FULL_TEXT "
         + "METADATA {\"analyzer\": \"org.apache.lucene.analysis.core.KeywordAnalyzer\"}");
     final Result result = rs.next();
     assertThat(result.<Boolean>getProperty("created")).isFalse();
     assertThat(result.<String>getProperty("name")).isEqualTo("Doc[title]");
+
+    assertThat(database.getSchema().existsIndex("Doc[title]")).isTrue();
+    assertThat(database.getSchema().existsIndex("SubDoc[title]")).isFalse();
+  }
+
+  /** The named form of the full-text no-op: matching settings, and the name is the only thing reported. */
+  @Test
+  void namedGuardedMatchingFullTextSettingsReportTheNameConflict() {
+    database.command("sql", "CREATE INDEX ON Doc (title) FULL_TEXT METADATA "
+        + "{\"analyzer\": \"org.apache.lucene.analysis.core.KeywordAnalyzer\"}");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX myTitleIdx IF NOT EXISTS ON Doc (title) FULL_TEXT "
+        + "METADATA {\"analyzer\": \"org.apache.lucene.analysis.core.KeywordAnalyzer\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("myTitleIdx")
+        .hasMessageContaining("Doc[title]")
+        .hasMessageNotContaining("analyzer=");
 
     assertThat(database.getSchema().existsIndex("Doc[title]")).isTrue();
     assertThat(database.getSchema().existsIndex("myTitleIdx")).isFalse();

--- a/engine/src/test/java/com/arcadedb/index/Issue6921CreateIndexIfNotExistsNameTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6921CreateIndexIfNotExistsNameTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6921: {@code CREATE INDEX <name> IF NOT EXISTS} answered the guard with the index
+ * already on those properties even when that index carries a DIFFERENT name. The requested name was never created,
+ * so every later lookup through it - {@code SEARCH_INDEX('<name>', ...)}, {@code DROP INDEX <name>},
+ * {@code REBUILD INDEX <name>} - failed on a name the statement had just reported on.
+ * <p>
+ * The rule these tests pin down: a name the statement WROTE is part of the request, not a label on it. A type keeps
+ * one index per property set, so the requested name cannot be added next to the existing index either - the conflict
+ * is reported, naming both indexes, instead of being answered by an index the caller cannot address. A statement that
+ * wrote no name is unaffected: the auto-derived {@code typeName[properties]} form is not something the caller asked
+ * for, so a guarded unnamed request stays the no-op it has always been.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+public class Issue6921CreateIndexIfNotExistsNameTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE RgDoc");
+      database.command("sql", "CREATE PROPERTY RgDoc.body STRING");
+      database.command("sql", "INSERT INTO RgDoc SET body = 'TOKEN one'");
+      database.command("sql", "INSERT INTO RgDoc SET body = 'TOKEN two'");
+    });
+  }
+
+  /**
+   * The reported case verbatim: a FULL_TEXT index named {@code rgFt} exists on the property, and a guarded statement
+   * asks for {@code rgFt2} on the same property. The requested name cannot be created, so the statement must say so
+   * rather than answer for {@code rgFt}.
+   */
+  @Test
+  void guardedNamedRequestOverADifferentlyNamedIndexIsReported() {
+    database.command("sql", "CREATE INDEX rgFt ON RgDoc (body) FULL_TEXT");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX rgFt2 IF NOT EXISTS ON RgDoc (body) FULL_TEXT"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rgFt2")
+        .hasMessageContaining("rgFt")
+        .hasMessageContaining("body");
+
+    // The refusal must leave the existing index untouched and must not have created the requested name.
+    assertThat(database.getSchema().existsIndex("rgFt")).isTrue();
+    assertThat(database.getSchema().existsIndex("rgFt2")).isFalse();
+  }
+
+  /**
+   * Why the name matters: ranking is reachable only through it. Before the fix the statement above reported on
+   * {@code rgFt2} while this query failed, which is the mismatch the issue is about.
+   */
+  @Test
+  void theRequestedNameIsNotUsableAfterTheRefusal() {
+    database.command("sql", "CREATE INDEX rgFt ON RgDoc (body) FULL_TEXT");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX rgFt2 IF NOT EXISTS ON RgDoc (body) FULL_TEXT"))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() -> database.query("sql", "SELECT FROM RgDoc WHERE SEARCH_INDEX('rgFt2', 'TOKEN') = true"))
+        .hasMessageContaining("rgFt2");
+
+    // ...while the index that DOES exist answers, so the refusal is about the name and nothing else.
+    try (final ResultSet rs = database.query("sql", "SELECT FROM RgDoc WHERE SEARCH_INDEX('rgFt', 'TOKEN') = true")) {
+      assertThat(rs.stream().count()).isEqualTo(2L);
+    }
+  }
+
+  /**
+   * The guard still works under the index's own name: re-running the very same statement is a no-op, so the fix
+   * cannot be passing the test above by refusing every guarded request.
+   */
+  @Test
+  void guardedNamedRequestUnderItsOwnNameStaysANoOp() {
+    database.command("sql", "CREATE INDEX rgFt ON RgDoc (body) FULL_TEXT");
+
+    try (final ResultSet rs = database.command("sql", "CREATE INDEX rgFt IF NOT EXISTS ON RgDoc (body) FULL_TEXT")) {
+      final Result result = rs.next();
+      assertThat(result.<Boolean>getProperty("created")).isFalse();
+      assertThat(result.<String>getProperty("name")).isEqualTo("rgFt");
+    }
+
+    assertThat(database.getSchema().existsIndex("rgFt")).isTrue();
+  }
+
+  /**
+   * A statement that wrote no name asked for no name, so the auto-derived form is not part of the request and the
+   * existing index answers the guard exactly as before.
+   */
+  @Test
+  void guardedUnnamedRequestOverANamedIndexStaysANoOp() {
+    database.command("sql", "CREATE INDEX rgFt ON RgDoc (body) FULL_TEXT");
+
+    try (final ResultSet rs = database.command("sql", "CREATE INDEX IF NOT EXISTS ON RgDoc (body) FULL_TEXT")) {
+      final Result result = rs.next();
+      assertThat(result.<Boolean>getProperty("created")).isFalse();
+      // Reported under the name of the index that actually satisfied it, never under a name that does not exist.
+      assertThat(result.<String>getProperty("name")).isEqualTo("rgFt");
+    }
+
+    assertThat(database.getSchema().existsIndex("rgFt")).isTrue();
+    assertThat(database.getSchema().existsIndex("RgDoc[body]")).isFalse();
+  }
+
+  /**
+   * The mirror of the unnamed case: a named request over the auto-derived index is still a name that does not exist,
+   * so it is reported too. Covers the ordinary LSM_TREE kind, to show the rule is not FULL_TEXT specific.
+   */
+  @Test
+  void guardedNamedRequestOverAnAutoNamedIndexIsReported() {
+    database.command("sql", "CREATE INDEX ON RgDoc (body) NOTUNIQUE");
+    assertThat(database.getSchema().existsIndex("RgDoc[body]")).isTrue();
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX rgIdx IF NOT EXISTS ON RgDoc (body) NOTUNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rgIdx")
+        .hasMessageContaining("RgDoc[body]");
+
+    assertThat(database.getSchema().existsIndex("rgIdx")).isFalse();
+    assertThat(database.getSchema().existsIndex("RgDoc[body]")).isTrue();
+  }
+
+  /**
+   * An index the type only INHERITS is the same story, and the message has to say where the index lives - dropping
+   * it takes it away from the parent type, which is never something this statement does implicitly (issue #4083).
+   */
+  @Test
+  void guardedNamedRequestOverAnInheritedIndexIsReported() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE RgChild EXTENDS RgDoc");
+      database.command("sql", "CREATE INDEX rgParentIdx ON RgDoc (body) NOTUNIQUE");
+    });
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX rgChildIdx IF NOT EXISTS ON RgChild (body) NOTUNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rgChildIdx")
+        .hasMessageContaining("rgParentIdx")
+        .hasMessageContaining("RgDoc");
+
+    assertThat(database.getSchema().existsIndex("rgChildIdx")).isFalse();
+    assertThat(database.getSchema().existsIndex("rgParentIdx")).isTrue();
+  }
+
+  /**
+   * Without the guard the statement was already refused, but with wording that offered {@code IF NOT EXISTS} as the
+   * way to make it idempotent. That advice is wrong for a name conflict - the guarded form is refused too - so the
+   * name conflict has to be reported as itself on both paths.
+   */
+  @Test
+  void unguardedNamedRequestOverADifferentlyNamedIndexNamesTheConflict() {
+    database.command("sql", "CREATE INDEX rgFt ON RgDoc (body) FULL_TEXT");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX rgFt2 ON RgDoc (body) FULL_TEXT"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rgFt2")
+        .hasMessageContaining("rgFt")
+        .hasMessageNotContaining("IF NOT EXISTS");
+
+    assertThat(database.getSchema().existsIndex("rgFt2")).isFalse();
+  }
+
+  /**
+   * The name is the LAST of the three things compared, so a request that gets both the definition and the name wrong
+   * is still told about the definition - the harder problem, and the one the #5675 rule is about. Written with a
+   * manual name on purpose: that is the case where the two answers compete.
+   */
+  @Test
+  void aKindConflictIsStillReportedAsAKindConflict() {
+    database.command("sql", "CREATE INDEX rgFt ON RgDoc (body) FULL_TEXT");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX rgIdx IF NOT EXISTS ON RgDoc (body) UNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("FULL_TEXT")
+        .hasMessageContaining("LSM_TREE");
+
+    // ...and the unnamed form, where nothing competes, reports the same conflict.
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX IF NOT EXISTS ON RgDoc (body) UNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("FULL_TEXT")
+        .hasMessageContaining("LSM_TREE");
+  }
+
+  /**
+   * And the requested name is created normally when the properties are free - the fix must not stand between a
+   * first guarded statement and the index it asks for.
+   */
+  @Test
+  void guardedNamedRequestOnFreePropertiesCreatesTheName() {
+    try (final ResultSet rs = database.command("sql", "CREATE INDEX rgFt IF NOT EXISTS ON RgDoc (body) FULL_TEXT")) {
+      final Result result = rs.next();
+      assertThat(result.<Boolean>getProperty("created")).isTrue();
+      assertThat(result.<String>getProperty("name")).isEqualTo("rgFt");
+    }
+
+    assertThat(database.getSchema().existsIndex("rgFt")).isTrue();
+
+    try (final ResultSet rs = database.query("sql", "SELECT FROM RgDoc WHERE SEARCH_INDEX('rgFt', 'TOKEN') = true")) {
+      assertThat(rs.stream().count()).isEqualTo(2L);
+    }
+  }
+}


### PR DESCRIPTION
Closes #6921.

## What was reported, and what is left of it on main

`CREATE INDEX rgFt2 IF NOT EXISTS ON RgDoc (body) FULL_TEXT` answered `created: true` for `rgFt2` while silently reusing `rgFt`, the index already on `RgDoc.body`. `rgFt2` never existed, so `SEARCH_INDEX('rgFt2', ...)` - the only way to reach full-text ranking - failed afterwards.

Half of that is already gone on `main`: #5992 made the statement report the index that actually satisfied it, under **its own** name, with `created: false`. Reproduced on `main` before writing anything:

```
FIRST : {"operation":"create index","name":"rgFt","type":"FULL_TEXT","created":true, "totalIndexed":2}
SECOND: {"operation":"create index","name":"rgFt","type":"FULL_TEXT","created":false,"totalIndexed":0}
existsIndex(rgFt2) = false
```

So `created: true` is fixed and unreleased (26.8.1 predates #5992). What is **not** fixed is the reporter's actual harm: the application asked for a name, got no error, and its full-text ranking was quietly gone. `created: false` under a different name is honest but easy to read as "already provisioned", and it is the only warning a migration script gets.

## The rule this PR adds

#5675 established that `IF NOT EXISTS` is satisfied only when the existing index **provides what was asked for**, comparing the index kind and the uniqueness, and #5765 added the settings the `METADATA` clause named. This PR adds the third thing a statement can ask for: the **name**.

A name a statement wrote is part of the request, not a label on it - an index is reachable only through it (`SEARCH_INDEX('<name>', ...)`, `DROP INDEX <name>`, `REBUILD INDEX <name>`). An index on the same properties under another name does not provide it, and ArcadeDB holds one index per property set per type, so the requested name cannot be added next to it either. The statement now says so:

```
Cannot create the index 'rgFt2' on type 'RgDoc' properties [body] because those properties are
already indexed by 'rgFt'. A type holds one index per property set, so the requested name cannot
be added next to it: use 'rgFt' to address the existing index, or drop it first to create the
index under the requested name
```

`IllegalArgumentException`, so the HTTP answer is a **400** - the same treatment #5675 gives every other unhonourable schema request, and the same treatment the *mirror* case already got: a manual name that exists on another type or other properties has been reported since #5740, and only the direction where the name does **not** exist stayed silent.

### What deliberately did not change

- **A statement that wrote no name asked for no name.** `CREATE INDEX IF NOT EXISTS ON RgDoc (body) FULL_TEXT` stays the no-op it has always been, reported under the existing index's name. The auto-derived `typeName[properties]` form is computed by `CreateIndexStatement` for its own `existsIndex` shortcut and is never forwarded to the builder, which is exactly what separates the two cases.
- **A definition mismatch is still reported as a definition mismatch.** The name is compared *last*, after the kind/uniqueness and the settings, so a named request over an index of the wrong kind or the wrong `dimensions` still names the kind or the settings - the harder problem stays the reported one.
- **Nothing is dropped implicitly**, on an inherited index least of all (#4083). The message names the parent type when the index lives there.

## Where the fix lives

`TypeIndexBuilder.create()`, next to the two comparisons it joins, with the message built by a new `IndexBuilder.conflictWithExistingIndexName(...)` sibling of `conflictWithExistingIndex(...)`. Both SQL entry points are covered without a second copy of the rule: the `existsIndex(name)` shortcut in `CreateIndexStatement` handles the case where the requested name already exists, and everything that gets past it reaches the builder. The only other production caller that sets a name on a **type** index is `RebuildIndexStatement`, which carries the logical index's own name across a rebuild (#5791). It never meets the new check: it calls `dropIndex(...)` first, inside the same `executeLockingFiles` closure, so the by-properties lookup in `create()` finds nothing. The one shape that still reaches the check - a type whose own index was just dropped while a **parent** type indexes the same properties - was already refused before this PR, by the unguarded branch further down; only the message changes. `RebuildIndexPreservesNameTest` (5 cases, plain/full-text/geospatial, single- and multi-bucket) is green, along with the rest of the rebuild suites. A comment at the check records this.

Everything else is out of reach: Cypher's `CREATE INDEX` / `CREATE CONSTRAINT` parse an index name but never pass it to the builder, `DatabaseChecker` and `LocalSchema`'s repair/rename paths build *bucket* indexes, and `LocalSchema.copyIndexDefinition` builds a type index but never sets a name, so `indexName` stays null there. The Cypher, Gremlin and GraphQL paths are untouched.

## Two behaviour changes, both deliberate

### 1. The unguarded path reports the name conflict too

The check is symmetric on purpose: it fires whether or not `IF NOT EXISTS` was written. So `CREATE INDEX rgFt2 ON RgDoc (body) FULL_TEXT` (no guard), over an index that already satisfies the *definition* under another name, now raises `conflictWithExistingIndexName` instead of the old "Found the existent index 'rgFt' ... It already provides what was requested: **use IF NOT EXISTS** to make this statement idempotent".

That hint is the reason to change it: after this PR the guarded form is refused too, so pointing at `IF NOT EXISTS` would send the caller to a statement that fails the same way. It was already an exception on this path and no test asserted the old wording, so nothing regresses - but it is a second, less obvious behaviour change and should not be discovered after merge. Pinned by `unguardedNamedRequestOverADifferentlyNamedIndexNamesTheConflict`, which asserts `hasMessageNotContaining("IF NOT EXISTS")`.

### 2. One previously-asserted behaviour is reversed - please confirm

`Issue5765IndexSettingsIfNotExistsTest` had two tests asserting the exact answer this issue calls a bug: a named guarded create whose settings match returns `created: false` and leaves the requested name uncreated. Any fix for #6921 contradicts them, so they are the one place where existing assertions changed. Each was split so nothing is lost:

| before | after |
|---|---|
| `namedGuardedMatchingSettingsStayANoOp` | `guardedMatchingSettingsStayANoOpInTheBuilder` (same assertions, reaching the builder through a **subtype** instead of a manual name) + `namedGuardedMatchingSettingsReportTheNameConflict` |
| `namedGuardedMatchingFullTextSettingsStayANoOp` | `guardedMatchingFullTextSettingsStayANoOpInTheBuilder` + `namedGuardedMatchingFullTextSettingsReportTheNameConflict` |

The manual name in the originals was only a **vehicle** to get past `CreateIndexStatement`'s `existsIndex(name)` shortcut and into `TypeIndexBuilder.create()`. A subtype (`SubDoc[embedding]` does not exist, the builder finds the parent's index by properties) is the same vehicle without asking for a name, so the builder-half coverage those tests exist for is preserved verbatim. The new named-form tests assert `hasMessageNotContaining("dimensions=")` / `("analyzer=")`, which pins the ordering: matching settings are not listed when the only thing in the way is the name.

The other two named tests in that class - `namedGuardedVectorDimensionsMismatchIsReportedByTheBuilder` and `namedGuardedFullTextAnalyzerMismatchIsReportedByTheBuilder` - are untouched and still green, because the name is compared last.

## Tests

`engine/.../index/Issue6921CreateIndexIfNotExistsNameTest` - 9 cases. **5 of the 9 fail on `main`** (verified before the fix: `Tests run: 9, Failures: 5`), and the 4 that pass are the ones guarding against a fix that just refuses everything:

- the reported case verbatim (`rgFt` / `rgFt2`), and that `SEARCH_INDEX('rgFt2', ...)` is unusable afterwards while `SEARCH_INDEX('rgFt', ...)` still returns both rows - the mismatch the issue is about
- the same statement under its **own** name is still an idempotent no-op
- the **unnamed** guarded request over a named index is still a no-op reported under `rgFt`
- the mirror (named request over the auto-derived `RgDoc[body]`), on `LSM_TREE`, so the rule is not full-text specific
- the inherited case, message naming the parent
- the **unguarded** named form, whose old message offered `IF NOT EXISTS` as the way to make the statement idempotent - wrong advice for a name conflict, so it reports the name too (`hasMessageNotContaining("IF NOT EXISTS")`)
- ordering: a named request that also gets the kind wrong still reports `FULL_TEXT` vs `LSM_TREE`
- a first guarded named create on free properties still creates the name and answers `created: true`

### Suites run

| suite | result |
|---|---|
| full `engine` module (`-DexcludedGroups=benchmark,vector,slow`) | **13,976 run, 0 failures**, 23 skipped |
| `gremlin` + `graphql` (`mvn -o verify`) | **101 run, 0 failures** |

Not run locally: the `server` module, because port 2480 is held by another ArcadeDB instance on this machine (`lsof -nP -iTCP:2480 -sTCP:LISTEN`), which turns those tests into a wall of 403s unrelated to this change. The HTTP surface of this path is the `IllegalArgumentException` -> 400 mapping already covered by `Issue5675CreateIndexIfNotExistsHttpTest`; CI will exercise it.

## Test plan

- [ ] CI green, `server` module included
- [ ] Against a fresh database, the reproduction from the issue now answers 400 with the message above instead of `created:`-anything, and `SELECT name FROM schema:indexes` is consistent with what the statement said
- [ ] `CREATE INDEX rgFt IF NOT EXISTS ON RgDoc (body) FULL_TEXT` run twice in a row is still idempotent (`created: false`, no error)
- [ ] `CREATE INDEX IF NOT EXISTS ON RgDoc (body) FULL_TEXT` (no name) over an existing named index is still a no-op
- [ ] Confirm both behaviour changes above are the intended contract - the reversal in the table is the one that contradicts something #5781/#5992 asserted

## Follow-up spotted, not fixed here

Cypher's `executeCreateIndex` parses an optional index name (`CREATE INDEX myIdx FOR (n:Foo) ON (n.bar)`) and then never passes it to the builder, so the index is created as `Foo[bar]` and `DROP INDEX myIdx` fails on a name that was accepted. Same family of defect as this issue, different statement and engine - worth its own issue.
