### PR TITLE
fix(#6977): scope the Cypher label-replacement map to the statement, not the step

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -400,6 +400,9 @@ public class CypherExecutionPlan {
       final List<ResultInternal> allResults = new ArrayList<>();
       final Set<String> seen = removeDuplicates ? new HashSet<>() : null;
       for (final CypherExecutionPlan branchPlan : branchPlans) {
+        // No inherit() here on purpose: the branch runs through this same method with the REAL outerContext,
+        // so it takes the non-union path below and does its own inherit under the same gate. A second copy
+        // here would be one more thing to keep in step with that gate (issue #6977).
         final ResultSet rs = branchPlan.executeWithSeedRow(seedRow, outerContext);
         while (rs.hasNext()) {
           unionGuard.check();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -425,8 +425,14 @@ public class CypherExecutionPlan {
     // Only share the outer statistics accumulator for a write CALL body: getStatistics() lazily
     // allocates, so sharing it unconditionally would allocate a QueryStatistics even for a
     // fully read-only CALL, violating the "read queries allocate nothing" constraint.
-    if (outerContext != null && !statement.isReadOnly())
+    if (outerContext != null && !statement.isReadOnly()) {
       context.setStatistics(outerContext.getStatistics());
+      // A label write moves the record, so the map of what it displaced has to outlive this plan: the body of a
+      // CALL { } is re-planned for every outer row, and without this the second row met the vertex the first one
+      // deleted (issue #6977). Same gate as the statistics above - a read-only body performs no label write and
+      // must not make the enclosing statement allocate a map for one.
+      LabelReplacements.inherit(context, outerContext);
+    }
     inheritCommandDeadline(context, outerContext);
 
     // Create a seed step that returns the seed row

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -28,6 +28,7 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.opencypher.traversal.TraversalPath;
+import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
@@ -50,18 +51,58 @@ import java.util.logging.Level;
  * as an "edge list not fully visible" complaint from the vertex delete that follows its dangling edge-list chunk
  * (issues #6312 and #6313).
  * <p>
- * One instance is held per running {@code SET}/{@code REMOVE} step, so a node replaced while processing one row is
- * redirected to its live replacement on every later row, and the write becomes idempotent instead of fatal. The
- * edges re-attached on the way are tracked the same, lightweight ones included: they have no record to address, but
- * their identity is the (type, out vertex, in vertex) triple, and that is what moved.
+ * One instance is held per running <b>statement</b> - {@link #of(CommandContext)} keeps it on the command context -
+ * so a node replaced while processing one row is redirected to its live replacement on every later row, and the write
+ * becomes idempotent instead of fatal. The edges re-attached on the way are tracked the same, lightweight ones
+ * included: they have no record to address, but their identity is the (type, out vertex, in vertex) triple, and that
+ * is what moved.
+ * <p>
+ * The scope is the statement and not the step because a {@code CALL { }} body is <b>re-planned for every outer
+ * row</b> ({@code SubqueryStep.executeInnerQuery} builds a fresh {@code CypherExecutionPlan} each time): a per-step
+ * instance there lives for exactly one row, so the second outer row met the vertex the first one had deleted and the
+ * label write followed a RID that was gone (issue #6977). {@link #inherit} is what carries the enclosing statement's
+ * map into such a nested plan's own context.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public final class LabelReplacements {
   private static final Object[] NO_PROPERTIES = new Object[0];
+  /**
+   * Where {@link #of} parks the statement-wide instance. Held as a context <i>cached value</i> rather than as a
+   * context variable: cached values are engine-internal, while variables are reachable from a query through
+   * {@code $CONTEXT} and fall back to the database's global variables when missing.
+   */
+  private static final String   CONTEXT_KEY   = "$cypher.labelReplacements";
 
   private final Map<RID, Vertex> vertices = new HashMap<>();
   private final Map<RID, Edge>   edges    = new HashMap<>();
+
+  /**
+   * The replacement map of the statement {@code context} belongs to, created on first use.
+   * <p>
+   * Every label write of one statement shares it: the three steps that perform one ({@code SET}, {@code REMOVE} and
+   * {@code MERGE}'s {@code ON CREATE}/{@code ON MATCH SET}) and, through {@link #inherit}, every plan nested inside
+   * it. Allocated only when a write step actually asks for it, so a read-only statement never builds one.
+   */
+  public static LabelReplacements of(final CommandContext context) {
+    if (context == null)
+      return new LabelReplacements();
+    if (context.getCachedValue(CONTEXT_KEY) instanceof LabelReplacements existing)
+      return existing;
+    final LabelReplacements created = new LabelReplacements();
+    context.setCachedValue(CONTEXT_KEY, created);
+    return created;
+  }
+
+  /**
+   * Makes a nested plan's context answer {@link #of} with the enclosing statement's map, so a label write inside a
+   * {@code CALL { }} body is seen by the next outer row even though the body is re-planned for each one.
+   */
+  public static void inherit(final CommandContext inner, final CommandContext outer) {
+    if (inner == null || outer == null)
+      return;
+    inner.setCachedValue(CONTEXT_KEY, of(outer));
+  }
 
   public boolean isEmpty() {
     return vertices.isEmpty();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -62,6 +62,15 @@ import java.util.logging.Level;
  * instance there lives for exactly one row, so the second outer row met the vertex the first one had deleted and the
  * label write followed a RID that was gone (issue #6977). {@link #inherit} is what carries the enclosing statement's
  * map into such a nested plan's own context.
+ * <p>
+ * <b>What the wider scope costs.</b> The map is keyed by RID, and a RID is a physical position, so a slot freed
+ * by the delete inside {@link #replace} can in principle be handed to a record created later in the same
+ * statement - which {@link #resolve} would then answer for with the replacement of the record that used to live
+ * there. The window was one step's rows before and is the statement's now, so the scope change widens it rather
+ * than opening it, and nothing here has been observed to reach it: {@link #replace} creates the replacement
+ * before deleting the original, so the two can never collide, and only a separate later insert landing on the
+ * exact freed slot could. Recorded because it is the one thing the wider scope makes more likely, not because
+ * a reproduction exists.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -83,6 +83,11 @@ public final class LabelReplacements {
    * Every label write of one statement shares it: the three steps that perform one ({@code SET}, {@code REMOVE} and
    * {@code MERGE}'s {@code ON CREATE}/{@code ON MATCH SET}) and, through {@link #inherit}, every plan nested inside
    * it. Allocated only when a write step actually asks for it, so a read-only statement never builds one.
+   * <p>
+   * A {@code null} context has no statement to share through, so the caller gets a private map rather than an
+   * exception: it is still correct for a single step, only unshared. No call site passes one today - every step
+   * that asks is constructed with the plan's context - and a new one that did would get the pre-#6977 behaviour
+   * back for itself, which is why the fallback is spelled out here rather than left to be inferred.
    */
   public static LabelReplacements of(final CommandContext context) {
     if (context == null)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -192,6 +192,14 @@ public final class LabelReplacements {
   public void redirect(final Result row) {
     if (row == null || vertices.isEmpty())
       return;
+    // The ResultInternal cast below is unguarded where SubqueryStep.refreshDocumentBindings guards its own, and
+    // deliberately so rather than by oversight. Both plan shapes feed the write steps ResultInternal rows -
+    // the optimizer is not disabled by a REMOVE/SET after the MATCH, but its NodeByLabelScan/ExpandAll chain
+    // materializes ResultInternal, and the one Result that is not (GAVResult, from the fused GAV chain) has
+    // no path into a label write today. Should one appear, failing loudly is the answer that matches what
+    // this method is for: skipping silently would leave the row pointing at the record the write deleted,
+    // which is the defect the class exists to prevent, whereas the refresh next door is an optimisation that
+    // is allowed to decline.
     for (final String name : row.getPropertyNames()) {
       final Object value = row.getProperty(name);
       final Object live = redirectValue(value);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -213,9 +213,10 @@ public class MergeStep extends AbstractExecutionStep {
     final Database database = context.getDatabase();
     final QueryStatistics stats = context.getStatistics();
     final QueryStatistics statsSnapshot = stats.copy();
-    // labelReplacements is step-wide (shared across every row this MergeStep processes, see the field
-    // Javadoc), so only the entries a FAILED attempt of THIS row added must be undone on retry - entries
-    // an earlier, already-committed row recorded are still live and must survive. Snapshotting here,
+    // labelReplacements is statement-wide (shared across every row this MergeStep processes and with every
+    // other label write of the same statement, see the field Javadoc), so only the entries a FAILED attempt
+    // of THIS row added must be undone on retry - entries an earlier, already-committed row recorded, here
+    // or in another step, are still live and must survive. Snapshotting here,
     // once per row before the first attempt, and restoring it at the top of every attempt (including the
     // first, a no-op there) does exactly that.
     final LabelReplacements.Snapshot labelReplacementsSnapshot = labelReplacements.copy();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -100,8 +100,9 @@ public class MergeStep extends AbstractExecutionStep {
       private boolean mergedStandalone = false;
       // Tracks the vertices an ON CREATE/ON MATCH SET n:Label replaced, so a node relabelled while processing one
       // row is not still the deleted original when a later row - or a second alias of the same row - reaches it.
-      // Same reasoning, and same class, as SetStep and RemoveStep (issues #6312, #6313).
-      private final LabelReplacements labelReplacements = new LabelReplacements();
+      // Same reasoning, same class and same statement-wide scope as SetStep and RemoveStep (issues #6312, #6313,
+      // #6977).
+      private final LabelReplacements labelReplacements = LabelReplacements.of(context);
 
       @Override
       public boolean hasNext() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -72,8 +72,10 @@ public class RemoveStep extends AbstractExecutionStep {
       private int bufferIndex = 0;
       private boolean finished = false;
       // Tracks the vertices a label removal replaced. A label change rewrites the record under a new type, so
-      // every later row still holding the original refers to a deleted RID (issues #6312, #6313).
-      private final LabelReplacements replacements = new LabelReplacements();
+      // every later row still holding the original refers to a deleted RID (issues #6312, #6313). Held on the
+      // command context rather than here, so a REMOVE inside a CALL { } body - re-planned once per outer row -
+      // still recognises what an earlier row moved (issue #6977).
+      private final LabelReplacements replacements = LabelReplacements.of(context);
 
       @Override
       public boolean hasNext() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -72,8 +72,9 @@ public class SetStep extends AbstractExecutionStep {
       private final Map<RID, MutableDocument> writtenDocs = new HashMap<>();
       // Tracks the vertices SET n:Label replaced so that when the same node appears on a later row
       // (row fanout), the operation is redirected to the already-replaced vertex and the idempotency
-      // check returns early.
-      private final LabelReplacements labelReplacements = new LabelReplacements();
+      // check returns early. Statement-scoped, so a SET inside a CALL { } body - re-planned once per outer
+      // row - still recognises what an earlier row moved (issue #6977).
+      private final LabelReplacements labelReplacements = LabelReplacements.of(context);
 
       @Override
       public boolean hasNext() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
@@ -35,6 +35,7 @@ import com.arcadedb.query.opencypher.ast.VariableExpression;
 import com.arcadedb.query.opencypher.ast.WithClause;
 import com.arcadedb.query.opencypher.executor.CypherExecutionPlan;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
+import com.arcadedb.query.opencypher.executor.LabelReplacements;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -456,8 +457,14 @@ public class SubqueryStep extends AbstractExecutionStep {
       // for a LATER row then shows through the binding of an EARLIER one. That is issue #6362: inserting the
       // identity subquery CALL (*) { RETURN 0 AS barrier } after MERGE ... ON MATCH SET turned [10, 99] into
       // [99, 99]. The refresh itself is still required for the writing case it was added for (issue #4182).
-      if (innerMayWrite)
+      if (innerMayWrite) {
+        // A label write inside the body rewrote the node under a new type, which means a new record and a new RID:
+        // the outer row is still holding the one the body deleted, and refreshing it by RID can only fail. Point it
+        // at the replacement first, so the merged output row - and every clause reading through it - answers with a
+        // live record instead of a gone one (issue #6977).
+        LabelReplacements.of(context).redirect(outerRow);
         refreshDocumentBindings(outerRow);
+      }
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryLabelWriteIssue6977Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryLabelWriteIssue6977Test.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6977: a label write inside a {@code CALL { }} body has to remember what it displaced for the whole
+ * statement, not for one plan.
+ * <p>
+ * A label change rewrites the vertex under a new type, so the original record is deleted and every other reference
+ * to it - including the next row of the same clause - has to be redirected to the replacement. {@code SubqueryStep}
+ * builds a <b>fresh execution plan for every outer row</b>, so the map that does the redirecting was born and died
+ * inside a single row: the second outer row reached the body still holding the vertex the first one had deleted, and
+ * the write followed its dangling edge list into
+ * {@code VertexNotFoundException: Vertex #x:0 does not exist, so it cannot be deleted}.
+ * <p>
+ * Two outer rows are all it takes; the report needed {@code CALL db.schema()} only because that is what multiplied
+ * one matched row into eight.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherSubqueryLabelWriteIssue6977Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testopencypher-subquery-labelwrite-6977").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void removeLabelInsideASubqueryOutlivesTheRowItsPlanWasBuiltFor() {
+    cypher("CREATE (b:Keep:Drop {name:'b'})-[:E {w:7}]->(a:Other:Drop {name:'a'})");
+
+    // Three outer rows, all binding the same node: the first relabels it, the other two must recognise the
+    // replacement instead of writing through the record it deleted.
+    assertThat(writingRows("""
+        UNWIND [1,2,3] AS i
+        MATCH (n:Other {name:'a'})
+        CALL (*) {
+          REMOVE n:Drop
+          RETURN n AS moved
+        }
+        RETURN moved.name + '/' + head(labels(moved)) + '/' + size(labels(moved)) AS v"""))
+        .containsExactly("a/Other/1", "a/Other/1", "a/Other/1");
+
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Other]");
+    // The relationship is re-attached to the replacement, with its properties, exactly once.
+    assertThat(rows("MATCH (x)-[r:E]->(y) RETURN x.name + '->' + y.name + '=' + r.w AS v")).containsExactly("b->a=7");
+  }
+
+  @Test
+  void theOuterRowFollowsTheNodeTheSubqueryMoved() {
+    cypher("CREATE (a:Other:Drop {name:'a'})");
+
+    // The outer binding is the record the body deleted. Reading it after the CALL has to answer with the state the
+    // write left behind, not with the vertex that is gone.
+    assertThat(writingRows("""
+        MATCH (n:Other {name:'a'})
+        CALL (*) {
+          REMOVE n:Drop
+          RETURN 1 AS ignored
+        }
+        RETURN labels(n) AS v""")).containsExactly("[Other]");
+  }
+
+  @Test
+  void setLabelInsideASubqueryOutlivesTheRowItsPlanWasBuiltFor() {
+    // The mirror of the REMOVE case: SET n:Label runs the same replacement machinery.
+    cypher("CREATE (a:Base {name:'a'})");
+
+    assertThat(writingRows("""
+        UNWIND [1,2,3] AS i
+        MATCH (n:Base {name:'a'})
+        CALL (*) {
+          SET n:Extra
+          RETURN n AS moved
+        }
+        RETURN labels(moved) AS v""")).containsExactly("[Base, Extra]", "[Base, Extra]", "[Base, Extra]");
+
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Base, Extra]");
+  }
+
+  @Test
+  void mergeOnMatchSetLabelInsideASubqueryOutlivesTheRowItsPlanWasBuiltFor() {
+    cypher("CREATE (a:Base {name:'a'})");
+
+    // MERGE re-reads the node from storage on every row, so the body itself always finds the live record. What
+    // does not survive on its own is the alias the OUTER row imported: the first row's ON MATCH SET moved the
+    // record out from under it.
+    assertThat(writingRows("""
+        MATCH (outer:Base {name:'a'})
+        UNWIND [1,2,3] AS i
+        CALL (*) {
+          MERGE (n:Base {name:'a'})
+          ON MATCH SET n:Extra
+          RETURN n AS moved
+        }
+        RETURN labels(moved) + labels(outer) AS v"""))
+        .containsExactly("[Base, Extra, Base, Extra]", "[Base, Extra, Base, Extra]", "[Base, Extra, Base, Extra]");
+
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Base, Extra]");
+  }
+
+  @Test
+  void labelIsRemovedOnceAcrossEveryOuterRowOfTheSubquery() {
+    cypher("CREATE (a:Other:Drop {name:'a'})");
+
+    final int[] labelsRemoved = new int[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("opencypher", """
+          UNWIND [1,2,3] AS i
+          MATCH (n:Other {name:'a'})
+          CALL (*) {
+            REMOVE n:Drop
+            RETURN 1 AS ignored
+          }
+          RETURN count(*) AS row_count""")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(((Number) rs.next().getProperty("row_count")).longValue()).isEqualTo(3);
+        labelsRemoved[0] = rs.getStatistics().map(s -> s.getLabelsRemoved()).orElse(-1);
+      }
+    });
+
+    assertThat(labelsRemoved[0]).isEqualTo(1);
+  }
+
+  @Test
+  void theReportedSchemaCallAndSubqueryRemovalCompletes() {
+    cypher("""
+        CREATE (b:l0:l4:l6:l9:l10:l5 {k4: 'kN1omHAd', k8: 'b'})
+          -[:rt5 {k3: true}]->
+          (a:l11:l4 {k9: false, k8: 'a'})""");
+
+    // CALL db.schema() yields one row per declared type, which fans the single matched row out into as many
+    // invocations of the body - the shape the issue was reported with.
+    final List<String> rows = writingRows("""
+        CALL db.schema() YIELD nodes, relationships
+        OPTIONAL MATCH (n5:l11 {k9: false}) <-[:rt5 {k3: true}]-
+          (n6:l0&l4&l6&l9&l10&l5 {k4: "kN1omHAd"})
+        WITH *
+        WHERE n5 IS NOT NULL AND n6 IS NOT NULL
+        CALL (*) {
+          REMOVE n5:l4
+          RETURN n5 AS n20, n6 AS n21
+        }
+        RETURN n20.k8 + '/' + head(labels(n20)) + '/' + size(labels(n20)) + '/' + n21.k8 AS v""");
+
+    assertThat(rows).isNotEmpty();
+    assertThat(rows).containsOnly("a/l11/1/b");
+
+    assertThat(rows("MATCH (n {k8:'a'}) RETURN labels(n) AS v")).containsExactly("[l11]");
+    assertThat(rows("MATCH (n {k8:'b'})-[r:rt5]->(m) RETURN m.k8 + '=' + r.k3 AS v")).containsExactly("a=true");
+  }
+
+  private List<String> rows(final String query) {
+    return rows(query, false);
+  }
+
+  /**
+   * Same as {@link #rows(String)} for a query that also writes, which the read-only entry point rejects.
+   */
+  private List<String> writingRows(final String query) {
+    return rows(query, true);
+  }
+
+  private List<String> rows(final String query, final boolean writes) {
+    final List<String> out = new ArrayList<>();
+    database.transaction(() -> {
+      try (final ResultSet rs = writes ? database.command("opencypher", query) : database.query("opencypher", query)) {
+        while (rs.hasNext()) {
+          final Result r = rs.next();
+          out.add(String.valueOf(r.<Object>getProperty("v")));
+        }
+      }
+    });
+    return out;
+  }
+
+  private void cypher(final String query) {
+    database.transaction(() -> database.command("opencypher", query));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryLabelWriteIssue6977Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryLabelWriteIssue6977Test.java
@@ -52,7 +52,12 @@ class CypherSubqueryLabelWriteIssue6977Test {
 
   @BeforeEach
   void setUp() {
-    database = new DatabaseFactory("./target/databases/testopencypher-subquery-labelwrite-6977").create();
+    // Same guard OpenCypherConstraintTest uses: a run killed before @AfterEach leaves the directory behind, and
+    // create() on an existing database throws, which would fail every method here for an environmental reason.
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/testopencypher-subquery-labelwrite-6977");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
   }
 
   @AfterEach
@@ -97,6 +102,29 @@ class CypherSubqueryLabelWriteIssue6977Test {
           RETURN 1 AS ignored
         }
         RETURN labels(n) AS v""")).containsExactly("[Other]");
+  }
+
+  @Test
+  void removeLabelSurvivesTwoLevelsOfNestedSubqueries() {
+    cypher("CREATE (a:Other:Drop {name:'a'})");
+
+    // The map reaches the innermost body only if it is inherited at every level. Two levels is where a future
+    // change to the isReadOnly()/inherit() chain would silently stop propagating it, and one level would not
+    // notice.
+    assertThat(writingRows("""
+        UNWIND [1,2,3] AS i
+        MATCH (n:Other {name:'a'})
+        CALL (*) {
+          CALL (*) {
+            REMOVE n:Drop
+            RETURN n AS innermost
+          }
+          RETURN innermost AS moved
+        }
+        RETURN moved.name + '/' + head(labels(moved)) + '/' + size(labels(moved)) AS v"""))
+        .containsExactly("a/Other/1", "a/Other/1", "a/Other/1");
+
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Other]");
   }
 
   @Test


### PR DESCRIPTION
Closes #6977

## What was wrong

A Cypher label write is not a metadata change in ArcadeDB: a record's type is the bucket it lives in, so
`REMOVE n:l4` rewrites the vertex under the reduced type, re-attaches every incident edge and **deletes the
original**. `LabelReplacements` exists to keep that survivable - it remembers `oldRID -> live replacement`, so any
row still holding the deleted original is redirected to the record that now carries its identity (issues #6312,
#6313).

That map was scoped to the running `SET`/`REMOVE`/`MERGE` **step**. `SubqueryStep.executeInnerQuery` builds a
**fresh `CypherExecutionPlan` for every outer row**, so inside a `CALL { }` body the step - and its map - is born
and dies within a single row. The second outer row entered the body still holding the vertex the first row had
deleted, and the write followed its dangling edge list straight into

```
VertexNotFoundException: Vertex #25:0 does not exist, so it cannot be deleted:
it was reached through a reference to a record that is gone (a stale edge entry, or a RID held past the delete)
```

`CALL db.schema()` is not implicated: it is simply what fanned one matched row out into eight, which is the
minimum the defect needs. Two outer rows reproduce it, and the report's own controls say the same thing - drop the
schema call (one row) or drop the subquery (one step, one map) and the query passes.

## The fix

Move the replacement map from the step to the **statement**.

- `LabelReplacements.of(context)` parks one instance on the command context, created on first use, so a read-only
  statement still allocates nothing. `SetStep`, `RemoveStep` and `MergeStep` all take theirs from there.
- `LabelReplacements.inherit(inner, outer)` carries it into a nested plan's own context.
  `CypherExecutionPlan.executeWithSeedRow` calls it under exactly the gate it already uses to share the statistics
  accumulator (`outerContext != null && !statement.isReadOnly()`), so a read-only `CALL { }`, `COUNT { }`,
  `COLLECT { }` or `EXISTS { }` body never makes the enclosing statement allocate one.
- `SubqueryStep` redirects the **outer** row through the shared map before refreshing its bindings by RID. The
  binding the body invalidated is the one `refreshDocumentBindings` could only ever fail to re-read (it swallows
  `RecordNotFoundException` and keeps the stale record), so without this the emitted row still carried a deleted
  vertex even when the write itself no longer crashed.

Held as a context *cached value* rather than a context variable: cached values are engine-internal, while
variables are reachable from a query through `$CONTEXT` and fall back to the database's global variables.

This is one write path, not two: the optimizer only ever replaces the MATCH portion of a plan, and all three
plan-building sites (`buildExecutionSteps`, `buildExecutionStepsWithOrder`,
`buildExecutionStepsWithOptimizer`) construct the same `SetStep`/`RemoveStep`/`MergeStep` against the same
context. A `CALL { }` disables the optimized physical plan outright (`canUseOptimizedPhysicalPlan()` refuses on
`hasSubquery()`), so the reported query is legacy-path by construction, and the fix lands where both shapes meet.

Allocation is not worse than before, it is better: the old code built a `LabelReplacements` (two `HashMap`s) per
outer row, the new code builds one per statement.

## Test plan

New `engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryLabelWriteIssue6977Test.java`, six tests,
**all six fail on `main` and pass with the fix** (verified by stashing the source change and re-running):

- [x] `removeLabelInsideASubqueryOutlivesTheRowItsPlanWasBuiltFor` - three outer rows, same node; asserts the
      surviving label set, that the relationship is re-attached with its property, and that it exists exactly once
- [x] `theOuterRowFollowsTheNodeTheSubqueryMoved` - the outer alias reads the live record after the body moved it
- [x] `setLabelInsideASubqueryOutlivesTheRowItsPlanWasBuiltFor` - the `SET n:Label` mirror
- [x] `mergeOnMatchSetLabelInsideASubqueryOutlivesTheRowItsPlanWasBuiltFor` - `MERGE ... ON MATCH SET n:Label`;
      the body re-reads the node itself, so what has to survive is the imported outer alias
- [x] `labelIsRemovedOnceAcrossEveryOuterRowOfTheSubquery` - three rows, `labelsRemoved == 1`: idempotent, not
      merely non-fatal
- [x] `theReportedSchemaCallAndSubqueryRemovalCompletes` - the issue's own query, verbatim shape
- [x] Full `engine` module, `mvn -o -pl engine test -DexcludedGroups=benchmark,vector,slow`: **14017 run,
      0 failures, 23 skipped** (baseline on the same worktree at `main`: 14011 run, 0 failures, 23 skipped - the
      difference is the six tests added here)
- [x] openCypher TCK, `mvn -o -pl engine verify -Dsurefire.includes='**/*Suite.java'`: **3897 scenarios, 3812
      passed, 0 failed, 85 skipped** - byte-identical to the baseline run at `main`, so no conformance movement

One unrelated flake was seen on the first full-suite run and did not reproduce:
`com.arcadedb.graph.Issue5596MergeCoverageTest.aCleanAppendConflictIsStillMerged` asserts that two racing writer
threads collide often enough for `edgeAppendMerges` to advance, and it saw zero on a loaded machine. It passes in
isolation and on the repeated full-suite run, it uses the native graph API with no Cypher anywhere in it, and
nothing in this diff leaves `com.arcadedb.query.opencypher.executor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1bu3QHjw5bgFKvfPSUoR7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenCypher `CALL` subqueries with label changes across multiple rows and nested executions.
  * Preserved correct record references after `SET`, `REMOVE`, and `MERGE ... ON MATCH SET` operations.
  * Corrected relationship reattachment, alias resolution, label-removal statistics, and schema-query behavior in affected subqueries.
  * Ensured write operations maintain consistent record mappings across repeated subquery executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->