### PR TITLE
fix(#6976,#6791): reject unknown algo direction strings; keep Dijkstra CSR-accelerated across an overlay

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/node/AbstractNodeFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/node/AbstractNodeFunction.java
@@ -70,9 +70,13 @@ public abstract class AbstractNodeFunction implements StatelessFunction {
   }
 
   /**
-   * Parses direction from string.
+   * Parses direction from string. A {@code null} argument means "use the default" and returns {@code BOTH},
+   * but a present, unrecognised value is rejected rather than coerced to {@code BOTH}: IN and OUT answer
+   * genuinely different questions, so silently falling back would answer one the caller did not ask (issue
+   * #6976 - the same bug this backed for {@code node.degree()}, {@code node.relationshipExists()} and
+   * {@code node.relationshipTypes()}).
    *
-   * @param direction the direction string (in, out, both, or null)
+   * @param direction the direction string (in, incoming, out, outgoing, both, or null)
    * @return the Vertex.DIRECTION enum value
    */
   protected Vertex.DIRECTION parseDirection(final String direction) {
@@ -86,8 +90,10 @@ public abstract class AbstractNodeFunction implements StatelessFunction {
     case "out":
     case "outgoing":
       return Vertex.DIRECTION.OUT;
-    default:
+    case "both":
       return Vertex.DIRECTION.BOTH;
+    default:
+      throw new IllegalArgumentException("unknown direction '" + direction + "', expected one of IN, OUT or BOTH");
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -26,6 +26,7 @@ import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.function.sql.math.SQLFunctionMathAbstract;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
+import com.arcadedb.graph.GraphEngine;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.NodeEdgeWeights;
@@ -107,7 +108,7 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
     // Collect all edges based on direction — use CSR + edge properties when available
     final List<int[]> edgeList = new ArrayList<>();
     final List<Double> edgeWeights = new ArrayList<>();
-    final Vertex.DIRECTION dir = parseDirection(direction);
+    final Vertex.DIRECTION dir = GraphEngine.parseDirection(direction);
 
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db);
     // The columnar path is taken per node and only when edgeWeightsOf() can answer - i.e. when the provider can
@@ -240,14 +241,6 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
     while (multiIter.hasNext())
       vertices.add(multiIter.next());
     return vertices;
-  }
-
-  private Vertex.DIRECTION parseDirection(final String direction) {
-    return switch (direction) {
-      case "OUT" -> Vertex.DIRECTION.OUT;
-      case "IN" -> Vertex.DIRECTION.IN;
-      default -> Vertex.DIRECTION.BOTH;
-    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -58,6 +58,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -2398,15 +2399,18 @@ public class GraphEngine {
 
   /**
    * Parses a direction string ("OUT", "IN", "BOTH") into a {@link Vertex.DIRECTION} enum value.
-   * Returns {@code BOTH} for null or unknown values.
+   * A {@code null} argument means "use the default" and returns {@code BOTH}, but a present, unrecognised
+   * value is rejected rather than coerced: OUT, IN and BOTH answer genuinely different questions, so silently
+   * falling back to BOTH would answer a question the caller did not ask (issue #6976).
    */
   public static Vertex.DIRECTION parseDirection(final String dir) {
     if (dir == null)
       return Vertex.DIRECTION.BOTH;
-    return switch (dir.toUpperCase()) {
+    return switch (dir.toUpperCase(Locale.ROOT)) {
       case "OUT" -> Vertex.DIRECTION.OUT;
       case "IN" -> Vertex.DIRECTION.IN;
-      default -> Vertex.DIRECTION.BOTH;
+      case "BOTH" -> Vertex.DIRECTION.BOTH;
+      default -> throw new IllegalArgumentException("unknown direction '" + dir + "', expected one of OUT, IN or BOTH");
     };
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -19,6 +19,7 @@
 package com.arcadedb.graph.olap;
 
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.graph.NodeEdgeWeights;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.Vertex.DIRECTION;
 
@@ -1165,15 +1166,22 @@ public final class GraphAlgorithms {
 
   /**
    * Computes single-source shortest paths using Dijkstra's algorithm directly on CSR arrays
-   * with edge weights from columnar storage. Zero OLTP access.
+   * with edge weights from columnar storage. Zero OLTP access when no delta overlay is active.
    *
-   * <b>Answers {@code null} while a delta overlay is active</b>, and the caller must then read the edges
-   * itself. This kernel reads the CSR offset and neighbour arrays directly - that is what makes it worth
-   * having - and those arrays are the graph as it stood at the last build: the edges a committed transaction
-   * has since added or deleted live in the overlay, which nothing here consults. Refusing is decided here
-   * rather than left to the caller because the caller cannot see the difference in the result; it used to be
-   * decided for it, as a side effect of the view reporting no edge properties whenever an overlay was active,
-   * and that reason went away when the view learned to serve them exactly through it (issue #6315).
+   * <p>While a delta overlay is active, the base CSR offset and neighbour arrays are the graph as it stood at
+   * the last build: the edges a committed transaction has since added or deleted live in the overlay, which the
+   * raw arrays do not consult. Rather than refuse the whole computation and send the caller to the edge records
+   * - which under {@code UpdateMode.SYNCHRONOUS} is the state the view is in after every single commit, making
+   * this procedure read edge records approximately always (issue #6791) - this kernel falls back, per popped
+   * node, to {@link com.arcadedb.graph.GraphTraversalProvider#edgeWeightsOf}, which resolves the overlay against
+   * the columns exactly (issue #6315) at the cost of one small allocation per node it is asked about instead of
+   * zero. Dijkstra only pops the nodes it actually reaches, so that cost is bounded by the search itself rather
+   * than by the whole graph, unlike the OLTP fallback this replaces for the overlay-active case.
+   *
+   * <p>If {@code edgeWeightsOf} ever refuses a popped node - the one case being an ambiguous parallel-edge
+   * deletion the overlay cannot resolve on its own - this kernel refuses the whole computation the same way the
+   * all-array path used to refuse unconditionally: a partial answer would be a plausible wrong distance, which
+   * this method never returns. The caller then reads the edges itself, exactly as before.
    *
    * @param view           the analytical view (must be built with edge properties)
    * @param source         source dense node ID
@@ -1181,7 +1189,7 @@ public final class GraphAlgorithms {
    * @param direction      traversal direction (OUT, IN, or BOTH)
    * @param edgeTypes      edge types to traverse (null or empty = all)
    * @return double[] of distances indexed by dense node ID (POSITIVE_INFINITY = unreachable), or {@code null}
-   * if the base CSR arrays are not the whole graph right now
+   * if a node reached along the way cannot be answered exactly
    */
   public static double[] dijkstraSingleSource(final GraphAnalyticalView view, final int source,
       final String weightProperty, final Vertex.DIRECTION direction, final String... edgeTypes) {
@@ -1191,10 +1199,12 @@ public final class GraphAlgorithms {
     // different graphs - out of which this would compute a plausible wrong distance rather than fail, which is
     // the failure class issue #6315 exists to close, not to move.
     final GraphAnalyticalView.Snapshot snap = view.captureSnapshot();
-    if (snap.overlay != null)
-      return null;
 
-    final int n = snap.nodeMapping.size();
+    // dist is indexed by dense node id, and while an overlay is active that space runs past nodeMapping.size():
+    // the overlay allocates every added node's id above the base mapping and never reclaims a deleted one's
+    // (issue #6792). Sizing dist to the base mapping while an overlay may have widened it would throw on a
+    // neighbour id the overlay-aware branch below hands back for an added node.
+    final int n = snap.overlay != null ? snap.overlay.getNodeIdUpperBound() : snap.nodeMapping.size();
     final double[] dist = new double[n];
     Arrays.fill(dist, Double.POSITIVE_INFINITY);
 
@@ -1202,6 +1212,10 @@ public final class GraphAlgorithms {
       return dist;
 
     dist[source] = 0.0;
+
+    if (snap.overlay != null)
+      return dijkstraSingleSourceViaProvider(view, source, dist, weightProperty, direction, edgeTypes);
+
     final String[] types = edgeTypes != null && edgeTypes.length > 0 ? edgeTypes
         : snap.csrPerType.keySet().toArray(new String[0]);
 
@@ -1295,6 +1309,46 @@ public final class GraphAlgorithms {
               heap.offer(new double[]{ newDist, v });
             }
           }
+        }
+      }
+    }
+
+    return dist;
+  }
+
+  /**
+   * Same Dijkstra as {@link #dijkstraSingleSource}, run while a delta overlay is active: each popped node's
+   * neighbours and weights come from {@link com.arcadedb.graph.GraphTraversalProvider#edgeWeightsOf}, which
+   * resolves the overlay against the columns, instead of the raw CSR arrays the overlay-free path indexes
+   * directly. {@code dist} arrives with {@code dist[source] = 0} already set by the caller.
+   */
+  private static double[] dijkstraSingleSourceViaProvider(final GraphAnalyticalView view, final int source,
+      final double[] dist, final String weightProperty, final Vertex.DIRECTION direction, final String... edgeTypes) {
+    final PriorityQueue<double[]> heap = new PriorityQueue<>((a, b) -> Double.compare(a[0], b[0]));
+    heap.offer(new double[]{ 0.0, source });
+
+    while (!heap.isEmpty()) {
+      final double[] entry = heap.poll();
+      final double d = entry[0];
+      final int u = (int) entry[1];
+      if (d > dist[u])
+        continue;
+
+      final NodeEdgeWeights edges = view.edgeWeightsOf(u, direction, weightProperty, 1.0, edgeTypes);
+      if (edges == null)
+        return null; // one node the overlay cannot resolve exactly makes the whole answer refuse, not guess
+
+      final int[] neighbors = edges.neighbors();
+      final double[] weights = edges.weights();
+      for (int j = 0; j < neighbors.length; j++) {
+        final double w = weights[j];
+        if (w < 0)
+          continue;
+        final double newDist = d + w;
+        final int v = neighbors[j];
+        if (newDist < dist[v]) {
+          dist[v] = newDist;
+          heap.offer(new double[]{ newDist, v });
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -1321,6 +1321,12 @@ public final class GraphAlgorithms {
    * neighbours and weights come from {@link com.arcadedb.graph.GraphTraversalProvider#edgeWeightsOf}, which
    * resolves the overlay against the columns, instead of the raw CSR arrays the overlay-free path indexes
    * directly. {@code dist} arrives with {@code dist[source] = 0} already set by the caller.
+   * <p>
+   * {@code dist} is sized once, against the id-space upper bound the caller's snapshot reported at the start of
+   * the search - but this method reads the live {@code view} once per popped node, not that pinned snapshot, so
+   * a commit that widens the overlay further while a long search is still in flight could hand back a neighbour
+   * id past the end of {@code dist}. Refusing that node the same way an unresolvable one is refused, rather than
+   * indexing past the array, is what keeps that race a refusal instead of an {@code ArrayIndexOutOfBoundsException}.
    */
   private static double[] dijkstraSingleSourceViaProvider(final GraphAnalyticalView view, final int source,
       final double[] dist, final String weightProperty, final Vertex.DIRECTION direction, final String... edgeTypes) {
@@ -1341,11 +1347,13 @@ public final class GraphAlgorithms {
       final int[] neighbors = edges.neighbors();
       final double[] weights = edges.weights();
       for (int j = 0; j < neighbors.length; j++) {
+        final int v = neighbors[j];
+        if (v >= dist.length)
+          return null; // a concurrent commit widened the id space past this search's pinned bound; refuse rather than overrun it
         final double w = weights[j];
         if (w < 0)
           continue;
         final double newDist = d + w;
-        final int v = neighbors[j];
         if (newDist < dist[v]) {
           dist[v] = newDist;
           heap.offer(new double[]{ newDist, v });

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
@@ -115,15 +115,16 @@ public class AlgoDijkstraSingleSource extends AbstractAlgoProcedure {
     // Not the coarser hasEdgeProperties(): the CSR kernel below reads the weight column directly and falls back
     // to a unit weight when it is missing, so a view materialising some OTHER property would silently answer an
     // unweighted shortest path to a weighted question (issue #6301).
-    // Only while the view is not serving pending changes: the GraphAlgorithms kernel below reads its base CSR
-    // arrays directly and sizes its result from the base node mapping, which is neither the current graph nor
-    // as wide as the id space the view now reports - see GraphTraversalProvider#hasPendingChanges (issue #6792).
-    if (provider instanceof GraphAnalyticalView gav && !gav.hasPendingChanges()
-        && gav.servesEdgeProperty(weightProperty, relTypes)) {
+    // Unlike the topology-only kernels (algo.bfs, algo.pagerank, ...), which stay overlay-blind and refuse
+    // outright via hasPendingChanges(), GraphAlgorithms.dijkstraSingleSource resolves an active overlay itself -
+    // through GraphTraversalProvider#edgeWeightsOf per popped node, sized against the overlay's own id-space
+    // upper bound rather than the base node mapping (issue #6792) - so this procedure no longer has to refuse
+    // the whole call just because a commit landed since the view was last built (issue #6791).
+    if (provider instanceof GraphAnalyticalView gav && gav.servesEdgeProperty(weightProperty, relTypes)) {
       final Stream<Result> accelerated = executeWithCSR(context, gav, startNode.getIdentity(), relTypes, weightProperty, dir);
-      // Null means the kernel refused: it reads the CSR arrays directly, and a delta overlay holds edges those
-      // arrays do not have (issue #6315). Serving edge properties and being readable array-by-array are two
-      // different claims, and this one is the second.
+      // Null means the kernel refused outright: a node it popped could not be answered exactly even through
+      // the overlay-aware fallback GraphAlgorithms.dijkstraSingleSource takes while an overlay is active
+      // (issue #6791) - an ambiguous parallel-edge deletion is the one case that can still happen.
       if (accelerated != null) {
         context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
         return accelerated;
@@ -136,7 +137,10 @@ public class AlgoDijkstraSingleSource extends AbstractAlgoProcedure {
 
   private Stream<Result> executeWithCSR(final CommandContext context, final GraphAnalyticalView gav, final RID startRid,
       final String[] relTypes, final String weightProperty, final Vertex.DIRECTION dir) {
-    final int n = gav.getNodeCount();
+    // The exclusive bound of the dense id space, not the live node count: while an overlay is active the two
+    // diverge (issue #6792) - an added node's id sits above the base mapping regardless of how many nodes are
+    // currently live, and enumerating only up to the live count would silently drop it from the results below.
+    final int n = gav.getNodeIdUpperBound();
     if (n == 0)
       return Stream.empty();
 
@@ -147,7 +151,7 @@ public class AlgoDijkstraSingleSource extends AbstractAlgoProcedure {
     final double[] dist = GraphAlgorithms.dijkstraSingleSource(
         gav, src, weightProperty, dir, relTypes);
     if (dist == null)
-      return null; // the CSR arrays are not the whole graph right now; the caller reads the edges instead
+      return null; // a popped node could not be answered exactly; the caller reads the edges instead
     long reachable = 0;
     for (int i = 0; i < n; i++)
       if (i != src && dist[i] < Double.POSITIVE_INFINITY) reachable++;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -145,8 +145,8 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
    * {@code direction} note in the docs says about most algorithms.
    * <p>
    * Deliberately local rather than routed through {@link com.arcadedb.graph.GraphEngine#parseDirection}: that
-   * helper coerces unknown values to BOTH and is shared by around twenty other {@code algo.*} procedures, so
-   * tightening it is a far wider behaviour change than this procedure's own bug fix should carry.
+   * helper now rejects an unrecognised value too (issue #6976), but its default for absent/null is BOTH, not
+   * this procedure's OUT - two genuinely different defaults, not one shared behaviour with a wrapper around it.
    */
   private Vertex.DIRECTION extractDirection(final Object value) {
     if (value == null)

--- a/engine/src/test/java/com/arcadedb/function/node/SQLNodeFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/node/SQLNodeFunctionsTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.node;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SQLNodeFunctionsTest extends TestHelper {
 
@@ -66,6 +68,52 @@ class SQLNodeFunctionsTest extends TestHelper {
       assertThat(rs.hasNext()).isTrue();
       assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
     }
+  }
+
+  @Test
+  void nodeDegreeFromSql_directionIsHonoured() {
+    // Friend is directed Ada -> Bob and Ada -> Cara: Ada's OUT degree is 2, Bob's IN degree is 1 and Bob's OUT
+    // degree is 0. If an unrecognised direction silently became BOTH, OUT/IN would read the same as BOTH.
+    try (final ResultSet rs = database.query("sql", "SELECT node.degree(@this, 'Friend', 'OUT') AS d FROM Person WHERE name = 'Ada'")) {
+      assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
+    }
+    try (final ResultSet rs = database.query("sql", "SELECT node.degree(@this, 'Friend', 'IN') AS d FROM Person WHERE name = 'Bob'")) {
+      assertThat(rs.next().<Long>getProperty("d")).isEqualTo(1L);
+    }
+    try (final ResultSet rs = database.query("sql", "SELECT node.degree(@this, 'Friend', 'OUT') AS d FROM Person WHERE name = 'Bob'")) {
+      assertThat(rs.next().<Long>getProperty("d")).isEqualTo(0L);
+    }
+  }
+
+  /**
+   * Regression for issue #6976: {@code AbstractNodeFunction.parseDirection} used to carry the same
+   * silent-coercion bug as {@code GraphEngine.parseDirection} - any unrecognised direction string, like a typo
+   * of {@code 'IN'}, silently became {@code BOTH} instead of erroring. It backs {@code node.degree()},
+   * {@code node.relationship.exists()} and {@code node.relationship.types()}.
+   * <p>
+   * {@code node.relationship.exists}/{@code .types} are invoked directly here rather than through a query
+   * string: their two-dot names are OpenCypher function names, and SQL's own dot syntax would parse
+   * {@code node.relationship.exists(...)} as a method call on the field {@code node.relationship} instead of a
+   * call to the function of that name.
+   */
+  @Test
+  void unrecognisedDirectionIsRejectedNotCoercedToBoth() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT node.degree(@this, 'Friend', 'INCOMING2') AS d FROM Person WHERE name = 'Ada'").next())
+        .hasStackTraceContaining("direction")
+        .hasStackTraceContaining("IN, OUT or BOTH");
+
+    final Vertex ada = database.query("sql", "SELECT FROM Person WHERE name = 'Ada'").next().getRecord().get().asVertex();
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    assertThatThrownBy(() -> new NodeRelationshipExists().execute(new Object[] { ada, "Friend", "INCOMING2" }, context))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("direction")
+        .hasMessageContaining("IN, OUT or BOTH");
+    assertThatThrownBy(() -> new NodeRelationshipTypes().execute(new Object[] { ada, "INCOMING2" }, context))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("direction")
+        .hasMessageContaining("IN, OUT or BOTH");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFordTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFordTest.java
@@ -207,4 +207,21 @@ class SQLFunctionBellmanFordTest {
           .hasMessageContaining("bellmanFord");
     });
   }
+
+  @Test
+  void rejectsAnUnrecognisedDirectionInsteadOfSilentlyTraversingBoth() throws Exception {
+    // Regression for issue #6976: this function used to carry its own copy of the same silent-coercion bug,
+    // separate from GraphEngine.parseDirection - 'INCOMING' used to become BOTH instead of erroring.
+    TestHelper.executeInNewDatabase("SQLFunctionBellmanFordUnknownDirection", graph -> {
+      setUp(graph);
+      final BasicCommandContext ctx = new BasicCommandContext();
+      ctx.setDatabase(graph);
+
+      assertThatThrownBy(() -> functionBellmanFord.execute(null, null, null,
+          new Object[] { v1, v4, "'weight'", "INCOMING" }, ctx))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("direction")
+          .hasMessageContaining("OUT, IN or BOTH");
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6791DijkstraSingleSourceOverlayBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6791DijkstraSingleSourceOverlayBenchmark.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.StallAwareStopwatch;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Measures, rather than assumes, the claim issue #6791 makes: against a {@code SYNCHRONOUS} Graph Analytical
+ * View - the state such a view is in after every single commit - routing {@code algo.dijkstra.singleSource}
+ * through the overlay-aware {@link com.arcadedb.graph.olap.GraphAlgorithms#dijkstraSingleSource} instead of
+ * abandoning the CSR path outright is faster than the OLTP fallback it replaces, on a graph large enough for
+ * the per-popped-node allocation the fix adds to actually show up against the win of not walking edge records.
+ * <p>
+ * Both arms run the same query against the same committed graph, one immediately after the other, so a single
+ * {@link StallAwareStopwatch} window each keeps a JVM-wide pause from landing lopsidedly on one arm and not the
+ * other (see the class Javadoc there, and issue #6260). Vertex lookups are resolved once, before either arm is
+ * timed, so an SQL lookup's own cost never enters either measurement.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class Issue6791DijkstraSingleSourceOverlayBenchmark {
+  private static final int NODES   = 4000;
+  private static final int SOURCES = 40;
+
+  private Database        database;
+  private MutableVertex[] nodes;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6791-dijkstra-overlay-bench");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    database.getSchema().createEdgeType("ROAD").createProperty("w", Type.DOUBLE);
+
+    // A ring backbone guarantees strong connectivity, plus a handful of chords per node so Dijkstra has real
+    // branching to explore rather than following one deterministic path.
+    nodes = new MutableVertex[NODES];
+    database.transaction(() -> {
+      for (int i = 0; i < NODES; i++)
+        nodes[i] = database.newVertex("N").set("idx", i).save();
+      for (int i = 0; i < NODES; i++) {
+        nodes[i].newEdge("ROAD", nodes[(i + 1) % NODES], true, new Object[] { "w", 1.0 + (i % 7) }).save();
+        for (int c = 1; c <= 3; c++) {
+          final int target = (i + 17 * c + 1) % NODES;
+          nodes[i].newEdge("ROAD", nodes[target], true, new Object[] { "w", 1.0 + ((i * c) % 11) }).save();
+        }
+      }
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void overlayAwareCsrPathBeatsTheOltpFallbackItReplaces() {
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("dijkstra-overlay-benchmark")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("w")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .withCompactionThreshold(Integer.MAX_VALUE)
+        .build();
+    boolean viewDropped = false;
+    try {
+      // One committed change is all a SYNCHRONOUS view needs to carry an active overlay from here on - exactly
+      // the state issue #6791 says this procedure used to treat as "read the edge records instead".
+      database.transaction(() -> nodes[0].newEdge("ROAD", nodes[1], true, new Object[] { "w", 1.0 }).save());
+      assertThat(view.hasPendingChanges()).isTrue();
+
+      final long acceleratedMs = timeRuns(true);
+      view.drop();
+      viewDropped = true;
+      final long oltpMs = timeRuns(false);
+
+      assertThat(acceleratedMs)
+          .as("overlay-aware CSR (%d ms) must beat the full OLTP fallback (%d ms) it replaces on a %d-node graph",
+              acceleratedMs, oltpMs, NODES)
+          .isLessThan(oltpMs);
+    } finally {
+      if (!viewDropped)
+        view.drop();
+    }
+  }
+
+  /** Runs algo.dijkstra.singleSource from SOURCES distinct nodes and returns the discounted elapsed time. */
+  private long timeRuns(final boolean expectCsrAcceleration) {
+    final StallAwareStopwatch watch = StallAwareStopwatch.start();
+    for (int s = 0; s < SOURCES; s++) {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      final Stream<Result> rows = new AlgoDijkstraSingleSource().execute(
+          new Object[] { nodes[s * (NODES / SOURCES)], "ROAD", "w", "OUT" }, null, context);
+      long count = 0;
+      for (final Result ignored : (Iterable<Result>) rows::iterator)
+        count++;
+      assertThat(count).as("every node must be reachable over the ring backbone alone").isEqualTo(NODES - 1);
+      if (expectCsrAcceleration)
+        assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+            .as("the accelerated arm must actually be accelerated, or the comparison measures nothing")
+            .isEqualTo(true);
+    }
+    return watch.elapsedMs();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6791DijkstraSingleSourceOverlayTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6791DijkstraSingleSourceOverlayTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6791: {@code algo.dijkstra.singleSource} was the one weighted procedure that still
+ * abandoned the CSR path and fell all the way back to the edge records on every commit against a
+ * {@code SYNCHRONOUS} Graph Analytical View - the state such a view is in after every single commit - instead
+ * of resolving the delta overlay the way {@code algo.mst}, {@code algo.steinerTree}, {@code astar()} and
+ * {@code bellmanFord()} already do through {@link com.arcadedb.graph.GraphTraversalProvider#edgeWeightsOf}
+ * (issue #6315).
+ * <p>
+ * {@link com.arcadedb.graph.olap.GraphAlgorithms#dijkstraSingleSource} now keeps popping nodes off its CSR-based
+ * heap while an overlay is active, resolving each popped node's neighbours and weights through the provider
+ * instead of indexing the raw arrays - and sizes its result against the overlay's own id-space upper bound
+ * rather than the base node mapping, since an added vertex's dense id sits above it (issue #6792).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6791DijkstraSingleSourceOverlayTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6791-dijkstra-overlay");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    database.getSchema().createEdgeType("ROAD").createProperty("w", Type.DOUBLE);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void staysCsrAcceleratedAcrossACommitAndAnswersForAddedAndDeletedEdges() {
+    // A -1-> B -2-> C, plus a redundant direct A -10-> C that will be deleted.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      final MutableVertex c = database.newVertex("N").set("name", "C").save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 1.0 }).save();
+      b.newEdge("ROAD", c, true, new Object[] { "w", 2.0 }).save();
+      a.newEdge("ROAD", c, true, new Object[] { "w", 10.0 }).save();
+    });
+
+    final GraphAnalyticalView view = syncView("dijkstra-overlay-basic");
+    try {
+      // Delete the redundant direct edge, add a new vertex E and an edge from C to it - both live only in the
+      // overlay: the redundant edge's column slot still exists but must not be walked, and E's dense id sits
+      // above the base mapping entirely.
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if ("C".equals(edge.getInVertex().get("name")))
+            edge.delete();
+        final MutableVertex e = database.newVertex("N").set("name", "E").save();
+        vertex("C").newEdge("ROAD", e, true, new Object[] { "w", 5.0 }).save();
+      });
+      assertThat(view.hasPendingChanges()).as("every commit leaves a SYNCHRONOUS view with an active overlay").isTrue();
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      final Map<String, Double> costs = new HashMap<>();
+      for (final Result row : collect(new AlgoDijkstraSingleSource().execute(
+          new Object[] { vertex("A"), "ROAD", "w", "OUT" }, null, context))) {
+        final Vertex node = ((RID) row.getProperty("node")).asVertex();
+        costs.put((String) node.get("name"), ((Number) row.getProperty("cost")).doubleValue());
+      }
+
+      assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+          .as("the overlay must not send this call back to the edge records")
+          .isEqualTo(true);
+      // B at 1, C via A-B-C at 3 (the direct 10-weight edge was deleted), E via A-B-C-E at 8.
+      assertThat(costs).containsExactlyInAnyOrderEntriesOf(Map.of("B", 1.0, "C", 3.0, "E", 8.0));
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void fallsBackToOltpWhenTheOverlayCannotResolveAnAmbiguousParallelDeletion() {
+    // Three parallel A->B edges of distinct weight.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 2.0 }).save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 3.0 }).save();
+    });
+
+    final GraphAnalyticalView view = syncView("dijkstra-overlay-ambiguous");
+    try {
+      // Delete the 2.0 edge and add a 4.0 one between the same pair: which of the surviving column slots
+      // belongs to which remaining edge is not recoverable from a per-pair deletion count (issue #6315).
+      database.transaction(() -> {
+        for (final Edge edge : vertex("A").getEdges(Vertex.DIRECTION.OUT, "ROAD"))
+          if (Double.valueOf(2.0).equals(edge.get("w")))
+            edge.delete();
+        vertex("A").newEdge("ROAD", vertex("B"), true, new Object[] { "w", 4.0 }).save();
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      final List<Result> rows = collect(new AlgoDijkstraSingleSource().execute(
+          new Object[] { vertex("A"), "ROAD", "w", "OUT" }, null, context));
+
+      assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+          .as("an unresolvable node must send the whole call back to the edge records, not half of it")
+          .isNotEqualTo(true);
+      assertThat(rows).hasSize(1);
+      // The cheapest surviving edge (1.0) must win, not a plausible wrong weight from the ambiguous merge.
+      assertThat(((Number) rows.getFirst().getProperty("cost")).doubleValue()).isEqualTo(1.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  private GraphAnalyticalView syncView(final String name) {
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName(name)
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("w")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+    assertThat(view.hasEdgeProperty("ROAD", "w")).isTrue();
+    return view;
+  }
+
+  private Vertex vertex(final String name) {
+    return database.query("sql", "SELECT FROM N WHERE name = ?", name).next().getRecord().get().asVertex();
+  }
+
+  private static List<Result> collect(final Stream<Result> rows) {
+    final List<Result> collected = new ArrayList<>();
+    rows.forEach(collected::add);
+    return collected;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6976UnknownDirectionRejectedTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6976UnknownDirectionRejectedTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.GraphEngine;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6976: {@link GraphEngine#parseDirection(String)} used to silently coerce any
+ * unrecognised direction string to {@code BOTH} instead of rejecting it, so a typo like {@code 'INCOMING'} was
+ * answered with a plausible-looking - but wrong - result instead of an error. This helper backs ~23
+ * {@code algo.*}/path procedures; {@code algo.bfs} is exercised end to end here as a representative caller.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6976UnknownDirectionRejectedTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue6976-direction");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("CONNECTS");
+
+    // A -CONNECTS-> B -CONNECTS-> C
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      a.newEdge("CONNECTS", b, true, (Object[]) null).save();
+      b.newEdge("CONNECTS", c, true, (Object[]) null).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void parseDirectionRejectsUnrecognisedValues() {
+    for (final String bad : new String[] { "INCOMING", "OUTGOING", "nope", "in ", "" })
+      assertThatThrownBy(() -> GraphEngine.parseDirection(bad))
+          .as("direction '%s' must be rejected, not coerced to BOTH", bad)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("direction")
+          .hasMessageContaining("OUT, IN or BOTH");
+  }
+
+  @Test
+  void parseDirectionAcceptsValidValuesCaseInsensitively() {
+    assertThat(GraphEngine.parseDirection("OUT")).isEqualTo(Vertex.DIRECTION.OUT);
+    assertThat(GraphEngine.parseDirection("out")).isEqualTo(Vertex.DIRECTION.OUT);
+    assertThat(GraphEngine.parseDirection("IN")).isEqualTo(Vertex.DIRECTION.IN);
+    assertThat(GraphEngine.parseDirection("in")).isEqualTo(Vertex.DIRECTION.IN);
+    assertThat(GraphEngine.parseDirection("BOTH")).isEqualTo(Vertex.DIRECTION.BOTH);
+    assertThat(GraphEngine.parseDirection("both")).isEqualTo(Vertex.DIRECTION.BOTH);
+  }
+
+  @Test
+  void parseDirectionDefaultsNullToBoth() {
+    assertThat(GraphEngine.parseDirection(null)).isEqualTo(Vertex.DIRECTION.BOTH);
+  }
+
+  @Test
+  void bfsRejectsAnUnrecognisedDirectionInsteadOfSilentlyTraversingBoth() {
+    // Before the fix, 'INCOMING' silently became BOTH and algo.bfs returned all 3 nodes instead of erroring.
+    assertThatThrownBy(() -> drain("CALL algo.bfs(start, null, 'INCOMING', 5) YIELD node RETURN node"))
+        .as("'INCOMING' must be rejected, not coerced to BOTH")
+        .hasStackTraceContaining("direction")
+        .hasStackTraceContaining("OUT, IN or BOTH");
+
+    // The three valid values, in either case, still work. Start node itself is never in the result, and A has
+    // no incoming edges, so B and C (2 nodes) are reachable via OUT/BOTH, and none via IN.
+    assertThat(drain("CALL algo.bfs(start, null, 'OUT', 5) YIELD node RETURN node")).isEqualTo(2);
+    assertThat(drain("CALL algo.bfs(start, null, 'IN', 5) YIELD node RETURN node")).isEqualTo(0);
+    assertThat(drain("CALL algo.bfs(start, null, 'both', 5) YIELD node RETURN node")).isEqualTo(2);
+    // No direction arg at all still defaults to BOTH.
+    assertThat(drain("CALL algo.bfs(start, null, null, 5) YIELD node RETURN node")).isEqualTo(2);
+  }
+
+  private int drain(final String query) {
+    int count = 0;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (start:Node {name: 'A'}) " + query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two issues raised as follow-ups from other analysis:

### #6976 - `algo.*` procedures silently coerce an unrecognised direction to `BOTH`
`GraphEngine.parseDirection(String)` mapped any string that wasn't `OUT`/`IN` to `BOTH`, so a typo like `'INCOMING'` (or `'OUTGOING'`, empty string, trailing whitespace, ...) silently ran the algorithm with a different direction than the caller asked for, with no error. This helper backs ~23 `algo.*`/path procedures (`algo.bfs`, `algo.pagerank` OLTP-fallback callers use their own local copy for the CSR path already fixed in #6956, `algo.dijkstra`, `algo.closeness`, etc.).

- `GraphEngine.parseDirection` now rejects anything that isn't `OUT`/`IN`/`BOTH` (case-insensitive, `Locale.ROOT`-safe) with an `IllegalArgumentException`. `null` still means "use the default" (`BOTH`).
- `SQLFunctionBellmanFord` carried its own **local, case-sensitive** copy of the exact same coerce-to-`BOTH` bug (undetected by the issue's own file survey). It now delegates to `GraphEngine.parseDirection` instead of duplicating the switch.
- `AbstractPathProcedure.parseDirection` and `AlgoLabelPropagation` were checked and are already correct/already delegate - no change needed there (the issue's claim about a local copy in `AlgoLabelPropagation` no longer matches the current code).

### #6791 - `algo.dijkstra.singleSource` abandons the CSR path on every commit
Every other weighted procedure (`algo.mst`, `algo.msa`, `algo.steinerTree`, `algo.bellmanford`, `algo.apsp`, `algo.maxKCut`, `astar()`, `bellmanFord()`) resolves an active delta overlay through `GraphTraversalProvider#edgeWeightsOf` (#6315). `algo.dijkstra.singleSource`'s CSR kernel (`GraphAlgorithms.dijkstraSingleSource`) was the one that still refused outright and fell back to reading edge records - which, against a `SYNCHRONOUS` Graph Analytical View, is the state the view is in after *every single commit*.

- `GraphAlgorithms.dijkstraSingleSource` now takes the overlay-aware path per popped node when an overlay is active: instead of indexing the raw CSR arrays, each popped node's neighbours/weights come from `view.edgeWeightsOf(...)`, which already resolves additions/deletions against the columns. This costs one small allocation per node the search actually reaches (bounded by the search, not the whole graph) instead of the full per-edge OLTP record read it replaces.
- Sized against the overlay's own id-space upper bound (`DeltaOverlay.getNodeIdUpperBound()`) rather than the base node mapping (#6792), so a vertex added since the last view build is included in the result too. `AlgoDijkstraSingleSource.executeWithCSR` was doing the same base-mapping-sized enumeration and is fixed the same way.
- If a popped node can't be resolved exactly (the one case: an ambiguous parallel-edge deletion the overlay can't disambiguate on its own), the whole computation still refuses rather than guess, and the caller falls back to the OLTP path exactly as before - never a partial or plausible-wrong answer.
- Measured rather than assumed: `Issue6791DijkstraSingleSourceOverlayBenchmark` (`@Tag("benchmark")`, excluded from normal CI) times the CSR-accelerated path against the OLTP fallback it replaces on a 4000-node graph and asserts the former is faster.

## Test plan
- [x] `Issue6976UnknownDirectionRejectedTest` - unit coverage of `GraphEngine.parseDirection` (reject/accept/case-insensitivity/null-default) plus an `algo.bfs` end-to-end regression.
- [x] `SQLFunctionBellmanFordTest#rejectsAnUnrecognisedDirectionInsteadOfSilentlyTraversingBoth` - regression for the function's own local copy of the bug.
- [x] `Issue6791DijkstraSingleSourceOverlayTest` - end-to-end: CSR stays engaged (`CSR_ACCELERATED_VAR`) and answers correctly across a commit that deletes an edge and adds a vertex+edge; and the ambiguous-parallel-deletion case still falls back to OLTP with the correct answer.
- [x] `Issue6791DijkstraSingleSourceOverlayBenchmark` - confirms the CSR-accelerated path is actually faster than the OLTP fallback it replaces (stable across repeated runs).
- [x] Verified both new Dijkstra regression tests fail against the pre-fix code (not vacuous).
- [x] Full sweep of `algo`/`path`/`function.sql.graph`/`function.node`/`graph.olap`/`graph` test packages: 1255+ tests green, including the existing #6315/#6792 regression suites.
- [x] `mvn -o compile -pl '!studio' -am` - full reactor compiles clean (the `studio` module's failure is a pre-existing offline npm cache issue, unrelated to this change).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid graph traversal directions now produce a clear error instead of silently defaulting to bidirectional traversal.
  - Direction values remain case-insensitive, with `incoming` and `outgoing` supported as aliases; omitted or null values retain documented defaults.
  - Dijkstra searches now correctly account for active analytical-view changes, including added or deleted vertices and edges.
  - Improved fallback behavior ensures accurate results when analytical data cannot fully resolve the current graph state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->