### PR TITLE
fix(#6942): Redis PING/INCR/DECR emit RESP-valid reply types

### DIFF
--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -424,10 +424,14 @@ public class RedisNetworkExecutor extends Thread {
     if (number == null) {
       number = 0L;
     } else if (!(number instanceof Number)) {
-      if (NumberUtils.isIntegerNumber(number.toString()))
+      // DECR/DECRBY only operate on integral values, and real Redis answers a stored value it cannot
+      // parse as a 64-bit integer - "3.3", "abc", or one simply out of Long range - with this exact
+      // message rather than a generic "not a number" (issue #6942 code review).
+      try {
         number = Long.parseLong(number.toString());
-      else
-        throw new RedisException("Key '" + k + "' is not a number");
+      } catch (final NumberFormatException e) {
+        throw new RedisException("value is not an integer or out of range");
+      }
     }
 
     // DECR/DECRBY only operate on integral values: a Double/Float (e.g. left behind by INCRBYFLOAT) has no
@@ -655,10 +659,24 @@ public class RedisNetworkExecutor extends Thread {
     if (number == null) {
       number = 0L;
     } else if (!(number instanceof Number)) {
-      if (NumberUtils.isIntegerNumber(number.toString()))
-        number = Long.parseLong(number.toString());
-      else
-        throw new RedisException("Key '" + k + "' is not a number");
+      // Real Redis parses the stored value against the command's own numeric type rather than a
+      // generic "is this a number" check (issue #6942 code review): INCRBYFLOAT accepts any stored
+      // value it can read as a float - "3.3" included - while INCR/INCRBY reject anything it cannot
+      // read as a 64-bit integer, with the same "not an integer or out of range" message whether the
+      // value is non-numeric or merely out of Long range.
+      //
+      // Deliberately two branches, not `decimal ? Double.parseDouble(...) : Long.parseLong(...)`: a
+      // Java conditional expression with one `double` arm and one `long` arm promotes BOTH arms to
+      // double (JLS 15.25), so the long arm's result would get silently widened and reboxed to Double
+      // even when decimal is false, turning every later `instanceof Long` check on it false.
+      try {
+        if (decimal)
+          number = Double.parseDouble(number.toString());
+        else
+          number = Long.parseLong(number.toString());
+      } catch (final NumberFormatException e) {
+        throw new RedisException(decimal ? "value is not a valid float" : "value is not an integer or out of range");
+      }
     }
 
     final boolean integralStorage = number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte;

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -430,15 +430,18 @@ public class RedisNetworkExecutor extends Thread {
         throw new RedisException("Key '" + k + "' is not a number");
     }
 
-    final Number newValue;
-    if (number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte) {
-      try {
-        newValue = Math.subtractExact(((Number) number).longValue(), by);
-      } catch (final ArithmeticException e) {
-        throw new RedisException("increment or decrement would overflow", e);
-      }
-    } else
-      newValue = Type.decrement((Number) number, by);
+    // DECR/DECRBY only operate on integral values: a Double/Float (e.g. left behind by INCRBYFLOAT) has no
+    // valid RESP integer reply, and real Redis rejects it rather than emitting a floating-point ":" reply
+    // (issue #6942).
+    if (!(number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte))
+      throw new RedisException("value is not an integer or out of range");
+
+    final long newValue;
+    try {
+      newValue = Math.subtractExact(((Number) number).longValue(), by);
+    } catch (final ArithmeticException e) {
+      throw new RedisException("increment or decrement would overflow", e);
+    }
 
     setVariable(k, newValue);
     value.append(":");
@@ -658,8 +661,16 @@ public class RedisNetworkExecutor extends Thread {
         throw new RedisException("Key '" + k + "' is not a number");
     }
 
+    final boolean integralStorage = number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte;
+
+    // INCR/INCRBY only operate on integral values: a Double/Float left behind by INCRBYFLOAT has no valid
+    // RESP integer reply, and real Redis rejects it rather than emitting a floating-point "+" reply
+    // (issue #6942). INCRBYFLOAT itself has no such restriction - it promotes an integral value to float.
+    if (!decimal && !integralStorage)
+      throw new RedisException("value is not an integer or out of range");
+
     final Number newValue;
-    if (!decimal && (number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte)) {
+    if (!decimal && integralStorage) {
       try {
         newValue = Math.addExact(((Number) number).longValue(), by.longValue());
       } catch (final ArithmeticException e) {
@@ -676,7 +687,7 @@ public class RedisNetworkExecutor extends Thread {
       appendCrLf();
       value.append(text);
     } else {
-      value.append(newValue instanceof Long ? ":" : "+");
+      value.append(":");
       value.append(newValue);
     }
   }
@@ -749,9 +760,15 @@ public class RedisNetworkExecutor extends Thread {
   }
 
   private void ping(final List<Object> list) {
-    final String response = list.size() > 1 ? (String) list.get(1) : "PONG";
-    value.append("+");
-    value.append(response);
+    if (list.size() > 1)
+      // The argument is echoed back verbatim, which can contain "\r\n" (issue #6942): a simple-string
+      // reply is CRLF-terminated, so that payload would split into two frames and desync the connection.
+      // The bulk-string encoding is length-prefixed and carries the CRLF as payload instead.
+      respondValue((String) list.get(1), true);
+    else {
+      value.append("+");
+      value.append("PONG");
+    }
   }
 
   /**

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -420,29 +420,11 @@ public class RedisNetworkExecutor extends Thread {
     final String k = (String) list.get(1);
     final long by = list.size() > 2 ? Long.parseLong((String) list.get(2)) : 1L;
 
-    Object number = getVariable(k);
-    if (number == null) {
-      number = 0L;
-    } else if (!(number instanceof Number)) {
-      // DECR/DECRBY only operate on integral values, and real Redis answers a stored value it cannot
-      // parse as a 64-bit integer - "3.3", "abc", or one simply out of Long range - with this exact
-      // message rather than a generic "not a number" (issue #6942 code review).
-      try {
-        number = Long.parseLong(number.toString());
-      } catch (final NumberFormatException e) {
-        throw new RedisException("value is not an integer or out of range");
-      }
-    }
-
-    // DECR/DECRBY only operate on integral values: a Double/Float (e.g. left behind by INCRBYFLOAT) has no
-    // valid RESP integer reply, and real Redis rejects it rather than emitting a floating-point ":" reply
-    // (issue #6942).
-    if (!(number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte))
-      throw new RedisException("value is not an integer or out of range");
+    final long number = requireIntegralValue(getVariable(k)).longValue();
 
     final long newValue;
     try {
-      newValue = Math.subtractExact(((Number) number).longValue(), by);
+      newValue = Math.subtractExact(number, by);
     } catch (final ArithmeticException e) {
       throw new RedisException("increment or decrement would overflow", e);
     }
@@ -450,6 +432,33 @@ public class RedisNetworkExecutor extends Thread {
     setVariable(k, newValue);
     value.append(":");
     value.append(newValue);
+  }
+
+  /**
+   * Normalizes a stored Redis value for DECR/DECRBY and the non-decimal path of INCR/INCRBY: a
+   * {@code null} key reads as {@code 0}, and a non-{@code Number} stored value (always a {@code String}
+   * here) is parsed as a 64-bit integer. Anything that isn't - or can't be parsed as - an integral value,
+   * such as a fractional string or a {@code Double} left behind by INCRBYFLOAT, is rejected with real
+   * Redis' own "value is not an integer or out of range" (issue #6942 code review) rather than emitting an
+   * invalid RESP integer reply.
+   */
+  private static Number requireIntegralValue(final Object stored) {
+    if (stored == null)
+      return 0L;
+
+    Object number = stored;
+    if (!(number instanceof Number)) {
+      try {
+        number = Long.parseLong(number.toString());
+      } catch (final NumberFormatException e) {
+        throw new RedisException("value is not an integer or out of range");
+      }
+    }
+
+    if (!(number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte))
+      throw new RedisException("value is not an integer or out of range");
+
+    return (Number) number;
   }
 
   private void exists(final List<Object> list) {
@@ -655,47 +664,35 @@ public class RedisNetworkExecutor extends Thread {
     } else
       by = 1L;
 
-    Object number = getVariable(k);
-    if (number == null) {
-      number = 0L;
-    } else if (!(number instanceof Number)) {
-      // Real Redis parses the stored value against the command's own numeric type rather than a
-      // generic "is this a number" check (issue #6942 code review): INCRBYFLOAT accepts any stored
-      // value it can read as a float - "3.3" included - while INCR/INCRBY reject anything it cannot
-      // read as a 64-bit integer, with the same "not an integer or out of range" message whether the
-      // value is non-numeric or merely out of Long range.
-      //
-      // Deliberately two branches, not `decimal ? Double.parseDouble(...) : Long.parseLong(...)`: a
-      // Java conditional expression with one `double` arm and one `long` arm promotes BOTH arms to
-      // double (JLS 15.25), so the long arm's result would get silently widened and reboxed to Double
-      // even when decimal is false, turning every later `instanceof Long` check on it false.
-      try {
-        if (decimal)
-          number = Double.parseDouble(number.toString());
-        else
-          number = Long.parseLong(number.toString());
-      } catch (final NumberFormatException e) {
-        throw new RedisException(decimal ? "value is not a valid float" : "value is not an integer or out of range");
+    // INCRBYFLOAT has no integral restriction - it promotes an integral value to float and accepts any
+    // stored value it can read as a float ("3.3" included, issue #6942 code review) - while INCR/INCRBY
+    // reuse the DECR/DECRBY validation in requireIntegralValue().
+    final Number number;
+    if (decimal) {
+      final Object stored = getVariable(k);
+      if (stored == null)
+        number = 0L;
+      else if (stored instanceof Number storedNumber)
+        number = storedNumber;
+      else {
+        try {
+          number = Double.parseDouble(stored.toString());
+        } catch (final NumberFormatException e) {
+          throw new RedisException("value is not a valid float");
+        }
       }
-    }
-
-    final boolean integralStorage = number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte;
-
-    // INCR/INCRBY only operate on integral values: a Double/Float left behind by INCRBYFLOAT has no valid
-    // RESP integer reply, and real Redis rejects it rather than emitting a floating-point "+" reply
-    // (issue #6942). INCRBYFLOAT itself has no such restriction - it promotes an integral value to float.
-    if (!decimal && !integralStorage)
-      throw new RedisException("value is not an integer or out of range");
+    } else
+      number = requireIntegralValue(getVariable(k));
 
     final Number newValue;
-    if (!decimal && integralStorage) {
+    if (!decimal) {
       try {
-        newValue = Math.addExact(((Number) number).longValue(), by.longValue());
+        newValue = Math.addExact(number.longValue(), by.longValue());
       } catch (final ArithmeticException e) {
         throw new RedisException("increment or decrement would overflow", e);
       }
     } else
-      newValue = Type.increment((Number) number, by);
+      newValue = Type.increment(number, by);
 
     setVariable(k, newValue);
     if (decimal) {

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -552,6 +552,58 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
   }
 
   @Test
+  void incrByAndDecrByWithExplicitAmountRejectFractionalValueTheSameWayAsIncrAndDecr() throws Exception {
+    // (issue #6942 code review): INCRBY/DECRBY dispatch through the same incrBy()/decrBy() as INCR/DECR
+    // (RedisNetworkExecutor's INCR/INCRBY and DECR/DECRBY cases both call the same method), so this locks
+    // in that the explicit-amount form goes through requireIntegralValue() exactly like the no-amount form.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "SET", "incrByDecrByFloatKey", "3.3");
+      readReply(socket); // +OK
+
+      sendCommand(socket, "INCRBY", "incrByDecrByFloatKey", "5");
+      String reply = readReply(socket);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("not an integer");
+
+      sendCommand(socket, "DECRBY", "incrByDecrByFloatKey", "5");
+      reply = readReply(socket);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("not an integer");
+
+      sendCommand(socket, "GET", "incrByDecrByFloatKey");
+      assertThat(readReply(socket)).isEqualTo("$3\r\n3.3");
+    }
+  }
+
+  @Test
+  void incrByOverflowStillReturnsOverflowErrorAfterIntegralValueRefactor() throws Exception {
+    // (issue #6942 code review): confirms Math.addExact's ArithmeticException -> "increment or decrement
+    // would overflow" still fires for INCRBY after routing the stored value through requireIntegralValue().
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "SET", "incrByOverflowKey", "9223372036854775807"); // Long.MAX_VALUE
+      readReply(socket); // +OK
+
+      sendCommand(socket, "INCRBY", "incrByOverflowKey", "1");
+      final String reply = readReply(socket);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("overflow");
+
+      sendCommand(socket, "GET", "incrByOverflowKey");
+      assertThat(readReply(socket)).isEqualTo("$19\r\n9223372036854775807");
+    }
+  }
+
+  @Test
   void concurrentSetNxOnSharedDatabaseKeyOnlyLetsOneWinnerThrough() throws Exception {
     // (issue #6466 follow-up): the initial fix evaluated NX as "does the key exist?" then "write it" as two
     // separate calls. That is only safe when the key lives in a per-connection bucket; once a key is backed

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -466,9 +466,7 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
       readReply(socket); // $3\r\n3.3
 
       sendCommand(socket, "DECR", "decrFloatKey");
-      final String reply = readReply(socket);
-      assertThat(reply).startsWith("-ERR");
-      assertThat(reply).containsIgnoringCase("not an integer");
+      assertThat(readReply(socket)).isEqualTo("-ERR value is not an integer or out of range");
 
       // A rejected DECR must be a no-op: the stored value stays untouched.
       sendCommand(socket, "GET", "decrFloatKey");
@@ -493,9 +491,7 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
       readReply(socket); // $3\r\n3.3
 
       sendCommand(socket, "INCR", "incrFloatKey");
-      final String reply = readReply(socket);
-      assertThat(reply).startsWith("-ERR");
-      assertThat(reply).containsIgnoringCase("not an integer");
+      assertThat(readReply(socket)).isEqualTo("-ERR value is not an integer or out of range");
 
       sendCommand(socket, "GET", "incrFloatKey");
       assertThat(readReply(socket)).isEqualTo("$3\r\n3.3");
@@ -518,14 +514,10 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
       readReply(socket); // +OK
 
       sendCommand(socket, "INCR", "fractionalStringKey");
-      String reply = readReply(socket);
-      assertThat(reply).startsWith("-ERR");
-      assertThat(reply).containsIgnoringCase("not an integer");
+      assertThat(readReply(socket)).isEqualTo("-ERR value is not an integer or out of range");
 
       sendCommand(socket, "DECR", "fractionalStringKey");
-      reply = readReply(socket);
-      assertThat(reply).startsWith("-ERR");
-      assertThat(reply).containsIgnoringCase("not an integer");
+      assertThat(readReply(socket)).isEqualTo("-ERR value is not an integer or out of range");
 
       // Neither rejected command touched the stored value.
       sendCommand(socket, "GET", "fractionalStringKey");
@@ -566,14 +558,10 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
       readReply(socket); // +OK
 
       sendCommand(socket, "INCRBY", "incrByDecrByFloatKey", "5");
-      String reply = readReply(socket);
-      assertThat(reply).startsWith("-ERR");
-      assertThat(reply).containsIgnoringCase("not an integer");
+      assertThat(readReply(socket)).isEqualTo("-ERR value is not an integer or out of range");
 
       sendCommand(socket, "DECRBY", "incrByDecrByFloatKey", "5");
-      reply = readReply(socket);
-      assertThat(reply).startsWith("-ERR");
-      assertThat(reply).containsIgnoringCase("not an integer");
+      assertThat(readReply(socket)).isEqualTo("-ERR value is not an integer or out of range");
 
       sendCommand(socket, "GET", "incrByDecrByFloatKey");
       assertThat(readReply(socket)).isEqualTo("$3\r\n3.3");

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -397,6 +397,112 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
   }
 
   @Test
+  void pingWithoutArgumentRepliesAsSimpleString() throws Exception {
+    // Real Redis: PING with no argument is +PONG, not a bulk string.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "PING");
+      assertThat(readReply(socket)).isEqualTo("+PONG");
+    }
+  }
+
+  @Test
+  void pingWithMessageRepliesAsBulkString() throws Exception {
+    // (issue #6942): PING <message> replied with a RESP simple string ("+hello\r\n") instead of a bulk
+    // string ("$5\r\nhello\r\n"). Real Redis always echoes the PING argument as a bulk string.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "PING", "hello");
+      assertThat(readReply(socket)).isEqualTo("$5\r\nhello");
+    }
+  }
+
+  @Test
+  void pingWithCrLfInMessageDoesNotDesyncConnection() throws Exception {
+    // (issue #6942): a simple-string PING reply is CRLF-terminated, so a message containing "\r\n" split
+    // the reply into two frames and desynchronized the connection permanently - every later reply on that
+    // connection was read one frame early. A length-prefixed bulk-string reply carries the CRLF as payload
+    // instead of treating it as a frame terminator, so the next command's reply must still line up.
+    final String payload = "a\r\n+INJECTED";
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "PING", payload);
+      assertThat(readReply(socket)).isEqualTo("$" + payload.length() + "\r\n" + payload);
+
+      // If the parser had desynced, this PING's reply would actually be leftover bytes from the previous
+      // frame instead of a fresh +PONG.
+      sendCommand(socket, "PING");
+      assertThat(readReply(socket)).isEqualTo("+PONG");
+    }
+  }
+
+  @Test
+  void decrOnFloatKeyReturnsErrorInsteadOfInvalidIntegerReply() throws Exception {
+    // (issue #6942): once INCRBYFLOAT turns a key into a Double, DECR blindly wrote a `:`-prefixed
+    // (RESP integer) header in front of a floating-point value, which is not a valid RESP integer. Real
+    // Redis rejects DECR/INCR on a non-integer value with "-ERR value is not an integer or out of range".
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "SET", "decrFloatKey", "0");
+      readReply(socket); // +OK
+
+      sendCommand(socket, "INCRBYFLOAT", "decrFloatKey", "3.3");
+      readReply(socket); // $3\r\n3.3
+
+      sendCommand(socket, "DECR", "decrFloatKey");
+      final String reply = readReply(socket);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("not an integer");
+
+      // A rejected DECR must be a no-op: the stored value stays untouched.
+      sendCommand(socket, "GET", "decrFloatKey");
+      assertThat(readReply(socket)).isEqualTo("$3\r\n3.3");
+    }
+  }
+
+  @Test
+  void incrOnFloatKeyReturnsErrorInsteadOfInvalidIntegerReply() throws Exception {
+    // (issue #6942): the mirror case for INCR - incrBy's non-decimal branch answered with a RESP simple
+    // string ("+3.3") rather than rejecting the non-integer value the way real Redis does.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "SET", "incrFloatKey", "0");
+      readReply(socket); // +OK
+
+      sendCommand(socket, "INCRBYFLOAT", "incrFloatKey", "3.3");
+      readReply(socket); // $3\r\n3.3
+
+      sendCommand(socket, "INCR", "incrFloatKey");
+      final String reply = readReply(socket);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("not an integer");
+
+      sendCommand(socket, "GET", "incrFloatKey");
+      assertThat(readReply(socket)).isEqualTo("$3\r\n3.3");
+    }
+  }
+
+  @Test
   void concurrentSetNxOnSharedDatabaseKeyOnlyLetsOneWinnerThrough() throws Exception {
     // (issue #6466 follow-up): the initial fix evaluated NX as "does the key exist?" then "write it" as two
     // separate calls. That is only safe when the key lives in a per-connection bucket; once a key is backed

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -503,6 +503,55 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
   }
 
   @Test
+  void incrOnDirectlySetFractionalStringReturnsIntegerTypeError() throws Exception {
+    // (issue #6942 code review): a key set directly to a fractional string via SET (never touched by
+    // INCRBYFLOAT) hit a different code path than the Double-typed case above and answered with the
+    // generic "Key 'x' is not a number" instead of Redis' exact integer-command error. Same fix, same
+    // message, for INCR/INCRBY/DECR/DECRBY, whichever way the non-integral value got there.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "SET", "fractionalStringKey", "3.3");
+      readReply(socket); // +OK
+
+      sendCommand(socket, "INCR", "fractionalStringKey");
+      String reply = readReply(socket);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("not an integer");
+
+      sendCommand(socket, "DECR", "fractionalStringKey");
+      reply = readReply(socket);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("not an integer");
+
+      // Neither rejected command touched the stored value.
+      sendCommand(socket, "GET", "fractionalStringKey");
+      assertThat(readReply(socket)).isEqualTo("$3\r\n3.3");
+    }
+  }
+
+  @Test
+  void incrByFloatOnDirectlySetFractionalStringSucceeds() throws Exception {
+    // (issue #6942 code review): INCRBYFLOAT has no integer restriction - it must accept a fractional
+    // string exactly like real Redis, not reject it the way INCR/DECR correctly do.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendCommand(socket, "SET", "incrByFloatStringKey", "3.3");
+      readReply(socket); // +OK
+
+      sendCommand(socket, "INCRBYFLOAT", "incrByFloatStringKey", "1.0");
+      assertThat(readReply(socket)).isEqualTo("$3\r\n4.3");
+    }
+  }
+
+  @Test
   void concurrentSetNxOnSharedDatabaseKeyOnlyLetsOneWinnerThrough() throws Exception {
     // (issue #6466 follow-up): the initial fix evaluated NX as "does the key exist?" then "write it" as two
     // separate calls. That is only safe when the key lives in a per-connection bucket; once a key is backed


### PR DESCRIPTION
## Summary
- `PING <message>` replied with a CRLF-terminated simple string (`+<message>`); a message containing `\r\n` split the reply into two frames and permanently desynchronized the connection. It now goes through the existing bulk-string encoder (`respondValue`), which is length-prefixed.
- `DECR`/`DECRBY` and `INCR`/`INCRBY` built their reply header (`:`/`+`) from whatever Java type the stored value happened to be, so a key turned into a `Double` by `INCRBYFLOAT` produced an invalid RESP integer reply (e.g. `:0.30000000000000027`). They now reject a non-integral stored value with `-ERR value is not an integer or out of range`, matching real Redis.

Fixes #6942.

## Test plan
- [x] New regression tests in `RedisRespCorrectnessTest`: `pingWithoutArgumentRepliesAsSimpleString`, `pingWithMessageRepliesAsBulkString`, `pingWithCrLfInMessageDoesNotDesyncConnection`, `decrOnFloatKeyReturnsErrorInsteadOfInvalidIntegerReply`, `incrOnFloatKeyReturnsErrorInsteadOfInvalidIntegerReply`
- [x] `mvn -o -pl redisw -am test` - full redisw module (83 tests) passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Numeric increment and decrement commands now reject fractional values without changing stored data.
  - Integer operations consistently return integer responses and safely report overflow errors.
  - Floating-point increment commands now correctly support stored decimal values.
  - `PING` responses safely preserve messages containing line breaks.

- **Tests**
  - Added coverage for response formatting, line-break handling, invalid numeric operations, floating-point increments, and integer overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->