### PR TITLE
fix(#7008): enforce the self-loop constraint in the edge-index scan seed

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2355,9 +2355,9 @@ public class CypherExecutionPlan {
       return null;
 
     // Both endpoints must be unselective (no labels, no inline properties) and not already bound - there
-    // is nothing to validate on them beyond what the WHERE filter above already re-checks. Repeating one
-    // variable at both endpoints - (a)-[t:TYPE]->(a) - leaves both unselective by this measure yet does
-    // constrain the hop to self-loops; MatchEdgeByIndexStep enforces that itself (issue #7008).
+    // is nothing to validate on them beyond what the WHERE filter above already re-checks. Note that a
+    // variable repeated at both endpoints is unselective by this measure yet still constrains the hop; see
+    // MatchEdgeByIndexStep's class javadoc for why the step, not this test, enforces it (issue #7008).
     final NodePattern srcNode = pathPattern.getFirstNode();
     final NodePattern tgtNode = pathPattern.getLastNode();
     if (isSelectiveEndpoint(srcNode, boundVariables, matchVariables)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2355,7 +2355,9 @@ public class CypherExecutionPlan {
       return null;
 
     // Both endpoints must be unselective (no labels, no inline properties) and not already bound - there
-    // is nothing to validate on them beyond what the WHERE filter above already re-checks.
+    // is nothing to validate on them beyond what the WHERE filter above already re-checks. Repeating one
+    // variable at both endpoints - (a)-[t:TYPE]->(a) - leaves both unselective by this measure yet does
+    // constrain the hop to self-loops; MatchEdgeByIndexStep enforces that itself (issue #7008).
     final NodePattern srcNode = pathPattern.getFirstNode();
     final NodePattern tgtNode = pathPattern.getLastNode();
     if (isSelectiveEndpoint(srcNode, boundVariables, matchVariables)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
@@ -163,15 +163,17 @@ public class MatchEdgeByIndexStep extends AbstractExecutionStep {
               if (!(record instanceof Edge))
                 continue;
               edge = (Edge) record;
+
+              // A repeated endpoint variable constrains the hop to self-loops. This reads the two RIDs the
+              // edge carries rather than resolving the vertex records, so a rejected edge costs no extra
+              // load - but getOut()/getIn() still lazy-load the EDGE's own content, so the comparison has to
+              // sit under the same dangling-entry guard as the resolution above.
+              if (selfLoopOnly && !edge.getOut().equals(edge.getIn()))
+                continue;
             } catch (final RecordNotFoundException e) {
               // Dangling index entry pointing at a removed edge: skip it, like every other RID resolver.
               continue;
             }
-
-            // A repeated endpoint variable constrains the hop to self-loops. Compare the two RIDs the edge
-            // already carries rather than the vertex records, so a rejected edge costs no record load.
-            if (selfLoopOnly && !edge.getOut().equals(edge.getIn()))
-              continue;
 
             final ResultInternal result = new ResultInternal();
             if (relationshipVariable != null && !relationshipVariable.isEmpty())

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
@@ -58,6 +58,12 @@ import java.util.NoSuchElementException;
  * key values. The MATCH clause's {@code WHERE} filter is still applied above this step, so any predicate
  * not part of the index key (or any looser interpretation) is re-validated - this step is only ever a
  * selective prefilter, never the final word on membership.
+ * <p>
+ * The one constraint the {@code WHERE} filter above cannot re-validate is the one the <em>pattern</em>
+ * carries rather than the predicate: writing the same variable at both endpoints, as in
+ * {@code (a)-[t:TYPE]->(a)}, asks for self-loops only. Binding both endpoints under one name would let the
+ * second {@code setProperty} silently overwrite the first and pass a non-self-loop edge off as a match
+ * (issue #7008), so this step enforces {@code out == in} itself for that shape and keeps the index seek.
  */
 public class MatchEdgeByIndexStep extends AbstractExecutionStep {
   private final String       edgeType;
@@ -68,6 +74,9 @@ public class MatchEdgeByIndexStep extends AbstractExecutionStep {
   private final String       sourceVariable;
   private final String       relationshipVariable; // may be null when the edge is anonymous
   private final String       targetVariable;
+  // True when the pattern repeats one variable at both endpoints - (a)-[t:TYPE]->(a) - which constrains the
+  // hop to self-loops. Anonymous endpoints get distinct generated names, so only an explicit repeat sets it.
+  private final boolean      selfLoopOnly;
 
   private final ExpressionEvaluator evaluator;
 
@@ -95,6 +104,7 @@ public class MatchEdgeByIndexStep extends AbstractExecutionStep {
     this.sourceVariable = sourceVariable;
     this.relationshipVariable = relationshipVariable;
     this.targetVariable = targetVariable;
+    this.selfLoopOnly = sourceVariable != null && sourceVariable.equals(targetVariable);
     this.evaluator = new ExpressionEvaluator(new CypherFunctionFactory(DefaultSQLFunctionFactory.getInstance()));
   }
 
@@ -157,6 +167,11 @@ public class MatchEdgeByIndexStep extends AbstractExecutionStep {
               // Dangling index entry pointing at a removed edge: skip it, like every other RID resolver.
               continue;
             }
+
+            // A repeated endpoint variable constrains the hop to self-loops. Compare the two RIDs the edge
+            // already carries rather than the vertex records, so a rejected edge costs no record load.
+            if (selfLoopOnly && !edge.getOut().equals(edge.getIn()))
+              continue;
 
             final ResultInternal result = new ResultInternal();
             if (relationshipVariable != null && !relationshipVariable.isEmpty())

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue7008EdgeIndexSelfLoopTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue7008EdgeIndexSelfLoopTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction for GitHub issue #7008.
+ * <p>
+ * The edge-index scan seed introduced for issue #740 accepts a single-hop pattern without noticing that
+ * the two endpoint variables may be the <em>same</em> variable. For the explicit self-loop shape
+ * {@code (a)-[t:TRANSFER]->(a)} the seed bound the edge's OUT vertex to {@code a} and then immediately
+ * overwrote it with the IN vertex, so the pattern's implicit {@code out == in} constraint was silently
+ * dropped and edges between two different vertices came back as if they were self-loops.
+ */
+class Issue7008EdgeIndexSelfLoopTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-7008-edge-index-self-loop").create();
+
+    database.getSchema().createVertexType("Account");
+    final var transfer = database.getSchema().createEdgeType("TRANSFER");
+    transfer.createProperty("transactionId", Type.STRING);
+    database.getSchema().buildTypeIndex("TRANSFER", new String[] { "transactionId" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
+
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Account").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Account").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Account").set("name", "C").save();
+
+      // A plain edge between two DIFFERENT accounts: no self-loop shape must ever match it.
+      a.newEdge("TRANSFER", b).set("transactionId", "74529884").save();
+      // A genuine self-loop on C: the self-loop shape must find exactly this one.
+      c.newEdge("TRANSFER", c).set("transactionId", "11112222").save();
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void repeatedEndpointVariableDoesNotMatchANonSelfLoopEdge() {
+    // The edge carrying '74529884' runs A -> B, so the self-loop pattern must return nothing.
+    assertThat(namesOf("MATCH (a)-[t:TRANSFER]->(a) WHERE t.transactionId = '74529884' RETURN a.name AS n"))
+        .isEmpty();
+  }
+
+  @Test
+  void controlDistinctEndpointVariablesStillSeeTheNonSelfLoopEdge() {
+    // Control for the assertion above: with two distinct variables the same edge IS matched, and its
+    // endpoints really are two different accounts.
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (x)-[t:TRANSFER]->(y) WHERE t.transactionId = '74529884' RETURN x.name AS xn, y.name AS yn")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result r = rs.next();
+      assertThat((String) r.getProperty("xn")).isEqualTo("A");
+      assertThat((String) r.getProperty("yn")).isEqualTo("B");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void repeatedEndpointVariableFindsAGenuineSelfLoop() {
+    // The fix must not simply refuse every repeated-variable pattern: the real self-loop is still found.
+    assertThat(namesOf("MATCH (a)-[t:TRANSFER]->(a) WHERE t.transactionId = '11112222' RETURN a.name AS n"))
+        .containsExactly("C");
+  }
+
+  @Test
+  void repeatedEndpointVariableHonoursTheIncomingDirectionForm() {
+    // The written direction only decides which endpoint binds to which variable; for a repeated variable
+    // both forms must behave identically.
+    assertThat(namesOf("MATCH (a)<-[t:TRANSFER]-(a) WHERE t.transactionId = '74529884' RETURN a.name AS n"))
+        .isEmpty();
+    assertThat(namesOf("MATCH (a)<-[t:TRANSFER]-(a) WHERE t.transactionId = '11112222' RETURN a.name AS n"))
+        .containsExactly("C");
+  }
+
+  @Test
+  void repeatedEndpointVariableWithoutAWhereFilterIsStillCorrect() {
+    // Without a WHERE on the edge the index seed does not apply at all; this pins the reference semantics
+    // the seeded plan has to agree with.
+    assertThat(namesOf("MATCH (a)-[t:TRANSFER]->(a) RETURN a.name AS n")).containsExactly("C");
+  }
+
+  @Test
+  void selfLoopPatternStillUsesTheEdgeIndexSeed() {
+    // The self-loop constraint has to be enforced without giving up the index speedup issue #740 added.
+    // Pinning the plan shape is what keeps this file honest: the alternative fix - refusing the seed for a
+    // repeated variable - would make every assertion above pass while silently losing the optimization.
+    try (final ResultSet rs = database.query("opencypher",
+        "PROFILE MATCH (a)-[t:TRANSFER]->(a) WHERE t.transactionId = '11112222' RETURN a.name AS n")) {
+      while (rs.hasNext())
+        rs.next();
+      final String planString = rs.getExecutionPlan().get().prettyPrint(0, 2);
+      assertThat(planString).contains("MATCH EDGE BY INDEX");
+    }
+  }
+
+  @Test
+  void labelledEndpointRoutesToTheOptimizerAndStaysCorrect() {
+    // A label on the endpoint makes the cost-based optimizer accept the pattern (ExpandInto BOUND-TARGET)
+    // instead of the legacy seed, so this pins the OTHER execution path against the same defect.
+    final String nonSelfLoop =
+        "MATCH (a:Account)-[t:TRANSFER]->(a) WHERE t.transactionId = '74529884' RETURN a.name AS n";
+    assertThat(planOf(nonSelfLoop)).contains("Cost-Based Query Optimizer");
+    assertThat(namesOf(nonSelfLoop)).isEmpty();
+
+    final String selfLoop =
+        "MATCH (a:Account)-[t:TRANSFER]->(a) WHERE t.transactionId = '11112222' RETURN a.name AS n";
+    assertThat(planOf(selfLoop)).contains("Cost-Based Query Optimizer");
+    assertThat(namesOf(selfLoop)).containsExactly("C");
+  }
+
+  private String planOf(final String cypher) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + cypher)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+
+  private List<String> namesOf(final String cypher) {
+    final List<String> names = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", cypher)) {
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("n"));
+    }
+    return names;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue7008EdgeIndexSelfLoopTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue7008EdgeIndexSelfLoopTest.java
@@ -53,7 +53,12 @@ class Issue7008EdgeIndexSelfLoopTest {
     database.getSchema().createVertexType("Account");
     final var transfer = database.getSchema().createEdgeType("TRANSFER");
     transfer.createProperty("transactionId", Type.STRING);
+    transfer.createProperty("date", Type.DATE);
     database.getSchema().buildTypeIndex("TRANSFER", new String[] { "transactionId" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
+    // A second, composite index. The seed picks the longest index its equality predicates fully cover, so a
+    // WHERE on transactionId alone still seeks the single-property one and a WHERE on both seeks this one.
+    database.getSchema().buildTypeIndex("TRANSFER", new String[] { "transactionId", "date" })
         .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
 
     database.transaction(() -> {
@@ -62,9 +67,9 @@ class Issue7008EdgeIndexSelfLoopTest {
       final MutableVertex c = database.newVertex("Account").set("name", "C").save();
 
       // A plain edge between two DIFFERENT accounts: no self-loop shape must ever match it.
-      a.newEdge("TRANSFER", b).set("transactionId", "74529884").save();
+      a.newEdge("TRANSFER", b).set("transactionId", "74529884").set("date", "2026-02-28").save();
       // A genuine self-loop on C: the self-loop shape must find exactly this one.
-      c.newEdge("TRANSFER", c).set("transactionId", "11112222").save();
+      c.newEdge("TRANSFER", c).set("transactionId", "11112222").set("date", "2026-02-28").save();
     });
   }
 
@@ -126,13 +131,24 @@ class Issue7008EdgeIndexSelfLoopTest {
     // The self-loop constraint has to be enforced without giving up the index speedup issue #740 added.
     // Pinning the plan shape is what keeps this file honest: the alternative fix - refusing the seed for a
     // repeated variable - would make every assertion above pass while silently losing the optimization.
-    try (final ResultSet rs = database.query("opencypher",
-        "PROFILE MATCH (a)-[t:TRANSFER]->(a) WHERE t.transactionId = '11112222' RETURN a.name AS n")) {
-      while (rs.hasNext())
-        rs.next();
-      final String planString = rs.getExecutionPlan().get().prettyPrint(0, 2);
-      assertThat(planString).contains("MATCH EDGE BY INDEX");
-    }
+    assertThat(profiledPlanOf("MATCH (a)-[t:TRANSFER]->(a) WHERE t.transactionId = '11112222' RETURN a.name AS n"))
+        .contains("MATCH EDGE BY INDEX");
+  }
+
+  @Test
+  void selfLoopConstraintSurvivesACompositeIndexSeek() {
+    // A multi-column key drives a different branch of the seed's index choice, so the constraint has to hold
+    // there too. Assert the composite index really is the one seeded, otherwise this only re-tests the
+    // single-property path under a longer WHERE clause.
+    final String nonSelfLoop = "MATCH (a)-[t:TRANSFER]->(a) "
+        + "WHERE t.transactionId = '74529884' AND t.date = date('2026-02-28') RETURN a.name AS n";
+    assertThat(profiledPlanOf(nonSelfLoop)).contains("on transactionId,date");
+    assertThat(namesOf(nonSelfLoop)).isEmpty();
+
+    final String selfLoop = "MATCH (a)-[t:TRANSFER]->(a) "
+        + "WHERE t.transactionId = '11112222' AND t.date = date('2026-02-28') RETURN a.name AS n";
+    assertThat(profiledPlanOf(selfLoop)).contains("on transactionId,date");
+    assertThat(namesOf(selfLoop)).containsExactly("C");
   }
 
   @Test
@@ -148,6 +164,15 @@ class Issue7008EdgeIndexSelfLoopTest {
         "MATCH (a:Account)-[t:TRANSFER]->(a) WHERE t.transactionId = '11112222' RETURN a.name AS n";
     assertThat(planOf(selfLoop)).contains("Cost-Based Query Optimizer");
     assertThat(namesOf(selfLoop)).containsExactly("C");
+  }
+
+  /** Drains a PROFILEd run so the plan reflects what actually executed, not just what was planned. */
+  private String profiledPlanOf(final String cypher) {
+    try (final ResultSet rs = database.query("opencypher", "PROFILE " + cypher)) {
+      while (rs.hasNext())
+        rs.next();
+      return rs.getExecutionPlan().get().prettyPrint(0, 2);
+    }
   }
 
   private String planOf(final String cypher) {


### PR DESCRIPTION
Closes #7008

## Summary

The edge-index scan seed added for #740 (`MatchEdgeByIndexStep`, planned in `CypherExecutionPlan.tryBuildEdgeIndexScanSeed`) accepted a single-hop pattern without noticing that the two endpoint variables could be the **same** variable. For the explicit self-loop shape `(a)-[t:TYPE]->(a)` the step bound the edge's OUT vertex to `a` and then immediately overwrote it with the IN vertex, so the pattern's implicit `out == in` constraint was silently dropped: a plain A -> B edge came back as a match, reported as if `a` were B.

`isSelectiveEndpoint()` is not the reason on its own. It answers "does this endpoint carry a constraint the seed cannot honour" by looking at labels, inline properties and prior binding, and a repeated variable has none of those, so both endpoints look equally unselective and the seed is accepted. The constraint lives in the *pattern*, not in the predicate, which is also why the `FILTER WHERE` step above the seed cannot re-validate it the way it re-validates every other predicate.

The fix keeps the index seek rather than refusing the seed, which is the option that preserves the #740 speedup for the self-loop shape (a common fraud/cycle-detection query, and the natural way to write it). `MatchEdgeByIndexStep` records `selfLoopOnly = sourceVariable.equals(targetVariable)` at construction and skips any edge whose two endpoint RIDs differ. Anonymous endpoints receive distinct generated names (`  src<n>` / `  tgt<n>`), so only an explicit repeat arms the check, and the comparison reads `edge.getOut()` / `edge.getIn()` rather than resolving the vertex records, so a rejected edge costs no extra load.

The comparison sits **inside** the existing `RecordNotFoundException` guard that wraps the edge resolution. `ImmutableEdge.getOut()`/`getIn()` both call `checkForLazyLoading()`, which resolves the edge's own content through `LocalBucket.getRecord()` and throws when that content is gone, so a dangling index entry would otherwise abort the whole query instead of skipping the row. That is also where the check belongs semantically: what it can fail on is the *edge's* content, not the endpoint vertices the second handler covers.

## Which execution path

Both were checked with `EXPLAIN`, since a fix on one is invisible to the other:

| Query shape | Plan | Before | After |
|---|---|---|---|
| `MATCH (a)-[t:TRANSFER]->(a) WHERE t.transactionId = '74529884'` | legacy, `MATCH EDGE BY INDEX (a)-[t:TRANSFER]->(a)` | **1 row (wrong)** | 0 rows |
| `MATCH (a)-[t:TRANSFER]->(a)` (no WHERE) | legacy, `MATCH NODE` + `MATCH RELATIONSHIP` | correct | correct |
| `MATCH (a:Account)-[t:TRANSFER]->(a) WHERE ...` | optimizer, `ExpandInto ⭐ BOUND-TARGET` | correct | correct |
| `MATCH (a)-[t:TRANSFER]->(a) WHERE t.transactionId <> 'zz'` | legacy, no seed (not an equality) | correct | correct |

So the defect was confined to the legacy seed: `MatchRelationshipStep` and the optimizer's `ExpandInto` bound-target operator both already enforced the equality. The regression test pins all three plan shapes, including the optimized one, so a future change to either path is caught.

## Verification

- `Issue7008EdgeIndexSelfLoopTest` - 8 new tests. Three of them fail against the unfixed step (`repeatedEndpointVariableDoesNotMatchANonSelfLoopEdge`, `repeatedEndpointVariableHonoursTheIncomingDirectionForm`, `selfLoopConstraintSurvivesACompositeIndexSeek`); measured by disarming the `selfLoopOnly` guard and re-running, which turns the class from 8/8 green to 3 failures.
  - A **control** (`controlDistinctEndpointVariablesStillSeeTheNonSelfLoopEdge`) asserts the same edge really does run A -> B under two distinct variables, so the empty results above cannot pass for the wrong reason (an empty fixture, a mis-keyed lookup).
  - `selfLoopPatternStillUsesTheEdgeIndexSeed` pins `MATCH EDGE BY INDEX` in the profiled plan. Without it, the alternative fix - refusing the seed for a repeated variable - would make every other assertion pass while silently losing the optimization.
  - `selfLoopConstraintSurvivesACompositeIndexSeek` asserts *which* index was seeded (`on transactionId,date`) before asserting the constraint, so it cannot degenerate into re-testing the single-property path under a longer WHERE clause.
- `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**'` - **9111 run, 0 failures, 98 skipped**, including `Issue740EdgeIndexWhereClauseTest` (the feature this regressed).
- openCypher TCK (`mvn -pl engine verify -Dsurefire.includes='**/*Suite.java'`) - **3897 scenarios, 0 failures, 85 skipped, both before and after** the change. No scenario drop.

## Test plan

- [ ] `mvn -o -pl engine test -Dtest=Issue7008EdgeIndexSelfLoopTest` passes; three assertions fail when the `selfLoopOnly` guard in `MatchEdgeByIndexStep.fetchMore()` is disarmed.
- [ ] `mvn -o -pl engine test -Dtest=Issue740EdgeIndexWhereClauseTest` still passes: the #740 index seed is untouched for distinct-variable patterns.
- [ ] `mvn -o -pl engine verify -Dsurefire.includes='**/*Suite.java'` reports 3897 TCK scenarios with 0 failures.
- [ ] `EXPLAIN MATCH (a)-[t:TYPE]->(a) WHERE t.<indexedProp> = <literal> RETURN a` still shows `MATCH EDGE BY INDEX`, confirming the index seek was kept rather than the seed refused.

## Review notes

Two nits were considered and deliberately not acted on:

- **The `sourceVariable != null` half of the `selfLoopOnly` guard is currently unreachable** (the single caller always supplies a generated or explicit name). Kept: a null name would mean the seed had nothing to bind, and defaulting that to "not a self-loop" is safer than an NPE inside the row loop.
- **`profiledPlanOf`/`planOf`/`namesOf` duplicate PROFILE/EXPLAIN plumbing that `Issue740EdgeIndexWhereClauseTest` also inlines.** Extracting a shared fixture would mean editing that existing test, which is out of scope for a regression fix. Worth doing when a third test in this family appears, as the reviewer suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1bu3QHjw5bgFKvfPSUoR7
