### PR TITLE
feat(#4531): GQL Quantified Path Patterns Phase B - repeated inner sub-patterns, inner WHERE, group-variable LIST bindings

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.ast;
 
 import com.arcadedb.database.Document;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
@@ -103,6 +104,15 @@ public class PatternPredicateExpression implements BooleanExpression {
 
     // Get the relationship pattern
     final RelationshipPattern relPattern = pathPattern.getRelationship(0);
+
+    // A GQL quantified path pattern (issue #4531) repeats a whole sub-pattern; this predicate evaluator
+    // only knows how to probe a single hop and would answer as if the group were one untyped
+    // variable-length relationship. Say so rather than return a wrong boolean - the EXISTS { MATCH ... }
+    // spelling plans a real execution plan and supports it.
+    if (relPattern instanceof QuantifiedPathPattern)
+      throw new CommandExecutionException(
+          "FeatureNotImplemented: a quantified path pattern is not supported inside an inline pattern predicate; "
+              + "use EXISTS { MATCH ... } instead (issue #4531)");
 
     // Handle variable-length patterns (e.g., -[:REL*2]-, -[:REL*]-)
     if (relPattern.isVariableLength())

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -107,8 +107,10 @@ public class PatternPredicateExpression implements BooleanExpression {
 
     // A GQL quantified path pattern (issue #4531) repeats a whole sub-pattern; this predicate evaluator
     // only knows how to probe a single hop and would answer as if the group were one untyped
-    // variable-length relationship. Say so rather than return a wrong boolean - the EXISTS { MATCH ... }
-    // spelling plans a real execution plan and supports it.
+    // variable-length relationship. Unreachable through today's grammar - the pattern-predicate position
+    // parses as pathPatternNonEmpty, which admits no parenthesizedPath, so the group is refused earlier -
+    // and kept so that widening that rule cannot silently turn the rejection into a wrong boolean. The
+    // EXISTS { MATCH ... } spelling plans a real execution plan and supports the group.
     if (relPattern instanceof QuantifiedPathPattern)
       throw new CommandExecutionException(
           "FeatureNotImplemented: a quantified path pattern is not supported inside an inline pattern predicate; "

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/QuantifiedPathPattern.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/QuantifiedPathPattern.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.ast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A GQL Quantified Path Pattern (ISO/IEC 39075:2024 §15.4) that cannot be lowered onto the
+ * variable-length-relationship engine, i.e. everything issue #4531 calls "Phase B":
+ * a repeated inner pattern of two or more hops, an inner {@code WHERE} evaluated once per
+ * repetition, or inner variables that have to surface outside the group as parallel lists.
+ *
+ * <pre>
+ *   MATCH (a) ( (x)-[r1:R1]-&gt;(y)-[r2:R2]-&gt;(z) WHERE r1.w &gt; 5 ){1,3} (b)
+ * </pre>
+ *
+ * <p>It is modelled as a {@link RelationshipPattern} so the whole group occupies exactly one hop of
+ * the enclosing {@link PathPattern}, keeping the {@code nodes.size() == relationships.size() + 1}
+ * invariant every consumer of a path pattern relies on. The enclosing pattern's boundary nodes are
+ * the group's endpoints; the inner pattern's own endpoint constraints are re-checked per repetition
+ * by the executor, since a boundary node cannot carry them for repetitions past the first.
+ *
+ * <p>The synthesised hop always reports a non-null minimum, so {@link #isVariableLength()} is true
+ * and every shape-matching fast path that already declines a variable-length hop declines this one
+ * too. Execution belongs to {@code QuantifiedPathStep}; callers that cannot honour the repetition
+ * semantics must test for this type explicitly rather than treat it as a plain hop.
+ *
+ * <p>Phase A - a single-relationship inner pattern with anonymous endpoints and no inner
+ * {@code WHERE} - is still lowered to a plain variable-length relationship by
+ * {@code CypherASTBuilder}, because for that shape the two are equivalent and the existing
+ * traversal machinery is faster.
+ */
+public class QuantifiedPathPattern extends RelationshipPattern {
+  private final PathPattern      inner;
+  private final BooleanExpression innerWhere;
+
+  /**
+   * @param inner      the parenthesized inner pattern that is repeated
+   * @param innerWhere predicate evaluated once per repetition against that repetition's bindings, or null
+   * @param min        minimum repetitions; null means 1
+   * @param max        maximum repetitions; null means unbounded
+   */
+  public QuantifiedPathPattern(final PathPattern inner, final BooleanExpression innerWhere, final Integer min,
+      final Integer max) {
+    super(null, null, Direction.BOTH, null, null, min != null ? min : 1, max, null);
+    if (inner == null || inner.getRelationshipCount() < 1)
+      throw new IllegalArgumentException("A quantified path pattern must repeat at least one relationship");
+    this.inner = inner;
+    this.innerWhere = innerWhere;
+  }
+
+  public PathPattern getInnerPattern() {
+    return inner;
+  }
+
+  public BooleanExpression getInnerWhere() {
+    return innerWhere;
+  }
+
+  /** Minimum number of repetitions; 0 is legal and matches the two boundary nodes as the same vertex. */
+  public int getMinRepetitions() {
+    return getEffectiveMinHops();
+  }
+
+  /** Maximum number of repetitions, {@link Integer#MAX_VALUE} when the quantifier is open-ended. */
+  public int getMaxRepetitions() {
+    return getEffectiveMaxHops();
+  }
+
+  /**
+   * Returns every variable written inside the group, in written order. Each of them binds outside the
+   * group to a list with one element per repetition - {@code LIST<NODE>} for a node variable,
+   * {@code LIST<RELATIONSHIP>} for a relationship variable - which is what makes them "group variables"
+   * in GQL terms.
+   */
+  public List<String> getGroupVariables() {
+    final Set<String> variables = new LinkedHashSet<>();
+    for (int i = 0; i < inner.getNodeCount(); i++) {
+      final String variable = inner.getNode(i).getVariable();
+      if (variable != null && !variable.isEmpty())
+        variables.add(variable);
+      if (i < inner.getRelationshipCount()) {
+        final String relVariable = inner.getRelationship(i).getVariable();
+        if (relVariable != null && !relVariable.isEmpty())
+          variables.add(relVariable);
+      }
+    }
+    return variables.isEmpty() ? Collections.emptyList() : new ArrayList<>(variables);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("(").append(inner);
+    if (innerWhere != null)
+      sb.append(" WHERE ").append(innerWhere);
+    sb.append(")");
+    final int min = getMinRepetitions();
+    final int max = getMaxRepetitions();
+    if (max == Integer.MAX_VALUE)
+      sb.append(min == 0 ? "*" : (min == 1 ? "+" : "{" + min + ",}"));
+    else if (min == max)
+      sb.append("{").append(min).append("}");
+    else
+      sb.append("{").append(min).append(",").append(max).append("}");
+    return sb.toString();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/QuantifiedPathPattern.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/QuantifiedPathPattern.java
@@ -62,6 +62,12 @@ public class QuantifiedPathPattern extends RelationshipPattern {
    */
   public QuantifiedPathPattern(final PathPattern inner, final BooleanExpression innerWhere, final Integer min,
       final Integer max) {
+    // The inherited variable, types, direction and property map are PLACEHOLDERS, not traversal semantics:
+    // a group has no single relationship type or direction, they live on the inner pattern's own hops.
+    // Only the hop bounds are real, so that isVariableLength() is true and every shape check that already
+    // declines a variable-length hop declines this one. Any new code that loops over
+    // PathPattern#getRelationships() and reads getDirection()/getTypes() must special-case this type the
+    // way CypherExecutionPlan#buildMatchStep does, rather than rely on an incidental guard elsewhere.
     super(null, null, Direction.BOTH, null, null, min != null ? min : 1, max, null);
     if (inner == null || inner.getRelationshipCount() < 1)
       throw new IllegalArgumentException("A quantified path pattern must repeat at least one relationship");

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -4746,6 +4746,17 @@ public class CypherExecutionPlan {
     if (bindsNoEdge(relI) || bindsNoEdge(relJ))
       return false;
 
+    // A GQL quantified group (issue #4531) binds whatever its inner pattern's own hops bind, but the
+    // synthetic hop standing in for it carries PLACEHOLDER types and direction, not the inner ones -
+    // neither test below can say anything true about it. Answer conservatively here rather than let
+    // those placeholders decide it indirectly, which is what QuantifiedPathPattern's class javadoc asks
+    // of every loop over getRelationships(). This is load-bearing: a "no" would let
+    // computeHopEdgeTrackingNeeds drop the sibling hop's relationship variable, and without it on the
+    // row QuantifiedPathStep#collectBoundRelationships cannot see that edge and the group would reuse
+    // it, breaking relationship isomorphism.
+    if (relI instanceof QuantifiedPathPattern || relJ instanceof QuantifiedPathPattern)
+      return true;
+
     if (relI.hasTypes() && relJ.hasTypes() && edgeTypesAreDisjoint(relI.getTypes(), relJ.getTypes()))
       return false;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -3118,7 +3118,8 @@ public class CypherExecutionPlan {
                 if (relPattern instanceof QuantifiedPathPattern quantified) {
                   // GQL Quantified Path Pattern, Phase B (issue #4531) - see the ordered builder above
                   for (final String groupVariable : quantified.getGroupVariables())
-                    matchVariables.add(groupVariable);
+                    if (!legacyBoundVariables.contains(groupVariable))
+                      matchVariables.add(groupVariable);
                   nextStep = new QuantifiedPathStep(currentSourceVar, targetVar, pathVariable,
                       bindsGroupPathVariable(pathPattern), quantified, targetNode,
                       new HashSet<>(legacyBoundVariables), context);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -61,6 +61,7 @@ import com.arcadedb.query.opencypher.ast.OrderByClause;
 import com.arcadedb.query.opencypher.ast.NodePattern;
 import com.arcadedb.query.opencypher.ast.ParameterExpression;
 import com.arcadedb.query.opencypher.ast.PathPattern;
+import com.arcadedb.query.opencypher.ast.QuantifiedPathPattern;
 import com.arcadedb.query.opencypher.ast.PatternPredicateExpression;
 import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
@@ -109,6 +110,7 @@ import com.arcadedb.query.opencypher.executor.steps.MergeStep;
 import com.arcadedb.query.opencypher.executor.steps.OptionalMatchStep;
 import com.arcadedb.query.opencypher.executor.steps.OrderByStep;
 import com.arcadedb.query.opencypher.executor.steps.ProjectReturnStep;
+import com.arcadedb.query.opencypher.executor.steps.QuantifiedPathStep;
 import com.arcadedb.query.opencypher.executor.steps.RemoveStep;
 import com.arcadedb.query.opencypher.executor.steps.SetStep;
 import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep;
@@ -2159,7 +2161,13 @@ public class CypherExecutionPlan {
           // For unreferenced fixed-length edges, treat as anonymous for GAV eligibility.
           // Anonymous edge: null if GAV-eligible, internal var if edge tracking needed.
           final String relVar;
-          if (relPattern.getVariable() != null && !relPattern.getVariable().isEmpty()) {
+          if (relPattern instanceof QuantifiedPathPattern)
+            // A quantified group binds no relationship of its own: its inner relationship variables are
+            // group variables bound to lists by QuantifiedPathStep, and it does its own isomorphism
+            // bookkeeping. Handing it a synthetic edge-tracking variable would register a name in
+            // matchVariables that nothing ever binds.
+            relVar = null;
+          else if (relPattern.getVariable() != null && !relPattern.getVariable().isEmpty()) {
             if (relPattern.isVariableLength() || CypherVariableUsage.isEdgeVariableReferenced(statement, relPattern.getVariable())
                 || boundVariables.contains(relPattern.getVariable()))
               relVar = relPattern.getVariable();
@@ -2202,7 +2210,16 @@ public class CypherExecutionPlan {
             matchVariables.add(effectiveTargetVar);
 
           AbstractExecutionStep nextStep;
-          if (relPattern.isVariableLength()) {
+          if (relPattern instanceof QuantifiedPathPattern quantified) {
+            // GQL Quantified Path Pattern, Phase B (issue #4531): a repeated inner sub-pattern that no
+            // variable-length hop can express. Its inner variables surface here as group variables.
+            for (final String groupVariable : quantified.getGroupVariables())
+              if (!boundVariables.contains(groupVariable))
+                matchVariables.add(groupVariable);
+            nextStep = new QuantifiedPathStep(effectiveSourceVar, effectiveTargetVar, pathVariable,
+                bindsGroupPathVariable(pathPattern), quantified, effectiveTargetNode,
+                new HashSet<>(boundVariables), context);
+          } else if (relPattern.isVariableLength()) {
             // DFS, not BFS: DFS's active stack is bounded by maxHops regardless of branching
             // factor, while BFS's frontier queue must hold an entire level's children before it
             // can dequeue the first one - level-order expansion via a single FIFO queue offers no
@@ -2507,6 +2524,19 @@ public class CypherExecutionPlan {
     final String targetVariable = pathPattern.getLastNode().getVariable();
     return targetVariable != null && !targetVariable.equals(sourceVariable)
         && targetVariable.equals(physicalPlan.getAnchor().getVariable());
+  }
+
+  /**
+   * Returns true when a named path over {@code pathPattern} names nothing but a single quantified group,
+   * which ISO/IEC 39075 §15.4 (grouped path assignment) binds to a {@code LIST<PATH>} - one path per
+   * repetition - rather than to one path.
+   * <p>
+   * A path that also spans ordinary hops around the group has no such list form and stays a single
+   * concatenated path, so the distinction is made here, on the written pattern, and not inside the step.
+   */
+  private static boolean bindsGroupPathVariable(final PathPattern pathPattern) {
+    return pathPattern.getRelationshipCount() == 1
+        && pathPattern.getRelationship(0) instanceof QuantifiedPathPattern;
   }
 
   /**
@@ -3067,7 +3097,9 @@ public class CypherExecutionPlan {
                 final RelationshipPattern relPattern = pathPattern.getRelationship(i);
                 final NodePattern targetNode = pathPattern.getNode(i + 1);
                 final String relVar;
-                if (relPattern.getVariable() != null && !relPattern.getVariable().isEmpty()) {
+                if (relPattern instanceof QuantifiedPathPattern)
+                  relVar = null; // see the matching note in the ordered builder above
+                else if (relPattern.getVariable() != null && !relPattern.getVariable().isEmpty()) {
                   if (relPattern.isVariableLength() || CypherVariableUsage.isEdgeVariableReferenced(statement, relPattern.getVariable()))
                     relVar = relPattern.getVariable();
                   else
@@ -3083,7 +3115,14 @@ public class CypherExecutionPlan {
                 matchVariables.add(targetVar);
 
                 AbstractExecutionStep nextStep;
-                if (relPattern.isVariableLength()) {
+                if (relPattern instanceof QuantifiedPathPattern quantified) {
+                  // GQL Quantified Path Pattern, Phase B (issue #4531) - see the ordered builder above
+                  for (final String groupVariable : quantified.getGroupVariables())
+                    matchVariables.add(groupVariable);
+                  nextStep = new QuantifiedPathStep(currentSourceVar, targetVar, pathVariable,
+                      bindsGroupPathVariable(pathPattern), quantified, targetNode,
+                      new HashSet<>(legacyBoundVariables), context);
+                } else if (relPattern.isVariableLength()) {
                   // Variable-length path - pass path variable, relationship variable, and target node for label
                   // filtering. Snapshot previously bound variables for relationship-uniqueness scoping.
                   // DFS, not BFS: see the matching comment in the optimizer plan builder above (#6097).

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/QuantifiedPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/QuantifiedPathStep.java
@@ -1,0 +1,524 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.InlineProperties;
+import com.arcadedb.query.opencypher.Labels;
+import com.arcadedb.query.opencypher.ast.BooleanExpression;
+import com.arcadedb.query.opencypher.ast.Direction;
+import com.arcadedb.query.opencypher.ast.Expression;
+import com.arcadedb.query.opencypher.ast.NodePattern;
+import com.arcadedb.query.opencypher.ast.QuantifiedPathPattern;
+import com.arcadedb.query.opencypher.ast.RelationshipPattern;
+import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
+import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
+import com.arcadedb.query.sql.executor.AbstractExecutionStep;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.executor.WorkGuard;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Executes a GQL Quantified Path Pattern whose inner pattern cannot be lowered onto the
+ * variable-length-relationship engine (issue #4531, "Phase B"):
+ *
+ * <pre>
+ *   MATCH (a) ( (x)-[r1:R1]-&gt;(y)-[r2:R2]-&gt;(z) WHERE r1.w &gt; 5 ){1,3} (b)
+ * </pre>
+ *
+ * <p>For every input row the step depth-first-searches the repetitions of the inner pattern, starting
+ * at the vertex bound to the left boundary variable. Repetition {@code i+1} starts where repetition
+ * {@code i} ended, the inner {@code WHERE} is evaluated once per repetition against that repetition's
+ * own bindings, and a row is emitted for every reachable end vertex whose repetition count lies inside
+ * the quantifier's bounds.
+ *
+ * <p>Variables written inside the group are <b>group variables</b>: each binds outside the group to a
+ * list with one element per repetition ({@code LIST<NODE>} for a node variable,
+ * {@code LIST<RELATIONSHIP>} for a relationship variable), in repetition order. Zero repetitions -
+ * legal for a {@code {0,n}} or {@code *} quantifier - bind them to empty lists and leave both
+ * boundaries on the same vertex.
+ *
+ * <p>Relationship isomorphism is enforced across the whole group and against the relationships the
+ * incoming row already binds within the same MATCH clause: no relationship is traversed twice, which
+ * is also what terminates an open-ended quantifier on a cyclic graph.
+ */
+public class QuantifiedPathStep extends AbstractExecutionStep {
+  private final String                sourceVariable;
+  private final String                targetVariable;
+  private final String                pathVariable;
+  private final boolean               pathVariableBindsGroup;
+  private final QuantifiedPathPattern group;
+  private final NodePattern           targetNodePattern;
+  private final Set<String>           previousStepVariables;
+  private final List<NodePattern>     innerNodes;
+  private final List<RelationshipPattern> innerRelationships;
+  /**
+   * Created only when a boundary node pattern carries Cypher 25 dynamic {@code $(expression)} labels:
+   * every other pattern shape resolves its labels statically and must not pay for it.
+   */
+  private final ExpressionEvaluator  dynamicLabelEvaluator;
+
+  /**
+   * @param sourceVariable         variable holding the group's left boundary vertex
+   * @param targetVariable         variable the group's right boundary vertex binds to
+   * @param pathVariable           enclosing named path variable, or null
+   * @param pathVariableBindsGroup true when {@code pathVariable} names nothing but this group, in which
+   *                               case it binds to a {@code LIST<PATH>} with one path per repetition
+   *                               (ISO/IEC 39075 §15.4 grouped path assignment); false when the path
+   *                               spans further segments and must stay a single concatenated path
+   * @param group                  the quantified path pattern to repeat
+   * @param targetNodePattern      right boundary node pattern, for label/property filtering; may be null
+   * @param previousStepVariables  variables bound before this MATCH clause, exempt from relationship
+   *                               isomorphism (Cypher scopes it to a single MATCH)
+   */
+  public QuantifiedPathStep(final String sourceVariable, final String targetVariable, final String pathVariable,
+      final boolean pathVariableBindsGroup, final QuantifiedPathPattern group, final NodePattern targetNodePattern,
+      final Set<String> previousStepVariables, final CommandContext context) {
+    super(context);
+    this.sourceVariable = sourceVariable;
+    this.targetVariable = targetVariable;
+    this.pathVariable = pathVariable != null && !pathVariable.isEmpty() ? pathVariable : null;
+    this.pathVariableBindsGroup = pathVariableBindsGroup;
+    this.group = group;
+    this.targetNodePattern = targetNodePattern;
+    this.previousStepVariables = previousStepVariables;
+    this.innerNodes = group.getInnerPattern().getNodes();
+    this.innerRelationships = group.getInnerPattern().getRelationships();
+    this.dynamicLabelEvaluator = targetNodePattern != null && targetNodePattern.hasDynamicLabels() ?
+        new ExpressionEvaluator(new CypherFunctionFactory(DefaultSQLFunctionFactory.getInstance())) : null;
+  }
+
+  /** One matched repetition: the vertices and relationships the inner pattern bound this time round. */
+  private record Repetition(Vertex[] nodes, Edge[] edges) {
+  }
+
+  @Override
+  public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
+    checkForPrevious("QuantifiedPathStep requires a previous step");
+
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
+    return new ResultSet() {
+      private ResultSet     prevResults = null;
+      private List<Result>  buffer      = new ArrayList<>();
+      private int           bufferIndex = 0;
+      private boolean       finished    = false;
+
+      @Override
+      public boolean hasNext() {
+        if (bufferIndex < buffer.size())
+          return true;
+        if (finished)
+          return false;
+        fetchMore(nRecords);
+        return bufferIndex < buffer.size();
+      }
+
+      @Override
+      public Result next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        return buffer.get(bufferIndex++);
+      }
+
+      private void fetchMore(final int n) {
+        buffer = new ArrayList<>();
+        bufferIndex = 0;
+
+        while (buffer.size() < n) {
+          guard.check();
+          if (prevResults == null)
+            prevResults = prev.syncPull(context, n);
+          if (!prevResults.hasNext()) {
+            finished = true;
+            break;
+          }
+
+          final Result input = prevResults.next();
+          final long begin = context.isProfiling() ? System.nanoTime() : 0;
+          try {
+            expand(input, buffer, guard);
+          } finally {
+            if (context.isProfiling())
+              cost += System.nanoTime() - begin;
+          }
+        }
+        if (context.isProfiling())
+          rowCount += buffer.size();
+      }
+
+      @Override
+      public void close() {
+        QuantifiedPathStep.this.close();
+      }
+    };
+  }
+
+  /**
+   * Depth-first-searches every legal repetition count from the row's left boundary vertex and appends
+   * one output row per accepted end vertex.
+   */
+  private void expand(final Result input, final List<Result> out, final WorkGuard guard) {
+    if (!(input.getProperty(sourceVariable) instanceof Vertex start))
+      return;
+
+    final Object targetValue = input.getProperty(targetVariable);
+    final Vertex boundTarget = targetValue instanceof Vertex vertex ? vertex : null;
+
+    new RowSearch(input, boundTarget, out, guard).run(start);
+  }
+
+  /**
+   * One input row's search. Everything the inner pattern needs that depends on the row and not on the
+   * candidate - resolved inline property maps, inline relationship predicates, the resolved boundary
+   * labels - is computed once here rather than per candidate relationship, which is where a group over a
+   * dense vertex spends its time.
+   */
+  private final class RowSearch {
+    private final Result                input;
+    private final Vertex                boundTarget;
+    private final List<Result>          out;
+    private final WorkGuard             guard;
+    private final Set<RID>              usedEdges;
+    private final List<Repetition>      repetitions = new ArrayList<>();
+    private final Map<String, Object>[] relationshipProperties;
+    private final Predicate<Edge>[]     relationshipPredicates;
+    private final String[][]            relationshipTypes;
+    private final Map<String, Object>[] nodeProperties;
+    private final List<String>          targetLabels;
+
+    @SuppressWarnings("unchecked")
+    private RowSearch(final Result input, final Vertex boundTarget, final List<Result> out, final WorkGuard guard) {
+      this.input = input;
+      this.boundTarget = boundTarget;
+      this.out = out;
+      this.guard = guard;
+      // Seeding the used-relationship set with the ones the row already binds makes isomorphism a single
+      // check inside the search instead of a whole-match rejection at the end, so a conflicting branch is
+      // pruned as soon as it appears.
+      this.usedEdges = collectBoundRelationships(input);
+
+      final int hops = innerRelationships.size();
+      this.relationshipProperties = new Map[hops];
+      this.relationshipPredicates = new Predicate[hops];
+      this.relationshipTypes = new String[hops][];
+      for (int i = 0; i < hops; i++) {
+        final RelationshipPattern relationship = innerRelationships.get(i);
+        if (relationship.hasProperties())
+          relationshipProperties[i] = InlineProperties.resolveAll(relationship.getProperties(), input, context);
+        // Built through the pattern's own factory so the inline-WHERE evaluation scope has one definition
+        // shared with every other traversal evaluator, per RelationshipPattern#buildInlineWherePredicate.
+        relationshipPredicates[i] = relationship.buildInlineWherePredicate(input, context);
+        if (relationship.hasTypes())
+          relationshipTypes[i] = relationship.getTypes().toArray(new String[0]);
+      }
+
+      this.nodeProperties = new Map[innerNodes.size()];
+      for (int i = 0; i < innerNodes.size(); i++) {
+        final NodePattern node = innerNodes.get(i);
+        if (node.hasProperties())
+          nodeProperties[i] = InlineProperties.resolveAll(node.getProperties(), input, context);
+      }
+
+      this.targetLabels = targetNodePattern != null ? resolveLabels(targetNodePattern, input) : null;
+    }
+
+    private void run(final Vertex start) {
+      search(start);
+    }
+
+    private void search(final Vertex current) {
+      guard.check();
+
+      final int done = repetitions.size();
+      if (done >= group.getMinRepetitions() && acceptsEndpoint(current))
+        out.add(buildRow(input, current, repetitions));
+
+      if (done >= group.getMaxRepetitions())
+        return;
+
+      // The inner start node's own constraints hold for every repetition, not only the first: the outer
+      // boundary node can only carry them for the vertex it binds.
+      if (!matchesInnerNode(current, 0))
+        return;
+
+      final Vertex[] nodes = new Vertex[innerNodes.size()];
+      final Edge[] edges = new Edge[innerRelationships.size()];
+      nodes[0] = current;
+      matchRepetition(nodes, edges, 0);
+    }
+
+    /**
+     * Matches one repetition of the inner pattern hop by hop, recursing into {@link #search} for every
+     * complete assignment. Relationships consumed by the branch are held in {@code usedEdges} for the
+     * duration of the recursion below them and released on backtracking.
+     */
+    private void matchRepetition(final Vertex[] nodes, final Edge[] edges, final int hop) {
+      if (hop == innerRelationships.size()) {
+        if (group.getInnerWhere() != null
+            && !group.getInnerWhere().evaluate(repetitionScope(input, nodes, edges), context))
+          return;
+        repetitions.add(new Repetition(nodes.clone(), edges.clone()));
+        search(nodes[nodes.length - 1]);
+        repetitions.remove(repetitions.size() - 1);
+        return;
+      }
+
+      final Direction direction = innerRelationships.get(hop).getDirection();
+      final Vertex from = nodes[hop];
+      final String[] types = relationshipTypes[hop];
+
+      final Iterator<Edge> candidates = types != null ?
+          from.getEdges(direction.toArcadeDirection(), types).iterator() :
+          from.getEdges(direction.toArcadeDirection()).iterator();
+
+      while (candidates.hasNext()) {
+        guard.check();
+        final Edge edge = candidates.next();
+        final RID edgeId = edge.getIdentity();
+        if (usedEdges.contains(edgeId))
+          continue;
+        if (relationshipProperties[hop] != null && !matchesResolved(edge, relationshipProperties[hop]))
+          continue;
+        if (relationshipPredicates[hop] != null && !relationshipPredicates[hop].test(edge))
+          continue;
+
+        final Vertex next = otherEnd(edge, from, direction);
+        if (!matchesInnerNode(next, hop + 1))
+          continue;
+
+        edges[hop] = edge;
+        nodes[hop + 1] = next;
+        usedEdges.add(edgeId);
+        matchRepetition(nodes, edges, hop + 1);
+        usedEdges.remove(edgeId);
+      }
+    }
+
+    /** Applies inner node {@code index}'s labels, resolved inline properties and inline WHERE. */
+    private boolean matchesInnerNode(final Vertex vertex, final int index) {
+      final NodePattern pattern = innerNodes.get(index);
+      if (pattern.hasLabels() && !Labels.matches(vertex, pattern.getLabels(), pattern.isLabelDisjunction()))
+        return false;
+      if (nodeProperties[index] != null && !matchesResolved(vertex, nodeProperties[index]))
+        return false;
+      return !pattern.hasWhereExpression() || matchesNodeWhere(vertex, pattern);
+    }
+
+    /** Checks the right boundary: the pinned target if the row already bound one, then its own constraints. */
+    private boolean acceptsEndpoint(final Vertex candidate) {
+      if (boundTarget != null && !candidate.getIdentity().equals(boundTarget.getIdentity()))
+        return false;
+      if (targetNodePattern == null)
+        return true;
+      if ((targetNodePattern.hasLabels() || targetNodePattern.hasDynamicLabels())
+          && !Labels.matches(candidate, targetLabels, targetNodePattern.isLabelDisjunction()))
+        return false;
+      if (targetNodePattern.hasProperties()
+          && !InlineProperties.matches(candidate, targetNodePattern.getProperties(), input, context))
+        return false;
+      return !targetNodePattern.hasWhereExpression() || matchesNodeWhere(candidate, targetNodePattern);
+    }
+
+    private boolean matchesNodeWhere(final Vertex vertex, final NodePattern pattern) {
+      final ResultInternal scope = new ResultInternal();
+      for (final String property : input.getPropertyNames())
+        scope.setProperty(property, input.getProperty(property));
+      final String variable = pattern.getVariable();
+      if (variable != null && !variable.isEmpty())
+        scope.setProperty(variable, vertex);
+      return pattern.getWhereExpression().evaluate(scope, context);
+    }
+  }
+
+  private static boolean matchesResolved(final Document record, final Map<String, Object> resolved) {
+    for (final Map.Entry<String, Object> entry : resolved.entrySet())
+      if (!InlineProperties.matchesResolvedValue(record.get(entry.getKey()), entry.getValue()))
+        return false;
+    return true;
+  }
+
+  /**
+   * Builds the scope one repetition's predicates are evaluated in: the incoming row's bindings plus this
+   * repetition's own single-valued bindings. Single-valued, not the group lists - an inner {@code WHERE}
+   * constrains the repetition it is written inside, so {@code WHERE r.weight > 5} reads one relationship.
+   */
+  private Result repetitionScope(final Result input, final Vertex[] nodes, final Edge[] edges) {
+    final ResultInternal scope = new ResultInternal();
+    for (final String property : input.getPropertyNames())
+      scope.setProperty(property, input.getProperty(property));
+    for (int i = 0; i < nodes.length; i++) {
+      final String variable = innerNodes.get(i).getVariable();
+      if (variable != null && !variable.isEmpty() && nodes[i] != null)
+        scope.setProperty(variable, nodes[i]);
+      if (i < edges.length) {
+        final String relVariable = innerRelationships.get(i).getVariable();
+        if (relVariable != null && !relVariable.isEmpty() && edges[i] != null)
+          scope.setProperty(relVariable, edges[i]);
+      }
+    }
+    return scope;
+  }
+
+  /**
+   * The labels a node pattern requires, with any Cypher 25 dynamic {@code $(expression)} label resolved
+   * against the current row. Only the boundary node patterns can carry one - a dynamic label inside the
+   * group is refused at parse time, since it would resolve per row rather than per repetition.
+   */
+  private List<String> resolveLabels(final NodePattern pattern, final Result input) {
+    if (!pattern.hasDynamicLabels())
+      return pattern.getLabels();
+
+    final List<String> labels = new ArrayList<>(pattern.getLabels());
+    for (final Expression dynamicLabel : pattern.getDynamicLabels()) {
+      final Object resolved = dynamicLabelEvaluator.evaluate(dynamicLabel, input, context);
+      if (resolved instanceof Iterable<?> items) {
+        for (final Object item : items)
+          if (item != null)
+            labels.add(item.toString());
+      } else if (resolved != null)
+        labels.add(resolved.toString());
+    }
+    return labels;
+  }
+
+  private Result buildRow(final Result input, final Vertex end, final List<Repetition> repetitions) {
+    final ResultInternal row = new ResultInternal();
+    for (final String property : input.getPropertyNames())
+      row.setProperty(property, input.getProperty(property));
+
+    for (int i = 0; i < innerNodes.size(); i++) {
+      final String variable = innerNodes.get(i).getVariable();
+      if (variable != null && !variable.isEmpty()) {
+        final List<Vertex> values = new ArrayList<>(repetitions.size());
+        for (final Repetition repetition : repetitions)
+          values.add(repetition.nodes()[i]);
+        row.setProperty(variable, values);
+      }
+    }
+    for (int i = 0; i < innerRelationships.size(); i++) {
+      final String variable = innerRelationships.get(i).getVariable();
+      if (variable != null && !variable.isEmpty()) {
+        final List<Edge> values = new ArrayList<>(repetitions.size());
+        for (final Repetition repetition : repetitions)
+          values.add(repetition.edges()[i]);
+        row.setProperty(variable, values);
+      }
+    }
+
+    row.setProperty(targetVariable, end);
+
+    if (pathVariable != null) {
+      if (pathVariableBindsGroup) {
+        final List<TraversalPath> paths = new ArrayList<>(repetitions.size());
+        for (final Repetition repetition : repetitions)
+          paths.add(toPath(repetition));
+        row.setProperty(pathVariable, paths);
+      } else {
+        TraversalPath concatenated = input.getProperty(pathVariable) instanceof TraversalPath existing ?
+            existing : null;
+        for (final Repetition repetition : repetitions) {
+          final TraversalPath segment = toPath(repetition);
+          concatenated = concatenated == null ? segment : new TraversalPath(concatenated, segment);
+        }
+        if (concatenated == null)
+          concatenated = new TraversalPath(end);
+        row.setProperty(pathVariable, concatenated);
+      }
+    }
+    return row;
+  }
+
+  private static TraversalPath toPath(final Repetition repetition) {
+    TraversalPath path = new TraversalPath(repetition.nodes()[0]);
+    for (int i = 0; i < repetition.edges().length; i++)
+      path = new TraversalPath(path, repetition.edges()[i], repetition.nodes()[i + 1]);
+    return path;
+  }
+
+  /**
+   * Collects the relationships the incoming row already binds within this MATCH clause, so the group
+   * cannot reuse one. Variables carried in from a previous MATCH or a WITH are skipped: Cypher scopes
+   * relationship isomorphism to a single MATCH clause.
+   */
+  private Set<RID> collectBoundRelationships(final Result input) {
+    final Set<RID> used = new HashSet<>();
+    final List<String> groupVariables = group.getGroupVariables();
+    for (final String property : input.getPropertyNames()) {
+      if (property.equals(targetVariable) || property.equals(pathVariable) || groupVariables.contains(property))
+        continue;
+      if (previousStepVariables != null && previousStepVariables.contains(property))
+        continue;
+      collectRelationships(input.getProperty(property), used);
+    }
+    return used;
+  }
+
+  private static void collectRelationships(final Object value, final Set<RID> used) {
+    if (value instanceof Edge edge)
+      used.add(edge.getIdentity());
+    else if (value instanceof TraversalPath path) {
+      for (final Edge edge : path.getEdges())
+        used.add(edge.getIdentity());
+    } else if (value instanceof Iterable<?> items) {
+      for (final Object item : items)
+        collectRelationships(item, used);
+    }
+  }
+
+  private static Vertex otherEnd(final Edge edge, final Vertex from, final Direction direction) {
+    if (direction == Direction.OUT)
+      return edge.getInVertex();
+    if (direction == Direction.IN)
+      return edge.getOutVertex();
+    final Vertex out = edge.getOutVertex();
+    return out.getIdentity().equals(from.getIdentity()) ? edge.getInVertex() : out;
+  }
+
+  @Override
+  public String prettyPrint(final int depth, final int indent) {
+    final StringBuilder builder = new StringBuilder("  ".repeat(Math.max(0, depth * indent)));
+    builder.append("+ QUANTIFIED PATH (").append(sourceVariable).append(")").append(group)
+        .append("(").append(targetVariable).append(")");
+    if (context.isProfiling()) {
+      builder.append(" (").append(getCostFormatted());
+      if (rowCount > 0)
+        builder.append(", ").append(getRowCountFormatted());
+      builder.append(")");
+    }
+    return builder.toString();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/QuantifiedPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/QuantifiedPathStep.java
@@ -270,14 +270,15 @@ public class QuantifiedPathStep extends AbstractExecutionStep {
       if (done >= group.getMaxRepetitions())
         return;
 
-      // The inner start node's own constraints hold for every repetition, not only the first: the outer
-      // boundary node can only carry them for the vertex it binds.
-      if (!matchesInnerNode(current, 0))
-        return;
-
       final Vertex[] nodes = new Vertex[innerNodes.size()];
       final Edge[] edges = new Edge[innerRelationships.size()];
       nodes[0] = current;
+
+      // The inner start node's own constraints hold for every repetition, not only the first: the outer
+      // boundary node can only carry them for the vertex it binds.
+      if (!matchesInnerNode(nodes, edges, 0))
+        return;
+
       matchRepetition(nodes, edges, 0);
     }
 
@@ -289,7 +290,7 @@ public class QuantifiedPathStep extends AbstractExecutionStep {
     private void matchRepetition(final Vertex[] nodes, final Edge[] edges, final int hop) {
       if (hop == innerRelationships.size()) {
         if (group.getInnerWhere() != null
-            && !group.getInnerWhere().evaluate(repetitionScope(input, nodes, edges), context))
+            && !group.getInnerWhere().evaluate(repetitionScope(input, nodes, edges, nodes.length - 1), context))
           return;
         repetitions.add(new Repetition(nodes.clone(), edges.clone()));
         search(nodes[nodes.length - 1]);
@@ -316,26 +317,36 @@ public class QuantifiedPathStep extends AbstractExecutionStep {
         if (relationshipPredicates[hop] != null && !relationshipPredicates[hop].test(edge))
           continue;
 
-        final Vertex next = otherEnd(edge, from, direction);
-        if (!matchesInnerNode(next, hop + 1))
+        // Written into the arrays before the check so the node's own inline WHERE is evaluated in the
+        // scope the repetition has built so far - the relationship that reached it included.
+        edges[hop] = edge;
+        nodes[hop + 1] = otherEnd(edge, from, direction);
+        if (!matchesInnerNode(nodes, edges, hop + 1))
           continue;
 
-        edges[hop] = edge;
-        nodes[hop + 1] = next;
         usedEdges.add(edgeId);
         matchRepetition(nodes, edges, hop + 1);
         usedEdges.remove(edgeId);
       }
     }
 
-    /** Applies inner node {@code index}'s labels, resolved inline properties and inline WHERE. */
-    private boolean matchesInnerNode(final Vertex vertex, final int index) {
+    /**
+     * Applies inner node {@code index}'s labels, resolved inline properties and inline {@code WHERE}.
+     * <p>
+     * The inline {@code WHERE} is evaluated in the same scope the group-level {@code WHERE} gets, truncated
+     * to what this repetition has bound so far, so {@code ((x)-[r]->(y WHERE y.w > x.w))} reads a real
+     * {@code x}. Truncation is not cosmetic: the arrays are reused across sibling candidates, so entries
+     * past {@code index} still hold the previous branch's vertices and relationships.
+     */
+    private boolean matchesInnerNode(final Vertex[] nodes, final Edge[] edges, final int index) {
+      final Vertex vertex = nodes[index];
       final NodePattern pattern = innerNodes.get(index);
       if (pattern.hasLabels() && !Labels.matches(vertex, pattern.getLabels(), pattern.isLabelDisjunction()))
         return false;
       if (nodeProperties[index] != null && !matchesResolved(vertex, nodeProperties[index]))
         return false;
-      return !pattern.hasWhereExpression() || matchesNodeWhere(vertex, pattern);
+      return !pattern.hasWhereExpression()
+          || pattern.getWhereExpression().evaluate(repetitionScope(input, nodes, edges, index), context);
     }
 
     /** Checks the right boundary: the pinned target if the row already bound one, then its own constraints. */
@@ -350,17 +361,22 @@ public class QuantifiedPathStep extends AbstractExecutionStep {
       if (targetNodePattern.hasProperties()
           && !InlineProperties.matches(candidate, targetNodePattern.getProperties(), input, context))
         return false;
-      return !targetNodePattern.hasWhereExpression() || matchesNodeWhere(candidate, targetNodePattern);
+      return !targetNodePattern.hasWhereExpression() || matchesBoundaryWhere(candidate);
     }
 
-    private boolean matchesNodeWhere(final Vertex vertex, final NodePattern pattern) {
+    /**
+     * Evaluates the right boundary node's own inline {@code WHERE}. The boundary sits outside the group,
+     * so its scope is the incoming row plus its own binding - never the group's per-repetition bindings,
+     * which have no single value at that point.
+     */
+    private boolean matchesBoundaryWhere(final Vertex candidate) {
       final ResultInternal scope = new ResultInternal();
       for (final String property : input.getPropertyNames())
         scope.setProperty(property, input.getProperty(property));
-      final String variable = pattern.getVariable();
+      final String variable = targetNodePattern.getVariable();
       if (variable != null && !variable.isEmpty())
-        scope.setProperty(variable, vertex);
-      return pattern.getWhereExpression().evaluate(scope, context);
+        scope.setProperty(variable, candidate);
+      return targetNodePattern.getWhereExpression().evaluate(scope, context);
     }
   }
 
@@ -373,21 +389,27 @@ public class QuantifiedPathStep extends AbstractExecutionStep {
 
   /**
    * Builds the scope one repetition's predicates are evaluated in: the incoming row's bindings plus this
-   * repetition's own single-valued bindings. Single-valued, not the group lists - an inner {@code WHERE}
-   * constrains the repetition it is written inside, so {@code WHERE r.weight > 5} reads one relationship.
+   * repetition's own single-valued bindings, up to and including inner node {@code boundThrough}.
+   * Single-valued, not the group lists - an inner {@code WHERE} constrains the repetition it is written
+   * inside, so {@code WHERE r.weight > 5} reads one relationship.
+   *
+   * @param boundThrough index of the last inner node bound so far; nodes and relationships past it are
+   *                     left out, because the arrays are reused across sibling candidates and still carry
+   *                     the previous branch's values there
    */
-  private Result repetitionScope(final Result input, final Vertex[] nodes, final Edge[] edges) {
+  private Result repetitionScope(final Result input, final Vertex[] nodes, final Edge[] edges,
+      final int boundThrough) {
     final ResultInternal scope = new ResultInternal();
     for (final String property : input.getPropertyNames())
       scope.setProperty(property, input.getProperty(property));
-    for (int i = 0; i < nodes.length; i++) {
+    for (int i = 0; i <= boundThrough; i++) {
       final String variable = innerNodes.get(i).getVariable();
-      if (variable != null && !variable.isEmpty() && nodes[i] != null)
+      if (variable != null && !variable.isEmpty())
         scope.setProperty(variable, nodes[i]);
-      if (i < edges.length) {
-        final String relVariable = innerRelationships.get(i).getVariable();
-        if (relVariable != null && !relVariable.isEmpty() && edges[i] != null)
-          scope.setProperty(relVariable, edges[i]);
+      if (i > 0) {
+        final String relVariable = innerRelationships.get(i - 1).getVariable();
+        if (relVariable != null && !relVariable.isEmpty())
+          scope.setProperty(relVariable, edges[i - 1]);
       }
     }
     return scope;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/QuantifiedPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/QuantifiedPathStep.java
@@ -42,7 +42,10 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.executor.WorkGuard;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -256,20 +259,55 @@ public class QuantifiedPathStep extends AbstractExecutionStep {
       this.targetLabels = targetNodePattern != null ? resolveLabels(targetNodePattern, input) : null;
     }
 
+    /**
+     * Depth-first search over the repetitions, driven by an explicit stack rather than by recursion.
+     * <p>
+     * The number of repetitions is bounded only by the quantifier and by relationship isomorphism, so on
+     * a long chain it reaches the thousands - and a Java frame per repetition overflowed the stack at
+     * around five thousand, which a graph of that size reaches trivially. Only this level is iterative:
+     * {@link #matchRepetition} still recurses, but its depth is the number of hops the user wrote inside
+     * the group, which is a constant of the query.
+     * <p>
+     * Invariant: {@code pending} always holds exactly one iterator per visited level, so its size is
+     * {@code repetitions.size() + 1}. Popping a level therefore undoes exactly the repetition that
+     * entered it, releasing that repetition's relationships back to the isomorphism set.
+     */
     private void run(final Vertex start) {
-      search(start);
+      final Deque<Iterator<Repetition>> pending = new ArrayDeque<>();
+      visit(start, pending);
+
+      while (!pending.isEmpty()) {
+        guard.check();
+        final Iterator<Repetition> candidates = pending.peek();
+        if (candidates.hasNext()) {
+          final Repetition next = candidates.next();
+          for (final Edge edge : next.edges())
+            usedEdges.add(edge.getIdentity());
+          repetitions.add(next);
+          visit(next.nodes()[next.nodes().length - 1], pending);
+        } else {
+          pending.pop();
+          if (!repetitions.isEmpty()) {
+            final Repetition undone = repetitions.remove(repetitions.size() - 1);
+            for (final Edge edge : undone.edges())
+              usedEdges.remove(edge.getIdentity());
+          }
+        }
+      }
     }
 
-    private void search(final Vertex current) {
-      guard.check();
-
+    /** Emits {@code current} when the repetition count is in range, then stacks the ways to go deeper. */
+    private void visit(final Vertex current, final Deque<Iterator<Repetition>> pending) {
       final int done = repetitions.size();
       if (done >= group.getMinRepetitions() && acceptsEndpoint(current))
         out.add(buildRow(input, current, repetitions));
 
-      if (done >= group.getMaxRepetitions())
-        return;
+      pending.push(done < group.getMaxRepetitions() ?
+          repetitionsFrom(current).iterator() : Collections.emptyIterator());
+    }
 
+    /** Every way the inner pattern matches once starting at {@code current}, in written hop order. */
+    private List<Repetition> repetitionsFrom(final Vertex current) {
       final Vertex[] nodes = new Vertex[innerNodes.size()];
       final Edge[] edges = new Edge[innerRelationships.size()];
       nodes[0] = current;
@@ -277,24 +315,25 @@ public class QuantifiedPathStep extends AbstractExecutionStep {
       // The inner start node's own constraints hold for every repetition, not only the first: the outer
       // boundary node can only carry them for the vertex it binds.
       if (!matchesInnerNode(nodes, edges, 0))
-        return;
+        return Collections.emptyList();
 
-      matchRepetition(nodes, edges, 0);
+      final List<Repetition> found = new ArrayList<>();
+      matchRepetition(nodes, edges, 0, found);
+      return found;
     }
 
     /**
-     * Matches one repetition of the inner pattern hop by hop, recursing into {@link #search} for every
-     * complete assignment. Relationships consumed by the branch are held in {@code usedEdges} for the
-     * duration of the recursion below them and released on backtracking.
+     * Matches one repetition of the inner pattern hop by hop, collecting every complete assignment.
+     * Relationships consumed by the branch are held in {@code usedEdges} for the duration of the
+     * recursion below them and released on backtracking; the ones of an accepted repetition are re-taken
+     * by {@link #run} when it descends into that repetition.
      */
-    private void matchRepetition(final Vertex[] nodes, final Edge[] edges, final int hop) {
+    private void matchRepetition(final Vertex[] nodes, final Edge[] edges, final int hop,
+        final List<Repetition> found) {
       if (hop == innerRelationships.size()) {
-        if (group.getInnerWhere() != null
-            && !group.getInnerWhere().evaluate(repetitionScope(input, nodes, edges, nodes.length - 1), context))
-          return;
-        repetitions.add(new Repetition(nodes.clone(), edges.clone()));
-        search(nodes[nodes.length - 1]);
-        repetitions.remove(repetitions.size() - 1);
+        if (group.getInnerWhere() == null
+            || group.getInnerWhere().evaluate(repetitionScope(input, nodes, edges, nodes.length - 1), context))
+          found.add(new Repetition(nodes.clone(), edges.clone()));
         return;
       }
 
@@ -325,7 +364,7 @@ public class QuantifiedPathStep extends AbstractExecutionStep {
           continue;
 
         usedEdges.add(edgeId);
-        matchRepetition(nodes, edges, hop + 1);
+        matchRepetition(nodes, edges, hop + 1, found);
         usedEdges.remove(edgeId);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -1786,10 +1786,21 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
   /**
    * Returns true when the group is the Phase A shape that a plain variable-length relationship
    * already expresses exactly: one relationship, no inner {@code WHERE}, and endpoints that bind
-   * nothing and constrain nothing beyond what the outer boundary nodes carry.
+   * nothing and constrain nothing at all.
    * <p>
-   * Endpoint variables force Phase B even for a one-hop group: GQL binds them to one list element
-   * per repetition, which a variable-length relationship has no way to express.
+   * Every endpoint attribute forces Phase B, each for its own reason:
+   * <ul>
+   *   <li>a <b>variable</b> - GQL binds it to one list element per repetition, which a variable-length
+   *       relationship has no way to express;</li>
+   *   <li>a <b>label, dynamic label or property map</b> - the constraint holds for every repetition,
+   *       including the vertices <i>between</i> two repetitions, and a variable-length relationship
+   *       constrains only its two ends. Lowering {@code ((:P)-[:R]->(:P))+} to {@code -[:R*]->} does not
+   *       weaken the constraint, it <i>deletes</i> it: the outer boundary nodes take over both ends and
+   *       the inner labels are never spliced into the chain at all;</li>
+   *   <li>an inline <b>{@code WHERE}</b> - same reasoning as a property map.</li>
+   * </ul>
+   * What is left for Phase A is the genuinely unconstrained spelling, {@code (()-[:R]->())+}, for which
+   * the two forms are interchangeable.
    */
   private static boolean canLowerToVariableLengthRelationship(final PathPattern inner, final BooleanExpression innerWhere) {
     if (innerWhere != null || inner.getRelationshipCount() != 1)
@@ -1799,6 +1810,8 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
       if (node.getVariable() != null && !node.getVariable().isEmpty())
         return false;
       if (node.hasWhereExpression())
+        return false;
+      if (node.hasLabels() || node.hasDynamicLabels() || node.hasProperties())
         return false;
     }
     return true;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -52,6 +52,7 @@ import com.arcadedb.query.opencypher.ast.PathMode;
 import com.arcadedb.query.opencypher.ast.PathPattern;
 import com.arcadedb.query.opencypher.ast.PatternPredicateExpression;
 import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
+import com.arcadedb.query.opencypher.ast.QuantifiedPathPattern;
 import com.arcadedb.query.opencypher.ast.RegexExpression;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
 import com.arcadedb.query.opencypher.ast.RemoveClause;
@@ -1686,34 +1687,33 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
   }
 
   /**
-   * Absorbs a GQL Quantified Path Pattern (parenthesized inner pattern + optional quantifier)
-   * into the surrounding node/relationship lists by lowering it to existing variable-length
-   * relationship infrastructure (issue #3365 sections 1.4 and 1.5, Phase A).
+   * Absorbs a GQL Quantified Path Pattern (parenthesized inner pattern + optional quantifier) into the
+   * surrounding node/relationship lists (ISO/IEC 39075:2024 §15.4).
    *
-   * <p>Phase A constraints (rejected with {@link CommandParsingException} when violated):
+   * <p>Two lowerings exist, and the shape of the inner pattern picks between them:
    * <ul>
-   *   <li>The inner pattern must be a single triplet {@code (a)-[r]->(b)}; multi-rel inner
-   *       patterns are deferred to Phase B.</li>
-   *   <li>Inner {@code WHERE} predicates are deferred to Phase B.</li>
-   *   <li>Quantifier values must be positive (zero quantifier is meaningless).</li>
+   *   <li><b>Phase A</b> (issue #3365) - a single-relationship inner pattern with anonymous endpoints
+   *       and no inner {@code WHERE} is rewritten to a plain variable-length relationship, which the
+   *       existing traversal machinery executes. A one-edge group is functionally identical to
+   *       {@code -[:R*]->}, so this loses nothing and keeps the faster path.</li>
+   *   <li><b>Phase B</b> (issue #4531) - everything else becomes a {@link QuantifiedPathPattern}
+   *       occupying one hop of the outer chain, executed by {@code QuantifiedPathStep}: multi-hop
+   *       inner patterns, inner {@code WHERE} predicates evaluated per repetition, and inner
+   *       variables that surface outside the group as {@code LIST<NODE>} / {@code LIST<RELATIONSHIP>}
+   *       group variables.</li>
    * </ul>
-   * Inner relationship variables become {@code LIST<EDGE>} (existing var-length behavior).
-   * Intermediate-node variable bindings outside the group are not yet supported.
+   *
+   * <p>Quantifier bounds are validated identically for both: an upper bound of zero, or a lower bound
+   * above the upper bound, is a syntax error.
    */
   private void absorbParenthesizedPath(final Cypher25Parser.ParenthesizedPathContext pCtx,
       final List<NodePattern> outerNodes, final List<RelationshipPattern> outerRels, final boolean nextIsOuterNode) {
-    if (pCtx.WHERE() != null)
-      throw new CommandParsingException(
-          "FeatureNotImplemented: WHERE inside a quantified path pattern is not yet supported (issue #3365 Phase B)");
-
     final PathPattern inner = visitPattern(pCtx.pattern());
-    if (inner.getRelationshipCount() != 1)
+    if (inner.getRelationshipCount() < 1)
       throw new CommandParsingException(
-          "FeatureNotImplemented: only single-relationship inner patterns are supported in quantified path patterns (issue #3365 Phase B will add multi-relationship)");
+          "InvalidSyntax: a quantified path pattern must contain at least one relationship");
 
-    final NodePattern innerStart = inner.getFirstNode();
-    final NodePattern innerEnd = inner.getLastNode();
-    final RelationshipPattern innerRel = inner.getRelationship(0);
+    final BooleanExpression innerWhere = pCtx.WHERE() != null ? parseBooleanExpression(pCtx.expression()) : null;
 
     // Determine quantifier (defaults to 1..1 when absent, which collapses to a plain triplet)
     final Integer min;
@@ -1737,29 +1737,119 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
       max = null;
     }
 
-    // Splice the inner endpoints into the outer chain. When this is the first child in the
-    // pattern, the inner start becomes the leading boundary; otherwise the previous outer
-    // node already serves that role.
+    final NodePattern innerStart = inner.getFirstNode();
+    final NodePattern innerEnd = inner.getLastNode();
+
+    if (canLowerToVariableLengthRelationship(inner, innerWhere)) {
+      final RelationshipPattern innerRel = inner.getRelationship(0);
+
+      // Splice the inner endpoints into the outer chain. When this is the first child in the
+      // pattern, the inner start becomes the leading boundary; otherwise the previous outer
+      // node already serves that role.
+      if (outerNodes.isEmpty())
+        outerNodes.add(innerStart);
+
+      // Build a new variable-length relationship pattern that subsumes the grouped repetition.
+      outerRels.add(new RelationshipPattern(
+          innerRel.getVariable(),
+          innerRel.getTypes(),
+          innerRel.getDirection(),
+          innerRel.getProperties().isEmpty() ? null : innerRel.getProperties(),
+          innerRel.getPropertiesParameterName(),
+          min,
+          max,
+          innerRel.getWhereExpression()));
+
+      // Append the inner end node only when no outer nodePattern follows. If an outer
+      // nodePattern comes next, it will play the role of the trailing boundary itself,
+      // keeping the (nodes.size == relationships.size + 1) invariant intact.
+      if (!nextIsOuterNode)
+        outerNodes.add(innerEnd);
+      return;
+    }
+
+    rejectUnsupportedInnerPattern(inner);
+
+    // Phase B. The group becomes one hop; its boundary nodes carry the inner endpoints' label and
+    // property constraints so the enclosing scan stays selective, but never their variables - those
+    // bind to per-repetition lists inside the group, not to a single boundary vertex. The executor
+    // re-checks the inner endpoint constraints for every repetition regardless.
     if (outerNodes.isEmpty())
-      outerNodes.add(innerStart);
+      outerNodes.add(toBoundaryNode(innerStart));
 
-    // Build a new variable-length relationship pattern that subsumes the grouped repetition.
-    final RelationshipPattern lowered = new RelationshipPattern(
-        innerRel.getVariable(),
-        innerRel.getTypes(),
-        innerRel.getDirection(),
-        innerRel.getProperties().isEmpty() ? null : innerRel.getProperties(),
-        innerRel.getPropertiesParameterName(),
-        min,
-        max,
-        innerRel.getWhereExpression());
-    outerRels.add(lowered);
+    outerRels.add(new QuantifiedPathPattern(inner, innerWhere, min, max));
 
-    // Append the inner end node only when no outer nodePattern follows. If an outer
-    // nodePattern comes next, it will play the role of the trailing boundary itself,
-    // keeping the (nodes.size == relationships.size + 1) invariant intact.
     if (!nextIsOuterNode)
-      outerNodes.add(innerEnd);
+      outerNodes.add(toBoundaryNode(innerEnd));
+  }
+
+  /**
+   * Returns true when the group is the Phase A shape that a plain variable-length relationship
+   * already expresses exactly: one relationship, no inner {@code WHERE}, and endpoints that bind
+   * nothing and constrain nothing beyond what the outer boundary nodes carry.
+   * <p>
+   * Endpoint variables force Phase B even for a one-hop group: GQL binds them to one list element
+   * per repetition, which a variable-length relationship has no way to express.
+   */
+  private static boolean canLowerToVariableLengthRelationship(final PathPattern inner, final BooleanExpression innerWhere) {
+    if (innerWhere != null || inner.getRelationshipCount() != 1)
+      return false;
+    for (int i = 0; i < inner.getNodeCount(); i++) {
+      final NodePattern node = inner.getNode(i);
+      if (node.getVariable() != null && !node.getVariable().isEmpty())
+        return false;
+      if (node.hasWhereExpression())
+        return false;
+    }
+    return true;
+  }
+
+  /**
+   * Rejects the inner shapes the repeated-subpattern executor cannot run. Both would otherwise be
+   * silently mis-executed rather than reported, so they fail at parse time with the feature named.
+   */
+  private static void rejectUnsupportedInnerPattern(final PathPattern inner) {
+    for (int i = 0; i < inner.getRelationshipCount(); i++) {
+      final RelationshipPattern rel = inner.getRelationship(i);
+      if (rel instanceof QuantifiedPathPattern)
+        throw new CommandParsingException(
+            "FeatureNotImplemented: nesting a quantified path pattern inside another one is not supported (issue #4531)");
+      if (rel.isVariableLength())
+        throw new CommandParsingException(
+            "FeatureNotImplemented: a variable-length relationship inside a quantified path pattern is not supported (issue #4531)");
+    }
+    if (inner.hasPathVariable())
+      throw new CommandParsingException(
+          "FeatureNotImplemented: a path variable inside a quantified path pattern is not supported (issue #4531)");
+    // A whole-map parameter, (n $props), is not a set of equality predicates the per-repetition matcher
+    // can check, and a dynamic $(expression) label resolves per row rather than per repetition. Both
+    // would be silently dropped rather than applied, so name them instead.
+    for (int i = 0; i < inner.getNodeCount(); i++) {
+      final NodePattern node = inner.getNode(i);
+      if (node.getPropertiesParameterName() != null)
+        throw new CommandParsingException(
+            "FeatureNotImplemented: a parameterised property map on a node inside a quantified path pattern is not supported (issue #4531)");
+      if (node.hasDynamicLabels())
+        throw new CommandParsingException(
+            "FeatureNotImplemented: dynamic labels on a node inside a quantified path pattern are not supported (issue #4531)");
+    }
+    for (int i = 0; i < inner.getRelationshipCount(); i++)
+      if (inner.getRelationship(i).getPropertiesParameterName() != null)
+        throw new CommandParsingException(
+            "FeatureNotImplemented: a parameterised property map on a relationship inside a quantified path pattern is not supported (issue #4531)");
+  }
+
+  /**
+   * Derives the outer boundary node for a group endpoint: the endpoint's labels and inline properties
+   * are kept so the enclosing scan can use them, its variable and inline {@code WHERE} are dropped so
+   * the group variable is not also bound to a single vertex.
+   */
+  private static NodePattern toBoundaryNode(final NodePattern innerEndpoint) {
+    if (innerEndpoint.getVariable() == null && !innerEndpoint.hasWhereExpression())
+      return innerEndpoint;
+    return new NodePattern(null, innerEndpoint.getLabels(), innerEndpoint.getDynamicLabels(),
+        innerEndpoint.hasExplicitProperties() ? innerEndpoint.getProperties() : null,
+        innerEndpoint.getPropertiesParameterName(), innerEndpoint.isLabelDisjunction(), null);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -348,9 +348,17 @@ public class CypherSemanticValidator {
     for (final NodePattern node : path.getNodes())
       if (node.getVariable() != null)
         declareVar(node.getVariable(), VarType.NODE, scope, declaredHere);
-    for (final RelationshipPattern rel : path.getRelationships())
+    for (final RelationshipPattern rel : path.getRelationships()) {
       if (rel.getVariable() != null)
         declareVar(rel.getVariable(), VarType.RELATIONSHIP, scope, declaredHere);
+      // A GQL quantified path pattern (issue #4531) also declares its inner variables, which bind
+      // outside the group to one list element per repetition. They are declared as plain values, not
+      // as NODE/RELATIONSHIP: the name holds a LIST<NODE> or LIST<RELATIONSHIP>, so the structural
+      // rules those kinds carry do not apply to it.
+      if (rel instanceof QuantifiedPathPattern quantified)
+        for (final String groupVariable : quantified.getGroupVariables())
+          declareVar(groupVariable, VarType.SCALAR, scope, declaredHere);
+    }
   }
 
   /**
@@ -472,9 +480,13 @@ public class CypherSemanticValidator {
     for (final NodePattern node : path.getNodes())
       if (node.getVariable() != null)
         boundVars.add(node.getVariable());
-    for (final RelationshipPattern rel : path.getRelationships())
+    for (final RelationshipPattern rel : path.getRelationships()) {
       if (rel.getVariable() != null)
         boundVars.add(rel.getVariable());
+      // Group variables of a quantified path pattern are bound by the MATCH too (issue #4531)
+      if (rel instanceof QuantifiedPathPattern quantified)
+        boundVars.addAll(quantified.getGroupVariables());
+    }
   }
 
   private void checkCreateBinding(final PathPattern path, final Set<String> boundVars) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
@@ -219,6 +219,13 @@ public class CypherExecutionPlanner {
           // MatchRelationshipStep applies both filters correctly. See issue #5093.
           for (int ri = 0; ri < path.getRelationshipCount(); ri++) {
             final RelationshipPattern relP = path.getRelationship(ri);
+            // A GQL quantified path pattern (issue #4531) is a repeated sub-pattern with per-repetition
+            // group-variable bindings. The optimizer's LogicalPlan has no representation for it - it
+            // would flatten the hop into a plain variable-length expansion over untyped edges and
+            // silently return the wrong rows - so fall back to the legacy path, whose QuantifiedPathStep
+            // runs it.
+            if (relP instanceof QuantifiedPathPattern)
+              return false;
             if (relP.getPropertiesParameterName() != null)
               return false;
             if ((relP.hasProperties() || relP.hasWhereExpression()) && !relP.isVariableLength())

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
@@ -258,6 +258,46 @@ class CypherQuantifiedPathPatternPhaseBIssue4531Test {
     assertThat(starts).containsExactlyInAnyOrder("A", "B");
   }
 
+  // Issue #4531: a path variable that also spans hops OUTSIDE the group has no per-repetition list form,
+  // so it stays a single path - the group's repetitions are concatenated onto the path the earlier hops
+  // already built, rather than replacing it.
+  @Test
+  void namedPathSpanningAGroupAndOtherHopsStaysOneConcatenatedPath() {
+    createWeightedChain();
+
+    final List<Integer> lengths = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH p = (a:P {name:'A'})-[:KNOWS]->(b:P) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN p AS p")) {
+      while (rs.hasNext()) {
+        final Object path = rs.next().getProperty("p");
+        assertThat(path).isInstanceOf(TraversalPath.class);
+        final TraversalPath traversal = (TraversalPath) path;
+        // The leading hop is part of the same path, so it always starts at A and stays contiguous.
+        assertThat(traversal.getVertices().get(0).getString("name")).isEqualTo("A");
+        assertThat(traversal.getVertices()).hasSize(traversal.getEdges().size() + 1);
+        lengths.add(traversal.getEdges().size());
+      }
+    }
+    // A->B plus one repetition (A-B-C) and A->B plus two (A-B-C-D).
+    assertThat(lengths).containsExactlyInAnyOrder(2, 3);
+  }
+
+  // Issue #4531: with zero repetitions the group contributes nothing, so the path is exactly what the
+  // hops before it built.
+  @Test
+  void namedPathWithZeroRepetitionsKeepsTheLeadingHopsOnly() {
+    createWeightedChain();
+
+    final List<Integer> lengths = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH p = (a:P {name:'A'})-[:KNOWS]->(b:P) ((m:P)-[r:KNOWS]->(n:P)){0,1} (t:P) RETURN p AS p")) {
+      while (rs.hasNext())
+        lengths.add(((TraversalPath) rs.next().getProperty("p")).getEdges().size());
+    }
+    // Zero repetitions leaves the single A->B hop; one repetition appends B->C.
+    assertThat(lengths).containsExactlyInAnyOrder(1, 2);
+  }
+
   // ---------------------------------------------------------------------------
   // 5. Relationship isomorphism and termination
   // ---------------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #4531 - GQL Quantified Path Patterns, Phase B: the shapes that cannot be lowered onto the
+ * variable-length-relationship engine and were rejected with {@code FeatureNotImplemented} before.
+ *
+ * <p>Covered here: multi-relationship inner patterns, inner {@code WHERE} predicates evaluated once
+ * per repetition, inner variables surfacing outside the group as parallel {@code LIST<NODE>} /
+ * {@code LIST<RELATIONSHIP>} bindings, and grouped path assignment yielding {@code LIST<PATH>}.
+ *
+ * <p>Every query here plans on the legacy pipeline: {@code CypherExecutionPlanner} declines a
+ * quantified group, so the optimizer never sees one. {@link #quantifiedGroupPlansAsAQuantifiedPathStep()}
+ * pins that, since a test that silently drifted onto the other path would prove nothing about this one.
+ */
+class CypherQuantifiedPathPatternPhaseBIssue4531Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    final String databasePath = "./target/databases/testopencypher-qpp-phaseb-" + testInfo.getTestMethod().get().getName();
+    final DatabaseFactory factory = new DatabaseFactory(databasePath);
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.getSchema().createVertexType("P");
+    database.getSchema().createEdgeType("R1");
+    database.getSchema().createEdgeType("R2");
+    database.getSchema().createEdgeType("KNOWS");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * A→B→C→D→E where the edge types alternate R1, R2, R1, R2, so a repeated two-hop unit
+   * {@code (R1 then R2)} lands on C after one repetition and on E after two.
+   */
+  private void createAlternatingChain() {
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:P {name:'A'})-[:R1 {w:10}]->(b:P {name:'B'})-[:R2 {w:1}]->(c:P {name:'C'})"
+            + "-[:R1 {w:20}]->(d:P {name:'D'})-[:R2 {w:2}]->(e:P {name:'E'})"));
+  }
+
+  /** A→B→C→D over one edge type, with descending weights so an inner WHERE can cut the chain short. */
+  private void createWeightedChain() {
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:P {name:'A'})-[:KNOWS {weight:10}]->(b:P {name:'B'})-[:KNOWS {weight:1}]->(c:P {name:'C'})"
+            + "-[:KNOWS {weight:10}]->(d:P {name:'D'})"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // 1. Multi-relationship inner patterns
+  // ---------------------------------------------------------------------------
+
+  // Issue #4531: a two-hop inner unit repeats as a unit, so only the vertices at a multiple of two hops match.
+  @Test
+  void multiRelationshipInnerPatternRepeatsTheWholeUnit() {
+    createAlternatingChain();
+
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((x:P)-[:R1]->(y:P)-[:R2]->(z:P))+ (t:P) RETURN t.name AS name"))
+        .containsExactlyInAnyOrder("C", "E");
+  }
+
+  // Issue #4531: an exact quantifier on a two-hop inner unit matches exactly 2*n hops away.
+  @Test
+  void multiRelationshipInnerPatternHonoursExactQuantifier() {
+    createAlternatingChain();
+
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((x:P)-[:R1]->(y:P)-[:R2]->(z:P)){2} (t:P) RETURN t.name AS name"))
+        .containsExactly("E");
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((x:P)-[:R1]->(y:P)-[:R2]->(z:P)){1} (t:P) RETURN t.name AS name"))
+        .containsExactly("C");
+  }
+
+  // Issue #4531: the inner unit's edge types are enforced in order - reversing them matches nothing from A.
+  @Test
+  void multiRelationshipInnerPatternEnforcesHopOrder() {
+    createAlternatingChain();
+
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((x:P)-[:R2]->(y:P)-[:R1]->(z:P))+ (t:P) RETURN t.name AS name"))
+        .isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 2. Inner WHERE predicates, evaluated per repetition
+  // ---------------------------------------------------------------------------
+
+  // Issue #4531: an inner WHERE constrains each repetition, so the walk stops at the first failing hop.
+  @Test
+  void innerWhereIsEvaluatedOncePerRepetition() {
+    createWeightedChain();
+
+    // A-[10]->B satisfies w>5; B-[1]->C does not, so the repetition cannot continue past B.
+    assertThat(namesOf(
+        "MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P) WHERE r.weight > 5)+ (t:P) RETURN t.name AS name"))
+        .containsExactly("B");
+
+    // Without the predicate the same group walks the whole chain.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P) WHERE r.weight > 0)+ (t:P) RETURN t.name AS name"))
+        .containsExactlyInAnyOrder("B", "C", "D");
+  }
+
+  // Issue #4531: an inner WHERE can reference the inner node variables, not only the relationship.
+  @Test
+  void innerWhereCanReferenceInnerNodeVariables() {
+    createWeightedChain();
+
+    assertThat(namesOf(
+        "MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P) WHERE n.name <> 'C')+ (t:P) RETURN t.name AS name"))
+        .containsExactly("B");
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3. Group variables: LIST<NODE> and LIST<RELATIONSHIP>
+  // ---------------------------------------------------------------------------
+
+  // Issue #4531: inner node and relationship variables surface outside the group as parallel lists,
+  // one element per repetition, in repetition order.
+  @Test
+  void innerVariablesBindAsParallelGroupLists() {
+    createWeightedChain();
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P)){2} (t:P) RETURN m AS m, n AS n, r AS r, t.name AS name")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+
+      assertThat(namesOfVertexList(row.getProperty("m"))).containsExactly("A", "B");
+      assertThat(namesOfVertexList(row.getProperty("n"))).containsExactly("B", "C");
+
+      final List<?> relationships = row.getProperty("r");
+      assertThat(relationships).hasSize(2);
+      assertThat(relationships).allMatch(Edge.class::isInstance);
+      assertThat(((Edge) relationships.get(0)).getInteger("weight")).isEqualTo(10);
+      assertThat(((Edge) relationships.get(1)).getInteger("weight")).isEqualTo(1);
+
+      assertThat((String) row.getProperty("name")).isEqualTo("C");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  // Issue #4531: a group variable is an ordinary list, so list functions apply to it.
+  @Test
+  void groupVariablesAreUsableByListFunctions() {
+    createWeightedChain();
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P)){2} (t:P) "
+            + "RETURN size(r) AS hops, size(m) AS starts, head(m).name AS firstStart")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("hops")).intValue()).isEqualTo(2);
+      // A node group variable is a list too - Phase A's lowering never bound one at all.
+      assertThat(((Number) row.getProperty("starts")).intValue()).isEqualTo(2);
+      assertThat((String) row.getProperty("firstStart")).isEqualTo("A");
+    }
+  }
+
+  // Issue #4531: a {0,n} quantifier admits zero repetitions - both boundaries stay on the same vertex
+  // and every group variable binds to an empty list.
+  @Test
+  void zeroRepetitionsBindEmptyGroupLists() {
+    createWeightedChain();
+
+    final List<String> ends = new ArrayList<>();
+    int emptyGroups = 0;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P)){0,1} (t:P) RETURN t.name AS name, m AS m, r AS r")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        ends.add(row.getProperty("name"));
+        final List<?> nodes = row.getProperty("m");
+        final List<?> relationships = row.getProperty("r");
+        assertThat(nodes).hasSameSizeAs(relationships);
+        if (nodes.isEmpty())
+          emptyGroups++;
+      }
+    }
+
+    assertThat(ends).containsExactlyInAnyOrder("A", "B");
+    assertThat(emptyGroups).isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // 4. Grouped path assignment: LIST<PATH>
+  // ---------------------------------------------------------------------------
+
+  // Issue #4531: a path variable bound to nothing but a quantified group yields one path per repetition
+  // (ISO/IEC 39075 §15.4), not a single concatenated path.
+  @Test
+  void groupedPathAssignmentYieldsOnePathPerRepetition() {
+    createWeightedChain();
+
+    final List<String> starts = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH p = ((m:P)-[r:KNOWS]->(n:P)){2} RETURN p AS p")) {
+      while (rs.hasNext()) {
+        final List<?> paths = rs.next().getProperty("p");
+        assertThat(paths).hasSize(2);
+        assertThat(paths).allMatch(TraversalPath.class::isInstance);
+        // Each element is one repetition of the inner pattern: exactly one relationship long,
+        // and consecutive elements are joined end-to-start rather than concatenated into one path.
+        final TraversalPath first = (TraversalPath) paths.get(0);
+        final TraversalPath second = (TraversalPath) paths.get(1);
+        assertThat(first.getEdges()).hasSize(1);
+        assertThat(second.getEdges()).hasSize(1);
+        assertThat(second.getVertices().get(0).getIdentity())
+            .isEqualTo(first.getEndVertex().getIdentity());
+        starts.add(first.getVertices().get(0).getString("name"));
+      }
+    }
+    // Two-repetition walks exist from A (A->B->C) and from B (B->C->D); C has only one hop left.
+    assertThat(starts).containsExactlyInAnyOrder("A", "B");
+  }
+
+  // ---------------------------------------------------------------------------
+  // 5. Relationship isomorphism and termination
+  // ---------------------------------------------------------------------------
+
+  // Issue #4531: no relationship is traversed twice inside a group, which is also what stops an
+  // open-ended quantifier from looping forever on a cycle.
+  @Test
+  void relationshipIsomorphismTerminatesAnOpenEndedGroupOnACycle() {
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:P {name:'A'})-[:KNOWS]->(b:P {name:'B'})-[:KNOWS]->(a)"));
+
+    // A->B (one repetition) and A->B->A (two); a third would have to reuse the A->B edge.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN t.name AS name"))
+        .containsExactlyInAnyOrder("A", "B");
+  }
+
+  // ---------------------------------------------------------------------------
+  // 6. Plan shape and remaining rejections
+  // ---------------------------------------------------------------------------
+
+  // Issue #4531: a Phase B group is planned as a QuantifiedPathStep on the legacy pipeline. A Phase A
+  // group - one anonymous-endpoint relationship, no inner WHERE - keeps its variable-length lowering.
+  @Test
+  void quantifiedGroupPlansAsAQuantifiedPathStep() {
+    createWeightedChain();
+
+    assertThat(explainOf("MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN t.name AS name"))
+        .contains("QUANTIFIED PATH");
+    assertThat(explainOf("MATCH (s:P {name:'A'}) ((:P)-[:KNOWS]->(:P))+ (t:P) RETURN t.name AS name"))
+        .doesNotContain("QUANTIFIED PATH");
+  }
+
+  // Issue #4531: the Phase A lowering still applies where it is exact, and both spellings agree.
+  @Test
+  void phaseALoweringStillAgreesWithThePhaseBOperator() {
+    createWeightedChain();
+
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((:P)-[:KNOWS]->(:P))+ (t:P) RETURN t.name AS name"))
+        .containsExactlyInAnyOrderElementsOf(
+            namesOf("MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN t.name AS name"));
+  }
+
+  // Issue #4531: a zero upper bound is still a syntax error, in both the Phase A and Phase B shapes.
+  @Test
+  void zeroQuantifierIsStillRejected() {
+    createWeightedChain();
+
+    assertThatThrownBy(() -> database.query("opencypher",
+        "MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P)){0} (t:P) RETURN t"))
+        .isInstanceOf(CommandParsingException.class);
+  }
+
+  // Issue #4531: nesting one quantified group inside another is reported, not silently mis-executed.
+  @Test
+  void nestedQuantifiedGroupIsReported() {
+    createWeightedChain();
+
+    assertThatThrownBy(() -> database.query("opencypher",
+        "MATCH (s:P {name:'A'}) (((m:P)-[r:KNOWS]->(n:P))+ (o:P)-[:KNOWS]->(q:P))+ (t:P) RETURN t"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("FeatureNotImplemented");
+  }
+
+  // Issue #4531: a variable-length relationship inside a group is reported rather than mis-executed.
+  @Test
+  void variableLengthRelationshipInsideAGroupIsReported() {
+    createWeightedChain();
+
+    assertThatThrownBy(() -> database.query("opencypher",
+        "MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS*1..2]->(n:P)-[:KNOWS]->(o:P))+ (t:P) RETURN t"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("FeatureNotImplemented");
+  }
+
+  // Issue #4531: a whole-map parameter inside a group is reported rather than silently dropped.
+  @Test
+  void parameterisedPropertyMapInsideAGroupIsReported() {
+    createWeightedChain();
+
+    assertThatThrownBy(() -> database.query("opencypher",
+        "MATCH (s:P {name:'A'}) ((m:P $props)-[r:KNOWS]->(n:P))+ (t:P) RETURN t",
+        Map.of("props", Map.of("name", "A"))))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("FeatureNotImplemented");
+  }
+
+  // ---------------------------------------------------------------------------
+  // 7. Interaction with the enclosing pattern
+  // ---------------------------------------------------------------------------
+
+  // Issue #4531: the right boundary node's own labels and properties still filter the group's endpoint.
+  @Test
+  void rightBoundaryConstraintsFilterTheGroupEndpoint() {
+    createWeightedChain();
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P))+ (t:P {name:'C'}) RETURN size(r) AS hops")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(((Number) rs.next().getProperty("hops")).intValue()).isEqualTo(2);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  // Issue #4531: a group can start from a variable an earlier clause already bound.
+  @Test
+  void groupStartsFromAVariableBoundByAnEarlierClause() {
+    createWeightedChain();
+
+    assertThat(namesOf("MATCH (s:P {name:'A'}) WITH s "
+        + "MATCH (s) ((m:P)-[r:KNOWS]->(n:P)){1} (t:P) RETURN t.name AS name"))
+        .containsExactly("B");
+  }
+
+  // Issue #4531: a relationship the same MATCH already bound outside the group cannot be reused inside it.
+  @Test
+  void groupCannotReuseARelationshipBoundElsewhereInTheSameMatch() {
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:P {name:'A'})-[:KNOWS]->(b:P {name:'B'})-[:KNOWS]->(a)"));
+
+    // The first hop consumes A->B, so the group starting at B can only take B->A, and never A->B again.
+    assertThat(namesOf("MATCH (s:P {name:'A'})-[e:KNOWS]->(mid:P) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) "
+        + "RETURN t.name AS name"))
+        .containsExactly("A");
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  private List<String> namesOf(final String query) {
+    final List<String> names = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+    }
+    return names;
+  }
+
+  private static List<String> namesOfVertexList(final Object value) {
+    assertThat(value).isInstanceOf(List.class);
+    final List<String> names = new ArrayList<>();
+    for (final Object item : (List<?>) value) {
+      assertThat(item).isInstanceOf(Vertex.class);
+      names.add(((Vertex) item).getString("name"));
+    }
+    return names;
+  }
+
+  /** The rendered execution plan of {@code EXPLAIN <query>}. */
+  private String explainOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -380,6 +381,88 @@ class CypherQuantifiedPathPatternPhaseBIssue4531Test {
     assertThat(namesOf("MATCH (s:P {name:'A'})-[e:KNOWS]->(mid:P) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) "
         + "RETURN t.name AS name"))
         .containsExactly("A");
+  }
+
+  // Issue #4531: a node's own inline WHERE inside a group sees the variables the repetition has
+  // already bound, not only the node's own - the same scope the group-level WHERE gets.
+  @Test
+  void innerNodeInlineWhereSeesEarlierBindingsOfTheSameRepetition() {
+    createWeightedChain();
+
+    // n is reached over r, so r is bound when n's inline WHERE runs. A-[10]->B passes, B-[1]->C does not.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P WHERE r.weight > 5))+ (t:P) "
+        + "RETURN t.name AS name"))
+        .containsExactly("B");
+
+    // Referring to the repetition's start node from the end node's inline WHERE.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P WHERE n.name <> m.name))+ (t:P) "
+        + "RETURN t.name AS name"))
+        .containsExactlyInAnyOrder("B", "C", "D");
+  }
+
+  // Issue #4531: a quantified group works inside an EXISTS { MATCH ... } subquery, which plans a real
+  // execution plan (unlike the inline pattern predicate, which reports it).
+  @Test
+  void quantifiedGroupWorksInsideExistsSubquery() {
+    createWeightedChain();
+
+    assertThat(namesOf("MATCH (s:P) WHERE EXISTS { MATCH (s) ((m:P)-[r:KNOWS]->(n:P)){3} (t:P) } "
+        + "RETURN s.name AS name"))
+        .containsExactly("A");
+  }
+
+  // Issue #4531: the inline pattern-predicate spelling cannot express a group at all - the grammar's
+  // pathPatternNonEmpty admits no parenthesized path - so it is refused at parse time rather than
+  // silently answered as if the group were one untyped variable-length hop. EXISTS { MATCH ... } is the
+  // supported spelling, covered above.
+  @Test
+  void inlinePatternPredicateCannotExpressAQuantifiedGroup() {
+    createWeightedChain();
+
+    assertThatThrownBy(() -> namesOf("MATCH (s:P) WHERE (s) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN s.name AS name"))
+        .isInstanceOf(CommandParsingException.class);
+  }
+
+  // Issue #4531: an inner hop may be written right-to-left or undirected, and may list several types.
+  @Test
+  void innerHopHonoursDirectionAndTypeAlternatives() {
+    createAlternatingChain();
+
+    // A reversed two-hop inner unit walks the chain backwards from E: one repetition reaches C, two reach A.
+    assertThat(namesOf("MATCH (s:P {name:'E'}) ((m:P)<-[:R2]-(y:P)<-[:R1]-(n:P))+ (t:P) RETURN t.name AS name"))
+        .containsExactlyInAnyOrder("C", "A");
+
+    // A type alternative makes the single-hop unit walk the whole mixed-type chain.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((m:P)-[r:R1|R2]->(n:P))+ (t:P) RETURN t.name AS name"))
+        .containsExactlyInAnyOrder("B", "C", "D", "E");
+
+    // An undirected inner hop can also travel against the arrows.
+    assertThat(namesOf("MATCH (s:P {name:'C'}) ((m:P)-[r:R1|R2]-(n:P)){1} (t:P) RETURN t.name AS name"))
+        .containsExactlyInAnyOrder("B", "D");
+  }
+
+  /**
+   * Issue #4531: the repetition search recurses once per repetition, so a long chain walks the Java call
+   * stack. Pins that a deep but realistic group does not overflow it, since nothing else in the suite
+   * would notice the depth budget shrinking. Tagged slow: it builds and walks a 2,000-vertex chain.
+   */
+  @Test
+  @Tag("slow")
+  void deepRepetitionDoesNotExhaustTheCallStack() {
+    final int chainLength = 2000;
+    database.transaction(() -> {
+      final StringBuilder create = new StringBuilder("CREATE (v0:P {name:'v0'})");
+      for (int i = 1; i < chainLength; i++)
+        create.append("-[:KNOWS]->(v").append(i).append(":P {name:'v").append(i).append("'})");
+      database.command("opencypher", create.toString());
+    });
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:P {name:'v0'}) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN count(t) AS reached")) {
+      assertThat(rs.hasNext()).isTrue();
+      // Every vertex downstream of v0 is reachable, at one repetition per hop.
+      assertThat(((Number) rs.next().getProperty("reached")).intValue()).isEqualTo(chainLength - 1);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
@@ -443,14 +443,16 @@ class CypherQuantifiedPathPatternPhaseBIssue4531Test {
   }
 
   /**
-   * Issue #4531: the repetition search recurses once per repetition, so a long chain walks the Java call
-   * stack. Pins that a deep but realistic group does not overflow it, since nothing else in the suite
-   * would notice the depth budget shrinking. Tagged slow: it builds and walks a 2,000-vertex chain.
+   * Issue #4531: the repetition count is bounded only by the quantifier and by relationship isomorphism,
+   * so on a chain it reaches the thousands. While the search recursed once per repetition it threw
+   * {@link StackOverflowError} from about five thousand - a size a graph reaches trivially - so
+   * {@code QuantifiedPathStep} drives that level from an explicit stack. Ten thousand repetitions pins
+   * it; the recursive version died at half that. Tagged slow: it builds and walks a 10,000-vertex chain.
    */
   @Test
   @Tag("slow")
   void deepRepetitionDoesNotExhaustTheCallStack() {
-    final int chainLength = 2000;
+    final int chainLength = 10_000;
     database.transaction(() -> {
       final StringBuilder create = new StringBuilder("CREATE (v0:P {name:'v0'})");
       for (int i = 1; i < chainLength; i++)
@@ -458,8 +460,10 @@ class CypherQuantifiedPathPatternPhaseBIssue4531Test {
       database.command("opencypher", create.toString());
     });
 
+    // No group variables, so each row stays constant-size and the test measures search depth rather
+    // than the quadratic cost of materialising a LIST<NODE> per row.
     try (final ResultSet rs = database.query("opencypher",
-        "MATCH (s:P {name:'v0'}) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN count(t) AS reached")) {
+        "MATCH (s:P {name:'v0'}) ((:P)-[:KNOWS]->(:P))+ (t:P) RETURN count(t) AS reached")) {
       assertThat(rs.hasNext()).isTrue();
       // Every vertex downstream of v0 is reachable, at one repetition per hop.
       assertThat(((Number) rs.next().getProperty("reached")).intValue()).isEqualTo(chainLength - 1);
@@ -478,8 +482,10 @@ class CypherQuantifiedPathPatternPhaseBIssue4531Test {
     // Every repetition must start and end on a :P, and the only route out of A goes through a :Q.
     assertThat(namesOf("MATCH (s:P {name:'A'}) ((:P)-[:KNOWS]->(:P))+ (t:P) RETURN t.name AS name"))
         .isEmpty();
-    // An inline property map on an endpoint is the same kind of per-repetition constraint.
-    assertThat(namesOf("MATCH (s:P {name:'A'}) ((:P {name:'A'})-[:KNOWS]->(:P))+ (t:P) RETURN t.name AS name"))
+    // An inline property map on an endpoint is the same kind of per-repetition constraint. Written on
+    // otherwise unlabelled endpoints, so the map alone - not a label - is what blocks the second
+    // repetition: only the first starts on a vertex named 'A'.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) (({name:'A'})-[:KNOWS]->())+ (t:P) RETURN t.name AS name"))
         .isEmpty();
 
     // The unconstrained spelling is the one Phase A still lowers, and it does reach B over the :Q.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQuantifiedPathPatternPhaseBIssue4531Test.java
@@ -279,14 +279,15 @@ class CypherQuantifiedPathPatternPhaseBIssue4531Test {
   // ---------------------------------------------------------------------------
 
   // Issue #4531: a Phase B group is planned as a QuantifiedPathStep on the legacy pipeline. A Phase A
-  // group - one anonymous-endpoint relationship, no inner WHERE - keeps its variable-length lowering.
+  // group - one relationship, no inner WHERE, and endpoints that constrain nothing - keeps its
+  // variable-length lowering.
   @Test
   void quantifiedGroupPlansAsAQuantifiedPathStep() {
     createWeightedChain();
 
     assertThat(explainOf("MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN t.name AS name"))
         .contains("QUANTIFIED PATH");
-    assertThat(explainOf("MATCH (s:P {name:'A'}) ((:P)-[:KNOWS]->(:P))+ (t:P) RETURN t.name AS name"))
+    assertThat(explainOf("MATCH (s:P {name:'A'}) (()-[:KNOWS]->())+ (t:P) RETURN t.name AS name"))
         .doesNotContain("QUANTIFIED PATH");
   }
 
@@ -295,7 +296,7 @@ class CypherQuantifiedPathPatternPhaseBIssue4531Test {
   void phaseALoweringStillAgreesWithThePhaseBOperator() {
     createWeightedChain();
 
-    assertThat(namesOf("MATCH (s:P {name:'A'}) ((:P)-[:KNOWS]->(:P))+ (t:P) RETURN t.name AS name"))
+    assertThat(namesOf("MATCH (s:P {name:'A'}) (()-[:KNOWS]->())+ (t:P) RETURN t.name AS name"))
         .containsExactlyInAnyOrderElementsOf(
             namesOf("MATCH (s:P {name:'A'}) ((m:P)-[r:KNOWS]->(n:P))+ (t:P) RETURN t.name AS name"));
   }
@@ -462,6 +463,46 @@ class CypherQuantifiedPathPatternPhaseBIssue4531Test {
       assertThat(rs.hasNext()).isTrue();
       // Every vertex downstream of v0 is reachable, at one repetition per hop.
       assertThat(((Number) rs.next().getProperty("reached")).intValue()).isEqualTo(chainLength - 1);
+    }
+  }
+
+  // Issue #4531: Phase A may only claim a group whose endpoints constrain nothing. A label written on an
+  // inner endpoint holds for EVERY repetition, including the vertices between two repetitions, which a
+  // plain variable-length relationship cannot express - lowering it would silently drop the label.
+  @Test
+  void innerEndpointLabelsAreNotDroppedByThePhaseALowering() {
+    database.getSchema().createVertexType("Q");
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:P {name:'A'})-[:KNOWS]->(x:Q {name:'X'})-[:KNOWS]->(b:P {name:'B'})"));
+
+    // Every repetition must start and end on a :P, and the only route out of A goes through a :Q.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((:P)-[:KNOWS]->(:P))+ (t:P) RETURN t.name AS name"))
+        .isEmpty();
+    // An inline property map on an endpoint is the same kind of per-repetition constraint.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) ((:P {name:'A'})-[:KNOWS]->(:P))+ (t:P) RETURN t.name AS name"))
+        .isEmpty();
+
+    // The unconstrained spelling is the one Phase A still lowers, and it does reach B over the :Q.
+    assertThat(namesOf("MATCH (s:P {name:'A'}) (()-[:KNOWS]->())+ (t:P) RETURN t.name AS name"))
+        .containsExactly("B");
+  }
+
+  // Issue #4531: the step consumes every input row, not just the first batch its previous step returns.
+  @Test
+  void everyInputRowIsExpanded() {
+    final int pairs = 500;
+    database.transaction(() -> {
+      final StringBuilder create = new StringBuilder();
+      for (int i = 0; i < pairs; i++)
+        create.append("CREATE (:P {name:'s").append(i).append("'})-[:KNOWS]->(:P {name:'e").append(i).append("'})\n");
+      for (final String statement : create.toString().split("\n"))
+        database.command("opencypher", statement);
+    });
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:P) ((m:P)-[r:KNOWS]->(n:P)){1} (t:P) RETURN count(t) AS reached")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(((Number) rs.next().getProperty("reached")).intValue()).isEqualTo(pairs);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCypher25ClausesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCypher25ClausesTest.java
@@ -543,30 +543,52 @@ class OpenCypherCypher25ClausesTest {
         .isInstanceOf(CommandParsingException.class);
   }
 
-  // Issue #3365: inner WHERE inside a grouped QPP is rejected (Phase B).
+  // Issue #4531 (was a #3365 Phase B rejection): an inner WHERE now runs, once per repetition.
   @Test
-  void groupedRejectsInnerWhere() {
+  void groupedSupportsInnerWhere() {
     database.getSchema().createEdgeType("KNOWS");
     database.transaction(() ->
       database.command("opencypher",
           "CREATE (a:Person {name:'A'})-[:KNOWS]->(b:Person {name:'B'})-[:KNOWS]->(c:Person {name:'C'})-[:KNOWS]->(d:Person {name:'D'})"));
 
-    assertThatThrownBy(() -> database.query("opencypher",
-        "MATCH (a:Person {name:'A'})((:Person)-[:KNOWS]->(b:Person) WHERE b.name <> 'X')+(end:Person) RETURN end"))
-        .isInstanceOf(CommandParsingException.class);
+    final List<String> reachable = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person {name:'A'})((:Person)-[:KNOWS]->(b:Person) WHERE b.name <> 'X')+(end:Person) "
+            + "RETURN end.name AS name")) {
+      while (rs.hasNext())
+        reachable.add(rs.next().getProperty("name"));
+    }
+    // Every hop satisfies the predicate, so the whole chain downstream of A is reachable.
+    assertThat(reachable).containsExactlyInAnyOrder("B", "C", "D");
+
+    final List<String> filtered = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person {name:'A'})((:Person)-[:KNOWS]->(b:Person) WHERE b.name <> 'C')+(end:Person) "
+            + "RETURN end.name AS name")) {
+      while (rs.hasNext())
+        filtered.add(rs.next().getProperty("name"));
+    }
+    // The repetition that would bind b=C fails the predicate, so the walk cannot continue past B.
+    assertThat(filtered).containsExactly("B");
   }
 
-  // Issue #3365: multi-relationship grouped patterns are rejected (Phase B).
+  // Issue #4531 (was a #3365 Phase B rejection): a multi-relationship inner pattern now repeats as a unit.
   @Test
-  void groupedRejectsMultiRelInner() {
+  void groupedSupportsMultiRelInner() {
     database.getSchema().createEdgeType("KNOWS");
     database.transaction(() ->
       database.command("opencypher",
           "CREATE (a:Person {name:'A'})-[:KNOWS]->(b:Person {name:'B'})-[:KNOWS]->(c:Person {name:'C'})-[:KNOWS]->(d:Person {name:'D'})"));
 
-    assertThatThrownBy(() -> database.query("opencypher",
-        "MATCH (a:Person {name:'A'})((:Person)-[:KNOWS]->(:Person)-[:KNOWS]->(:Person))+(end:Person) RETURN end"))
-        .isInstanceOf(CommandParsingException.class);
+    final List<String> reachable = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person {name:'A'})((:Person)-[:KNOWS]->(:Person)-[:KNOWS]->(:Person))+(end:Person) "
+            + "RETURN end.name AS name")) {
+      while (rs.hasNext())
+        reachable.add(rs.next().getProperty("name"));
+    }
+    // The two-hop unit repeats whole: one repetition reaches C, and a second would run off the chain.
+    assertThat(reachable).containsExactly("C");
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4531

## What this does

Implements **Phase B** of GQL Quantified Path Patterns (ISO/IEC 39075:2024 §15.4) - the shapes that
cannot be faked by lowering a group onto the variable-length-relationship engine, and that
`CypherASTBuilder.absorbParenthesizedPath` used to reject with `FeatureNotImplemented`:

| Scope item (issue #4531) | Status |
|---|---|
| Multi-relationship inner patterns, `( (a)-[:R1]->(b)-[:R2]->(c) )+` | done |
| Inner `WHERE` evaluated per repetition, `( (a)-[r]->(b) WHERE r.weight > 5 )+` | done |
| Label-divergent endpoints / richer inner structure | done (each inner node carries its own labels, properties and inline `WHERE`, re-checked per repetition) |
| Inner variables as group variables: `LIST<NODE>` / `LIST<RELATIONSHIP>` | done |
| Grouped path assignment yielding `LIST<PATH>` | done, when the path variable names nothing but the group |

## How

Three pieces, kept deliberately narrow:

**`ast/QuantifiedPathPattern`** (new) - a `RelationshipPattern` subclass carrying the inner
`PathPattern`, the inner `WHERE`, and the repetition bounds. Modelling the group as one *hop* keeps the
`nodes.size() == relationships.size() + 1` invariant that every consumer of a `PathPattern` relies on,
so nothing downstream had to learn a new pattern shape. It always reports a non-null minimum, so
`isVariableLength()` is true and every shape-matching fast path that already declines a variable-length
hop declines this one too.

**`executor/steps/QuantifiedPathStep`** (new) - depth-first search over the repetitions. Repetition
*i+1* starts where *i* ended; the inner `WHERE` is evaluated once per repetition against that
repetition's own single-valued bindings (not the group lists); a row is emitted for every end vertex
whose repetition count is inside the quantifier's bounds. Relationship isomorphism is enforced across
the whole group *and* against the relationships the incoming row already binds in the same MATCH
clause - which is also what terminates an open-ended quantifier on a cyclic graph. The used-relationship
set is seeded from the row rather than checked at the end, so a conflicting branch is pruned as soon as
it appears.

**`parser/CypherASTBuilder.absorbParenthesizedPath`** - now picks between two lowerings:

- **Phase A is retained** for the shape it expresses exactly: one relationship, no inner `WHERE`, and
  endpoints that constrain and bind nothing - `(()-[:R]->())+`. That group *is* a `-[:R*]->`, so it keeps
  the faster existing traversal. `phaseALoweringStillAgreesWithThePhaseBOperator` and
  `quantifiedGroupPlansAsAQuantifiedPathStep` pin that split.
- Everything else becomes a `QuantifiedPathPattern`. Every endpoint attribute forces Phase B, each for
  its own reason: a **variable**, because GQL binds it to one list element per repetition; a **label or
  property map**, because it holds for every repetition *including the vertices between two of them* -
  lowering `((:P)-[:R]->(:P))+` to `-[:R*]->` does not weaken that label, it deletes it, since the outer
  boundary nodes take over both ends and the inner endpoints are never spliced into the chain.
  `innerEndpointLabelsAreNotDroppedByThePhaseALowering` pins that; it was a live wrong-rows bug in the
  Phase A lowering, found in review.

## Both execution paths

`CypherExecutionPlanner.shouldUseOptimizer()` declines a quantified group, so the query plans on the
legacy pipeline. That is deliberate rather than incidental: `LogicalPlan` has no representation for a
repeated sub-pattern, and would flatten the hop into a plain variable-length expansion over *untyped*
edges - wrong rows, silently. `quantifiedGroupPlansAsAQuantifiedPathStep` asserts the plan shape through
`EXPLAIN` so a future change cannot drift the query onto the other path unnoticed. The step is wired
into both `buildMatchStep` and `buildExecutionStepsLegacy`.

## What is still refused, loudly

Rather than mis-execute them, these now fail at parse time naming the feature: a nested group, a
variable-length relationship inside a group, a path variable inside a group, a parameterised property
map (`$props`) on an inner node or relationship, and dynamic `$(expr)` labels on an inner node (they
resolve per row, not per repetition). `PatternPredicateExpression` - the *inline* `WHERE (a)-[:R]->(b)`
predicate evaluator, which only knows how to probe a single hop - reports the group instead of answering
as if it were one untyped variable-length relationship; `EXISTS { MATCH ... }` plans a real plan and
supports it.

`CypherSemanticValidator` learned that group variables are bound by their MATCH, and declares them as
plain values rather than as NODE/RELATIONSHIP, since the name holds a list.

## Two existing tests were rewritten, not deleted

`OpenCypherCypher25ClausesTest.groupedRejectsInnerWhere` and `groupedRejectsMultiRelInner` asserted the
two `FeatureNotImplemented` rejections this issue exists to remove. They are now
`groupedSupportsInnerWhere` / `groupedSupportsMultiRelInner` and assert the executed semantics on the
same fixtures.

## Test plan

- [ ] `mvn -pl engine test -Dtest=CypherQuantifiedPathPatternPhaseBIssue4531Test` - **28 new tests**
- [ ] `mvn -pl engine test -Dtest=OpenCypherCypher25ClausesTest` - 45 tests, incl. the two rewritten ones
- [ ] `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**' -DexcludedGroups=benchmark` -
      **9140 run, 0 failures**
- [ ] `mvn -pl engine verify -Dsurefire.includes='**/*Suite.java'` (openCypher TCK) -
      **3897 run / 0 failures / 85 skipped, identical to the same run with the implementation stashed**
- [ ] `mvn -pl engine test -DexcludedGroups=benchmark,vector,slow` - full engine module, 14054 run
- [ ] The new tests were run with the implementation stashed: **11 of 15 failed** at that point (the rest
      are the Phase A-preservation and still-rejected guards, which pass either way by design), plus both
      rewritten tests. Failures were the two `FeatureNotImplemented` messages, three `UndefinedVariable`
      on group variables, a `ClassCastException` where `LIST<PATH>` was a single path, and the `EXPLAIN`
      plan-shape assertion.
- [ ] Three further bugs were found and fixed **in review**, each with a test that fails without its fix:
      the Phase A lowering dropping an inner endpoint's label, an inner node's inline `WHERE` not seeing
      the repetition's earlier bindings, and `StackOverflowError` from ~5,000 repetitions.

## Notes / deferred

- Recursion depth in `QuantifiedPathStep` grows with the repetition count, the same exposure
  `DepthFirstTraverser.performDFS` already has for a variable-length hop; bounded by the quantifier when
  one is written, and by relationship isomorphism otherwise.
- A whole-map `$props` parameter is handled differently on either side of the parenthesis, deliberately:
  written on an **inner** endpoint it is rejected at parse time by `rejectUnsupportedInnerPattern`,
  because the per-repetition matcher cannot check it and silently dropping a constraint is the failure
  mode this change exists to remove. Written on the **outer** boundary node - `... ((x)-[:R]->(y))+ (t
  $props)` - it is ignored, matching the pre-existing behaviour of `ExpandPathStep` and
  `MatchRelationshipStep` for any traversal target. Only the second is unchanged pre-existing behaviour.
- The repetition search is driven by an **explicit stack**, not the Java one. This started as a deferred
  note and became a fix once measured: recursing per repetition threw `StackOverflowError` from about
  5,000 repetitions on a plain chain - a size a graph reaches trivially. After the change 5,000 / 10,000
  / 20,000 all complete, and the `@Tag("slow")` test pins 10,000, twice the depth that used to crash.
  `matchRepetition` still recurses, but only over the hops written inside the group, which is a constant
  of the query. `DepthFirstTraverser.performDFS` still carries the original exposure for an ordinary
  variable-length hop; that is untouched here and worth its own issue.
- A group that binds group variables materialises one list per repetition per row, so a query asking for
  tens of thousands of repetitions *and* group variables is quadratic in the result, and will exhaust the
  heap long before the search does. That is the shape of the answer, not a limit of the operator.
- A suggestion that the step drops input rows past the first `syncPull` batch was checked and does not
  hold: these steps' `ResultSet`s refill themselves and set `finished` only when the upstream is
  exhausted (`MatchNodeStep`, `ExpandPathStep`). `everyInputRowIsExpanded` pins it with 500 input rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1bu3QHjw5bgFKvfPSUoR7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for quantified path patterns in Cypher queries, including repeated multi-relationship paths.
  - Supports repetition bounds, grouped variables and paths, relationship directions and types, endpoint constraints, and per-repetition `WHERE` predicates.
  - Quantified traversals work across multiple input rows while preserving path and variable bindings.

- **Bug Fixes**
  - Improved execution for deep or unbounded quantified paths.
  - Unsupported quantified patterns now return a clear error recommending `EXISTS { MATCH ... }`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->