### PR TITLE
fix(engine,postgresw) #6996, #7021, #7017: unanswered Describe('P'), inherited-index seeks in OpenCypher, and the zero-length self path

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -19,9 +19,11 @@
 package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.Index;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
@@ -428,6 +430,66 @@ public final class Labels {
       if (!type.instanceOf(labels.get(i)))
         return false;
     return true;
+  }
+
+  /**
+   * Whether an index resolved for {@code label} can hand back records that do not carry it: true exactly when the
+   * index is declared on a supertype. An inherited index is a single logical index over the whole hierarchy - the
+   * schema gives it a sub-index for every bucket of every subtype - so a seek on it from a child type also walks
+   * the parent's own records and every sibling child's, and has to filter them out. That filter is what the SQL
+   * plan for the same query spells as {@code FILTER ITEMS BY TYPE} (issue #7021).
+   * <p>
+   * A seek on the type's own index needs no filter, which is why this is asked before wrapping a cursor rather
+   * than filtering unconditionally.
+   */
+  public static boolean isInheritedIndex(final Index index, final String label) {
+    return index != null && label != null && !label.equals(index.getTypeName());
+  }
+
+  /**
+   * Whether the record {@code identifiable} names carries {@code label}, answered from the bucket its RID names
+   * so a record of another type in the hierarchy is rejected without ever being loaded. This is the row-level
+   * form of the filter an inherited-index seek owes (see {@link #isInheritedIndex}); a cursor that can be walked
+   * as a plain iterator gets it applied by {@link #filterByLabel} instead.
+   */
+  public static boolean carriesLabel(final Schema schema, final Identifiable identifiable, final String label) {
+    final DocumentType type = schema.getTypeByBucketId(identifiable.getIdentity().getBucketId());
+    return type != null && type.instanceOf(label);
+  }
+
+  /**
+   * Filters an index cursor down to the records that carry {@code label}, for the seeks that read an inherited
+   * index (see {@link #isInheritedIndex}).
+   */
+  public static Iterator<Identifiable> filterByLabel(final Iterator<Identifiable> source, final Database database,
+      final String label) {
+    final Schema schema = database.getSchema();
+    return new Iterator<>() {
+      private Identifiable next = advance();
+
+      private Identifiable advance() {
+        while (source.hasNext()) {
+          final Identifiable candidate = source.next();
+          if (carriesLabel(schema, candidate, label))
+            return candidate;
+        }
+        return null;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return next != null;
+      }
+
+      @Override
+      public Identifiable next() {
+        if (next == null)
+          throw new NoSuchElementException();
+        final Identifiable current = next;
+        next = advance();
+        return current;
+      }
+    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -460,6 +460,11 @@ public final class Labels {
   /**
    * Filters an index cursor down to the records that carry {@code label}, for the seeks that read an inherited
    * index (see {@link #isInheritedIndex}).
+   * <p>
+   * The wrapper is a plain {@link Iterator}, so it does NOT forward {@code close()} to a source that has one.
+   * That is safe for its callers, which all wrap a full-key {@code Database.lookupByKey()} - an already-drained
+   * collection holding no file open - but it is the thing to fix first if this is ever pointed at a live range
+   * cursor, which does hold its file's retire guard until closed (issue #5635).
    */
   public static Iterator<Identifiable> filterByLabel(final Iterator<Identifiable> source, final Database database,
       final String label) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -176,9 +176,11 @@ public class ShortestPathExpression implements Expression {
     if (pathRids == null || pathRids.isEmpty())
       return allPaths ? new ArrayList<>() : null;
 
-    // Endpoints resolving to the same vertex short-circuit to the zero-length path before any bound applies,
-    // matching what the MATCH form has always answered for shortestPath((a)-[:R*]-(a)). See issue #7017.
-    if (pathRids.size() > 1 && !bounds.accepts(pathRids.size() - 1))
+    // Endpoints resolving to the same vertex yield the zero-length path, whose admissibility is
+    // HopBounds.acceptsSelfPath()'s call rather than accepts(0)'s (issue #7017); every longer answer is
+    // checked against both declared bounds.
+    final int hops = pathRids.size() - 1;
+    if (hops == 0 ? !bounds.acceptsSelfPath() : !bounds.accepts(hops))
       return allPaths ? new ArrayList<>() : null;
 
     // Resolve vertex RIDs and find connecting edges to build a proper path

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2402,7 +2402,10 @@ public class CypherExecutionPlan {
     // every key column). A partial-prefix seek would need an index range cursor and is left for later.
     TypeIndex bestIndex = null;
     List<String> bestKey = null;
-    for (final TypeIndex index : edgeType.getAllIndexes(false)) {
+    // Polymorphic, for the same reason node patterns are (issue #7021): an index declared on a parent edge
+    // type is inherited by this one, and a relationship pattern already matches every subtype of the type it
+    // names. MatchEdgeByIndexStep filters an inherited index's cursor back down to that same rule.
+    for (final TypeIndex index : edgeType.getAllIndexes(true)) {
       final List<String> keyProps = index.getPropertyNames();
       if (keyProps.isEmpty() || !predicates.keySet().containsAll(keyProps))
         continue;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeIndexSeek.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeIndexSeek.java
@@ -33,6 +33,7 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.VertexType;
 
+import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.LiteralExpression;
 import com.arcadedb.query.opencypher.ast.ParameterExpression;
@@ -96,6 +97,8 @@ public class NodeIndexSeek extends AbstractPhysicalOperator {
     final WorkGuard guard = WorkGuard.forCommandDeadline(context);
     return new ResultSet() {
       private TypeIndex index = null;
+      /** The index is declared on a supertype, so its cursor carries records that are not of {@link #label}. */
+      private boolean inheritedIndex = false;
       private List<Object[]> seekKeys = null; // one key per value to seek (IN-list expands to N keys)
       private int seekIndex = 0;
       private boolean wholeKey = false;        // the key covers every index property: single-entry lookup
@@ -149,6 +152,11 @@ public class NodeIndexSeek extends AbstractPhysicalOperator {
           // set here would silently drop rows the query must return, so fail instead.
           throw new CommandExecutionException(
               "Index '" + indexName + "' on type '" + label + "' is no longer available: re-plan the query");
+
+        // An index inherited from a supertype spans every bucket in the hierarchy, so its cursor also yields
+        // the parent's own records and every sibling child's. Those are not answers to (n:label) and are
+        // dropped below - the same thing the SQL plan for this query spells as FILTER ITEMS BY TYPE (#7021).
+        inheritedIndex = Labels.isInheritedIndex(index, label);
 
         // The prefix values are shared by every seek; only the leading value varies over an IN-list.
         final List<Object> trailing = new ArrayList<>(keyValues.size() - 1);
@@ -243,6 +251,11 @@ public class NodeIndexSeek extends AbstractPhysicalOperator {
 
           // Skip already-emitted vertices when seeking multiple IN-list values (set semantics).
           if (seen != null && !seen.add(identifiable.getIdentity()))
+            continue;
+
+          // Reject a record of another type in the hierarchy without loading it: the bucket the RID names
+          // already says which type it belongs to (issue #7021).
+          if (inheritedIndex && !Labels.carriesLabel(context.getDatabase().getSchema(), identifiable, label))
             continue;
 
           // Load the actual record from the identifiable (may be RID)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
@@ -178,7 +178,7 @@ public class MatchEdgeByIndexStep extends AbstractExecutionStep {
             // An index inherited from a parent edge type spans the whole hierarchy, so its cursor also
             // carries the parent's own edges and every sibling's. A relationship pattern matches a type and
             // its subtypes, never its ancestors, so those are not answers (issue #7021).
-            // <p>
+            //
             // Unconditional, unlike the equivalent in NodeIndexSeek/MatchNodeStep, which skip the check
             // entirely for an index the queried type owns: those pay a bucket-id lookup per row to learn the
             // type, while the record here is already loaded (the Edge cast above needs it), so the check is

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
@@ -178,6 +178,12 @@ public class MatchEdgeByIndexStep extends AbstractExecutionStep {
             // An index inherited from a parent edge type spans the whole hierarchy, so its cursor also
             // carries the parent's own edges and every sibling's. A relationship pattern matches a type and
             // its subtypes, never its ancestors, so those are not answers (issue #7021).
+            // <p>
+            // Unconditional, unlike the equivalent in NodeIndexSeek/MatchNodeStep, which skip the check
+            // entirely for an index the queried type owns: those pay a bucket-id lookup per row to learn the
+            // type, while the record here is already loaded (the Edge cast above needs it), so the check is
+            // one instanceOf on a type reference already in hand and a flag to skip it would cost more to
+            // carry than to ignore.
             if (!edge.getType().instanceOf(edgeType))
               continue;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchEdgeByIndexStep.java
@@ -175,6 +175,12 @@ public class MatchEdgeByIndexStep extends AbstractExecutionStep {
               continue;
             }
 
+            // An index inherited from a parent edge type spans the whole hierarchy, so its cursor also
+            // carries the parent's own edges and every sibling's. A relationship pattern matches a type and
+            // its subtypes, never its ancestors, so those are not answers (issue #7021).
+            if (!edge.getType().instanceOf(edgeType))
+              continue;
+
             final ResultInternal result = new ResultInternal();
             if (relationshipVariable != null && !relationshipVariable.isEmpty())
               result.setProperty(relationshipVariable, edge);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -685,7 +685,12 @@ public class MatchNodeStep extends AbstractExecutionStep {
     int bestMatchCount = 0;
     List<String> bestMatchedProperties = null;
 
-    for (final TypeIndex index : type.getAllIndexes(false)) {
+    // Polymorphic: an index declared on a supertype is inherited by this type - the schema keeps a sub-index
+    // for every bucket in the hierarchy - and is exactly as seekable from here as one this type declares
+    // itself. Asking for the type's own indexes only left a child type with no usable index at all, since a
+    // child cannot own a second index on a property its parent already indexes, and fell back to a full label
+    // scan where SQL had always planned a fetch from the inherited index (issue #7021).
+    for (final TypeIndex index : type.getAllIndexes(true)) {
       final List<String> indexProperties = index.getPropertyNames();
 
       // Check how many properties match as a leftmost prefix
@@ -723,14 +728,26 @@ public class MatchNodeStep extends AbstractExecutionStep {
       for (int i = 0; i < propertyNames.length; i++)
         propertyValues[i] = properties.get(propertyNames[i]);
 
-      // Track which index was used for profiling output
-      usedIndexName = label + "[" + String.join(", ", propertyNames) + "]";
+      // Track which index was used for profiling output, named after the type that DECLARES it: an inherited
+      // index reported under the queried type would name an index that does not exist (issue #7021).
+      usedIndexName = bestIndex.getTypeName() + "[" + String.join(", ", propertyNames) + "]";
 
-      final Iterator<Identifiable> iter = context.getDatabase().lookupByKey(label, propertyNames, propertyValues);
-      return iter;
+      return lookupByKey(bestIndex, label, propertyNames, propertyValues);
     }
 
     return null;
+  }
+
+  /**
+   * Seeks {@code index} for the given key and, when the index is inherited from a supertype, filters its
+   * cursor down to the records that really carry {@code label} - the step's own label check short-circuits a
+   * single-label pattern on the grounds that the iterator already selected the type, which a polymorphic
+   * index does not do (issue #7021).
+   */
+  private Iterator<Identifiable> lookupByKey(final TypeIndex index, final String label, final String[] propertyNames,
+      final Object[] propertyValues) {
+    final Iterator<Identifiable> cursor = context.getDatabase().lookupByKey(label, propertyNames, propertyValues);
+    return Labels.isInheritedIndex(index, label) ? Labels.filterByLabel(cursor, context.getDatabase(), label) : cursor;
   }
 
   /**
@@ -754,7 +771,8 @@ public class MatchNodeStep extends AbstractExecutionStep {
     int bestMatchCount = 0;
     List<String> bestMatchedProperties = null;
 
-    for (final TypeIndex index : type.getAllIndexes(false)) {
+    // Polymorphic for the same reason as tryFindAndUseIndex above (issue #7021).
+    for (final TypeIndex index : type.getAllIndexes(true)) {
       final List<String> indexProperties = index.getPropertyNames();
       int matchCount = 0;
       final List<String> matchedProperties = new ArrayList<>();
@@ -781,10 +799,9 @@ public class MatchNodeStep extends AbstractExecutionStep {
       for (int i = 0; i < propertyNames.length; i++)
         propertyValues[i] = equalityPredicates.get(propertyNames[i]);
 
-      usedIndexName = label + "[" + String.join(", ", propertyNames) + "]";
+      usedIndexName = bestIndex.getTypeName() + "[" + String.join(", ", propertyNames) + "]";
 
-      final Iterator<Identifiable> iter = context.getDatabase().lookupByKey(label, propertyNames, propertyValues);
-      return iter;
+      return lookupByKey(bestIndex, label, propertyNames, propertyValues);
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -53,6 +53,7 @@ import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.VertexType;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -120,6 +121,15 @@ public class MatchNodeStep extends AbstractExecutionStep {
   // live cursor per row is exactly the mechanism issue #6602 exploits, and the RID list is far lighter than
   // the vertices it names.
   private       List<Identifiable>  cachedFullScanCandidates;
+  // The type whose polymorphic index set is held below, compared by identity so a re-resolved type (a
+  // schema change mid-query) resolves afresh rather than answering from the old one's indexes.
+  private       DocumentType        indexesResolvedForType;
+  // Resolved once per type rather than per input row: unlike a type's own index collection, which is a
+  // view over a map it already keeps, the polymorphic one is BUILT - a HashSet plus a walk of every
+  // supertype - so a chained MATCH that re-opens this scan per outer row was allocating one per row from
+  // the moment issue #7021 made this lookup polymorphic. Same write-once-per-execution contract as the
+  // fields above, and cleared with them.
+  private       Collection<TypeIndex> polymorphicIndexes;
 
   /**
    * Creates a match node step.
@@ -685,12 +695,7 @@ public class MatchNodeStep extends AbstractExecutionStep {
     int bestMatchCount = 0;
     List<String> bestMatchedProperties = null;
 
-    // Polymorphic: an index declared on a supertype is inherited by this type - the schema keeps a sub-index
-    // for every bucket in the hierarchy - and is exactly as seekable from here as one this type declares
-    // itself. Asking for the type's own indexes only left a child type with no usable index at all, since a
-    // child cannot own a second index on a property its parent already indexes, and fell back to a full label
-    // scan where SQL had always planned a fetch from the inherited index (issue #7021).
-    for (final TypeIndex index : type.getAllIndexes(true)) {
+    for (final TypeIndex index : polymorphicIndexesOf(type)) {
       final List<String> indexProperties = index.getPropertyNames();
 
       // Check how many properties match as a leftmost prefix
@@ -739,6 +744,25 @@ public class MatchNodeStep extends AbstractExecutionStep {
   }
 
   /**
+   * Every index seekable from {@code type}, its supertypes' included: an index declared on a supertype is
+   * inherited - the schema keeps a sub-index for every bucket in the hierarchy - and is exactly as seekable
+   * from here as one this type declares itself. Asking for the type's OWN indexes left a child type with no
+   * usable index at all, since a child cannot own a second index on a property its parent already indexes,
+   * and fell back to a full label scan where SQL had always planned a fetch from the inherited index
+   * (issue #7021).
+   * <p>
+   * Memoized because the answer is built rather than viewed (see {@link #polymorphicIndexes}) and this runs
+   * once per input row on a chained MATCH.
+   */
+  private Collection<TypeIndex> polymorphicIndexesOf(final DocumentType type) {
+    if (polymorphicIndexes == null || indexesResolvedForType != type) {
+      indexesResolvedForType = type;
+      polymorphicIndexes = type.getAllIndexes(true);
+    }
+    return polymorphicIndexes;
+  }
+
+  /**
    * Seeks {@code index} for the given key and, when the index is inherited from a supertype, filters its
    * cursor down to the records that really carry {@code label} - the step's own label check short-circuits a
    * single-label pattern on the grounds that the iterator already selected the type, which a polymorphic
@@ -771,8 +795,7 @@ public class MatchNodeStep extends AbstractExecutionStep {
     int bestMatchCount = 0;
     List<String> bestMatchedProperties = null;
 
-    // Polymorphic for the same reason as tryFindAndUseIndex above (issue #7021).
-    for (final TypeIndex index : type.getAllIndexes(true)) {
+    for (final TypeIndex index : polymorphicIndexesOf(type)) {
       final List<String> indexProperties = index.getPropertyNames();
       int matchCount = 0;
       final List<String> matchedProperties = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1004,7 +1004,11 @@ public class MergeStep extends AbstractExecutionStep {
     int bestMatchCount = 0;
     List<String> bestMatchedProperties = null;
 
-    for (final TypeIndex index : type.getAllIndexes(false)) {
+    // Polymorphic: an index declared on a supertype is inherited by this type and is just as seekable from it
+    // (issue #7021). The cursor it opens is filtered by label below, since it also carries the parent's own
+    // records and every sibling child's - and findAllNodes(), unlike the anchor walk, re-verifies only the
+    // properties, so a MERGE could otherwise match a record of the wrong type and skip the creation.
+    for (final TypeIndex index : type.getAllIndexes(true)) {
       final List<String> indexProperties = index.getPropertyNames();
       int matchCount = 0;
       final List<String> matchedProperties = new ArrayList<>();
@@ -1033,8 +1037,10 @@ public class MergeStep extends AbstractExecutionStep {
     for (int i = 0; i < propertyNames.length; i++)
       propertyValues[i] = evaluatedProperties.get(propertyNames[i]);
 
-    final Iterator<Identifiable> iter = context.getDatabase().lookupByKey(label, propertyNames, propertyValues);
-    return iter;
+    final Iterator<Identifiable> cursor = context.getDatabase().lookupByKey(label, propertyNames, propertyValues);
+    return Labels.isInheritedIndex(bestIndex, label) ?
+        Labels.filterByLabel(cursor, context.getDatabase(), label) :
+        cursor;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -268,10 +268,11 @@ public class ShortestPathStep extends AbstractExecutionStep {
     if (pathRids == null || pathRids.isEmpty())
       return null;
 
-    // A source that already is the target short-circuits to the zero-length path before any bound applies:
-    // that is what MATCH p = shortestPath((a)-[:R*]-(a)) has always answered, and the implicit minimum of 1
-    // that [*] carries would otherwise suppress it. See HopBounds and issue #7017.
-    if (pathRids.size() > 1 && !bounds.accepts(pathRids.size() - 1))
+    // A source that already is the target yields the zero-length path, whose admissibility is
+    // HopBounds.acceptsSelfPath()'s call rather than accepts(0)'s (issue #7017); every longer answer is
+    // checked against both declared bounds.
+    final int hops = pathRids.size() - 1;
+    if (hops == 0 ? !bounds.acceptsSelfPath() : !bounds.accepts(hops))
       return null;
 
     // Build a proper path with alternating Vertex and Edge objects
@@ -328,6 +329,10 @@ public class ShortestPathStep extends AbstractExecutionStep {
     final RID targetRid = target.getIdentity();
 
     if (sourceRid.equals(targetRid)) {
+      // The zero-length path is the only shortest path between a vertex and itself; a declared minimum of
+      // more than one hop rejects it (issue #7017).
+      if (!bounds.acceptsSelfPath())
+        return Collections.emptyList();
       final List<Object> singleNode = new ArrayList<>(1);
       singleNode.add(source);
       return Collections.singletonList(singleNode);
@@ -560,6 +565,10 @@ public class ShortestPathStep extends AbstractExecutionStep {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
+      // The zero-length path is the only shortest path between a vertex and itself; a declared minimum of
+      // more than one hop rejects it (issue #7017).
+      if (!bounds.acceptsSelfPath())
+        return null;
       final List<Object> single = new ArrayList<>(1);
       single.add(source);
       return single;
@@ -656,6 +665,10 @@ public class ShortestPathStep extends AbstractExecutionStep {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
+      // The zero-length path is the only shortest path between a vertex and itself; a declared minimum of
+      // more than one hop rejects it (issue #7017).
+      if (!bounds.acceptsSelfPath())
+        return Collections.emptyList();
       final List<Object> single = new ArrayList<>(1);
       single.add(source);
       return Collections.singletonList(single);
@@ -795,12 +808,9 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * rather than a longer path satisfying it: finding that path is a different (non-shortest, simple-path
    * enumerating) search, and Neo4j rejects such a pattern outright.
    * <p>
-   * One shape stays outside the check: endpoints resolving to the same vertex short-circuit to the
-   * zero-length path in every evaluator, before any bound applies, so a declared minimum is unenforceable
-   * there. That is the answer the engine has always given (pinned by
-   * {@code CypherReduceAndShortestPathTest.shortestPathSameNode}), and {@code [*]} is lowered to
-   * {@code minHops = 1} by the parser, so it cannot be told apart from an explicit {@code [*1..]} here.
-   * Changing it is a semantic decision tracked by issue #7017.
+   * Endpoints resolving to the same vertex are the one shape that does not go through {@link #accepts}:
+   * the only shortest path from a vertex to itself is the zero-length one, and whether that is an answer is
+   * {@link #acceptsSelfPath}'s call - see there for why it is not simply {@code accepts(0)} (issue #7017).
    */
   public static final class HopBounds {
     /** No bound at all: accepts every path length. */
@@ -837,6 +847,27 @@ public class ShortestPathStep extends AbstractExecutionStep {
      */
     public boolean accepts(final int hops) {
       return hops >= min && hops <= max;
+    }
+
+    /**
+     * Whether the zero-length path - the only shortest path from a vertex to itself - answers this pattern.
+     * <p>
+     * Deliberately not {@code accepts(0)}. Neo4j accepts a {@code shortestPath()} pattern only with a minimum
+     * of 0 or 1 hops, rejecting anything else outright, and answers both of those spellings for identical
+     * endpoints with the zero-length path; the parser here lowers a bare {@code [*]} to {@code minHops = 1},
+     * so an implicit minimum is indistinguishable from an explicitly written {@code [*1..]} and treating
+     * either as a rejection would change the answer to {@code shortestPath((a)-[:R*]-(a))}, which
+     * {@code CypherReduceAndShortestPathTest.shortestPathSameNode} pins to that same zero-length path.
+     * <p>
+     * A minimum above one hop is a pattern Neo4j would not have accepted at all, so nothing is owed to it
+     * beyond reading it literally: zero hops is not in {@code [min, max]}, so the pattern has no answer here.
+     * Answering it with a cycle back to the source instead - the shortest path of at least {@code min} hops
+     * that leaves and returns - would be the same substitution {@link #accepts} already refuses for distinct
+     * endpoints, where a shortest path below the declared minimum yields no row rather than a longer one
+     * (issue #7017).
+     */
+    public boolean acceptsSelfPath() {
+      return min <= 1;
     }
 
     /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -885,8 +885,10 @@ public class ShortestPathStep extends AbstractExecutionStep {
     @Override
     public String toString() {
       // "*", not "*1..": the parser lowers a bare [*] to minHops = 1, so an EXPLAIN that spelled it out
-      // would render the commonest pattern of all under a name nobody writes it by.
-      if (min <= 1 && max == Integer.MAX_VALUE)
+      // would render the commonest pattern of all under a name nobody writes it by. Exactly one, though -
+      // a written [*0..] is a different pattern (it is the one spelling that admits the zero-length path
+      // outright, see acceptsSelfPath) and keeps its lower bound on show.
+      if (min == 1 && max == Integer.MAX_VALUE)
         return "*";
       if (min == max)
         return "*" + min;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -861,6 +861,10 @@ public class ShortestPathStep extends AbstractExecutionStep {
      * <p>
      * A minimum above one hop is a pattern Neo4j would not have accepted at all, so nothing is owed to it
      * beyond reading it literally: zero hops is not in {@code [min, max]}, so the pattern has no answer here.
+     * Only the minimum decides this - an upper bound cannot exclude a zero-length path, since it is at least
+     * zero hops long - so an exact quantifier answers by its minimum like any other: {@code [*1..1]}, and the
+     * unquantified {@code -[:R]-} that means the same thing, keep the zero-length self path, {@code [*2..2]}
+     * rejects it.
      * Answering it with a cycle back to the source instead - the shortest path of at least {@code min} hops
      * that leaves and returns - would be the same substitution {@link #accepts} already refuses for distinct
      * endpoints, where a shortest path below the declared minimum yields no row rather than a longer one
@@ -880,6 +884,10 @@ public class ShortestPathStep extends AbstractExecutionStep {
 
     @Override
     public String toString() {
+      // "*", not "*1..": the parser lowers a bare [*] to minHops = 1, so an EXPLAIN that spelled it out
+      // would render the commonest pattern of all under a name nobody writes it by.
+      if (min <= 1 && max == Integer.MAX_VALUE)
+        return "*";
       if (min == max)
         return "*" + min;
       return "*" + min + ".." + (max == Integer.MAX_VALUE ? "" : max);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/StatisticsProvider.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/StatisticsProvider.java
@@ -113,7 +113,12 @@ public class StatisticsProvider {
     final String typeName = type.getName();
     final List<IndexStatistics> indexStatsList = new ArrayList<>();
 
-    final Collection<TypeIndex> indexes = type.getAllIndexes(false);
+    // Polymorphic: an index declared on a supertype is inherited by this type and is just as seekable from
+    // it, so leaving it out of the statistics is what made the planner fall back to a full label scan for a
+    // child type whose only index lives on its parent (issue #7021). NodeIndexSeek resolves the index it is
+    // handed polymorphically and filters the cursor by the queried label, exactly as SQL's
+    // FETCH FROM INDEX / FILTER ITEMS BY TYPE plan does.
+    final Collection<TypeIndex> indexes = type.getAllIndexes(true);
     for (final TypeIndex index : indexes) {
       final List<String> propertyNames = index.getPropertyNames();
       final boolean isUnique = index.isUnique();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathHopBoundsIssue7009Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathHopBoundsIssue7009Test.java
@@ -272,10 +272,11 @@ class CypherShortestPathHopBoundsIssue7009Test extends TestHelper {
 
   @Test
   void aZeroLengthSelfPathIsStillReturned() {
-    // The endpoints resolving to the same vertex short-circuits to the zero-length path before any hop
-    // bound applies, which is what MATCH p = shortestPath((a)-[:KNOWS*]-(a)) has always answered
-    // (CypherReduceAndShortestPathTest.shortestPathSameNode). Whether an explicit minimum should suppress
-    // it is a semantic decision tracked by issue #7017.
+    // Endpoints resolving to the same vertex answer with the zero-length path, which is what
+    // MATCH p = shortestPath((a)-[:KNOWS*]-(a)) has always answered
+    // (CypherReduceAndShortestPathTest.shortestPathSameNode). [*] carries an implicit minimum of one hop
+    // and keeps that answer; a minimum ABOVE one hop rejects it - see
+    // CypherShortestPathSelfPathBoundsIssue7017Test and HopBounds.acceptsSelfPath() (issue #7017).
     try (final ResultSet rs = database.query("opencypher",
         "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len")) {
       assertThat(rs.hasNext()).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathSelfPathBoundsIssue7017Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathSelfPathBoundsIssue7017Test.java
@@ -109,6 +109,34 @@ class CypherShortestPathSelfPathBoundsIssue7017Test extends TestHelper {
   }
 
   @Test
+  void anExactQuantifierAnswersByItsMinimumLikeAnyOther() {
+    // An upper bound cannot exclude a zero-length path - it is at least zero hops long - so an exact
+    // quantifier is decided by its minimum alone, and [*1..1] keeps the self path exactly as [*] does.
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*1..1]-(e)) RETURN length(p) AS len"))
+        .containsExactly(0);
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK]-(e)) RETURN length(p) AS len"))
+        .as("an unquantified relationship declares the same single hop (issue #7009), so it answers the same")
+        .containsExactly(0);
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*2..2]-(e)) RETURN length(p) AS len"))
+        .as("a minimum of two rejects it, upper bound or not")
+        .isEmpty();
+  }
+
+  @Test
+  void theExplainedPatternKeepsTheSpellingItWasWrittenIn() {
+    // [*] is lowered to minHops = 1 internally; EXPLAIN must not render the commonest pattern of all as
+    // "*1..", a spelling nobody writes it by.
+    assertThat(explain("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN p"))
+        .contains("[:LINK*]");
+    assertThat(explain("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*2..3]-(e)) RETURN p"))
+        .as("a pattern that really carries bounds still shows them")
+        .contains("[:LINK*2..3]");
+    assertThat(explain("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK]-(e)) RETURN p"))
+        .as("and one with no quantifier shows none")
+        .contains("[:LINK]");
+  }
+
+  @Test
   void distinctEndpointsAreUnaffected() {
     assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len"))
         .as("control: the self-path rule must not touch a genuine two-endpoint search")
@@ -180,6 +208,13 @@ class CypherShortestPathSelfPathBoundsIssue7017Test extends TestHelper {
         "MATCH (s:N {k:'a'}), (e:N {k:'a'}) RETURN allShortestPaths((s)-[:LINK*3..5]-(e)) AS p")) {
       assertThat(rs.hasNext()).isTrue();
       assertThat(rs.next().<List<?>>getProperty("p")).isEmpty();
+    }
+  }
+
+  private String explain(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().<Object>getProperty("executionPlanAsString").toString();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathSelfPathBoundsIssue7017Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathSelfPathBoundsIssue7017Test.java
@@ -63,6 +63,7 @@ class CypherShortestPathSelfPathBoundsIssue7017Test extends TestHelper {
 
     // a -> b -> c -> a : a 3-hop cycle through every one of its vertices. Every LINK carries w=1, so an
     // inline {w: 1} filter routes the query to the edge-aware BFS without changing reachability.
+    // d -> d : a real one-hop self loop, so the zero-length answer can be told apart from "found nothing".
     database.transaction(() -> {
       final MutableVertex a = node("a");
       final MutableVertex b = node("b");
@@ -70,6 +71,9 @@ class CypherShortestPathSelfPathBoundsIssue7017Test extends TestHelper {
       link(a, b);
       link(b, c);
       link(c, a);
+
+      final MutableVertex d = node("d");
+      link(d, d);
     });
   }
 
@@ -119,6 +123,20 @@ class CypherShortestPathSelfPathBoundsIssue7017Test extends TestHelper {
         .containsExactly(0);
     assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*2..2]-(e)) RETURN length(p) AS len"))
         .as("a minimum of two rejects it, upper bound or not")
+        .isEmpty();
+  }
+
+  @Test
+  void aRealSelfLoopDoesNotChangeTheAnswer() {
+    // d carries a one-hop LINK to itself, so a 1-hop answer genuinely exists here. The zero-length path is
+    // still the shorter one and still the answer - which is also what makes the assertions above meaningful:
+    // they read 0 because 0 is the shortest path, not because nothing was found.
+    assertThat(selfLengths("MATCH (s:N {k:'d'}), (e:N {k:'d'}), p = shortestPath((s)-[:LINK]-(e)) RETURN length(p) AS len"))
+        .containsExactly(0);
+    assertThat(selfLengths("MATCH (s:N {k:'d'}), (e:N {k:'d'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len"))
+        .containsExactly(0);
+    assertThat(selfLengths("MATCH (s:N {k:'d'}), (e:N {k:'d'}), p = shortestPath((s)-[:LINK*2..]-(e)) RETURN length(p) AS len"))
+        .as("and a minimum above one hop rejects the zero-length path without reaching for the loop instead")
         .isEmpty();
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathSelfPathBoundsIssue7017Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathSelfPathBoundsIssue7017Test.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/ArcadeData/arcadedb/issues/7017, the shape issue #7009 left
+ * outside its bound check on purpose.
+ * <p>
+ * When both endpoints of a {@code shortestPath()} resolve to the SAME vertex, the answer is the
+ * zero-length path, and every evaluator produced it before consulting the {@code *min..max} bounds - so
+ * {@code shortestPath((a)-[:LINK*3..5]-(a))} answered with a path of length 0, which is not in [3, 5],
+ * and a declared minimum was silently unenforceable for exactly this one endpoint pair.
+ * <p>
+ * The rule settled here, and implemented by {@code ShortestPathStep.HopBounds.acceptsSelfPath()}:
+ * <ul>
+ *   <li>a minimum of 0 or 1 hops - which is every minimum Neo4j accepts on a {@code shortestPath()}
+ *       pattern at all, and what a bare {@code [*]} is lowered to - keeps answering with the zero-length
+ *       path, so {@code shortestPath((a)-[:LINK*]-(a))} is unchanged;</li>
+ *   <li>a minimum above one hop, which Neo4j would have rejected outright, is read literally: zero hops
+ *       is not in the declared range, so the pattern has no answer. It is NOT re-interpreted as a request
+ *       for the shortest cycle back to the source - the same substitution the bound check already refuses
+ *       for distinct endpoints, where a shortest path below the declared minimum yields no row rather
+ *       than a longer one that would fit.</li>
+ * </ul>
+ * The graph deliberately contains a 3-hop cycle through {@code a}, so the "no answer" cases below are
+ * choosing not to return a cycle that exists rather than failing to find one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherShortestPathSelfPathBoundsIssue7017Test extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("N").createProperty("k", Type.STRING);
+    database.getSchema().createEdgeType("LINK");
+
+    // a -> b -> c -> a : a 3-hop cycle through every one of its vertices. Every LINK carries w=1, so an
+    // inline {w: 1} filter routes the query to the edge-aware BFS without changing reachability.
+    database.transaction(() -> {
+      final MutableVertex a = node("a");
+      final MutableVertex b = node("b");
+      final MutableVertex c = node("c");
+      link(a, b);
+      link(b, c);
+      link(c, a);
+    });
+  }
+
+  private MutableVertex node(final String key) {
+    return database.newVertex("N").set("k", key).save();
+  }
+
+  private void link(final MutableVertex from, final MutableVertex to) {
+    from.newEdge("LINK", to, true, new Object[] { "w", 1 }).save();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // shortestPath(), MATCH form
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void aMinimumAboveOneHopRejectsTheZeroLengthSelfPath() {
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*3..5]-(e)) RETURN length(p) AS len"))
+        .as("a zero-length path is not in [3, 5], and the 3-hop cycle is not a shortest path answer either")
+        .isEmpty();
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*2..]-(e)) RETURN length(p) AS len"))
+        .as("two hops is already above the minimum every Neo4j-accepted spelling declares")
+        .isEmpty();
+  }
+
+  @Test
+  void anImplicitOrExplicitMinimumOfOneKeepsTheZeroLengthSelfPath() {
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len"))
+        .as("[*] is lowered to minHops = 1 and must keep answering with the zero-length path")
+        .containsExactly(0);
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*1..]-(e)) RETURN length(p) AS len"))
+        .as("an explicitly written [*1..] is the same pattern as [*], so it must answer identically")
+        .containsExactly(0);
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*0..]-(e)) RETURN length(p) AS len"))
+        .as("a minimum of zero admits the zero-length path outright")
+        .containsExactly(0);
+  }
+
+  @Test
+  void distinctEndpointsAreUnaffected() {
+    assertThat(selfLengths("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*]-(e)) RETURN length(p) AS len"))
+        .as("control: the self-path rule must not touch a genuine two-endpoint search")
+        .containsExactly(1);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // allShortestPaths(), MATCH form (layered BFS)
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void allShortestPathsAppliesTheSameSelfPathRule() {
+    assertThat(selfLengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = allShortestPaths((s)-[:LINK*3..5]-(e)) RETURN length(p) AS len"))
+        .isEmpty();
+    assertThat(selfLengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = allShortestPaths((s)-[:LINK*]-(e)) RETURN length(p) AS len"))
+        .as("control: the unbounded spelling still yields the single zero-length path")
+        .containsExactly(0);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Edge-aware BFS (an inline property map / WHERE routes both forms away from SQLFunctionShortestPath)
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void theEdgeAwareBfsAppliesTheSameSelfPathRule() {
+    assertThat(selfLengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[:LINK*3..5 {w: 1}]-(e)) RETURN length(p) AS len"))
+        .isEmpty();
+    assertThat(selfLengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = shortestPath((s)-[r:LINK* WHERE r.w = 1]-(e)) RETURN length(p) AS len"))
+        .as("control: every LINK carries w=1, so the unbounded filtered form still answers zero-length")
+        .containsExactly(0);
+    assertThat(selfLengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = allShortestPaths((s)-[:LINK*3..5 {w: 1}]-(e)) RETURN length(p) AS len"))
+        .isEmpty();
+    assertThat(selfLengths(
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}), p = allShortestPaths((s)-[:LINK* {w: 1}]-(e)) RETURN length(p) AS len"))
+        .containsExactly(0);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Expression form: RETURN shortestPath(...)
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void theExpressionFormAppliesTheSameSelfPathRule() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}) RETURN shortestPath((s)-[:LINK*3..5]-(e)) AS p")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("p"))
+          .as("the zero-length path does not satisfy [3, 5], so the expression yields null")
+          .isNull();
+    }
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}) RETURN shortestPath((s)-[:LINK*]-(e)) AS p")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<List<?>>getProperty("p"))
+          .as("control: the unbounded spelling still yields the one-vertex, zero-length path")
+          .hasSize(1);
+    }
+  }
+
+  @Test
+  void theAllShortestPathsExpressionFormAppliesTheSameSelfPathRule() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (s:N {k:'a'}), (e:N {k:'a'}) RETURN allShortestPaths((s)-[:LINK*3..5]-(e)) AS p")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<List<?>>getProperty("p")).isEmpty();
+    }
+  }
+
+  private List<Integer> selfLengths(final String query) {
+    final List<Integer> lengths = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final Number len = row.getProperty("len");
+        lengths.add(len == null ? null : len.intValue());
+      }
+    }
+    return lengths;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathSelfPathBoundsIssue7017Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathSelfPathBoundsIssue7017Test.java
@@ -149,6 +149,10 @@ class CypherShortestPathSelfPathBoundsIssue7017Test extends TestHelper {
     assertThat(explain("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*2..3]-(e)) RETURN p"))
         .as("a pattern that really carries bounds still shows them")
         .contains("[:LINK*2..3]");
+    assertThat(explain("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK*0..]-(e)) RETURN p"))
+        .as("a written zero minimum is a different pattern from [*] - the one that admits the zero-length "
+            + "path outright - so it keeps its lower bound on show")
+        .contains("[:LINK*0..]");
     assertThat(explain("MATCH (s:N {k:'a'}), (e:N {k:'b'}), p = shortestPath((s)-[:LINK]-(e)) RETURN p"))
         .as("and one with no quantifier shows none")
         .contains("[:LINK]");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue7021InheritedIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue7021InheritedIndexTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7021: an index declared on a parent type is inherited by every child type - the schema creates a
+ * sub-index for each child bucket - and SQL has always used it, planning
+ * {@code FETCH FROM INDEX Node[id] / FILTER ITEMS BY TYPE Entity}. OpenCypher asked the type for
+ * {@code getAllIndexes(false)}, which answers only with the indexes the type declares ITSELF, so a query on
+ * the child type found no index and fell back to a full label scan. Since a child type cannot own a second
+ * index on a property its parent already indexes, that left no way at all to get an index seek on the child.
+ * <p>
+ * The seek that replaces the scan reads a polymorphic index, so its cursor also carries the parent's own
+ * records and every sibling child's: the label filter that keeps the answer right is what the SQL plan
+ * spells as FILTER ITEMS BY TYPE. Every test below therefore checks the rows, not only the plan, and pins
+ * them against the SQL engine over the same data.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7021InheritedIndexTest {
+  private static final String DATABASE_PATH = "./target/databases/issue-7021-inherited-index";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DATABASE_PATH).create();
+
+    // Node <- Entity, and Node <- Other: a sibling child whose records live in the same polymorphic index
+    // and must never leak into an Entity answer.
+    database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+    database.getSchema().getType("Node").createProperty("code", Type.STRING);
+    database.getSchema().createVertexType("Entity").addSuperType("Node");
+    database.getSchema().createVertexType("Other").addSuperType("Node");
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Node", "id");
+    // Non-unique, so the same code can legitimately be carried by records of two different child types.
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Node", "code");
+
+    // The same shape on the relationship side: LINK <- SUBLINK, with the index declared on the parent.
+    database.getSchema().createEdgeType("LINK").createProperty("tag", Type.STRING);
+    database.getSchema().createEdgeType("SUBLINK").addSuperType("LINK");
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "LINK", "tag");
+
+    database.transaction(() -> {
+      database.newVertex("Entity").set("id", "foo-1").save();
+      database.newVertex("Entity").set("id", "foo-2").save();
+      // Same property, same index, different concrete types.
+      database.newVertex("Node").set("id", "bar-1").save();
+      database.newVertex("Other").set("id", "baz-1").set("code", "shared").save();
+      for (int i = 0; i < 64; i++)
+        database.newVertex("Entity").set("id", "decoy-" + i).save();
+    });
+
+    database.transaction(() -> {
+      final MutableVertex from = (MutableVertex) database.lookupByKey("Entity", "id", "foo-1").next().asVertex().modify();
+      final MutableVertex to = (MutableVertex) database.lookupByKey("Entity", "id", "foo-2").next().asVertex().modify();
+      from.newEdge("SUBLINK", to, "tag", "sub").save();
+      from.newEdge("LINK", to, "tag", "parent").save();
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void anEqualityPredicateOnAChildTypeUsesTheInheritedIndex() {
+    assertThat(cypher("MATCH (e:Entity) WHERE e.id = 'foo-1' RETURN e.id AS value")).containsExactly("foo-1");
+    assertSqlParity("MATCH (e:Entity) WHERE e.id = 'foo-1' RETURN e.id AS value",
+        "SELECT id AS value FROM Entity WHERE id = 'foo-1'");
+    assertThat(planOf("MATCH (e:Entity) WHERE e.id = 'foo-1' RETURN e.id AS value"))
+        .as("the inherited Node[id] index must be seekable from the child type")
+        .contains("NodeIndexSeek");
+  }
+
+  @Test
+  void anInlinePropertyOnAChildTypeUsesTheInheritedIndex() {
+    assertThat(cypher("MATCH (e:Entity {id: 'foo-2'}) RETURN e.id AS value")).containsExactly("foo-2");
+    assertThat(planOf("MATCH (e:Entity {id: 'foo-2'}) RETURN e.id AS value")).contains("NodeIndexSeek");
+  }
+
+  @Test
+  void anInListPredicateOnAChildTypeUsesTheInheritedIndex() {
+    assertThat(cypher("MATCH (e:Entity) WHERE e.id IN ['foo-1', 'foo-2'] RETURN e.id AS value ORDER BY value"))
+        .containsExactly("foo-1", "foo-2");
+    assertSqlParity("MATCH (e:Entity) WHERE e.id IN ['foo-1', 'foo-2'] RETURN e.id AS value ORDER BY value",
+        "SELECT id AS value FROM Entity WHERE id IN ['foo-1', 'foo-2'] ORDER BY id");
+    assertThat(planOf("MATCH (e:Entity) WHERE e.id IN ['foo-1', 'foo-2'] RETURN e.id AS value")).contains("NodeIndexSeek");
+  }
+
+  @Test
+  void aParameterizedInListOnAChildTypeUsesTheInheritedIndex() {
+    assertThat(cypher("MATCH (e:Entity) WHERE e.id IN $ids RETURN e.id AS value ORDER BY value",
+        Map.of("ids", List.of("foo-1", "foo-2")))).containsExactly("foo-1", "foo-2");
+  }
+
+  @Test
+  void aSeekOnTheInheritedIndexNeverReturnsARecordOfAnotherType() {
+    // bar-1 is a Node and baz-1 an Other: both are in the very index the Entity seek reads, and neither is
+    // an Entity. This is the check the SQL plan spells as FILTER ITEMS BY TYPE.
+    assertThat(cypher("MATCH (e:Entity) WHERE e.id = 'bar-1' RETURN e.id AS value")).isEmpty();
+    assertThat(cypher("MATCH (e:Entity {id: 'bar-1'}) RETURN e.id AS value")).isEmpty();
+    assertThat(cypher("MATCH (e:Entity) WHERE e.id IN ['foo-1', 'bar-1', 'baz-1'] RETURN e.id AS value ORDER BY value"))
+        .containsExactly("foo-1");
+    assertSqlParity("MATCH (e:Entity) WHERE e.id IN ['foo-1', 'bar-1', 'baz-1'] RETURN e.id AS value ORDER BY value",
+        "SELECT id AS value FROM Entity WHERE id IN ['foo-1', 'bar-1', 'baz-1'] ORDER BY id");
+  }
+
+  @Test
+  void aSeekOnTheParentTypeStillSeesEveryChildRecord() {
+    assertThat(cypher("MATCH (n:Node) WHERE n.id IN ['foo-1', 'bar-1', 'baz-1'] RETURN n.id AS value ORDER BY value"))
+        .as("the parent type is polymorphic: its own records and every child's satisfy (n:Node)")
+        .containsExactly("bar-1", "baz-1", "foo-1");
+    assertSqlParity("MATCH (n:Node) WHERE n.id IN ['foo-1', 'bar-1', 'baz-1'] RETURN n.id AS value ORDER BY value",
+        "SELECT id AS value FROM Node WHERE id IN ['foo-1', 'bar-1', 'baz-1'] ORDER BY id");
+  }
+
+  @Test
+  void aMergeOnAChildTypeUsesTheInheritedIndexWithoutMatchingAnotherType() {
+    // code 'shared' is carried by an Other, not by an Entity, so MERGE must CREATE an Entity rather than
+    // adopt it - which is what a polymorphic index seek without the label filter would have done.
+    database.transaction(() -> query("opencypher", "MERGE (e:Entity {code: 'shared'})"));
+    assertThat(cypher("MATCH (e:Entity) WHERE e.code = 'shared' RETURN e.code AS value")).containsExactly("shared");
+    assertThat(cypher("MATCH (n:Node) WHERE n.code = 'shared' RETURN n.code AS value"))
+        .as("the pre-existing Other and the newly merged Entity both answer (n:Node)")
+        .containsExactly("shared", "shared");
+
+    // A second MERGE finds the Entity the first one created and must not add another.
+    database.transaction(() -> query("opencypher", "MERGE (e:Entity {code: 'shared'})"));
+    assertThat(cypher("MATCH (e:Entity) WHERE e.code = 'shared' RETURN e.code AS value")).containsExactly("shared");
+  }
+
+  @Test
+  void anEdgePredicateOnAChildEdgeTypeUsesTheInheritedIndex() {
+    // A relationship pattern matches the type it names and its subtypes, never its ancestors: the LINK edge
+    // tagged 'parent' lives in the very index the SUBLINK seek reads and must not answer (r:SUBLINK).
+    assertThat(cypher("MATCH (a)-[r:SUBLINK]->(b) WHERE r.tag = 'sub' RETURN r.tag AS value")).containsExactly("sub");
+    assertThat(cypher("MATCH (a)-[r:SUBLINK]->(b) WHERE r.tag = 'parent' RETURN r.tag AS value")).isEmpty();
+    assertThat(cypher("MATCH (a)-[r:LINK]->(b) WHERE r.tag = 'sub' RETURN r.tag AS value"))
+        .as("the parent edge type is polymorphic, so a SUBLINK edge answers (r:LINK)")
+        .containsExactly("sub");
+  }
+
+  @Test
+  void aChainedMatchOnAChildTypeUsesTheInheritedIndex() {
+    // UNWIND ... MATCH routes through MatchNodeStep's WHERE-driven lookup rather than the optimizer's seek.
+    assertThat(cypher("UNWIND ['foo-1', 'bar-1'] AS wanted MATCH (e:Entity) WHERE e.id = wanted RETURN e.id AS value"))
+        .as("the row-driven lookup must use the inherited index and still reject the Node record")
+        .containsExactly("foo-1");
+  }
+
+  private void query(final String language, final String command) {
+    try (final ResultSet resultSet = database.command(language, command)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+    }
+  }
+
+  private void assertSqlParity(final String cypherQuery, final String sqlQuery) {
+    assertThat(cypher(cypherQuery))
+        .as("the Cypher engine must agree with SQL: %s", cypherQuery)
+        .isEqualTo(values(database.query("sql", sqlQuery)));
+  }
+
+  private List<String> cypher(final String query) {
+    return values(database.query("opencypher", query));
+  }
+
+  private List<String> cypher(final String query, final Map<String, Object> parameters) {
+    return values(database.query("opencypher", query, parameters));
+  }
+
+  private String planOf(final String query) {
+    try (final ResultSet resultSet = database.query("opencypher", "PROFILE " + query)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      return resultSet.getExecutionPlan().orElseThrow().prettyPrint(0, 2);
+    }
+  }
+
+  private static List<String> values(final ResultSet resultSet) {
+    final List<String> values = new ArrayList<>();
+    try (resultSet) {
+      while (resultSet.hasNext())
+        values.add(String.valueOf(resultSet.next().<Object>getProperty("value")));
+    }
+    return values;
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -416,9 +416,13 @@ public class PostgresNetworkExecutor extends Thread {
         answerWithColumns(portal);
       } else if (portal.isExpectingResult && portal.columns != null) {
         // Already materialized: a synthetic answer fixed at PARSE (SHOW/system/catalog), or a portal a
-        // previous Describe/Execute already ran.
-        if (portal.executed && portal.fullResultSet != null)
-          resolvePortalColumns(portal);
+        // previous Describe/Execute already ran. Its columns are answered as they stand rather than
+        // re-derived: the rows they came from cannot have changed - the portal is run exactly once - so a
+        // rescan of fullResultSet could only produce the same map, and where it would NOT, it would be
+        // wrong to: a shape promised by an earlier Describe('S') (portal.columnsDescribed) is a contract
+        // executeCommand() already refuses to re-derive, since a schemaless property can type differently
+        // per row and a client that negotiated binary transfer off the promise cannot have it swapped
+        // underneath (issue #6725).
         answerWithColumns(portal);
       } else
         // In practice, SAVEPOINT/RELEASE/ROLLBACK TO/SET and nothing else (issue #6930): they are the only

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -421,8 +421,12 @@ public class PostgresNetworkExecutor extends Thread {
           resolvePortalColumns(portal);
         answerWithColumns(portal);
       } else
-        // No rows are coming: an INSERT/UPDATE/DELETE portal, or SAVEPOINT/RELEASE/ROLLBACK TO/SET, which
-        // carry no statement and never produce a result (issue #6930).
+        // In practice, SAVEPOINT/RELEASE/ROLLBACK TO/SET and nothing else (issue #6930): they are the only
+        // portals that carry no statement, never produce a result, and never get columns. An INSERT/UPDATE/
+        // DELETE does NOT land here - it is run by the first arm and announced under whatever columns its
+        // rows carried, empty ones included, exactly like the {cypher} write with no RETURN. The arm is kept
+        // general rather than written as `ignoreExecution` because it is also the backstop that keeps the
+        // reply count right: whatever state a portal reaches Describe in, it leaves with exactly one answer.
         writeNoData();
     } else if (type == 'S') {
       // Describe Statement: send ParameterDescription followed by RowDescription/NoData

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -393,51 +393,39 @@ public class PostgresNetworkExecutor extends Thread {
     }
 
     if (type == 'P') {
-      if (portal.sqlStatement != null) {
-        if (!portal.executed) {
-          // Guarded so a second Describe('P') on the same portal (or one arriving after an Execute already
-          // ran the statement) reuses the materialized result instead of running the statement again - issue
-          // #6458's follow-up Execute(s) depend on this same fullResultSet being run exactly once.
-          final Object[] parameters = portal.parameterValues != null ? portal.parameterValues.toArray() : new Object[0];
-          final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
-          final ResultSet resultSet;
-          try {
-            resultSet = portal.sqlStatement.execute(database, parameters, createCommandContext());
-          } finally {
-            QueryMetricsRecorder.Holder.record(metricsStart, database.getName(), portal.language, "command");
-          }
-          portal.executed = true;
-          if (portal.isExpectingResult)
-            // Materializes the whole result now (issue #6458): Describe needs every row's columns, not just
-            // the first, to catch a property that only shows up on a later row (documents can be sparse) -
-            // and the portal keeps this list so the Execute(s) that follow slice it by their own row-limit
-            // instead of re-running the statement or losing what Describe already had to read.
-            portal.fullResultSet = browseAndCacheResultSet(resultSet, 0);
-        }
-        if (portal.isExpectingResult) {
-          final List<Result> forColumns = portal.fullResultSet != null ? portal.fullResultSet : Collections.emptyList();
-          portal.columns = getColumns(forColumns, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
-          if (portal.columns.isEmpty() && forColumns.isEmpty()) {
-            final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
-                getParams(portal), portal.sqlStatement);
-            if (schemaColumns != null)
-              portal.columns = schemaColumns;
-          }
-          writeRowDescription(portal.columns, portal.resultFormats);
-          portal.rowDescriptionSent = true;
-        } else
-          writeNoData();
-      } else {
-        if (portal.columns != null) {
-          writeRowDescription(portal.columns, portal.resultFormats);
-          portal.rowDescriptionSent = true;
-        } else if (portal.ignoreExecution)
-          // SAVEPOINT/RELEASE/ROLLBACK TO/SET: no statement AND no result ever coming, so Describe still owes
-          // exactly one reply (issue #6930). A non-"sql" language (e.g. cypher) also has no statement here, but
-          // unlike these it DOES expect a result once executed - its columns just are not known yet at Describe
-          // time, so it is deliberately left out of this branch rather than answered with a premature NoData.
-          writeNoData();
-      }
+      // Every Describe is owed exactly one reply - RowDescription or NoData - and a client counting one reply
+      // per request desynchronizes on anything else, so the three arms below are exhaustive by construction
+      // (issue #6996). Which one applies is decided by whether rows are still coming, NOT by whether PARSE
+      // left a parsed SQL statement behind: a portal in a non-"sql" language (cypher/gremlin/graphql) and a
+      // catalog query whose filters are bound parameters both arrive here with no statement and no columns,
+      // and both do produce rows.
+      if (portal.isExpectingResult && !portal.executed && !portal.ignoreExecution) {
+        // Runs the query now and answers from the rows it actually produced - the truthful answer, and the
+        // only one available for a language whose columns no schema resolution can name ahead of execution.
+        // Guarded on !executed so a second Describe('P') on the same portal (or one arriving after an Execute
+        // already ran it) reuses the materialized result instead of running it again: issue #6458's follow-up
+        // Execute(s) depend on this same fullResultSet being run exactly once.
+        final ResultSet resultSet = runPortalQuery(portal);
+        portal.executed = true;
+        // Materializes the whole result now (issue #6458): Describe needs every row's columns, not just the
+        // first, to catch a property that only shows up on a later row (documents can be sparse) - and the
+        // portal keeps this list so the Execute(s) that follow slice it by their own row-limit instead of
+        // re-running the statement or losing what Describe already had to read.
+        portal.fullResultSet = browseAndCacheResultSet(resultSet, 0);
+        resolvePortalColumns(portal);
+        writeRowDescription(portal.columns, portal.resultFormats);
+        portal.rowDescriptionSent = true;
+      } else if (portal.isExpectingResult && portal.columns != null) {
+        // Already materialized: a synthetic answer fixed at PARSE (SHOW/system/catalog), or a portal a
+        // previous Describe/Execute already ran.
+        if (portal.executed && portal.fullResultSet != null)
+          resolvePortalColumns(portal);
+        writeRowDescription(portal.columns, portal.resultFormats);
+        portal.rowDescriptionSent = true;
+      } else
+        // No rows are coming: an INSERT/UPDATE/DELETE portal, or SAVEPOINT/RELEASE/ROLLBACK TO/SET, which
+        // carry no statement and never produce a result (issue #6930).
+        writeNoData();
     } else if (type == 'S') {
       // Describe Statement: send ParameterDescription followed by RowDescription/NoData
       // This tells the client how many parameters the prepared statement expects
@@ -465,6 +453,55 @@ public class PostgresNetworkExecutor extends Thread {
       }
     } else
       throw new PostgresProtocolException("Unexpected describe type '" + type + "'");
+  }
+
+  /**
+   * Runs a portal's query, whichever of the three forms PARSE left it in, and returns its result set.
+   * <p>
+   * Shared by {@code Describe('P')} and {@code Execute} so a portal is run exactly once no matter which of
+   * the two reaches it first (issue #6996): the other finds {@code portal.executed} already true and reads
+   * what this left behind. Before the split existed, Describe could only run the parsed-SQL form, so a portal
+   * in another language had no columns to announce and was answered with nothing at all.
+   */
+  private ResultSet runPortalQuery(final PostgresPortal portal) {
+    if (portal.catalogQuery) {
+      // Deferred from parseCommand because the query's filters are bound parameters (issue #6412).
+      final CatalogAnswer catalogAnswer = handleCatalogQuery(portal.query, getParams(portal));
+      if (catalogAnswer != null)
+        portal.columns = catalogAnswer.columns();
+      return new IteratorResultSet(
+          (catalogAnswer != null ? catalogAnswer.rows() : Collections.<Result>emptyList()).iterator());
+    }
+
+    if (portal.sqlStatement == null)
+      // No parsed statement: a non-"sql" language (cypher/gremlin/graphql) goes straight to its own engine.
+      return database.command(portal.language, portal.query, server.getConfiguration(), getParams(portal));
+
+    final Object[] parameters = portal.parameterValues != null ? portal.parameterValues.toArray() : new Object[0];
+    final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return portal.sqlStatement.execute(database, parameters, createCommandContext());
+    } finally {
+      QueryMetricsRecorder.Holder.record(metricsStart, database.getName(), portal.language, "command");
+    }
+  }
+
+  /**
+   * Resolves the columns a materialized portal must be announced under, from the rows it actually produced.
+   * A catalog answer keeps its own columns, which are fixed by the catalog table being emulated rather than
+   * by whichever rows happened to match; a query that came back empty falls back to the schema, so a client
+   * probing a shape with {@code WHERE 1=0} or {@code LIMIT 0} still gets a typed result set.
+   */
+  private void resolvePortalColumns(final PostgresPortal portal) {
+    final List<Result> rows = portal.fullResultSet != null ? portal.fullResultSet : Collections.emptyList();
+    if (!portal.catalogQuery || portal.columns == null)
+      portal.columns = getColumns(rows, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
+    if (portal.columns.isEmpty() && rows.isEmpty()) {
+      final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
+          getParams(portal), portal.sqlStatement);
+      if (schemaColumns != null)
+        portal.columns = schemaColumns;
+    }
   }
 
   private void executeCommand() {
@@ -502,25 +539,7 @@ public class PostgresNetworkExecutor extends Thread {
       else {
         if (!portal.executed) {
           final long engineStart = System.nanoTime();
-          ResultSet resultSet;
-          if (portal.catalogQuery) {
-            // Deferred from parseCommand because the query's filters are bound parameters (issue #6412).
-            final CatalogAnswer catalogAnswer = handleCatalogQuery(portal.query, getParams(portal));
-            resultSet = new IteratorResultSet(
-                (catalogAnswer != null ? catalogAnswer.rows() : Collections.<Result>emptyList()).iterator());
-            if (catalogAnswer != null)
-              portal.columns = catalogAnswer.columns();
-          } else if (portal.sqlStatement != null) {
-            final Object[] parameters = portal.parameterValues != null ? portal.parameterValues.toArray() : new Object[0];
-            final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
-            try {
-              resultSet = portal.sqlStatement.execute(database, parameters, createCommandContext());
-            } finally {
-              QueryMetricsRecorder.Holder.record(metricsStart, database.getName(), portal.language, "command");
-            }
-          } else {
-            resultSet = database.command(portal.language, portal.query, server.getConfiguration(), getParams(portal));
-          }
+          final ResultSet resultSet = runPortalQuery(portal);
           portal.executed = true;
           if (portal.isExpectingResult) {
             // Materializes the whole result now (issue #6458), the same way Describe('P') does: a client that
@@ -540,16 +559,7 @@ public class PostgresNetworkExecutor extends Thread {
               // mark this portal as having satisfied it, matching real PostgreSQL - a portal never gets a
               // second RowDescription once its statement was already Described.
               if (!portal.columnsDescribed) {
-                // A catalog answer already carries the columns it must be announced under (set on
-                // portal.columns above); only compute from the actual rows when there is none to fall back on.
-                if (!portal.catalogQuery || portal.columns == null)
-                  portal.columns = getColumns(portal.fullResultSet, resolveQueryTargetType(portal), resolveAliasToSourceProperty(portal));
-                if (portal.columns.isEmpty() && portal.fullResultSet.isEmpty()) {
-                  final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
-                      getParams(portal), portal.sqlStatement);
-                  if (schemaColumns != null)
-                    portal.columns = schemaColumns;
-                }
+                resolvePortalColumns(portal);
                 writeRowDescription(portal.columns, portal.resultFormats);
               }
               portal.rowDescriptionSent = true;

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -413,15 +413,13 @@ public class PostgresNetworkExecutor extends Thread {
         // re-running the statement or losing what Describe already had to read.
         portal.fullResultSet = browseAndCacheResultSet(resultSet, 0);
         resolvePortalColumns(portal);
-        writeRowDescription(portal.columns, portal.resultFormats);
-        portal.rowDescriptionSent = true;
+        answerWithColumns(portal);
       } else if (portal.isExpectingResult && portal.columns != null) {
         // Already materialized: a synthetic answer fixed at PARSE (SHOW/system/catalog), or a portal a
         // previous Describe/Execute already ran.
         if (portal.executed && portal.fullResultSet != null)
           resolvePortalColumns(portal);
-        writeRowDescription(portal.columns, portal.resultFormats);
-        portal.rowDescriptionSent = true;
+        answerWithColumns(portal);
       } else
         // No rows are coming: an INSERT/UPDATE/DELETE portal, or SAVEPOINT/RELEASE/ROLLBACK TO/SET, which
         // carry no statement and never produce a result (issue #6930).
@@ -453,6 +451,27 @@ public class PostgresNetworkExecutor extends Thread {
       }
     } else
       throw new PostgresProtocolException("Unexpected describe type '" + type + "'");
+  }
+
+  /**
+   * Answers a {@code Describe('P')} on a portal whose result is already materialized, under the columns
+   * {@link #resolvePortalColumns} named for it.
+   * <p>
+   * <b>An empty column set is announced as a zero-field {@code RowDescription}, not as {@code NoData}</b>,
+   * and that is deliberate. {@code NoData} promises the portal will return no result set at all, which
+   * pgjdbc holds it to: {@code executeQuery()} on a portal described that way throws "No results were
+   * returned by the query" rather than yielding an empty result. Only two things reach here with no column
+   * to name - a command with nothing to return ({@code {cypher} CREATE (n)}) and a query whose rows simply
+   * did not match, an unmodelled catalog relation included (issue #6412, pinned by
+   * {@code Issue6412CatalogIT.anUnmodelledCatalogRelationIsDeclinedRatherThanGuessedAt}) - and for a
+   * language this server does not parse, nothing distinguishes them: the row count cannot, since both come
+   * back empty, and the query text cannot without a parser per language. Announcing an empty result set is
+   * the answer that is merely uninformative for the first and correct for the second; {@code NoData} would
+   * be correct for the first and would BREAK the second.
+   */
+  private void answerWithColumns(final PostgresPortal portal) {
+    writeRowDescription(portal.columns, portal.resultFormats);
+    portal.rowDescriptionSent = true;
   }
 
   /**

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6996DescribeNonSqlLanguagePortalIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6996DescribeNonSqlLanguagePortalIT.java
@@ -52,6 +52,12 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
  * done - and answers from the rows it actually produced, so the announced shape is the real one. The run is
  * shared with {@code Execute}, so the query is still executed exactly once per portal however the client
  * orders the two messages; {@code aWriteCommandDescribedThenExecutedRunsExactlyOnce} pins that.
+ * <p>
+ * A portal that names no column at all is still announced as an (empty) {@code RowDescription} rather than
+ * {@code NoData} - see {@code PostgresNetworkExecutor.answerWithColumns}. The two tests below that reach
+ * that state, a write with nothing to return and a query that matched nothing, are indistinguishable from
+ * each other on this side of the wire, and {@code NoData} is only correct for the first: it promises no
+ * result set at all, which pgjdbc holds the server to.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -111,7 +117,11 @@ class Issue6996DescribeNonSqlLanguagePortalIT extends PostgresWireProtocolTestBa
       final WireMessage describeReply = readWireMessage(in);
       assertThat(describeReply.type())
           .as("one reply, whatever the row count: silence is what desynchronizes the client")
-          .isIn('T', 'n');
+          .isEqualTo('T');
+      assertThat(fieldNamesOf(describeReply))
+          .as("a query that matched nothing names no column: the columns come from the rows, and the schema "
+              + "fallback behind them (issues #6156/#6185) reads the SQL parser, so it cannot answer for {cypher}")
+          .isEmpty();
       assertThat(readWireMessage(in).type()).isEqualTo('Z');
 
       // No rows, so Execute answers with the command tag alone, and the connection stays in sync.
@@ -153,6 +163,47 @@ class Issue6996DescribeNonSqlLanguagePortalIT extends PostgresWireProtocolTestBa
   }
 
   /**
+   * A {@code {cypher}} write with no {@code RETURN} produces no row, so the Describe has no column to name.
+   * It is still answered with an (empty) {@code RowDescription} rather than {@code NoData} - see
+   * {@code PostgresNetworkExecutor.answerWithColumns} for why: {@code NoData} promises no result set at all,
+   * and nothing distinguishes this portal from a query whose rows merely did not match, which pgjdbc's
+   * {@code executeQuery()} would then reject outright.
+   */
+  @Test
+  @DisplayName("[#6996] Describe(P) on a {cypher} write with no RETURN is still answered exactly once")
+  void aWriteWithNothingToReturnIsStillAnsweredExactlyOnce() throws Exception {
+    withConnection((out, in) -> {
+      runSimpleQuery(out, in, "CREATE VERTEX TYPE V6996NoReturn IF NOT EXISTS");
+
+      sendParse(out, "{cypher} CREATE (n:V6996NoReturn {name: 'silent'})");
+      sendBind(out);
+      sendDescribePortal(out);
+      sendSync(out);
+
+      assertThat(readWireMessage(in).type()).isEqualTo('1');
+      assertThat(readWireMessage(in).type()).isEqualTo('2');
+      final WireMessage describeReply = readWireMessage(in);
+      assertThat(describeReply.type())
+          .as("a write with nothing to return is owed a reply like any other portal")
+          .isEqualTo('T');
+      assertThat(fieldNamesOf(describeReply))
+          .as("and it names no column, because the command returns none")
+          .isEmpty();
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      // The Execute that follows answers CommandComplete alone: no rows, and no second RowDescription.
+      sendExecute(out);
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('C');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      assertThat(rowCountOf(out, in, "SELECT count(*) AS total FROM V6996NoReturn"))
+          .as("and the write happened exactly once, at Describe")
+          .isEqualTo(1);
+    });
+  }
+
+  /**
    * The simple-query ('Q') form of the same {@code {cypher}} query, which has always worked: the extended
    * protocol's answer above must carry the same column.
    */
@@ -188,6 +239,10 @@ class Issue6996DescribeNonSqlLanguagePortalIT extends PostgresWireProtocolTestBa
       sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
       readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
 
+      // A hang detector, not a latency bound: the bug under test is a reply the server never sends, which
+      // leaves the client blocked in readFully() forever. Only a preemptive timeout can end that - a
+      // stopwatch cannot interrupt a blocked socket read, and neither can @Timeout's default thread mode -
+      // so it is sized generously (a stall inside it cannot turn a passing run red) rather than tightly.
       assertTimeoutPreemptively(Duration.ofSeconds(30), () -> exchange.run(out, in));
     }
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6996DescribeNonSqlLanguagePortalIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6996DescribeNonSqlLanguagePortalIT.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression test for issue #6996, the half of #6930 that stayed unanswered: a portal whose query names a
+ * language other than {@code "sql"} - {@code {cypher} MATCH ...} and friends - reaches {@code Describe('P')}
+ * with no parsed SQL statement and no columns, and used to be answered with NOTHING at all.
+ * <p>
+ * The protocol has no such reply. Every {@code Describe} is owed exactly one of {@code RowDescription} or
+ * {@code NoData}, so a client that counts one reply per request (pgjdbc does) consumed the {@code Execute}'s
+ * own {@code RowDescription} as the answer to its pending {@code Describe} and read every later reply on the
+ * connection one message off.
+ * <p>
+ * {@code NoData} would have kept the stream aligned but lied: a {@code {cypher}} portal does produce rows.
+ * The fix runs the portal at {@code Describe} time - which is exactly what the parsed-SQL form has always
+ * done - and answers from the rows it actually produced, so the announced shape is the real one. The run is
+ * shared with {@code Execute}, so the query is still executed exactly once per portal however the client
+ * orders the two messages; {@code aWriteCommandDescribedThenExecutedRunsExactlyOnce} pins that.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6996DescribeNonSqlLanguagePortalIT extends PostgresWireProtocolTestBase {
+
+  @Test
+  @DisplayName("[#6996] Describe(P) on a {cypher} portal answers RowDescription with the real columns")
+  void cypherPortalDescribeIsAnsweredWithTheColumnsItWillReturn() throws Exception {
+    withConnection((out, in) -> {
+      runSimpleQuery(out, in, "CREATE VERTEX TYPE V6996 IF NOT EXISTS");
+      runSimpleQuery(out, in, "INSERT INTO V6996 SET name = 'alice'");
+
+      // Sync BEFORE Execute, so the Describe's reply cannot be confused with the Execute's own
+      // RowDescription: this is the exchange that makes the missing reply observable at all. Sent in one
+      // message batch and read afterwards, the two are indistinguishable - '1','2','T','D','C','Z' either
+      // way - which is exactly the accidental compensation the issue describes.
+      sendParse(out, "{cypher} MATCH (n:V6996) RETURN n.name AS name");
+      sendBind(out);
+      sendDescribePortal(out);
+      sendSync(out);
+
+      assertThat(readWireMessage(in).type()).isEqualTo('1'); // ParseComplete
+      assertThat(readWireMessage(in).type()).isEqualTo('2'); // BindComplete
+
+      final WireMessage describeReply = readWireMessage(in);
+      assertThat(describeReply.type())
+          .as("Describe('P') on a {cypher} portal must answer RowDescription, not silence and not NoData")
+          .isEqualTo('T');
+      assertThat(fieldNamesOf(describeReply))
+          .as("and the shape it announces must be the one the rows actually carry")
+          .containsExactly("name");
+      assertThat(readWireMessage(in).type()).isEqualTo('Z'); // ReadyForQuery
+
+      // Execute must NOT re-announce the shape: the portal was already described.
+      sendExecute(out);
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('D');
+      assertThat(readWireMessage(in).type()).isEqualTo('C');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+    });
+  }
+
+  @Test
+  @DisplayName("[#6996] A {cypher} portal returning no row still answers Describe(P) exactly once")
+  void anEmptyCypherResultStillGetsExactlyOneDescribeReply() throws Exception {
+    withConnection((out, in) -> {
+      runSimpleQuery(out, in, "CREATE VERTEX TYPE V6996Empty IF NOT EXISTS");
+
+      sendParse(out, "{cypher} MATCH (n:V6996Empty) RETURN n.name AS name");
+      sendBind(out);
+      sendDescribePortal(out);
+      sendSync(out);
+
+      assertThat(readWireMessage(in).type()).isEqualTo('1');
+      assertThat(readWireMessage(in).type()).isEqualTo('2');
+
+      final WireMessage describeReply = readWireMessage(in);
+      assertThat(describeReply.type())
+          .as("one reply, whatever the row count: silence is what desynchronizes the client")
+          .isIn('T', 'n');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      // No rows, so Execute answers with the command tag alone, and the connection stays in sync.
+      sendExecute(out);
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('C');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+    });
+  }
+
+  @Test
+  @DisplayName("[#6996] Describe(P)+Execute of a {cypher} write command runs it exactly once")
+  void aWriteCommandDescribedThenExecutedRunsExactlyOnce() throws Exception {
+    withConnection((out, in) -> {
+      runSimpleQuery(out, in, "CREATE VERTEX TYPE V6996Write IF NOT EXISTS");
+
+      sendParse(out, "{cypher} CREATE (n:V6996Write {name: 'once'}) RETURN n.name AS name");
+      sendBind(out);
+      sendDescribePortal(out);
+      sendSync(out);
+
+      assertThat(readWireMessage(in).type()).isEqualTo('1');
+      assertThat(readWireMessage(in).type()).isEqualTo('2');
+      assertThat(readWireMessage(in).type())
+          .as("the write is run once, at Describe, and its own rows describe it")
+          .isEqualTo('T');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      sendExecute(out);
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('D');
+      assertThat(readWireMessage(in).type()).isEqualTo('C');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      // The Execute that followed the Describe must have replayed the materialized result rather than
+      // running the CREATE a second time.
+      assertThat(rowCountOf(out, in, "SELECT count(*) AS total FROM V6996Write")).isEqualTo(1);
+    });
+  }
+
+  /**
+   * The simple-query ('Q') form of the same {@code {cypher}} query, which has always worked: the extended
+   * protocol's answer above must carry the same column.
+   */
+  @Test
+  @DisplayName("[#6996] The extended protocol announces the same columns the simple query does")
+  void theSimpleQueryFormAgrees() throws Exception {
+    withConnection((out, in) -> {
+      runSimpleQuery(out, in, "CREATE VERTEX TYPE V6996Simple IF NOT EXISTS");
+      runSimpleQuery(out, in, "INSERT INTO V6996Simple SET name = 'bob'");
+
+      sendSimpleQuery(out, "{cypher} MATCH (n:V6996Simple) RETURN n.name AS name");
+      WireMessage message = readWireMessage(in);
+      while (message.type() != 'T' && message.type() != 'Z')
+        message = readWireMessage(in);
+      assertThat(message.type()).isEqualTo('T');
+      assertThat(fieldNamesOf(message)).containsExactly("name");
+      drainToReadyForQuery(in);
+    });
+  }
+
+  private interface Exchange {
+    void run(DataOutputStream out, DataInputStream in) throws Exception;
+  }
+
+  private void withConnection(final Exchange exchange) throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+
+      assertTimeoutPreemptively(Duration.ofSeconds(30), () -> exchange.run(out, in));
+    }
+  }
+
+  /**
+   * Runs one simple query and drains its replies up to ReadyForQuery.
+   */
+  private static void runSimpleQuery(final DataOutputStream out, final DataInputStream in, final String query)
+      throws Exception {
+    sendSimpleQuery(out, query);
+    drainToReadyForQuery(in);
+  }
+
+  /**
+   * Runs a one-row, one-column count query over the simple protocol and returns the number it answered.
+   */
+  private static long rowCountOf(final DataOutputStream out, final DataInputStream in, final String query)
+      throws Exception {
+    sendSimpleQuery(out, query);
+    long count = -1;
+    while (true) {
+      final WireMessage message = readWireMessage(in);
+      if (message.type() == 'Z')
+        break;
+      if (message.type() == 'D')
+        count = Long.parseLong(firstColumnOf(message));
+    }
+    return count;
+  }
+
+  private static void drainToReadyForQuery(final DataInputStream in) throws Exception {
+    while (readWireMessage(in).type() != 'Z')
+      ;
+  }
+
+  private static void sendSimpleQuery(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, query);
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('Q');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // unnamed statement
+    writeCString(body, query);
+    body.write(0);
+    body.write(0); // int16 numParamDataTypes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('P');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendBind(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    writeCString(body, ""); // statement name
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0
+    body.write(0);
+    body.write(0); // int16 numParamValues = 0
+    body.write(0);
+    body.write(0); // int16 numResultFormatCodes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('B');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendDescribePortal(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    body.write('P'); // describe a portal, not a prepared statement
+    writeCString(body, ""); // unnamed portal
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('D');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendExecute(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0); // int32 limit = 0 (no limit)
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('E');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendSync(final DataOutputStream out) throws Exception {
+    out.writeByte('S');
+    out.writeInt(4);
+    out.flush();
+  }
+
+  /**
+   * A {@code RowDescription} body is an int16 field count followed by one null-terminated name and six
+   * fixed-width fields per column.
+   */
+  private static List<String> fieldNamesOf(final WireMessage message) {
+    final ByteBuffer buffer = ByteBuffer.wrap(message.body());
+    final int fields = buffer.getShort() & 0xFFFF;
+    final List<String> names = new ArrayList<>(fields);
+    for (int i = 0; i < fields; i++) {
+      names.add(readCString(buffer));
+      buffer.position(buffer.position() + 18); // tableOid, columnIndex, typeOid, typeSize, typeModifier, format
+    }
+    return names;
+  }
+
+  /**
+   * A {@code DataRow} body is an int16 column count followed by, per column, an int32 length and its bytes.
+   */
+  private static String firstColumnOf(final WireMessage message) {
+    final ByteBuffer buffer = ByteBuffer.wrap(message.body());
+    buffer.getShort(); // column count
+    final int length = buffer.getInt();
+    final byte[] value = new byte[length];
+    buffer.get(value);
+    return new String(value, StandardCharsets.UTF_8);
+  }
+
+  private static String readCString(final ByteBuffer buffer) {
+    final StringBuilder text = new StringBuilder();
+    for (byte b = buffer.get(); b != 0; b = buffer.get())
+      text.append((char) (b & 0xFF));
+    return text.toString();
+  }
+
+  private record WireMessage(char type, byte[] body) {
+  }
+
+  private static WireMessage readWireMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] body = new byte[length - 4];
+    in.readFully(body);
+    return new WireMessage((char) type, body);
+  }
+}


### PR DESCRIPTION
Fixes #6996, fixes #7021, fixes #7017.

> [!NOTE]
> This PR was stacked on #7016 (issue #7009), which introduced the `HopBounds` type the #7017 fix builds on. **#7016 has now merged**, and this branch has been rebased onto `main`: the diff is this PR's own commits only, and the conflict its squash-merge created is resolved. Re-verified after the rebase against main's new #7008/#7010/#6977 work, which touches the same edge-index and Cypher-executor code (95 tests across the affected classes, all green).

---

## #6996 - `Describe('P')` on a non-`"sql"`-language portal was answered with nothing

A portal whose query names another language (`{cypher}`, `{gremlin}`, `{graphql}`) reaches `Describe('P')` with no parsed SQL statement and no columns, and fell off the end of the `else if` without writing anything. The protocol has no such reply: every `Describe` is owed exactly one of `RowDescription` or `NoData`, so a client counting one reply per request (pgjdbc does) consumes the `Execute`'s own `RowDescription` as the answer to its pending `Describe` and reads every later reply on the connection one message off.

The issue proposed `writeNoData()` as the fallback and teaching `resolveEmptyResultSchemaColumns` about other languages as the preferred remedy. **Neither is what landed, and here is why a third option is better than both:**

- `NoData` keeps the stream aligned but lies - a `{cypher}` portal does produce rows - and a client that believed it would not decode the rows that follow.
- `resolveEmptyResultSchemaColumns` cannot serve a non-`sql` language even in principle: every shape it recognises is read off ArcadeDB's **SQL** AST (`SelectStatement`, `MatchStatement`, `Limit.isAlwaysEmpty`, `WhereClause.isAlwaysFalse`). Teaching it Cypher would mean a second static column resolver per language, each guessing a projection's shape.

**What landed:** the `Describe` **runs the portal and answers from the rows it actually produced** - exactly what the parsed-SQL arm immediately above has always done. The announced shape is the real one, by construction, for any language the engine can run. `runPortalQuery()` and `resolvePortalColumns()` are now shared with `Execute`, so a portal is still executed exactly once whichever message reaches it first, and the same restructuring answers the *deferred catalog query* (#6412) - which arrives here in the same stateless shape - instead of skipping it. The three `Describe('P')` arms are exhaustive by construction: rows coming → `RowDescription`, nothing coming → `NoData`.

`Issue6996DescribeNonSqlLanguagePortalIT` sends `Sync` **between** `Describe` and `Execute` on purpose: batched, the fixed and unfixed exchanges are byte-identical (`'1','2','T','D','C','Z'`), which is precisely the accidental client-side compensation the issue describes. Verified against the unfixed path: 3 of the 4 tests fail.

## #7021 - OpenCypher ignored an index inherited from a parent type

Confirmed, and the reported lead is right. SQL plans `FETCH FROM INDEX Node[id]` + `FILTER ITEMS BY TYPE Entity`; OpenCypher asked for `getAllIndexes(false)`, which answers only with the indexes a type declares **itself**, so `MATCH (e:Entity) WHERE e.id = ...` found no index and full-scanned the label.

The issue's alternative - "provide a workable mechanism for a concrete child-type index that can coexist" - is the one thing that should **not** change: refusing a child index on a property the parent already indexes is deliberate (#4083), because replacing it implicitly would take the index away from the parent type. With the seek working, the duplicate index is not wanted anyway - a `UNIQUE` index on the parent already covers every child bucket, which is why the child duplicate is redundant rather than missing.

All four discovery sites are polymorphic now - the optimizer's `StatisticsProvider`, `MatchNodeStep`'s inline-property and WHERE-driven lookups, `MergeStep`'s, and the edge-index rule in `CypherExecutionPlan` - and each pays for it with the filter SQL spells as `FILTER ITEMS BY TYPE`: a polymorphic index also carries the parent's own records and every sibling child's, which are not answers to `(n:Entity)`. `Labels.carriesLabel()` reads the type off the **bucket the RID names**, so a record of another type is rejected without being loaded. Two consequences worth calling out:

- **`MERGE` is a correctness case, not a performance one.** `MergeStep.findAllNodes()` re-verifies only the properties, so an unfiltered polymorphic seek would have adopted a record of the wrong type instead of creating one. Pinned by a test.
- Profiling output now names the index after the type that **declares** it - an inherited index reported under the queried type names an index that does not exist.

`Issue7021InheritedIndexTest` covers equality, inline property, `IN` list (literal and `$param`), the parent-type query, the `UNWIND`-driven lookup, `MERGE`, and an edge-type hierarchy, checking rows (against SQL) as well as plans. Verified against the unfixed code: 3 tests fail without the polymorphic discovery, 4 more without the label filter.

## #7017 - the zero-length self path ignored an explicit minimum

Settled by `HopBounds.acceptsSelfPath()`, **deliberately not `accepts(0)`**:

- **minimum of 0 or 1 hop → the zero-length path stands.** That is every minimum Neo4j accepts on a `shortestPath()` pattern at all (it rejects anything else outright), and what it answers for identical endpoints. The parser lowers a bare `[*]` to `minHops = 1`, so rejecting it would change the answer to `shortestPath((a)-[:R*]-(a))`, which `CypherReduceAndShortestPathTest.shortestPathSameNode` pins - so, answering question 1 in the issue: the existing pinned answer is **not** wrong, and it stays.
- **minimum above one hop → no row.** That is a pattern Neo4j would not have accepted, so it is read literally: zero hops is not in `[min, max]`. It is *not* re-interpreted as a request for the shortest cycle back to the source, which would be the same substitution the bound check already refuses for distinct endpoints (a shortest path below the declared minimum yields no row rather than a longer one that fits).

The new test's graph carries a 3-hop cycle through the endpoint, so the "no answer" cases are choosing not to return a cycle that exists rather than failing to find one. All four evaluators plus the expression form are covered; 5 of the 7 tests fail without the fix.

## Verification

- `Issue6996DescribeNonSqlLanguagePortalIT` - 4/4 green; 3 fail on the unfixed path.
- `Issue7021InheritedIndexTest` - 9/9 green; 7 fail across the two halves of the fix.
- `CypherShortestPathSelfPathBoundsIssue7017Test` - 7/7 green; 5 fail without the fix.
- Full OpenCypher suite (`com.arcadedb.query.opencypher.**`, TCK included): **9145 tests, 0 failures**.
- `postgresw` module ITs green, including #6930, #6458, #6412, #6543/45/48 and #6725.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cypher shortest-path queries support minimum, maximum, exact, and variable-length hop constraints, including zero-length paths.
  * Queries can use indexes inherited from parent vertex and edge types while returning only matching types.
  * PostgreSQL portal descriptions report column metadata for SQL, Cypher, catalog, and deferred queries.

* **Bug Fixes**
  * Improved type filtering for indexed node, edge, and `MERGE` lookups.
  * Fixed PostgreSQL portal response handling to prevent duplicate or missing metadata responses.
  * Corrected shortest-path handling for hop limits and zero-length self-paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
