### PR TITLE
fix(#6922): make FOREACH eager with respect to a following graph read

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -710,6 +710,11 @@ public enum GlobalConfiguration {
       Higher values improve performance but consume more memory. Default: 20000. Recommended range: 10000-100000. Set to 0 to disable batching.""",
       Integer.class, 20_000),
 
+  OPENCYPHER_FOREACH_EAGER_READ("arcadedb.opencypher.foreachEagerRead", SCOPE.DATABASE,
+      """
+      Make FOREACH eager when a later clause in the same query reads the graph (MATCH, MERGE, CALL or a CALL {} subquery).       Eager means the FOREACH body runs for every input row before the first row reaches that reader, so every row sees the       same, complete post-FOREACH graph instead of whichever writes happened to land inside the pull batch it was produced in       (issue #6922). The cost is that the FOREACH's input rows are held in memory until the last write is applied. Set to false       to restore the streaming, batch-at-a-time behaviour for a bulk query whose input does not fit in memory - at the price of       the following read observing a partially applied FOREACH.""",
+      Boolean.class, true),
+
   OPENCYPHER_LOAD_CSV_ALLOW_FILE_URLS("arcadedb.opencypher.loadCsv.allowFileUrls", SCOPE.DATABASE,
       """
       Allow LOAD CSV to access local files via file:/// URLs and bare file paths. \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -712,7 +712,14 @@ public enum GlobalConfiguration {
 
   OPENCYPHER_FOREACH_EAGER_READ("arcadedb.opencypher.foreachEagerRead", SCOPE.DATABASE,
       """
-      Make FOREACH eager when a later clause in the same query reads the graph (MATCH, MERGE, CALL or a CALL {} subquery).       Eager means the FOREACH body runs for every input row before the first row reaches that reader, so every row sees the       same, complete post-FOREACH graph instead of whichever writes happened to land inside the pull batch it was produced in       (issue #6922). The cost is that the FOREACH's input rows are held in memory until the last write is applied. Set to false       to restore the streaming, batch-at-a-time behaviour for a bulk query whose input does not fit in memory - at the price of       the following read observing a partially applied FOREACH.""",
+      Make FOREACH eager when a later clause in the same query reads the graph (MATCH, MERGE, CALL, a CALL {} subquery, \
+      or a later FOREACH whose own body contains a MERGE). Eager means the FOREACH body runs for every input row before \
+      the first row reaches that reader, so every row sees the same, complete post-FOREACH graph instead of whichever \
+      writes happened to land inside the pull batch it was produced in. The cost is that the FOREACH input rows are held \
+      in memory until the last write is applied. Set to false to restore the streaming, batch-at-a-time behaviour for a \
+      bulk query whose input does not fit in memory, at the price of the following read observing a partially applied \
+      FOREACH. Read when the execution plan is built, so a change takes effect for statements planned afterwards \
+      (see arcadedb.opencypher.planCache).""",
       Boolean.class, true),
 
   OPENCYPHER_LOAD_CSV_ALLOW_FILE_URLS("arcadedb.opencypher.loadCsv.allowFileUrls", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -59,6 +59,12 @@ import com.arcadedb.query.opencypher.ast.MapExpression;
 import com.arcadedb.query.opencypher.ast.MatchClause;
 import com.arcadedb.query.opencypher.ast.MergeClause;
 import com.arcadedb.query.opencypher.ast.OrderByClause;
+import com.arcadedb.query.opencypher.ast.CollectExpression;
+import com.arcadedb.query.opencypher.ast.CountExpression;
+import com.arcadedb.query.opencypher.ast.ExistsExpression;
+import com.arcadedb.query.opencypher.ast.PatternComprehensionExpression;
+import com.arcadedb.query.opencypher.ast.ShortestPathExpression;
+import com.arcadedb.query.opencypher.rewriter.ExpressionRewriter;
 import com.arcadedb.query.opencypher.ast.NodePattern;
 import com.arcadedb.query.opencypher.ast.ParameterExpression;
 import com.arcadedb.query.opencypher.ast.PathPattern;
@@ -4936,12 +4942,17 @@ public class CypherExecutionPlan {
    * <p>
    * The set is deliberately conservative on CALL: a procedure is opaque here, so any procedure call
    * after the update counts as a read - which is what {@code CALL meta.stats()} in issue #6922 is.
-   * SUBQUERY counts because a CALL {{ ... }} block can contain a MATCH. RETURN, WITH and UNWIND do
-   * not: they only project rows the pipeline already produced.
+   * SUBQUERY counts because a CALL { ... } block can contain a MATCH.
    * <p>
    * A later FOREACH counts only when its own body reads, which the grammar narrows to MERGE (and a
    * nested FOREACH containing one): CREATE, SET, REMOVE and DELETE all act on variables the row
    * already carries, and MATCH and CALL are not valid inside a FOREACH body at all.
+   * <p>
+   * RETURN, WITH and UNWIND are not reads in themselves - they project rows the pipeline already
+   * produced - but the expressions they carry can be. {@code EXISTS { }}, {@code COUNT { }} and
+   * {@code COLLECT { }} run a real query against the live graph per row, and a pattern predicate,
+   * pattern comprehension or shortestPath() traverses it, so those clauses are scanned for such an
+   * expression instead of being waved through on their clause type alone.
    *
    * @param clausesInOrder the query's clauses in textual order
    * @param clauseIndex    index of the updating clause, or a negative value when it is not in the list
@@ -4959,6 +4970,26 @@ public class CypherExecutionPlan {
         return true;
       case FOREACH:
         if (foreachBodyReadsGraph(laterClause.getTypedClause()))
+          return true;
+        break;
+      case RETURN:
+        if (returnItemsReadGraph(((ReturnClause) laterClause.getClause()).getReturnItems()))
+          return true;
+        break;
+      case WITH:
+        final WithClause withClause = laterClause.getTypedClause();
+        if (returnItemsReadGraph(withClause.getItems()))
+          return true;
+        if (withClause.getWhereClause() != null
+            && expressionReadsGraph(withClause.getWhereClause().getConditionExpression()))
+          return true;
+        if (withClause.getOrderByClause() != null)
+          for (final OrderByClause.OrderByItem orderByItem : withClause.getOrderByClause().getItems())
+            if (expressionReadsGraph(orderByItem.getExpressionAST()))
+              return true;
+        break;
+      case UNWIND:
+        if (expressionReadsGraph(((UnwindClause) laterClause.getClause()).getListExpression()))
           return true;
         break;
       default:
@@ -4987,6 +5018,76 @@ public class CypherExecutionPlan {
       }
     }
     return false;
+  }
+
+  private boolean returnItemsReadGraph(final List<ReturnClause.ReturnItem> returnItems) {
+    for (final ReturnClause.ReturnItem returnItem : returnItems)
+      if (expressionReadsGraph(returnItem.getExpression()))
+        return true;
+    return false;
+  }
+
+  /**
+   * Tells whether an expression tree holds anything that goes back to the graph while the row is
+   * being projected: a subquery expression ({@code EXISTS { }}, {@code COUNT { }}, {@code COLLECT { }},
+   * which all run a real query per row through {@code CorrelatedSubqueryRunner}) or a pattern that is
+   * traversed ({@code (n)-->()} as a predicate, a pattern comprehension, {@code shortestPath()}).
+   * Used by {@link #graphReadFollows(List, int)} for issue #6922.
+   */
+  private boolean expressionReadsGraph(final Object expression) {
+    if (expression == null)
+      return false;
+    final GraphReadDetector detector = new GraphReadDetector();
+    detector.rewrite(expression);
+    return detector.found;
+  }
+
+  /**
+   * Walks an expression tree looking for a node that reads the graph, reusing {@link ExpressionRewriter}'s
+   * traversal instead of re-deriving one: the check sits in the {@code rewrite} entry point every node
+   * passes through, so it also catches the expression types the rewriter's own dispatch does not know
+   * (COUNT and COLLECT subqueries among them). Nothing is rewritten - every visit returns its input.
+   * <p>
+   * Three of the base class's visits are {@code TODO} stubs that return without recursing, and each one
+   * hides a real case here: {@code size(collect {{ ... }})} behind {@code visitFunctionCall}, and
+   * {@code WHERE exists {{ ... }}} behind the boolean coercion/wrapper pair. They are overridden here
+   * rather than filled in on the shared base class, where every other rewriter would inherit a traversal
+   * change none of them asked for.
+   */
+  private static final class GraphReadDetector extends ExpressionRewriter {
+    private boolean found = false;
+
+    @Override
+    public Object rewrite(final Object expression) {
+      if (found || expression == null)
+        return expression;
+      if (expression instanceof ExistsExpression || expression instanceof CountExpression
+          || expression instanceof CollectExpression || expression instanceof PatternPredicateExpression
+          || expression instanceof PatternComprehensionExpression || expression instanceof ShortestPathExpression) {
+        found = true;
+        return expression;
+      }
+      return super.rewrite(expression);
+    }
+
+    @Override
+    protected Expression visitFunctionCall(final FunctionCallExpression expr) {
+      for (final Expression argument : expr.getArguments())
+        rewrite(argument);
+      return expr;
+    }
+
+    @Override
+    protected BooleanExpression visitBooleanCoercion(final BooleanCoercionExpression expr) {
+      rewrite(expr.getExpression());
+      return expr;
+    }
+
+    @Override
+    protected Expression visitBooleanWrapper(final BooleanWrapperExpression expr) {
+      rewrite(expr.getBooleanExpression());
+      return expr;
+    }
   }
 
   private boolean isFollowedByCountOnlyReturn(final List<ClauseEntry> clausesInOrder, final int callIndex) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1539,7 +1539,7 @@ public class CypherExecutionPlan {
             && (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
                 || deleteMayTargetTaintedVariable(collectForeachDeleteTargetVariables(foreachClause), disconnectedTaintedVariables));
         final boolean foreachEagerExecution =
-            (Boolean) GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ.getValue()
+            database.getConfiguration().getValueAsBoolean(GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ)
                 && graphReadFollows(clausesInOrder, entryIndex);
         final ForeachStep foreachStep =
             new ForeachStep(foreachClause, context, functionFactory, foreachEagerMaterialize, foreachEagerExecution);
@@ -4938,6 +4938,10 @@ public class CypherExecutionPlan {
    * after the update counts as a read - which is what {@code CALL meta.stats()} in issue #6922 is.
    * SUBQUERY counts because a CALL {{ ... }} block can contain a MATCH. RETURN, WITH and UNWIND do
    * not: they only project rows the pipeline already produced.
+   * <p>
+   * A later FOREACH counts only when its own body reads, which the grammar narrows to MERGE (and a
+   * nested FOREACH containing one): CREATE, SET, REMOVE and DELETE all act on variables the row
+   * already carries, and MATCH and CALL are not valid inside a FOREACH body at all.
    *
    * @param clausesInOrder the query's clauses in textual order
    * @param clauseIndex    index of the updating clause, or a negative value when it is not in the list
@@ -4946,12 +4950,38 @@ public class CypherExecutionPlan {
     if (clauseIndex < 0)
       return false;
     for (int i = clauseIndex + 1; i < clausesInOrder.size(); i++) {
-      switch (clausesInOrder.get(i).getType()) {
+      final ClauseEntry laterClause = clausesInOrder.get(i);
+      switch (laterClause.getType()) {
       case MATCH:
       case MERGE:
       case CALL:
       case SUBQUERY:
         return true;
+      case FOREACH:
+        if (foreachBodyReadsGraph(laterClause.getTypedClause()))
+          return true;
+        break;
+      default:
+        break;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Tells whether a FOREACH body reads the graph, i.e. contains a MERGE at any nesting depth. Used by
+   * {@link #graphReadFollows(List, int)} so that a MERGE tucked inside a following FOREACH arms the
+   * eager mode just like a bare one would (issue #6922).
+   */
+  private boolean foreachBodyReadsGraph(final ForeachClause foreachClause) {
+    for (final ClauseEntry innerClause : foreachClause.getInnerClauses()) {
+      switch (innerClause.getType()) {
+      case MERGE:
+        return true;
+      case FOREACH:
+        if (foreachBodyReadsGraph(innerClause.getTypedClause()))
+          return true;
+        break;
       default:
         break;
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -4950,9 +4950,16 @@ public class CypherExecutionPlan {
    * after the update counts as a read - which is what {@code CALL meta.stats()} in issue #6922 is.
    * SUBQUERY counts because a CALL { ... } block can contain a MATCH.
    * <p>
-   * A later FOREACH counts only when its own body reads, which the grammar narrows to MERGE (and a
-   * nested FOREACH containing one): CREATE, SET, REMOVE and DELETE all act on variables the row
-   * already carries, and MATCH and CALL are not valid inside a FOREACH body at all.
+   * A later FOREACH counts only when its own body reads. MATCH and CALL are not valid inside a FOREACH
+   * body at all, so that means a MERGE (at any nesting depth), or an expression that reads: the list
+   * the FOREACH iterates, or - because the grammar lets a general expression stand wherever a value
+   * does - a CREATE property value, a SET right-hand side, or a DELETE/REMOVE target. Those clauses
+   * act on variables the row already carries, but the values they compute need not.
+   * <p>
+   * A terminal RETURN's ORDER BY is deliberately NOT scanned. It is parsed onto the statement rather
+   * than onto the ReturnClause, and unlike the WITH case just below it is unreachable: OrderByStep
+   * materializes its whole input before the comparator that evaluates those expressions ever runs, so
+   * the FOREACH has already finished by then no matter what this predicate answered.
    * <p>
    * RETURN, WITH and UNWIND are not reads in themselves - they project rows the pipeline already
    * produced - but the expressions they carry can be. {@code EXISTS { }}, {@code COUNT { }} and
@@ -5023,10 +5030,73 @@ public class CypherExecutionPlan {
         if (foreachBodyReadsGraph(innerClause.getTypedClause()))
           return true;
         break;
+      case CREATE:
+        if (createValuesReadGraph(innerClause.getTypedClause()))
+          return true;
+        break;
+      case SET:
+        for (final SetClause.SetItem setItem : ((SetClause) innerClause.getClause()).getItems())
+          if (expressionReadsGraph(setItem.getValueExpression()) || expressionReadsGraph(setItem.getKeyExpression())
+              || expressionReadsGraph(setItem.getTargetExpression()))
+            return true;
+        break;
+      case REMOVE:
+        for (final RemoveClause.RemoveItem removeItem : ((RemoveClause) innerClause.getClause()).getItems())
+          if (expressionReadsGraph(removeItem.getKeyExpression()))
+            return true;
+        break;
+      case DELETE:
+        for (final Expression deleteExpression : ((DeleteClause) innerClause.getClause()).getExpressions())
+          if (expressionReadsGraph(deleteExpression))
+            return true;
+        break;
       default:
         break;
       }
     }
+    return false;
+  }
+
+  /**
+   * Tells whether a CREATE inside a FOREACH body reads the graph through one of its property values.
+   * <p>
+   * The pattern itself creates rather than matches, but the grammar lets a general expression stand
+   * as a property value, and a general expression can be {@code count { ... }}: in
+   * {@code FOREACH (x IN [1] | CREATE (:S {n: count {{ MATCH (m:L1) }}}))} the value is evaluated per
+   * row against the live graph, which makes the FOREACH before it a reader after all.
+   */
+  private boolean createValuesReadGraph(final CreateClause createClause) {
+    for (final PathPattern pathPattern : createClause.getPathPatterns()) {
+      for (final NodePattern nodePattern : pathPattern.getNodes())
+        if (propertyValuesReadGraph(nodePattern.getProperties()) || expressionsReadGraph(nodePattern.getDynamicLabels()))
+          return true;
+      for (final RelationshipPattern relationshipPattern : pathPattern.getRelationships())
+        if (propertyValuesReadGraph(relationshipPattern.getProperties()))
+          return true;
+    }
+    return false;
+  }
+
+  /**
+   * Tells whether any value of an inline property map reads the graph. The map holds already-evaluated
+   * literals alongside unevaluated {@code Expression} nodes, so every value is offered to the detector
+   * and a non-expression simply answers false.
+   */
+  private boolean propertyValuesReadGraph(final Map<String, Object> properties) {
+    if (properties == null)
+      return false;
+    for (final Object value : properties.values())
+      if (expressionReadsGraph(value))
+        return true;
+    return false;
+  }
+
+  private boolean expressionsReadGraph(final List<Expression> expressions) {
+    if (expressions == null)
+      return false;
+    for (final Expression expression : expressions)
+      if (expressionReadsGraph(expression))
+        return true;
     return false;
   }
 
@@ -5058,11 +5128,12 @@ public class CypherExecutionPlan {
    * passes through, so it also catches the expression types the rewriter's own dispatch does not know
    * (COUNT and COLLECT subqueries among them). Nothing is rewritten - every visit returns its input.
    * <p>
-   * Three of the base class's visits are {@code TODO} stubs that return without recursing, and each one
-   * hides a real case here: {@code size(collect {{ ... }})} behind {@code visitFunctionCall}, and
-   * {@code WHERE exists {{ ... }}} behind the boolean coercion/wrapper pair. They are overridden here
-   * rather than filled in on the shared base class, where every other rewriter would inherit a traversal
-   * change none of them asked for.
+   * Eighteen of the base class's visits return without recursing into what they wrap, and each one can
+   * hide a real case here: {@code size(collect {{ ... }})} behind {@code visitFunctionCall}, and
+   * {@code WHERE exists {{ ... }}} behind the boolean coercion/wrapper pair. Every one is overridden
+   * below rather than filled in on the shared base class, where every other rewriter would inherit a
+   * traversal change none of them asked for. {@code visitUnknown} then closes the remaining hole: a
+   * type the base dispatch does not know at all counts as a read rather than as a leaf.
    */
   private static final class GraphReadDetector extends ExpressionRewriter {
     private boolean found = false;
@@ -5077,7 +5148,33 @@ public class CypherExecutionPlan {
         found = true;
         return expression;
       }
+      // The general expression parser builds this for a top-level AND/OR/XOR/NOT, so it is far too
+      // common to leave to the conservative visitUnknown default: doing so would arm the eager mode
+      // behind every `RETURN a AND b` following a FOREACH, whether or not anything there reads.
+      if (expression instanceof TernaryLogicalExpression ternary) {
+        rewrite(ternary.getLeft());
+        if (!found)
+          rewrite(ternary.getRight());
+        return expression;
+      }
       return super.rewrite(expression);
+    }
+
+    /**
+     * Fails CLOSED where the base class fails open: an expression type {@link ExpressionRewriter}'s
+     * dispatch does not know is treated as a possible read rather than waved through.
+     * <p>
+     * For the rewriters the base class was written for, an unreached subtree costs an optimization.
+     * Here it costs correctness - a missed read leaves the FOREACH streaming and the query answers
+     * from a batch-boundary snapshot - so the two defaults have to differ. This also covers
+     * {@code CypherExpressionBuilder.ChainedPropertyAccessExpression} (package-private, so it cannot
+     * be dispatched on by type from here) and any {@code Expression} subtype added later, which would
+     * otherwise each need their own fix to this class.
+     */
+    @Override
+    protected Object visitUnknown(final Object expression) {
+      found = true;
+      return expression;
     }
 
     @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -28,6 +28,7 @@ import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.query.opencypher.ast.AllReduceExpression;
 import com.arcadedb.query.opencypher.ast.ArithmeticExpression;
 import com.arcadedb.query.opencypher.ast.BooleanCoercionExpression;
 import com.arcadedb.query.opencypher.ast.BooleanExpression;
@@ -36,50 +37,54 @@ import com.arcadedb.query.opencypher.ast.CallClause;
 import com.arcadedb.query.opencypher.ast.CaseAlternative;
 import com.arcadedb.query.opencypher.ast.CaseExpression;
 import com.arcadedb.query.opencypher.ast.ClauseEntry;
+import com.arcadedb.query.opencypher.ast.CollectExpression;
 import com.arcadedb.query.opencypher.ast.ComparisonExpression;
 import com.arcadedb.query.opencypher.ast.ComparisonExpressionWrapper;
+import com.arcadedb.query.opencypher.ast.CountExpression;
 import com.arcadedb.query.opencypher.ast.CreateClause;
 import com.arcadedb.query.opencypher.ast.CypherReferencedVariables;
 import com.arcadedb.query.opencypher.ast.CypherStatement;
 import com.arcadedb.query.opencypher.ast.DeleteClause;
 import com.arcadedb.query.opencypher.ast.Direction;
+import com.arcadedb.query.opencypher.ast.ExistsExpression;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.ForeachClause;
 import com.arcadedb.query.opencypher.ast.FunctionCallExpression;
 import com.arcadedb.query.opencypher.ast.InExpression;
 import com.arcadedb.query.opencypher.ast.IsNullExpression;
 import com.arcadedb.query.opencypher.ast.LabelCheckExpression;
+import com.arcadedb.query.opencypher.ast.ListComprehensionExpression;
 import com.arcadedb.query.opencypher.ast.ListExpression;
 import com.arcadedb.query.opencypher.ast.ListIndexExpression;
+import com.arcadedb.query.opencypher.ast.ListPredicateExpression;
 import com.arcadedb.query.opencypher.ast.ListSliceExpression;
 import com.arcadedb.query.opencypher.ast.LiteralExpression;
 import com.arcadedb.query.opencypher.ast.LoadCSVClause;
 import com.arcadedb.query.opencypher.ast.LogicalExpression;
 import com.arcadedb.query.opencypher.ast.MapExpression;
+import com.arcadedb.query.opencypher.ast.MapProjectionExpression;
 import com.arcadedb.query.opencypher.ast.MatchClause;
 import com.arcadedb.query.opencypher.ast.MergeClause;
-import com.arcadedb.query.opencypher.ast.OrderByClause;
-import com.arcadedb.query.opencypher.ast.CollectExpression;
-import com.arcadedb.query.opencypher.ast.CountExpression;
-import com.arcadedb.query.opencypher.ast.ExistsExpression;
-import com.arcadedb.query.opencypher.ast.PatternComprehensionExpression;
-import com.arcadedb.query.opencypher.ast.ShortestPathExpression;
-import com.arcadedb.query.opencypher.rewriter.ExpressionRewriter;
 import com.arcadedb.query.opencypher.ast.NodePattern;
+import com.arcadedb.query.opencypher.ast.OrderByClause;
 import com.arcadedb.query.opencypher.ast.ParameterExpression;
 import com.arcadedb.query.opencypher.ast.PathPattern;
+import com.arcadedb.query.opencypher.ast.PatternComprehensionExpression;
 import com.arcadedb.query.opencypher.ast.PatternPredicateExpression;
 import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
+import com.arcadedb.query.opencypher.ast.ReduceExpression;
+import com.arcadedb.query.opencypher.ast.RegexExpression;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
 import com.arcadedb.query.opencypher.ast.RemoveClause;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
 import com.arcadedb.query.opencypher.ast.SetClause;
+import com.arcadedb.query.opencypher.ast.ShortestPathExpression;
 import com.arcadedb.query.opencypher.ast.ShortestPathPattern;
 import com.arcadedb.query.opencypher.ast.StarExpression;
-import com.arcadedb.query.opencypher.ast.RegexExpression;
 import com.arcadedb.query.opencypher.ast.StringMatchExpression;
 import com.arcadedb.query.opencypher.ast.SubqueryClause;
 import com.arcadedb.query.opencypher.ast.TernaryLogicalExpression;
+import com.arcadedb.query.opencypher.ast.UnionStatement;
 import com.arcadedb.query.opencypher.ast.UnwindClause;
 import com.arcadedb.query.opencypher.ast.VariableExpression;
 import com.arcadedb.query.opencypher.ast.WhereClause;
@@ -87,19 +92,16 @@ import com.arcadedb.query.opencypher.ast.WithClause;
 import com.arcadedb.query.opencypher.executor.operators.GAVFusedChainOperator;
 import com.arcadedb.query.opencypher.executor.operators.InListValues;
 import com.arcadedb.query.opencypher.executor.steps.AggregationStep;
-import com.arcadedb.query.opencypher.executor.steps.CallStep;
 import com.arcadedb.query.opencypher.executor.steps.AntiJoinChainOp;
 import com.arcadedb.query.opencypher.executor.steps.CSRCountStep;
+import com.arcadedb.query.opencypher.executor.steps.CallStep;
 import com.arcadedb.query.opencypher.executor.steps.ConstantCountStep;
 import com.arcadedb.query.opencypher.executor.steps.CountChainedEdgesStep;
-import com.arcadedb.query.opencypher.executor.steps.CountOp;
-import com.arcadedb.query.opencypher.executor.steps.DegreeProductOp;
-import com.arcadedb.query.opencypher.executor.steps.PairHashJoinOp;
-import com.arcadedb.query.opencypher.executor.steps.PartitionedTriangleOp;
-import com.arcadedb.query.opencypher.executor.steps.PropagateChainOp;
 import com.arcadedb.query.opencypher.executor.steps.CountEdgesReturnStep;
 import com.arcadedb.query.opencypher.executor.steps.CountEdgesStep;
+import com.arcadedb.query.opencypher.executor.steps.CountOp;
 import com.arcadedb.query.opencypher.executor.steps.CreateStep;
+import com.arcadedb.query.opencypher.executor.steps.DegreeProductOp;
 import com.arcadedb.query.opencypher.executor.steps.DeleteStep;
 import com.arcadedb.query.opencypher.executor.steps.ExpandPathStep;
 import com.arcadedb.query.opencypher.executor.steps.FilterPropertiesStep;
@@ -115,20 +117,23 @@ import com.arcadedb.query.opencypher.executor.steps.MatchRelationshipStep;
 import com.arcadedb.query.opencypher.executor.steps.MergeStep;
 import com.arcadedb.query.opencypher.executor.steps.OptionalMatchStep;
 import com.arcadedb.query.opencypher.executor.steps.OrderByStep;
+import com.arcadedb.query.opencypher.executor.steps.PairHashJoinOp;
+import com.arcadedb.query.opencypher.executor.steps.PartitionedTriangleOp;
 import com.arcadedb.query.opencypher.executor.steps.ProjectReturnStep;
+import com.arcadedb.query.opencypher.executor.steps.PropagateChainOp;
 import com.arcadedb.query.opencypher.executor.steps.RemoveStep;
 import com.arcadedb.query.opencypher.executor.steps.SetStep;
 import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep;
 import com.arcadedb.query.opencypher.executor.steps.SkipStep;
 import com.arcadedb.query.opencypher.executor.steps.SubqueryStep;
 import com.arcadedb.query.opencypher.executor.steps.TypeCountStep;
-import com.arcadedb.query.opencypher.ast.UnionStatement;
 import com.arcadedb.query.opencypher.executor.steps.UnionStep;
 import com.arcadedb.query.opencypher.executor.steps.UnwindStep;
 import com.arcadedb.query.opencypher.executor.steps.VariableProjectionStep;
 import com.arcadedb.query.opencypher.executor.steps.WithStep;
 import com.arcadedb.query.opencypher.executor.steps.ZeroLengthPathStep;
 import com.arcadedb.query.opencypher.optimizer.plan.PhysicalPlan;
+import com.arcadedb.query.opencypher.rewriter.ExpressionRewriter;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
@@ -148,6 +153,7 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 import com.arcadedb.query.sql.parser.ExplainResultSet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -5000,11 +5006,15 @@ public class CypherExecutionPlan {
   }
 
   /**
-   * Tells whether a FOREACH body reads the graph, i.e. contains a MERGE at any nesting depth. Used by
-   * {@link #graphReadFollows(List, int)} so that a MERGE tucked inside a following FOREACH arms the
-   * eager mode just like a bare one would (issue #6922).
+   * Tells whether a FOREACH reads the graph: a MERGE in its body at any nesting depth, or a read in
+   * the list expression it iterates over. Used by {@link #graphReadFollows(List, int)} so that a read
+   * tucked inside a following FOREACH arms the eager mode just like a bare one would (issue #6922).
    */
   private boolean foreachBodyReadsGraph(final ForeachClause foreachClause) {
+    // The list a FOREACH drives off is an expression like any other: it can be a pattern
+    // comprehension or hold a subquery, and it is evaluated per row against the live graph.
+    if (expressionReadsGraph(foreachClause.getListExpression()))
+      return true;
     for (final ClauseEntry innerClause : foreachClause.getInnerClauses()) {
       switch (innerClause.getType()) {
       case MERGE:
@@ -5072,20 +5082,129 @@ public class CypherExecutionPlan {
 
     @Override
     protected Expression visitFunctionCall(final FunctionCallExpression expr) {
-      for (final Expression argument : expr.getArguments())
-        rewrite(argument);
-      return expr;
+      return descend(expr, expr.getArguments());
     }
 
     @Override
     protected BooleanExpression visitBooleanCoercion(final BooleanCoercionExpression expr) {
-      rewrite(expr.getExpression());
-      return expr;
+      return descend(expr, expr.getExpression());
     }
 
     @Override
     protected Expression visitBooleanWrapper(final BooleanWrapperExpression expr) {
-      rewrite(expr.getBooleanExpression());
+      return descend(expr, expr.getBooleanExpression());
+    }
+
+    @Override
+    protected Expression visitCase(final CaseExpression expr) {
+      rewrite(expr.getCaseExpression());
+      for (final CaseAlternative alternative : expr.getAlternatives()) {
+        rewrite(alternative.getWhenExpression());
+        rewrite(alternative.getThenExpression());
+      }
+      return descend(expr, expr.getElseExpression());
+    }
+
+    @Override
+    protected Expression visitList(final ListExpression expr) {
+      return descend(expr, expr.getElements());
+    }
+
+    @Override
+    protected Expression visitMap(final MapExpression expr) {
+      return descend(expr, expr.getEntries().values());
+    }
+
+    @Override
+    protected Expression visitMapProjection(final MapProjectionExpression expr) {
+      for (final MapProjectionExpression.ProjectionElement element : expr.getElements())
+        rewrite(element.getExpression());
+      return expr;
+    }
+
+    @Override
+    protected Expression visitListComprehension(final ListComprehensionExpression expr) {
+      rewrite(expr.getListExpression());
+      rewrite(expr.getWhereExpression());
+      return descend(expr, expr.getMapExpression());
+    }
+
+    @Override
+    protected Expression visitListPredicate(final ListPredicateExpression expr) {
+      rewrite(expr.getListExpression());
+      return descend(expr, expr.getWhereExpression());
+    }
+
+    @Override
+    protected Expression visitReduce(final ReduceExpression expr) {
+      rewrite(expr.getInitialValue());
+      rewrite(expr.getListExpression());
+      return descend(expr, expr.getReduceExpression());
+    }
+
+    @Override
+    protected Expression visitAllReduce(final AllReduceExpression expr) {
+      rewrite(expr.getInitialValue());
+      rewrite(expr.getListExpression());
+      rewrite(expr.getReduceExpression());
+      return descend(expr, expr.getPredicateExpression());
+    }
+
+    @Override
+    protected Expression visitListIndex(final ListIndexExpression expr) {
+      rewrite(expr.getListExpression());
+      return descend(expr, expr.getIndexExpression());
+    }
+
+    @Override
+    protected Expression visitListSlice(final ListSliceExpression expr) {
+      rewrite(expr.getListExpression());
+      rewrite(expr.getFromExpression());
+      return descend(expr, expr.getToExpression());
+    }
+
+    @Override
+    protected Expression visitArithmetic(final ArithmeticExpression expr) {
+      rewrite(expr.getLeft());
+      return descend(expr, expr.getRight());
+    }
+
+    @Override
+    protected BooleanExpression visitIn(final InExpression expr) {
+      rewrite(expr.getExpression());
+      return descend(expr, expr.getList());
+    }
+
+    @Override
+    protected BooleanExpression visitIsNull(final IsNullExpression expr) {
+      return descend(expr, expr.getExpression());
+    }
+
+    @Override
+    protected BooleanExpression visitStringMatch(final StringMatchExpression expr) {
+      rewrite(expr.getExpression());
+      return descend(expr, expr.getPattern());
+    }
+
+    @Override
+    protected BooleanExpression visitRegex(final RegexExpression expr) {
+      rewrite(expr.getExpression());
+      return descend(expr, expr.getPattern());
+    }
+
+    @Override
+    protected BooleanExpression visitLabelCheck(final LabelCheckExpression expr) {
+      return descend(expr, expr.getVariableExpression());
+    }
+
+    private <T> T descend(final T expr, final Object child) {
+      rewrite(child);
+      return expr;
+    }
+
+    private <T> T descend(final T expr, final Collection<? extends Object> children) {
+      for (final Object child : children)
+        rewrite(child);
       return expr;
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1537,8 +1537,9 @@ public class CypherExecutionPlan {
         final boolean foreachEagerMaterialize = foreachClause.containsDelete()
             && (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
                 || deleteMayTargetTaintedVariable(collectForeachDeleteTargetVariables(foreachClause), disconnectedTaintedVariables));
+        final boolean foreachEagerExecution = graphReadFollows(clausesInOrder, clausesInOrder.indexOf(entry));
         final ForeachStep foreachStep =
-            new ForeachStep(foreachClause, context, functionFactory, foreachEagerMaterialize);
+            new ForeachStep(foreachClause, context, functionFactory, foreachEagerMaterialize, foreachEagerExecution);
         if (currentStep != null) {
           foreachStep.setPrevious(currentStep);
         }
@@ -4921,6 +4922,40 @@ public class CypherExecutionPlan {
    * that contains only count(*) aggregations (no property access needed from procedure results).
    * Used to enable the count-only fast path in CallStep.
    */
+  /**
+   * Tells whether any clause after {@code clauseIndex} reads the graph, which makes the updating
+   * clause at {@code clauseIndex} eager with respect to that read (issue #6922).
+   * <p>
+   * The pipeline pulls in batches of 100 rows, so a write step that applies one batch of writes per
+   * pull lets a following reader observe a snapshot taken at an arbitrary batch boundary rather than
+   * the pre- or post-write graph. openCypher resolves the same read/write conflict by making the
+   * update eager; this predicate decides when to pay for that.
+   * <p>
+   * The set is deliberately conservative on CALL: a procedure is opaque here, so any procedure call
+   * after the update counts as a read - which is what {@code CALL meta.stats()} in issue #6922 is.
+   * SUBQUERY counts because a CALL {{ ... }} block can contain a MATCH. RETURN, WITH and UNWIND do
+   * not: they only project rows the pipeline already produced.
+   *
+   * @param clausesInOrder the query's clauses in textual order
+   * @param clauseIndex    index of the updating clause, or a negative value when it is not in the list
+   */
+  private boolean graphReadFollows(final List<ClauseEntry> clausesInOrder, final int clauseIndex) {
+    if (clauseIndex < 0)
+      return false;
+    for (int i = clauseIndex + 1; i < clausesInOrder.size(); i++) {
+      switch (clausesInOrder.get(i).getType()) {
+      case MATCH:
+      case MERGE:
+      case CALL:
+      case SUBQUERY:
+        return true;
+      default:
+        break;
+      }
+    }
+    return false;
+  }
+
   private boolean isFollowedByCountOnlyReturn(final List<ClauseEntry> clausesInOrder, final int callIndex) {
     if (callIndex < 0)
       return false;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor;
 
 import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Identifiable;
@@ -1526,7 +1527,7 @@ public class CypherExecutionPlan {
         }
         // Detect count-only pattern: CALL ... YIELD ... RETURN count(*)
         // When detected, enable fast-path that skips per-row Result object creation
-        if (isFollowedByCountOnlyReturn(clausesInOrder, clausesInOrder.indexOf(entry))) {
+        if (isFollowedByCountOnlyReturn(clausesInOrder, entryIndex)) {
           callStep.setCountOnlyOptimization(true);
         }
         currentStep = callStep;
@@ -1537,7 +1538,9 @@ public class CypherExecutionPlan {
         final boolean foreachEagerMaterialize = foreachClause.containsDelete()
             && (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
                 || deleteMayTargetTaintedVariable(collectForeachDeleteTargetVariables(foreachClause), disconnectedTaintedVariables));
-        final boolean foreachEagerExecution = graphReadFollows(clausesInOrder, clausesInOrder.indexOf(entry));
+        final boolean foreachEagerExecution =
+            (Boolean) GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ.getValue()
+                && graphReadFollows(clausesInOrder, entryIndex);
         final ForeachStep foreachStep =
             new ForeachStep(foreachClause, context, functionFactory, foreachEagerMaterialize, foreachEagerExecution);
         if (currentStep != null) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
@@ -351,6 +351,9 @@ public class ForeachStep extends AbstractExecutionStep {
         final RemoveClause removeClause = clauseEntry.getTypedClause();
         return new RemoveStep(removeClause, context, functionFactory);
       case FOREACH:
+        // eagerExecution is deliberately left off for a nested FOREACH rather than forgotten: the
+        // chain built here is drained to exhaustion by executeInnerClauses() once per outer iteration,
+        // so the nRecords cap never splits a nested body across two pulls in the first place.
         final ForeachClause nestedForeach = clauseEntry.getTypedClause();
         return new ForeachStep(nestedForeach, context, functionFactory);
       default:

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
@@ -67,18 +67,40 @@ public class ForeachStep extends AbstractExecutionStep {
    */
   private final boolean eagerMaterialize;
 
+  /**
+   * When true, the FOREACH body is executed for every upstream row before the first output row is
+   * emitted, instead of one {@code nRecords}-sized batch at a time.
+   * <p>
+   * The pull model hands {@code nRecords} (100, see {@code CypherExecutionPlan}) down the pipeline,
+   * so without this flag a FOREACH followed by a clause that reads the graph applies the writes of a
+   * whole batch of rows and only then lets the reader see the first of them. The reader therefore
+   * observes neither the pre-FOREACH state nor the post-FOREACH state but a snapshot taken at an
+   * arbitrary batch boundary: {@code UNWIND range(0, 100) AS i FOREACH (j IN range(0, 9) | CREATE
+   * (:L1)) CALL meta.stats() YIELD value AS stats RETURN stats.nodeCount} reported 1000 for the
+   * first 100 rows and 1010 for the 101st, purely because 100 is the batch size (issue #6922).
+   * <p>
+   * openCypher makes an updating clause eager with respect to a following read for exactly this
+   * reason, so the fix is to finish all the writes first: every downstream row then sees the same,
+   * complete post-FOREACH graph. The flag is set by the planner only when a later clause actually
+   * reads the graph, so the streaming {@code MATCH ... FOREACH ... RETURN} bulk-update shape keeps
+   * its bounded memory profile.
+   */
+  private final boolean eagerExecution;
+
   public ForeachStep(final ForeachClause foreachClause, final CommandContext context,
                      final CypherFunctionFactory functionFactory) {
-    this(foreachClause, context, functionFactory, false);
+    this(foreachClause, context, functionFactory, false, false);
   }
 
   public ForeachStep(final ForeachClause foreachClause, final CommandContext context,
-                     final CypherFunctionFactory functionFactory, final boolean eagerMaterialize) {
+                     final CypherFunctionFactory functionFactory, final boolean eagerMaterialize,
+                     final boolean eagerExecution) {
     super(context);
     this.foreachClause = foreachClause;
     this.functionFactory = functionFactory;
     this.evaluator = new ExpressionEvaluator(functionFactory);
     this.eagerMaterialize = eagerMaterialize;
+    this.eagerExecution = eagerExecution;
   }
 
   @Override
@@ -141,7 +163,7 @@ public class ForeachStep extends AbstractExecutionStep {
           }
         }
 
-        while (buffer.size() < n && hasMoreInput()) {
+        while ((eagerExecution || buffer.size() < n) && hasMoreInput()) {
           final Result inputRow = nextInput();
           final long begin = context.isProfiling() ? System.nanoTime() : 0;
           try {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
@@ -84,6 +84,11 @@ public class ForeachStep extends AbstractExecutionStep {
    * complete post-FOREACH graph. The flag is set by the planner only when a later clause actually
    * reads the graph, so the streaming {@code MATCH ... FOREACH ... RETURN} bulk-update shape keeps
    * its bounded memory profile.
+   * <p>
+   * What eagerness costs is memory: the input rows are held until the last write is applied. A bulk
+   * query whose input does not fit in memory can trade the guarantee back for streaming by setting
+   * {@code arcadedb.opencypher.foreachEagerRead} to false. Chunking instead of streaming would not
+   * be a fix - a smaller chunk only moves the boundary the reader sees the writes at.
    */
   private final boolean eagerExecution;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/rewriter/ExpressionRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/rewriter/ExpressionRewriter.java
@@ -138,7 +138,25 @@ public abstract class ExpressionRewriter {
     if (expression instanceof StarExpression)
       return visitStar((StarExpression) expression);
 
-    // Unknown expression type: return as-is
+    // Unknown expression type: hand it to the fail-open/fail-closed hook below.
+    return visitUnknown(expression);
+  }
+
+  /**
+   * Handles an expression whose concrete type {@code rewriteDispatch} does not know.
+   * <p>
+   * The default is to fail OPEN - return the node untouched, without descending into whatever it
+   * wraps - which is right for a rewriter: a rewrite that does not reach a subtree merely misses an
+   * optimization. A subclass whose answer is a SAFETY property rather than an optimization must
+   * override this and fail CLOSED, because for it a subtree the walk never reached is a wrong answer
+   * and not a missed one. {@code CypherExecutionPlan.GraphReadDetector} is such a subclass.
+   * <p>
+   * Two live types reach this today: {@code TernaryLogicalExpression}, which the general expression
+   * parser builds for a top-level {@code AND}/{@code OR}/{@code XOR}/{@code NOT}, and
+   * {@code CypherExpressionBuilder.ChainedPropertyAccessExpression}, which is package-private and so
+   * cannot be dispatched on from here at all.
+   */
+  protected Object visitUnknown(final Object expression) {
     return expression;
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for GitHub issue #6922: a clause that reads the graph after a FOREACH saw the
+ * writes of a whole 100-row pull batch rather than either the pre- or the post-FOREACH graph, so the
+ * value it reported depended on where the batch boundaries happened to fall.
+ * <p>
+ * {@code CALL meta.stats() YIELD value} after {@code UNWIND range(0, 100) AS i FOREACH (j IN
+ * range(0, 9) | CREATE (:L1 ...))} reported {@code nodeCount = 1000} for the first 100 rows and
+ * {@code 1010} for the 101st, and adding a row-preserving {@code collect()}/{@code UNWIND} behind it
+ * changed the already-yielded numbers. FOREACH is now eager with respect to a following read, so
+ * every row sees the same, complete post-FOREACH graph.
+ */
+class CypherForeachEagerReadIssue6922Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testopencypher-foreach-eager-read-6922").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void metaStatsAfterForeachIsUnaffectedByDownstreamCollectUnwind() {
+    final List<Object> control = queryColumn("""
+        UNWIND range(0, 100) AS i
+        FOREACH (j IN range(0, 9) | CREATE (:L1 {k5: j}))
+        CALL meta.stats() YIELD value AS stats
+        RETURN stats.nodeCount AS nodeCount""", "nodeCount");
+
+    assertThat(control).as("one row per UNWIND value").hasSize(101);
+    assertThat(totalNodes()).isEqualTo(1010L);
+    assertThat(control)
+        .as("every row must observe the whole FOREACH, not a 100-row pull batch of it")
+        .containsOnly(1010L);
+
+    // Fresh database: the materialized variant must produce exactly the same values.
+    database.drop();
+    database = new DatabaseFactory("./target/databases/testopencypher-foreach-eager-read-6922").create();
+
+    final List<Object> materialized = queryColumn("""
+        UNWIND range(0, 100) AS i
+        FOREACH (j IN range(0, 9) | CREATE (:L1 {k5: j}))
+        CALL meta.stats() YIELD value AS stats
+        WITH stats.nodeCount AS nodeCount
+        WITH collect(nodeCount) AS values
+        UNWIND values AS nodeCount
+        RETURN nodeCount""", "nodeCount");
+
+    assertThat(totalNodes()).isEqualTo(1010L);
+    assertThat(materialized)
+        .as("a row-preserving collect()/UNWIND must not change an already-yielded value")
+        .isEqualTo(control);
+  }
+
+  @Test
+  void metaStatsAfterForeachDoesNotDependOnThePullBatchSize() {
+    // 250 rows spans three 100-row pull batches: before the fix this returned 200 for the first 100
+    // rows, 400 for the next 100 and 500 for the last 50 - three values chosen by the batch size.
+    final List<Object> counts = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        CALL meta.stats() YIELD value AS stats
+        RETURN stats.nodeCount AS nodeCount""", "nodeCount");
+
+    assertThat(counts).hasSize(250);
+    assertThat(totalNodes()).isEqualTo(500L);
+    assertThat(counts).containsOnly(500L);
+  }
+
+  @Test
+  void matchAfterForeachSeesEveryCreatedNode() {
+    // Same read/write conflict reached through MATCH instead of CALL: the MATCH used to re-scan the
+    // graph once per pull batch and count only the nodes created so far.
+    final List<Object> counts = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        WITH i
+        MATCH (n:L1)
+        WITH i, count(n) AS visible
+        RETURN visible""", "visible");
+
+    assertThat(counts).hasSize(250);
+    assertThat(counts).containsOnly(500L);
+  }
+
+  @Test
+  void foreachWithoutAFollowingReadStillPassesEveryRowThrough() {
+    // The eager mode must not be armed when nothing downstream reads the graph: the rows still flow
+    // through unchanged and every write lands.
+    final List<Object> rows = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        RETURN i AS value""", "value");
+
+    assertThat(rows).hasSize(250);
+    assertThat(rows).containsOnlyOnceElementsOf(rows);
+    assertThat(rows.getFirst()).isEqualTo(1L);
+    assertThat(rows.getLast()).isEqualTo(250L);
+    assertThat(totalNodes()).isEqualTo(500L);
+  }
+
+  private List<Object> queryColumn(final String cypher, final String column) {
+    final List<Object> values = new ArrayList<>();
+    database.transaction(() -> {
+      final ResultSet resultSet = database.command("opencypher", cypher);
+      while (resultSet.hasNext())
+        values.add(resultSet.next().getProperty(column));
+    });
+    return values;
+  }
+
+  private long totalNodes() {
+    final ResultSet resultSet = database.query("opencypher", "MATCH (n) RETURN count(n) AS nodes");
+    return ((Number) resultSet.next().getProperty("nodes")).longValue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
@@ -127,6 +127,48 @@ class CypherForeachEagerReadIssue6922Test {
   }
 
   @Test
+  void countSubqueryExpressionInReturnSeesEveryCreatedNode() {
+    // The read is an expression inside a RETURN item, not a clause of its own: a scan that classifies
+    // a later clause by its type alone waves the RETURN through and leaves the FOREACH streaming.
+    final List<Object> counts = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        RETURN count { MATCH (n:L1) } AS visible""", "visible");
+
+    assertThat(counts).hasSize(250);
+    assertThat(counts).containsOnly(500L);
+  }
+
+  @Test
+  void collectSubqueryExpressionNestedInAFunctionCallSeesEveryCreatedNode() {
+    // Same read, one level deeper: the COLLECT subquery is an argument of size(), so finding it needs
+    // the walk to descend through the function call.
+    final List<Object> counts = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        RETURN size(collect { MATCH (n:L1) RETURN n.i }) AS visible""", "visible");
+
+    assertThat(counts).hasSize(250);
+    assertThat(counts).containsOnly(500L);
+  }
+
+  @Test
+  void existsSubqueryExpressionInWithWhereSeesEveryCreatedNode() {
+    // The read is in a WITH's WHERE, reached through the boolean coercion the predicate is wrapped in.
+    // It asks for the node the FOREACH only creates on the last row, so a streaming pipeline filtered
+    // out every row produced before that write landed and returned 50 of the 250.
+    final List<Object> rows = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN [0] | CREATE (:L1 {i: i}))
+        WITH i WHERE exists { MATCH (n:L1 {i: 250}) }
+        RETURN i AS value""", "value");
+
+    assertThat(rows).hasSize(250);
+    assertThat(rows.getFirst()).isEqualTo(1L);
+    assertThat(rows.getLast()).isEqualTo(250L);
+  }
+
+  @Test
   void foreachWithoutAFollowingReadStillPassesEveryRowThrough() {
     // The eager mode must not be armed when nothing downstream reads the graph: the rows still flow
     // through unchanged and every write lands.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
@@ -169,6 +169,45 @@ class CypherForeachEagerReadIssue6922Test {
   }
 
   @Test
+  void graphReadNestedInsideAContainerExpressionArmsEagerness() {
+    // The subquery is buried in a CASE branch and in a list literal. Both are containers whose walk
+    // has to descend into them; stopping at the top of the RETURN item finds nothing.
+    final List<Object> fromCase = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        RETURN CASE WHEN true THEN count { MATCH (n:L1) } ELSE 0 END AS visible""", "visible");
+
+    assertThat(fromCase).hasSize(250);
+    assertThat(fromCase).containsOnly(500L);
+
+    database.drop();
+    database = new DatabaseFactory("./target/databases/testopencypher-foreach-eager-read-6922").create();
+
+    final List<Object> fromList = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        RETURN [count { MATCH (n:L1) }] AS visible""", "visible");
+
+    assertThat(fromList).hasSize(250);
+    assertThat(fromList).containsOnly(List.of(500L));
+  }
+
+  @Test
+  void graphReadInALaterForeachListExpressionArmsEagerness() {
+    // A FOREACH's driving list is an expression like any other and is evaluated per row against the
+    // live graph. Here it filters on a node the first FOREACH only creates on its last row, so a
+    // streaming pipeline produced an empty list - and no :Marker - for every row before that write.
+    final List<Object> rows = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN [1] | CREATE (:L1 {i: i}))
+        FOREACH (n IN [x IN range(1, 1) WHERE exists { MATCH (m:L1 {i: 250}) } | x] | CREATE (:Marker {i: i}))
+        RETURN i AS value""", "value");
+
+    assertThat(rows).hasSize(250);
+    assertThat(countOf("Marker")).as("every row's FOREACH body ran").isEqualTo(250L);
+  }
+
+  @Test
   void foreachWithoutAFollowingReadStillPassesEveryRowThrough() {
     // The eager mode must not be armed when nothing downstream reads the graph: the rows still flow
     // through unchanged and every write lands.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
@@ -44,6 +44,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * every row sees the same, complete post-FOREACH graph.
  */
 class CypherForeachEagerReadIssue6922Test {
+  /** 250 rows spans three of the pipeline's 100-row pull batches, and creates 500 nodes in total. */
+  private static final String BATCH_VISIBILITY_QUERY = """
+      UNWIND range(1, 250) AS i
+      FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+      CALL meta.stats() YIELD value AS stats
+      RETURN stats.nodeCount AS nodeCount""";
+
   private Database database;
 
   @BeforeEach
@@ -53,7 +60,6 @@ class CypherForeachEagerReadIssue6922Test {
 
   @AfterEach
   void tearDown() {
-    GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ.reset();
     if (database != null) {
       database.drop();
       database = null;
@@ -95,13 +101,9 @@ class CypherForeachEagerReadIssue6922Test {
 
   @Test
   void metaStatsAfterForeachDoesNotDependOnThePullBatchSize() {
-    // 250 rows spans three 100-row pull batches: before the fix this returned 200 for the first 100
-    // rows, 400 for the next 100 and 500 for the last 50 - three values chosen by the batch size.
-    final List<Object> counts = queryColumn("""
-        UNWIND range(1, 250) AS i
-        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
-        CALL meta.stats() YIELD value AS stats
-        RETURN stats.nodeCount AS nodeCount""", "nodeCount");
+    // Before the fix this returned 200 for the first 100 rows, 400 for the next 100 and 500 for the
+    // last 50 - three values chosen by the pull batch size rather than by the graph.
+    final List<Object> counts = queryColumn(BATCH_VISIBILITY_QUERY, "nodeCount");
 
     assertThat(counts).hasSize(250);
     assertThat(totalNodes()).isEqualTo(500L);
@@ -158,6 +160,22 @@ class CypherForeachEagerReadIssue6922Test {
   }
 
   @Test
+  void mergeInsideALaterForeachAlsoArmsEagerness() {
+    // Same failure as mergeAfterForeachMatchesANodeTheForeachCreatedForALaterRow, only the MERGE is
+    // tucked inside a second FOREACH. A scan that looks at the later clause's own type alone sees a
+    // FOREACH, calls it a write, and leaves the first FOREACH streaming - so the nested MERGE created
+    // a 251st node.
+    final List<Object> rows = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN [1] | CREATE (:L1 {i: i}))
+        FOREACH (j IN [1] | MERGE (last:L1 {i: 250}))
+        RETURN i AS value""", "value");
+
+    assertThat(rows).hasSize(250);
+    assertThat(countOf("L1")).as("the nested MERGE matched instead of creating a 251st node").isEqualTo(250L);
+  }
+
+  @Test
   void callSubqueryAfterForeachSeesEveryCreatedNode() {
     // A CALL {} subquery is opaque to the clause scan but can hold a MATCH, so it counts as a read.
     final List<Object> counts = queryColumn("""
@@ -171,25 +189,30 @@ class CypherForeachEagerReadIssue6922Test {
   }
 
   @Test
-  void eagerReadCanBeTradedBackForStreaming() {
+  void eagerReadIsTradedBackForStreamingPerDatabase() {
     // arcadedb.opencypher.foreachEagerRead is the escape hatch for a bulk query whose input does not
-    // fit in memory: with it off the reader is back to seeing whatever the pull batch had applied, so
-    // the 250 rows no longer agree - which is what proves the setting reaches the planner.
-    GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ.setValue(false);
-    try {
-      final List<Object> counts = queryColumn("""
-          UNWIND range(1, 250) AS i
-          FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
-          CALL meta.stats() YIELD value AS stats
-          RETURN stats.nodeCount AS nodeCount""", "nodeCount");
+    // fit in memory. It is SCOPE.DATABASE, so it is read off this database's ContextConfiguration:
+    // turning it off here must not reach a second database that never set it.
+    database.getConfiguration().setValue(GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ, false);
 
-      assertThat(counts).hasSize(250);
-      assertThat(totalNodes()).as("every write still lands").isEqualTo(500L);
-      assertThat(new LinkedHashSet<>(counts))
-          .as("streaming visibility restored: the rows disagree again")
-          .hasSizeGreaterThan(1);
+    final List<Object> streamed = queryColumn(BATCH_VISIBILITY_QUERY, "nodeCount");
+    assertThat(streamed).hasSize(250);
+    assertThat(totalNodes()).as("every write still lands").isEqualTo(500L);
+    assertThat(new LinkedHashSet<>(streamed))
+        .as("streaming visibility restored: the rows disagree again")
+        .hasSizeGreaterThan(1);
+
+    final Database other = new DatabaseFactory("./target/databases/testopencypher-foreach-eager-read-6922-other").create();
+    try {
+      final List<Object> eager = new ArrayList<>();
+      other.transaction(() -> {
+        final ResultSet resultSet = other.command("opencypher", BATCH_VISIBILITY_QUERY);
+        while (resultSet.hasNext())
+          eager.add(resultSet.next().getProperty("nodeCount"));
+      });
+      assertThat(eager).as("a database that never set the flag keeps the eager default").containsOnly(500L);
     } finally {
-      GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ.setValue(true);
+      other.drop();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
@@ -270,6 +270,90 @@ class CypherForeachEagerReadIssue6922Test {
   }
 
   @Test
+  void subqueryUnderATopLevelNotIsStillARead() {
+    // The general expression parser lowers a top-level NOT/AND/OR/XOR to TernaryLogicalExpression,
+    // which ExpressionRewriter's dispatch does not know: the walk used to stop at the operator and
+    // never reach the subquery under it, leaving the FOREACH streaming.
+    final List<Object> values = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        RETURN NOT exists { MATCH (n:L1 {i: 250}) } AS missing""", "missing");
+
+    assertThat(values).hasSize(250);
+    assertThat(values).as("the last row's node exists for every row, or none of them").containsOnly(false);
+  }
+
+  @Test
+  void subqueryUnderATopLevelAndIsStillARead() {
+    final List<Object> values = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        RETURN true AND exists { MATCH (n:L1 {i: 250}) } AS present""", "present");
+
+    assertThat(values).hasSize(250);
+    assertThat(values).containsOnly(true);
+  }
+
+  @Test
+  void subqueryUnderAChainedPropertyAccessIsStillARead() {
+    // (CASE ... END).v parses to CypherExpressionBuilder.ChainedPropertyAccessExpression, which is
+    // package-private and so cannot appear in the rewriter's dispatch at all. It is the fail-closed
+    // default, not a type-specific arm, that has to catch this one.
+    final List<Object> counts = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        RETURN (CASE WHEN true THEN {v: count { MATCH (n:L1) }} ELSE {v: 0} END).v AS visible""", "visible");
+
+    assertThat(counts).hasSize(250);
+    assertThat(counts).containsOnly(500L);
+  }
+
+  @Test
+  void aLaterForeachCreatingFromASubqueryValueIsARead() {
+    // CREATE inside a FOREACH acts on variables the row carries, but its property VALUES are general
+    // expressions and may read: the second FOREACH's count{} must see the first FOREACH completed.
+    final List<Object> rows = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN [1] | CREATE (:L1 {i: i}))
+        FOREACH (j IN [1] | CREATE (:Snapshot {n: count { MATCH (m:L1) }}))
+        RETURN i AS value""", "value");
+
+    assertThat(rows).hasSize(250);
+    assertThat(countOf("L1")).isEqualTo(250L);
+    assertThat(distinctSnapshotCounts())
+        .as("every snapshot must see all 250 nodes, not a 100-row batch boundary")
+        .containsExactly(250L);
+  }
+
+  @Test
+  void aLaterForeachSettingFromASubqueryValueIsARead() {
+    final List<Object> rows = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN [1] | CREATE (:L1 {i: i}))
+        FOREACH (n IN [1] | CREATE (:Snapshot {n: 0}))
+        RETURN i AS value""", "value");
+    assertThat(rows).hasSize(250);
+
+    // The first FOREACH adds to the very label the second one counts, so a SET evaluated mid-drain
+    // reports a batch boundary (350, 450, ...) instead of the completed 500.
+    final List<Object> updated = queryColumn("""
+        MATCH (s:Snapshot)
+        FOREACH (x IN [1] | CREATE (:L1 {i: 0}))
+        FOREACH (x IN [1] | SET s.n = count { MATCH (m:L1) })
+        RETURN s.n AS value""", "value");
+    assertThat(updated).as("one row per Snapshot").hasSize(250);
+    assertThat(countOf("L1")).isEqualTo(500L);
+    assertThat(distinctSnapshotCounts())
+        .as("a SET right-hand side that reads must see the preceding FOREACH completed")
+        .containsExactly(500L);
+  }
+
+  private List<Object> distinctSnapshotCounts() {
+    final ResultSet resultSet = database.query("opencypher", "MATCH (s:Snapshot) RETURN collect(DISTINCT s.n) AS counts");
+    return new ArrayList<>((List<Object>) resultSet.next().getProperty("counts"));
+  }
+
+  @Test
   void eagerReadIsTradedBackForStreamingPerDatabase() {
     // arcadedb.opencypher.foreachEagerRead is the escape hatch for a bulk query whose input does not
     // fit in memory. It is SCOPE.DATABASE, so it is read off this database's ContextConfiguration:

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +53,7 @@ class CypherForeachEagerReadIssue6922Test {
 
   @AfterEach
   void tearDown() {
+    GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ.reset();
     if (database != null) {
       database.drop();
       database = null;
@@ -137,6 +140,59 @@ class CypherForeachEagerReadIssue6922Test {
     assertThat(totalNodes()).isEqualTo(500L);
   }
 
+  @Test
+  void mergeAfterForeachMatchesANodeTheForeachCreatedForALaterRow() {
+    // MERGE is a read as well as a write, and it is the only triggering clause here - adding a MATCH
+    // or CALL to observe the graph would arm the eager mode by itself and prove nothing about MERGE.
+    // The FOREACH gives every row its own (:L1 {i}); MERGE then asks for the very last one, which
+    // only a fully applied FOREACH can already hold. Streaming batches emit the first row while
+    // i = 250 is still 150 rows away, so MERGE creates a 251st node instead of matching.
+    final List<Object> rows = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN [0] | CREATE (:L1 {i: i}))
+        MERGE (last:L1 {i: 250})
+        RETURN i AS value""", "value");
+
+    assertThat(rows).hasSize(250);
+    assertThat(countOf("L1")).as("MERGE matched the existing node instead of creating a 251st").isEqualTo(250L);
+  }
+
+  @Test
+  void callSubqueryAfterForeachSeesEveryCreatedNode() {
+    // A CALL {} subquery is opaque to the clause scan but can hold a MATCH, so it counts as a read.
+    final List<Object> counts = queryColumn("""
+        UNWIND range(1, 250) AS i
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+        CALL { MATCH (n:L1) RETURN count(n) AS visible }
+        RETURN visible""", "visible");
+
+    assertThat(counts).hasSize(250);
+    assertThat(counts).containsOnly(500L);
+  }
+
+  @Test
+  void eagerReadCanBeTradedBackForStreaming() {
+    // arcadedb.opencypher.foreachEagerRead is the escape hatch for a bulk query whose input does not
+    // fit in memory: with it off the reader is back to seeing whatever the pull batch had applied, so
+    // the 250 rows no longer agree - which is what proves the setting reaches the planner.
+    GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ.setValue(false);
+    try {
+      final List<Object> counts = queryColumn("""
+          UNWIND range(1, 250) AS i
+          FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
+          CALL meta.stats() YIELD value AS stats
+          RETURN stats.nodeCount AS nodeCount""", "nodeCount");
+
+      assertThat(counts).hasSize(250);
+      assertThat(totalNodes()).as("every write still lands").isEqualTo(500L);
+      assertThat(new LinkedHashSet<>(counts))
+          .as("streaming visibility restored: the rows disagree again")
+          .hasSizeGreaterThan(1);
+    } finally {
+      GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ.setValue(true);
+    }
+  }
+
   private List<Object> queryColumn(final String cypher, final String column) {
     final List<Object> values = new ArrayList<>();
     database.transaction(() -> {
@@ -149,6 +205,11 @@ class CypherForeachEagerReadIssue6922Test {
 
   private long totalNodes() {
     final ResultSet resultSet = database.query("opencypher", "MATCH (n) RETURN count(n) AS nodes");
+    return ((Number) resultSet.next().getProperty("nodes")).longValue();
+  }
+
+  private long countOf(final String label) {
+    final ResultSet resultSet = database.query("opencypher", "MATCH (n:" + label + ") RETURN count(n) AS nodes");
     return ((Number) resultSet.next().getProperty("nodes")).longValue();
   }
 }


### PR DESCRIPTION
Closes #6922

## Summary

`CALL meta.stats() YIELD value` placed after a `FOREACH` reported a `nodeCount` that depended on
where the pipeline's pull batches happened to fall, not on the graph. The pipeline pulls
`nRecords = 100` rows at a time (`CypherExecutionPlan`), and `ForeachStep.fetchMore()` filled that
whole 100-row buffer - running the FOREACH body, and therefore its writes, for all 100 rows - before
handing the first of those rows to the downstream step. The reader following the FOREACH therefore
observed neither the pre-FOREACH graph nor the post-FOREACH graph, but a snapshot taken at an
arbitrary batch boundary.

That is exactly the reported shape. For the issue's query the first 100 rows saw `nodeCount = 1000`
and the 101st saw `1010`, and stretching the query to 250 rows made the batch dependence explicit -
three different answers, one per batch:

```cypher
UNWIND range(1, 250) AS i
FOREACH (j IN range(0, 1) | CREATE (:L1 {i: i, j: j}))
CALL meta.stats() YIELD value AS stats
RETURN stats.nodeCount AS nodeCount
```

before: `{200 x100, 400 x100, 500 x50}` &nbsp;&nbsp; after: `{500 x250}` (the graph really does hold 500 nodes)

openCypher resolves this class of read/write conflict by making the updating clause eager with
respect to the following read, which is also what this engine's `CREATE` already does in practice
(its bulk batch is 20,000, so a realistic `UNWIND ... CREATE ... CALL ...` applies every write before
the first row is read). `FOREACH` is now consistent with both.

## The change

- **`ForeachStep`** gains an `eagerExecution` mode. When set, `fetchMore()` drops the `buffer.size() < n`
  cap and runs the FOREACH body for every upstream row before emitting the first output row, so every
  downstream row sees the same, complete post-FOREACH graph. This is separate from the existing
  `eagerMaterialize` flag, which pre-reads the *upstream* rows to protect against a FOREACH-body
  `DELETE` invalidating a row the upstream MATCH has yet to produce (#6491) and does nothing about
  *when* the writes land.
- **`CypherExecutionPlan`** arms the mode via a new `graphReadFollows()` predicate: a later `MATCH`,
  `MERGE`, `CALL` or `SUBQUERY` clause counts as a graph read, as does a later `FOREACH` whose own
  body contains a `MERGE` at any nesting depth (the grammar allows no other read inside a FOREACH
  body). `RETURN`, `WITH` and `UNWIND` are not reads in themselves, but the expressions they carry
  can be, so those clauses are scanned for an `EXISTS { }` / `COUNT { }` / `COLLECT { }` subquery
  (each runs a real query per row through `CorrelatedSubqueryRunner`), a pattern predicate, a pattern
  comprehension or a `shortestPath()`. The same scan runs over a later FOREACH's own driving list,
  which is an expression evaluated per row against the live graph. It reuses `ExpressionRewriter`'s
  traversal, hooked at its `rewrite()` entry point so it also sees the expression types the
  rewriter's own dispatch does not know; that class carries a row of `TODO` visit stubs that do not
  recurse, and they are overridden on the detector (CASE, list, map, map projection, list
  comprehension, ALL/ANY/NONE/SINGLE, reduce, list index and slice, arithmetic, IN, IS NULL, string
  match, regex, label check, function call, boolean coercion and wrapper) rather than filled in on
  the shared base class, where every other rewriter would inherit a traversal change it never asked
  for. `CALL` is treated conservatively
  because a procedure is opaque to the planner - which is what `meta.stats()` is here. `RETURN`,
  `WITH` and `UNWIND` do not count: they only project rows the pipeline has already produced, so the
  common streaming `MATCH ... FOREACH ... RETURN` bulk-update shape keeps its bounded memory profile
  and is unaffected by this PR.
- **`GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ`** (`arcadedb.opencypher.foreachEagerRead`,
  `SCOPE.DATABASE`, default `true`) turns the eager mode off, see the trade-off section below. It is
  read off the bound database's `ContextConfiguration`, so one database's setting does not reach
  another, and it is read when the plan is built.
- The now-unused 4-argument `ForeachStep` constructor was folded into the 5-argument one.

Only the legacy execution path builds a `ForeachStep`: `CypherExecutionPlanner` returns `false` for
any statement containing `FOREACH` or `CALL`, and `EXPLAIN` on the issue's query confirms
`Using Traditional Execution (Non-Optimized)`. There is no second path to patch.

## Test plan

New `engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java`,
13 tests. 12 of them fail with the eager mode off - i.e. on the pre-fix behaviour - and pass with it
on; the thirteenth is the negative control, which must pass either way.

- [x] `metaStatsAfterForeachIsUnaffectedByDownstreamCollectUnwind` - the issue's two queries verbatim,
      on fresh databases. Both return 101 rows, every row `1010`, and the two lists are equal, so the
      row-preserving `collect()`/`UNWIND` no longer changes an already-yielded value.
- [x] `metaStatsAfterForeachDoesNotDependOnThePullBatchSize` - 250 rows spans three pull batches;
      asserts all 250 rows report `500`, the count an independent `MATCH (n) RETURN count(n)` confirms.
- [x] `matchAfterForeachSeesEveryCreatedNode` - the same conflict reached through `MATCH` instead of
      `CALL` (returned `400` before the fix).
- [x] `mergeAfterForeachMatchesANodeTheForeachCreatedForALaterRow` - `MERGE` as the *only* triggering
      clause (adding a MATCH or CALL to observe would arm the mode by itself): it asks for the node
      the FOREACH creates on the last row, which streaming batches have not created yet, so before the
      fix it created a 251st node instead of matching.
- [x] `mergeInsideALaterForeachAlsoArmsEagerness` - the same MERGE, one level down inside a second
      FOREACH, which a clause-type-only scan reads as a write and skips. Verified against the code
      before fixing it: the query created a 251st node.
- [x] `callSubqueryAfterForeachSeesEveryCreatedNode` - the same through a `CALL { ... }` subquery.
- [x] `countSubqueryExpressionInReturnSeesEveryCreatedNode`,
      `collectSubqueryExpressionNestedInAFunctionCallSeesEveryCreatedNode` and
      `existsSubqueryExpressionInWithWhereSeesEveryCreatedNode` - the read as an *expression* rather
      than a clause. Confirmed against the code before fixing: `RETURN count { MATCH (n:L1) }` and
      `RETURN size(collect { ... })` both returned 200/400/500, and `WITH i WHERE exists { MATCH
      (:L1 {i: 250}) }` returned 50 of the 250 rows.
- [x] `graphReadNestedInsideAContainerExpressionArmsEagerness` - the subquery buried in a `CASE`
      branch and in a list literal, i.e. containers the walk has to descend into.
- [x] `graphReadInALaterForeachListExpressionArmsEagerness` - the read in a later FOREACH's driving
      list: it filters on a node the first FOREACH creates only on its last row, so before the fix
      the body ran for 50 rows instead of 250.
- [x] `eagerReadIsTradedBackForStreamingPerDatabase` - the off switch reaches the planner and stays
      inside its database: with `foreachEagerRead=false` on this database all 500 nodes still land but
      the 250 rows disagree again, while a second database that never set it keeps the eager default.
- [x] `foreachWithoutAFollowingReadStillPassesEveryRowThrough` - negative control: with nothing
      downstream reading the graph the eager mode stays off, all 250 rows still flow through in order
      and all 500 nodes are still created.
- [x] openCypher TCK (`mvn -pl engine verify -Dsurefire.includes='**/*Suite.java'`):
      **3897 scenarios, 0 failures, 85 skipped - identical before and after the change.**
- [x] Full `engine` module (`-DexcludedGroups=benchmark,vector,slow`): **14,024 tests run, 1 failure,
      23 skipped** - the one failure is `Issue6559ApproximateDeltaScoringScaleTest`, a PQ delta-buffer
      timing flake in `com.arcadedb.index.vector` that green in the five preceding full runs of this
      branch and passes 3/3 in isolation. Nothing in this PR touches vector indexing.

## The trade-off eagerness buys, and why not a chunk cap

Eagerness is not free: the FOREACH's input rows are held until the last write is applied, where
before this PR they streamed 100 at a time. A query such as

```cypher
UNWIND $bigBatch AS row
FOREACH (x IN CASE WHEN row.flag THEN [1] ELSE [] END | CREATE (:Audit {row: row}))
MERGE (n:Entity {id: row.id})
```

now materializes `$bigBatch` before the first row reaches `MERGE`. That is inherent to the guarantee -
openCypher's own Eager operator costs exactly the same - so it is a switch, not a cap:
`arcadedb.opencypher.foreachEagerRead=false` restores streaming for an input that does not fit in
memory, at the documented price of the read seeing a partially applied FOREACH.

Capping the eager mode at a chunk size was considered and rejected. A chunk cap does not weaken the
guarantee, it *deletes* it: whatever the chunk size, the reader is back to seeing whichever writes
happened to land inside its chunk, which is the defect this PR fixes - and it would do it silently,
with no setting in the log to explain the numbers.

## Known related gap (not fixed here)

`CreateStep` has the same shape of boundary, just further out: it flushes in
`arcadedb.opencypher.bulkCreateBatchSize` chunks (default 20,000), so
`UNWIND range(1, 50000) AS i CREATE (:L1) CALL meta.stats() ...` would still report three different
counts. It is the same root cause and would take the same treatment, but it needs its own memory
analysis for the bulk-ingest path that batch size exists to serve, so it is left out of this fix
rather than folded into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1bu3QHjw5bgFKvfPSUoR7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `FOREACH` reliability before graph-reading operations, including `MATCH`, `MERGE`, `CALL`, subqueries, nested expressions, and nested `FOREACH` clauses.
  - Ensured updates complete before subsequent reads, providing consistent results across batching and materialization.
  - Preserved streaming behavior when eager processing is unnecessary or disabled.

- **Documentation**
  - Clarified eager `FOREACH` processing, memory considerations, and configuration behavior.

- **Tests**
  - Added regression coverage for downstream reads, batching, nested processing, and complete update visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->