### PR TITLE
Fix custom function double-execution, DEFINE FUNCTION race, and Java overload collapse

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/FunctionLibraryDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/FunctionLibraryDefinition.java
@@ -54,7 +54,9 @@ public interface FunctionLibraryDefinition<T extends FunctionDefinition> {
   Iterable<T> getFunctions();
 
   /**
-   * Returns a function by its name
+   * Returns a function by its name. Implementations must never return {@code null}: an undefined function is
+   * reported via the {@link IllegalArgumentException} below, not a {@code null} return value. Callers (e.g.
+   * {@code CustomFunctionAdapter}) rely on this to treat a successful return as always non-null.
    *
    * @param functionName Name of the function to retrieve
    *

--- a/engine/src/main/java/com/arcadedb/function/cypher/CustomFunctionAdapter.java
+++ b/engine/src/main/java/com/arcadedb/function/cypher/CustomFunctionAdapter.java
@@ -54,13 +54,14 @@ public class CustomFunctionAdapter implements StatelessFunction {
       throw new CommandExecutionException("Unknown function: " + fullName);
 
     // Try exact match first
+    FunctionDefinition function = null;
     try {
-      final FunctionDefinition function = database.getSchema().getFunction(libraryName, functionName);
-      if (function != null)
-        return function.execute(args);
+      function = database.getSchema().getFunction(libraryName, functionName);
     } catch (final IllegalArgumentException e) {
       // Fall through to case-insensitive search
     }
+    if (function != null)
+      return function.execute(args);
 
     // Case-insensitive search - iterate through all functions in library
     final var library = database.getSchema().getFunctionLibrary(libraryName);

--- a/engine/src/main/java/com/arcadedb/function/cypher/CustomFunctionAdapter.java
+++ b/engine/src/main/java/com/arcadedb/function/cypher/CustomFunctionAdapter.java
@@ -54,16 +54,17 @@ public class CustomFunctionAdapter implements StatelessFunction {
       throw new CommandExecutionException("Unknown function: " + fullName);
 
     // Try exact match first
-    FunctionDefinition function = null;
+    final FunctionDefinition function;
     try {
       function = database.getSchema().getFunction(libraryName, functionName);
     } catch (final IllegalArgumentException e) {
-      // Fall through to case-insensitive search
+      // Not found under this exact name: fall through to a case-insensitive search
+      return executeCaseInsensitive(database, args);
     }
-    if (function != null)
-      return function.execute(args);
+    return function.execute(args);
+  }
 
-    // Case-insensitive search - iterate through all functions in library
+  private Object executeCaseInsensitive(final Database database, final Object[] args) {
     final var library = database.getSchema().getFunctionLibrary(libraryName);
     for (final Object funcObj : library.getFunctions()) {
       if (funcObj instanceof FunctionDefinition) {

--- a/engine/src/main/java/com/arcadedb/function/cypher/CustomFunctionAdapter.java
+++ b/engine/src/main/java/com/arcadedb/function/cypher/CustomFunctionAdapter.java
@@ -61,6 +61,11 @@ public class CustomFunctionAdapter implements StatelessFunction {
       // Not found under this exact name: fall through to a case-insensitive search
       return executeCaseInsensitive(database, args);
     }
+    // FunctionLibraryDefinition is a public extension point: a third-party implementation that violates the
+    // "getFunction() never returns null" contract gets a clear error here instead of a raw NPE.
+    if (function == null)
+      throw new CommandExecutionException(
+          "Function library '" + libraryName + "' returned null for '" + functionName + "', violating the FunctionLibraryDefinition.getFunction() contract");
     return function.execute(args);
   }
 

--- a/engine/src/main/java/com/arcadedb/function/java/JavaClassFunctionLibraryDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaClassFunctionLibraryDefinition.java
@@ -22,13 +22,21 @@ import com.arcadedb.function.FunctionLibraryDefinition;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
  * Binds a Java class into a function library, where each method of the class are invokable functions. At construction time, the class is inspected to
  * find the methods by using reflection This library definition implementation does not allow dynamic function registration.
+ * <p>
+ * Overloaded public methods (same name, different signature) are all bound under their shared name: the matching
+ * overload is picked at call time by {@link JavaMethodFunctionDefinition} based on the arguments actually passed,
+ * rather than only one overload surviving registration depending on the JVM's unspecified method enumeration order.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -50,17 +58,22 @@ public class JavaClassFunctionLibraryDefinition implements FunctionLibraryDefini
       throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     this.libraryName = libraryName;
 
-    Object instance = null;
+    final Map<String, List<Method>> methodsByName = new LinkedHashMap<>();
     for (final Method m : impl.getDeclaredMethods()) {
       if (!Modifier.isPublic(m.getModifiers()))
         continue;
-
-      final JavaMethodFunctionDefinition f = new JavaMethodFunctionDefinition(instance, m);
-      if (f.getInstance() != null)
-        instance = f.getInstance();
-
-      functions.put(m.getName(), f);
+      methodsByName.computeIfAbsent(m.getName(), k -> new ArrayList<>()).add(m);
     }
+
+    // A SINGLE INSTANCE IS SHARED BY ALL THE NON-STATIC METHODS OF THE CLASS
+    Object instance = null;
+    for (final List<Method> group : methodsByName.values())
+      for (final Method m : group)
+        if (!Modifier.isStatic(m.getModifiers()) && instance == null)
+          instance = impl.getConstructor().newInstance();
+
+    for (final Map.Entry<String, List<Method>> entry : methodsByName.entrySet())
+      functions.put(entry.getKey(), new JavaMethodFunctionDefinition(instance, entry.getValue()));
   }
 
   public String getName() {

--- a/engine/src/main/java/com/arcadedb/function/java/JavaClassFunctionLibraryDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaClassFunctionLibraryDefinition.java
@@ -66,11 +66,8 @@ public class JavaClassFunctionLibraryDefinition implements FunctionLibraryDefini
     }
 
     // A SINGLE INSTANCE IS SHARED BY ALL THE NON-STATIC METHODS OF THE CLASS
-    Object instance = null;
-    for (final List<Method> group : methodsByName.values())
-      for (final Method m : group)
-        if (!Modifier.isStatic(m.getModifiers()) && instance == null)
-          instance = impl.getConstructor().newInstance();
+    final boolean hasInstanceMethod = methodsByName.values().stream().flatMap(List::stream).anyMatch(m -> !Modifier.isStatic(m.getModifiers()));
+    final Object instance = hasInstanceMethod ? impl.getConstructor().newInstance() : null;
 
     for (final Map.Entry<String, List<Method>> entry : methodsByName.entrySet())
       functions.put(entry.getKey(), new JavaMethodFunctionDefinition(instance, entry.getValue()));

--- a/engine/src/main/java/com/arcadedb/function/java/JavaClassFunctionLibraryDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaClassFunctionLibraryDefinition.java
@@ -60,7 +60,10 @@ public class JavaClassFunctionLibraryDefinition implements FunctionLibraryDefini
 
     final Map<String, List<Method>> methodsByName = new LinkedHashMap<>();
     for (final Method m : impl.getDeclaredMethods()) {
-      if (!Modifier.isPublic(m.getModifiers()))
+      // Bridge/synthetic methods (generated for generic or covariant-return overrides) are public too, and would
+      // otherwise be grouped alongside the real method under the same name - making an unambiguous call reject as
+      // ambiguous between the real method and its own compiler-generated bridge.
+      if (!Modifier.isPublic(m.getModifiers()) || m.isBridge() || m.isSynthetic())
         continue;
       methodsByName.computeIfAbsent(m.getName(), k -> new ArrayList<>()).add(m);
     }

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -134,16 +134,12 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
    * unchanged.
    */
   private static Object[] toInvokeArgs(final Method method, final Object[] args) {
-    if (!method.isVarArgs())
+    if (!method.isVarArgs() || isPrePacked(method, args))
       return args;
 
     final Class<?>[] paramTypes = method.getParameterTypes();
     final int fixedCount = paramTypes.length - 1;
     final Class<?> varargsType = paramTypes[fixedCount];
-
-    // Already in invoke() shape: the caller passed the vararg part pre-packed as a single matching array.
-    if (args.length == paramTypes.length && (args[fixedCount] == null || varargsType.isInstance(args[fixedCount])))
-      return args;
 
     final Object varargsArray = java.lang.reflect.Array.newInstance(varargsType.getComponentType(), args.length - fixedCount);
     for (int i = fixedCount; i < args.length; i++)
@@ -153,6 +149,17 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     System.arraycopy(args, 0, invokeArgs, 0, fixedCount);
     invokeArgs[fixedCount] = varargsArray;
     return invokeArgs;
+  }
+
+  /**
+   * True when the caller already passed the vararg part pre-packed as a single array matching the vararg component
+   * type - i.e. {@code args} is already in the exact shape {@link Method#invoke} requires - rather than as flat,
+   * positionally-passed elements.
+   */
+  private static boolean isPrePacked(final Method method, final Object[] args) {
+    final Class<?>[] paramTypes = method.getParameterTypes();
+    final int fixedCount = paramTypes.length - 1;
+    return args.length == paramTypes.length && (args[fixedCount] == null || paramTypes[fixedCount].isInstance(args[fixedCount]));
   }
 
   private List<Method> candidatesByParameterCount(final int received) {
@@ -178,7 +185,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
       }
     }
     if (match == null)
-      throw ambiguousOverloadException(candidates, args);
+      throw noMatchingOverloadException(candidates, args);
     return match;
   }
 
@@ -192,6 +199,11 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
         return false;
 
     if (varArgs) {
+      if (isPrePacked(method, args))
+        // the vararg part was passed as a single, already-built array: match it against the array type itself
+        // rather than element-by-element, otherwise e.g. a pre-packed String[] would be compared to String and fail.
+        return typeMatches(paramTypes[fixedCount], args[fixedCount]);
+
       final Class<?> componentType = paramTypes[fixedCount].getComponentType();
       for (int i = fixedCount; i < args.length; i++)
         if (!typeMatches(componentType, args[i]))
@@ -228,16 +240,25 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     return type;
   }
 
+  private FunctionExecutionException noMatchingOverloadException(final List<Method> candidates, final Object[] args) {
+    return new FunctionExecutionException(
+        "Error on executing function '" + getName() + "': none of " + candidates + " accepts argument type(s) [" + describeArgumentTypes(args) + "]");
+  }
+
   private FunctionExecutionException ambiguousOverloadException(final List<Method> candidates, final Object[] args) {
+    return new FunctionExecutionException(
+        "Error on executing function '" + getName() + "': cannot resolve which overload to call among " + candidates
+            + " for argument type(s) [" + describeArgumentTypes(args) + "]");
+  }
+
+  private static String describeArgumentTypes(final Object[] args) {
     final StringBuilder argTypes = new StringBuilder();
     for (int i = 0; i < args.length; i++) {
       if (i > 0)
         argTypes.append(", ");
       argTypes.append(args[i] != null ? args[i].getClass().getName() : "null");
     }
-    return new FunctionExecutionException(
-        "Error on executing function '" + getName() + "': cannot resolve which overload to call among " + candidates
-            + " for argument type(s) [" + argTypes + "]");
+    return argTypes.toString();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -20,10 +20,13 @@ package com.arcadedb.function.java;/*
 import com.arcadedb.function.FunctionDefinition;
 import com.arcadedb.function.FunctionExecutionException;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -87,7 +90,11 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     if (methods.isEmpty())
       throw new IllegalArgumentException("At least one method is required");
     this.instance = instance;
-    this.methods = List.copyOf(methods);
+    // Sorted so which overload names an error message (getName(), or the "expected/received" and ambiguity
+    // messages) is deterministic, rather than depending on the JVM's unspecified getDeclaredMethods() order.
+    this.methods = methods.stream()
+        .sorted(Comparator.<Method>comparingInt(Method::getParameterCount).thenComparing(m -> Arrays.toString(m.getParameterTypes())))
+        .toList();
   }
 
   @Override
@@ -141,9 +148,9 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     final int fixedCount = paramTypes.length - 1;
     final Class<?> varargsType = paramTypes[fixedCount];
 
-    final Object varargsArray = java.lang.reflect.Array.newInstance(varargsType.getComponentType(), args.length - fixedCount);
+    final Object varargsArray = Array.newInstance(varargsType.getComponentType(), args.length - fixedCount);
     for (int i = fixedCount; i < args.length; i++)
-      java.lang.reflect.Array.set(varargsArray, i - fixedCount, args[i]);
+      Array.set(varargsArray, i - fixedCount, args[i]);
 
     final Object[] invokeArgs = new Object[fixedCount + 1];
     System.arraycopy(args, 0, invokeArgs, 0, fixedCount);
@@ -162,30 +169,53 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     return args.length == paramTypes.length && (args[fixedCount] == null || paramTypes[fixedCount].isInstance(args[fixedCount]));
   }
 
+  /**
+   * All overloads whose parameter count can possibly accept {@code received} arguments - both an exact-arity
+   * non-varargs match and a varargs match that could still absorb them. Both kinds are kept together (rather than
+   * a fixed-arity match with a matching count unconditionally winning regardless of its parameter types) so that
+   * {@link #disambiguateByArgumentType} gets the chance to fall back to a type-compatible varargs overload when the
+   * fixed-arity one does not actually accept the arguments' runtime types.
+   */
   private List<Method> candidatesByParameterCount(final int received) {
-    final List<Method> exact = new ArrayList<>();
-    final List<Method> varargs = new ArrayList<>();
+    final List<Method> candidates = new ArrayList<>();
     for (final Method m : methods) {
       if (m.isVarArgs()) {
         if (received >= m.getParameterCount() - 1)
-          varargs.add(m);
+          candidates.add(m);
       } else if (m.getParameterCount() == received)
-        exact.add(m);
+        candidates.add(m);
     }
-    return !exact.isEmpty() ? exact : varargs;
+    return candidates;
   }
 
+  /**
+   * Picks the overload matching the arguments' runtime types, preferring a fixed-arity match over a varargs one -
+   * mirroring how {@code javac} only falls back to varargs (its resolution phase 3) once no fixed-arity applicable
+   * method exists - rather than ranking by parameter-type specificity in general (see the class Javadoc).
+   */
   private Method disambiguateByArgumentType(final List<Method> candidates, final Object[] args) {
+    final List<Method> fixedArity = new ArrayList<>();
+    final List<Method> varArgs = new ArrayList<>();
+    for (final Method m : candidates)
+      (m.isVarArgs() ? varArgs : fixedArity).add(m);
+
+    Method match = matchByType(candidates, fixedArity, args);
+    if (match == null)
+      match = matchByType(candidates, varArgs, args);
+    if (match == null)
+      throw noMatchingOverloadException(candidates, args);
+    return match;
+  }
+
+  private Method matchByType(final List<Method> allCandidates, final List<Method> pool, final Object[] args) {
     Method match = null;
-    for (final Method m : candidates) {
+    for (final Method m : pool) {
       if (acceptsArgumentTypes(m, args)) {
         if (match != null)
-          throw ambiguousOverloadException(candidates, args);
+          throw ambiguousOverloadException(allCandidates, args);
         match = m;
       }
     }
-    if (match == null)
-      throw noMatchingOverloadException(candidates, args);
     return match;
   }
 

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -32,6 +32,10 @@ import java.util.List;
  * the number of arguments (and, if that is not enough to disambiguate, their runtime type) actually passed is
  * selected on every {@link #execute(Object...)} call, instead of registering only one of them depending on the
  * JVM's unspecified {@link Class#getDeclaredMethods()} order.
+ * <p>
+ * Unlike the Java compiler, this does not rank overloads by specificity: if more than one overload's parameter
+ * types accept the arguments (e.g. {@code foo(Object)} and {@code foo(String)} both called with a {@code String}),
+ * the call is rejected as ambiguous rather than silently picking the most specific match.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -112,7 +116,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     final Method method = candidates.size() == 1 ? candidates.get(0) : disambiguateByArgumentType(candidates, args);
 
     try {
-      return method.invoke(instance, args);
+      return method.invoke(instance, toInvokeArgs(method, args));
     } catch (final InvocationTargetException e) {
       // PRESERVE THE ORIGINAL EXCEPTION THROWN BY THE TARGET METHOD INSTEAD OF THE REFLECTION WRAPPER
       final Throwable cause = e.getCause() != null ? e.getCause() : e;
@@ -120,6 +124,35 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     } catch (final IllegalAccessException | IllegalArgumentException e) {
       throw new FunctionExecutionException("Error on executing function '" + method + "'", e);
     }
+  }
+
+  /**
+   * Unlike a normal (compiled) varargs call, {@link Method#invoke} does not pack trailing arguments into an array
+   * itself: it requires the args array to have exactly as many elements as the method's formal parameters, with the
+   * last one already being an array of the vararg component type. This packs the flat, positionally-passed
+   * arguments this class receives into that shape for a varargs method; non-varargs methods are passed through
+   * unchanged.
+   */
+  private static Object[] toInvokeArgs(final Method method, final Object[] args) {
+    if (!method.isVarArgs())
+      return args;
+
+    final Class<?>[] paramTypes = method.getParameterTypes();
+    final int fixedCount = paramTypes.length - 1;
+    final Class<?> varargsType = paramTypes[fixedCount];
+
+    // Already in invoke() shape: the caller passed the vararg part pre-packed as a single matching array.
+    if (args.length == paramTypes.length && (args[fixedCount] == null || varargsType.isInstance(args[fixedCount])))
+      return args;
+
+    final Object varargsArray = java.lang.reflect.Array.newInstance(varargsType.getComponentType(), args.length - fixedCount);
+    for (int i = fixedCount; i < args.length; i++)
+      java.lang.reflect.Array.set(varargsArray, i - fixedCount, args[i]);
+
+    final Object[] invokeArgs = new Object[fixedCount + 1];
+    System.arraycopy(args, 0, invokeArgs, 0, fixedCount);
+    invokeArgs[fixedCount] = varargsArray;
+    return invokeArgs;
   }
 
   private List<Method> candidatesByParameterCount(final int received) {
@@ -138,7 +171,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
   private Method disambiguateByArgumentType(final List<Method> candidates, final Object[] args) {
     Method match = null;
     for (final Method m : candidates) {
-      if (!m.isVarArgs() && acceptsArgumentTypes(m, args)) {
+      if (acceptsArgumentTypes(m, args)) {
         if (match != null)
           throw ambiguousOverloadException(candidates, args);
         match = m;
@@ -151,17 +184,26 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
 
   private static boolean acceptsArgumentTypes(final Method method, final Object[] args) {
     final Class<?>[] paramTypes = method.getParameterTypes();
-    for (int i = 0; i < paramTypes.length; i++) {
-      final Object arg = args[i];
-      if (arg == null) {
-        if (paramTypes[i].isPrimitive())
-          return false;
-        continue;
-      }
-      if (!wrap(paramTypes[i]).isInstance(arg))
+    final boolean varArgs = method.isVarArgs();
+    final int fixedCount = varArgs ? paramTypes.length - 1 : paramTypes.length;
+
+    for (int i = 0; i < fixedCount; i++)
+      if (!typeMatches(paramTypes[i], args[i]))
         return false;
+
+    if (varArgs) {
+      final Class<?> componentType = paramTypes[fixedCount].getComponentType();
+      for (int i = fixedCount; i < args.length; i++)
+        if (!typeMatches(componentType, args[i]))
+          return false;
     }
     return true;
+  }
+
+  private static boolean typeMatches(final Class<?> paramType, final Object arg) {
+    if (arg == null)
+      return !paramType.isPrimitive();
+    return wrap(paramType).isInstance(arg);
   }
 
   private static Class<?> wrap(final Class<?> type) {

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Maps one or more overloaded Java methods sharing the same name to a callable function. When more than one public
@@ -108,20 +110,27 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     final Object[] args = parameters != null ? parameters : new Object[0];
     final int received = args.length;
 
-    final List<Method> candidates = candidatesByParameterCount(received);
-
-    if (candidates.isEmpty()) {
-      if (methods.size() == 1) {
-        final Method only = methods.get(0);
+    if (methods.size() == 1) {
+      // Fast path for the overwhelmingly common non-overloaded case: skips the List allocation
+      // candidatesByParameterCount()/disambiguateByArgumentType() would otherwise do on every single call.
+      final Method only = methods.get(0);
+      final int minReceived = only.isVarArgs() ? only.getParameterCount() - 1 : only.getParameterCount();
+      if (only.isVarArgs() ? received < minReceived : received != minReceived)
         throw new FunctionExecutionException(
             "Error on executing function '" + only + "': expected " + only.getParameterCount() + " parameter(s) but received " + received);
-      }
-      throw new FunctionExecutionException(
-          "Error on executing function '" + getName() + "': none of the " + methods.size() + " overloads accepts " + received + " parameter(s)");
+      return invoke(only, args);
     }
 
-    final Method method = candidates.size() == 1 ? candidates.get(0) : disambiguateByArgumentType(candidates, args);
+    final List<Method> candidates = candidatesByParameterCount(received);
+    if (candidates.isEmpty())
+      throw new FunctionExecutionException(
+          "Error on executing function '" + getName() + "': none of the " + methods.size() + " overloads accepts " + received + " parameter(s)");
 
+    final Method method = candidates.size() == 1 ? candidates.get(0) : disambiguateByArgumentType(candidates, args);
+    return invoke(method, args);
+  }
+
+  private Object invoke(final Method method, final Object[] args) {
     try {
       return method.invoke(instance, toInvokeArgs(method, args));
     } catch (final InvocationTargetException e) {
@@ -242,32 +251,49 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     return true;
   }
 
+  // JLS 5.1.2 widening primitive conversions that method.invoke() itself accepts (after unboxing the argument):
+  // e.g. an Integer argument is a valid call-site match for a `long` parameter.
+  private static final Map<Class<?>, Set<Class<?>>> WIDENING_CONVERSIONS = Map.of(//
+      byte.class, Set.of(short.class, int.class, long.class, float.class, double.class), //
+      short.class, Set.of(int.class, long.class, float.class, double.class), //
+      char.class, Set.of(int.class, long.class, float.class, double.class), //
+      int.class, Set.of(long.class, float.class, double.class), //
+      long.class, Set.of(float.class, double.class), //
+      float.class, Set.of(double.class));
+
   private static boolean typeMatches(final Class<?> paramType, final Object arg) {
     if (arg == null)
       return !paramType.isPrimitive();
-    return wrap(paramType).isInstance(arg);
+    if (paramType.isPrimitive()) {
+      final Class<?> argPrimitiveType = unwrap(arg.getClass());
+      return argPrimitiveType != null
+          && (argPrimitiveType == paramType || WIDENING_CONVERSIONS.getOrDefault(argPrimitiveType, Set.of()).contains(paramType));
+    }
+    return paramType.isInstance(arg);
   }
 
-  private static Class<?> wrap(final Class<?> type) {
-    if (!type.isPrimitive())
-      return type;
-    if (type == int.class)
-      return Integer.class;
-    if (type == long.class)
-      return Long.class;
-    if (type == double.class)
-      return Double.class;
-    if (type == float.class)
-      return Float.class;
-    if (type == boolean.class)
-      return Boolean.class;
-    if (type == byte.class)
-      return Byte.class;
-    if (type == short.class)
-      return Short.class;
-    if (type == char.class)
-      return Character.class;
-    return type;
+  /**
+   * The primitive type a wrapper class unboxes to, or {@code null} if {@code wrapperType} is not one of the eight
+   * primitive wrapper classes.
+   */
+  private static Class<?> unwrap(final Class<?> wrapperType) {
+    if (wrapperType == Integer.class)
+      return int.class;
+    if (wrapperType == Long.class)
+      return long.class;
+    if (wrapperType == Double.class)
+      return double.class;
+    if (wrapperType == Float.class)
+      return float.class;
+    if (wrapperType == Boolean.class)
+      return boolean.class;
+    if (wrapperType == Byte.class)
+      return byte.class;
+    if (wrapperType == Short.class)
+      return short.class;
+    if (wrapperType == Character.class)
+      return char.class;
+    return null;
   }
 
   private FunctionExecutionException noMatchingOverloadException(final List<Method> candidates, final Object[] args) {

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -45,6 +45,16 @@ import java.util.Set;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class JavaMethodFunctionDefinition implements FunctionDefinition {
+  // JLS 5.1.2 widening primitive conversions that method.invoke() itself accepts (after unboxing the argument):
+  // e.g. an Integer argument is a valid call-site match for a `long` parameter.
+  private static final Map<Class<?>, Set<Class<?>>> WIDENING_CONVERSIONS = Map.of(//
+      byte.class, Set.of(short.class, int.class, long.class, float.class, double.class), //
+      short.class, Set.of(int.class, long.class, float.class, double.class), //
+      char.class, Set.of(int.class, long.class, float.class, double.class), //
+      int.class, Set.of(long.class, float.class, double.class), //
+      long.class, Set.of(float.class, double.class), //
+      float.class, Set.of(double.class));
+
   private final List<Method> methods;
   private final Object       instance;
 
@@ -250,16 +260,6 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     }
     return true;
   }
-
-  // JLS 5.1.2 widening primitive conversions that method.invoke() itself accepts (after unboxing the argument):
-  // e.g. an Integer argument is a valid call-site match for a `long` parameter.
-  private static final Map<Class<?>, Set<Class<?>>> WIDENING_CONVERSIONS = Map.of(//
-      byte.class, Set.of(short.class, int.class, long.class, float.class, double.class), //
-      short.class, Set.of(int.class, long.class, float.class, double.class), //
-      char.class, Set.of(int.class, long.class, float.class, double.class), //
-      int.class, Set.of(long.class, float.class, double.class), //
-      long.class, Set.of(float.class, double.class), //
-      float.class, Set.of(double.class));
 
   private static boolean typeMatches(final Class<?> paramType, final Object arg) {
     if (arg == null)

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -318,11 +318,4 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     }
     return argTypes.toString();
   }
-
-  /**
-   * Returns the current java object instance to use for method calling. If the instance is null, then the method is static.
-   */
-  public Object getInstance() {
-    return instance;
-  }
 }

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -124,10 +124,12 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
       // Fast path for the overwhelmingly common non-overloaded case: skips the List allocation
       // candidatesByParameterCount()/disambiguateByArgumentType() would otherwise do on every single call.
       final Method only = methods.get(0);
-      final int minReceived = only.isVarArgs() ? only.getParameterCount() - 1 : only.getParameterCount();
-      if (only.isVarArgs() ? received < minReceived : received != minReceived)
+      final boolean varArgs = only.isVarArgs();
+      final int minReceived = varArgs ? only.getParameterCount() - 1 : only.getParameterCount();
+      if (varArgs ? received < minReceived : received != minReceived)
         throw new FunctionExecutionException(
-            "Error on executing function '" + only + "': expected " + only.getParameterCount() + " parameter(s) but received " + received);
+            "Error on executing function '" + only + "': expected " + (varArgs ? "at least " + minReceived : minReceived)
+                + " parameter(s) but received " + received);
       return invoke(only, args);
     }
 

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -23,18 +23,24 @@ import com.arcadedb.function.FunctionExecutionException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Maps a Java method execution to a callable function.
+ * Maps one or more overloaded Java methods sharing the same name to a callable function. When more than one public
+ * method of a class shares a name (Java method overloading), all the overloads are bound here and the one matching
+ * the number of arguments (and, if that is not enough to disambiguate, their runtime type) actually passed is
+ * selected on every {@link #execute(Object...)} call, instead of registering only one of them depending on the
+ * JVM's unspecified {@link Class#getDeclaredMethods()} order.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class JavaMethodFunctionDefinition implements FunctionDefinition {
-  private final Method method;
-  private final Object instance;
+  private final List<Method> methods;
+  private final Object       instance;
 
   /**
-   * Creates a function bound to a Java method.
+   * Creates a function bound to a single Java method.
    *
    * @param instance Java object against where to invoke the method
    * @param method   Java Method object to invoke
@@ -47,7 +53,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
   public JavaMethodFunctionDefinition(final Object instance, final Method method)
       throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
     this.instance = Modifier.isStatic(method.getModifiers()) ? null : instance != null ? instance : method.getDeclaringClass().getConstructor().newInstance();
-    this.method = method;
+    this.methods = List.of(method);
   }
 
   /**
@@ -65,20 +71,48 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     this(null, method);
   }
 
+  /**
+   * Creates a function bound to a group of overloaded Java methods that share the same name. All the methods must
+   * belong to the same declaring class; {@code instance} is used for the ones that are not static and is ignored
+   * (may be {@code null}) if every overload is static.
+   *
+   * @param instance Java object against where to invoke the non-static overloads, or {@code null} if all of them are static
+   * @param methods  the overloads, all sharing the same method name
+   */
+  public JavaMethodFunctionDefinition(final Object instance, final List<Method> methods) {
+    if (methods.isEmpty())
+      throw new IllegalArgumentException("At least one method is required");
+    this.instance = instance;
+    this.methods = List.copyOf(methods);
+  }
+
   @Override
   public String getName() {
-    return method.getDeclaringClass() + "::" + method.getName();
+    final Method first = methods.get(0);
+    return first.getDeclaringClass() + "::" + first.getName();
   }
 
   @Override
   public Object execute(final Object... parameters) {
-    final int received = parameters != null ? parameters.length : 0;
-    if (!method.isVarArgs() && received != method.getParameterCount())
+    final Object[] args = parameters != null ? parameters : new Object[0];
+    final int received = args.length;
+
+    final List<Method> candidates = candidatesByParameterCount(received);
+
+    if (candidates.isEmpty()) {
+      if (methods.size() == 1) {
+        final Method only = methods.get(0);
+        throw new FunctionExecutionException(
+            "Error on executing function '" + only + "': expected " + only.getParameterCount() + " parameter(s) but received " + received);
+      }
       throw new FunctionExecutionException(
-          "Error on executing function '" + method + "': expected " + method.getParameterCount() + " parameter(s) but received " + received);
+          "Error on executing function '" + getName() + "': none of the " + methods.size() + " overloads accepts " + received + " parameter(s)");
+    }
+
+    final Method method = candidates.size() == 1 ? candidates.get(0) : disambiguateByArgumentType(candidates, args);
 
     try {
-      return method.invoke(instance, parameters);
+      return method.invoke(instance, args);
     } catch (final InvocationTargetException e) {
       // PRESERVE THE ORIGINAL EXCEPTION THROWN BY THE TARGET METHOD INSTEAD OF THE REFLECTION WRAPPER
       final Throwable cause = e.getCause() != null ? e.getCause() : e;
@@ -86,6 +120,82 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     } catch (final IllegalAccessException | IllegalArgumentException e) {
       throw new FunctionExecutionException("Error on executing function '" + method + "'", e);
     }
+  }
+
+  private List<Method> candidatesByParameterCount(final int received) {
+    final List<Method> exact = new ArrayList<>();
+    final List<Method> varargs = new ArrayList<>();
+    for (final Method m : methods) {
+      if (m.isVarArgs()) {
+        if (received >= m.getParameterCount() - 1)
+          varargs.add(m);
+      } else if (m.getParameterCount() == received)
+        exact.add(m);
+    }
+    return !exact.isEmpty() ? exact : varargs;
+  }
+
+  private Method disambiguateByArgumentType(final List<Method> candidates, final Object[] args) {
+    Method match = null;
+    for (final Method m : candidates) {
+      if (!m.isVarArgs() && acceptsArgumentTypes(m, args)) {
+        if (match != null)
+          throw ambiguousOverloadException(candidates, args);
+        match = m;
+      }
+    }
+    if (match == null)
+      throw ambiguousOverloadException(candidates, args);
+    return match;
+  }
+
+  private static boolean acceptsArgumentTypes(final Method method, final Object[] args) {
+    final Class<?>[] paramTypes = method.getParameterTypes();
+    for (int i = 0; i < paramTypes.length; i++) {
+      final Object arg = args[i];
+      if (arg == null) {
+        if (paramTypes[i].isPrimitive())
+          return false;
+        continue;
+      }
+      if (!wrap(paramTypes[i]).isInstance(arg))
+        return false;
+    }
+    return true;
+  }
+
+  private static Class<?> wrap(final Class<?> type) {
+    if (!type.isPrimitive())
+      return type;
+    if (type == int.class)
+      return Integer.class;
+    if (type == long.class)
+      return Long.class;
+    if (type == double.class)
+      return Double.class;
+    if (type == float.class)
+      return Float.class;
+    if (type == boolean.class)
+      return Boolean.class;
+    if (type == byte.class)
+      return Byte.class;
+    if (type == short.class)
+      return Short.class;
+    if (type == char.class)
+      return Character.class;
+    return type;
+  }
+
+  private FunctionExecutionException ambiguousOverloadException(final List<Method> candidates, final Object[] args) {
+    final StringBuilder argTypes = new StringBuilder();
+    for (int i = 0; i < args.length; i++) {
+      if (i > 0)
+        argTypes.append(", ");
+      argTypes.append(args[i] != null ? args[i].getClass().getName() : "null");
+    }
+    return new FunctionExecutionException(
+        "Error on executing function '" + getName() + "': cannot resolve which overload to call among " + candidates
+            + " for argument type(s) [" + argTypes + "]");
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/polyglot/JavascriptFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/polyglot/JavascriptFunctionDefinition.java
@@ -74,7 +74,8 @@ public class JavascriptFunctionDefinition implements PolyglotFunctionDefinition 
         declaration.append(" }");
         return polyglotEngine.eval(declaration.toString());
       } catch (final Exception e) {
-        throw new FunctionExecutionException("Error on definition of function '" + functionName + "': " + e.getMessage(), e);
+        final String detail = e.getMessage() != null ? e.getMessage() : e.toString();
+        throw new FunctionExecutionException("Error on definition of function '" + functionName + "': " + detail, e);
       }
     });
   }

--- a/engine/src/main/java/com/arcadedb/function/polyglot/JavascriptFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/polyglot/JavascriptFunctionDefinition.java
@@ -74,7 +74,7 @@ public class JavascriptFunctionDefinition implements PolyglotFunctionDefinition 
         declaration.append(" }");
         return polyglotEngine.eval(declaration.toString());
       } catch (final Exception e) {
-        throw new FunctionExecutionException("Error on definition of function '" + functionName + "'");
+        throw new FunctionExecutionException("Error on definition of function '" + functionName + "': " + e.getMessage(), e);
       }
     });
   }

--- a/engine/src/main/java/com/arcadedb/function/polyglot/PolyglotFunctionLibraryDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/polyglot/PolyglotFunctionLibraryDefinition.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public abstract class PolyglotFunctionLibraryDefinition<T extends PolyglotFunctionDefinition> implements FunctionLibraryDefinition<T> {
   protected final Database                 database;
@@ -35,6 +36,11 @@ public abstract class PolyglotFunctionLibraryDefinition<T extends PolyglotFuncti
   protected final String                   language;
   protected final List<String>             allowedPackages;
   protected final ConcurrentMap<String, T> functions = new ConcurrentHashMap<>();
+  // Dedicated, never-reassigned lock so the monitor identity stays stable across an engine swap in reloadEngine():
+  // callers of execute() take the read lock, reloadEngine() takes the write lock around the close+rebuild, so an
+  // in-flight call either finishes against the old engine before the swap or waits for the new one instead of
+  // having its engine closed underneath it (issue #7006).
+  private final    ReentrantReadWriteLock  engineLock = new ReentrantReadWriteLock();
   protected       GraalPolyglotEngine      polyglotEngine;
 
   public interface Callback {
@@ -77,12 +83,17 @@ public abstract class PolyglotFunctionLibraryDefinition<T extends PolyglotFuncti
    * method throw, leaving the caller to decide how to recover.
    */
   private void reloadEngine() {
-    // REGISTER ALL THE FUNCTIONS UNDER THE NEW ENGINE INSTANCE
-    this.polyglotEngine.close();
-    this.polyglotEngine = GraalPolyglotEngine.newBuilder(database, PolyglotEngineManager.getInstance().getSharedEngine())
-        .setLanguage(language).setAllowedPackages(allowedPackages).build();
-    for (final T f : functions.values())
-      f.init(this);
+    engineLock.writeLock().lock();
+    try {
+      // REGISTER ALL THE FUNCTIONS UNDER THE NEW ENGINE INSTANCE
+      this.polyglotEngine.close();
+      this.polyglotEngine = GraalPolyglotEngine.newBuilder(database, PolyglotEngineManager.getInstance().getSharedEngine())
+          .setLanguage(language).setAllowedPackages(allowedPackages).build();
+      for (final T f : functions.values())
+        f.init(this);
+    } finally {
+      engineLock.writeLock().unlock();
+    }
   }
 
   @Override
@@ -136,8 +147,11 @@ public abstract class PolyglotFunctionLibraryDefinition<T extends PolyglotFuncti
   }
 
   public Object execute(final Callback callback) {
-    synchronized (polyglotEngine) {
+    engineLock.readLock().lock();
+    try {
       return callback.execute(polyglotEngine);
+    } finally {
+      engineLock.readLock().unlock();
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/polyglot/PolyglotFunctionLibraryDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/polyglot/PolyglotFunctionLibraryDefinition.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public abstract class PolyglotFunctionLibraryDefinition<T extends PolyglotFunctionDefinition> implements FunctionLibraryDefinition<T> {
   protected final Database                 database;
@@ -36,11 +35,17 @@ public abstract class PolyglotFunctionLibraryDefinition<T extends PolyglotFuncti
   protected final String                   language;
   protected final List<String>             allowedPackages;
   protected final ConcurrentMap<String, T> functions = new ConcurrentHashMap<>();
-  // Dedicated, never-reassigned lock so the monitor identity stays stable across an engine swap in reloadEngine():
-  // callers of execute() take the read lock, reloadEngine() takes the write lock around the close+rebuild, so an
-  // in-flight call either finishes against the old engine before the swap or waits for the new one instead of
-  // having its engine closed underneath it (issue #7006).
-  private final    ReentrantReadWriteLock  engineLock = new ReentrantReadWriteLock();
+  /**
+   * Dedicated, never-reassigned lock so the monitor identity stays stable across an engine swap in reloadEngine():
+   * {@code synchronized} on the {@code polyglotEngine} field itself let a thread inside {@link #execute(Callback)}
+   * and a concurrent {@code reloadEngine()} lock two different monitors over what is meant to be a serialized
+   * engine, so a redefinition could close the engine underneath an in-flight call (issue #7006). A plain mutex -
+   * rather than a read-write lock - keeps every caller of {@link #execute(Callback)} serialized against every other
+   * caller too: the shared GraalVM {@code Context} does not support concurrent invocation without explicit
+   * multi-threaded access configuration, which is exactly the problem {@code PolyglotQueryEngine} already solved
+   * the same way for issue #6759.
+   */
+  private final    Object                  engineLock = new Object();
   protected       GraalPolyglotEngine      polyglotEngine;
 
   public interface Callback {
@@ -83,16 +88,13 @@ public abstract class PolyglotFunctionLibraryDefinition<T extends PolyglotFuncti
    * method throw, leaving the caller to decide how to recover.
    */
   private void reloadEngine() {
-    engineLock.writeLock().lock();
-    try {
+    synchronized (engineLock) {
       // REGISTER ALL THE FUNCTIONS UNDER THE NEW ENGINE INSTANCE
       this.polyglotEngine.close();
       this.polyglotEngine = GraalPolyglotEngine.newBuilder(database, PolyglotEngineManager.getInstance().getSharedEngine())
           .setLanguage(language).setAllowedPackages(allowedPackages).build();
       for (final T f : functions.values())
         f.init(this);
-    } finally {
-      engineLock.writeLock().unlock();
     }
   }
 
@@ -147,11 +149,8 @@ public abstract class PolyglotFunctionLibraryDefinition<T extends PolyglotFuncti
   }
 
   public Object execute(final Callback callback) {
-    engineLock.readLock().lock();
-    try {
+    synchronized (engineLock) {
       return callback.execute(polyglotEngine);
-    } finally {
-      engineLock.readLock().unlock();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/cypher/CustomFunctionAdapterTest.java
+++ b/engine/src/test/java/com/arcadedb/function/cypher/CustomFunctionAdapterTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.cypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.function.FunctionDefinition;
+import com.arcadedb.function.FunctionLibraryDefinition;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #7005: {@link CustomFunctionAdapter#execute(Object[], CommandContext)} wrapped the
+ * exact-match function <b>call</b> inside the {@code try} meant to guard only the lookup, so a function body
+ * throwing {@link IllegalArgumentException} was misread as "function not found" and the case-insensitive fallback
+ * ran (and executed) the same function a second time.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CustomFunctionAdapterTest extends TestHelper {
+
+  private static final String LIBRARY_NAME  = "adapterTest";
+  private static final String FUNCTION_NAME = "throwing";
+
+  /**
+   * A function whose body always throws {@link IllegalArgumentException}, counting how many times it was invoked.
+   */
+  private static class ThrowingFunction implements FunctionDefinition {
+    final AtomicInteger invocations = new AtomicInteger();
+
+    @Override
+    public String getName() {
+      return FUNCTION_NAME;
+    }
+
+    @Override
+    public Object execute(final Object... parameters) {
+      invocations.incrementAndGet();
+      throw new IllegalArgumentException("invalid argument from function body");
+    }
+  }
+
+  private static class SingleFunctionLibrary implements FunctionLibraryDefinition<FunctionDefinition> {
+    final FunctionDefinition function;
+
+    SingleFunctionLibrary(final FunctionDefinition function) {
+      this.function = function;
+    }
+
+    @Override
+    public String getName() {
+      return LIBRARY_NAME;
+    }
+
+    @Override
+    public Iterable<FunctionDefinition> getFunctions() {
+      return Collections.singletonList(function);
+    }
+
+    @Override
+    public FunctionDefinition getFunction(final String functionName) throws IllegalArgumentException {
+      if (!function.getName().equals(functionName))
+        throw new IllegalArgumentException("Function '" + functionName + "' not defined");
+      return function;
+    }
+
+    @Override
+    public boolean hasFunction(final String functionName) {
+      return function.getName().equals(functionName);
+    }
+
+    @Override
+    public FunctionLibraryDefinition<FunctionDefinition> registerFunction(final FunctionDefinition registerFunction) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionLibraryDefinition<FunctionDefinition> unregisterFunction(final String functionName) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @Test
+  void bodyThrowingIllegalArgumentExceptionIsNotSwallowedNorRetried() {
+    final ThrowingFunction function = new ThrowingFunction();
+    database.getSchema().registerFunctionLibrary(new SingleFunctionLibrary(function));
+    try {
+      final CustomFunctionAdapter adapter = new CustomFunctionAdapter(LIBRARY_NAME, FUNCTION_NAME);
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+
+      assertThatThrownBy(() -> adapter.execute(new Object[0], context))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("invalid argument from function body");
+
+      // The exact-match lookup must not fall through to the case-insensitive search and execute the function again.
+      assertThat(function.invocations.get()).isEqualTo(1);
+    } finally {
+      database.getSchema().unregisterFunctionLibrary(LIBRARY_NAME);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -59,6 +59,22 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public static class VarargsOverloaded {
+    public static String join(final String sep, final String... parts) {
+      return "strs:" + String.join(sep, parts);
+    }
+
+    public static String join(final String sep, final Integer... parts) {
+      final StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < parts.length; i++) {
+        if (i > 0)
+          sb.append(sep);
+        sb.append(parts[i]);
+      }
+      return "ints:" + sb;
+    }
+  }
+
   @Test
   void registration()
     throws Exception {
@@ -197,6 +213,23 @@ class JavaFunctionTest extends TestHelper {
       assertThatThrownBy(() -> function.execute("a", "b", "c")).isInstanceOf(FunctionExecutionException.class);
     } finally {
       database.getSchema().unregisterFunctionLibrary("fmt");
+    }
+  }
+
+  @Test
+  void overloadedVarargsMethodsAreDispatchedByArgumentType()
+    throws Exception {
+    // Regression for a gap the overload-dispatch fix (issue #7007) left open: when candidatesByParameterCount()
+    // returns only varargs candidates, disambiguateByArgumentType() must still be able to pick among them by the
+    // type of the trailing (vararg) arguments instead of unconditionally rejecting the call as ambiguous.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("vjoin", JavaFunctionTest.VarargsOverloaded.class));
+    try {
+      final var function = database.getSchema().getFunction("vjoin", "join");
+
+      assertThat(function.execute("-", "a", "b", "c")).isEqualTo("strs:a-b-c");
+      assertThat(function.execute("-", 1, 2, 3)).isEqualTo("ints:1-2-3");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("vjoin");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -69,6 +69,33 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public interface Formatter<T> {
+    String format(T value);
+  }
+
+  public static class StringFormatter implements Formatter<String> {
+    @Override
+    public String format(final String value) {
+      return "fmt:" + value;
+    }
+  }
+
+  public static class MixedFixedAndVarargs {
+    public static String format(final Integer a, final Integer b) {
+      return "ints:" + (a + b);
+    }
+
+    public static String format(final String sep, final String... parts) {
+      return "strs:" + String.join(sep, parts);
+    }
+  }
+
+  public static class SingleVarargs {
+    public static String join(final String sep, final String... parts) {
+      return String.join(sep, parts);
+    }
+  }
+
   public static class VarargsOverloaded {
     public static String join(final String sep, final String... parts) {
       return "strs:" + String.join(sep, parts);
@@ -257,6 +284,58 @@ class JavaFunctionTest extends TestHelper {
           .hasMessageContaining("cannot resolve which overload");
     } finally {
       database.getSchema().unregisterFunctionLibrary("amb");
+    }
+  }
+
+  @Test
+  void bridgeMethodsAreExcludedFromOverloadRegistration()
+    throws Exception {
+    // A generic interface override - Formatter<String>.format(String) implemented by StringFormatter - makes the
+    // compiler synthesize a public bridge method format(Object) on StringFormatter. Without excluding
+    // bridge/synthetic methods, that bridge would be grouped as a second "format" overload, and every call would be
+    // rejected as ambiguous between the real method and its own compiler-generated bridge.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("bridge", JavaFunctionTest.StringFormatter.class));
+    try {
+      final var function = database.getSchema().getFunction("bridge", "format");
+      assertThat(function.execute("x")).isEqualTo("fmt:x");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("bridge");
+    }
+  }
+
+  @Test
+  void fixedArityOverloadRejectedByTypeFallsBackToVarargsOverload()
+    throws Exception {
+    // Regression: candidatesByParameterCount() used to let an exact-arity, non-varargs match with the right
+    // parameter count win outright, even when its parameter types did not accept the arguments and a type-compatible
+    // varargs overload existed. format(Integer,Integer) and format(String,String...) both accept 2 arguments; a
+    // call with two Strings must fall back to the varargs overload instead of failing against the mismatched one.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("mixed", JavaFunctionTest.MixedFixedAndVarargs.class));
+    try {
+      final var function = database.getSchema().getFunction("mixed", "format");
+
+      assertThat(function.execute(3, 4)).isEqualTo("ints:7");
+      assertThat(function.execute("-", "a", "b")).isEqualTo("strs:a-b");
+      // Two arguments: matches format(Integer,Integer) by count but not by type, and format(String,String...) by
+      // both count and type (sep="x", one vararg element "y") - must fall back to the varargs overload.
+      assertThat(function.execute("x", "y")).isEqualTo("strs:y");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("mixed");
+    }
+  }
+
+  @Test
+  void singleNonOverloadedVarargsMethodIsInvokedCorrectly()
+    throws Exception {
+    // Pins the toInvokeArgs() vararg-packing fix independently of overload disambiguation: a single, non-overloaded
+    // varargs method takes the candidates.size() == 1 short-circuit path in execute(), which must still pack the
+    // flat, positionally-passed arguments into the array Method.invoke() requires.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("sjoin", JavaFunctionTest.SingleVarargs.class));
+    try {
+      final var function = database.getSchema().getFunction("sjoin", "join");
+      assertThat(function.execute("-", "a", "b", "c")).isEqualTo("a-b-c");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("sjoin");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -45,6 +45,20 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public static class Overloaded {
+    public static String format(final String s) {
+      return "one:" + s;
+    }
+
+    public static String format(final String s, final int repeat) {
+      return "two:" + s.repeat(repeat);
+    }
+
+    public static String format(final int n) {
+      return "int:" + n;
+    }
+  }
+
   @Test
   void registration()
     throws Exception {
@@ -154,6 +168,36 @@ class JavaFunctionTest extends TestHelper {
         .isInstanceOf(FunctionExecutionException.class)
         .hasRootCauseInstanceOf(IllegalStateException.class)
         .hasRootCauseMessage("boom from target method");
+  }
+
+  @Test
+  void overloadsAreAllKeptAndDispatchedByArgumentCountAndType()
+    throws Exception {
+    // issue #7007: overloaded public methods used to collapse to whichever one Class.getDeclaredMethods() happened
+    // to return last, non-deterministically. All overloads must survive registration and be dispatched by the
+    // actual arguments passed at call time.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("fmt", JavaFunctionTest.Overloaded.class));
+    try {
+      final var function = database.getSchema().getFunction("fmt", "format");
+
+      assertThat(function.execute("x")).isEqualTo("one:x");
+      assertThat(function.execute("ab", 3)).isEqualTo("two:ababab");
+      assertThat(function.execute(7)).isEqualTo("int:7");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("fmt");
+    }
+  }
+
+  @Test
+  void overloadWithNoMatchingParameterCountThrows()
+    throws Exception {
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("fmt", JavaFunctionTest.Overloaded.class));
+    try {
+      final var function = database.getSchema().getFunction("fmt", "format");
+      assertThatThrownBy(() -> function.execute("a", "b", "c")).isInstanceOf(FunctionExecutionException.class);
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("fmt");
+    }
   }
 
   private void registerClass() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -59,6 +59,16 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public static class AmbiguousOverloaded {
+    public static String describe(final Object o) {
+      return "object:" + o;
+    }
+
+    public static String describe(final String s) {
+      return "string:" + s;
+    }
+  }
+
   public static class VarargsOverloaded {
     public static String join(final String sep, final String... parts) {
       return "strs:" + String.join(sep, parts);
@@ -230,6 +240,40 @@ class JavaFunctionTest extends TestHelper {
       assertThat(function.execute("-", 1, 2, 3)).isEqualTo("ints:1-2-3");
     } finally {
       database.getSchema().unregisterFunctionLibrary("vjoin");
+    }
+  }
+
+  @Test
+  void genuinelyAmbiguousOverloadThrows()
+    throws Exception {
+    // Documents the deliberate, javadoc'd tradeoff: unlike the Java compiler, dispatch here does not rank
+    // overloads by specificity, so a String argument matching both describe(Object) and describe(String) is
+    // rejected rather than silently resolved to the more specific overload.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("amb", JavaFunctionTest.AmbiguousOverloaded.class));
+    try {
+      final var function = database.getSchema().getFunction("amb", "describe");
+      assertThatThrownBy(() -> function.execute("x"))
+          .isInstanceOf(FunctionExecutionException.class)
+          .hasMessageContaining("cannot resolve which overload");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("amb");
+    }
+  }
+
+  @Test
+  void prePackedVarargsArrayIsDispatchedAmongMultipleVarargsOverloads()
+    throws Exception {
+    // Regression for a narrower gap in the varargs-dispatch fix: when the vararg part is passed pre-packed as a
+    // single array (the shape Method.invoke() itself requires) rather than as flat elements, type matching against
+    // more than one varargs candidate must compare the array itself to the candidate's vararg array type instead of
+    // (incorrectly) treating the array object as one flat vararg element.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("vjoin2", JavaFunctionTest.VarargsOverloaded.class));
+    try {
+      final var function = database.getSchema().getFunction("vjoin2", "join");
+      assertThat(function.execute("-", new String[] { "a", "b" })).isEqualTo("strs:a-b");
+      assertThat(function.execute("-", new Integer[] { 1, 2 })).isEqualTo("ints:1-2");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("vjoin2");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -96,6 +96,16 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public static class NumericVarargsOverloaded {
+    public static String describe(final long... values) {
+      return "longs:" + values.length;
+    }
+
+    public static String describe(final String... values) {
+      return "strings:" + values.length;
+    }
+  }
+
   public static class VarargsOverloaded {
     public static String join(final String sep, final String... parts) {
       return "strs:" + String.join(sep, parts);
@@ -336,6 +346,21 @@ class JavaFunctionTest extends TestHelper {
       assertThat(function.execute("-", "a", "b", "c")).isEqualTo("a-b-c");
     } finally {
       database.getSchema().unregisterFunctionLibrary("sjoin");
+    }
+  }
+
+  @Test
+  void primitiveWideningIsAcceptedDuringOverloadSelection()
+    throws Exception {
+    // typeMatches() used to accept only the exact wrapper type for a primitive parameter, so an Integer argument
+    // was rejected for a `long` parameter even though Method.invoke() itself accepts the unboxing+widening
+    // conversion. A call that should widen into the numeric overload must not be swallowed by an unrelated one.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("wide", JavaFunctionTest.NumericVarargsOverloaded.class));
+    try {
+      final var function = database.getSchema().getFunction("wide", "describe");
+      assertThat(function.execute(1)).isEqualTo("longs:1");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("wide");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentCallSerializationTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentCallSerializationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.polyglot;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.function.FunctionDefinition;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test guarding the fix for #7006 against reintroducing concurrent access to the shared GraalVM
+ * {@code Context}. An earlier version of the fix replaced the old (broken) {@code synchronized(polyglotEngine)}
+ * with a {@link java.util.concurrent.locks.ReentrantReadWriteLock}, which correctly stopped {@code reloadEngine()}
+ * from closing the engine under an in-flight call, but let multiple callers hold the read lock and invoke
+ * {@code callback.execute(polyglotEngine)} concurrently - something GraalVM's JS context does not support without
+ * explicit multi-threaded access configuration (the same class of problem already fixed for
+ * {@code PolyglotQueryEngine} under issue #6759). The final fix uses a plain mutex instead, so every caller of
+ * {@link PolyglotFunctionLibraryDefinition#execute} stays fully serialized.
+ * <p>
+ * This test increments a JS-global counter with a non-atomic read-modify-write from many threads. If calls into
+ * the shared context were ever allowed to run concurrently, the lost-update race would make the final count come
+ * out lower than the number of calls with overwhelming probability; under full serialization it is always exact.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7006ConcurrentCallSerializationTest extends TestHelper {
+
+  @Test
+  void concurrentCallersOfTheSameFunctionAreSerialized() throws Exception {
+    database.command("sql", """
+        DEFINE FUNCTION issue7006.bump "globalThis.counter7006 = (globalThis.counter7006 || 0) + 1; return globalThis.counter7006;" LANGUAGE js;
+        """);
+    final FunctionDefinition function = database.getSchema().getFunction("issue7006", "bump");
+
+    final int threadCount     = 8;
+    final int callsPerThread  = 200;
+    final ExecutorService     pool  = Executors.newFixedThreadPool(threadCount);
+    final CountDownLatch      ready = new CountDownLatch(threadCount);
+    final CountDownLatch      go    = new CountDownLatch(1);
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    final AtomicInteger       completed = new AtomicInteger();
+
+    try {
+      for (int t = 0; t < threadCount; t++) {
+        pool.submit(() -> {
+          try {
+            ready.countDown();
+            go.await(10, TimeUnit.SECONDS);
+            for (int i = 0; i < callsPerThread; i++)
+              function.execute();
+            completed.incrementAndGet();
+          } catch (final Throwable e) {
+            error.set(e);
+          }
+        });
+      }
+
+      assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+      go.countDown();
+
+      pool.shutdown();
+      assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+
+      assertThat(error.get()).isNull();
+      assertThat(completed.get()).isEqualTo(threadCount);
+
+      final Number finalCount = (Number) function.execute();
+      assertThat(finalCount.intValue()).isEqualTo(threadCount * callsPerThread + 1);
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("issue7006");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentCallSerializationTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentCallSerializationTest.java
@@ -28,14 +28,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Regression test guarding the fix for #7006 against reintroducing concurrent access to the shared GraalVM
  * {@code Context}. An earlier version of the fix replaced the old (broken) {@code synchronized(polyglotEngine)}
- * with a {@link java.util.concurrent.locks.ReentrantReadWriteLock}, which correctly stopped {@code reloadEngine()}
- * from closing the engine under an in-flight call, but let multiple callers hold the read lock and invoke
+ * with a {@link ReentrantReadWriteLock}, which correctly stopped {@code reloadEngine()} from closing the engine
+ * under an in-flight call, but let multiple callers hold the read lock and invoke
  * {@code callback.execute(polyglotEngine)} concurrently - something GraalVM's JS context does not support without
  * explicit multi-threaded access configuration (the same class of problem already fixed for
  * {@code PolyglotQueryEngine} under issue #6759). The final fix uses a plain mutex instead, so every caller of

--- a/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentRedefinitionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentRedefinitionTest.java
@@ -82,6 +82,9 @@ class Issue7006ConcurrentRedefinitionTest extends TestHelper {
     // The redefinition is started while the caller is inside execute(), holding engineLock: reloadEngine() must
     // block on that same monitor until the call below releases it, rather than closing the engine underneath it.
     redefiner.start();
+    // Best-effort nudge to increase the odds the redefiner has actually reached (and blocked on) the lock before
+    // we release the call; not required for correctness (the assertions below hold either way), just makes the
+    // race window this test targets more likely to actually be exercised on a given run.
     Thread.sleep(200);
     releaseCall.countDown();
 

--- a/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentRedefinitionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentRedefinitionTest.java
@@ -33,9 +33,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@code registerFunction()}) reassigns without holding that same monitor. A call already in flight on the old
  * engine had it closed underneath it instead of either completing first or being serialized behind the swap.
  * <p>
- * The fix introduces a dedicated {@link java.util.concurrent.locks.ReentrantReadWriteLock}: {@code execute()} takes
- * the read lock and {@code reloadEngine()} takes the write lock around the close-and-rebuild, so a redefinition
- * always waits for in-flight calls to finish before closing their engine.
+ * The fix introduces a dedicated, never-reassigned {@code engineLock} monitor: {@code execute()} and
+ * {@code reloadEngine()} both synchronize on it (a plain mutex, not a read-write lock, since the shared GraalVM
+ * {@code Context} does not support concurrent callers either - see {@link Issue7006ConcurrentCallSerializationTest}),
+ * so a redefinition always waits for in-flight calls to finish before closing their engine.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentRedefinitionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentRedefinitionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.polyglot;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7006: {@code PolyglotFunctionLibraryDefinition.execute()} used to synchronize on the
+ * {@code polyglotEngine} field itself, whose value {@code reloadEngine()} (triggered by {@code DEFINE FUNCTION} /
+ * {@code registerFunction()}) reassigns without holding that same monitor. A call already in flight on the old
+ * engine had it closed underneath it instead of either completing first or being serialized behind the swap.
+ * <p>
+ * The fix introduces a dedicated {@link java.util.concurrent.locks.ReentrantReadWriteLock}: {@code execute()} takes
+ * the read lock and {@code reloadEngine()} takes the write lock around the close-and-rebuild, so a redefinition
+ * always waits for in-flight calls to finish before closing their engine.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7006ConcurrentRedefinitionTest extends TestHelper {
+
+  @Test
+  void redefinitionWaitsForInFlightCallInsteadOfClosingItsEngine() throws Exception {
+    final JavascriptFunctionLibraryDefinition library = new JavascriptFunctionLibraryDefinition(database, "issue7006");
+    database.getSchema()
+        .registerFunctionLibrary(library.registerFunction(new JavascriptFunctionDefinition("sum", "return a + b;", "a", "b")));
+
+    final CountDownLatch callStarted = new CountDownLatch(1);
+    final CountDownLatch releaseCall = new CountDownLatch(1);
+    final AtomicReference<Throwable> callError = new AtomicReference<>();
+    final AtomicReference<Object> callResult = new AtomicReference<>();
+
+    final Thread caller = new Thread(() -> {
+      try {
+        callResult.set(library.execute(polyglotEngine -> {
+          callStarted.countDown();
+          try {
+            assertThat(releaseCall.await(10, TimeUnit.SECONDS)).isTrue();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          try {
+            return polyglotEngine.eval("40 + 2").asInt();
+          } catch (final Exception e) {
+            throw new RuntimeException(e);
+          }
+        }));
+      } catch (final Throwable t) {
+        callError.set(t);
+      }
+    }, "issue7006-caller");
+
+    final Thread redefiner = new Thread(() -> library.registerFunction(new JavascriptFunctionDefinition("avg", "return (a + b) / 2;", "a", "b")),
+        "issue7006-redefiner");
+
+    caller.start();
+    assertThat(callStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+    // The redefinition is started while the caller is inside execute(), holding the read lock: reloadEngine() must
+    // block on the write lock until the call below releases it, rather than closing the engine underneath it.
+    redefiner.start();
+    Thread.sleep(200);
+    releaseCall.countDown();
+
+    caller.join(10_000);
+    redefiner.join(10_000);
+
+    assertThat(callError.get()).isNull();
+    assertThat(callResult.get()).isEqualTo(42);
+    assertThat(database.getSchema().getFunctionLibrary("issue7006").hasFunction("avg")).isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentRedefinitionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/Issue7006ConcurrentRedefinitionTest.java
@@ -79,8 +79,8 @@ class Issue7006ConcurrentRedefinitionTest extends TestHelper {
     caller.start();
     assertThat(callStarted.await(10, TimeUnit.SECONDS)).isTrue();
 
-    // The redefinition is started while the caller is inside execute(), holding the read lock: reloadEngine() must
-    // block on the write lock until the call below releases it, rather than closing the engine underneath it.
+    // The redefinition is started while the caller is inside execute(), holding engineLock: reloadEngine() must
+    // block on that same monitor until the call below releases it, rather than closing the engine underneath it.
     redefiner.start();
     Thread.sleep(200);
     releaseCall.countDown();

--- a/engine/src/test/java/com/arcadedb/function/polyglot/PolyglotFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/PolyglotFunctionTest.java
@@ -84,6 +84,20 @@ class PolyglotFunctionTest extends TestHelper {
   }
 
   @Test
+  void definitionSyntaxErrorPreservesCause() {
+    // issue #7006 (part 2 of the batch, filed under #7007): a JS syntax error in DEFINE FUNCTION used to be
+    // reported as a bare "Error on definition of function 'x'" with no line, column or message from the
+    // underlying polyglot parser. The fix chains the polyglot exception as the cause and folds its message in.
+    assertThatThrownBy(() -> database.getSchema().registerFunctionLibrary(//
+        new JavascriptFunctionLibraryDefinition(database, "badJs")//
+            // missing closing brace: guaranteed JS parse error, not a runtime one
+            .registerFunction(new JavascriptFunctionDefinition("broken", "if (a > b) { return a;", "a", "b"))))
+        .isInstanceOf(FunctionExecutionException.class)
+        .hasMessageContaining("broken")
+        .hasCauseInstanceOf(Exception.class);
+  }
+
+  @Test
   void jsonObjectAsInput() {
     database.command("sql", """
         DEFINE FUNCTION Test.objectComparison "return a.foo == 'bar'" PARAMETERS [a] LANGUAGE js;

--- a/engine/src/test/java/com/arcadedb/function/polyglot/PolyglotFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/PolyglotFunctionTest.java
@@ -94,6 +94,10 @@ class PolyglotFunctionTest extends TestHelper {
             .registerFunction(new JavascriptFunctionDefinition("broken", "if (a > b) { return a;", "a", "b"))))
         .isInstanceOf(FunctionExecutionException.class)
         .hasMessageContaining("broken")
+        // Assert the forwarded parser diagnostic itself, not just the wrapper text naming the function - the
+        // message would still contain "broken" even if e.getMessage() were dropped from JavascriptFunctionDefinition.
+        .hasMessageContaining("SyntaxError")
+        .hasMessageContaining("Expected")
         .hasCauseInstanceOf(Exception.class);
   }
 


### PR DESCRIPTION
## Summary
Fixes three related bugs in the function library / custom function call path:

- **#7005** - `CustomFunctionAdapter.execute()` wrapped the function *call* inside the `try` meant to guard only the *lookup*. A function body throwing `IllegalArgumentException` was misread as "not found", fell through to the case-insensitive search, and was executed a second time (duplicate side effects, or a masked first failure). Fixed by narrowing the `try` to the lookup only.
- **#7006** - `PolyglotFunctionLibraryDefinition` synchronized on the `polyglotEngine` field itself, which `DEFINE FUNCTION`'s `reloadEngine()` reassigns without holding that monitor. A call in flight on the old engine could have it closed underneath it during a concurrent redefinition. Fixed with a dedicated, never-reassigned mutex (`engineLock`): `execute()` and `reloadEngine()` both synchronize on it, so a redefinition always waits for in-flight calls to finish before closing their engine. (An intermediate version of this fix used a `ReentrantReadWriteLock`, but that would have let multiple callers invoke the shared GraalVM `Context` concurrently, which GraalVM does not support without explicit multi-threaded configuration - the same class of problem already fixed for `PolyglotQueryEngine` under issue #6759. Reverted to a plain mutex so every caller stays fully serialized.)
- **#7007** (two issues in one report):
  - Java functions were keyed by bare method name, so registering a class with overloaded public methods kept only whichever overload `Class.getDeclaredMethods()` happened to return last - an order the JDK does not guarantee. Fixed by binding every overload under the shared name and dispatching to the correct one at call time by argument count and, when that alone doesn't disambiguate, by runtime argument type (going a step further than the two options the issue proposed, which were "pick one and reject the rest" or "reject the ambiguity outright"). This also required: packing flat positional arguments into the array `Method.invoke()` requires for a varargs call (a latent bug independent of overloading - any real varargs Java function would previously fail to invoke at all); preferring a type-matching fixed-arity overload over a varargs one before falling back to varargs (mirroring `javac`'s own resolution phases); and excluding compiler-generated bridge/synthetic methods (a generic or covariant-return override otherwise registers as a spurious second overload of itself).
  - A JS syntax error in `DEFINE FUNCTION` reported only `Error on definition of function 'x'` with no detail. Fixed by chaining the polyglot exception as the cause and folding its message in.

**Behavior note:** overload dispatch here does not rank by specificity the way `javac` does - if more than one overload's parameter types accept the arguments (e.g. `foo(Object)` and `foo(String)` both called with a `String`), the call is rejected as ambiguous rather than silently picking the more specific match. This is a deliberate, documented scope cut (see the `JavaMethodFunctionDefinition` Javadoc and `genuinelyAmbiguousOverloadThrows`), but is a behavior change from the old bug's "silently pick one overload" for any existing user-registered Java function library that happens to rely on that shape of overloading.

## Test plan
- [x] New regression tests across all three fixes and their follow-ups: `CustomFunctionAdapterTest`, `Issue7006ConcurrentRedefinitionTest`, `Issue7006ConcurrentCallSerializationTest` (proves concurrent callers stay serialized via a non-atomic counter race probe), overload-dispatch/varargs/bridge-method tests in `JavaFunctionTest`, cause-preservation test in `PolyglotFunctionTest`
- [x] `mvn -o -pl engine -am test -Dtest="com.arcadedb.function.**"` - 1231 tests, 0 failures
- [x] `mvn -o -pl engine -am test` on the specific affected suites (`JavaFunctionTest`, `PolyglotFunctionTest`, `Issue7006ConcurrentRedefinitionTest`, `Issue7006ConcurrentCallSerializationTest`, `CustomFunctionAdapterTest`, `OpenCypherCustomFunctionTest`, `SQLDefinedJavascriptFunctionTest`, `SQLDefinedFunctionPersistenceTest`, `TriggerSQLTest`) - all green
- [x] `postgresw` module (consumer of `JavaClassFunctionLibraryDefinition`) test-compiles cleanly against the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Java function overload resolution for fixed-arity, varargs, primitive, wrapper, null, and pre-packed array arguments.
  * Enhanced JavaScript function-definition errors with clearer messages and preserved underlying causes.

* **Bug Fixes**
  * Fixed custom function execution and exception propagation, including case-insensitive function lookup.
  * Improved reliability during concurrent JavaScript execution and function redefinition.
  * Prevented ambiguous or unsupported overload calls from executing incorrectly.
  * Improved consistency when discovering overloaded Java functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
