### PR TITLE
build(native): move the GraalVM pin and the native-image builder together to CE 25.2.4 (#7055) [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,8 +49,14 @@ updates:
       # JVM-side JS engine. A coordinate-wide ignore would freeze the engine
       # along with the native pin. A GraalVM PR is therefore reviewed by hand:
       # merge it only together with a matching java-version bump in
-      # native-image.yml, otherwise close it. Bump 3fecba4bf did exactly this
-      # wrong and broke all four native legs.
+      # native-image.yml, otherwise close it. Bumps 3fecba4bf (-> 25.2.4) and
+      # b53c48c1e2 (-> 25.3.4.1) both did exactly this wrong and broke every
+      # native leg.
+      #
+      # Two guards now back that up, because "reviewed by hand" was not one:
+      # .github/scripts/check-native-graalvm-pin.py fails the always-on `lint`
+      # job on any skew, and .mergify.yml no longer auto-merges a Dependabot PR
+      # that touches native/pom.xml.
       - dependency-name: "org.apache.groovy:*"
         update-types: ["version-update:semver-major"]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,11 +53,13 @@ updates:
       # b53c48c1e2 (-> 25.3.4.1) both did exactly this wrong and broke every
       # native leg.
       #
-      # A bump is not impossible, just not a one-line edit: setup-graalvm's
-      # `java-version` input can only address jdk-* releases, so reaching an
-      # intermediate release such as graal-25.2.4 means switching
-      # native-image.yml to the `version` input. graal-25.3.4.1 is reachable
-      # through neither input - node-semver rejects its four-component tag.
+      # A bump is not impossible, just not a one-line edit. native-image.yml
+      # pins the builder through setup-graalvm's `version` input precisely so
+      # it can address the intermediate release graal-25.2.4; the
+      # `java-version` input reaches jdk-* releases only. Whatever the new
+      # version is, its tag must parse as three-component semver -
+      # graal-25.3.4.1 is reachable through neither input, because node-semver
+      # rejects its four numeric components.
       #
       # Two guards now back that up, because "reviewed by hand" was not one:
       # .github/scripts/check-native-graalvm-pin.py fails the always-on `lint`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,12 @@ updates:
       # b53c48c1e2 (-> 25.3.4.1) both did exactly this wrong and broke every
       # native leg.
       #
+      # A bump is not impossible, just not a one-line edit: setup-graalvm's
+      # `java-version` input can only address jdk-* releases, so reaching an
+      # intermediate release such as graal-25.2.4 means switching
+      # native-image.yml to the `version` input. graal-25.3.4.1 is reachable
+      # through neither input - node-semver rejects its four-component tag.
+      #
       # Two guards now back that up, because "reviewed by hand" was not one:
       # .github/scripts/check-native-graalvm-pin.py fails the always-on `lint`
       # job on any skew, and .mergify.yml no longer auto-merges a Dependabot PR

--- a/.github/scripts/check-native-graalvm-pin.py
+++ b/.github/scripts/check-native-graalvm-pin.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Fails when native/pom.xml's GraalVM pin and native-image.yml's builder JDK disagree.
+
+The native image embeds GraalJS, so the build runs Truffle's own SVM feature
+(TruffleBaseFeature.afterRegistration) inside the native-image builder. That feature comes from the
+builder's JDK, the Truffle API it calls comes from the Maven coordinates pinned by
+native/pom.xml's `native.graalvm.version`, and the two are compiled against each other. Let them
+drift and the build dies at feature registration with:
+
+    NoSuchMethodError: OptimizedTruffleRuntime.getLoopNodeFactory()
+
+which names neither the pom nor the workflow, so the cause has to be known rather than read.
+
+This has now shipped twice from a Dependabot bump nobody could refuse in time (3fecba4bf ->
+25.2.4, then b53c48c1e2 -> 25.3.4.1), each time taking out every leg of the Native Image workflow.
+A comment in the pom did not stop the second one: .mergify.yml merges a Dependabot PR on one
+approval with no green-CI condition and stamps [skip ci] on the merge commit, so main never
+re-tests it either. Hence a check that runs in the always-on `lint` job on every PR.
+
+Two things are enforced:
+
+  1. `native.graalvm.version` equals the `java-version` of every graalvm/setup-graalvm step in
+     native-image.yml.
+  2. That version has the three-component shape of a MAINLINE JDK release (25.0.2). GraalVM's
+     intermediate releases carry four components (25.2.4, 25.3.4.1) and are published under
+     `graal-*` tags with `jdk-25i2-*` / `jdk-25i3-*` assets, which graalvm/setup-graalvm cannot
+     select through a plain java-version at all - so making the two sides "agree" on one of those
+     just moves the failure into the setup step.
+
+If native-image.yml stops using graalvm/setup-graalvm, this check fails rather than passing
+vacuously: a guard that silently stops guarding is how the pin drifted in the first place.
+
+Usage:
+  check-native-graalvm-pin.py [pom] [workflow]   # defaults to the repository's own two files
+
+@author Luca Garulli (l.garulli@arcadedata.com)
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+SETUP_ACTION = "graalvm/setup-graalvm"
+POM_PROPERTY = "native.graalvm.version"
+
+# A mainline GraalVM Community JDK release: exactly three numeric components, e.g. 25.0.2. Anything
+# with a fourth component is an intermediate release - see the module docstring.
+MAINLINE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+
+PROPERTY_PATTERN = re.compile(rf"<{re.escape(POM_PROPERTY)}>\s*([^<\s]+)\s*</{re.escape(POM_PROPERTY)}>")
+
+
+def pinned_version(pom):
+    """Returns the value of native.graalvm.version, or None when the property is absent."""
+    match = PROPERTY_PATTERN.search(pom.read_text())
+    return match.group(1) if match else None
+
+
+def builder_versions(workflow):
+    """Yields (job, step name, java-version) for every graalvm/setup-graalvm step in the workflow."""
+    document = yaml.safe_load(workflow.read_text())
+
+    for job_id, job in (document.get("jobs") or {}).items():
+        for step in job.get("steps") or []:
+            uses = step.get("uses", "")
+            # `uses` carries a SHA pin and a version comment, so match the action, not the whole string.
+            if not uses.startswith(f"{SETUP_ACTION}@"):
+                continue
+            java_version = (step.get("with") or {}).get("java-version")
+            yield job_id, step.get("name", uses), str(java_version) if java_version is not None else None
+
+
+def main(argv):
+    root = Path(__file__).resolve().parents[2]
+    pom = Path(argv[1]) if len(argv) > 1 else root / "native" / "pom.xml"
+    workflow = Path(argv[2]) if len(argv) > 2 else root / ".github" / "workflows" / "native-image.yml"
+
+    for path in (pom, workflow):
+        if not path.is_file():
+            print(f"{path}: not found")
+            return 1
+
+    pinned = pinned_version(pom)
+    if pinned is None:
+        print(f"{pom}: no <{POM_PROPERTY}> property found.")
+        print("The native image build pins the Truffle/polyglot artifacts through that property; if it")
+        print("was renamed, rename it here too rather than dropping the check.")
+        return 1
+
+    try:
+        setups = list(builder_versions(workflow))
+    except yaml.YAMLError as e:
+        print(f"{workflow}: not parseable as YAML ({e})")
+        return 1
+
+    if not setups:
+        print(f"{workflow}: no {SETUP_ACTION} step found.")
+        print(f"This check exists to keep that step's java-version equal to {POM_PROPERTY}")
+        print(f"({pinned}). If the builder is now installed some other way, teach this script how to read")
+        print("it - leaving the check to pass on nothing is how the pin drifted before.")
+        return 1
+
+    problems = []
+
+    if not MAINLINE_VERSION.match(pinned):
+        problems.append(
+            f"{pom}: {POM_PROPERTY} is {pinned}, which is a GraalVM INTERMEDIATE release "
+            f"(four components). Those ship under graal-* tags with jdk-25iN-* assets, which "
+            f"graalvm/setup-graalvm cannot select through a plain java-version, so no builder can "
+            f"be matched to it. Pin the newest mainline release instead."
+        )
+
+    for job_id, step_name, java_version in setups:
+        if java_version is None:
+            problems.append(f"{workflow}: job '{job_id}', step '{step_name}' sets no java-version, so the builder is unpinned.")
+        elif java_version != pinned:
+            problems.append(
+                f"{workflow}: job '{job_id}', step '{step_name}' installs java-version {java_version}, "
+                f"but {pom}'s {POM_PROPERTY} is {pinned}."
+            )
+        elif step_name and re.search(r"\d+\.\d+\.\d+", step_name) and pinned not in step_name:
+            problems.append(
+                f"{workflow}: job '{job_id}', step name '{step_name}' names a version other than the "
+                f"{pinned} it actually installs."
+            )
+
+    if problems:
+        for problem in problems:
+            print(problem)
+        print()
+        print("The native image embeds GraalJS, so a builder/Truffle skew aborts the image build with")
+        print("NoSuchMethodError OptimizedTruffleRuntime.getLoopNodeFactory() - an error that names")
+        print("neither file. Move both sides together, or neither.")
+        return 1
+
+    print(f"GraalVM pin consistent: {POM_PROPERTY}={pinned} matches {len(setups)} {SETUP_ACTION} step(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/check-native-graalvm-pin.py
+++ b/.github/scripts/check-native-graalvm-pin.py
@@ -19,13 +19,26 @@ re-tests it either. Hence a check that runs in the always-on `lint` job on every
 
 Two things are enforced:
 
-  1. `native.graalvm.version` equals the `java-version` of every graalvm/setup-graalvm step in
-     native-image.yml.
-  2. That version has the three-component shape of a MAINLINE JDK release (25.0.2). GraalVM's
-     intermediate releases carry four components (25.2.4, 25.3.4.1) and are published under
-     `graal-*` tags with `jdk-25i2-*` / `jdk-25i3-*` assets, which graalvm/setup-graalvm cannot
-     select through a plain java-version at all - so making the two sides "agree" on one of those
-     just moves the failure into the setup step.
+  1. `native.graalvm.version` equals the version every graalvm/setup-graalvm step in
+     native-image.yml installs. That is the step's `version` input when it has one and its
+     `java-version` otherwise, which is the same precedence setup-graalvm's own main.ts applies
+     (`graalVMVersion.length > 0 ? setUpGraalVMJDKCE(...) : setUpGraalVMJDKCEByJavaVersion(...)`).
+  2. That version is parseable as three-component semver. Both of setup-graalvm's CE resolution
+     paths require it, so a version that is not is not installable by ANY input:
+
+       - `java-version` (setUpGraalVMJDKCEByJavaVersion) throws outright unless the resolved
+         version splits into exactly three dot-components, then fetches the `jdk-<version>` release.
+       - `version` (setUpGraalVMJDKCE -> findReleaseTag -> findLatestGraalVMCEVersion) looks up the
+         `graal-<version>` tag first and the `jdk-<version>` tag second, but skips any matching tag
+         that `semver.valid()` rejects.
+
+     This is what makes 25.3.4.1 unreachable: the tag `graal-25.3.4.1` exists, but node-semver
+     rejects four numeric components, so findLatestGraalVMCEVersion logs "Skipping unexpected
+     GraalVM CE release 25.3.4.1", finds no `jdk-25.3.4.1` either, and throws. Note the corollary,
+     because it is easy to get backwards: an INTERMEDIATE release is not itself the problem.
+     `graal-25.2.4` is an intermediate release with a three-component tag, and
+     `version: "25.2.4"` installs it fine - it is only unreachable through `java-version`, which
+     can address `jdk-*` tags alone.
 
 If native-image.yml stops using graalvm/setup-graalvm, this check fails rather than passing
 vacuously: a guard that silently stops guarding is how the pin drifted in the first place.
@@ -45,9 +58,9 @@ import yaml
 SETUP_ACTION = "graalvm/setup-graalvm"
 POM_PROPERTY = "native.graalvm.version"
 
-# A mainline GraalVM Community JDK release: exactly three numeric components, e.g. 25.0.2. Anything
-# with a fourth component is an intermediate release - see the module docstring.
-MAINLINE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+# What node-semver's semver.valid() accepts, which is what both of setup-graalvm's CE resolution
+# paths require: exactly three numeric components, e.g. 25.0.2. See the module docstring.
+INSTALLABLE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
 
 PROPERTY_PATTERN = re.compile(rf"<{re.escape(POM_PROPERTY)}>\s*([^<\s]+)\s*</{re.escape(POM_PROPERTY)}>")
 
@@ -59,7 +72,10 @@ def pinned_version(pom):
 
 
 def builder_versions(workflow):
-    """Yields (job, step name, java-version) for every graalvm/setup-graalvm step in the workflow."""
+    """Yields (job, step name, input name, version) for every graalvm/setup-graalvm step.
+
+    `version` wins over `java-version` when both are set, matching setup-graalvm's own main.ts.
+    """
     document = yaml.safe_load(workflow.read_text())
 
     for job_id, job in (document.get("jobs") or {}).items():
@@ -68,8 +84,14 @@ def builder_versions(workflow):
             # `uses` carries a SHA pin and a version comment, so match the action, not the whole string.
             if not uses.startswith(f"{SETUP_ACTION}@"):
                 continue
-            java_version = (step.get("with") or {}).get("java-version")
-            yield job_id, step.get("name", uses), str(java_version) if java_version is not None else None
+            with_block = step.get("with") or {}
+            for input_name in ("version", "java-version"):
+                value = with_block.get(input_name)
+                if value is not None and str(value) != "":
+                    yield job_id, step.get("name", uses), input_name, str(value)
+                    break
+            else:
+                yield job_id, step.get("name", uses), None, None
 
 
 def main(argv):
@@ -97,27 +119,31 @@ def main(argv):
 
     if not setups:
         print(f"{workflow}: no {SETUP_ACTION} step found.")
-        print(f"This check exists to keep that step's java-version equal to {POM_PROPERTY}")
+        print(f"This check exists to keep the version that step installs equal to {POM_PROPERTY}")
         print(f"({pinned}). If the builder is now installed some other way, teach this script how to read")
         print("it - leaving the check to pass on nothing is how the pin drifted before.")
         return 1
 
     problems = []
 
-    if not MAINLINE_VERSION.match(pinned):
+    if not INSTALLABLE_VERSION.match(pinned):
         problems.append(
-            f"{pom}: {POM_PROPERTY} is {pinned}, which is a GraalVM INTERMEDIATE release "
-            f"(four components). Those ship under graal-* tags with jdk-25iN-* assets, which "
-            f"graalvm/setup-graalvm cannot select through a plain java-version, so no builder can "
-            f"be matched to it. Pin the newest mainline release instead."
+            f"{pom}: {POM_PROPERTY} is {pinned}, which node-semver's semver.valid() rejects "
+            f"(it takes exactly three numeric components). Both of setup-graalvm's CE resolution "
+            f"paths require that, so no builder can be installed at this version through either "
+            f"`java-version` or `version` - the matching graal-* tag, if one exists, is skipped as "
+            f"an unexpected release. Pin a three-component version instead."
         )
 
-    for job_id, step_name, java_version in setups:
-        if java_version is None:
-            problems.append(f"{workflow}: job '{job_id}', step '{step_name}' sets no java-version, so the builder is unpinned.")
-        elif java_version != pinned:
+    for job_id, step_name, input_name, version in setups:
+        if version is None:
             problems.append(
-                f"{workflow}: job '{job_id}', step '{step_name}' installs java-version {java_version}, "
+                f"{workflow}: job '{job_id}', step '{step_name}' sets neither `version` nor "
+                f"`java-version`, so the builder is unpinned."
+            )
+        elif version != pinned:
+            problems.append(
+                f"{workflow}: job '{job_id}', step '{step_name}' installs {input_name} {version}, "
                 f"but {pom}'s {POM_PROPERTY} is {pinned}."
             )
         elif step_name and re.search(r"\d+\.\d+\.\d+", step_name) and pinned not in step_name:

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -29,6 +29,7 @@ DBDOCSSYNC="$SCRIPTS/check-database-docs-sync.py"
 CONTROLCHARS="$SCRIPTS/check-source-control-chars.py"
 NEEDSOUTPUTS="$SCRIPTS/check-workflow-needs-outputs.py"
 STATUSCOMPLETE="$SCRIPTS/check-ci-status-completeness.py"
+GRAALVMPIN="$SCRIPTS/check-native-graalvm-pin.py"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -1380,6 +1381,132 @@ jobs:
 YAML
 expect "reports a workflow it cannot parse as YAML" 1 "not parseable as YAML" \
     "$STATUSCOMPLETE" "$work/status-unparseable"
+
+echo "check-native-graalvm-pin.py"
+
+# A tiny helper: these cases only ever vary the pinned property and the installed java-version, so
+# writing two whole files per case would bury the one number that matters in boilerplate.
+graalvm_pom() {
+    cat >"$1" <<XML
+<project>
+    <properties>
+        <native.graalvm.version>$2</native.graalvm.version>
+    </properties>
+</project>
+XML
+}
+
+graalvm_workflow() {
+    local path="$1" java_version="$2" step_name="${3:-Set up GraalVM}"
+    cat >"$path" <<YAML
+name: Native Image
+on: [ workflow_dispatch ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: $step_name
+        uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.1
+        with:
+          java-version: "$java_version"
+          distribution: "graalvm-community"
+YAML
+}
+
+mkdir -p "$work/graalvm"
+
+# The happy path: a mainline three-component pin the builder can actually be set to.
+graalvm_pom "$work/graalvm/ok-pom.xml" 25.0.2
+graalvm_workflow "$work/graalvm/ok.yml" 25.0.2 "Set up GraalVM (Community, JDK 25.0.2)"
+expect "accepts a pin equal to the builder java-version" 0 "consistent" \
+    "$GRAALVMPIN" "$work/graalvm/ok-pom.xml" "$work/graalvm/ok.yml"
+
+# The regression this script exists for: run 33608446679, where dependabot's b53c48c1e2 left the
+# pom at 25.3.4.1 while the workflow still installed 25.0.2. All three native legs died in
+# TruffleBaseFeature.afterRegistration.
+graalvm_pom "$work/graalvm/skew-pom.xml" 25.3.4.1
+graalvm_workflow "$work/graalvm/skew.yml" 25.0.2
+expect "rejects the b53c48c1e2 skew (pom 25.3.4.1, builder 25.0.2)" 1 "getLoopNodeFactory" \
+    "$GRAALVMPIN" "$work/graalvm/skew-pom.xml" "$work/graalvm/skew.yml"
+
+# Making the two sides "agree" on an intermediate release is not a fix: setup-graalvm cannot select
+# graal-25.3.4.1 through a plain java-version, so this would just fail one step earlier.
+graalvm_pom "$work/graalvm/intermediate-pom.xml" 25.3.4.1
+graalvm_workflow "$work/graalvm/intermediate.yml" 25.3.4.1
+expect "rejects an intermediate release even when both sides agree" 1 "INTERMEDIATE" \
+    "$GRAALVMPIN" "$work/graalvm/intermediate-pom.xml" "$work/graalvm/intermediate.yml"
+
+# The step name is the first thing a reader sees, so it may not name a version other than the one
+# it installs.
+graalvm_pom "$work/graalvm/stale-name-pom.xml" 25.0.2
+graalvm_workflow "$work/graalvm/stale-name.yml" 25.0.2 "Set up GraalVM (Community, JDK 24.0.2)"
+expect "rejects a step name that contradicts the version it installs" 1 "names a version other than" \
+    "$GRAALVMPIN" "$work/graalvm/stale-name-pom.xml" "$work/graalvm/stale-name.yml"
+
+# A version-free step name is not a contradiction, so it passes.
+graalvm_pom "$work/graalvm/plain-name-pom.xml" 25.0.2
+graalvm_workflow "$work/graalvm/plain-name.yml" 25.0.2 "Set up GraalVM"
+expect "accepts a step name that names no version at all" 0 "consistent" \
+    "$GRAALVMPIN" "$work/graalvm/plain-name-pom.xml" "$work/graalvm/plain-name.yml"
+
+# Fail closed: a workflow that no longer sets up GraalVM leaves nothing to compare, and passing on
+# nothing is exactly how the pin drifted unnoticed.
+graalvm_pom "$work/graalvm/no-setup-pom.xml" 25.0.2
+cat >"$work/graalvm/no-setup.yml" <<'YAML'
+name: Native Image
+on: [ workflow_dispatch ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo building
+YAML
+expect "reports a workflow with no setup-graalvm step" 1 "no graalvm/setup-graalvm step" \
+    "$GRAALVMPIN" "$work/graalvm/no-setup-pom.xml" "$work/graalvm/no-setup.yml"
+
+# Same posture on the other side: a renamed or deleted property is reported, not skipped.
+cat >"$work/graalvm/no-property-pom.xml" <<'XML'
+<project>
+    <properties>
+        <graalvm.version>25.0.2</graalvm.version>
+    </properties>
+</project>
+XML
+graalvm_workflow "$work/graalvm/no-property.yml" 25.0.2
+expect "reports a pom with no native.graalvm.version property" 1 "no <native.graalvm.version>" \
+    "$GRAALVMPIN" "$work/graalvm/no-property-pom.xml" "$work/graalvm/no-property.yml"
+
+# An unpinned builder is a skew waiting to happen, so it is a failure rather than a pass.
+graalvm_pom "$work/graalvm/unpinned-pom.xml" 25.0.2
+cat >"$work/graalvm/unpinned.yml" <<'YAML'
+name: Native Image
+on: [ workflow_dispatch ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.1
+        with:
+          distribution: "graalvm-community"
+YAML
+expect "reports a setup-graalvm step that pins no java-version" 1 "sets no java-version" \
+    "$GRAALVMPIN" "$work/graalvm/unpinned-pom.xml" "$work/graalvm/unpinned.yml"
+
+# Same as the sibling scripts: a workflow that will not parse is reported, never silently skipped.
+graalvm_pom "$work/graalvm/broken-pom.xml" 25.0.2
+cat >"$work/graalvm/broken.yml" <<'YAML'
+name: broken
+on: [workflow_dispatch
+jobs:
+  build:
+YAML
+expect "reports a workflow it cannot parse as YAML" 1 "not parseable as YAML" \
+    "$GRAALVMPIN" "$work/graalvm/broken-pom.xml" "$work/graalvm/broken.yml"
+
+# The repository's own two files must agree - this is the case that would have caught b53c48c1e2.
+expect "the repository's own native pin matches its own workflow" 0 "consistent" \
+    "$GRAALVMPIN"
 
 echo
 if [[ $failures -gt 0 ]]; then

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -1429,12 +1429,56 @@ graalvm_workflow "$work/graalvm/skew.yml" 25.0.2
 expect "rejects the b53c48c1e2 skew (pom 25.3.4.1, builder 25.0.2)" 1 "getLoopNodeFactory" \
     "$GRAALVMPIN" "$work/graalvm/skew-pom.xml" "$work/graalvm/skew.yml"
 
-# Making the two sides "agree" on an intermediate release is not a fix: setup-graalvm cannot select
-# graal-25.3.4.1 through a plain java-version, so this would just fail one step earlier.
-graalvm_pom "$work/graalvm/intermediate-pom.xml" 25.3.4.1
-graalvm_workflow "$work/graalvm/intermediate.yml" 25.3.4.1
-expect "rejects an intermediate release even when both sides agree" 1 "INTERMEDIATE" \
-    "$GRAALVMPIN" "$work/graalvm/intermediate-pom.xml" "$work/graalvm/intermediate.yml"
+# Making the two sides "agree" on 25.3.4.1 is not a fix. The tag graal-25.3.4.1 exists, but
+# node-semver rejects four numeric components, so findLatestGraalVMCEVersion skips it as an
+# "unexpected GraalVM CE release", finds no jdk-25.3.4.1 either, and throws - this would just fail
+# one step earlier, in the setup step.
+graalvm_pom "$work/graalvm/unreachable-pom.xml" 25.3.4.1
+graalvm_workflow "$work/graalvm/unreachable.yml" 25.3.4.1
+expect "rejects a version semver.valid() cannot parse, even when both sides agree" 1 "semver.valid" \
+    "$GRAALVMPIN" "$work/graalvm/unreachable-pom.xml" "$work/graalvm/unreachable.yml"
+
+# The corollary, and the thing this check must NOT get backwards: an intermediate release is not
+# itself unusable. graal-25.2.4 is one, its tag has three components, and `version: "25.2.4"`
+# installs it through setUpGraalVMJDKCE - it is only unreachable through `java-version`, which can
+# address jdk-* tags alone. So a pom pinned at 25.2.4 against a `version`-pinned step is fine.
+graalvm_pom "$work/graalvm/version-input-pom.xml" 25.2.4
+cat >"$work/graalvm/version-input.yml" <<'YAML'
+name: Native Image
+on: [ workflow_dispatch ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.1
+        with:
+          version: "25.2.4"
+          distribution: "graalvm-community"
+YAML
+expect "accepts an intermediate release pinned through the version input" 0 "consistent" \
+    "$GRAALVMPIN" "$work/graalvm/version-input-pom.xml" "$work/graalvm/version-input.yml"
+
+# `version` wins over `java-version` when a step sets both, the same precedence setup-graalvm's
+# main.ts applies - so the pom is compared against `version`, and matching only the java-version
+# is a failure.
+graalvm_pom "$work/graalvm/both-inputs-pom.xml" 25.0.2
+cat >"$work/graalvm/both-inputs.yml" <<'YAML'
+name: Native Image
+on: [ workflow_dispatch ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.1
+        with:
+          version: "25.2.4"
+          java-version: "25.0.2"
+          distribution: "graalvm-community"
+YAML
+expect "compares against version, not java-version, when a step sets both" 1 "installs version 25.2.4" \
+    "$GRAALVMPIN" "$work/graalvm/both-inputs-pom.xml" "$work/graalvm/both-inputs.yml"
 
 # The step name is the first thing a reader sees, so it may not name a version other than the one
 # it installs.
@@ -1490,7 +1534,7 @@ jobs:
         with:
           distribution: "graalvm-community"
 YAML
-expect "reports a setup-graalvm step that pins no java-version" 1 "sets no java-version" \
+expect "reports a setup-graalvm step that pins no version at all" 1 "neither \`version\` nor" \
     "$GRAALVMPIN" "$work/graalvm/unpinned-pom.xml" "$work/graalvm/unpinned.yml"
 
 # Same as the sibling scripts: a workflow that will not parse is reported, never silently skipped.

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -61,6 +61,11 @@ jobs:
         run: ./.github/scripts/check-test-reporter-guards.py
       - name: Check source files for raw control bytes
         run: ./.github/scripts/check-source-control-chars.py
+      # native-image.yml runs only on dispatch/release, so nothing else in CI ever notices that its
+      # builder JDK and native/pom.xml's Truffle pin have drifted apart - two Dependabot bumps have
+      # now shipped that skew and broken every native leg. This is cheap and runs on every PR.
+      - name: Check native image GraalVM pin
+        run: ./.github/scripts/check-native-graalvm-pin.py
       - name: Check CI scripts
         run: ./.github/scripts/tests/test-ci-scripts.sh
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -77,16 +77,24 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # java-version is pinned to the EXACT patch release (not "25") to match
-      # native/pom.xml's native.graalvm.version, which pins the Truffle/polyglot artifacts to the
-      # same patch. A builder/Truffle version skew fails the native build at feature registration
-      # (NoSuchMethodError: OptimizedTruffleRuntime.getLoopNodeFactory()) - see docs/native-image.md
-      # "Prerequisites". If you bump native.graalvm.version in native/pom.xml, bump this
-      # java-version to match in the SAME change.
-      - name: Set up GraalVM (Community, JDK 25.0.2)
+      # `version`, NOT `java-version`, and the difference is load-bearing. setup-graalvm resolves a
+      # Community build two ways: `java-version` fetches a `jdk-<version>` release and so can only
+      # ever reach GraalVM's MAINLINE builds, while `version` looks up `graal-<version>` first and
+      # falls back to `jdk-<version>`. 25.2.4 is an intermediate release, published as the tag
+      # graal-25.2.4 (assets graalvm-community-jdk-25i2-25.0.4_*), so it is reachable through
+      # `version` alone. Both paths still go through findLatestGraalVMCEVersion, which skips any
+      # tag node-semver's semver.valid() rejects - which is why the four-component 25.3.4.1 is
+      # reachable through NEITHER input, and must never be pinned in native/pom.xml.
+      #
+      # This is pinned to the EXACT release that native/pom.xml's native.graalvm.version pins the
+      # Truffle/polyglot artifacts to. A builder/Truffle version skew fails the native build at
+      # feature registration (NoSuchMethodError: OptimizedTruffleRuntime.getLoopNodeFactory()) -
+      # see docs/native-image.md "Prerequisites". Move the two together or not at all;
+      # .github/scripts/check-native-graalvm-pin.py fails the `lint` job if they disagree.
+      - name: Set up GraalVM (Community 25.2.4, JDK 25.0.4)
         uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.1
         with:
-          java-version: "25.0.2"
+          version: "25.2.4"
           distribution: "graalvm-community"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: "true"
@@ -121,10 +129,10 @@ jobs:
       #     --static --libc=musl, nothing path-related).
       #
       # linux/arm64 (linkmode: mostly-static) deliberately does NOT run this step: GraalVM CE
-      # ships no static musl JDK libraries for aarch64 (the graalvm-community-jdk-25.0.2
+      # ships no static musl JDK libraries for aarch64 (the graalvm-community-jdk-25i2-25.0.4
       # linux-aarch64 release tarball has lib/static/linux-aarch64/glibc but not
       # lib/static/linux-aarch64/musl - linux-amd64 ships both - see oracle/graal#4645, closed
-      # not-planned), so --static --libc=musl can never link on that architecture regardless of
+      # not-planned; re-checked against this tarball when the pin moved off 25.0.2), so --static --libc=musl can never link on that architecture regardless of
       # toolchain setup. Rather than run a toolchain step known to be useless there, the arm64 leg
       # instead builds with -Dnative.mostlystatic=true (native/pom.xml's native-mostly-static
       # profile: -H:+StaticExecutableWithDynamicLibC - static except glibc itself), which needs no

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -9,6 +9,26 @@ on:
         default: false
   release:
     types: [published]
+  # Daily, because nothing else exercises this workflow. It has no `push`/`pull_request` trigger -
+  # a native image build is far too slow to gate a PR on - so before this schedule existed the only
+  # runs were a manual dispatch and a published release. That is how the GraalVM pin skew of run
+  # 33608446679 sat broken on main for over a month: the Dependabot merge that caused it carried
+  # [skip ci], the workflow that would have caught it does not run on push, and the breakage
+  # surfaced only when somebody dispatched it by hand. A nightly run turns "discovered at release
+  # time" into "discovered the next morning".
+  #
+  # A scheduled run is behaviourally identical to an ordinary dispatch: three free-runner legs
+  # (linux/amd64, linux/arm64, windows/amd64), no paid macOS leg, and every outward-facing step is
+  # gated on `github.event_name == 'release'` - no Docker Hub login, no image push (buildx runs
+  # --load, and the container is still smoke-tested locally), no release asset upload, and the
+  # `manifest` job does not run at all. So this costs free CI minutes and publishes nothing.
+  #
+  # 01:41 UTC is an otherwise empty slot: 00:00 already carries load-tests, ha-resilience-tests and
+  # the Sunday benchmark, 03:00 bolt-nightly, 04:17 meterian. Off the hour on purpose - GitHub
+  # queues on-the-hour crons hardest, and a scheduled run is dropped rather than delayed when the
+  # queue is long.
+  schedule:
+    - cron: "41 1 * * *"
 
 # Least privilege by default: only the build job's "Attach to release" step needs write, and it
 # scopes it below. The docker/manifest jobs authenticate to Docker Hub via secrets, not the
@@ -23,8 +43,9 @@ jobs:
   # native-image wants ~80% of system RAM against a ~630 MB build heap, which does not fit; the xlarge
   # runner has the headroom it needs). To avoid burning paid minutes on routine runs, that leg is only
   # added to the matrix on a published `release`, or on a manual dispatch that explicitly ticks
-  # `include_macos`. On an ordinary dispatch it is absent from the matrix entirely, so no paid runner
-  # is ever allocated (gating the STEPS instead would still allocate and bill the runner). The three
+  # `include_macos`. On an ordinary dispatch - and on the nightly schedule, where `inputs` is empty
+  # so the `= "true"` test is false - it is absent from the matrix entirely, so no paid runner is
+  # ever allocated (gating the STEPS instead would still allocate and bill the runner). The three
   # always-on legs - linux/amd64, linux/arm64 (both required) and windows/amd64 (best-effort) - build
   # on free runners. There is no free hosted x64 macOS runner (GitHub retired macos-13) and no free
   # Windows-on-ARM runner, and native-image cannot cross-compile, so each target builds on its own
@@ -59,7 +80,7 @@ jobs:
             echo "macOS arm64 leg INCLUDED (event=${{ github.event_name }}, include_macos=${{ inputs.include_macos }})"
           else
             include="$(jq -c '.' <<<"$include")"
-            echo "macOS arm64 leg EXCLUDED (ordinary dispatch; tick include_macos or publish a release to build it)"
+            echo "macOS arm64 leg EXCLUDED (scheduled run or ordinary dispatch; tick include_macos or publish a release to build it)"
           fi
           echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,14 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - "author=dependabot[bot]"
+      # native/pom.xml's native.graalvm.version MUST equal the native-image builder JDK pinned by
+      # native-image.yml's java-version, or the image build dies in TruffleBaseFeature with
+      # NoSuchMethodError getLoopNodeFactory(). Dependabot cannot move both sides, and this rule
+      # merges on ONE approval with no green-CI condition, then stamps [skip ci] on the merge - so
+      # neither the reviewer's attention nor `lint` is a backstop here. It has let the skew through
+      # twice (3fecba4bf, b53c48c1e2). A GraalVM PR is handled by hand instead: merge it only
+      # together with a matching java-version bump in native-image.yml, otherwise close it.
+      - "-files~=^native/pom\\.xml$"
     actions:
       merge:
         method: merge

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -23,6 +23,15 @@ treat it as best-effort outside Linux.
   OptimizedTruffleRuntime.getLoopNodeFactory()`). That error names neither file, and two Dependabot
   bumps have shipped the skew, so `.github/scripts/check-native-graalvm-pin.py` now enforces the
   equality in the always-on `lint` job. Move both sides in the same change, or neither.
+
+  A newer pin is possible but is not a one-line edit. `graalvm/setup-graalvm` resolves a CE build
+  two different ways: `java-version` fetches a `jdk-<version>` release and requires exactly three
+  dot-components, while `version` looks up `graal-<version>` first and falls back to
+  `jdk-<version>`. So an *intermediate* release such as `graal-25.2.4` is reachable, but only
+  through `version`, not through the `java-version` this workflow uses. `graal-25.3.4.1` is
+  reachable through neither: node-semver rejects its four-component tag, so setup-graalvm skips it
+  as an "unexpected GraalVM CE release" and fails. `jdk-25.0.2` remains the newest mainline JDK 25
+  Community build.
 - **`JAVA_HOME` (and `GRAALVM_HOME`) must point at the GraalVM home itself.** The
   `native-maven-plugin` resolves the native-image builder from `JAVA_HOME`/`GRAALVM_HOME`, not by
   searching `PATH` for a `native-image` executable. A version-manager shim (jenv, sdkman shell

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -14,24 +14,28 @@ treat it as best-effort outside Linux.
 
 ## Prerequisites
 
-- **GraalVM CE 25 (JDK 25).** The build uses the GraalVM Native Image Community Edition builder for
-  JDK 25 (CI pins `graalvm-community-jdk-25.0.2` via
-  [`graalvm/setup-graalvm`](https://github.com/graalvm/setup-graalvm)). `native/pom.xml` also pins
-  the GraalVM polyglot/Truffle artifacts (`graal-sdk`, `polyglot`, `js-language`, `truffle-*`, etc.)
-  to `25.0.2` to match the builder exactly; a Truffle version skew between the builder and those
-  artifacts fails the build at feature registration (`NoSuchMethodError:
+- **GraalVM CE 25.2.4 (JDK 25.0.4).** The build uses the GraalVM Native Image Community Edition
+  builder pinned by CI to `graal-25.2.4` (assets `graalvm-community-jdk-25i2-25.0.4_*`) via
+  [`graalvm/setup-graalvm`](https://github.com/graalvm/setup-graalvm). `native/pom.xml` pins the
+  GraalVM polyglot/Truffle artifacts (`graal-sdk`, `polyglot`, `js-language`, `truffle-*`, etc.) to
+  the same `25.2.4` to match the builder exactly; a Truffle version skew between the builder and
+  those artifacts fails the build at feature registration (`NoSuchMethodError:
   OptimizedTruffleRuntime.getLoopNodeFactory()`). That error names neither file, and two Dependabot
-  bumps have shipped the skew, so `.github/scripts/check-native-graalvm-pin.py` now enforces the
+  bumps have shipped the skew, so `.github/scripts/check-native-graalvm-pin.py` enforces the
   equality in the always-on `lint` job. Move both sides in the same change, or neither.
 
-  A newer pin is possible but is not a one-line edit. `graalvm/setup-graalvm` resolves a CE build
-  two different ways: `java-version` fetches a `jdk-<version>` release and requires exactly three
-  dot-components, while `version` looks up `graal-<version>` first and falls back to
-  `jdk-<version>`. So an *intermediate* release such as `graal-25.2.4` is reachable, but only
-  through `version`, not through the `java-version` this workflow uses. `graal-25.3.4.1` is
-  reachable through neither: node-semver rejects its four-component tag, so setup-graalvm skips it
-  as an "unexpected GraalVM CE release" and fails. `jdk-25.0.2` remains the newest mainline JDK 25
-  Community build.
+  **The workflow pins the builder through setup-graalvm's `version` input, not `java-version`, and
+  that is not interchangeable.** The action resolves a CE build two ways: `java-version` fetches a
+  `jdk-<version>` release and requires exactly three dot-components, so it reaches *mainline*
+  builds only; `version` looks up `graal-<version>` first and falls back to `jdk-<version>`.
+  25.2.4 is an *intermediate* release published under the `graal-25.2.4` tag, so only `version`
+  can select it - switching that step back to `java-version` would stop resolving this build.
+
+  Any future pin must be a version whose tag parses as three-component semver. `graal-25.3.4.1` is
+  reachable through **neither** input: node-semver rejects its four numeric components, so
+  `findLatestGraalVMCEVersion` skips it as an "unexpected GraalVM CE release", finds no
+  `jdk-25.3.4.1` either, and throws. It has been pinned here by mistake once already.
+
 - **`JAVA_HOME` (and `GRAALVM_HOME`) must point at the GraalVM home itself.** The
   `native-maven-plugin` resolves the native-image builder from `JAVA_HOME`/`GRAALVM_HOME`, not by
   searching `PATH` for a `native-image` executable. A version-manager shim (jenv, sdkman shell
@@ -40,7 +44,7 @@ treat it as best-effort outside Linux.
   JAVA_HOME`. Export both explicitly before building locally, e.g. on macOS:
 
   ```bash
-  export JAVA_HOME=/Library/Java/JavaVirtualMachines/graalvm-community-openjdk-25/Contents/Home
+  export JAVA_HOME=/path/to/graalvm-community-25.2.4/Contents/Home
   export GRAALVM_HOME=$JAVA_HOME
   ```
 

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -20,7 +20,9 @@ treat it as best-effort outside Linux.
   the GraalVM polyglot/Truffle artifacts (`graal-sdk`, `polyglot`, `js-language`, `truffle-*`, etc.)
   to `25.0.2` to match the builder exactly; a Truffle version skew between the builder and those
   artifacts fails the build at feature registration (`NoSuchMethodError:
-  OptimizedTruffleRuntime.getLoopNodeFactory()`).
+  OptimizedTruffleRuntime.getLoopNodeFactory()`). That error names neither file, and two Dependabot
+  bumps have shipped the skew, so `.github/scripts/check-native-graalvm-pin.py` now enforces the
+  equality in the always-on `lint` job. Move both sides in the same change, or neither.
 - **`JAVA_HOME` (and `GRAALVM_HOME`) must point at the GraalVM home itself.** The
   `native-maven-plugin` resolves the native-image builder from `JAVA_HOME`/`GRAALVM_HOME`, not by
   searching `PATH` for a `native-image` executable. A version-manager shim (jenv, sdkman shell

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -72,13 +72,26 @@
                  that still said 25.2.4, silently undoing that revert, and broke all three legs of
                  run 33608446679 the same way.
 
-            Neither of those is a version the builder can be moved to. Both are GraalVM
-            INTERMEDIATE releases, published by graalvm/graalvm-ce-builds under the tags
-            graal-25.2.4 and graal-25.3.4.1, whose assets are named graalvm-community-jdk-25i2-*
-            and graalvm-community-jdk-25i3-* - graalvm/setup-graalvm cannot select either through a
-            plain java-version. jdk-25.0.2 is still the newest mainline JDK 25 Community build, so
-            25.0.2 remains the version both sides can agree on. A newer pin needs the builder side
-            proven first.
+            25.3.4.1 is not installable by graalvm/setup-graalvm at all, through either of its
+            inputs. Its release tag graal-25.3.4.1 does exist, but node-semver rejects four numeric
+            components, so setup-graalvm's findLatestGraalVMCEVersion skips the tag as an
+            "unexpected GraalVM CE release", finds no jdk-25.3.4.1 either, and throws. The
+            java-version input cannot reach it under any spelling: it requires exactly three
+            dot-components and only ever fetches a jdk-<version> release.
+
+            Do NOT read that as "intermediate releases are off limits" - that is the wrong lesson,
+            and the earlier revision of this comment had it wrong. graal-25.2.4 IS an intermediate
+            release, its tag has three components, and setup-graalvm installs it happily from
+            `version: "25.2.4"` (setUpGraalVMJDKCE looks up graal-<version> before jdk-<version>).
+            It is unreachable only through java-version. So moving this module to 25.2.4 is a real
+            option, at the cost of switching native-image.yml from java-version to version and
+            accepting an intermediate release's support window. It just has to be proven on the
+            builder side first, in the same change.
+
+            What is pinned here today is the conservative choice: jdk-25.0.2 is the newest MAINLINE
+            JDK 25 Community build, addressable by the java-version input the workflow already
+            uses, and verified end to end (image builds, smoke test passes including the JS
+            round-trip).
 
             A comment is not a control: it did not stop attempt 2, because .mergify.yml auto-merges
             a dependabot PR on one approval with no green-CI condition, and stamps [skip ci] on the

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -53,54 +53,56 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <!--
             GraalVM polyglot/Truffle version used ONLY for the native image build. It MUST match the
-            native-image builder (GraalVM CE 25.0.2) shipped with the local GRAALVM_HOME and pinned
-            by native-image.yml's java-version, otherwise the in-image Truffle feature
-            (TruffleBaseFeature.afterRegistration) fails at build time with NoSuchMethodError
-            OptimizedTruffleRuntime.getLoopNodeFactory() because the SVM Truffle runtime bundled in
-            the builder is compiled against a different Truffle API than the one the engine pulls
-            transitively. Pinning here (native module only) leaves the JVM engine build untouched
-            (engine/pom.xml's own graalvm.version tracks latest independently) while letting the JS
+            native-image builder (GraalVM CE 25.2.4, which carries JDK 25.0.4) shipped with the
+            local GRAALVM_HOME and pinned by native-image.yml's `version` input, otherwise the
+            in-image Truffle feature (TruffleBaseFeature.afterRegistration) fails at build time with
+            NoSuchMethodError OptimizedTruffleRuntime.getLoopNodeFactory(), because the SVM Truffle
+            runtime bundled in the builder is compiled against a different Truffle API than the one
+            the engine pulls transitively. Pinning here (native module only) leaves the JVM engine
+            build untouched (engine/pom.xml's own graalvm.version tracks latest independently -
+            currently also 25.2.4, which is a coincidence, not a constraint) while letting the JS
             language embed into the image.
 
-            DEPENDABOT WILL TRY TO BUMP THIS AND MUST BE REFUSED unless native-image.yml's
-            java-version moves in the same change. It has now got through twice:
+            HOW THE BUILDER IS SELECTED, because it is not the obvious input. setup-graalvm resolves
+            a Community build two ways, and only one of them can reach this version:
 
-              1. 3fecba4bf (merged [skip ci] as d463a31d0) raised this to 25.2.4 and broke every
-                 native leg with exactly the getLoopNodeFactory() error above. Reverted, and this
-                 warning written, by #5811 (1ca1bc4420).
+              - `java-version` -> setUpGraalVMJDKCEByJavaVersion: requires exactly three
+                dot-components, then fetches the `jdk-<version>` release. Reaches MAINLINE builds
+                only.
+              - `version` -> setUpGraalVMJDKCE -> findReleaseTag: looks up `graal-<version>` FIRST
+                and `jdk-<version>` second. Reaches both.
+
+            25.2.4 is an INTERMEDIATE release - tag graal-25.2.4, assets
+            graalvm-community-jdk-25i2-25.0.4_* - so native-image.yml pins it through `version`.
+            Switching that step back to `java-version` would silently stop resolving this build.
+
+            DEPENDABOT WILL TRY TO BUMP THIS AND MUST BE REFUSED unless native-image.yml moves in
+            the same change. It has got through twice:
+
+              1. 3fecba4bf (merged [skip ci] as d463a31d0) raised this to 25.2.4 while the workflow
+                 stayed on java-version 25.0.2, and broke every native leg with exactly the
+                 getLoopNodeFactory() error above. Reverted, and this warning first written, by
+                 #5811 (1ca1bc4420). Note what that means: the VERSION was never the problem, only
+                 the skew - which is why the pin sits at 25.2.4 today, with the builder moved too.
               2. b53c48c1e2 (merged [skip ci] as e32e663604) then raised it to 25.3.4.1 from a base
                  that still said 25.2.4, silently undoing that revert, and broke all three legs of
                  run 33608446679 the same way.
 
-            25.3.4.1 is not installable by graalvm/setup-graalvm at all, through either of its
-            inputs. Its release tag graal-25.3.4.1 does exist, but node-semver rejects four numeric
-            components, so setup-graalvm's findLatestGraalVMCEVersion skips the tag as an
-            "unexpected GraalVM CE release", finds no jdk-25.3.4.1 either, and throws. The
-            java-version input cannot reach it under any spelling: it requires exactly three
-            dot-components and only ever fetches a jdk-<version> release.
+            25.3.4.1 in particular must NEVER be pinned here: it is not installable by setup-graalvm
+            through either input. Its tag graal-25.3.4.1 exists, but node-semver rejects four
+            numeric components, so findLatestGraalVMCEVersion skips it as an "unexpected GraalVM CE
+            release", finds no jdk-25.3.4.1 either, and throws. Any future pin must be a version
+            whose graal-* or jdk-* tag parses as three-component semver.
 
-            Do NOT read that as "intermediate releases are off limits" - that is the wrong lesson,
-            and the earlier revision of this comment had it wrong. graal-25.2.4 IS an intermediate
-            release, its tag has three components, and setup-graalvm installs it happily from
-            `version: "25.2.4"` (setUpGraalVMJDKCE looks up graal-<version> before jdk-<version>).
-            It is unreachable only through java-version. So moving this module to 25.2.4 is a real
-            option, at the cost of switching native-image.yml from java-version to version and
-            accepting an intermediate release's support window. It just has to be proven on the
-            builder side first, in the same change.
-
-            What is pinned here today is the conservative choice: jdk-25.0.2 is the newest MAINLINE
-            JDK 25 Community build, addressable by the java-version input the workflow already
-            uses, and verified end to end (image builds, smoke test passes including the JS
-            round-trip).
-
-            A comment is not a control: it did not stop attempt 2, because .mergify.yml auto-merges
-            a dependabot PR on one approval with no green-CI condition, and stamps [skip ci] on the
-            merge so main never re-tests it either. The enforcement now lives in
+            A comment is not a control: it did not stop attempt 2, because .mergify.yml auto-merged
+            a dependabot PR on one approval with no green-CI condition, and stamped [skip ci] on the
+            merge so main never re-tested it either. The enforcement now lives in
             .github/scripts/check-native-graalvm-pin.py, which fails the always-on `lint` job the
-            moment this property and native-image.yml's java-version disagree, and .mergify.yml no
-            longer auto-merges a PR that touches this file.
+            moment this property and native-image.yml's setup step disagree (it reads `version` and
+            `java-version` both, preferring `version` as setup-graalvm itself does), and .mergify.yml
+            no longer auto-merges a PR that touches this file.
         -->
-        <native.graalvm.version>25.0.2</native.graalvm.version>
+        <native.graalvm.version>25.2.4</native.graalvm.version>
         <!--
             Flag plumbed through by the CI matrix (native-image.yml) for the linux/amd64 job.
             Activates the native-static profile below, which appends the fully-static musl

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -63,16 +63,31 @@
             language embed into the image.
 
             DEPENDABOT WILL TRY TO BUMP THIS AND MUST BE REFUSED unless native-image.yml's
-            java-version moves in the same change. Its last attempt (3fecba4bf, merged [skip ci] as
-            d463a31d0) raised this to 25.2.4 and broke every native leg with exactly the
-            getLoopNodeFactory() error above. 25.2.4 is NOT a drop-in for the builder: it is a
-            GraalVM intermediate release, published by graalvm/graalvm-ce-builds under the tag
-            graal-25.2.4 with assets named graalvm-community-jdk-25i2-25.0.4_*, which
-            graalvm/setup-graalvm cannot select through a plain java-version. jdk-25.0.2 is the
-            newest mainline JDK 25 Community build, so 25.0.2 is the version both sides can agree
-            on. A newer pin needs the builder side proven first.
+            java-version moves in the same change. It has now got through twice:
+
+              1. 3fecba4bf (merged [skip ci] as d463a31d0) raised this to 25.2.4 and broke every
+                 native leg with exactly the getLoopNodeFactory() error above. Reverted, and this
+                 warning written, by #5811 (1ca1bc4420).
+              2. b53c48c1e2 (merged [skip ci] as e32e663604) then raised it to 25.3.4.1 from a base
+                 that still said 25.2.4, silently undoing that revert, and broke all three legs of
+                 run 33608446679 the same way.
+
+            Neither of those is a version the builder can be moved to. Both are GraalVM
+            INTERMEDIATE releases, published by graalvm/graalvm-ce-builds under the tags
+            graal-25.2.4 and graal-25.3.4.1, whose assets are named graalvm-community-jdk-25i2-*
+            and graalvm-community-jdk-25i3-* - graalvm/setup-graalvm cannot select either through a
+            plain java-version. jdk-25.0.2 is still the newest mainline JDK 25 Community build, so
+            25.0.2 remains the version both sides can agree on. A newer pin needs the builder side
+            proven first.
+
+            A comment is not a control: it did not stop attempt 2, because .mergify.yml auto-merges
+            a dependabot PR on one approval with no green-CI condition, and stamps [skip ci] on the
+            merge so main never re-tests it either. The enforcement now lives in
+            .github/scripts/check-native-graalvm-pin.py, which fails the always-on `lint` job the
+            moment this property and native-image.yml's java-version disagree, and .mergify.yml no
+            longer auto-merges a PR that touches this file.
         -->
-        <native.graalvm.version>25.3.4.1</native.graalvm.version>
+        <native.graalvm.version>25.0.2</native.graalvm.version>
         <!--
             Flag plumbed through by the CI matrix (native-image.yml) for the linux/amd64 job.
             Activates the native-static profile below, which appends the fully-static musl


### PR DESCRIPTION
## The failure

[Native Image run 33608446679](https://github.com/ArcadeData/arcadedb/actions/runs/33608446679) failed on **all three legs** - `linux-amd64`, `linux-arm64` and `windows-amd64` - inside the native-image builder, before analysis even started:

```
NoSuchMethodError: 'com.oracle.truffle.runtime.LoopNodeFactory
                    com.oracle.truffle.runtime.OptimizedTruffleRuntime.getLoopNodeFactory()'
  at com.oracle.svm.truffle.api.SubstrateTruffleRuntime.<init>(SubstrateTruffleRuntime.java:133)
  ... TruffleBaseFeature.afterRegistration -> NativeImageGenerator.setupNativeImage
```

`native-image.yml` installs GraalVM CE **25.0.2**; `native/pom.xml`'s `native.graalvm.version` said **25.3.4.1**. The image embeds GraalJS, so the builder's own SVM Truffle feature runs against the Truffle API those Maven coordinates pin, and the two are compiled against each other. The error names neither file, which is what makes it expensive to diagnose.

## Why not just move the action to 25.3.4.1 as well?

Checked against `graalvm/setup-graalvm` v1.6.1's source and `graalvm-ce-builds`' live tags, because the pom comment inherited from #5811 gave a reason that does not hold.

`setup-graalvm` resolves a Community build two different ways:

| input | resolution | reaches |
|---|---|---|
| `java-version` | `setUpGraalVMJDKCEByJavaVersion` - throws unless the resolved version splits into exactly three dot-components, then fetches `jdk-<version>` | `jdk-*` tags only |
| `version` | `setUpGraalVMJDKCE` -> `findReleaseTag` - looks up `graal-<version>` **first**, `jdk-<version>` second | `graal-*` and `jdk-*` |

Both go through `findLatestGraalVMCEVersion`, which skips any matching tag that node-semver's `semver.valid()` rejects.

So **an intermediate release is not off limits** - that was the wrong lesson, and I had it wrong in the first revision of this PR. `graal-25.2.4` *is* an intermediate release, its tag has three components, and `version: "25.2.4"` installs it fine. It is unreachable only through `java-version`.

**25.3.4.1 is genuinely unreachable, but because of its tag shape, not its release channel.** `semver.valid('25.3.4.1')` is `null` (node-semver takes exactly three numeric components), so `findLatestGraalVMCEVersion` logs `Skipping unexpected GraalVM CE release 25.3.4.1`, finds no `jdk-25.3.4.1` either, and throws. Confirmed against the live API - `graal-25.3.4.1` is the only tag that matches, and no `jdk-` tag does:

```
$ gh api repos/graalvm/graalvm-ce-builds/git/matching-refs/tags/graal-25.3.4.1
refs/tags/graal-25.3.4.1
$ gh api repos/graalvm/graalvm-ce-builds/git/matching-refs/tags/jdk-25.3.4.1
(empty)
$ node -e "console.log(require('semver').valid('25.3.4.1'))"
null
```

`version: "25.3"` fails identically - `matching-refs` returns the same four-component tag.

### What this PR pins

**25.2.4, with the builder moved to match** - `native/pom.xml` at `25.2.4` and `native-image.yml` switched from `java-version: "25.0.2"` to `version: "25.2.4"`. Both sides move in one change, which is the only way this pin is allowed to move.

That also settles what the earlier reverts left ambiguous: **25.2.4 was never a bad version.** Bump `3fecba4bf` broke the build because it moved the pin *alone*, leaving the builder on 25.0.2. The skew was the defect, not the release. 25.3.4.1 stays unpinnable for a different and permanent reason, and the comments now say which is which.

`engine/pom.xml`'s `graalvm.version` already tracks 25.2.4 independently, so the two modules now agree - a coincidence, not a constraint; engine deliberately tracks latest and will drift again.

## What this PR does

- **`native/pom.xml`** - pin back to `25.0.2`; the comment now records both escapes and says plainly that a comment is not a control.
- **`.github/scripts/check-native-graalvm-pin.py`** (new) - fails when `native.graalvm.version` and *every* `graalvm/setup-graalvm` step disagree (comparing against the step's `version` input when it has one, `java-version` otherwise), when the pin is not parseable as three-component semver and so cannot be installed through either input, when a step's *name* contradicts the version it installs, or when either side goes missing. It fails **closed** rather than passing vacuously - a guard that silently stops guarding is how the pin drifted in the first place.
- **`.github/workflows/mvn-test.yml`** - wired into the always-on `lint` job, so every PR sees it in about a second.
- **`.mergify.yml`** - Dependabot auto-merge no longer covers a PR touching `native/pom.xml`. A coordinate-wide Dependabot ignore is not an option here: `org.graalvm.sdk:graal-sdk` and `org.graalvm.polyglot:polyglot` are declared in `engine/pom.xml` too, where `graalvm.version` deliberately tracks latest for the JVM-side JS engine, and ignore rules match coordinates rather than modules.
- **`.github/dependabot.yml`, `docs/native-image.md`** - point at the enforcement.
- **`.github/workflows/native-image.yml`** - a **nightly schedule** (`41 1 * * *`). This workflow has no `push`/`pull_request` trigger, so its only runs were a manual dispatch and a published release - which is exactly why the skew sat broken on `main` for over a month. A scheduled run is behaviourally identical to an ordinary dispatch: three free-runner legs, no paid macOS runner (`inputs` is empty on a schedule, so the `include_macos` test is false), and every outward-facing step - release asset upload, Docker Hub login, the `--push` mode, the whole `manifest` job - is gated on `github.event_name == 'release'`. It builds, smoke-tests the binaries, container-smokes the images with `--load`, and publishes nothing. I rendered the matrix-assembly script as GitHub would for a `schedule` event and ran it: `linux/amd64`, `linux/arm64`, `windows/amd64`, no paid runner. 01:41 UTC is an empty slot (00:00 has three workflows, 03:00 bolt-nightly, 04:17 meterian) and deliberately off the hour.

## Verification

Run on macos/arm64 (the `dynamic` linkmode, same as the macOS leg), against real GraalVM CE builders downloaded for the purpose - **25.0.2** and **25.2.4** (JDK 25.0.4):

1. Pom at 25.3.4.1 against the 25.0.2 builder **reproduces** the exact `getLoopNodeFactory()` failure. Pom at 25.2.4 against the 25.0.2 builder reproduces it too - confirming the skew, not the release, is the defect.
2. Pom and builder both at **25.2.4**: `native-image` executed from the 25.2.4 `GRAALVM_HOME`, **zero** `getLoopNodeFactory()` occurrences, **BUILD SUCCESS**, 745 MB `arcadedb-26.9.1-SNAPSHOT-osx-aarch_64` (down from 790 MB at 25.0.2).
3. `native/src/test/scripts/smoke.sh` on that binary: **PASS**, including the **JS round-trip** - the GraalJS/Truffle path the skew used to break. (Wire-protocol assertions are skipped; that is the non-linux branch of the workflow's own smoke step.)
4. Re-checked the arm64 leg's premise against the *current* release: `graalvm-community-jdk-25i2-25.0.4_linux-aarch64` ships `lib/static/linux-aarch64/glibc` and **no** musl directory, exactly as 25.0.2 did (oracle/graal#4645), so `-Dnative.mostlystatic=true` is still the right mode there. The comment in `native-image.yml` now cites this tarball.
5. `check-native-graalvm-pin.py` reproduces the failure against `git show origin/main:native/pom.xml` and passes on the new pin through the `version` input.
5. `test-ci-scripts.sh` gains 12 cases, including the literal `b53c48c1e2` skew, the "both sides agree on an unresolvable version" shape, an intermediate release pinned through `version` (must be *accepted*), and a step setting both inputs: **96 checks passed**.

The linux-only static/mostly-static link modes cannot be exercised locally; CI is the check for those. The Truffle skew this fixes is upstream of linking and identical on all four legs.

The local runs also surfaced a trap worth writing down for whoever reproduces this: `export JAVA_HOME=<new> GRAALVM_HOME=$JAVA_HOME` in a **single** statement gives `GRAALVM_HOME` the *old* value, and `native-maven-plugin` resolves the builder from `GRAALVM_HOME`. The build then runs against whatever JDK was there before, and the failure is indistinguishable from a real skew. Export them separately.

## Note for the reviewer

The `.mergify.yml` change is a policy change rather than part of the build fix. It is the only one of these that would have actually stopped `b53c48c1e2`, but if you would rather keep handling GraalVM PRs by review alone, that hunk can be dropped without affecting anything else here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CETU1fizepsqjtSJaTDj6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added daily scheduled native-image builds alongside manual and release-triggered builds.
  - Scheduled builds use standard runners without release uploads or Docker publishing.

- **Documentation**
  - Updated native-image prerequisites and setup guidance for GraalVM Community 25.2.4.
  - Clarified supported GraalVM release formats and configuration options.

- **Chores**
  - Updated native-image builds to use GraalVM 25.2.4 and matching JDK artifacts.
  - Added automated validation to keep GraalVM versions synchronized across build configuration.

- **Tests**
  - Expanded validation coverage for supported, unsupported, missing, and mismatched GraalVM configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->