### PR TITLE
fix(#7023): DETACH DELETE fed by a variable-length MATCH no longer walks unlinked edge segments

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/MatchClause.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/MatchClause.java
@@ -175,6 +175,33 @@ public class MatchClause {
     return computeDisconnected(allPathPatterns);
   }
 
+  /**
+   * True when any path pattern of any given MATCH clause contains a variable-length relationship
+   * ({@code -[*1..6]->}) or a quantified path pattern ({@code ((a)-[]->(b)){1,5}}, which reports itself
+   * as variable-length too).
+   * <p>
+   * Such a MATCH is expanded by a depth-first traverser that keeps live edge-segment cursors open across
+   * the output rows it is still producing. A write clause following it with no intervening WITH therefore
+   * mutates the very structure the traverser is mid-walk over: a {@code DETACH DELETE} of a bound node
+   * unlinks the edge chunks the cursor is about to follow, and the next {@code hasNext()} dereferences an
+   * already-removed segment record ({@code RecordNotFoundException}, issue #7023). The hazard is the same
+   * one {@link #hasDisconnectedPathPatterns(List)} guards - a row observing what an earlier row's write
+   * already removed - reached through the traversal cursor rather than through a cross join, and it has
+   * the same remedy: read the upstream rows to completion before applying the first write.
+   *
+   * @param matchClauses the MATCH clause(s) of the segment feeding the write clause in question
+   * @return true when at least one of them has a variable-length or quantified relationship
+   */
+  public static boolean hasVariableLengthRelationships(final List<MatchClause> matchClauses) {
+    if (matchClauses == null)
+      return false;
+    for (final MatchClause match : matchClauses)
+      for (final PathPattern path : match.pathPatterns)
+        if (path.hasVariableLengthRelationships())
+          return true;
+    return false;
+  }
+
   private static boolean computeDisconnected(final List<PathPattern> pathPatterns) {
     if (pathPatterns.size() < 2)
       return false;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1097,7 +1097,7 @@ public class CypherExecutionPlan {
     // in the query (e.g. WITH before UNWIND, not the other way around).
     final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
     // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
-    // whichever DELETE segment is reached next - see matchClausesHaveDisconnectedPatterns().
+    // whichever DELETE segment is reached next - see matchClausesNeedEagerDelete().
     final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
     if (clausesInOrder != null) {
       for (final ClauseEntry entry : clausesInOrder) {
@@ -1140,7 +1140,7 @@ public class CypherExecutionPlan {
           final DeleteClause deleteClause = entry.getTypedClause();
           if (!deleteClause.isEmpty()) {
             final DeleteStep deleteStep = new DeleteStep(deleteClause, context,
-                matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
+                matchClausesNeedEagerDelete(currentSegmentMatchClauses));
             deleteStep.setPrevious(currentStep);
             currentStep = deleteStep;
           }
@@ -1365,10 +1365,11 @@ public class CypherExecutionPlan {
     final Set<String> boundVariables = new HashSet<>(seedVariableNames);
 
     // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
-    // whichever DELETE/FOREACH segment is reached next - see matchClausesHaveDisconnectedPatterns().
+    // whichever DELETE/FOREACH segment is reached next - see matchClausesNeedEagerDelete().
     final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
-    // Variables bound by a segment that WAS disconnected, kept forever once tainted (even across a WITH
-    // that merely forwards them unchanged) - see closeMatchSegment() and deleteMayTargetTaintedVariable().
+    // Variables bound by a segment that needed the eager guard (disconnected patterns, or a
+    // variable-length relationship), kept forever once tainted (even across a WITH that merely forwards
+    // them unchanged) - see closeMatchSegment() and deleteMayTargetTaintedVariable().
     final Set<String> disconnectedTaintedVariables = new HashSet<>();
 
     // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
@@ -1548,7 +1549,7 @@ public class CypherExecutionPlan {
       case DELETE:
         final DeleteClause deleteClause = entry.getTypedClause();
         if (!deleteClause.isEmpty() && currentStep != null) {
-          final boolean eagerMaterialize = matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
+          final boolean eagerMaterialize = matchClausesNeedEagerDelete(currentSegmentMatchClauses)
               || deleteMayTargetTaintedVariable(deleteClause.getVariables(), disconnectedTaintedVariables);
           final DeleteStep deleteStep = new DeleteStep(deleteClause, context, eagerMaterialize);
           deleteStep.setPrevious(currentStep);
@@ -1578,7 +1579,7 @@ public class CypherExecutionPlan {
       case FOREACH:
         final ForeachClause foreachClause = entry.getTypedClause();
         final boolean foreachEagerMaterialize = foreachClause.containsDelete()
-            && (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
+            && (matchClausesNeedEagerDelete(currentSegmentMatchClauses)
                 || deleteMayTargetTaintedVariable(collectForeachDeleteTargetVariables(foreachClause), disconnectedTaintedVariables));
         final boolean foreachEagerExecution =
             database.getConfiguration().getValueAsBoolean(GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ)
@@ -2786,10 +2787,33 @@ public class CypherExecutionPlan {
   }
 
   /**
+   * True when a DELETE (or a FOREACH containing one) fed by the given MATCH clause(s) must read its whole
+   * upstream row set before applying the first deletion, because that MATCH can let a later row observe
+   * what an earlier row's deletion already removed.
+   * <p>
+   * Two independent shapes carry that hazard, and either one alone is enough:
+   * <ul>
+   *   <li>disconnected path patterns, which re-enumerate one component per row of the other and so can
+   *       bind the very same vertex/edge from more than one row (issue #6491);</li>
+   *   <li>a variable-length or quantified relationship, whose depth-first traverser keeps edge-segment
+   *       cursors open across the rows it is still producing, so a {@code DETACH DELETE} of a bound node
+   *       unlinks chunks that same cursor is about to follow (issue #7023).</li>
+   * </ul>
+   *
+   * @param matchClauses the MATCH clause(s) of the segment feeding the write clause (the ones since the
+   *                     last WITH), not every MATCH clause of the statement - see issue #6631
+   */
+  private static boolean matchClausesNeedEagerDelete(final List<MatchClause> matchClauses) {
+    return matchClausesHaveDisconnectedPatterns(matchClauses)
+        || MatchClause.hasVariableLengthRelationships(matchClauses);
+  }
+
+  /**
    * Closes the MATCH segment tracked in {@code currentSegmentMatchClauses} at a WITH boundary: if the
-   * segment being closed is itself disconnected, every node AND relationship variable it bound is added
-   * to {@code disconnectedTaintedVariables} before the segment list is cleared for the next one - a
-   * disconnected MATCH can rebind the same underlying edge across rows exactly as it can a vertex (see
+   * segment being closed needs the eager guard at all ({@link #matchClausesNeedEagerDelete}), every node
+   * AND relationship variable it bound is added to {@code disconnectedTaintedVariables} before the
+   * segment list is cleared for the next one - a disconnected MATCH can rebind the same underlying edge
+   * across rows exactly as it can a vertex, and a variable-length traverser is mid-walk over both (see
    * {@code DeleteStep}'s own {@code eagerMaterialize} field doc), so {@code DELETE r} needs the same
    * guard as {@code DELETE n}.
    * <p>
@@ -2803,7 +2827,7 @@ public class CypherExecutionPlan {
    */
   private static void closeMatchSegment(final List<MatchClause> currentSegmentMatchClauses,
       final Set<String> disconnectedTaintedVariables) {
-    if (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses))
+    if (matchClausesNeedEagerDelete(currentSegmentMatchClauses))
       for (final MatchClause match : currentSegmentMatchClauses)
         for (final PathPattern path : match.getPathPatterns()) {
           for (final NodePattern node : path.getNodes())
@@ -3404,7 +3428,7 @@ public class CypherExecutionPlan {
     // sees the multi-segment shape #6631 is about.
     if (statement.getDeleteClause() != null && !statement.getDeleteClause().isEmpty() && currentStep != null) {
       final DeleteStep deleteStep = new DeleteStep(
-          statement.getDeleteClause(), context, matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));
+          statement.getDeleteClause(), context, matchClausesNeedEagerDelete(statement.getMatchClauses()));
       deleteStep.setPrevious(currentStep);
       currentStep = deleteStep;
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2800,6 +2800,15 @@ public class CypherExecutionPlan {
    *       unlinks chunks that same cursor is about to follow (issue #7023).</li>
    * </ul>
    *
+   * The answer is deliberately segment-wide rather than per-variable: it is not narrowed to whether the
+   * DELETE's own target is one of the variables the hazardous pattern binds, so {@code MATCH (a)-[*1..3]->(b),
+   * (c:Foo) DETACH DELETE c} materializes eagerly even though {@code c} touches neither the cross join's
+   * other component nor the traversed edges. That over-approximation is inherited from the #6491 gate this
+   * extends and is kept on purpose - a DELETE reaches the graph through more than its named target
+   * (DETACH sweeps incident edges; a path variable expands to entities never named in the DELETE), so
+   * proving non-overlap is harder than it looks, and getting it wrong reintroduces a wrong-results bug to
+   * save memory on a shape that is rare in practice.
+   *
    * @param matchClauses the MATCH clause(s) of the segment feeding the write clause (the ones since the
    *                     last WITH), not every MATCH clause of the statement - see issue #6631
    */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
@@ -70,18 +70,28 @@ public class DeleteStep extends AbstractExecutionStep {
 
   /**
    * When true, the whole upstream row set is read to completion before the first DELETE is applied.
-   * Needed only when the MATCH feeding this DELETE has disconnected path patterns (see
-   * {@link com.arcadedb.query.opencypher.ast.MatchClause#hasDisconnectedPathPatterns()}): such a MATCH
-   * can bind the same underlying vertex/edge across more than one output row, and deleting it while a
-   * later row is still being produced makes that row dereference an already-removed record
-   * (issue #6491). Ordinary connected patterns bind each row's variables independently, so they are
-   * left on the cheaper streaming path.
+   * Needed when the MATCH feeding this DELETE can let a later row observe what an earlier row's DELETE
+   * already removed, which happens in two independent shapes:
+   * <ul>
+   *   <li>disconnected path patterns (see
+   *       {@link com.arcadedb.query.opencypher.ast.MatchClause#hasDisconnectedPathPatterns()}): such a
+   *       MATCH re-enumerates one component per row of the other, so it can bind the same underlying
+   *       vertex/edge across more than one output row, and deleting it while a later row is still being
+   *       produced makes that row dereference an already-removed record (issue #6491);</li>
+   *   <li>a variable-length or quantified relationship (see
+   *       {@link com.arcadedb.query.opencypher.ast.MatchClause#hasVariableLengthRelationships(java.util.List)}):
+   *       its depth-first traverser keeps edge-segment cursors open across the rows it is still
+   *       producing, so a {@code DETACH DELETE} of a bound node unlinks the edge chunks that same cursor
+   *       is about to follow and the next {@code hasNext()} dereferences a removed segment record
+   *       (issue #7023).</li>
+   * </ul>
+   * Ordinary fixed-length connected patterns bind each row's variables independently and keep no cursor
+   * open across rows, so they are left on the cheaper streaming path.
    * <p>
    * The cost of this path is the whole upstream row set held in memory at once (see
-   * {@code materializedInput} below) rather than streamed - acceptable for the disconnected-pattern
-   * shapes this guards (rare, and typically a deliberate, bounded cross join), but a disconnected
-   * pattern deliberately combined with a very large cartesian product feeding a DELETE would still pay
-   * that memory cost in full.
+   * {@code materializedInput} below) rather than streamed - acceptable for the shapes this guards, but a
+   * disconnected pattern deliberately combined with a very large cartesian product, or an unbounded
+   * {@code -[*]->} over a dense graph, would still pay that memory cost in full.
    */
   private final boolean eagerMaterialize;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
@@ -57,13 +57,17 @@ public class ForeachStep extends AbstractExecutionStep {
 
   /**
    * When true, the whole upstream row set is read to completion before the first FOREACH iteration
-   * runs. Needed only when the MATCH feeding this FOREACH has disconnected path patterns (see
-   * {@link com.arcadedb.query.opencypher.ast.MatchClause#hasDisconnectedPathPatterns(java.util.List)})
-   * AND this FOREACH's body contains a DELETE ({@link ForeachClause#containsDelete()}): such a MATCH
-   * can bind the same underlying vertex/edge across more than one output row, and a DELETE inside one
-   * iteration's body removing it while a later row is still being produced makes that row dereference
-   * an already-removed record (issue #6491) - the identical hazard {@code DeleteStep} guards against,
-   * just reached through FOREACH's own row-by-row loop instead.
+   * runs. Needed only when this FOREACH's body contains a DELETE ({@link ForeachClause#containsDelete()})
+   * AND the MATCH feeding this FOREACH can let a later row observe what an earlier row's DELETE already
+   * removed - either because it has disconnected path patterns (see
+   * {@link com.arcadedb.query.opencypher.ast.MatchClause#hasDisconnectedPathPatterns(java.util.List)}),
+   * which can bind the same underlying vertex/edge across more than one output row (issue #6491), or
+   * because it has a variable-length/quantified relationship (see
+   * {@link com.arcadedb.query.opencypher.ast.MatchClause#hasVariableLengthRelationships(java.util.List)}),
+   * whose traverser keeps edge-segment cursors open across the rows it is still producing (issue #7023).
+   * Either way, a DELETE inside one iteration's body removing an entity while a later row is still being
+   * produced makes that row dereference an already-removed record - the identical hazard
+   * {@code DeleteStep} guards against, just reached through FOREACH's own row-by-row loop instead.
    */
   private final boolean eagerMaterialize;
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVarLengthDetachDeleteIssue7023Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVarLengthDetachDeleteIssue7023Test.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.executor.steps.DeleteStep;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
+import com.arcadedb.query.sql.executor.ExecutionStep;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for issue #7023: {@code MATCH p = ()<-[*1..6]-(n0) DETACH DELETE n0} failed with
+ * {@code RecordNotFoundException: Record #12:0 not found} raised from inside {@code MutableEdgeSegment
+ * #getPrevious()}.
+ * <p>
+ * A variable-length relationship is expanded by {@code DepthFirstTraverser}, which keeps edge-segment
+ * cursors open across the rows it is still producing. The DELETE ran on the streaming path, so the very
+ * first row's {@code DETACH DELETE n0} unlinked the edge chunks that same cursor was about to follow, and
+ * the next {@code hasNext()} dereferenced an already-removed segment record. That is the issue #6491
+ * hazard - a row observing what an earlier row's write already removed - reached through the traversal
+ * cursor instead of through a disconnected pattern's cross join, so it gets the same remedy: the DELETE
+ * reads the upstream MATCH to completion before removing anything.
+ */
+class OpenCypherVarLengthDetachDeleteIssue7023Test {
+  private static final String CREATE_NODES =
+      "UNWIND [0,1,2,3,4,7,8,9,11,14,15,16,18,19,20,22,23,24,26,28,30,32,33,35,37,39,40,44,47,49,52,53,54,55,56,57,58,59,60,62,63,64,68,69,73,74,75,76,77,78,79,80,81,82,84,85,87,89,91,92,94,95,96,97,98,99,100,101,102,108,110,111,112,116,117,119,120,121,122,123,124,126,127] AS i CREATE (:V {id: i})";
+
+  private static final String CREATE_EDGES =
+      "UNWIND [[73,85],[52,77],[116,56],[47,74],[58,16],[108,94],[87,2],[76,94],[28,23],[39,97],[23,62],[108,47],[77,49],[111,7],[28,87],[39,87],[80,119],[68,52],[116,35],[35,112],[127,39],[11,49],[97,81],[26,28],[35,62],[44,77],[22,108],[18,49],[47,63],[73,73],[127,108],[39,108],[74,68],[44,2],[121,19],[63,35],[119,49],[14,122],[0,30],[101,8],[111,44],[120,68],[102,40],[108,55],[112,112],[108,85],[73,73],[28,28],[26,53],[60,112],[82,53],[99,76],[111,120],[116,108],[40,108],[1,19],[108,126],[80,68],[16,26],[49,22],[28,99],[85,62],[24,39],[110,47],[30,8],[35,14],[56,68],[54,37],[2,97],[116,3],[98,4],[14,7],[64,44],[7,122],[68,81],[80,39],[28,108],[47,89],[49,37],[124,108],[121,30],[99,102],[14,2],[91,7],[68,47],[64,94],[116,22],[94,26],[116,117],[28,1],[124,119],[9,112],[57,108],[116,23],[59,91],[78,87],[100,87],[124,39],[81,19],[49,49],[68,108],[89,32],[78,23],[73,9],[16,91],[52,14],[102,126],[68,55],[2,26],[68,96],[3,60],[56,2],[14,91],[3,3],[68,28],[22,91],[52,91],[89,37],[53,53],[47,73],[1,75],[7,68],[52,127],[119,4],[14,52],[23,19],[37,116],[28,60],[37,108],[84,52],[1,68],[39,99],[123,98],[30,91],[117,30],[119,102],[52,35],[99,24],[99,116],[116,68],[22,58],[117,23],[111,108],[110,22],[37,116],[7,52],[0,8],[95,77],[116,57],[23,116],[39,91],[19,100],[7,18],[68,68],[37,52],[116,11],[40,11],[108,121],[56,62],[112,22],[14,76],[15,19],[81,20],[112,49],[8,127],[89,68],[40,14],[120,39],[73,73],[37,37],[116,39],[58,11],[55,92],[126,80],[35,91],[116,8],[80,73],[4,110],[4,75],[47,75],[119,119],[44,32],[94,116],[23,52],[57,28],[7,108],[37,37],[7,121],[2,119],[111,110],[124,2],[26,102],[68,74],[121,30],[18,62],[119,58],[35,84],[8,2],[60,91],[59,82],[69,58],[64,32],[11,55],[120,60],[32,73],[121,94],[14,53],[123,117],[33,39],[122,35],[116,22],[73,79],[26,126],[122,74],[89,89],[54,78],[14,121],[80,116],[99,99],[47,30],[98,102],[110,60],[39,26],[98,98],[7,55],[116,3],[19,19],[14,112],[116,116],[75,30],[4,4],[32,32],[30,94],[32,14],[96,81],[68,0],[28,7],[32,15],[91,24],[78,47],[26,111],[22,47],[28,28],[52,121],[78,56],[44,60],[26,7],[32,49],[97,2],[62,62],[52,19],[54,39],[68,68],[56,58],[62,122]] AS e MATCH (a {id: e[0]}), (b {id: e[1]}) CREATE (a)-[:E]->(b)";
+
+  private Database database;
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+  }
+
+  private static boolean eagerMaterializeOf(final Object step) {
+    try {
+      final Field field = step.getClass().getDeclaredField("eagerMaterialize");
+      field.setAccessible(true);
+      return field.getBoolean(step);
+    } catch (final ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static <T> T findStep(final ResultSet result, final Class<T> type) {
+    final Optional<ExecutionPlan> plan = result.getExecutionPlan();
+    assertThat(plan).isPresent();
+    for (final ExecutionStep step : plan.get().getSteps())
+      if (type.isInstance(step))
+        return type.cast(step);
+    throw new IllegalStateException("No " + type.getSimpleName() + " found in execution plan");
+  }
+
+  private void createFixture(final String databaseName) {
+    database = new DatabaseFactory("./target/databases/" + databaseName).create();
+    database.transaction(() -> {
+      database.command("opencypher", CREATE_NODES);
+      database.command("opencypher", "MATCH (n) WHERE n.id IN [65, 66, 67, 68] SET n:l3:l2 SET n.k4 = -1012660514");
+      database.command("opencypher", CREATE_EDGES);
+      database.command("opencypher", "MATCH (a {id: 26}), (b {id: 52}) CREATE (a)-[:E]->(b)");
+    });
+  }
+
+  /** Number of paths the MATCH alone produces, i.e. how many rows the DELETE variant must also return. */
+  private long countPathsWithoutDelete() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH p = () <-[*1..6]-(n0:l3&l2 {k4: -1012660514}) RETURN count(p) AS c")) {
+      return rs.next().<Number>getProperty("c").longValue();
+    }
+  }
+
+  @Test
+  void detachDeleteWhileVariableLengthTraversalIsStillStreaming() {
+    createFixture("testopencypher-issue7023");
+
+    final long expectedRows = countPathsWithoutDelete();
+    assertThat(expectedRows)
+        .withFailMessage("fixture did not land: the variable-length MATCH must produce rows for this test to mean anything")
+        .isGreaterThan(1L);
+
+    final long[] returnedRows = { -1 };
+    database.transaction(() -> assertThatCode(() -> {
+      try (final ResultSet rs = database.command("opencypher",
+          "MATCH p = () <-[*1..6]-(n0:l3&l2 {k4: -1012660514}) DETACH DELETE n0 RETURN 1 AS ok")) {
+        long rows = 0;
+        while (rs.hasNext()) {
+          assertThat(rs.next().<Number>getProperty("ok").intValue()).isEqualTo(1);
+          rows++;
+        }
+        returnedRows[0] = rows;
+      }
+    }).doesNotThrowAnyException());
+
+    assertThat(returnedRows[0])
+        .withFailMessage("the DELETE must not truncate the traversal it is fed by")
+        .isEqualTo(expectedRows);
+
+    // The single node carrying both labels (id 68) and every edge incident to it are gone...
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:l3) RETURN count(n) AS c")) {
+      assertThat(rs.next().<Number>getProperty("c").longValue()).isZero();
+    }
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n {id: 68}) RETURN count(n) AS c")) {
+      assertThat(rs.next().<Number>getProperty("c").longValue()).isZero();
+    }
+    // ...while the rest of the graph is untouched: 83 created nodes minus the one deleted.
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n) RETURN count(n) AS c")) {
+      assertThat(rs.next().<Number>getProperty("c").longValue()).isEqualTo(82L);
+    }
+    // Only edges incident to id 68 disappear: 256 created, 19 of them touch node 68.
+    try (final ResultSet rs = database.query("opencypher", "MATCH ()-[r]->() RETURN count(r) AS c")) {
+      assertThat(rs.next().<Number>getProperty("c").longValue()).isEqualTo(237L);
+    }
+  }
+
+  @Test
+  void deleteFedByAVariableLengthMatchIsEagerlyMaterialized() {
+    createFixture("testopencypher-issue7023-plan");
+
+    database.transaction(() -> {
+      try (final ResultSet result = database.command("opencypher",
+          "PROFILE MATCH p = () <-[*1..6]-(n0:l3&l2 {k4: -1012660514}) DETACH DELETE n0 RETURN 1 AS ok")) {
+        while (result.hasNext())
+          result.next();
+
+        assertThat(eagerMaterializeOf(findStep(result, DeleteStep.class)))
+            .withFailMessage("a DELETE fed by a variable-length MATCH must read the traversal to completion "
+                + "before removing anything, or the still-open edge-segment cursor follows an unlinked chunk")
+            .isTrue();
+      }
+    });
+  }
+
+  @Test
+  void deleteOfAVariableLengthBoundVariableForwardedThroughWithIsEagerlyMaterialized() {
+    createFixture("testopencypher-issue7023-with");
+
+    database.transaction(() -> {
+      try (final ResultSet result = database.command("opencypher",
+          "PROFILE MATCH p = () <-[*1..6]-(n0:l3&l2 {k4: -1012660514}) WITH n0 DETACH DELETE n0 RETURN 1 AS ok")) {
+        while (result.hasNext())
+          result.next();
+
+        assertThat(eagerMaterializeOf(findStep(result, DeleteStep.class)))
+            .withFailMessage("a plain WITH forwards rows one at a time, so it does not neutralize the hazard "
+                + "for a variable-length-bound variable deleted after it")
+            .isTrue();
+      }
+    });
+  }
+
+  @Test
+  void deleteFedByAPlainConnectedMatchStaysOnTheStreamingPath() {
+    createFixture("testopencypher-issue7023-streaming");
+
+    database.transaction(() -> {
+      try (final ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (n:l3&l2 {k4: -1012660514}) DETACH DELETE n RETURN 1 AS ok")) {
+        while (result.hasNext())
+          result.next();
+
+        assertThat(eagerMaterializeOf(findStep(result, DeleteStep.class)))
+            .withFailMessage("a fixed-length, connected MATCH keeps no traversal cursor open across rows, so it "
+                + "must not pay the eager-materialization memory cost")
+            .isFalse();
+      }
+    });
+  }
+}


### PR DESCRIPTION
Closes #7023

## What was wrong

`MATCH p = () <-[*1..6]-(n0:l3&l2 {k4: -1012660514}) DETACH DELETE n0 RETURN 1 AS ok` failed with a `RecordNotFoundException` and the server logged the `GhostEdgeReporter` warning. The reproduction from the issue fails on `main` with exactly the reported stack:

```
Caused by: com.arcadedb.exception.RecordNotFoundException: Record #12:0 not found
	at com.arcadedb.graph.MutableEdgeSegment.getPrevious(MutableEdgeSegment.java:465)
	at com.arcadedb.graph.ResettableIteratorBase.moveToPreviousChunk(ResettableIteratorBase.java:95)
	at com.arcadedb.graph.EdgeIterator.hasNext(EdgeIterator.java:85)
	at com.arcadedb.query.opencypher.traversal.DepthFirstTraverser$DFSPathIterator.advance(DepthFirstTraverser.java:172)
	...
	at com.arcadedb.query.opencypher.executor.steps.ExpandPathStep$1.hasNext(ExpandPathStep.java:196)
	at com.arcadedb.query.opencypher.executor.steps.DeleteStep$1.hasMoreInput(DeleteStep.java:134)
```

The stack is the whole story. A variable-length relationship is expanded by `DepthFirstTraverser`, which keeps live edge-segment cursors open across the rows it is still producing. `DeleteStep` ran on its streaming path here, so the very first row's `DETACH DELETE n0` unlinked the edge chunks that same cursor was about to follow, and the next `hasNext()` dereferenced an already-removed segment record.

That is precisely the hazard `DeleteStep`'s `eagerMaterialize` flag already existed to guard - a row observing what an earlier row's write already removed (issue #6491) - only reached through the traversal cursor instead of through a disconnected pattern's cross join. The gate that sets the flag only asked `hasDisconnectedPathPatterns()`, and this MATCH is perfectly connected, so the flag stayed false.

## The fix

Widen the gate. `MatchClause.hasVariableLengthRelationships(List<MatchClause>)` is new; `CypherExecutionPlan.matchClausesNeedEagerDelete()` combines it with the existing disconnected-pattern check, and every site that previously called `matchClausesHaveDisconnectedPatterns()` to decide eagerness now calls it:

- the three `DeleteStep` construction sites (optimizer-fed builder, ordered builder, legacy builder),
- the `FOREACH`-containing-a-DELETE site,
- `closeMatchSegment()`, so a variable-length-bound variable forwarded across a plain `WITH` stays tainted exactly as a disconnected-pattern-bound one does - a non-aggregating `WITH` still forwards rows one at a time, so it does not neutralize the hazard.

Quantified path patterns are covered for free: `QuantifiedPathPattern extends RelationshipPattern` with its hop bounds set, so it already reports `isVariableLength() == true`.

The segment scoping from #6631 is preserved throughout - only the MATCH clauses since the last `WITH` are consulted, so a variable-length MATCH in one segment does not force eagerness on an unrelated DELETE in another.

### Cost

The eager path holds the whole upstream row set in memory rather than streaming it. That trade-off is not new (it is what #6491 already bought for disconnected patterns), but it now also applies to a `DELETE` fed by a variable-length MATCH - an unbounded `-[*]->` over a dense graph feeding a DELETE will pay it in full. The alternative is returning wrong results or throwing, so correctness wins; the field javadocs on `DeleteStep.eagerMaterialize` and `ForeachStep.eagerMaterialize` now say so explicitly.

### Known over-approximation (inherited, deliberate)

The decision is segment-wide, not narrowed to whether the DELETE's own target variable overlaps the hazardous pattern. `MATCH (a)-[*1..3]->(b), (c:Foo) DETACH DELETE c` therefore materializes eagerly even though `c` touches neither component. This imprecision is inherited from the #6491 gate rather than introduced here, and it is kept on purpose: a DELETE reaches the graph through more than its named target (DETACH sweeps incident edges; a path variable expands to entities the DELETE never names), so proving non-overlap is harder than it looks and getting it wrong trades a wrong-results bug for a memory saving on a rare shape. `matchClausesNeedEagerDelete()`'s javadoc now says this explicitly; narrowing it is not in scope for this PR.

## Test plan

New `engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVarLengthDetachDeleteIssue7023Test.java`, using the issue's own 83-node / 256-edge fixture verbatim:

- [x] `detachDeleteWhileVariableLengthTraversalIsStillStreaming` - the reported query does not throw; it returns exactly as many rows as the same MATCH without the DELETE (so the DELETE does not truncate the traversal it is fed by); node `id: 68` and its 19 incident edges are gone; the other 82 nodes and 237 edges survive.
- [x] `deleteFedByAVariableLengthMatchIsEagerlyMaterialized` - reads `eagerMaterialize` off the built `DeleteStep` (same reflection helper as the #6631 test) and asserts it is now set.
- [x] `deleteOfAVariableLengthBoundVariableForwardedThroughWithIsEagerlyMaterialized` - the `WITH n0` spelling stays guarded via the taint set.
- [x] `deleteFedByAPlainConnectedMatchStaysOnTheStreamingPath` - negative control: a fixed-length connected MATCH must NOT pay the eager cost.

Proven to fail without the fix: with the four main-source files reverted to `HEAD`, 3 of the 4 fail (the first with the reported `RecordNotFoundException`); the negative control correctly passes both before and after.

Regression runs (all on this branch, `-Dmaven.repo.local` isolated):

- [x] `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**' -DexcludedGroups=benchmark,vector,slow` → **9195 tests, 0 failures, 98 skipped**
- [x] openCypher TCK, `mvn -pl engine verify -Dsurefire.includes='**/*Suite.java'` → **3897 scenarios, 0 failures, 85 skipped** - identical to the baseline measured on the same worktree with the fix reverted (3897 / 0 / 85), so no conformance drop.
- [x] `OpenCypherTrailDetachDeleteIssue6491Test` (4), `OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test` (11), `OpenCypherDeleteTest` (9), `CypherQueryStatisticsTest` (36) - all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrkSJbxfRn77hGhUp7oQJG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `DELETE` and `FOREACH` reliability for queries using variable-length or quantified relationships.
  - Prevented traversal results from becoming invalid during mutations, including `DETACH DELETE` and queries passing through `WITH`.
  - Preserved streaming behavior for applicable fixed-length relationship matches.

- **Tests**
  - Added regression coverage confirming correct path results and deletion behavior for variable-length relationship queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->