### PR TITLE
fix(#7010): close the openCypher CartesianProduct children and stream its right input

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1033,14 +1033,17 @@ public class CypherExecutionPlan {
     // Create a wrapper step that executes the physical operators
     AbstractExecutionStep currentStep = new AbstractExecutionStep(context) {
       private ResultSet operatorResults = null;
+      private boolean closed = false;
 
       @Override
       public ResultSet syncPull(final CommandContext ctx, final int nRecords) {
-        if (operatorResults == null) {
+        // Once closed this step stays closed: re-executing the operator tree here would open a second
+        // set of cursors that the already-spent close() chain would never reach.
+        if (operatorResults == null && !closed) {
           // Execute physical operators on first pull
           operatorResults = physicalPlan.getRootOperator().execute(ctx, nRecords);
         }
-        return operatorResults;
+        return operatorResults != null ? operatorResults : new IteratorResultSet(Collections.<Result>emptyList().iterator());
       }
 
       /**
@@ -1051,9 +1054,10 @@ public class CypherExecutionPlan {
        */
       @Override
       public void close() {
-        if (operatorResults != null) {
-          operatorResults.close();
-          operatorResults = null;
+        if (!closed) {
+          closed = true;
+          if (operatorResults != null)
+            operatorResults.close();
         }
         super.close();
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1043,6 +1043,21 @@ public class CypherExecutionPlan {
         return operatorResults;
       }
 
+      /**
+       * The physical-operator tree hangs off this step's result set, not off a previous step, so
+       * without this override the close() chain stopped one step short of the operators and every
+       * cursor they hold stayed open for as long as the plan was retained (issue #7010, and #5635
+       * for why an index cursor has to be closed explicitly).
+       */
+      @Override
+      public void close() {
+        if (operatorResults != null) {
+          operatorResults.close();
+          operatorResults = null;
+        }
+        super.close();
+      }
+
       @Override
       public String prettyPrint(final int depth, final int indent) {
         return "  ".repeat(Math.max(0, depth * indent)) + "+ OPTIMIZED MATCH (physical operators)\n" +

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/CartesianProduct.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/CartesianProduct.java
@@ -35,8 +35,14 @@ import java.util.function.BiPredicate;
  * Used for multi-MATCH queries where each MATCH has independent single-node patterns
  * (e.g., MATCH (a:T) WHERE a.id=$x MATCH (b:T) WHERE b.id=$y CREATE ...).
  * <p>
- * For point lookups (index seeks returning 1 row each), this is O(1) — it simply
+ * For point lookups (index seeks returning 1 row each), this is O(1) - it simply
  * merges the properties of both results into a single row.
+ * <p>
+ * The right input is pulled lazily and buffered as it is consumed, so the first row costs one right
+ * row rather than the whole right side, and a consumer that stops early (a LIMIT above this operator)
+ * never pays for the rows it did not ask for. The buffer is what lets the second and later left rows
+ * replay the right side without re-executing it. Both children are closed once - on exhaustion, or on
+ * {@code close()}, whichever comes first (issue #7010).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -69,13 +75,15 @@ public class CartesianProduct extends AbstractPhysicalOperator {
     final WorkGuard guard = WorkGuard.forCommandDeadline(context);
 
     return new ResultSet() {
-      private ResultSet leftResults = null;
-      private List<Result> rightResultsCache = null;
-      private Result currentLeft = null;
-      private int rightIndex = 0;
-      private boolean finished = false;
-      private boolean initialized = false;
-      private Result pendingRight;
+      private ResultSet   leftResults    = null;
+      private ResultSet   rightResults   = null;
+      private List<Result> rightBuffer   = null;
+      private Result      currentLeft    = null;
+      private int         rightIndex     = 0;
+      private boolean     rightExhausted = false;
+      private boolean     finished       = false;
+      private boolean     initialized    = false;
+      private Result      pendingRight;
 
       @Override
       public boolean hasNext() {
@@ -109,22 +117,57 @@ public class CartesianProduct extends AbstractPhysicalOperator {
       // leaving it in pendingRight without merging it - a rejected pair never allocates a merged row.
       private boolean advance() {
         while (currentLeft != null) {
-          while (rightIndex < rightResultsCache.size()) {
+          Result candidate;
+          while ((candidate = nextRight()) != null) {
             guard.check();
-            final Result candidate = rightResultsCache.get(rightIndex++);
             if (pairFilter == null || pairFilter.test(currentLeft, candidate)) {
               pendingRight = candidate;
               return true;
             }
           }
-          if (leftResults.hasNext()) {
+          // An empty right side crosses to nothing, so there is no point walking the remaining left rows.
+          if (rightExhausted && rightBuffer.isEmpty())
+            break;
+          if (leftResults != null && leftResults.hasNext()) {
             currentLeft = leftResults.next();
             rightIndex = 0;
           } else
             currentLeft = null;
         }
         finished = true;
+        // Nothing more will be pulled from either side: release both cursors now rather than waiting
+        // for a close() the consumer may never call.
+        closeChildren();
         return false;
+      }
+
+      /**
+       * Returns the next right row for the current left row, or null once the right side is exhausted.
+       * <p>
+       * Issue #7010: the right input used to be drained into a list in full before the first row was
+       * emitted, so a LIMIT above this operator paid for the whole right side in scan work and in heap.
+       * It is now pulled one row at a time and buffered as it goes - a consumer that stops early never
+       * touches the rows it did not ask for, while the buffer is what replays the right side for the
+       * second and later left rows.
+       */
+      private Result nextRight() {
+        if (rightIndex < rightBuffer.size())
+          return rightBuffer.get(rightIndex++);
+        if (rightExhausted)
+          return null;
+
+        guard.check();
+        if (rightResults != null && rightResults.hasNext()) {
+          final Result row = rightResults.next();
+          rightBuffer.add(row);
+          ++rightIndex;
+          return row;
+        }
+
+        rightExhausted = true;
+        // The right cursor has nothing left to give and the buffer replays it from here on.
+        closeRight();
+        return null;
       }
 
       private void ensureInitialized(final CommandContext ctx, final int n) {
@@ -132,27 +175,48 @@ public class CartesianProduct extends AbstractPhysicalOperator {
           return;
         initialized = true;
 
-        // Execute left and right operators
+        // Execute left and right operators. The right side is NOT drained here (issue #7010).
         leftResults = child.execute(ctx, n);
-        final ResultSet rightResults = right.execute(ctx, n);
-
-        // Materialize right side for reuse across left rows
-        rightResultsCache = new ArrayList<>();
-        while (rightResults.hasNext()) {
-          guard.check();
-          rightResultsCache.add(rightResults.next());
-        }
+        rightResults = right.execute(ctx, n);
+        rightBuffer = new ArrayList<>();
 
         // Get first left row
         if (leftResults.hasNext())
           currentLeft = leftResults.next();
-        else
+        else {
           finished = true;
+          closeChildren();
+        }
       }
 
+      private void closeRight() {
+        if (rightResults != null) {
+          rightResults.close();
+          rightResults = null;
+        }
+      }
+
+      // Idempotent: a child is closed at most once, whether the release comes from exhaustion or from close().
+      private void closeChildren() {
+        closeRight();
+        if (leftResults != null) {
+          leftResults.close();
+          leftResults = null;
+        }
+      }
+
+      /**
+       * Issue #7010: this was an empty method, so the close() chain stopped here and an index-backed
+       * child kept its cursor open for as long as the plan was retained (see #5635).
+       */
       @Override
       public void close() {
-        // nothing to close
+        finished = true;
+        pendingRight = null;
+        currentLeft = null;
+        closeChildren();
+        if (rightBuffer != null)
+          rightBuffer.clear();
       }
     };
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/CartesianProduct.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/CartesianProduct.java
@@ -75,15 +75,15 @@ public class CartesianProduct extends AbstractPhysicalOperator {
     final WorkGuard guard = WorkGuard.forCommandDeadline(context);
 
     return new ResultSet() {
-      private ResultSet   leftResults    = null;
-      private ResultSet   rightResults   = null;
-      private List<Result> rightBuffer   = null;
-      private Result      currentLeft    = null;
-      private int         rightIndex     = 0;
-      private boolean     rightExhausted = false;
-      private boolean     finished       = false;
-      private boolean     initialized    = false;
-      private Result      pendingRight;
+      private ResultSet leftResults = null;
+      private ResultSet rightResults = null;
+      private List<Result> rightBuffer = null;
+      private Result currentLeft = null;
+      private int rightIndex = 0;
+      private boolean rightExhausted = false;
+      private boolean finished = false;
+      private boolean initialized = false;
+      private Result pendingRight;
 
       @Override
       public boolean hasNext() {
@@ -156,7 +156,7 @@ public class CartesianProduct extends AbstractPhysicalOperator {
         if (rightExhausted)
           return null;
 
-        guard.check();
+        // No guard.check() here: advance() checks every candidate this returns, buffered or freshly pulled.
         if (rightResults != null && rightResults.hasNext()) {
           final Result row = rightResults.next();
           rightBuffer.add(row);
@@ -171,7 +171,9 @@ public class CartesianProduct extends AbstractPhysicalOperator {
       }
 
       private void ensureInitialized(final CommandContext ctx, final int n) {
-        if (initialized)
+        // "finished" covers close(): a closed result set must never execute its children again, or a
+        // close() before the first pull would open two cursors that nothing then closes.
+        if (initialized || finished)
           return;
         initialized = true;
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCartesianProductIssue7010Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCartesianProductIssue7010Test.java
@@ -112,6 +112,30 @@ class CypherCartesianProductIssue7010Test {
     assertThat(right.closeCount).as("a second close() must not re-close the children").isEqualTo(1);
   }
 
+  @Test
+  void aClosedResultSetDoesNotReopenItsChildren() {
+    // close() before the first pull leaves initialized == false, so a later hasNext() used to run
+    // ensureInitialized() and execute both children again - two cursors nothing would ever close,
+    // the very leak this issue is about.
+    final RecordingOperator left = new RecordingOperator("a", 3);
+    final RecordingOperator right = new RecordingOperator("b", 3);
+    final ResultSet rs = product(left, right).execute(context(), -1);
+
+    rs.close();
+
+    assertThat(rs.hasNext()).as("a closed result set is exhausted").isFalse();
+    assertThat(left.executeCount).as("the left child must not be executed by a closed result set").isZero();
+    assertThat(right.executeCount).as("the right child must not be executed by a closed result set").isZero();
+
+    // Same guarantee once the rows have been consumed and close() has already run.
+    final ResultSet consumed = product(left, right).execute(context(), -1);
+    drainPairs(consumed);
+    consumed.close();
+    assertThat(consumed.hasNext()).isFalse();
+    assertThat(left.executeCount).as("no re-execution after a drained-then-closed result set").isEqualTo(1);
+    assertThat(right.executeCount).as("no re-execution after a drained-then-closed result set").isEqualTo(1);
+  }
+
   // ---------------------------------------------------------------------------------------------
   // 2. the right input must not be materialized before the first row
   // ---------------------------------------------------------------------------------------------
@@ -276,6 +300,7 @@ class CypherCartesianProductIssue7010Test {
     private final int    rowCount;
     int rowsProduced;
     int closeCount;
+    int executeCount;
 
     RecordingOperator(final String propertyName, final int rowCount) {
       this.propertyName = propertyName;
@@ -284,6 +309,7 @@ class CypherCartesianProductIssue7010Test {
 
     @Override
     public ResultSet execute(final CommandContext context, final int nRecords) {
+      ++executeCount;
       return new ResultSet() {
         private int emitted = 0;
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCartesianProductIssue7010Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCartesianProductIssue7010Test.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.executor.operators.CartesianProduct;
+import com.arcadedb.query.opencypher.executor.operators.PhysicalOperator;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.BiPredicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7010: two defects in the openCypher {@code CartesianProduct} physical operator.
+ * <ol>
+ *   <li>its {@code ResultSet.close()} was an empty method, so it never reached either child and an
+ *       index-backed child kept its cursor open for as long as the plan was retained (the chaining
+ *       contract established by #5635);</li>
+ *   <li>the right input was drained into a list in full before the first row was emitted, so a
+ *       {@code LIMIT 1} probe over a big type paid for the whole type in heap and in scan work.</li>
+ * </ol>
+ * The operator is exercised directly here: the row counts and the close calls of a Cartesian product
+ * are not observable from the outside of a query, and the end-to-end tests at the bottom only pin the
+ * result semantics that the streaming rewrite must not change.
+ */
+class CypherCartesianProductIssue7010Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/CypherCartesianProductIssue7010Test").create();
+    database.getSchema().createVertexType("Item");
+    database.transaction(() -> {
+      for (int i = 0; i < 4; i++)
+        database.newVertex("Item").set("id", i).save();
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // 1. close() must reach both children
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void closeReachesBothChildren() {
+    final RecordingOperator left = new RecordingOperator("a", 3);
+    final RecordingOperator right = new RecordingOperator("b", 3);
+    final ResultSet rs = product(left, right).execute(context(), -1);
+
+    assertThat(rs.hasNext()).isTrue();
+    rs.next();
+    rs.close();
+
+    assertThat(left.closeCount).as("left child result set closed exactly once").isEqualTo(1);
+    assertThat(right.closeCount).as("right child result set closed exactly once").isEqualTo(1);
+  }
+
+  @Test
+  void closeIsIdempotentAndSafeBeforeTheFirstRow() {
+    final RecordingOperator left = new RecordingOperator("a", 3);
+    final RecordingOperator right = new RecordingOperator("b", 3);
+    final ResultSet rs = product(left, right).execute(context(), -1);
+
+    // Closing without ever pulling must not blow up on the not-yet-created child result sets.
+    rs.close();
+    rs.close();
+
+    assertThat(left.closeCount).isZero();
+    assertThat(right.closeCount).isZero();
+
+    final ResultSet pulled = product(left, right).execute(context(), -1);
+    pulled.next();
+    pulled.close();
+    pulled.close();
+
+    assertThat(left.closeCount).as("a second close() must not re-close the children").isEqualTo(1);
+    assertThat(right.closeCount).as("a second close() must not re-close the children").isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // 2. the right input must not be materialized before the first row
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void firstRowDoesNotDrainTheRightInput() {
+    final RecordingOperator left = new RecordingOperator("a", 500);
+    final RecordingOperator right = new RecordingOperator("b", 500);
+    final ResultSet rs = product(left, right).execute(context(), -1);
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result first = rs.next();
+
+    assertThat(first.<Integer>getProperty("a")).isEqualTo(0);
+    assertThat(first.<Integer>getProperty("b")).isEqualTo(0);
+    assertThat(right.rowsProduced).as("only the right rows the consumer actually needed were pulled").isEqualTo(1);
+    rs.close();
+  }
+
+  @Test
+  void abandonedScanPullsOnlyTheRowsItConsumed() {
+    // This is the shape of "MATCH (a:Big), (b:Big) RETURN a, b LIMIT 3": the consumer stops after 3
+    // rows, so exactly 3 right rows may be touched, not the whole right input.
+    final RecordingOperator left = new RecordingOperator("a", 500);
+    final RecordingOperator right = new RecordingOperator("b", 500);
+    final ResultSet rs = product(left, right).execute(context(), -1);
+
+    for (int i = 0; i < 3; i++)
+      rs.next();
+    rs.close();
+
+    assertThat(right.rowsProduced).isEqualTo(3);
+    assertThat(left.rowsProduced).as("a single left row covers the first 3 pairs").isEqualTo(1);
+  }
+
+  @Test
+  void everyPairIsStillProducedInOrder() {
+    final RecordingOperator left = new RecordingOperator("a", 3);
+    final RecordingOperator right = new RecordingOperator("b", 2);
+    final ResultSet rs = product(left, right).execute(context(), -1);
+
+    final List<String> pairs = drainPairs(rs);
+    rs.close();
+
+    // The right input is re-iterated for every left row even though it is pulled lazily.
+    assertThat(pairs).containsExactly("0/0", "0/1", "1/0", "1/1", "2/0", "2/1");
+    assertThat(right.rowsProduced).as("the right input is pulled once and replayed from the buffer").isEqualTo(2);
+  }
+
+  @Test
+  void pairFilterStillSkipsRejectedPairs() {
+    final RecordingOperator left = new RecordingOperator("a", 3);
+    final RecordingOperator right = new RecordingOperator("b", 3);
+    final BiPredicate<Result, Result> sameId =
+        (l, r) -> l.<Integer>getProperty("a").equals(r.<Integer>getProperty("b"));
+    final ResultSet rs = new CartesianProduct(left, right, 1.0, 9L, sameId).execute(context(), -1);
+
+    final List<String> pairs = drainPairs(rs);
+    rs.close();
+
+    assertThat(pairs).containsExactly("0/0", "1/1", "2/2");
+  }
+
+  @Test
+  void anEmptyLeftInputProducesNoRowsAndClosesBothChildren() {
+    final RecordingOperator left = new RecordingOperator("a", 0);
+    final RecordingOperator right = new RecordingOperator("b", 3);
+    final ResultSet rs = product(left, right).execute(context(), -1);
+
+    assertThat(rs.hasNext()).isFalse();
+    assertThat(right.rowsProduced).as("an empty left input must not pull the right input at all").isZero();
+    rs.close();
+
+    assertThat(left.closeCount).isEqualTo(1);
+    assertThat(right.closeCount).isEqualTo(1);
+  }
+
+  @Test
+  void anEmptyRightInputProducesNoRows() {
+    final RecordingOperator left = new RecordingOperator("a", 3);
+    final RecordingOperator right = new RecordingOperator("b", 0);
+    final ResultSet rs = product(left, right).execute(context(), -1);
+
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+
+    assertThat(left.closeCount).isEqualTo(1);
+    assertThat(right.closeCount).isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // 3. end-to-end semantics the rewrite must not change
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void queryLevelCartesianProductKeepsEveryPair() {
+    final List<String> pairs = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Item) MATCH (b:Item) RETURN a.id AS x, b.id AS y ORDER BY x, y")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        pairs.add(row.<Object>getProperty("x") + "/" + row.<Object>getProperty("y"));
+      }
+    }
+
+    assertThat(pairs).hasSize(16);
+    assertThat(pairs).startsWith("0/0", "0/1", "0/2", "0/3", "1/0");
+    assertThat(pairs).endsWith("3/3");
+  }
+
+  @Test
+  void queryLevelLimitReturnsTheSameRowsAsTheUnlimitedQuery() {
+    final List<String> unlimited = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Item) MATCH (b:Item) RETURN a.id AS x, b.id AS y")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        unlimited.add(row.<Object>getProperty("x") + "/" + row.<Object>getProperty("y"));
+      }
+    }
+
+    final List<String> limited = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Item) MATCH (b:Item) RETURN a.id AS x, b.id AS y LIMIT 3")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        limited.add(row.<Object>getProperty("x") + "/" + row.<Object>getProperty("y"));
+      }
+    }
+
+    assertThat(limited).hasSize(3);
+    assertThat(limited).isEqualTo(unlimited.subList(0, 3));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+
+  private static CartesianProduct product(final PhysicalOperator left, final PhysicalOperator right) {
+    return new CartesianProduct(left, right, 1.0, 1L);
+  }
+
+  private BasicCommandContext context() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    return context;
+  }
+
+  private static List<String> drainPairs(final ResultSet rs) {
+    final List<String> pairs = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      pairs.add(row.<Object>getProperty("a") + "/" + row.<Object>getProperty("b"));
+    }
+    return pairs;
+  }
+
+  /**
+   * A leaf operator producing {@code rowCount} single-property rows lazily, recording how many rows
+   * were actually pulled out of it and how many times its result set was closed.
+   */
+  private static final class RecordingOperator implements PhysicalOperator {
+    private final String propertyName;
+    private final int    rowCount;
+    int rowsProduced;
+    int closeCount;
+
+    RecordingOperator(final String propertyName, final int rowCount) {
+      this.propertyName = propertyName;
+      this.rowCount = rowCount;
+    }
+
+    @Override
+    public ResultSet execute(final CommandContext context, final int nRecords) {
+      return new ResultSet() {
+        private int emitted = 0;
+
+        @Override
+        public boolean hasNext() {
+          return emitted < rowCount;
+        }
+
+        @Override
+        public Result next() {
+          if (!hasNext())
+            throw new NoSuchElementException();
+          final ResultInternal row = new ResultInternal();
+          row.setProperty(propertyName, emitted++);
+          ++rowsProduced;
+          return row;
+        }
+
+        @Override
+        public void close() {
+          ++closeCount;
+        }
+      };
+    }
+
+    @Override
+    public double getEstimatedCost() {
+      return rowCount;
+    }
+
+    @Override
+    public long getEstimatedCardinality() {
+      return rowCount;
+    }
+
+    @Override
+    public String getOperatorType() {
+      return "Recording";
+    }
+
+    @Override
+    public String explain(final int depth) {
+      return "  ".repeat(depth) + "+ Recording[" + propertyName + "]\n";
+    }
+
+    @Override
+    public PhysicalOperator getChild() {
+      return null;
+    }
+
+    @Override
+    public void setChild(final PhysicalOperator child) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
Closes #7010

## What was wrong

`com.arcadedb.query.opencypher.executor.operators.CartesianProduct` had two defects, both in the anonymous `ResultSet` its `execute()` returns.

**1. `close()` was an empty method.** It never reached either child, so an index-backed child under a Cartesian product kept its cursor open for as long as the plan was retained - the chaining contract every sibling operator honours (`FilterOperator`, `ExpandAll`, `NodeHashJoin`) and the reason #5635 gave for closing index cursors explicitly.

The chain was severed one step higher too. The physical-operator tree hangs off the result set of the wrapper step built in `CypherExecutionPlan.buildExecutionStepsWithOptimizer()`, and that step had no `close()` override, so `AbstractExecutionStep.close()` walked past it to `prev` (which is null there) and the operators' result set was never closed at all. Fixing only the operator would have left the fix inert on every optimized plan, so the wrapper now closes its `operatorResults` before delegating to `super.close()`, the same shape `ExpandIntoStep` and `IndexSeekStep` already use.

**2. The right input was drained in full before the first row.** `ensureInitialized()` looped the right child into an `ArrayList` up front, unbounded and regardless of any `LIMIT` above the operator, so `MATCH (a:Big), (b:Big) RETURN a, b LIMIT 1` bought the whole of `Big` in scan work and in heap to produce one row.

## The fix

The right side is now pulled one row at a time and buffered as it goes (`nextRight()`): the first row costs one right row, a consumer that stops early never touches the rows it did not ask for, and the buffer is still what replays the right side for the second and later left rows - so a full drain does the same amount of work it did before, just later. Both children are closed exactly once, whichever comes first: the right one the moment it is exhausted, both of them when the iteration finishes or when `close()` is called. `close()` is idempotent and safe before the first pull. An empty right side now short-circuits instead of walking every remaining left row for nothing.

Row semantics are untouched: same pairs, same order, same `pairFilter` behaviour (a rejected pair still never allocates a merged row), same `WorkGuard` deadline check per candidate.

## Test plan

New `engine/src/test/java/com/arcadedb/query/opencypher/CypherCartesianProductIssue7010Test.java`, 11 tests. Six of them fail against `main` and pass with the fix; the rest pin the semantics the rewrite must not change.

- [x] `closeReachesBothChildren` - was `0`/`0` closes, now `1`/`1`
- [x] `closeIsIdempotentAndSafeBeforeTheFirstRow` - closing before the first pull closes nothing, a second `close()` does not re-close
- [x] `aClosedResultSetDoesNotReopenItsChildren` - a `close()`-then-`hasNext()` must not execute the children again (added in review cycle 2)
- [x] `firstRowDoesNotDrainTheRightInput` - one right row pulled for the first result row, was 500
- [x] `abandonedScanPullsOnlyTheRowsItConsumed` - the `LIMIT 3` shape pulls 3 right rows and 1 left row, was 500
- [x] `everyPairIsStillProducedInOrder` - all 6 pairs in the same order, right side pulled once and replayed from the buffer
- [x] `pairFilterStillSkipsRejectedPairs`
- [x] `anEmptyLeftInputProducesNoRowsAndClosesBothChildren` / `anEmptyRightInputProducesNoRows`
- [x] `queryLevelCartesianProductKeepsEveryPair` / `queryLevelLimitReturnsTheSameRowsAsTheUnlimitedQuery` - end-to-end through `MATCH (a:Item) MATCH (b:Item)`

Suite runs (all with an isolated `-Dmaven.repo.local`):

- [x] the whole `com.arcadedb.query.opencypher.**` package in `engine`, which includes the openCypher TCK suite: `main` baseline **9103 tests, 0 failures, 98 skipped**; with the fix **9114, 0 failures, 98 skipped** (the 11 new ones). TCK passing steps identical at **15647** before and after.

## Review cycles

- **cycle 1** (`953b577`) - review raised one real edge case: `close()` left `initialized` false, so a later `hasNext()` ran `ensureInitialized()` and executed both children again, stranding two cursors nothing would close. `ensureInitialized()` now returns early when the result set is finished, and the `CypherExecutionPlan` wrapper step got the same treatment (a latched `closed` flag instead of nulling `operatorResults`, so `syncPull()` cannot re-execute the operator tree after a close). Also dropped the field-alignment padding and the duplicate `guard.check()` on a freshly pulled right row, both flagged as style.
- **cycle 2** (`0af7595`) - no changes requested.

### Deferred, by the reviewer's own suggestion

`closeChildren()` closes the right child then the left with no `try`/`finally`, so a throwing `close()` on the right would skip the left. Every sibling operator in the package (`NodeHashJoin` among them) has the same shape, and the review suggested hardening them together in a future pass rather than making this one file the odd one out. Not changed here.

## Note for the reviewer

The wrapper-step `close()` in `CypherExecutionPlan` is plumbing with no observable from the public API - ArcadeDB keeps no registry of open index cursors, so there is nothing a test can assert on beyond "the query still works". It is covered by the suite runs above rather than by a dedicated test; the operator contract it now reaches is what the unit tests pin.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1bu3QHjw5bgFKvfPSUoR7
