### PR TITLE
fix(#7054): @rid IN (SELECT ...) no longer answers empty

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -60,6 +60,7 @@ import com.arcadedb.query.sql.parser.LeOperator;
 import com.arcadedb.query.sql.parser.LetClause;
 import com.arcadedb.query.sql.parser.LetItem;
 import com.arcadedb.query.sql.parser.LtOperator;
+import com.arcadedb.query.sql.parser.MathExpression;
 import com.arcadedb.query.sql.parser.Node;
 import com.arcadedb.query.sql.parser.OrBlock;
 import com.arcadedb.query.sql.parser.OrderBy;
@@ -2070,19 +2071,33 @@ public class SelectExecutionPlanner {
     if (info.flattenedWhereClause == null || info.flattenedWhereClause.size() != 1)
       return false; // OR at the top level: other branches may match records outside this RID set
 
-    // A remaining (non-@rid) condition that references a per-record LET variable can't be
-    // evaluated here: LET is computed after the fetch step, in handleLet(), which runs after this
-    // method. Chaining it into a FilterStep on the fetch-side plan would evaluate it before LET
-    // populates the variable. Defer to the normal scan path, which applies WHERE only after LET.
-    if (info.perRecordLetClause != null && info.whereClause != null && info.whereClause.toString().contains("$"))
-      return false;
+    final boolean hasPerRecordLet =
+        info.perRecordLetClause != null && info.perRecordLetClause.getItems() != null && !info.perRecordLetClause.getItems()
+            .isEmpty();
 
     final AndBlock andBlock = info.flattenedWhereClause.getFirst();
 
     for (int i = 0; i < andBlock.getSubBlocks().size(); i++) {
       final BooleanExpression expr = andBlock.getSubBlocks().get(i);
-      if (extractRidEqualityOrInList(expr, context) == null)
-        continue; // not one of the @rid = <RID> / @rid IN [<RID list>] shapes
+
+      // `@rid IN $var` - which is also what `@rid IN (SELECT ...)` becomes once extractSubQueries() has lifted the
+      // sub-query into a LET under a generated alias. A variable that is still unset at plan time cannot be decided
+      // by extractRidEqualityOrInList() (it would read the null as "IN nothing" and answer the whole query empty for
+      // every execution - issue #7054); it is usable only when something is guaranteed to populate it before the
+      // fetch step pulls, which is what a GLOBAL let does - handleGlobalLet() chains ahead of the fetch, handleLet()
+      // after it.
+      final String ridVariable = ridInVariableName(expr);
+      final boolean unresolvedAtPlanTime = ridVariable != null && context.getVariable(ridVariable) == null;
+      if (unresolvedAtPlanTime ? !isGlobalLetVariable(ridVariable, info) : extractRidEqualityOrInList(expr, context) == null)
+        continue; // not one of the @rid = <RID> / @rid IN [<RID list>] / @rid IN $globalLetVar shapes
+
+      // A condition OTHER than the one matched above that references a per-record LET variable can't be evaluated
+      // here: that LET is computed after the fetch step, in handleLet(), which runs after this method. Chaining such
+      // a condition into a FilterStep on the fetch-side plan would evaluate it before LET populates the variable.
+      // Defer to the normal scan path, which applies WHERE only after LET. The matched condition itself is exempt:
+      // any variable IT reads has just been established to be a global one, computed ahead of the fetch.
+      if (hasPerRecordLet && referencesAVariableOutside(andBlock, i))
+        return false;
 
       // Known tradeoff: this shape check runs against THIS build's bound value, and its true/false
       // outcome (not the resolved RIDs themselves, which are re-resolved per execution below) is
@@ -2105,7 +2120,14 @@ public class SelectExecutionPlanner {
       plan.chain(new FilterByTypeStep(identifier, context));
 
       final List<BooleanExpression> remaining = new ArrayList<>(andBlock.getSubBlocks());
-      remaining.remove(i);
+      // The literal/parameter shapes resolve to exactly the RIDs the condition accepts, so the fetch step fully
+      // replaces them. A variable does not: it can hold projected sub-query rows, which
+      // resolveRidEqualityOrInListAtRuntime() deliberately widens into every RID they could possibly carry, so the
+      // condition has to stay as a residual filter to narrow that over-approximation back to what a plain scan
+      // would have answered. Kept for EVERY variable right-hand side, resolvable at plan time or not, so that the
+      // filter is present exactly whenever the runtime resolution widens.
+      if (ridVariable == null)
+        remaining.remove(i);
       if (!remaining.isEmpty()) {
         final AndBlock remainingBlock = new AndBlock();
         remainingBlock.getSubBlocks().addAll(remaining);
@@ -2122,6 +2144,59 @@ public class SelectExecutionPlanner {
     return false;
   }
 
+  /** Whether any sub-block of {@code andBlock} other than the one at {@code skipIndex} mentions a variable. */
+  private static boolean referencesAVariableOutside(final AndBlock andBlock, final int skipIndex) {
+    for (int i = 0; i < andBlock.getSubBlocks().size(); i++)
+      if (i != skipIndex && andBlock.getSubBlocks().get(i).toString().contains("$"))
+        return true;
+
+    return false;
+  }
+
+  /**
+   * The variable a {@code @rid IN $var} condition reads, or {@code null} when {@code expr} is any other shape.
+   * {@code @rid IN (SELECT ...)} lands here too: {@link #extractSubQueries} has by then replaced the statement with
+   * a {@link SubQueryCollector}-generated alias naming the LET that computes it.
+   */
+  private static String ridInVariableName(final BooleanExpression expr) {
+    if (!(expr instanceof InCondition in) || in.not || !RID_PROPERTY.equalsIgnoreCase(in.getLeft().toString()))
+      return null;
+    return variableName(in.getRightMathExpression());
+  }
+
+  /**
+   * The variable name behind a bare identifier expression - a user {@code $var} or a
+   * {@link SubQueryCollector}-generated sub-query alias, the two names {@code SuffixIdentifier.execute()} resolves
+   * against the command context - or {@code null} when {@code expr} is anything else (a field, a literal).
+   */
+  private static String variableName(final MathExpression expr) {
+    if (!(expr instanceof BaseExpression base) || base.getIdentifier() == null)
+      return null;
+    final SuffixIdentifier suffix = base.getIdentifier().getSuffix();
+    if (suffix == null || suffix.identifier == null)
+      return null;
+    final String name = suffix.identifier.getStringValue();
+    return name.startsWith("$") || SubQueryCollector.isGeneratedAlias(name) ? name : null;
+  }
+
+  /**
+   * Whether {@code variable} is computed by a GLOBAL let, the only kind {@link FetchFromRidsStep} can read: those
+   * steps are chained ahead of the fetch by {@link #handleGlobalLet}. A sub-query that refers to the outer record
+   * ({@code Statement.refersToParent()}) is lifted into the per-record LET clause instead, which
+   * {@link #handleLet} chains AFTER the fetch - its alias is still unset when the fetch pulls, so that shape has to
+   * keep the ordinary scan.
+   */
+  private static boolean isGlobalLetVariable(final String variable, final QueryPlanningInfo info) {
+    if (info.globalLetClause == null || info.globalLetClause.getItems() == null)
+      return false;
+
+    for (final LetItem item : info.globalLetClause.getItems())
+      if (item.getVarName() != null && variable.equals(item.getVarName().getStringValue()))
+        return true;
+
+    return false;
+  }
+
   /**
    * Build-time-only: recognizes {@code @rid = <RID>} and {@code @rid IN [<RID list>]} (also
    * {@code IN (<RID list>)} and {@code IN <bind parameter>}) and resolves the RID(s) against
@@ -2133,7 +2208,9 @@ public class SelectExecutionPlanner {
    * partially-resolvable list correctly on its own. Returns an empty list if the condition can never
    * match any record (empty IN-list, or a bind parameter bound to null). {@code @rid NOT IN [...]}
    * is deliberately not handled here: excluding a RID set still requires scanning every other record
-   * of the type, which this optimization cannot help with.
+   * of the type, which this optimization cannot help with. Neither is {@code @rid IN $var} whose
+   * variable is still unset at plan time - {@link #handleTypeWithRidFilter} decides that shape on
+   * its own, see issue #7054.
    * <p>
    * Do NOT call this from {@link FetchFromRidsStep#syncPull} - once the plan has committed to a
    * {@code FetchFromRidsStep}, there is no scan fallback left, so "abort the whole list to null on
@@ -2147,6 +2224,15 @@ public class SelectExecutionPlanner {
     }
 
     if (!(expr instanceof InCondition in) || in.not || !RID_PROPERTY.equalsIgnoreCase(in.getLeft().toString()))
+      return null;
+
+    // A variable that is still unset - typically the LET alias a lifted sub-query leaves behind (see
+    // extractSubQueries), computed only at execution time. Evaluating it now yields null, which the rawValue == null
+    // branch below would read as "IN nothing" and answer with an empty result for every execution - issue #7054.
+    // Whether that shape is usable anyway is decided by handleTypeWithRidFilter (it needs a global LET); here it is
+    // simply "not a plan-time-resolvable RID list".
+    final String variable = variableName(in.getRightMathExpression());
+    if (variable != null && context.getVariable(variable) == null)
       return null;
 
     final Object rawValue;
@@ -2230,22 +2316,57 @@ public class SelectExecutionPlanner {
     if (rawValue == NOT_A_RESOLVABLE_RID_SHAPE || rawValue == null)
       return List.of(); // subquery on the right, or WHERE @rid IN <null>: matches nothing
 
+    // A variable can hold projected sub-query rows rather than bare RIDs, and a row can carry the RID under any
+    // projection name (SELECT @rid ..., SELECT link_property ...), inside a collection, or not at all. Widen those
+    // rows into every RID they could possibly match: handleTypeWithRidFilter keeps the IN condition as a residual
+    // filter for every variable right-hand side, so an over-approximation here still answers exactly what a plain
+    // scan would.
+    final boolean widen = variableName(in.getRightMathExpression()) != null;
+
     // Same dedup rationale as extractRidEqualityOrInList; unresolvable elements are skipped instead
     // of aborting the whole list, matching how a normal IN scan treats a non-RID element (no match
     // for that element, not a failure of the whole condition).
     final Set<RID> rids = new LinkedHashSet<>();
     if (rawValue instanceof Iterable<?> iterable) {
-      for (final Object item : iterable) {
-        final RID rid = toRid(item, context);
+      for (final Object item : iterable)
+        collectRids(item, widen, context, rids);
+    } else
+      collectRids(rawValue, widen, context, rids);
+
+    return new ArrayList<>(rids);
+  }
+
+  /**
+   * Adds the RID(s) that one element of an {@code @rid IN <list>} right-hand side can stand for to {@code rids}.
+   * With {@code widen} off this is exactly {@link #toRid} - at most one RID per element. With it on (the lifted
+   * sub-query shape) a {@link Result} that is not itself a record also contributes every RID reachable through its
+   * properties, one level of collection included, because the projection name that carries the RID is not known
+   * here and picking one would silently drop the others.
+   */
+  private static void collectRids(final Object value, final boolean widen, final CommandContext context, final Set<RID> rids) {
+    final RID direct = toRid(value, context);
+    if (direct != null) {
+      rids.add(direct);
+      return;
+    }
+
+    if (!widen || !(value instanceof Result result) || result.isElement())
+      return;
+
+    for (final String propertyName : result.getPropertyNames()) {
+      final Object property = result.getProperty(propertyName);
+      if (MultiValue.isMultiValue(property)) {
+        for (final Object item : MultiValue.getMultiValueIterable(property, false)) {
+          final RID rid = toRid(item, context);
+          if (rid != null)
+            rids.add(rid);
+        }
+      } else {
+        final RID rid = toRid(property, context);
         if (rid != null)
           rids.add(rid);
       }
-    } else {
-      final RID rid = toRid(rawValue, context);
-      if (rid != null)
-        rids.add(rid);
     }
-    return new ArrayList<>(rids);
   }
 
   private static RID toRid(final Object value, final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -2087,6 +2087,14 @@ public class SelectExecutionPlanner {
       // fetch step pulls, which is what a GLOBAL let does - handleGlobalLet() chains ahead of the fetch, handleLet()
       // after it.
       final String ridVariable = ridInVariableName(expr);
+
+      // A variable a PER-RECORD let owns is recomputed for every row by handleLet(), which runs after the fetch. Any
+      // value the context happens to carry for that name right now - an outer script LET of the same name, say - is
+      // about to be shadowed, so resolving RIDs from it would fetch the wrong records rather than merely fewer. This
+      // has to be checked before the "already resolved at plan time" branch below, which would otherwise accept it.
+      if (ridVariable != null && isPerRecordLetVariable(ridVariable, info))
+        continue;
+
       final boolean unresolvedAtPlanTime = ridVariable != null && context.getVariable(ridVariable) == null;
       if (unresolvedAtPlanTime ? !isGlobalLetVariable(ridVariable, info) : extractRidEqualityOrInList(expr, context) == null)
         continue; // not one of the @rid = <RID> / @rid IN [<RID list>] / @rid IN $globalLetVar shapes
@@ -2187,10 +2195,19 @@ public class SelectExecutionPlanner {
    * keep the ordinary scan.
    */
   private static boolean isGlobalLetVariable(final String variable, final QueryPlanningInfo info) {
-    if (info.globalLetClause == null || info.globalLetClause.getItems() == null)
+    return declaresVariable(info.globalLetClause, variable);
+  }
+
+  /** Whether {@code variable} is (re)computed per row by {@link #handleLet}, which is chained after the fetch step. */
+  private static boolean isPerRecordLetVariable(final String variable, final QueryPlanningInfo info) {
+    return declaresVariable(info.perRecordLetClause, variable);
+  }
+
+  private static boolean declaresVariable(final LetClause letClause, final String variable) {
+    if (letClause == null || letClause.getItems() == null)
       return false;
 
-    for (final LetItem item : info.globalLetClause.getItems())
+    for (final LetItem item : letClause.getItems())
       if (item.getVarName() != null && variable.equals(item.getVarName().getStringValue()))
         return true;
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SubQueryCollector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SubQueryCollector.java
@@ -49,6 +49,16 @@ public class SubQueryCollector {
 
   protected final Map<Identifier, Statement> subQueries = new LinkedHashMap<>();
 
+  /**
+   * Tells whether {@code name} is one of the aliases this collector generates when it lifts a sub-query out of an
+   * expression and into a LET clause. Such an alias is not a user-visible variable: it holds a value only once the
+   * LET step that computes it has run, so a planner that evaluates it earlier than that must not read the resulting
+   * {@code null} as "the sub-query returned nothing" (issue #7054).
+   */
+  public static boolean isGeneratedAlias(final String name) {
+    return name != null && name.startsWith(GENERATED_ALIAS_PREFIX);
+  }
+
   protected Identifier getNextAlias() {
     final Identifier result = new Identifier(GENERATED_ALIAS_PREFIX + (nextAliasId++));
     result.internalAlias = true;

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RidInSubQueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RidInSubQueryTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins {@code SELECT ... WHERE @rid IN (SELECT ...)}, which used to answer nothing while the same query with a RID
+ * literal answered correctly (issue #7054). The planner lifts the sub-query into a global LET and leaves a generated
+ * alias on the right-hand side of the {@code IN}; the RID-address optimization then evaluated that alias at PLAN
+ * time, got the {@code null} of a variable no step had populated yet, and read it as "IN nothing", committing the
+ * plan to a {@link FetchFromRidsStep} over an empty RID set.
+ * <p>
+ * The fetch is still used - the sub-query's rows are widened into candidate RIDs at execution time, once the LET has
+ * run - so these tests also assert the plan shape, and every one of them cross-checks the answer against the plain
+ * scan that {@code @rid NOT IN} (which declines the optimization) forces, so the two paths cannot drift apart.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class RidInSubQueryTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("Supplier").createProperty("name", Type.STRING);
+    database.getSchema().createVertexType("TopSuppliers").createProperty("name", Type.STRING);
+    database.getSchema().getType("TopSuppliers").createProperty("target_rid", Type.LINK);
+    database.getSchema().getType("TopSuppliers").createProperty("targets", Type.LIST);
+    database.command("sql", "CREATE INDEX ON TopSuppliers (name) NOTUNIQUE");
+
+    database.transaction(() -> {
+      for (final String name : new String[] { "S1", "S2", "S3" }) {
+        database.command("sql", "INSERT INTO Supplier SET name = '" + name + "'");
+        database.command("sql", "INSERT INTO TopSuppliers SET name = '" + name + "', target_rid = (SELECT @rid FROM Supplier "
+            + "WHERE name = '" + name + "')");
+      }
+      // One row whose link lives inside a collection instead of a scalar LINK property.
+      database.command("sql",
+          "INSERT INTO TopSuppliers SET name = 'group', targets = (SELECT @rid FROM Supplier WHERE name IN ['S1', 'S2'])");
+    });
+  }
+
+  @Test
+  void ridInSubQueryOnLinkPropertyMatchesTheLinkedRecord() {
+    final ResultSet rs = database.query("sql",
+        "SELECT FROM `Supplier` WHERE @rid IN (SELECT target_rid FROM TopSuppliers WHERE name = 'S1')");
+
+    assertThat(findStep(rs.getExecutionPlan().orElseThrow(), FetchFromRidsStep.class))
+        .as("@rid IN (SELECT ...) must still be answered by address, not by a full type scan").isNotNull();
+    assertThat(collectNames(rs)).containsExactly("S1");
+  }
+
+  @Test
+  void ridInSubQueryProjectingRidMatchesTheProjectedRecords() {
+    assertThat(names("SELECT FROM Supplier WHERE @rid IN (SELECT @rid FROM Supplier WHERE name <> 'S2')"))
+        .containsExactlyInAnyOrder("S1", "S3");
+  }
+
+  @Test
+  void ridInSubQueryReturningSeveralRowsMatchesAllOfThem() {
+    assertThat(names("SELECT FROM Supplier WHERE @rid IN (SELECT target_rid FROM TopSuppliers WHERE name IN ['S1', 'S3'])"))
+        .containsExactlyInAnyOrder("S1", "S3");
+  }
+
+  @Test
+  void ridInEmptySubQueryReturnsNoRows() {
+    assertThat(names("SELECT FROM Supplier WHERE @rid IN (SELECT target_rid FROM TopSuppliers WHERE name = 'nobody')")).isEmpty();
+  }
+
+  @Test
+  void ridInSubQueryProjectingSomethingThatIsNotARidReturnsNoRows() {
+    // The residual filter is what makes this exact: the widened candidate set is empty here anyway, but a projection
+    // that is not a RID must never match, the same way the plain scan answers it.
+    assertBehavesLikeAScan("SELECT FROM Supplier WHERE @rid IN (SELECT name FROM TopSuppliers)", List.of());
+  }
+
+  @Test
+  void ridInSubQueryProjectingACollectionOfLinksMatchesEveryElement() {
+    assertBehavesLikeAScan("SELECT FROM Supplier WHERE @rid IN (SELECT targets FROM TopSuppliers WHERE name = 'group')",
+        List.of("S1", "S2"));
+  }
+
+  @Test
+  void ridInSubQueryProjectingSeveralColumnsBehavesLikeTheScan() {
+    // Ambiguous by construction: a scan compares @rid against the row's FIRST projected column ('name' here), so it
+    // never matches. The widened candidate set does contain the target_rid, which the residual filter then drops -
+    // the whole point of keeping the condition after the fetch.
+    assertBehavesLikeAScan("SELECT FROM Supplier WHERE @rid IN (SELECT name, target_rid FROM TopSuppliers WHERE name = 'S1')",
+        List.of());
+  }
+
+  @Test
+  void ridInSubQueryOverElementsMatchesByIdentity() {
+    assertThat(names("SELECT FROM Supplier WHERE @rid IN (SELECT FROM Supplier WHERE name = 'S2')")).containsExactly("S2");
+  }
+
+  @Test
+  void ridInSubQueryCombinesWithAnAdditionalCondition() {
+    assertThat(names("SELECT FROM Supplier WHERE @rid IN (SELECT target_rid FROM TopSuppliers) AND name = 'S3'"))
+        .containsExactly("S3");
+  }
+
+  @Test
+  void ridNotInSubQueryReturnsTheComplement() {
+    // NOT IN declines the address optimization by construction and is answered by the scan.
+    assertThat(names("SELECT FROM Supplier WHERE @rid NOT IN (SELECT target_rid FROM TopSuppliers WHERE name = 'S1')"))
+        .containsExactlyInAnyOrder("S2", "S3");
+  }
+
+  @Test
+  void ridInSubQueryWithAnOrBranchStaysCorrect() {
+    assertThat(names("SELECT FROM Supplier WHERE @rid IN (SELECT target_rid FROM TopSuppliers WHERE name = 'S1') "
+        + "OR name = 'S3'")).containsExactlyInAnyOrder("S1", "S3");
+  }
+
+  @Test
+  void ridInCorrelatedSubQueryKeepsTheScan() {
+    // A sub-query that reads the outer record becomes a PER-RECORD let, computed after the fetch step: the address
+    // optimization must decline it, or the fetch would resolve an alias no step has populated yet.
+    final ResultSet rs = database.query("sql",
+        "SELECT FROM Supplier WHERE @rid IN (SELECT target_rid FROM TopSuppliers WHERE name = $parent.$current.name)");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(findStep(plan, FetchFromRidsStep.class)).as("a correlated sub-query cannot be fetched by address").isNull();
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("S1", "S2", "S3");
+  }
+
+  @Test
+  void ridInGlobalLetVariableMatchesTheLinkedRecords() {
+    // Same hazard reached through an explicit LET rather than an inline sub-query: splitLet() promotes it to a
+    // global LET, so the variable is just as unset at plan time as a generated sub-query alias.
+    final ResultSet rs = database.query("sql", "SELECT FROM Supplier LET $top = (SELECT target_rid FROM TopSuppliers "
+        + "WHERE name IN ['S1', 'S2']) WHERE @rid IN $top");
+
+    assertThat(findStep(rs.getExecutionPlan().orElseThrow(), FetchFromRidsStep.class)).isNotNull();
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("S1", "S2");
+  }
+
+  /**
+   * Asserts the query answers {@code expected}, and that a plain scan of the same predicate answers the same thing.
+   * The scan is reached by negating the condition: {@code @rid NOT IN} declines the address optimization, so its
+   * complement is what the unoptimized path would have returned.
+   */
+  private void assertBehavesLikeAScan(final String query, final List<String> expected) {
+    assertThat(names(query)).as("optimized answer").containsExactlyInAnyOrderElementsOf(expected);
+
+    final List<String> all = names("SELECT FROM Supplier");
+    final List<String> viaScan = new ArrayList<>(all);
+    viaScan.removeAll(names(query.replace("@rid IN", "@rid NOT IN")));
+    assertThat(viaScan).as("scan answer for " + query).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  private List<String> names(final String query) {
+    return collectNames(database.query("sql", query));
+  }
+
+  private static List<String> collectNames(final ResultSet rs) {
+    final List<String> names = new ArrayList<>();
+    while (rs.hasNext())
+      names.add(rs.next().getProperty("name"));
+    rs.close();
+    return names;
+  }
+
+  private static <T extends ExecutionStep> T findStep(final ExecutionPlan plan, final Class<T> type) {
+    for (final ExecutionStep step : plan.getSteps())
+      if (type.isInstance(step))
+        return type.cast(step);
+    return null;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RidInSubQueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RidInSubQueryTest.java
@@ -159,6 +159,22 @@ class RidInSubQueryTest extends TestHelper {
     assertThat(collectNames(rs)).containsExactlyInAnyOrder("S1", "S2");
   }
 
+  @Test
+  void ridInVariableShadowedByAPerRecordLetKeepsTheScan() {
+    // $top is assigned twice: the first assignment is early-calculated and becomes a GLOBAL let, the second reads the
+    // record and stays PER-RECORD, shadowing it for every row. Only the global one has run by the time the fetch step
+    // would pull, so resolving RIDs from it fetches the WRONG records (just S1) rather than merely fewer - the
+    // per-record value is each record's own @rid, which every row satisfies. A variable a per-record LET owns has to
+    // keep the scan, whether or not the fetch could otherwise read a value for that name.
+    final ResultSet rs = database.query("sql",
+        "SELECT FROM Supplier LET $top = (SELECT target_rid FROM TopSuppliers WHERE name = 'S1'), $top = @rid "
+            + "WHERE @rid IN $top");
+
+    assertThat(findStep(rs.getExecutionPlan().orElseThrow(), FetchFromRidsStep.class))
+        .as("a variable a per-record LET recomputes cannot be fetched by address").isNull();
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("S1", "S2", "S3");
+  }
+
   /**
    * Asserts the query answers {@code expected}, and that a plain scan of the same predicate answers the same thing.
    * The scan is reached by negating the condition: {@code @rid NOT IN} declines the address optimization, so its


### PR DESCRIPTION
Closes #7054.

### The bug

`SELECT FROM Supplier WHERE @rid IN (SELECT target_rid FROM TopSuppliers WHERE name = 'S1')` returned nothing, while `SELECT FROM Supplier WHERE @rid IN [#1:0]` returned the row.

`optimizeQuery()` lifts every sub-query out of the WHERE clause into a global LET, so by the time the RID-address optimization (`handleTypeWithRidFilter`, issue #5824) sees the condition it reads `@rid IN _$$$SUBQUERY$$$_0`. `extractRidEqualityOrInList()` evaluated that alias against the plan-time context, got the `null` of a variable no step had populated yet, and took its `rawValue == null` branch - "`WHERE @rid IN <null>` matches nothing". That is the right reading for a bind parameter bound to null and the wrong one for a LET alias, and it committed the plan to a `FetchFromRidsStep` over an empty RID set:

```
+ LET (once)
  _$$$SUBQUERY$$$_0 = ( ... )
+ FETCH FROM RIDs
  @rid IN _$$$SUBQUERY$$$_0      <- resolved to zero RIDs
+ FILTER ITEMS BY TYPE Supplier
```

The `NOT_A_RESOLVABLE_RID_SHAPE` guard that was meant to catch this only fires on `InCondition.rightStatement`, which `extractSubQueries()` has always already nulled out.

### The fix

An unset variable on the right-hand side is now "not resolvable at plan time" rather than "matches nothing". The same shape is reached by an explicit `LET $top = (SELECT ...) ... WHERE @rid IN $top`, which `splitLet()` promotes to a global LET, so the check is on variables generally, not just on generated sub-query aliases.

Rather than decline the optimization and fall back to an O(n) type scan - which is what the "get these records by RID" shape most wants to avoid - the fetch is kept, because `handleGlobalLet()` chains the LET **ahead** of the fetch: the variable is populated by the time `FetchFromRidsStep` pulls. Two things make that exact:

- **Only a global LET qualifies.** A correlated sub-query (`Statement.refersToParent()`) is lifted into the per-record LET clause instead, which `handleLet()` chains *after* the fetch; that shape keeps the ordinary scan.
- **The condition is retained as a residual filter.** A projected row can carry its RID under any column name (`SELECT @rid ...`, `SELECT link_property ...`), inside a collection, or not at all, so the runtime resolution widens each row into every RID it could possibly match. Over-approximating and then re-applying the original `IN` gives provably the same answer as the plain scan, instead of a second interpretation of "which column is the RID" that could drift from `QueryOperatorEquals`.

The per-record-LET guard at the head of `handleTypeWithRidFilter` moved into the loop so it examines the conditions that actually get chained into the fetch-side `FilterStep`, exempting the matched `@rid` condition itself - whose variable has just been established to be a global one.

### Tests

New `RidInSubQueryTest` (13 cases): the reported repro, `SELECT @rid` and element sub-queries, multi-row, empty, non-RID and multi-column projections, a collection-valued projection, `NOT IN`, an `OR` branch, an extra `AND` condition, the correlated sub-query (asserted to keep the scan), and the explicit-LET variant. Every ambiguous case cross-checks the optimized answer against the plain scan reached through the negated predicate, so the two paths cannot drift apart.

`mvn -o -pl engine test -DexcludedGroups=benchmark,slow,vector`: 14158 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `RID IN` query handling when conditions use global variables or subqueries.
  - Corrected behavior for empty, projected, nested, and non-record subquery results.
  - Preserved accurate filtering for correlated queries, `NOT IN` conditions, and record-level variables.
  - Fixed cases where per-record `LET` variables shadow RID values, ensuring all matching records are evaluated correctly.

- **Tests**
  - Added coverage for RID variables shadowed by per-record `LET` clauses in correlated subqueries.
  - Expanded validation of `RID IN` queries involving projections, collections, empty results, additional predicates, and `OR` conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->