### PR TITLE
fix(#7042): stop the deletion side of overlay re-application masking a live edge

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/olap/CSRAdjacencyIndex.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/CSRAdjacencyIndex.java
@@ -144,6 +144,33 @@ public class CSRAdjacencyIndex {
   }
 
   /**
+   * Returns how many forward (outgoing) edges {@code src -> tgt} this base CSR holds, i.e. the length of the
+   * run of parallel edges between the pair. Each node's neighbour slice is stored sorted, so the run is
+   * contiguous: a binary search followed by a walk to both of its ends.
+   * <p>
+   * Unlike {@link #hasForwardEdge}, which only answers "is the pair present at all", this is the multiplicity
+   * the post-compaction delta re-application needs to tell a deletion the freshly built CSR has ALREADY
+   * absorbed apart from one it has not: the two differ only in how many occurrences of the pair survived the
+   * scan, never in whether the pair is present. See issue #7042.
+   */
+  public int forwardEdgeCount(final int src, final int tgt) {
+    if (src < 0 || src >= nodeCount)
+      return 0;
+    final int from = fwdOffsets[src];
+    final int to = fwdOffsets[src + 1];
+    final int hit = Arrays.binarySearch(fwdNeighbors, from, to, tgt);
+    if (hit < 0)
+      return 0;
+    int start = hit;
+    while (start > from && fwdNeighbors[start - 1] == tgt)
+      --start;
+    int end = hit + 1;
+    while (end < to && fwdNeighbors[end] == tgt)
+      ++end;
+    return end - start;
+  }
+
+  /**
    * Direct access to the forward neighbors array for vectorized batch processing.
    * The array is the internal buffer — do NOT modify it.
    * Package-private: callers outside the package should use offset-based access methods.

--- a/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DeltaOverlay.java
@@ -74,6 +74,16 @@ class DeltaOverlay {
   // pair carries more than one parallel edge.
   private final Map<String, Set<RID>>       deletedEdgeRIDsPerType;
 
+  // Buffered deletions the freshly built base CSR had ALREADY absorbed at post-compaction re-application time,
+  // per type and packed pair. Non-empty only on that path (see the merge() overload taking a
+  // PreCompactionPairCount): everywhere else a deletion is always news to the base run it is spent against.
+  // These deletions must NOT contribute to deletedEdgesPerType - their edge is already missing from the fresh
+  // run, so an exclusion budget for them would be taken from a still-live parallel edge of the same pair and
+  // mask it from reads until the next compaction (issue #7042). Kept as a count rather than dropped on the
+  // floor because the absorbed population is a PREFIX of the pair's buffered deletions: once as many have been
+  // absorbed as the scan swallowed, the next one is genuine and does have to spend a budget.
+  private final Map<String, Map<Long, Integer>> absorbedDeletedEdgesPerType;
+
   // Per-node deleted edge counts for O(1) lookup: edgeType -> nodeId -> count
   private final Map<String, IntIntHashMap> deletedOutEdgeCounts;
   private final Map<String, IntIntHashMap> deletedInEdgeCounts;
@@ -112,6 +122,7 @@ class DeltaOverlay {
     this.addedEdgesPerType = Collections.emptyMap();
     this.deletedEdgesPerType = Collections.emptyMap();
     this.deletedEdgeRIDsPerType = Collections.emptyMap();
+    this.absorbedDeletedEdgesPerType = Collections.emptyMap();
     this.deletedOutEdgeCounts = Collections.emptyMap();
     this.deletedInEdgeCounts = Collections.emptyMap();
     this.propertyOverrides = Collections.emptyMap();
@@ -134,6 +145,7 @@ class DeltaOverlay {
       final Map<String, Map<RID, AddedEdge>> addedEdgesPerType,
       final Map<String, Map<Long, Integer>> deletedEdgesPerType,
       final Map<String, Set<RID>> deletedEdgeRIDsPerType,
+      final Map<String, Map<Long, Integer>> absorbedDeletedEdgesPerType,
       final Map<String, IntIntHashMap> deletedOutEdgeCounts,
       final Map<String, IntIntHashMap> deletedInEdgeCounts,
       final Map<Integer, Map<String, Object>> propertyOverrides,
@@ -150,6 +162,7 @@ class DeltaOverlay {
     this.addedEdgesPerType = addedEdgesPerType;
     this.deletedEdgesPerType = deletedEdgesPerType;
     this.deletedEdgeRIDsPerType = deletedEdgeRIDsPerType;
+    this.absorbedDeletedEdgesPerType = absorbedDeletedEdgesPerType;
     this.deletedOutEdgeCounts = deletedOutEdgeCounts;
     this.deletedInEdgeCounts = deletedInEdgeCounts;
     this.propertyOverrides = propertyOverrides;
@@ -166,7 +179,26 @@ class DeltaOverlay {
    * The previous overlay is not modified.
    */
   DeltaOverlay merge(final TxDelta delta, final NodeIdMapping baseMapping) {
-    return merge(delta, baseMapping, null);
+    return merge(delta, baseMapping, null, null);
+  }
+
+  /**
+   * How many times a pair was visible for one edge type at the moment a compaction started, asked by the RIDs
+   * of its endpoints so the answer can be resolved against the OLD node id mapping - the dense ids the fresh
+   * mapping hands out are unrelated to the ones the pre-compaction snapshot used.
+   * <p>
+   * This is the reference the deletion side of the post-compaction re-application needs. The freshly built
+   * base CSR is a read-committed, non-atomic scan, so a buffered deletion may or may not already be reflected
+   * in it, and the fresh multiplicity alone cannot say which: it is the DROP from the pre-compaction
+   * multiplicity that counts the deletions the scan swallowed. See issue #7042.
+   */
+  @FunctionalInterface
+  interface PreCompactionPairCount {
+    /**
+     * Visible occurrences of {@code source -> target} for {@code edgeType} as of the compaction start, or 0
+     * when either endpoint was not part of the view then.
+     */
+    int occurrences(String edgeType, RID source, RID target);
   }
 
   /**
@@ -180,9 +212,31 @@ class DeltaOverlay {
    * delta may already be reflected in the new base CSR; re-adding it to the overlay would surface a
    * duplicate neighbour and inflate the delta edge counter.
    */
-  @SuppressWarnings("unchecked")
   DeltaOverlay merge(final TxDelta delta, final NodeIdMapping baseMapping,
       final Map<String, CSRAdjacencyIndex> baseCsrPerType) {
+    return merge(delta, baseMapping, baseCsrPerType, null);
+  }
+
+  /**
+   * As {@link #merge(TxDelta, NodeIdMapping, Map)}, with the pre-compaction multiplicity of a pair available
+   * to the DELETION side as well.
+   * <p>
+   * The add side has had a fresh-CSR probe since issue #4588; the deletion side re-applied buffered deltas
+   * blindly, which spends an exclusion budget against the fresh base run for an edge that run no longer holds.
+   * That budget is then taken from whichever occurrence of the pair DID survive the scan, hiding a live edge
+   * from {@code getNeighborIds}/{@code isConnectedTo} until the next compaction rather than merely skewing a
+   * counter (issue #7042).
+   * <p>
+   * The discriminator is the drop in multiplicity: with {@code before} the pair's visible occurrences at
+   * compaction start and {@code fresh} its occurrences in the newly scanned base, exactly
+   * {@code max(0, before - fresh)} of the pair's buffered deletions are already reflected in the fresh run.
+   * Those are recorded as absorbed and spend nothing; any beyond them committed after the scan crossed the
+   * bucket and are budgeted as before. When {@code preCount} is null the reference is unavailable, no deletion
+   * can be shown to be absorbed, and every one is budgeted - the pre-#7042 behaviour.
+   */
+  @SuppressWarnings("unchecked")
+  DeltaOverlay merge(final TxDelta delta, final NodeIdMapping baseMapping,
+      final Map<String, CSRAdjacencyIndex> baseCsrPerType, final PreCompactionPairCount preCount) {
     // Copy mutable structures from previous overlay
     final Map<RID, Integer> newOverflowIds = new HashMap<>(overflowNodeIds);
     final List<RID> overflowRIDsList = new ArrayList<>(Arrays.asList(overflowIdToRID));
@@ -198,6 +252,9 @@ class DeltaOverlay {
     final Map<String, Set<RID>> newDeletedEdgeRIDs = new HashMap<>();
     for (final var entry : deletedEdgeRIDsPerType.entrySet())
       newDeletedEdgeRIDs.put(entry.getKey(), new HashSet<>(entry.getValue()));
+    final Map<String, Map<Long, Integer>> newAbsorbedDeletions = new HashMap<>();
+    for (final var entry : absorbedDeletedEdgesPerType.entrySet())
+      newAbsorbedDeletions.put(entry.getKey(), new HashMap<>(entry.getValue()));
     final Map<Integer, Map<String, Object>> newPropOverrides = new HashMap<>(propertyOverrides.size());
     for (final var propEntry : propertyOverrides.entrySet())
       newPropOverrides.put(propEntry.getKey(), new HashMap<>(propEntry.getValue()));
@@ -357,11 +414,42 @@ class DeltaOverlay {
       // the post-compaction re-application skip a few lines up (issue #4588): there, a reused RID's stale
       // entry in this set is explicitly cleared at the point the add is skipped, so it cannot be mistaken
       // for a replay of the unrelated edge that originally freed the slot (issue #6777).
-      if (newDeletedEdgeRIDs.computeIfAbsent(ed.edgeType, k -> new HashSet<>()).add(ed.rid)) {
-        newDeletedEdges.computeIfAbsent(ed.edgeType, k -> new HashMap<>())
-            .merge(packEdge(srcId, tgtId), 1, Integer::sum);
-        newDeltaEdgeCount--;
+      if (!newDeletedEdgeRIDs.computeIfAbsent(ed.edgeType, k -> new HashSet<>()).add(ed.rid))
+        continue;
+
+      // Post-compaction re-application, deletion side (issue #7042). The exclusion budget recorded below is
+      // spent against the FRESHLY scanned base run for the pair, so it may only be recorded for a deletion
+      // that run still carries. The scan is read-committed and non-atomic: a deletion that committed before
+      // it crossed the source's bucket is already missing from the fresh run, and budgeting for it again
+      // takes the slot of whichever parallel edge DID survive - copyBaseExcludingDeleted then physically
+      // drops that live edge from the neighbour list, so the pair stops being reported at all until the next
+      // compaction. Exactly max(0, before - fresh) of this pair's buffered deletions were swallowed by the
+      // scan; they are the prefix, and are recorded as absorbed instead of budgeted. The identity is still
+      // remembered above, so a replay of the same deletion cannot fall through and spend a budget later.
+      if (baseCsrPerType != null && preCount != null && srcId < baseNodeCount && tgtId < baseNodeCount) {
+        final CSRAdjacencyIndex csr = baseCsrPerType.get(ed.edgeType);
+        if (csr != null) {
+          final int absorbable = preCount.occurrences(ed.edgeType, ed.source, ed.target)
+              - csr.forwardEdgeCount(srcId, tgtId);
+          if (absorbable > 0) {
+            final long packed = packEdge(srcId, tgtId);
+            final Map<Long, Integer> absorbedForType = newAbsorbedDeletions.computeIfAbsent(ed.edgeType,
+                k -> new HashMap<>());
+            final int absorbedSoFar = absorbedForType.getOrDefault(packed, 0);
+            if (absorbedSoFar < absorbable) {
+              // Already reflected in the fresh base run: no budget, and no contribution to the delta edge
+              // counter either - the overlay is in step with the base for this edge, exactly as it is for an
+              // add the fresh CSR already carries (#4588).
+              absorbedForType.put(packed, absorbedSoFar + 1);
+              continue;
+            }
+          }
+        }
       }
+
+      newDeletedEdges.computeIfAbsent(ed.edgeType, k -> new HashMap<>())
+          .merge(packEdge(srcId, tgtId), 1, Integer::sum);
+      newDeltaEdgeCount--;
     }
 
     // Process property updates
@@ -384,7 +472,7 @@ class DeltaOverlay {
         overflowRIDsList.toArray(new RID[0]),
         overflowPropsList.toArray(new Map[0]),
         newDeleted, newDeletedOverflow, newAddedEdges, newDeletedEdges, newDeletedEdgeRIDs,
-        newDelOutCounts, newDelInCounts, newPropOverrides,
+        newAbsorbedDeletions, newDelOutCounts, newDelInCounts, newPropOverrides,
         newOutIndex, newInIndex,
         newOverflowCount, newDeltaEdgeCount, newDirtyTypes, newAllDirty);
   }
@@ -467,6 +555,16 @@ class DeltaOverlay {
   int countDeletedEdges(final String edgeType, final int srcId, final int tgtId) {
     final Map<Long, Integer> deleted = deletedEdgesPerType.get(edgeType);
     return deleted == null ? 0 : deleted.getOrDefault(packEdge(srcId, tgtId), 0);
+  }
+
+  /**
+   * Returns how many of the pair's buffered deletions the freshly built base CSR had already absorbed at
+   * post-compaction re-application time, and which therefore spend no exclusion budget. Zero on every path
+   * other than that re-application. See issue #7042.
+   */
+  int countAbsorbedDeletions(final String edgeType, final int srcId, final int tgtId) {
+    final Map<Long, Integer> absorbed = absorbedDeletedEdgesPerType.get(edgeType);
+    return absorbed == null ? 0 : absorbed.getOrDefault(packEdge(srcId, tgtId), 0);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -2380,6 +2380,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       // Start buffering raw deltas for re-application after the swap
       pendingDeltas = new ArrayList<>();
 
+      // The view as of this instant - after the triggering delta was merged above, before the first BUFFERED
+      // one arrives. It is the reference the deletion side of the re-application below needs: the fresh CSR
+      // scan is read-committed and non-atomic, so the drop from a pair's multiplicity HERE to its
+      // multiplicity in the fresh base is exactly the number of that pair's buffered deletions the scan
+      // already swallowed (issue #7042). Immutable, so holding the reference across the rebuild is free and
+      // safe from the compaction thread.
+      final Snapshot preCompaction = this.snapshot;
+
       // See the `generation` field javadoc (issue #6636): captured at dispatch time, deliberately NOT
       // bumped by the synchronous overlay merge just above (or by any applyDelta() call re-entering while
       // this compaction is in flight) - those deltas are buffered and re-applied against this same
@@ -2424,12 +2432,18 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
                   // These may not be in the fresh CSR (committed after the CSR scan of their bucket).
                   // Merging against the new mapping resolves RIDs to correct dense IDs.
                   if (!buffered.isEmpty()) {
+                    // Asked of the pre-compaction snapshot rather than of the fresh one: it answers "how many
+                    // of this pair did the view hold before any buffered delta", which is what tells a
+                    // deletion the scan already swallowed apart from one that committed behind it (#7042).
+                    final DeltaOverlay.PreCompactionPairCount preCount =
+                        (type, src, tgt) -> preCompactionPairCount(preCompaction, type, src, tgt);
                     DeltaOverlay overlay = new DeltaOverlay(result.getMapping().size());
                     for (final TxDelta d : buffered) {
                       // Dedup against the fresh base CSR: a buffered delta committed before the scan
                       // crossed its bucket is already in the new base, so re-merging it blindly would
-                      // create duplicate neighbours. See issue #4588.
-                      overlay = overlay.merge(d, result.getMapping(), result.getCsrPerType());
+                      // create duplicate neighbours (adds, issue #4588) or spend an exclusion budget the
+                      // fresh run cannot pay without hiding a live parallel edge (deletions, issue #7042).
+                      overlay = overlay.merge(d, result.getMapping(), result.getCsrPerType(), preCount);
                     }
                     // A change to a base edge's properties has no overlay representation, so a delta buffered
                     // during this rebuild may not be reflected in the fresh CSR (if it committed after the
@@ -2489,6 +2503,25 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
         LogManager.instance().log(this, Level.WARNING, "GraphAnalyticalView '%s': compaction rejected (executor shut down)", name);
       }
     }
+  }
+
+  /**
+   * How many times the pair {@code source -> target} was visible for {@code edgeType} in {@code snap}, asked by
+   * RID so it can be answered against a mapping other than the current one.
+   * <p>
+   * Backs the {@link DeltaOverlay.PreCompactionPairCount} the post-compaction delta re-application hands to
+   * {@link DeltaOverlay#merge}: the buffered deltas carry RIDs, and the dense ids of the pre-compaction
+   * mapping have nothing to do with the ones the freshly built mapping assigns. Zero when either endpoint was
+   * not part of the view at that point - it then held none of the pair, which is what the caller needs to
+   * know. See issue #7042.
+   */
+  private int preCompactionPairCount(final Snapshot snap, final String edgeType, final RID source, final RID target) {
+    final DeltaOverlay ov = snap.overlay;
+    final int src = ov != null ? ov.resolveNodeId(source, snap.nodeMapping) : snap.nodeMapping.getGlobalId(source);
+    final int tgt = ov != null ? ov.resolveNodeId(target, snap.nodeMapping) : snap.nodeMapping.getGlobalId(target);
+    if (src < 0 || tgt < 0)
+      return 0;
+    return (int) countBetweenForType(snap, src, tgt, Vertex.DIRECTION.OUT, edgeType);
   }
 
   private boolean isConnectedForType(final Snapshot snap, final int nodeA, final int nodeB,
@@ -2557,9 +2590,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * neighbour was the very inconsistency #6775 is about, so the two agree instead.
    * <p>
    * The subtraction is clamped at zero rather than trusted to stay non-negative: a budget wider than the
-   * base run is exactly what the two documented overlay gaps (#4588's pair-level re-application dedup and
-   * #6777's RID reuse) can produce, and a negative contribution would corrupt the sum for the OTHER edge
-   * types {@link #countEdgesBetween} adds it to.
+   * base run is what the remaining overlay gaps can produce, and a negative contribution would corrupt the
+   * sum for the OTHER edge types {@link #countEdgesBetween} adds it to. Issue #7042 closed the one that made
+   * this reachable in ordinary use - the deletion side of the post-compaction re-application, which used to
+   * budget for edges the freshly scanned base had already dropped - and the deletion side now spends a budget
+   * only for a deletion the fresh run still carries. What is left is #6777's RID reuse, and the add side's
+   * dedup being by presence rather than by multiplicity (a buffered add of a SECOND parallel edge to a pair
+   * the fresh base already holds one of is skipped, which undercounts rather than overspending). The clamp
+   * stays: it costs nothing, and it is the last line between either of those and a corrupted cross-type sum.
    */
   private long countBetweenForType(final Snapshot snap, final int nodeA, final int nodeB,
       final Vertex.DIRECTION direction, final String edgeType) {

--- a/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDeleteDedupTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDeleteDedupTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import com.arcadedb.database.RID;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #7042: the DELETION side of the post-compaction delta re-application.
+ * <p>
+ * Issue #4588 gave the ADD side a probe against the freshly built base CSR, so a buffered add the
+ * read-committed scan had already captured is not appended a second time. The deletion side kept re-applying
+ * buffered deltas blindly, which is worse than a skewed counter: the per-pair deleted count is an exclusion
+ * BUDGET spent against the fresh base run for the pair ({@code copyBaseExcludingDeleted}), so budgeting for an
+ * edge that run no longer holds takes the slot of whichever parallel edge DID survive the scan - and that live
+ * edge disappears from {@code getNeighborIds}/{@code isConnectedTo} until the next compaction.
+ * <p>
+ * The discriminator the deletion side needs is the pair's multiplicity at compaction start against its
+ * multiplicity in the fresh base: the drop between the two is exactly how many of that pair's buffered
+ * deletions the scan already swallowed. The fresh multiplicity alone cannot say - "one occurrence left"
+ * describes both "two edges, one deleted behind the scan" and "one edge, nothing deleted yet".
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class DeltaOverlayCompactionDeleteDedupTest {
+  private static final String EDGE_TYPE = "Knows";
+
+  /**
+   * Builds a single-bucket mapping where global ids match positions 0..count-1.
+   */
+  private NodeIdMapping baseMappingWith(final int count) {
+    final NodeIdMapping mapping = new NodeIdMapping(1);
+    final int bucketIdx = mapping.registerBucket(1, "V", count);
+    for (int i = 0; i < count; i++)
+      mapping.addNode(bucketIdx, i);
+    mapping.compact();
+    return mapping;
+  }
+
+  private RID rid(final int position) {
+    return new RID(1, position);
+  }
+
+  /**
+   * Builds a base CSR over {@code nodeCount} nodes holding {@code count} parallel forward edges
+   * {@code src -> tgt} and nothing else.
+   */
+  private Map<String, CSRAdjacencyIndex> freshBaseWith(final int nodeCount, final int src, final int tgt,
+      final int count) {
+    final int[] fwdOffsets = new int[nodeCount + 1];
+    final int[] bwdOffsets = new int[nodeCount + 1];
+    for (int i = 0; i <= nodeCount; i++) {
+      fwdOffsets[i] = i > src ? count : 0;
+      bwdOffsets[i] = i > tgt ? count : 0;
+    }
+    final int[] fwdNeighbors = new int[count];
+    final int[] bwdNeighbors = new int[count];
+    Arrays.fill(fwdNeighbors, tgt);
+    Arrays.fill(bwdNeighbors, src);
+    return Map.of(EDGE_TYPE, new CSRAdjacencyIndex(fwdOffsets, fwdNeighbors, bwdOffsets, bwdNeighbors, nodeCount, count));
+  }
+
+  /**
+   * The pre-compaction multiplicity of the one pair these fixtures use.
+   */
+  private DeltaOverlay.PreCompactionPairCount preCompactionOccurrences(final int occurrences) {
+    return (edgeType, source, target) -> occurrences;
+  }
+
+  private TxDelta deletionOf(final RID edgeRid) {
+    final TxDelta delta = new TxDelta();
+    delta.deletedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), edgeRid));
+    return delta;
+  }
+
+  /**
+   * The issue's own repro. Two parallel edges E1 and E2 (0-&gt;1) in the base at compaction start; E1 is
+   * deleted during the rebuild and the scan crosses node 0's bucket after that commit, so the fresh base
+   * carries only E2. Re-applying E1's deletion spends a budget of 1 against a run of exactly one - and that
+   * one is E2, which nobody deleted.
+   */
+  @Test
+  void aDeletionTheFreshScanAlreadySwallowedDoesNotMaskTheSurvivingParallelEdge() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final Map<String, CSRAdjacencyIndex> freshBase = freshBaseWith(2, 0, 1, 1);
+
+    // Without the pre-compaction reference nothing can be shown absorbed, so the deletion is budgeted - the
+    // pre-fix behaviour, and the exact over-spend that hides E2.
+    final DeltaOverlay blind = new DeltaOverlay(mapping.size()).merge(deletionOf(rid(10)), mapping, freshBase);
+    assertThat(blind.countDeletedEdges(EDGE_TYPE, 0, 1))
+        .as("blind re-application budgets against a fresh run that no longer holds the deleted edge").isEqualTo(1);
+
+    // With it, the drop from two occurrences to one identifies the deletion as already reflected in the
+    // fresh base: no budget, so E2 stays discoverable.
+    final DeltaOverlay deduped = new DeltaOverlay(mapping.size())
+        .merge(deletionOf(rid(10)), mapping, freshBase, preCompactionOccurrences(2));
+    assertThat(deduped.countDeletedEdges(EDGE_TYPE, 0, 1))
+        .as("the surviving parallel edge must keep its slot in the fresh base run").isZero();
+    assertThat(deduped.countAbsorbedDeletions(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(deduped.countDeletedOutEdges(0, EDGE_TYPE)).isZero();
+    assertThat(deduped.countDeletedInEdges(1, EDGE_TYPE)).isZero();
+    assertThat(deduped.getDeltaEdgeCount())
+        .as("the overlay is in step with the fresh base for this edge, exactly as for a skipped add").isZero();
+  }
+
+  /**
+   * The other half of the same race: the scan crossed the bucket BEFORE the delete committed, so the fresh
+   * base still holds both edges and the deletion must be budgeted as before. Same fresh multiplicity question
+   * as the test above answers the other way, which is why the pre-compaction count is the discriminator.
+   */
+  @Test
+  void aDeletionThatCommittedBehindTheScanStillSpendsItsBudget() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final Map<String, CSRAdjacencyIndex> freshBase = freshBaseWith(2, 0, 1, 2);
+
+    final DeltaOverlay merged = new DeltaOverlay(mapping.size())
+        .merge(deletionOf(rid(10)), mapping, freshBase, preCompactionOccurrences(2));
+
+    assertThat(merged.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(merged.countAbsorbedDeletions(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(merged.countDeletedOutEdges(0, EDGE_TYPE)).isEqualTo(1);
+    assertThat(merged.getDeltaEdgeCount()).isEqualTo(-1);
+  }
+
+  /**
+   * The single-edge shape. The over-spend masks nothing in the neighbour list here - there is no surviving
+   * occurrence of the pair to take the slot from - but the per-node deleted counts it feeds are what
+   * {@code getDegree} subtracts from the fresh base degree, so the node's degree comes out one short.
+   */
+  @Test
+  void aDeletionOfTheOnlyEdgeAlreadyGoneFromTheFreshScanDoesNotUnderCountTheDegree() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final Map<String, CSRAdjacencyIndex> freshBase = freshBaseWith(2, 0, 1, 0);
+
+    final DeltaOverlay merged = new DeltaOverlay(mapping.size())
+        .merge(deletionOf(rid(10)), mapping, freshBase, preCompactionOccurrences(1));
+
+    assertThat(merged.countDeletedEdges(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(merged.countAbsorbedDeletions(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(merged.countDeletedOutEdges(0, EDGE_TYPE))
+        .as("the fresh base already excludes this edge, so nothing may be subtracted from node 0's degree").isZero();
+    assertThat(merged.countDeletedInEdges(1, EDGE_TYPE)).isZero();
+    assertThat(merged.getDeltaEdgeCount()).isZero();
+  }
+
+  /**
+   * Only the deletions the scan actually swallowed are absorbed, and they are the PREFIX of the pair's
+   * buffered deletions: three parallel edges at compaction start, one occurrence left in the fresh base, all
+   * three deleted. Two were swallowed by the scan, the third committed behind it and still has to spend the
+   * one budget the surviving run can pay.
+   */
+  @Test
+  void onlyTheDeletionsTheScanSwallowedAreAbsorbedAndTheRestStillBudget() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final Map<String, CSRAdjacencyIndex> freshBase = freshBaseWith(2, 0, 1, 1);
+    final DeltaOverlay.PreCompactionPairCount preCount = preCompactionOccurrences(3);
+
+    DeltaOverlay overlay = new DeltaOverlay(mapping.size());
+    for (final int edgePosition : new int[] { 10, 11, 12 })
+      overlay = overlay.merge(deletionOf(rid(edgePosition)), mapping, freshBase, preCount);
+
+    assertThat(overlay.countAbsorbedDeletions(EDGE_TYPE, 0, 1)).isEqualTo(2);
+    assertThat(overlay.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(overlay.getDeltaEdgeCount()).isEqualTo(-1);
+  }
+
+  /**
+   * A deletion replayed under the same identity - across merges, or emitted twice within one TxDelta - is
+   * absorbed exactly once, the way the identity dedup #6769 added already absorbs a replayed budget. Counting
+   * it twice would eat the absorbable prefix and let the genuine deletion behind it fall through unbudgeted.
+   */
+  @Test
+  void aReplayedDeletionIsAbsorbedOnlyOnce() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final Map<String, CSRAdjacencyIndex> freshBase = freshBaseWith(2, 0, 1, 1);
+    final DeltaOverlay.PreCompactionPairCount preCount = preCompactionOccurrences(2);
+
+    final DeltaOverlay once = new DeltaOverlay(mapping.size()).merge(deletionOf(rid(10)), mapping, freshBase, preCount);
+    final DeltaOverlay twice = once.merge(deletionOf(rid(10)), mapping, freshBase, preCount);
+
+    assertThat(twice.countAbsorbedDeletions(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(twice.countDeletedEdges(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(twice.getDeltaEdgeCount()).isZero();
+  }
+
+  /**
+   * The fresh base can also be WIDER than the pre-compaction view - the scan captured a buffered add - and a
+   * deletion arriving after it must then be budgeted normally. Guards the arithmetic against reading a
+   * negative drop as something absorbable.
+   */
+  @Test
+  void aDeletionIsBudgetedNormallyWhenTheScanCapturedAnAddInstead() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final Map<String, CSRAdjacencyIndex> freshBase = freshBaseWith(2, 0, 1, 2);
+
+    final DeltaOverlay merged = new DeltaOverlay(mapping.size())
+        .merge(deletionOf(rid(10)), mapping, freshBase, preCompactionOccurrences(1));
+
+    assertThat(merged.countAbsorbedDeletions(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(merged.countDeletedEdges(EDGE_TYPE, 0, 1)).isEqualTo(1);
+    assertThat(merged.getDeltaEdgeCount()).isEqualTo(-1);
+  }
+
+  /**
+   * An edge the overlay window added itself is still withdrawn rather than masked (issue #6775): that branch
+   * runs before the absorbed check and must keep doing so, or the add would be cancelled AND a budget spent.
+   */
+  @Test
+  void anAddWithdrawnWithinTheWindowIsStillNotBudgetedNorAbsorbed() {
+    final NodeIdMapping mapping = baseMappingWith(2);
+    final Map<String, CSRAdjacencyIndex> freshBase = freshBaseWith(2, 0, 1, 0);
+    final DeltaOverlay.PreCompactionPairCount preCount = preCompactionOccurrences(1);
+
+    final TxDelta add = new TxDelta();
+    add.addedEdges.add(new TxDelta.EdgeDelta(EDGE_TYPE, rid(0), rid(1), rid(20)));
+    final DeltaOverlay afterAdd = new DeltaOverlay(mapping.size()).merge(add, mapping, freshBase, preCount);
+    assertThat(afterAdd.getAddedOutNeighbors(0, EDGE_TYPE)).containsExactly(1);
+
+    final DeltaOverlay afterDelete = afterAdd.merge(deletionOf(rid(20)), mapping, freshBase, preCount);
+    assertThat(afterDelete.getAddedOutNeighbors(0, EDGE_TYPE)).isEmpty();
+    assertThat(afterDelete.countDeletedEdges(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(afterDelete.countAbsorbedDeletions(EDGE_TYPE, 0, 1)).isZero();
+    assertThat(afterDelete.getDeltaEdgeCount()).isZero();
+  }
+}


### PR DESCRIPTION
Closes #7042

## The gap

Issue #4588 gave the **add** side of the post-compaction delta re-application a probe against the freshly built base CSR, so a buffered add the read-committed scan had already captured is not appended a second time. The **deletion** side kept re-applying buffered deltas blindly, and the codebase's own javadoc named that as a still-open residual (`GraphAnalyticalView:2558-2561`, the reason the `countBetweenForType` subtraction is clamped at zero).

The clamp only protects the aggregate. The per-pair deleted count is an exclusion **budget** spent against the fresh base run for the pair (`copyBaseExcludingDeleted`), so budgeting for an edge that run no longer holds takes the slot of whichever parallel edge *did* survive the scan - and that live edge disappears from `getNeighborIds`/`isConnectedTo` until the next compaction. In the single-edge shape nothing is masked in the neighbour list, but the same over-spend feeds `deletedOutEdgeCounts`/`deletedInEdgeCounts`, which `getDegree` subtracts from the fresh base degree, so the degree comes out one short.

## Why the issue's own "minimal" suggestion is not enough

The issue suggests, minimally, "record a pair deletion only while the fresh base still carries an occurrence of that pair that no earlier buffered deletion has already claimed". That does not fix the issue's own repro: with two parallel edges `E1`/`E2` at compaction start and the scan crossing `s`'s bucket after `E1`'s delete, the fresh base carries one unclaimed occurrence (`E2`), so the deletion would still be recorded and `E2` would still be dropped.

The fresh multiplicity alone cannot answer the question - "one occurrence left" describes both *"two edges, one deleted behind the scan"* and *"one edge, nothing deleted yet"*.

## The fix

The discriminator is the **drop in multiplicity**: with `before` the pair's visible occurrences at compaction start and `fresh` its occurrences in the newly scanned base, exactly `max(0, before - fresh)` of that pair's buffered deletions are already reflected in the fresh run. Those are the *prefix* of the pair's buffered deletions; they are recorded as absorbed and spend nothing (and contribute nothing to `deltaEdgeCount`, exactly as a skipped add does). Any beyond them committed after the scan crossed the bucket and budget as before.

- `GraphAnalyticalView.applyDelta` captures the snapshot as of the instant compaction starts - after the triggering delta is merged, before the first *buffered* one arrives. It is immutable, so holding the reference across the rebuild is free.
- A `DeltaOverlay.PreCompactionPairCount` probe answers `before` **by RID**: the dense ids of the pre-compaction mapping have nothing to do with the ones the fresh mapping assigns. It reuses the existing `countBetweenForType` arithmetic against the pre-compaction snapshot, so it already accounts for that snapshot's own overlay adds and deletions.
- `CSRAdjacencyIndex.forwardEdgeCount` answers `fresh` - the multiplicity, where `hasForwardEdge` only answers presence.
- `DeltaOverlay` carries the absorbed count per type and packed pair (non-empty only on the re-application path), because the absorbed population is a prefix and the count has to survive across merges of successive buffered deltas.

The identity gate (`deletedEdgeRIDsPerType`, #6769/#6777) was hoisted to an early-`continue` ahead of the new check - behaviour-identical - so a replayed deletion is still absorbed exactly once and cannot fall through and spend a budget later. The #6775 withdraw-the-add branch still runs first.

Worked through by hand and covered by tests: every ordering of a buffered add and a buffered delete on the same pair against every position of the scan lands on the correct visible count.

## What is deliberately left open

- The **add** side still dedups by *presence* rather than by multiplicity: a buffered add of a *second* parallel edge to a pair the fresh base already holds one of is skipped. That undercounts rather than over-spending a budget, so it cannot mask a live edge; out of scope here.
- #6777's RID reuse.

The `countBetweenForType` clamp therefore stays, and its javadoc is rewritten to say which gap #7042 closed and which two remain, rather than continuing to name #4588's deletion half as open.

## Test plan

- [x] New `engine/src/test/java/com/arcadedb/graph/olap/DeltaOverlayCompactionDeleteDedupTest` (7 tests), at the same `DeltaOverlay.merge` level as every prior regression test for this path (#4588, #6769, #6775, #6777) - the race itself (a delete committing between compaction start and the scan crossing that specific bucket) is not deterministically forceable end to end.
  - the issue's repro: two parallel edges, one deleted behind the scan - the survivor keeps its slot
  - the mirror case: the same fresh multiplicity with the delete committed *after* the scan - still budgets
  - single edge already gone from the fresh scan - no per-node deleted count, so no degree under-count
  - three parallel edges, one left in the fresh base, all three deleted - two absorbed, one budgeted
  - a replayed deletion is absorbed only once
  - a fresh base *wider* than the pre-compaction view (the scan captured an add) - budgets normally
  - #6775's withdraw-the-add still runs ahead of the new check
- [x] **Proven to fail before the fix**: with the new branch disabled, 4 of the 7 fail; the other 3 are the must-not-change guards.
- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.graph.olap.**'` - 297 tests, 0 failures.
- [x] Full engine module: `mvn -o -pl engine test -DexcludedGroups=benchmark,vector,slow` - **14,130 tests, 0 failures, 23 skipped**.
- n/a openCypher TCK: the issue carries the `opencypher` label, but nothing under `com.arcadedb.query.opencypher` is touched - this is the OLAP `GraphAnalyticalView` overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrkSJbxfRn77hGhUp7oQJG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph compaction handling for buffered edge additions and deletions.
  * Prevented duplicate neighbors and incorrect edge counts when parallel edges or previously applied deletions are present.
  * Preserved accurate degree and deletion tracking during compaction, including partial deletion scenarios.

* **Tests**
  * Added regression coverage for compaction, duplicate replay prevention, parallel-edge handling, and add-withdrawal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->