### PR TITLE
fix(#6981): shutdown-hook WARNING and setting description no longer point at shutdownTimeout on the STARTING path that ignores it

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1315,8 +1315,9 @@ public enum GlobalConfiguration {
   SERVER_SHUTDOWN_TIMEOUT("arcadedb.server.shutdownTimeout", SCOPE.SERVER,
       """
       Milliseconds the JVM shutdown hook waits for the server lifecycle lock before giving up and letting \
-      the JVM exit WITHOUT a graceful stop. It only matters when another thread is inside stop() when the \
-      shutdown signal arrives: normally the hook takes the lock immediately and this value is never \
+      the JVM exit WITHOUT a graceful stop. It only matters when another thread holds the lifecycle lock \
+      when the shutdown signal arrives - a stop() in progress, or the tail of start() after the status has \
+      already turned ONLINE: normally the hook takes the lock immediately and this value is never \
       reached, and while the server is still STARTING the hook uses a fixed 2000ms bound instead, which \
       this setting does not govern. Giving up leaves databases as a kill would - the next open replays the \
       WAL - which is the lesser evil, because a hook that waits forever can make the process unkillable \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1315,11 +1315,12 @@ public enum GlobalConfiguration {
   SERVER_SHUTDOWN_TIMEOUT("arcadedb.server.shutdownTimeout", SCOPE.SERVER,
       """
       Milliseconds the JVM shutdown hook waits for the server lifecycle lock before giving up and letting \
-      the JVM exit WITHOUT a graceful stop. It only matters when another thread is inside start()/stop() \
-      when the shutdown signal arrives: normally the hook takes the lock immediately and this value is \
-      never reached. Giving up leaves databases as a kill would - the next open replays the WAL - which is \
-      the lesser evil, because a hook that waits forever can make the process unkillable (issue #5418). \
-      Raise it if a legitimate shutdown of very large databases needs longer than the default.""",
+      the JVM exit WITHOUT a graceful stop. It only matters when another thread is inside stop() when the \
+      shutdown signal arrives: normally the hook takes the lock immediately and this value is never \
+      reached, and while the server is still STARTING the hook uses a fixed 2000ms bound instead, which \
+      this setting does not govern. Giving up leaves databases as a kill would - the next open replays the \
+      WAL - which is the lesser evil, because a hook that waits forever can make the process unkillable \
+      (issue #5418). Raise it if a legitimate shutdown of very large databases needs longer than the default.""",
       Long.class, 60_000L),
 
   // Metrics

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -542,12 +542,16 @@ public class ArcadeDBServer {
    * exactly as after a kill. That is strictly better than a process that cannot be stopped.
    */
   private void stopFromShutdownHook() {
-    final long timeout = status == STATUS.STARTING
+    // Snapshot the status once: start() can flip it STARTING -> ONLINE while still holding the
+    // lifecycle lock, so re-reading it after the bounded wait could describe a bound that was not
+    // the one actually applied. The warning must be built from the same snapshot that chose the bound.
+    final STATUS observedStatus = status;
+    final long timeout = observedStatus == STATUS.STARTING
         ? SHUTDOWN_HOOK_STARTING_TIMEOUT_MS
         : configuration.getValueAsLong(GlobalConfiguration.SERVER_SHUTDOWN_TIMEOUT);
 
     if (!awaitLifecycleLock(lifecycleLock, timeout)) {
-      LogManager.instance().log(this, Level.WARNING, shutdownHookLockTimeoutWarning(timeout, status));
+      LogManager.instance().log(this, Level.WARNING, shutdownHookLockTimeoutWarning(timeout, observedStatus));
       return;
     }
 

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -547,14 +547,7 @@ public class ArcadeDBServer {
         : configuration.getValueAsLong(GlobalConfiguration.SERVER_SHUTDOWN_TIMEOUT);
 
     if (!awaitLifecycleLock(lifecycleLock, timeout)) {
-      LogManager.instance().log(this, Level.WARNING,
-          """
-          Could not acquire the server lifecycle lock within %dms while status is %s, so the shutdown hook is \
-          returning WITHOUT a graceful stop and the JVM will exit. Another thread is inside start()/stop() and \
-          did not release it - typically a startup failure that called System.exit() from inside start() (e.g. a \
-          port already in use). Open databases were not closed cleanly; the next open replays the WAL. Raise \
-          arcadedb.server.shutdownTimeout if a legitimate shutdown needs longer.""",
-          timeout, status);
+      LogManager.instance().log(this, Level.WARNING, shutdownHookLockTimeoutWarning(timeout, status));
       return;
     }
 
@@ -563,6 +556,27 @@ public class ArcadeDBServer {
     } finally {
       lifecycleLock.unlock();
     }
+  }
+
+  /**
+   * Builds the WARNING for a shutdown hook that could not acquire the lifecycle lock. The advice depends
+   * on which bound was in effect: while {@code STARTING} the wait is the fixed
+   * {@link #SHUTDOWN_HOOK_STARTING_TIMEOUT_MS}, so pointing the operator at
+   * {@code arcadedb.server.shutdownTimeout} would name the one setting that provably had no effect on
+   * that branch (issue #6981). Extracted so the message can be tested without driving a real JVM shutdown.
+   */
+  // @VisibleForTesting
+  static String shutdownHookLockTimeoutWarning(final long timeout, final STATUS status) {
+    final String hint = status == STATUS.STARTING ?
+        "This wait during STARTING is a fixed " + SHUTDOWN_HOOK_STARTING_TIMEOUT_MS
+            + "ms bound not governed by arcadedb.server.shutdownTimeout." :
+        "Raise arcadedb.server.shutdownTimeout if a legitimate shutdown needs longer.";
+    return """
+        Could not acquire the server lifecycle lock within %dms while status is %s, so the shutdown hook is \
+        returning WITHOUT a graceful stop and the JVM will exit. Another thread is inside start()/stop() and \
+        did not release it - typically a startup failure that called System.exit() from inside start() (e.g. a \
+        port already in use). Open databases were not closed cleanly; the next open replays the WAL. %s""".formatted(
+        timeout, status, hint);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -534,8 +534,9 @@ public class ArcadeDBServer {
    *   <li>{@code STARTING}: the server never came up, so there is nothing worth flushing and the holder
    *       is very likely the thread that triggered this shutdown. Wait only briefly, for the benign race
    *       where a concurrent start is about to finish.</li>
-   *   <li>anything else: a legitimate concurrent {@code stop()} may be flushing databases, and cutting
-   *       that short would cost a WAL recovery on the next open. Wait up to
+   *   <li>anything else: a legitimate concurrent {@code stop()} may be flushing databases - and so may the
+   *       tail of a {@code start()} that already flipped the status to {@code ONLINE} but has not released
+   *       the mutex yet - and cutting that short would cost a WAL recovery on the next open. Wait up to
    *       {@code arcadedb.server.shutdownTimeout}.</li>
    * </ul>
    * If the mutex never arrives, the databases are left as they are: the next open replays the WAL,

--- a/server/src/test/java/com/arcadedb/server/Issue6981ShutdownHookHintTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue6981ShutdownHookHintTest.java
@@ -67,5 +67,8 @@ class Issue6981ShutdownHookHintTest {
         .as("the setting does not bound the shutdown-hook wait during start(), so its description must not say so")
         .doesNotContain("start()/stop()");
     assertThat(description).contains("this setting does not govern");
+    assertThat(description)
+        .as("the configured bound DOES apply once the status left STARTING, even before start() releases the lock")
+        .contains("the tail of start() after the status has already turned ONLINE");
   }
 }

--- a/server/src/test/java/com/arcadedb/server/Issue6981ShutdownHookHintTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue6981ShutdownHookHintTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6981: the shutdown-hook WARNING (and the setting description) pointed the
+ * operator at {@code arcadedb.server.shutdownTimeout} on the one path that ignores it.
+ * <p>
+ * While the server is {@code STARTING} the hook waits a fixed 2000ms, not the configured timeout; an
+ * operator who followed the "raise arcadedb.server.shutdownTimeout" advice on that branch changed a value
+ * that provably had no effect. The hint must name the setting only on the branch it governs.
+ */
+class Issue6981ShutdownHookHintTest {
+
+  @Test
+  void startingWarningMustNotAdviseRaisingTheSettingItIgnores() {
+    final String message = ArcadeDBServer.shutdownHookLockTimeoutWarning(2_000, ArcadeDBServer.STATUS.STARTING);
+
+    assertThat(message).contains("2000ms").contains("STARTING");
+    assertThat(message)
+        .as("on the STARTING branch the configured timeout is not in effect, so 'raise it' advice is misleading")
+        .doesNotContain("Raise arcadedb.server.shutdownTimeout");
+    assertThat(message)
+        .as("the operator should learn the wait is a fixed bound the setting does not govern")
+        .contains("not governed by arcadedb.server.shutdownTimeout");
+  }
+
+  @Test
+  void warningOutsideStartingKeepsTheRaiseHint() {
+    for (final ArcadeDBServer.STATUS status : new ArcadeDBServer.STATUS[] { ArcadeDBServer.STATUS.OFFLINE,
+        ArcadeDBServer.STATUS.ONLINE, ArcadeDBServer.STATUS.SHUTTING_DOWN }) {
+      final String message = ArcadeDBServer.shutdownHookLockTimeoutWarning(60_000, status);
+
+      assertThat(message).contains("60000ms").contains(status.toString());
+      assertThat(message)
+          .as("on every non-STARTING branch the setting IS the bound, so the advice stays")
+          .contains("Raise arcadedb.server.shutdownTimeout if a legitimate shutdown needs longer.");
+    }
+  }
+
+  @Test
+  void settingDescriptionMustNotClaimToCoverStart() {
+    final String description = GlobalConfiguration.SERVER_SHUTDOWN_TIMEOUT.getDescription();
+
+    assertThat(description)
+        .as("the setting does not bound the shutdown-hook wait during start(), so its description must not say so")
+        .doesNotContain("start()/stop()");
+    assertThat(description).contains("this setting does not govern");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/Issue6981ShutdownHookHintTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue6981ShutdownHookHintTest.java
@@ -21,6 +21,9 @@ package com.arcadedb.server;
 import com.arcadedb.GlobalConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -70,5 +73,21 @@ class Issue6981ShutdownHookHintTest {
     assertThat(description)
         .as("the configured bound DOES apply once the status left STARTING, even before start() releases the lock")
         .contains("the tail of start() after the status has already turned ONLINE");
+  }
+
+  @Test
+  void settingDescriptionMustQuoteTheSameStartingBoundTheHookApplies() {
+    // The description spells the STARTING bound out as a literal, because GlobalConfiguration lives in the
+    // engine module and cannot see the server's SHUTDOWN_HOOK_STARTING_TIMEOUT_MS. Nothing but this test
+    // keeps the two in step, and a description quoting a bound the hook no longer applies is exactly the
+    // defect #6981 reports - one module edit away from coming back.
+    final Matcher bound = Pattern.compile("fixed (\\d+)ms bound")
+        .matcher(ArcadeDBServer.shutdownHookLockTimeoutWarning(2_000, ArcadeDBServer.STATUS.STARTING));
+
+    assertThat(bound.find()).as("the STARTING warning must state the fixed bound it applied").isTrue();
+
+    assertThat(GlobalConfiguration.SERVER_SHUTDOWN_TIMEOUT.getDescription())
+        .as("the setting description quotes the STARTING bound as a literal: it must match the constant the hook uses")
+        .contains("fixed " + bound.group(1) + "ms bound");
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the misleading operator hint reported in #6981. The shutdown hook waits a fixed 2000ms when `status == STARTING` and `arcadedb.server.shutdownTimeout` on every other status, but both user-facing texts pointed at the setting on the STARTING branch too - the one branch where raising it provably changes nothing.

- `ArcadeDBServer`: the WARNING's advice is now built per status. During STARTING it says the wait is a fixed 2000ms bound that `arcadedb.server.shutdownTimeout` does not govern; on every other status the "raise it" advice is unchanged. The message assembly is extracted to a package-private static (same style as the existing `awaitLifecycleLock`) so it can be asserted without driving a real JVM shutdown.
- `GlobalConfiguration.SERVER_SHUTDOWN_TIMEOUT`: the description no longer claims to cover `start()`, and states that the STARTING phase uses a fixed short bound instead.

No behavioral change to the timeout selection itself, and no change to the STARTING bound - the issue's secondary question (whether the 2000ms should cover the window after databases are open but before `start()` returns) is left for maintainers to decide.

## Motivation

An operator who hits this WARNING during startup (e.g. a liveness probe killing a pod mid-start) is told to raise a setting that cannot affect the path they are on, as described first-hand in #6981.

## Related issues

Fixes #6981

## Additional Notes

Regression test `Issue6981ShutdownHookHintTest` pins the three texts: the STARTING warning must not advise raising the setting, the non-STARTING warnings must keep the advice, and the setting description must not claim `start()/stop()` coverage. Disclosure: this change was authored with Claude Code, following the repo's CLAUDE.md guidelines, and human-reviewed before submission.

## Checklist

- [x] I have run the build using `mvn clean package` command (engine + server modules; `Issue5418ShutdownHookDeadlockTest` and the new `Issue6981ShutdownHookHintTest` pass, 8/8)
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown timeout warnings to accurately distinguish server startup from normal shutdown.
  * Startup shutdown waits now use a fixed two-second limit and no longer suggest changing the configurable shutdown timeout.
  * Normal shutdown warnings continue to provide relevant configuration guidance.

* **Documentation**
  * Clarified that the configurable shutdown timeout applies after the server is online, including the final startup phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->