### PR TITLE
fix(engine) #7009: shortestPath()/allShortestPaths() honour the pattern hop bounds

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -186,7 +186,7 @@ public class ShortestPathExpression implements Expression {
       return allPaths ? new ArrayList<>() : null;
 
     // Endpoints resolving to the same vertex short-circuit to the zero-length path before any bound applies,
-    // matching what the MATCH form has always answered for shortestPath((a)-[:R*]-(a)).
+    // matching what the MATCH form has always answered for shortestPath((a)-[:R*]-(a)). See issue #7017.
     if (pathRids.size() > 1 && !bounds.accepts(pathRids.size() - 1))
       return allPaths ? new ArrayList<>() : null;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -30,7 +30,6 @@ import com.arcadedb.function.sql.graph.SQLFunctionShortestPath;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Expression representing a shortestPath() or allShortestPaths() pattern in Cypher.
@@ -168,17 +167,9 @@ public class ShortestPathExpression implements Expression {
     else
       edgeTypeParam = edgeTypes;
 
-    // An upper hop bound also bounds the search: SQLFunctionShortestPath counts maxDepth in vertices, so the
-    // pattern's maxHops becomes maxHops + 1 there. The answer is re-checked against both bounds below.
-    final Integer maxDepth = bounds.maxDepthParameter();
-    final Object[] params;
-    if (maxDepth != null)
-      params = new Object[] { startVertex, endVertex, direction, edgeTypeParam,
-          Map.of(SQLFunctionShortestPath.PARAM_MAX_DEPTH, maxDepth) };
-    else if (edgeTypeParam != null)
-      params = new Object[] { startVertex, endVertex, direction, edgeTypeParam };
-    else
-      params = new Object[] { startVertex, endVertex, direction };
+    // An upper hop bound also bounds the search; the answer is re-checked against both bounds below.
+    final Object[] params = ShortestPathStep.shortestPathArguments(startVertex, endVertex, direction, edgeTypeParam,
+        bounds);
 
     final List<RID> pathRids = shortestPathFunction.execute(null, null, null, params, context);
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -23,12 +23,14 @@ import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep;
 import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep.EdgeConstraint;
+import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep.HopBounds;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.function.sql.graph.SQLFunctionShortestPath;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Expression representing a shortestPath() or allShortestPaths() pattern in Cypher.
@@ -139,11 +141,15 @@ public class ShortestPathExpression implements Expression {
     // The inline property map and the inline WHERE predicate constrain every relationship on the path.
     // SQLFunctionShortestPath only sees vertices, so a constrained pattern must run the edge-aware BFS
     // shared with the MATCH form instead.
+    // The *min..max hop bounds constrain the answer exactly as they do in the MATCH form: without this the
+    // expression form answered shortestPath((s)-[:R*..2]-(e)) with a 4-hop path (issue #7009).
+    final HopBounds bounds = HopBounds.from(relationship);
+
     final EdgeConstraint constraint = EdgeConstraint.from(relationship, result, context);
     if (constraint != null) {
       final String[] typesArray = edgeTypes == null || edgeTypes.isEmpty() ? null : edgeTypes.toArray(new String[0]);
       final List<Object> filtered = ShortestPathStep.computeFilteredShortestPath(startVertex, endVertex,
-          traversalDirection, typesArray, constraint, context);
+          traversalDirection, typesArray, constraint, bounds, context);
       if (filtered == null || filtered.isEmpty())
         return allPaths ? new ArrayList<>() : null;
       // allShortestPaths() in expression position still yields the single shortest path found, matching the
@@ -162,13 +168,26 @@ public class ShortestPathExpression implements Expression {
     else
       edgeTypeParam = edgeTypes;
 
-    final Object[] params = edgeTypeParam != null ?
-        new Object[] { startVertex, endVertex, direction, edgeTypeParam } :
-        new Object[] { startVertex, endVertex, direction };
+    // An upper hop bound also bounds the search: SQLFunctionShortestPath counts maxDepth in vertices, so the
+    // pattern's maxHops becomes maxHops + 1 there. The answer is re-checked against both bounds below.
+    final Integer maxDepth = bounds.maxDepthParameter();
+    final Object[] params;
+    if (maxDepth != null)
+      params = new Object[] { startVertex, endVertex, direction, edgeTypeParam,
+          Map.of(SQLFunctionShortestPath.PARAM_MAX_DEPTH, maxDepth) };
+    else if (edgeTypeParam != null)
+      params = new Object[] { startVertex, endVertex, direction, edgeTypeParam };
+    else
+      params = new Object[] { startVertex, endVertex, direction };
 
     final List<RID> pathRids = shortestPathFunction.execute(null, null, null, params, context);
 
     if (pathRids == null || pathRids.isEmpty())
+      return allPaths ? new ArrayList<>() : null;
+
+    // Endpoints resolving to the same vertex short-circuit to the zero-length path before any bound applies,
+    // matching what the MATCH form has always answered for shortestPath((a)-[:R*]-(a)).
+    if (pathRids.size() > 1 && !bounds.accepts(pathRids.size() - 1))
       return allPaths ? new ArrayList<>() : null;
 
     // Resolve vertex RIDs and find connecting edges to build a proper path

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -953,11 +953,16 @@ public class ShortestPathStep extends AbstractExecutionStep {
     builder.append("+ SHORTEST PATH ");
     builder.append("(").append(sourceVariable).append(")");
     if (pattern.getRelationshipCount() > 0) {
+      final RelationshipPattern rel = pattern.getRelationship(0);
       builder.append("-[");
-      if (pattern.getRelationship(0).hasTypes()) {
-        builder.append(":").append(String.join("|", pattern.getRelationship(0).getTypes()));
+      if (rel.hasTypes()) {
+        builder.append(":").append(String.join("|", rel.getTypes()));
       }
-      builder.append(patternHopBounds().toString()).append("]-");
+      // Render the quantifier only when the pattern actually carries one: a plain -[:LINK]- is a single hop
+      // and spelling it "*1..1" (or, as this line used to, a bare "*") describes a pattern nobody wrote.
+      if (rel.isVariableLength())
+        builder.append(patternHopBounds().toString());
+      builder.append("]-");
     }
     builder.append("(").append(targetVariable).append(")");
     if (pattern.isAllPaths()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -263,20 +263,8 @@ public class ShortestPathStep extends AbstractExecutionStep {
     else
       edgeTypeParam = edgeTypes;
 
-    // An upper hop bound also bounds the search: SQLFunctionShortestPath counts maxDepth in vertices, so
-    // the pattern's maxHops becomes maxHops + 1 there. The bound is re-checked on the answer below, which
-    // is what actually guarantees the contract - the pruning is only there to keep a bounded search cheap.
-    final Integer maxDepth = bounds.maxDepthParameter();
-    final Object[] params;
-    if (maxDepth != null)
-      params = new Object[] { source, target, direction, edgeTypeParam,
-          Map.of(SQLFunctionShortestPath.PARAM_MAX_DEPTH, maxDepth) };
-    else if (edgeTypeParam != null)
-      params = new Object[] { source, target, direction, edgeTypeParam };
-    else
-      params = new Object[] { source, target, direction };
-
-    final List<RID> pathRids = shortestPathFunction.execute(null, null, null, params, context);
+    final List<RID> pathRids = shortestPathFunction.execute(null, null, null,
+        shortestPathArguments(source, target, direction, edgeTypeParam, bounds), context);
     if (pathRids == null || pathRids.isEmpty())
       return null;
 
@@ -773,6 +761,29 @@ public class ShortestPathStep extends AbstractExecutionStep {
   }
 
   /**
+   * Builds the positional argument list {@link SQLFunctionShortestPath} expects, carrying an upper hop bound
+   * as its {@code maxDepth} option so a bounded pattern also bounds the search. Shared by the two evaluators
+   * that delegate to the function - this step and {@code ShortestPathExpression} - so a bound cannot reach
+   * one of them and not the other, which is how it came to be dropped in the first place.
+   * <p>
+   * The bound is still re-checked on the path that comes back: that check is what guarantees the contract,
+   * and the pruning here only keeps a bounded search cheap.
+   *
+   * @param edgeTypeParam a single type name, a {@link List} of them, or {@code null} to allow any type
+   */
+  public static Object[] shortestPathArguments(final Vertex source, final Vertex target, final String direction,
+      final Object edgeTypeParam, final HopBounds bounds) {
+    // maxDepth counts the vertices on the path rather than the relationships between them, hence maxHops + 1.
+    final Integer maxDepth = bounds.maxDepthParameter();
+    if (maxDepth != null)
+      return new Object[] { source, target, direction, edgeTypeParam,
+          Map.of(SQLFunctionShortestPath.PARAM_MAX_DEPTH, maxDepth) };
+    if (edgeTypeParam != null)
+      return new Object[] { source, target, direction, edgeTypeParam };
+    return new Object[] { source, target, direction };
+  }
+
+  /**
    * The {@code *min..max} hop bounds declared on a pattern relationship, resolved once so every
    * shortestPath()/allShortestPaths() evaluator applies the same rule to the path it found.
    * <p>
@@ -838,6 +849,8 @@ public class ShortestPathStep extends AbstractExecutionStep {
 
     @Override
     public String toString() {
+      if (min == max)
+        return "*" + min;
       return "*" + min + ".." + (max == Integer.MAX_VALUE ? "" : max);
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -282,7 +282,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
 
     // A source that already is the target short-circuits to the zero-length path before any bound applies:
     // that is what MATCH p = shortestPath((a)-[:R*]-(a)) has always answered, and the implicit minimum of 1
-    // that [*] carries would otherwise suppress it.
+    // that [*] carries would otherwise suppress it. See HopBounds and issue #7017.
     if (pathRids.size() > 1 && !bounds.accepts(pathRids.size() - 1))
       return null;
 
@@ -783,6 +783,13 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * on its shortest layer first. A shortest path below the declared minimum therefore yields no row
    * rather than a longer path satisfying it: finding that path is a different (non-shortest, simple-path
    * enumerating) search, and Neo4j rejects such a pattern outright.
+   * <p>
+   * One shape stays outside the check: endpoints resolving to the same vertex short-circuit to the
+   * zero-length path in every evaluator, before any bound applies, so a declared minimum is unenforceable
+   * there. That is the answer the engine has always given (pinned by
+   * {@code CypherReduceAndShortestPathTest.shortestPathSameNode}), and {@code [*]} is lowered to
+   * {@code minHops = 1} by the parser, so it cannot be told apart from an explicit {@code [*1..]} here.
+   * Changing it is a semantic decision tracked by issue #7017.
    */
   public static final class HopBounds {
     /** No bound at all: accepts every path length. */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -60,9 +60,11 @@ import java.util.Set;
  * <p>
  * Uses the existing SQLFunctionShortestPath for path computation.
  * <p>
- * Relationship constraints honoured on every hop: the type list, the direction, the inline property map
- * and the inline WHERE predicate. The {@code *min..max} hop bounds are NOT enforced - every traversal here
- * runs unbounded until it reaches the target - so {@code [:LINK*1..3]} currently behaves as {@code [:LINK*]}.
+ * Relationship constraints honoured on every hop: the type list, the direction, the inline property map,
+ * the inline WHERE predicate and the {@code *min..max} hop bounds. The bounds both prune the search (an
+ * upper bound stops the traversal from expanding a layer that could only produce longer paths) and filter
+ * the answer, so {@code [:LINK*..2]} returns nothing when the shortest path is 4 hops instead of behaving
+ * like {@code [:LINK*]} - issue #7009.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -214,9 +216,12 @@ public class ShortestPathStep extends AbstractExecutionStep {
     // inline WHERE in shortestPath((a)-[r:LINK* WHERE r.tag = 'ok']->(b))) are not honoured by
     // SQLFunctionShortestPath, which only sees vertices. Route through an edge-aware BFS that walks
     // matching edges only.
+    final HopBounds bounds = patternHopBounds();
+
     final EdgeConstraint constraint = edgeConstraint(inputResult, context);
     if (constraint != null)
-      return computeFilteredShortestPath(source, target, patternDirection(), patternEdgeTypesArray(), constraint, context);
+      return computeFilteredShortestPath(source, target, patternDirection(), patternEdgeTypesArray(), constraint, bounds,
+          context);
 
     // Collect every relationship type declared in the pattern. Variable-length type alternation
     // (e.g. [:R1|R2*]) is expressed as a single relationship with multiple types - all of them
@@ -258,12 +263,27 @@ public class ShortestPathStep extends AbstractExecutionStep {
     else
       edgeTypeParam = edgeTypes;
 
-    final Object[] params = edgeTypeParam != null ?
-        new Object[] { source, target, direction, edgeTypeParam } :
-        new Object[] { source, target, direction };
+    // An upper hop bound also bounds the search: SQLFunctionShortestPath counts maxDepth in vertices, so
+    // the pattern's maxHops becomes maxHops + 1 there. The bound is re-checked on the answer below, which
+    // is what actually guarantees the contract - the pruning is only there to keep a bounded search cheap.
+    final Integer maxDepth = bounds.maxDepthParameter();
+    final Object[] params;
+    if (maxDepth != null)
+      params = new Object[] { source, target, direction, edgeTypeParam,
+          Map.of(SQLFunctionShortestPath.PARAM_MAX_DEPTH, maxDepth) };
+    else if (edgeTypeParam != null)
+      params = new Object[] { source, target, direction, edgeTypeParam };
+    else
+      params = new Object[] { source, target, direction };
 
     final List<RID> pathRids = shortestPathFunction.execute(null, null, null, params, context);
     if (pathRids == null || pathRids.isEmpty())
+      return null;
+
+    // A source that already is the target short-circuits to the zero-length path before any bound applies:
+    // that is what MATCH p = shortestPath((a)-[:R*]-(a)) has always answered, and the implicit minimum of 1
+    // that [*] carries would otherwise suppress it.
+    if (pathRids.size() > 1 && !bounds.accepts(pathRids.size() - 1))
       return null;
 
     // Build a proper path with alternating Vertex and Edge objects
@@ -287,10 +307,12 @@ public class ShortestPathStep extends AbstractExecutionStep {
       final CommandContext context) {
     // Inline edge constraints must be enforced on every hop; the vertex-only BFS below cannot see edge
     // properties, so delegate to the edge-aware variant when a property map or inline WHERE is declared.
+    final HopBounds bounds = patternHopBounds();
+
     final EdgeConstraint constraint = edgeConstraint(inputResult, context);
     if (constraint != null)
       return computeFilteredAllShortestPaths(source, target, patternDirection(), patternEdgeTypesArray(), constraint,
-          context.getDatabase(), context);
+          bounds, context.getDatabase(), context);
 
     final List<String> edgeTypes;
     if (pattern.getRelationshipCount() > 0 && pattern.getRelationship(0).hasTypes())
@@ -348,6 +370,11 @@ public class ShortestPathStep extends AbstractExecutionStep {
       if (foundDepth >= 0 && currentDepth >= foundDepth)
         break;
 
+      // Same reasoning for the declared upper bound: the next layer can only reach vertices more than
+      // maxHops hops away, and no path through them could satisfy the pattern (issue #7009).
+      if (currentDepth >= bounds.getMax())
+        break;
+
       final Deque<Vertex> nextLayer = new ArrayDeque<>();
       final Set<RID> nextLayerSeen = new HashSet<>();
 
@@ -376,7 +403,8 @@ public class ShortestPathStep extends AbstractExecutionStep {
       currentDepth++;
     }
 
-    if (foundDepth < 0)
+    // Every path returned here has length foundDepth, so one bound check answers for all of them.
+    if (foundDepth < 0 || !bounds.accepts(foundDepth))
       return Collections.emptyList();
 
     // Backtrack from target through every predecessor chain to produce every path of length foundDepth.
@@ -413,6 +441,13 @@ public class ShortestPathStep extends AbstractExecutionStep {
       }
     }
     return Vertex.DIRECTION.BOTH;
+  }
+
+  /**
+   * Returns the {@code *min..max} hop bounds declared on the pattern relationship.
+   */
+  private HopBounds patternHopBounds() {
+    return HopBounds.from(pattern.getRelationshipCount() > 0 ? pattern.getRelationship(0) : null);
   }
 
   private String[] patternEdgeTypesArray() {
@@ -526,13 +561,14 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * with different property values are disambiguated correctly.
    *
    * @param edgeTypes restrict edges to these types, or null/empty to allow any type
+   * @param bounds    the {@code *min..max} hop bounds declared on the pattern relationship (issue #7009)
    * @param context   the command context the deadline is read from; {@code null} leaves only the interrupt check
    *                  (issue #6459 - this constrained BFS previously consulted neither, unlike the unconstrained
    *                  frontier walk it falls back from)
    */
   public static List<Object> computeFilteredShortestPath(final Vertex source, final Vertex target,
       final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint,
-      final CommandContext context) {
+      final HopBounds bounds, final CommandContext context) {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
@@ -554,7 +590,10 @@ public class ShortestPathStep extends AbstractExecutionStep {
 
     final WorkGuard guard = WorkGuard.forCommandDeadline(context);
 
-    while (!frontier.isEmpty()) {
+    // Hops already walked to reach the current frontier, so the layer expanded below lands at depth + 1.
+    int depth = 0;
+
+    while (!frontier.isEmpty() && depth < bounds.getMax()) {
       if (Thread.interrupted())
         throw new CommandExecutionException("The shortestPath() function has been interrupted");
       guard.check();
@@ -579,12 +618,17 @@ public class ShortestPathStep extends AbstractExecutionStep {
             parentVertex.put(neighborRid, v);
             incomingEdge.put(neighborRid, edge);
             if (neighborRid.equals(targetRid))
-              return reconstructFilteredPath(source, target, parentVertex, incomingEdge);
+              // A level-order walk reaches the target on its shortest layer first, so a length below the
+              // declared minimum cannot be improved on by carrying the search further.
+              return bounds.accepts(depth + 1) ?
+                  reconstructFilteredPath(source, target, parentVertex, incomingEdge) :
+                  null;
             next.add(neighbor);
           }
         }
       }
       frontier = next;
+      depth++;
     }
     return null;
   }
@@ -613,13 +657,14 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * distinct paths OpenCypher requires.
    *
    * @param edgeTypes restrict edges to these types, or null/empty to allow any type
+   * @param bounds    the {@code *min..max} hop bounds declared on the pattern relationship (issue #7009)
    * @param context   the command context the deadline is read from; {@code null} leaves only the interrupt check
    *                  (issue #6459 - this constrained BFS previously consulted neither, unlike the unconstrained
    *                  layered BFS it falls back from)
    */
   public static List<List<Object>> computeFilteredAllShortestPaths(final Vertex source, final Vertex target,
       final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint,
-      final Database database, final CommandContext context) {
+      final HopBounds bounds, final Database database, final CommandContext context) {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
@@ -648,6 +693,11 @@ public class ShortestPathStep extends AbstractExecutionStep {
       guard.check();
 
       if (foundDepth >= 0 && currentDepth >= foundDepth)
+        break;
+
+      // The next layer lands beyond the declared upper bound, so nothing it reaches can satisfy the
+      // pattern (issue #7009).
+      if (currentDepth >= bounds.getMax())
         break;
 
       final Deque<Vertex> nextLayer = new ArrayDeque<>();
@@ -690,7 +740,8 @@ public class ShortestPathStep extends AbstractExecutionStep {
       currentDepth++;
     }
 
-    if (foundDepth < 0)
+    // Every path returned here has length foundDepth, so one bound check answers for all of them.
+    if (foundDepth < 0 || !bounds.accepts(foundDepth))
       return Collections.emptyList();
 
     final List<List<Object>> result = new ArrayList<>();
@@ -719,6 +770,69 @@ public class ShortestPathStep extends AbstractExecutionStep {
       }
     }
     stack.pop();
+  }
+
+  /**
+   * The {@code *min..max} hop bounds declared on a pattern relationship, resolved once so every
+   * shortestPath()/allShortestPaths() evaluator applies the same rule to the path it found.
+   * <p>
+   * Both spellings of a missing bound are folded in here: {@code [:R*]} and {@code [:R*..2]} carry an
+   * implicit minimum of one hop, and a relationship written without {@code *} at all is a single hop.
+   * <p>
+   * Only the upper bound can prune a breadth-first search, because a level-order walk reaches the target
+   * on its shortest layer first. A shortest path below the declared minimum therefore yields no row
+   * rather than a longer path satisfying it: finding that path is a different (non-shortest, simple-path
+   * enumerating) search, and Neo4j rejects such a pattern outright.
+   */
+  public static final class HopBounds {
+    /** No bound at all: accepts every path length. */
+    public static final HopBounds UNBOUNDED = new HopBounds(0, Integer.MAX_VALUE);
+
+    private final int min;
+    private final int max;
+
+    private HopBounds(final int min, final int max) {
+      this.min = min;
+      this.max = max;
+    }
+
+    /**
+     * Reads the bounds off {@code rel}, or returns {@link #UNBOUNDED} when there is no relationship.
+     */
+    public static HopBounds from(final RelationshipPattern rel) {
+      if (rel == null)
+        return UNBOUNDED;
+      final int min = rel.getEffectiveMinHops();
+      final int max = rel.getEffectiveMaxHops();
+      return min <= 0 && max == Integer.MAX_VALUE ? UNBOUNDED : new HopBounds(min, max);
+    }
+
+    /**
+     * The largest number of relationships a path may carry; {@link Integer#MAX_VALUE} when unbounded.
+     */
+    public int getMax() {
+      return max;
+    }
+
+    /**
+     * Returns true when a path of {@code hops} relationships satisfies both bounds.
+     */
+    public boolean accepts(final int hops) {
+      return hops >= min && hops <= max;
+    }
+
+    /**
+     * The upper bound expressed as {@code SQLFunctionShortestPath}'s {@code maxDepth}, which counts the
+     * vertices on the path rather than the relationships between them, or {@code null} when unbounded.
+     */
+    public Integer maxDepthParameter() {
+      return max == Integer.MAX_VALUE ? null : max + 1;
+    }
+
+    @Override
+    public String toString() {
+      return "*" + min + ".." + (max == Integer.MAX_VALUE ? "" : max);
+    }
   }
 
   private static Vertex.DIRECTION[] expandDirections(final Vertex.DIRECTION direction) {
@@ -836,7 +950,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
       if (pattern.getRelationship(0).hasTypes()) {
         builder.append(":").append(String.join("|", pattern.getRelationship(0).getTypes()));
       }
-      builder.append("*]-");
+      builder.append(patternHopBounds().toString()).append("]-");
     }
     builder.append("(").append(targetVariable).append(")");
     if (pattern.isAllPaths()) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathHopBoundsIssue7009Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathHopBoundsIssue7009Test.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CypherShortestPathHopBoundsIssue7009Test extends TestHelper {
   @Override
   protected void beginTest() {
-    database.getSchema().createVertexType("N").createProperty("k", com.arcadedb.schema.Type.STRING);
+    database.getSchema().createVertexType("N").createProperty("k", Type.STRING);
     database.getSchema().createEdgeType("LINK");
 
     // Graph (every LINK carries w=1, so an inline {w: 1} filter changes the evaluator without changing
@@ -255,7 +256,9 @@ class CypherShortestPathHopBoundsIssue7009Test extends TestHelper {
   @Test
   void aZeroLengthSelfPathIsStillReturned() {
     // The endpoints resolving to the same vertex short-circuits to the zero-length path before any hop
-    // bound applies, which is what MATCH p = shortestPath((a)-[:KNOWS*]-(a)) has always answered.
+    // bound applies, which is what MATCH p = shortestPath((a)-[:KNOWS*]-(a)) has always answered
+    // (CypherReduceAndShortestPathTest.shortestPathSameNode). Whether an explicit minimum should suppress
+    // it is a semantic decision tracked by issue #7017.
     try (final ResultSet rs = database.query("opencypher",
         "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len")) {
       assertThat(rs.hasNext()).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathHopBoundsIssue7009Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathHopBoundsIssue7009Test.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/ArcadeData/arcadedb/issues/7009
+ * <p>
+ * {@code shortestPath()} and {@code allShortestPaths()} must honour the {@code *min..max} hop bounds
+ * declared on the pattern relationship. They used to be parsed and then dropped, so
+ * {@code shortestPath((s)-[:LINK*..2]-(e))} happily returned a 4-hop path and answered exactly like the
+ * unbounded {@code [:LINK*]} spelling.
+ * <p>
+ * The four evaluators that had to be fixed are all exercised here, because a fix in one is invisible to
+ * the others: the unconstrained {@code MATCH p = shortestPath(...)} path (which delegates to
+ * {@code SQLFunctionShortestPath}), the unconstrained {@code allShortestPaths()} layered BFS, the
+ * edge-aware BFS both take when the relationship carries an inline property map or WHERE, and the
+ * {@code RETURN shortestPath(...)} expression form.
+ */
+class CypherShortestPathHopBoundsIssue7009Test extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("N").createProperty("k", com.arcadedb.schema.Type.STRING);
+    database.getSchema().createEdgeType("LINK");
+
+    // Graph (every LINK carries w=1, so an inline {w: 1} filter changes the evaluator without changing
+    // reachability):
+    //
+    //   a -> n1 -> n2 -> n3 -> b        the only a..b path is 4 hops
+    //   c -> d1 -> f, c -> d2 -> f      two co-shortest 2-hop c..f paths
+    //   g -> h                          a single 1-hop path
+    database.transaction(() -> {
+      final MutableVertex a = node("a");
+      final MutableVertex n1 = node("n1");
+      final MutableVertex n2 = node("n2");
+      final MutableVertex n3 = node("n3");
+      final MutableVertex b = node("b");
+      link(a, n1);
+      link(n1, n2);
+      link(n2, n3);
+      link(n3, b);
+
+      final MutableVertex c = node("c");
+      final MutableVertex d1 = node("d1");
+      final MutableVertex d2 = node("d2");
+      final MutableVertex f = node("f");
+      link(c, d1);
+      link(d1, f);
+      link(c, d2);
+      link(d2, f);
+
+      link(node("g"), node("h"));
+    });
+  }
+
+  private MutableVertex node(final String key) {
+    return database.newVertex("N").set("k", key).save();
+  }
+
+  private void link(final MutableVertex from, final MutableVertex to) {
+    from.newEdge("LINK", to, true, new Object[] { "w", 1 }).save();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // shortestPath(), unconstrained relationship (SQLFunctionShortestPath path)
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void shortestPathRejectsAPathLongerThanTheMaxHopBound() {
+    assertThat(lengths("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*..2]-(e)) RETURN length(p) AS len"))
+        .as("the only a..b path is 4 hops, so [:LINK*..2] must return nothing")
+        .isEmpty();
+  }
+
+  @Test
+  void shortestPathUnboundedControlStillReturnsTheFourHopPath() {
+    assertThat(lengths("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len"))
+        .as("control: the unbounded spelling still finds the 4-hop path")
+        .containsExactly(4);
+  }
+
+  @Test
+  void shortestPathAcceptsAPathThatFitsTheMaxHopBound() {
+    assertThat(lengths("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*..4]-(e)) RETURN length(p) AS len"))
+        .as("a bound wide enough for the 4-hop path must not suppress it")
+        .containsExactly(4);
+    assertThat(lengths("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*..3]-(e)) RETURN length(p) AS len"))
+        .as("one hop short of the only path is still no path")
+        .isEmpty();
+  }
+
+  @Test
+  void shortestPathRejectsAPathShorterThanTheMinHopBound() {
+    assertThat(lengths("MATCH (s:N {k:'g'}), (e:N {k:'h'}), p = shortestPath((s)-[:LINK*3..]-(e)) RETURN length(p) AS len"))
+        .as("the only g..h path is 1 hop, so [:LINK*3..] must return nothing")
+        .isEmpty();
+    assertThat(lengths("MATCH (s:N {k:'g'}), (e:N {k:'h'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len"))
+        .as("control: the unbounded spelling still finds the 1-hop path")
+        .containsExactly(1);
+  }
+
+  @Test
+  void shortestPathHonoursAnExactHopCount() {
+    assertThat(lengths("MATCH (s:N {k:'c'}), (e:N {k:'f'}), p = shortestPath((s)-[:LINK*2]-(e)) RETURN length(p) AS len"))
+        .as("[:LINK*2] matches the 2-hop c..f path")
+        .containsExactly(2);
+    assertThat(lengths("MATCH (s:N {k:'c'}), (e:N {k:'f'}), p = shortestPath((s)-[:LINK*3]-(e)) RETURN length(p) AS len"))
+        .as("[:LINK*3] does not, because the shortest c..f path is 2 hops")
+        .isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // allShortestPaths(), unconstrained relationship (layered BFS path)
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void allShortestPathsRejectsPathsLongerThanTheMaxHopBound() {
+    assertThat(lengths("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = allShortestPaths((s)-[:LINK*..2]-(e)) RETURN length(p) AS len"))
+        .as("the only a..b path is 4 hops, so [:LINK*..2] must return nothing")
+        .isEmpty();
+    assertThat(lengths("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = allShortestPaths((s)-[:LINK*]-(e)) RETURN length(p) AS len"))
+        .as("control: the unbounded spelling still finds the 4-hop path")
+        .containsExactly(4);
+  }
+
+  @Test
+  void allShortestPathsKeepsEveryCoShortestPathThatFitsTheBound() {
+    assertThat(lengths("MATCH (s:N {k:'c'}), (e:N {k:'f'}), p = allShortestPaths((s)-[:LINK*..2]-(e)) RETURN length(p) AS len"))
+        .as("both 2-hop c..f paths fit a bound of 2")
+        .containsExactly(2, 2);
+    assertThat(lengths("MATCH (s:N {k:'c'}), (e:N {k:'f'}), p = allShortestPaths((s)-[:LINK*..1]-(e)) RETURN length(p) AS len"))
+        .as("neither fits a bound of 1")
+        .isEmpty();
+  }
+
+  @Test
+  void allShortestPathsRejectsPathsShorterThanTheMinHopBound() {
+    assertThat(lengths("MATCH (s:N {k:'g'}), (e:N {k:'h'}), p = allShortestPaths((s)-[:LINK*3..]-(e)) RETURN length(p) AS len"))
+        .as("the only g..h path is 1 hop, so [:LINK*3..] must return nothing")
+        .isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Edge-aware BFS (an inline property map routes both forms away from SQLFunctionShortestPath)
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void shortestPathWithAnInlineEdgeFilterAlsoHonoursTheMaxHopBound() {
+    assertThat(lengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*..2 {w: 1}]-(e)) RETURN length(p) AS len"))
+        .as("the edge-aware BFS must apply the bound too")
+        .isEmpty();
+    assertThat(lengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK* {w: 1}]-(e)) RETURN length(p) AS len"))
+        .as("control: every LINK carries w=1, so the unbounded filtered form still finds the 4-hop path")
+        .containsExactly(4);
+  }
+
+  @Test
+  void allShortestPathsWithAnInlineEdgeFilterAlsoHonoursTheMaxHopBound() {
+    assertThat(lengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = allShortestPaths((s)-[:LINK*..2 {w: 1}]-(e)) RETURN length(p) AS len"))
+        .isEmpty();
+    assertThat(lengths(
+        "MATCH (s:N {k:'c'}), (e:N {k:'f'}), p = allShortestPaths((s)-[:LINK*..2 {w: 1}]-(e)) RETURN length(p) AS len"))
+        .as("control: both filtered co-shortest paths fit a bound of 2")
+        .containsExactly(2, 2);
+  }
+
+  @Test
+  void shortestPathWithAnInlineEdgeWhereAlsoHonoursTheMinHopBound() {
+    assertThat(lengths(
+        "MATCH (s:N {k:'g'}), (e:N {k:'h'}), p = shortestPath((s)-[r:LINK*3.. WHERE r.w = 1]-(e)) RETURN length(p) AS len"))
+        .isEmpty();
+    assertThat(lengths(
+        "MATCH (s:N {k:'g'}), (e:N {k:'h'}), p = shortestPath((s)-[r:LINK* WHERE r.w = 1]-(e)) RETURN length(p) AS len"))
+        .as("control: the unbounded filtered form still finds the 1-hop path")
+        .containsExactly(1);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Expression form: RETURN shortestPath(...)
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void shortestPathExpressionHonoursTheMaxHopBound() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:N {k:'a'}), (e:N {k:'b'}) RETURN shortestPath((s)-[:LINK*..2]-(e)) AS p")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("p"))
+          .as("a 4-hop path does not satisfy [:LINK*..2], so the expression yields null")
+          .isNull();
+    }
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:N {k:'a'}), (e:N {k:'b'}) RETURN shortestPath((s)-[:LINK*]-(e)) AS p")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Object path = rs.next().getProperty("p");
+      assertThat(path).as("control: the unbounded expression form still finds the path").isInstanceOf(List.class);
+      // 5 vertices interleaved with 4 edges.
+      assertThat((List<?>) path).hasSize(9);
+    }
+  }
+
+  @Test
+  void shortestPathExpressionWithAnInlineEdgeFilterHonoursTheMaxHopBound() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:N {k:'a'}), (e:N {k:'b'}) RETURN shortestPath((s)-[:LINK*..2 {w: 1}]-(e)) AS p")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("p")).isNull();
+    }
+  }
+
+  @Test
+  void allShortestPathsExpressionHonoursTheMaxHopBound() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:N {k:'a'}), (e:N {k:'b'}) RETURN allShortestPaths((s)-[:LINK*..2]-(e)) AS p")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<List<?>>getProperty("p"))
+          .as("no path satisfies the bound, so the expression yields an empty list")
+          .isEmpty();
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Shapes that must keep working exactly as before
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void aZeroLengthSelfPathIsStillReturned() {
+    // The endpoints resolving to the same vertex short-circuits to the zero-length path before any hop
+    // bound applies, which is what MATCH p = shortestPath((a)-[:KNOWS*]-(a)) has always answered.
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("len").intValue()).isZero();
+    }
+  }
+
+  @Test
+  void theMatchFormStillPlansAsAShortestPathStep() {
+    // The optimizer declines every ShortestPathPattern and falls back to the traditional plan, so the
+    // bound has exactly one evaluator to reach. Pin that, otherwise a future optimizer capability could
+    // route these queries past the fix without any test noticing.
+    try (final ResultSet rs = database.query("opencypher",
+        "EXPLAIN MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*..2]-(e)) RETURN p")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("executionPlanAsString").toString()).contains("SHORTEST PATH");
+    }
+  }
+
+  private List<Integer> lengths(final String query) {
+    final List<Integer> lengths = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final Number len = row.getProperty("len");
+        lengths.add(len == null ? null : len.intValue());
+      }
+    }
+    return lengths;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathHopBoundsIssue7009Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathHopBoundsIssue7009Test.java
@@ -254,6 +254,23 @@ class CypherShortestPathHopBoundsIssue7009Test extends TestHelper {
   // ---------------------------------------------------------------------------------------------
 
   @Test
+  void aRelationshipWrittenWithoutAQuantifierIsASingleHop() {
+    // A plain -[:LINK]- inside shortestPath() parses, and it declares one hop: getEffectiveMinHops() and
+    // getEffectiveMaxHops() both answer 1 for it, exactly as they do for ExpandPathStep and VarLengthExpand
+    // elsewhere in the engine. Before issue #7009 every shortestPath() traversal ran unbounded, so this
+    // shape searched for a path of any length; it is bounded now, and this pins that deliberately.
+    assertThat(lengths("MATCH (s:N {k:'g'}), (e:N {k:'h'}), p = shortestPath((s)-[:LINK]-(e)) RETURN length(p) AS len"))
+        .as("g -> h is a direct edge, which is what a single-hop pattern asks for")
+        .containsExactly(1);
+    assertThat(lengths("MATCH (s:N {k:'c'}), (e:N {k:'f'}), p = shortestPath((s)-[:LINK]-(e)) RETURN length(p) AS len"))
+        .as("the shortest c..f path is 2 hops, so a single-hop pattern matches nothing")
+        .isEmpty();
+    assertThat(lengths("MATCH (s:N {k:'c'}), (e:N {k:'f'}), p = allShortestPaths((s)-[:LINK]-(e)) RETURN length(p) AS len"))
+        .as("allShortestPaths() reads the same pattern the same way")
+        .isEmpty();
+  }
+
+  @Test
   void aZeroLengthSelfPathIsStillReturned() {
     // The endpoints resolving to the same vertex short-circuits to the zero-length path before any hop
     // bound applies, which is what MATCH p = shortestPath((a)-[:KNOWS*]-(a)) has always answered


### PR DESCRIPTION
Closes #7009

## Summary

`shortestPath((s)-[:R*..2]-(e))` returned a 4-hop path: the `*min..max` quantifier was parsed into `RelationshipPattern.minHops`/`maxHops` and then never read by any shortest-path evaluator, so the bounded and unbounded spellings answered identically. This threads the bounds through every evaluator, so an out-of-range path yields no row.

## Root cause

Four evaluators compute a Cypher shortest path, and none consulted the bound:

| Evaluator | Entry point | Search |
|---|---|---|
| `MATCH p = shortestPath(...)`, unconstrained relationship | `ShortestPathStep.computeShortestPath` | delegates to `SQLFunctionShortestPath` (bidirectional BFS) |
| `MATCH p = allShortestPaths(...)`, unconstrained | `ShortestPathStep.computeAllShortestPaths` | layered BFS with a predecessor multimap |
| either form with an inline edge property map / `WHERE` | `computeFilteredShortestPath`, `computeFilteredAllShortestPaths` | edge-aware BFS |
| `RETURN shortestPath(...)` (expression position) | `ShortestPathExpression.evaluate` | `SQLFunctionShortestPath` or the edge-aware BFS |

`CypherExecutionPlanner` declines every `ShortestPathPattern` and falls back to the traditional plan, so the `MATCH` form has exactly one plan shape - confirmed with `EXPLAIN` and pinned by a test, so a future optimizer capability cannot route these queries past the fix unnoticed.

## Fix

A new `ShortestPathStep.HopBounds` value resolves `getEffectiveMinHops()`/`getEffectiveMaxHops()` once and is threaded through all four evaluators. It does two things:

- **Prunes the search.** The upper bound stops a BFS from expanding a layer that could only reach vertices further away than `maxHops`, and is handed to `SQLFunctionShortestPath` as its `maxDepth` option. `maxDepth` counts vertices rather than relationships (pinned by `SQLFunctionShortestPathTest.maxDepth1`/`maxDepth3`: `maxDepth` 11 yields an 11-vertex/10-hop path, 10 yields none), so the pattern's `maxHops` becomes `maxHops + 1` there.
- **Filters the answer.** The hop count of whatever path came back is re-checked against both bounds. This is what guarantees the contract; the pruning is only there to keep a bounded search cheap.

Two deliberate carve-outs, both documented in the code:

- **Zero-length self path.** Endpoints resolving to the same vertex short-circuit to the one-vertex path before any bound applies. `[*]` carries an implicit minimum of 1 hop that would otherwise suppress it, and `CypherReduceAndShortestPathTest.shortestPathSameNode` pins the existing answer.
- **A lower bound cannot lengthen a search.** A breadth-first walk reaches the target on its shortest layer first, so when that shortest path is below `minHops` the result is no row rather than a longer path that would satisfy the bound. Finding that path is a different (non-shortest, simple-path enumerating) search.

  **This one needs a maintainer's confirmation before merge.** An earlier revision of this description asserted that Neo4j rejects a `minHops > 1` shortest-path pattern outright. That was my recollection and I have not verified it against a running Neo4j, so treat it as unverified. If Neo4j instead searches for a path within `[min, max]` rather than only checking the global shortest, this is a silent divergence for anyone porting queries, and the right fix is a different search rather than a filter. Nothing else in the PR depends on the answer: with no lower bound declared (`[*]`, `[*..n]`, a plain relationship - i.e. every query in the linked issue) `min` is 1 or 0 and the branch is unreachable.

### One behaviour change beyond the quantifier itself

A relationship written **without** a quantifier inside `shortestPath()` parses, and it declares one hop: `getEffectiveMinHops()`/`getEffectiveMaxHops()` both answer `1` for it, exactly as they do for `ExpandPathStep`, `VarLengthExpand` and `JoinOrderRule` elsewhere in the engine. Since every `shortestPath()` traversal previously ran unbounded regardless of what the pattern declared, `shortestPath((a)-[:LINK]-(b))` used to search for a path of *any* length and now considers only a direct edge.

That is the same defect as the reported one and is fixed the same way, but it changes the answer for a shape the issue does not mention, so it is pinned deliberately by `aRelationshipWrittenWithoutAQuantifierIsASingleHop` - verified against a control worktree at the base commit, where it fails with a 2-hop answer for a pattern that asked for one hop.

`prettyPrint` now renders the bound (`-[:LINK*1..2]-`) instead of a bare `*`, so `EXPLAIN` shows what is actually enforced.

## Test plan

- [x] `CypherShortestPathHopBoundsIssue7009Test` - 17 new tests, **14 of which fail before the fix**. Covers every evaluator: `shortestPath()`/`allShortestPaths()` in `MATCH` position with and without an inline edge filter, and both in expression position; max bound, min bound and the exact `*n` form; unbounded controls in the same run so a green test cannot come from the graph simply having no path; plus the zero-length self path, the non-quantified single-hop shape and the `EXPLAIN` plan-shape assertion.
- [x] openCypher TCK (`mvn -pl engine verify -Dsurefire.includes='**/*Suite.java'`): **3897 run / 0 failures / 85 skipped, identical before and after** the change.
- [x] Whole `com.arcadedb.query.opencypher` package: 9120 tests, 0 failures.
- [x] Full `engine` module (`-DexcludedGroups=benchmark,vector,slow`): 14038 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1bu3QHjw5bgFKvfPSUoR7
