### PR TITLE
fix(#6923,#6984): DISTINCT+ORDER BY+LIMIT regression test and CONTAINS on split() array

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
@@ -44,7 +44,10 @@ public class ContainsCondition extends BooleanExpression {
       // Normalize an array left-hand side (e.g. the result of split()) to a List so it gets the same
       // CONTAINS semantics as a Collection below; MultiValue's iterator covers both object and primitive
       // arrays via reflection, unlike a direct `instanceof Iterable`/`instanceof Collection` check, which
-      // an array never satisfies (issue #6984).
+      // an array never satisfies (issue #6984). Deliberately recurses into the Collection branch rather
+      // than delegating straight to MultiValue.contains(): the Collection branch also unwraps a
+      // single-item Result/Identifiable on the right-hand side (lines below), and a direct delegation
+      // would silently drop that behavior for an array left-hand side.
       final List<Object> leftAsList = new ArrayList<>(MultiValue.getSize(left));
       final Iterator<?> leftArrayIterator = MultiValue.getMultiValueIterator(left);
       while (leftArrayIterator.hasNext())

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
@@ -40,6 +40,18 @@ public class ContainsCondition extends BooleanExpression {
   }
 
   public boolean execute(final Object left, Object right) {
+    if (left != null && left.getClass().isArray()) {
+      // Normalize an array left-hand side (e.g. the result of split()) to a List so it gets the same
+      // CONTAINS semantics as a Collection below; MultiValue's iterator covers both object and primitive
+      // arrays via reflection, unlike a direct `instanceof Iterable`/`instanceof Collection` check, which
+      // an array never satisfies (issue #6984).
+      final List<Object> leftAsList = new ArrayList<>(MultiValue.getSize(left));
+      final Iterator<?> leftArrayIterator = MultiValue.getMultiValueIterator(left);
+      while (leftArrayIterator.hasNext())
+        leftAsList.add(leftArrayIterator.next());
+      return execute(leftAsList, right);
+    }
+
     if (left instanceof Collection) {
       if (right instanceof Collection) {
         if (((Collection<?>) right).size() == 1) {

--- a/engine/src/test/java/com/arcadedb/query/sql/QueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/QueryTest.java
@@ -1433,6 +1433,33 @@ class QueryTest extends TestHelper {
     });
   }
 
+  // Issue #6984: CONTAINS with a method call (split) on the LHS matches a scalar RHS instead of always returning false
+  @Test
+  void containsWithSplitOnLhs() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc6984 IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc6984 SET txt = 'a b c'");
+      database.command("sql", "INSERT INTO doc6984 SET txt = 'hello world'");
+
+      final ResultSet rs = database.query("sql", "SELECT FROM doc6984 WHERE txt.split(' ') CONTAINS 'a'");
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("txt")).isEqualTo("a b c");
+      assertThat(rs.hasNext()).isFalse();
+    });
+  }
+
+  // Issue #6984: CONTAINS with a method call (split) on the LHS returns no rows when nothing matches
+  @Test
+  void containsWithSplitOnLhsNoMatch() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc6984b IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc6984b SET txt = 'hello world'");
+
+      final ResultSet rs = database.query("sql", "SELECT FROM doc6984b WHERE txt.split(' ') CONTAINS 'a'");
+      assertThat(rs.hasNext()).isFalse();
+    });
+  }
+
   // Issue #3583: chained replace().ilike() inside a LET subquery combined with UNIONALL evaluates without $current null
   @Test
   void replaceWithIlikeInLetSubquery() {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DistinctExecutionStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DistinctExecutionStepTest.java
@@ -130,6 +130,40 @@ class DistinctExecutionStepTest extends TestHelper {
     result.close();
   }
 
+  /**
+   * Regression test for issue #6923: the planner turns SKIP+LIMIT into a Top-K bound on the ORDER BY step,
+   * which used to truncate the sort buffer to SKIP+LIMIT rows before DISTINCT got a chance to dedup them, so
+   * fewer rows than LIMIT asked for came back.
+   */
+  @Test
+  void shouldReturnDistinctWithOrderByAndLimit() {
+    database.getSchema().createDocumentType("Staff");
+
+    database.transaction(() -> {
+      database.newDocument("Staff").set("department", "Engineering").save();
+      database.newDocument("Staff").set("department", "Engineering").save();
+      database.newDocument("Staff").set("department", "Sales").save();
+    });
+
+    final ResultSet limited = database.query("sql",
+        "SELECT DISTINCT department FROM Staff ORDER BY department ASC LIMIT 2");
+
+    assertThat(limited.hasNext()).isTrue();
+    assertThat(limited.next().<String>getProperty("department")).isEqualTo("Engineering");
+    assertThat(limited.hasNext()).isTrue();
+    assertThat(limited.next().<String>getProperty("department")).isEqualTo("Sales");
+    assertThat(limited.hasNext()).isFalse();
+    limited.close();
+
+    final ResultSet skipped = database.query("sql",
+        "SELECT DISTINCT department FROM Staff ORDER BY department ASC SKIP 1 LIMIT 1");
+
+    assertThat(skipped.hasNext()).isTrue();
+    assertThat(skipped.next().<String>getProperty("department")).isEqualTo("Sales");
+    assertThat(skipped.hasNext()).isFalse();
+    skipped.close();
+  }
+
   @Test
   void shouldReturnDistinctWithLimit() {
     database.getSchema().createDocumentType("Tag");

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
@@ -87,4 +87,24 @@ class ContainsConditionTest {
 
     assertThat(op.execute(nullList, nullList)).isTrue();
   }
+
+  /**
+   * Regression test for issue #6984: a String[] left-hand side - such as the result of split() - satisfies
+   * neither `instanceof Collection` nor `instanceof Iterable` (arrays don't implement Iterable), so it used
+   * to fall through to the final `return false` instead of being matched against the scalar/collection on
+   * the right.
+   */
+  @Test
+  void issue6984ArrayLeftHandSide() {
+    final ContainsCondition op = new ContainsCondition();
+
+    final String[] left = "a b c".split(" ");
+
+    assertThat(op.execute(left, "a")).isTrue();
+    assertThat(op.execute(left, "z")).isFalse();
+
+    final int[] primitiveLeft = { 1, 2, 3 };
+    assertThat(op.execute(primitiveLeft, 2)).isTrue();
+    assertThat(op.execute(primitiveLeft, 5)).isFalse();
+  }
 }


### PR DESCRIPTION
## Summary
- fix(#6984): `ContainsCondition.execute()` fell through to `return false` when the left-hand side was an array (e.g. the result of `split()`, `text.split()`, or Cypher `split()`), because arrays satisfy neither `instanceof Collection` nor `instanceof Iterable`. The fix normalizes an array left-hand side to a `List` up front, reusing `MultiValue`'s reflection-based iterator (already used elsewhere in this class) so it goes through the exact same CONTAINS semantics as any other Collection.
- #6923 (`SELECT DISTINCT ... ORDER BY ... LIMIT n` truncating the sort buffer before DISTINCT dedups it) turned out to already be fixed on `main` by the #6925 fix (`80424c15f`, PR #6978), which added `info.distinct` to the condition that disables the ORDER BY Top-K bound. Added a regression test that reproduces the exact repro from #6923 (plain `DISTINCT ... ORDER BY ... LIMIT` / `SKIP ... LIMIT`, without GROUP BY/UNWIND/expand) to lock that behavior in, since the existing #6925 tests only covered the GROUP BY/UNWIND/expand combinations.

## Repro (before the fix, #6984)
```sql
SELECT (['a','b','c'] CONTAINS 'a')          -- true  (already worked)
SELECT ('a b c'.split(' ') CONTAINS 'a')     -- false (bug - now true)
```

## Test plan
- [x] `ContainsConditionTest.issue6984ArrayLeftHandSide` - new unit test, verified it fails without the fix (reverted the production change, confirmed red, restored it)
- [x] `DistinctExecutionStepTest.shouldReturnDistinctWithOrderByAndLimit` - new regression test for #6923's exact repro (LIMIT and SKIP+LIMIT cases)
- [x] Full `engine` module test run for `com.arcadedb.query.sql.executor.*Test` and `com.arcadedb.query.sql.parser.**.*Test`: 2029 tests, 0 failures, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `CONTAINS` queries so they correctly evaluate object and primitive arrays.
  - Preserved expected matching behavior when comparing arrays with individual values.
  - Corrected `CONTAINS` queries using `split()` for matching and non-matching values.
  - Corrected `DISTINCT` query results when combined with `ORDER BY`, `LIMIT`, and `SKIP`, ensuring deduplication occurs before pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->