### PR TITLE
Enforce per-type permissions on every TimeSeries access path

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1530,7 +1530,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   @Override
   public void appendSamples(final String typeName, final long[] timestamps, final Object[]... columnValues) {
     final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(typeName);
-    final TimeSeriesEngine engine = tsType.requireEngine();
+    final TimeSeriesEngine engine = tsType.requireEngine(SecurityDatabaseUser.ACCESS.CREATE_RECORD);
     final int shardIdx = (int) (tsAppendCounter.getAndIncrement() % engine.getShardCount());
     final int slot = getSlot(shardIdx);
     scheduleTask(slot, new DatabaseAsyncAppendSamples(engine, shardIdx, timestamps, columnValues), true,
@@ -1540,7 +1540,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   @Override
   public void appendSamples(final String typeName, final TimeSeriesRowSource source) {
     final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(typeName);
-    final TimeSeriesEngine engine = tsType.requireEngine();
+    final TimeSeriesEngine engine = tsType.requireEngine(SecurityDatabaseUser.ACCESS.CREATE_RECORD);
     final int shardIdx = (int) (tsAppendCounter.getAndIncrement() % engine.getShardCount());
     final int slot = getSlot(shardIdx);
     scheduleTask(slot, new DatabaseAsyncAppendSamples(engine, shardIdx, source), true, backPressurePercentage);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -46,6 +46,7 @@ import com.arcadedb.engine.timeseries.promql.ast.PromQLExpr.UnaryExpr;
 import com.arcadedb.engine.timeseries.promql.ast.PromQLExpr.VectorSelector;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -228,10 +229,15 @@ public class PromQLEvaluator {
       return new InstantVector(List.of());
 
     final DocumentType docType = database.getSchema().getType(typeName);
-    if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null)
+    if (!(docType instanceof LocalTimeSeriesType tsType))
       return new InstantVector(List.of());
 
-    final TimeSeriesEngine engine = tsType.getEngine();
+    // Gated accessor: PromQL reads the same samples a SELECT would, so a metric the caller is denied must fail
+    // loudly here rather than be served through this side door. Checked before the engine-availability test so a
+    // denied caller learns nothing about the type's storage state.
+    final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
+    if (engine == null)
+      return new InstantVector(List.of());
     final List<ColumnDefinition> columns = tsType.getTsColumns();
 
     warnIfMultipleFields(columns, vs.metricName());
@@ -281,10 +287,13 @@ public class PromQLEvaluator {
       return new RangeVector(List.of());
 
     final DocumentType docType = database.getSchema().getType(typeName);
-    if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null)
+    if (!(docType instanceof LocalTimeSeriesType tsType))
       return new RangeVector(List.of());
 
-    final TimeSeriesEngine engine = tsType.getEngine();
+    // Same per-type read check as the instant-vector selector above.
+    final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
+    if (engine == null)
+      return new RangeVector(List.of());
     final List<ColumnDefinition> columns = tsType.getTsColumns();
 
     warnIfMultipleFields(columns, vs.metricName());

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/AggregateFromTimeSeriesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/AggregateFromTimeSeriesStep.java
@@ -26,6 +26,7 @@ import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.utility.DateUtils;
 
 import java.io.IOException;
@@ -80,7 +81,9 @@ public class AggregateFromTimeSeriesStep extends AbstractExecutionStep {
     try {
       if (!fetched) {
         try {
-          final TimeSeriesEngine engine = tsType.getEngine();
+          // Gated accessor: the push-down aggregation reads the very same samples a plain scan would, so it has
+          // to apply the same per-type read check (a TimeSeries type owns no bucket to gate by file id).
+          final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
           if (engine == null)
             throw new CommandExecutionException(
                 "TimeSeries engine for type '" + tsType.getName() + "' is not initialized");

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTimeSeriesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTimeSeriesStep.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.query.sql.executor;
 
-import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
@@ -26,7 +25,6 @@ import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.security.SecurityDatabaseUser;
-import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.utility.DateUtils;
 
 import java.io.IOException;
@@ -90,10 +88,8 @@ public class FetchFromTimeSeriesStep extends AbstractExecutionStep {
       if (!fetched) {
         try {
           // A TimeSeries type stores its rows in its own engine, not in a bucket LocalBucket's read check could
-          // gate, so apply the equivalent per-type read check here.
-          SecurityHelper.checkAccessOnType((DatabaseInternal) context.getDatabase(), tsType, SecurityDatabaseUser.ACCESS.READ_RECORD);
-
-          final TimeSeriesEngine engine = tsType.getEngine();
+          // gate, so the gated accessor applies the equivalent per-type read check.
+          final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
           if (engine == null)
             throw new CommandExecutionException(
                 "TimeSeries engine for type '" + tsType.getName() + "' is not initialized");

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java
@@ -37,6 +37,7 @@ import com.arcadedb.schema.ContinuousAggregateRefresher;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.Type;
+import com.arcadedb.security.SecurityDatabaseUser;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -116,7 +117,9 @@ public class SaveElementStep extends AbstractExecutionStep {
             // requireEngine() fails loudly - naming the type and, when known, why - instead of silently falling
             // through to the generic document save below, which a TimeSeries type with no record bucket of its
             // own cannot serve correctly either (issue #6356).
-            saveToTimeSeries(tsType, tsType.requireEngine(), doc, context);
+            // Gated accessor: appending a sample is a record creation on a type that owns no bucket, so the
+            // per-type check is the only thing that can enforce a "createRecord" denial on it.
+            saveToTimeSeries(tsType, tsType.requireEngine(SecurityDatabaseUser.ACCESS.CREATE_RECORD), doc, context);
             scheduleContinuousAggregateRefresh(context, tsType);
             return result;
           }

--- a/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
@@ -27,6 +27,8 @@ import com.arcadedb.engine.timeseries.TimeSeriesSealedStore;
 import com.arcadedb.engine.timeseries.codec.TimeSeriesCodec;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
@@ -94,8 +96,44 @@ public class LocalTimeSeriesType extends LocalDocumentType {
     engineUnavailableReason = null;
   }
 
+  /**
+   * Unchecked accessor, for engine-internal callers only (schema load/save, {@code CHECK DATABASE}, the
+   * maintenance scheduler): it performs NO authorization. Every path that reaches the samples on behalf of a
+   * user must go through {@link #getEngine(SecurityDatabaseUser.ACCESS)} or
+   * {@link #requireEngine(SecurityDatabaseUser.ACCESS)} instead - a TimeSeries type owns no record bucket, so
+   * the per-file check {@code LocalBucket} applies to a normal record never runs for it and the type-name check
+   * these overloads perform is the only thing standing between a denied user and the data.
+   */
   public TimeSeriesEngine getEngine() {
     return engine;
+  }
+
+  /**
+   * Same as {@link #getEngine()} after verifying that the current user (if any) is entitled to {@code access} on
+   * this type, throwing {@code SecurityException} otherwise. The check runs BEFORE the engine is looked at, so a
+   * denied caller cannot tell an unavailable engine from an available one.
+   */
+  public TimeSeriesEngine getEngine(final SecurityDatabaseUser.ACCESS access) {
+    checkAccess(access);
+    return engine;
+  }
+
+  /**
+   * Same as {@link #requireEngine()} after verifying that the current user (if any) is entitled to {@code access}
+   * on this type, throwing {@code SecurityException} otherwise.
+   */
+  public TimeSeriesEngine requireEngine(final SecurityDatabaseUser.ACCESS access) {
+    checkAccess(access);
+    return requireEngine();
+  }
+
+  /**
+   * Applies the per-type ACL for {@code access} on this type, throwing {@code SecurityException} when the current
+   * user is not entitled to it. A no-op when no user is bound to the current context (embedded usage, internal
+   * replication/import).
+   */
+  public void checkAccess(final SecurityDatabaseUser.ACCESS access) {
+    SecurityHelper.checkAccessOnType((DatabaseInternal) schema.getDatabase(), this, access);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/security/SecurityHelper.java
+++ b/engine/src/main/java/com/arcadedb/security/SecurityHelper.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.security;
 
+import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.index.Index;
 import com.arcadedb.schema.DocumentType;
@@ -72,6 +73,16 @@ public final class SecurityHelper {
    * type's buckets (or, for a bucket-less type, by name). A {@code null} user (no security context: embedded usage
    * or root) or a {@code null} type sees everything.
    */
+  /**
+   * Same as {@link #canAccessType(SecurityDatabaseUser, DocumentType, SecurityDatabaseUser.ACCESS)}, resolving the
+   * user bound to {@code database}'s current context. For listings that must silently hide what the caller cannot
+   * see rather than fail the whole request.
+   */
+  public static boolean canAccessType(final DatabaseInternal database, final DocumentType type, final SecurityDatabaseUser.ACCESS access) {
+    final DatabaseContext.DatabaseContextTL dbContext = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
+    return canAccessType(dbContext == null ? null : dbContext.getCurrentUser(), type, access);
+  }
+
   public static boolean canAccessType(final SecurityDatabaseUser user, final DocumentType type, final SecurityDatabaseUser.ACCESS access) {
     if (user == null || type == null)
       return true;

--- a/engine/src/main/java/com/arcadedb/security/SecurityHelper.java
+++ b/engine/src/main/java/com/arcadedb/security/SecurityHelper.java
@@ -68,12 +68,6 @@ public final class SecurityHelper {
   }
 
   /**
-   * Non-throwing form for catalog listings (e.g. {@code SELECT FROM schema:types}, {@code schema:indexes}): whether
-   * {@code type} should be visible to {@code user} at all, i.e. it grants {@code access} on at least one of the
-   * type's buckets (or, for a bucket-less type, by name). A {@code null} user (no security context: embedded usage
-   * or root) or a {@code null} type sees everything.
-   */
-  /**
    * Same as {@link #canAccessType(SecurityDatabaseUser, DocumentType, SecurityDatabaseUser.ACCESS)}, resolving the
    * user bound to {@code database}'s current context. For listings that must silently hide what the caller cannot
    * see rather than fail the whole request.
@@ -83,6 +77,12 @@ public final class SecurityHelper {
     return canAccessType(dbContext == null ? null : dbContext.getCurrentUser(), type, access);
   }
 
+  /**
+   * Non-throwing form for catalog listings (e.g. {@code SELECT FROM schema:types}, {@code schema:indexes}): whether
+   * {@code type} should be visible to {@code user} at all, i.e. it grants {@code access} on at least one of the
+   * type's buckets (or, for a bucket-less type, by name). A {@code null} user (no security context: embedded usage
+   * or root) or a {@code null} type sees everything.
+   */
   public static boolean canAccessType(final SecurityDatabaseUser user, final DocumentType type, final SecurityDatabaseUser.ACCESS access) {
     if (user == null || type == null)
       return true;

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/PerTypeAclTimeSeriesPathsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/PerTypeAclTimeSeriesPathsTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.security.SecurityDatabaseUser;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * A TimeSeries type owns no record bucket, so the only thing that can gate it is the type-name ACL. Every path that
+ * reaches its {@code TimeSeriesEngine} on behalf of a user - the plain scan, the {@code ts.timeBucket} push-down
+ * aggregation, {@code INSERT}, the async sample append and the PromQL evaluator - has to apply that check, exactly
+ * as {@code LocalBucket} applies the per-file one to a normal record.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PerTypeAclTimeSeriesPathsTest {
+  private static final String PATH             = "target/databases/PerTypeAclTimeSeriesPathsTest";
+  private static final String RESTRICTED_TYPE  = "SecretMetrics";
+  private static final String AUTHORIZED_TYPE  = "PublicMetrics";
+
+  private DatabaseFactory factory;
+  private Database        database;
+
+  @BeforeEach
+  void setUp() {
+    factory = new DatabaseFactory(PATH).setSecurity(db -> {
+    });
+    if (factory.exists())
+      factory.open().drop();
+
+    database = factory.create();
+
+    for (final String typeName : new String[] { RESTRICTED_TYPE, AUTHORIZED_TYPE }) {
+      database.command("sql", "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts FIELDS (value DOUBLE)");
+      database.transaction(() -> {
+        database.command("sql", "INSERT INTO " + typeName + " SET ts = 1000, value = 42.0");
+        database.command("sql", "INSERT INTO " + typeName + " SET ts = 2000, value = 1337.0");
+      });
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    unbindUser();
+    database.drop();
+    factory.close();
+  }
+
+  @Test
+  void aggregatePushDownDeniedOnRestrictedType() {
+    denyOn(RESTRICTED_TYPE, SecurityDatabaseUser.ACCESS.READ_RECORD);
+
+    final Throwable thrown = catchThrowable(() -> database.query("sql",
+        "SELECT ts.timeBucket('1s', ts) AS b, avg(value) AS v FROM " + RESTRICTED_TYPE + " GROUP BY b").next());
+    assertThat(thrown).as("the TimeSeries push-down aggregation must be gated like a plain scan of the same type")
+        .isInstanceOf(SecurityException.class);
+
+    final ResultSet allowed = database.query("sql",
+        "SELECT ts.timeBucket('1s', ts) AS b, avg(value) AS v FROM " + AUTHORIZED_TYPE + " GROUP BY b");
+    assertThat(allowed.hasNext()).as("the same aggregation on an authorized type must still work").isTrue();
+  }
+
+  @Test
+  void insertDeniedOnRestrictedType() {
+    denyOn(RESTRICTED_TYPE, SecurityDatabaseUser.ACCESS.CREATE_RECORD);
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(
+        () -> database.command("sql", "INSERT INTO " + RESTRICTED_TYPE + " SET ts = 9999, value = -1.0")));
+    assertThat(thrown).as("inserting a sample into a denied TimeSeries type must be rejected")
+        .isInstanceOf(SecurityException.class);
+
+    database.transaction(
+        () -> database.command("sql", "INSERT INTO " + AUTHORIZED_TYPE + " SET ts = 9999, value = -1.0"));
+
+    unbindUser();
+    assertThat(database.countType(RESTRICTED_TYPE, false)).as("the rejected sample must not have been persisted")
+        .isEqualTo(2);
+    assertThat(database.countType(AUTHORIZED_TYPE, false)).as("the authorized insert must have been persisted")
+        .isEqualTo(3);
+  }
+
+  @Test
+  void asyncAppendSamplesDeniedOnRestrictedType() {
+    denyOn(RESTRICTED_TYPE, SecurityDatabaseUser.ACCESS.CREATE_RECORD);
+
+    final Throwable thrown = catchThrowable(() -> database.async()
+        .appendSamples(RESTRICTED_TYPE, new long[] { 9999L }, new Object[] { -1.0 }));
+    assertThat(thrown).as("the async sample-append API must apply the same per-type check as INSERT")
+        .isInstanceOf(SecurityException.class);
+
+    database.async().appendSamples(AUTHORIZED_TYPE, new long[] { 9999L }, new Object[] { -1.0 });
+    database.async().waitCompletion();
+
+    unbindUser();
+    assertThat(database.countType(RESTRICTED_TYPE, false)).as("the rejected sample must not have been persisted")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void promQlEvaluationDeniedOnRestrictedType() {
+    denyOn(RESTRICTED_TYPE, SecurityDatabaseUser.ACCESS.READ_RECORD);
+
+    final Throwable thrown = catchThrowable(
+        () -> database.query("sql", "SELECT promql('" + RESTRICTED_TYPE + "', 2000) AS r").next());
+    assertThat(thrown).as("PromQL must not be a side door onto a denied TimeSeries type")
+        .isInstanceOf(SecurityException.class);
+
+    final Result allowed = database.query("sql", "SELECT promql('" + AUTHORIZED_TYPE + "', 2000) AS r").next();
+    assertThat(allowed).as("PromQL on an authorized type must still work").isNotNull();
+  }
+
+  @Test
+  void plainScanStillDeniedOnRestrictedType() {
+    denyOn(RESTRICTED_TYPE, SecurityDatabaseUser.ACCESS.READ_RECORD);
+
+    final Throwable thrown = catchThrowable(() -> database.query("sql", "SELECT FROM " + RESTRICTED_TYPE).hasNext());
+    assertThat(thrown).isInstanceOf(SecurityException.class);
+
+    assertThat(database.query("sql", "SELECT FROM " + AUTHORIZED_TYPE).hasNext()).isTrue();
+  }
+
+  private void denyOn(final String typeName, final SecurityDatabaseUser.ACCESS... accesses) {
+    final Set<SecurityDatabaseUser.ACCESS> denied = EnumSet.noneOf(SecurityDatabaseUser.ACCESS.class);
+    for (final SecurityDatabaseUser.ACCESS access : accesses)
+      denied.add(access);
+
+    DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(restrictedUser(Map.of(typeName, denied)));
+  }
+
+  private void unbindUser() {
+    DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(null);
+  }
+
+  /**
+   * Grants everything except the listed {@code ACCESS} values on the listed type names, so a query that still
+   * succeeds proves the check is scoped to the denied type and access rather than a blanket lockout.
+   */
+  private SecurityDatabaseUser restrictedUser(final Map<String, Set<SecurityDatabaseUser.ACCESS>> deniedByType) {
+    return new SecurityDatabaseUser() {
+      @Override
+      public String getName() {
+        return "restricted";
+      }
+
+      @Override
+      public boolean requestAccessOnDatabase(final DATABASE_ACCESS access) {
+        return true;
+      }
+
+      @Override
+      public boolean requestAccessOnFile(final int fileId, final ACCESS access) {
+        return true;
+      }
+
+      @Override
+      public boolean requestAccessOnType(final String typeName, final ACCESS access) {
+        final Set<ACCESS> denied = deniedByType.get(typeName);
+        return denied == null || !denied.contains(access);
+      }
+
+      @Override
+      public long getResultSetLimit() {
+        return -1L;
+      }
+
+      @Override
+      public long getReadTimeout() {
+        return -1L;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/PerTypeAclTimeSeriesPathsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/PerTypeAclTimeSeriesPathsTest.java
@@ -123,6 +123,9 @@ class PerTypeAclTimeSeriesPathsTest {
     unbindUser();
     assertThat(database.countType(RESTRICTED_TYPE, false)).as("the rejected sample must not have been persisted")
         .isEqualTo(2);
+    // Without this the test would also pass if the authorized append had silently done nothing.
+    assertThat(database.countType(AUTHORIZED_TYPE, false)).as("the authorized sample must have been persisted")
+        .isEqualTo(3);
   }
 
   @Test

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetGrafanaMetadataHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetGrafanaMetadataHandler.java
@@ -23,6 +23,8 @@ import com.arcadedb.engine.timeseries.AggregationType;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
@@ -59,6 +61,9 @@ public class GetGrafanaMetadataHandler extends AbstractServerHttpHandler {
 
     for (final DocumentType docType : database.getSchema().getTypes()) {
       if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null)
+        continue;
+      // Metadata discovery must not expose the field/tag names of a type the caller cannot read.
+      if (!SecurityHelper.canAccessType(database, tsType, SecurityDatabaseUser.ACCESS.READ_RECORD))
         continue;
 
       final JSONObject typeObj = new JSONObject();

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLLabelValuesHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLLabelValuesHandler.java
@@ -23,6 +23,8 @@ import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -70,12 +72,17 @@ public class GetPromQLLabelValuesHandler extends AbstractServerHttpHandler {
     if ("__name__".equals(labelName)) {
       // Return all TimeSeries type names
       for (final DocumentType type : database.getSchema().getTypes())
-        if (type instanceof LocalTimeSeriesType tsType && tsType.getEngine() != null)
+        if (type instanceof LocalTimeSeriesType tsType && tsType.getEngine() != null
+            && SecurityHelper.canAccessType(database, tsType, SecurityDatabaseUser.ACCESS.READ_RECORD))
+          // A metric the caller cannot read must not be named back to it.
           values.add(type.getName());
     } else {
       // Scan types that have this TAG column, query distinct values
       for (final DocumentType type : database.getSchema().getTypes()) {
         if (!(type instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null)
+          continue;
+        // Same filter for the value scan below, which reads the samples themselves.
+        if (!SecurityHelper.canAccessType(database, tsType, SecurityDatabaseUser.ACCESS.READ_RECORD))
           continue;
         final List<ColumnDefinition> columns = tsType.getTsColumns();
         final int colIdx = findColumnIndex(labelName, columns);

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLLabelsHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLLabelsHandler.java
@@ -22,6 +22,8 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -63,6 +65,9 @@ public class GetPromQLLabelsHandler extends AbstractServerHttpHandler {
 
     for (final DocumentType type : database.getSchema().getTypes()) {
       if (!(type instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null)
+        continue;
+      // Label discovery must not expose the tag names of a type the caller cannot read.
+      if (!SecurityHelper.canAccessType(database, tsType, SecurityDatabaseUser.ACCESS.READ_RECORD))
         continue;
       for (final ColumnDefinition col : tsType.getTsColumns())
         if (col.getRole() == ColumnDefinition.ColumnRole.TAG)

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLSeriesHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetPromQLSeriesHandler.java
@@ -27,6 +27,8 @@ import com.arcadedb.engine.timeseries.promql.ast.PromQLExpr;
 import com.arcadedb.engine.timeseries.promql.ast.PromQLExpr.VectorSelector;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityHelper;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -89,6 +91,11 @@ public class GetPromQLSeriesHandler extends AbstractServerHttpHandler {
 
         final DocumentType docType = database.getSchema().getType(typeName);
         if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null)
+          continue;
+
+        // Series discovery: a type the caller cannot read is omitted rather than reported as an error, the same
+        // way SELECT FROM schema:types hides it - a matcher legitimately spans several metrics here.
+        if (!SecurityHelper.canAccessType(database, tsType, SecurityDatabaseUser.ACCESS.READ_RECORD))
           continue;
 
         final TimeSeriesEngine engine = tsType.getEngine();

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
@@ -72,7 +72,10 @@ public class GetTimeSeriesLatestHandler extends AbstractServerHttpHandler {
     // the only thing that can enforce a "readRecord" denial on it. Throws SecurityException -> HTTP 403.
     // It runs BEFORE the engine-availability branch below (it returns null exactly where isEngineAvailable()
     // was false) so a denied caller gets the 403 and not the unavailable-engine diagnostic, which names a file
-    // path on disk.
+    // path on disk. The "does not exist" / "is not a TimeSeries type" answers above stay where they are: the ACL
+    // is keyed by type NAME and has no entry for a name that is not in the schema, so it cannot be consulted
+    // before the type resolves - and a 403 that only a real type can produce is the behaviour every other
+    // per-type check in the engine already has.
     final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
     if (engine == null)
       // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS one,

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
@@ -68,17 +68,19 @@ public class GetTimeSeriesLatestHandler extends AbstractServerHttpHandler {
     final DocumentType docType = database.getSchema().getType(typeName);
     if (!(docType instanceof LocalTimeSeriesType tsType))
       return new ExecutionResponse(400, "{ \"error\" : \"Type '" + typeName + "' is not a TimeSeries type\"}");
-    if (!tsType.isEngineAvailable())
+    // Gated accessor (per-type ACL): a TimeSeries type owns no record bucket, so this type-name check is
+    // the only thing that can enforce a "readRecord" denial on it. Throws SecurityException -> HTTP 403.
+    // It runs BEFORE the engine-availability branch below (it returns null exactly where isEngineAvailable()
+    // was false) so a denied caller gets the 403 and not the unavailable-engine diagnostic, which names a file
+    // path on disk.
+    final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
+    if (engine == null)
       // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS one,
       // its storage just failed to load - the old shared message sent an operator chasing the wrong cause.
       // Built with JSONObject rather than string concatenation because the reason embeds a file path that could
       // contain a double quote or backslash, which raw concatenation would turn into invalid JSON.
       return new ExecutionResponse(400, new JSONObject().put("error", "TimeSeries type '" + typeName
           + "' has no storage engine available: " + tsType.getEngineUnavailableReason()).toString());
-
-    // Gated accessor (per-type ACL): a TimeSeries type owns no record bucket, so this type-name check is
-    // the only thing that can enforce a "readRecord" denial on it. Throws SecurityException -> HTTP 403.
-    final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
     final List<ColumnDefinition> columns = tsType.getTsColumns();
 
     // Build tag filter from query param

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
@@ -24,6 +24,7 @@ import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
@@ -75,7 +76,9 @@ public class GetTimeSeriesLatestHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(400, new JSONObject().put("error", "TimeSeries type '" + typeName
           + "' has no storage engine available: " + tsType.getEngineUnavailableReason()).toString());
 
-    final TimeSeriesEngine engine = tsType.getEngine();
+    // Gated accessor (per-type ACL): a TimeSeries type owns no record bucket, so this type-name check is
+    // the only thing that can enforce a "readRecord" denial on it. Throws SecurityException -> HTTP 403.
+    final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
     final List<ColumnDefinition> columns = tsType.getTsColumns();
 
     // Build tag filter from query param

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
@@ -95,17 +95,18 @@ public class PostGrafanaQueryHandler extends AbstractServerHttpHandler {
         results.put(refId, buildErrorFrame("Type '" + typeName + "' is not a TimeSeries type"));
         continue;
       }
-      if (!tsType.isEngineAvailable()) {
+      // Gated accessor (per-type ACL): fail the whole request with 403 rather than emitting an error frame
+      // for the denied target - an error frame would confirm the type exists to a caller denied on it, and the
+      // engine-unavailable frame below would hand it a file path too. Hence before the availability branch: the
+      // accessor returns null exactly where isEngineAvailable() was false.
+      final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
+      if (engine == null) {
         // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS
         // one, its storage just failed to load - the old shared message sent an operator chasing the wrong cause.
         results.put(refId, buildErrorFrame(
             "TimeSeries type '" + typeName + "' has no storage engine available: " + tsType.getEngineUnavailableReason()));
         continue;
       }
-
-      // Gated accessor (per-type ACL): fail the whole request with 403 rather than emitting an error frame
-      // for the denied target - an error frame would confirm the type exists to a caller denied on it.
-      final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
       final List<ColumnDefinition> columns = tsType.getTsColumns();
 
       // Build tag filter

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
@@ -27,6 +27,7 @@ import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
@@ -102,7 +103,9 @@ public class PostGrafanaQueryHandler extends AbstractServerHttpHandler {
         continue;
       }
 
-      final TimeSeriesEngine engine = tsType.getEngine();
+      // Gated accessor (per-type ACL): fail the whole request with 403 rather than emitting an error frame
+      // for the denied target - an error frame would confirm the type exists to a caller denied on it.
+      final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
       final List<ColumnDefinition> columns = tsType.getTsColumns();
 
       // Build tag filter

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
@@ -27,8 +27,8 @@ import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
-import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.schema.Type;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
@@ -95,10 +95,11 @@ public class PostGrafanaQueryHandler extends AbstractServerHttpHandler {
         results.put(refId, buildErrorFrame("Type '" + typeName + "' is not a TimeSeries type"));
         continue;
       }
-      // Gated accessor (per-type ACL): fail the whole request with 403 rather than emitting an error frame
-      // for the denied target - an error frame would confirm the type exists to a caller denied on it, and the
-      // engine-unavailable frame below would hand it a file path too. Hence before the availability branch: the
-      // accessor returns null exactly where isEngineAvailable() was false.
+      // Gated accessor (per-type ACL): a denial fails the whole request with 403 rather than being folded into
+      // an error frame, which a Grafana panel would render as a data problem instead of an access problem. Placed
+      // before the availability branch below because that frame carries getEngineUnavailableReason(), i.e. a path
+      // on disk, which a caller denied on this type must not receive; the accessor returns null in exactly the
+      // cases isEngineAvailable() was false, so it replaces that test rather than following it.
       final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
       if (engine == null) {
         // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusReadHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusReadHandler.java
@@ -24,6 +24,7 @@ import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Label;
@@ -115,12 +116,19 @@ public class PostPrometheusReadHandler extends AbstractBinaryHttpHandler {
       }
 
       final DocumentType docType = database.getSchema().getType(typeName);
-      if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null) {
+      if (!(docType instanceof LocalTimeSeriesType tsType)) {
         queryResults.add(new QueryResult(List.of()));
         continue;
       }
 
-      final TimeSeriesEngine engine = tsType.getEngine();
+      // Gated accessor (per-type ACL): the query names this metric explicitly, so a denial is answered with a
+      // 403 rather than an empty result - an empty result is how a NON-EXISTENT metric answers, and conflating
+      // the two would let the caller keep probing a type it has no read right on.
+      final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
+      if (engine == null) {
+        queryResults.add(new QueryResult(List.of()));
+        continue;
+      }
       final List<ColumnDefinition> columns = tsType.getTsColumns();
 
       // Build TagFilter from label matchers (EQ only for now)

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
@@ -23,6 +23,7 @@ import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.schema.TimeSeriesTypeBuilder;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
@@ -123,7 +124,7 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
           // state its storage is in, so this is where a missing engine is reported - naming the type and why the
           // engine never started, rather than letting a null reach an NPE (issue #6356) or, as before, a phantom
           // "already exists" from the auto-create branch (issue #6839).
-          final TimeSeriesEngine engine = tsType.requireEngine();
+          final TimeSeriesEngine engine = tsType.requireEngine(SecurityDatabaseUser.ACCESS.CREATE_RECORD);
           final List<ColumnDefinition> columns = tsType.getTsColumns();
 
           // Append this series' samples as ONE batch. All samples of a remote-write TimeSeries share the

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
@@ -103,6 +103,19 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
     // TimeSeriesShard.appendSamples commits its own shard transaction per series, so a series already
     // appended before a later one throws is durable regardless of how this request rolls back (issue #5866).
     final HAReplicatedDatabase haDb = resolveHAReplicatedDatabase(database);
+
+    // Per-type ACL preflight, before the first append and before getOrCreateType() can mutate the schema:
+    // TimeSeriesShard.appendSamples commits its own shard transaction, so a denial discovered mid-loop would
+    // return 403 with the earlier series already durable. Checked by NAME so a denied metric is refused without
+    // its type being auto-created first; an unknown name has no entry in the permission map and stays allowed,
+    // which is what keeps auto-create working for a brand-new metric.
+    for (final TimeSeries ts : writeRequest.getTimeSeries()) {
+      final String metricName = ts.getMetricName();
+      if (metricName == null || metricName.isEmpty())
+        continue;
+      database.checkPermissionsOnType(sanitizeTypeName(metricName), SecurityDatabaseUser.ACCESS.CREATE_RECORD);
+    }
+
     try {
       // NOTE: this transaction does NOT make the request atomic. TimeSeriesShard.appendSamples runs its own
       // begin/commit on getWrappedDatabaseInstance(), so every appendBatch below has already committed its

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -29,6 +29,7 @@ import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
@@ -87,7 +88,9 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(400, new JSONObject().put("error", "TimeSeries type '" + typeName
           + "' has no storage engine available: " + tsType.getEngineUnavailableReason()).toString());
 
-    final TimeSeriesEngine engine = tsType.getEngine();
+    // Gated accessor (per-type ACL): a TimeSeries type owns no record bucket, so this type-name check is
+    // the only thing that can enforce a "readRecord" denial on it. Throws SecurityException -> HTTP 403.
+    final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
     final List<ColumnDefinition> columns = tsType.getTsColumns();
 
     final long fromTs = payload.getLong("from", Long.MIN_VALUE);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -84,7 +84,10 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
     // the only thing that can enforce a "readRecord" denial on it. Throws SecurityException -> HTTP 403.
     // It runs BEFORE the engine-availability branch below (it returns null exactly where isEngineAvailable()
     // was false) so a denied caller gets the 403 and not the unavailable-engine diagnostic, which names a file
-    // path on disk.
+    // path on disk. The "does not exist" / "is not a TimeSeries type" answers above stay where they are: the ACL
+    // is keyed by type NAME and has no entry for a name that is not in the schema, so it cannot be consulted
+    // before the type resolves - and a 403 that only a real type can produce is the behaviour every other
+    // per-type check in the engine already has.
     final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
     if (engine == null)
       // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS one,

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -80,17 +80,19 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
     final DocumentType docType = database.getSchema().getType(typeName);
     if (!(docType instanceof LocalTimeSeriesType tsType))
       return new ExecutionResponse(400, "{ \"error\" : \"Type '" + typeName + "' is not a TimeSeries type\"}");
-    if (!tsType.isEngineAvailable())
+    // Gated accessor (per-type ACL): a TimeSeries type owns no record bucket, so this type-name check is
+    // the only thing that can enforce a "readRecord" denial on it. Throws SecurityException -> HTTP 403.
+    // It runs BEFORE the engine-availability branch below (it returns null exactly where isEngineAvailable()
+    // was false) so a denied caller gets the 403 and not the unavailable-engine diagnostic, which names a file
+    // path on disk.
+    final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
+    if (engine == null)
       // Distinct from "not a TimeSeries type" (issue #6356 follow-up, claude-review on PR #6779): this type IS one,
       // its storage just failed to load - the old shared message sent an operator chasing the wrong cause.
       // Built with JSONObject rather than string concatenation because the reason embeds a file path that could
       // contain a double quote or backslash, which raw concatenation would turn into invalid JSON.
       return new ExecutionResponse(400, new JSONObject().put("error", "TimeSeries type '" + typeName
           + "' has no storage engine available: " + tsType.getEngineUnavailableReason()).toString());
-
-    // Gated accessor (per-type ACL): a TimeSeries type owns no record bucket, so this type-name check is
-    // the only thing that can enforce a "readRecord" denial on it. Throws SecurityException -> HTTP 403.
-    final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
     final List<ColumnDefinition> columns = tsType.getTsColumns();
 
     final long fromTs = payload.getLong("from", Long.MIN_VALUE);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
@@ -186,6 +186,12 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
           nonTimeSeriesTypes.add(measurement);
           continue;
         }
+        // Per-type ACL, checked HERE rather than only at the append below: TimeSeriesShard.appendSamples commits
+        // its own shard transaction, so a denial discovered mid-write would return 403 with the measurements
+        // before it already durable. Grouping runs entirely before the first append, so refusing here is the only
+        // placement that keeps a rejected request from writing anything. Also before the isEngineAvailable() check
+        // so a denied caller cannot learn from the drop report that the type exists.
+        tsType.checkAccess(SecurityDatabaseUser.ACCESS.CREATE_RECORD);
         if (!tsType.isEngineAvailable()) {
           unavailableTypes.add(measurement);
           continue;

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
@@ -28,6 +28,7 @@ import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.HAReplicatedDatabase;
@@ -208,7 +209,7 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
           // claude-review on PR #6779): every batch here was already filtered by isEngineAvailable() above, so
           // this can never actually throw, but getEngine() alone would silently reintroduce the "no engine"
           // possibility at the type level if that filtering were ever changed.
-          final TimeSeriesEngine engine = batch.type().requireEngine();
+          final TimeSeriesEngine engine = batch.type().requireEngine(SecurityDatabaseUser.ACCESS.CREATE_RECORD);
           final List<ColumnDefinition> columns = batch.type().getTsColumns();
           final List<Sample> group = batch.samples();
           final int count = group.size();

--- a/server/src/test/java/com/arcadedb/server/security/TimeSeriesPerTypeAclIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/TimeSeriesPerTypeAclIT.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A TimeSeries type owns no record bucket, so the bucket/file-id permission map a group's {@code types} ACL is
+ * compiled into has no entry for it and every check on it used to fall back to "allow". A user explicitly denied
+ * on a TimeSeries type could therefore read its samples and insert new ones - through SQL and through every
+ * TimeSeries, Prometheus and Grafana endpoint - while the identical policy correctly restricted a normal document
+ * type.
+ * <p>
+ * This test grants the user every access on every type EXCEPT the TimeSeries type it names explicitly, then walks
+ * the read, aggregate and write paths. A positive control on a second, authorized TimeSeries type keeps each 403
+ * honest: it proves the refusal is per-type authorization and not a blanket lockout of the TimeSeries endpoints.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TimeSeriesPerTypeAclIT extends BaseGraphServerTest {
+
+  private static final String SCOPED_USER     = "ts-scoped-user";
+  private static final String SCOPED_PWD      = "tsscopeduser1";
+  private static final String RESTRICTED_TYPE = "SecretMetrics";
+  private static final String AUTHORIZED_TYPE = "PublicMetrics";
+
+  private String lastResponseBody = "";
+
+  @Test
+  void perTypeAclEnforcedOnEveryTimeSeriesPath() throws Exception {
+    testEachServer((serverIndex) -> {
+      // Types must exist BEFORE the scoped user's per-type map is built, so the map segments the restricted one.
+      for (final String typeName : new String[] { RESTRICTED_TYPE, AUTHORIZED_TYPE }) {
+        command(serverIndex, "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts FIELDS (value DOUBLE)");
+        command(serverIndex, "INSERT INTO " + typeName + " SET ts = 1000, value = 42.0");
+        command(serverIndex, "INSERT INTO " + typeName + " SET ts = 2000, value = 1337.0");
+      }
+
+      createScopedUser(serverIndex);
+      try {
+        final String auth = basicAuth(SCOPED_USER, SCOPED_PWD);
+
+        // --- SQL read ---
+        assertThat(sqlStatus(serverIndex, auth, "query", "SELECT FROM " + RESTRICTED_TYPE))
+            .as("reading a denied TimeSeries type's samples must be rejected").isEqualTo(403);
+        assertThat(sqlStatus(serverIndex, auth, "query", "SELECT FROM " + AUTHORIZED_TYPE))
+            .as("reading an authorized TimeSeries type must still work").isEqualTo(200);
+
+        // --- SQL push-down aggregation: a different execution step, same samples ---
+        final String aggregate = "SELECT ts.timeBucket('1s', ts) AS b, avg(value) AS v FROM %s GROUP BY b";
+        assertThat(sqlStatus(serverIndex, auth, "query", String.format(aggregate, RESTRICTED_TYPE)))
+            .as("the TimeSeries push-down aggregation must be gated like a plain scan").isEqualTo(403);
+        assertThat(sqlStatus(serverIndex, auth, "query", String.format(aggregate, AUTHORIZED_TYPE)))
+            .as("the same aggregation on an authorized type must still work").isEqualTo(200);
+
+        // --- SQL write ---
+        assertThat(sqlStatus(serverIndex, auth, "command", "INSERT INTO " + RESTRICTED_TYPE + " SET ts = 9999, value = -1.0"))
+            .as("inserting into a denied TimeSeries type must be rejected").isEqualTo(403);
+
+        // --- TimeSeries endpoints ---
+        assertThat(postJsonStatus(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/query", auth,
+            new JSONObject().put("type", RESTRICTED_TYPE).toString()))
+            .as("the TimeSeries query endpoint must apply the same per-type check").isEqualTo(403);
+        assertThat(postJsonStatus(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/query", auth,
+            new JSONObject().put("type", AUTHORIZED_TYPE).toString()))
+            .as("the same endpoint on an authorized type must still work: %s", lastResponseBody).isEqualTo(200);
+
+        assertThat(getStatus(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/latest?type=" + RESTRICTED_TYPE, auth))
+            .as("the TimeSeries latest endpoint must apply the same per-type check").isEqualTo(403);
+
+        assertThat(postTextStatus(serverIndex,
+            "/api/v1/ts/" + getDatabaseName() + "/write?precision=ms", auth, RESTRICTED_TYPE + " value=-1.0 9999"))
+            .as("the TimeSeries line-protocol write endpoint must apply the same per-type check").isEqualTo(403);
+        assertThat(postTextStatus(serverIndex,
+            "/api/v1/ts/" + getDatabaseName() + "/write?precision=ms", auth, AUTHORIZED_TYPE + " value=-1.0 9999"))
+            // 204, not 200: the line-protocol endpoint answers an accepted write the InfluxDB way, with no body.
+            .as("the same endpoint on an authorized type must still work: %s", lastResponseBody).isEqualTo(204);
+
+        // --- Grafana ---
+        assertThat(postJsonStatus(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/grafana/query", auth,
+            new JSONObject().put("targets", new JSONArray().put(
+                new JSONObject().put("refId", "A").put("type", RESTRICTED_TYPE))).toString()))
+            .as("the Grafana query endpoint must apply the same per-type check").isEqualTo(403);
+
+        final JSONObject metadata = new JSONObject(
+            getBody(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/grafana/metadata", auth));
+        final JSONArray listedTypes = metadata.getJSONArray("types");
+        final JSONArray listedNames = new JSONArray();
+        for (int i = 0; i < listedTypes.length(); i++)
+          listedNames.put(listedTypes.getJSONObject(i).getString("name"));
+        assertThat(listedNames.toList()).as("a denied TimeSeries type must not be listed, nor its tags/fields")
+            .doesNotContain(RESTRICTED_TYPE).contains(AUTHORIZED_TYPE);
+
+        // --- PromQL ---
+        assertThat(getStatus(serverIndex,
+            "/api/v1/ts/" + getDatabaseName() + "/prom/api/v1/query?query=" + RESTRICTED_TYPE, auth))
+            .as("PromQL must not be a side door onto a denied TimeSeries type").isEqualTo(403);
+
+        final JSONObject labelValues = new JSONObject(getBody(serverIndex,
+            "/api/v1/ts/" + getDatabaseName() + "/prom/api/v1/label/__name__/values", auth));
+        assertThat(labelValues.getJSONArray("data").toList())
+            .as("a denied TimeSeries type's name must not be discoverable through PromQL label values")
+            .doesNotContain(RESTRICTED_TYPE).contains(AUTHORIZED_TYPE);
+
+        // --- Decisive check (as root): nothing was written to the denied type ---
+        assertThat(countSamples(serverIndex, RESTRICTED_TYPE))
+            .as("no sample may have been written to the denied type").isEqualTo(2);
+        assertThat(countSamples(serverIndex, AUTHORIZED_TYPE))
+            .as("the authorized line-protocol write must have been persisted").isEqualTo(3);
+      } finally {
+        deleteUser(serverIndex, SCOPED_USER);
+      }
+    });
+  }
+
+  private long countSamples(final int serverIndex, final String typeName) throws Exception {
+    final JSONArray result = new JSONObject(command(serverIndex, "SELECT count(*) AS c FROM " + typeName))
+        .getJSONArray("result");
+    return result.isEmpty() ? 0 : result.getJSONObject(0).getLong("c");
+  }
+
+  private void createScopedUser(final int serverIndex) throws Exception {
+    final ServerSecurity security = getServer(serverIndex).getSecurity();
+
+    security.getDatabaseGroupsConfiguration(getDatabaseName()).put("tsScoped",
+        new JSONObject().put("access", new JSONArray().put("updateSecurity").put("updateSchema"))
+            .put("types", new JSONObject()
+                .put("*", new JSONObject().put("access",
+                    new JSONArray().put("readRecord").put("createRecord").put("updateRecord").put("deleteRecord")))
+                .put(RESTRICTED_TYPE, new JSONObject().put("access", new JSONArray()))));
+    security.saveGroups();
+
+    if (security.existsUser(SCOPED_USER))
+      security.dropUser(SCOPED_USER);
+
+    final JSONObject payload = new JSONObject()
+        .put("name", SCOPED_USER)
+        .put("password", SCOPED_PWD)
+        .put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put("tsScoped")));
+
+    final HttpURLConnection connection = open(serverIndex, "POST", "/api/v1/server/users",
+        basicAuth("root", DEFAULT_PASSWORD_FOR_TESTS));
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream().write(payload.toString().getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(201);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void deleteUser(final int serverIndex, final String name) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "DELETE",
+        "/api/v1/server/users?name=" + URLEncoder.encode(name, StandardCharsets.UTF_8),
+        basicAuth("root", DEFAULT_PASSWORD_FOR_TESTS));
+    connection.connect();
+    try {
+      connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int sqlStatus(final int serverIndex, final String auth, final String endpoint, final String sql) throws Exception {
+    return postJsonStatus(serverIndex, "/api/v1/" + endpoint + "/" + getDatabaseName(), auth,
+        new JSONObject().put("language", "sql").put("command", sql).toString());
+  }
+
+  private int postJsonStatus(final int serverIndex, final String path, final String auth, final String body) throws Exception {
+    return postStatus(serverIndex, path, auth, "application/json", body);
+  }
+
+  private int postTextStatus(final int serverIndex, final String path, final String auth, final String body) throws Exception {
+    return postStatus(serverIndex, path, auth, "text/plain", body);
+  }
+
+  private int postStatus(final int serverIndex, final String path, final String auth, final String contentType,
+      final String body) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "POST", path, auth);
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", contentType);
+    connection.getOutputStream().write(body.getBytes(StandardCharsets.UTF_8));
+    connection.connect();
+    try {
+      return statusOf(connection);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int getStatus(final int serverIndex, final String path, final String auth) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "GET", path, auth);
+    connection.connect();
+    try {
+      return statusOf(connection);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  /**
+   * Keeps the response body of the last call in {@link #lastResponseBody} so an unexpected status reports WHY the
+   * server refused instead of only that it did - the difference between a per-type denial and a malformed request
+   * is exactly what this test has to tell apart.
+   */
+  private int statusOf(final HttpURLConnection connection) throws Exception {
+    final int status = connection.getResponseCode();
+    final var stream = status < 400 ? connection.getInputStream() : connection.getErrorStream();
+    lastResponseBody = stream == null ? "" : new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    return status;
+  }
+
+  private String getBody(final int serverIndex, final String path, final String auth) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "GET", path, auth);
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      return new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private HttpURLConnection open(final int serverIndex, final String method, final String path, final String auth)
+      throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + path).openConnection();
+    connection.setRequestMethod(method);
+    connection.setRequestProperty("Authorization", auth);
+    return connection;
+  }
+
+  private String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/TimeSeriesPerTypeAclIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/TimeSeriesPerTypeAclIT.java
@@ -21,13 +21,23 @@ package com.arcadedb.server.security;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Label;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.LabelMatcher;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.MatchType;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Query;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.ReadRequest;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Sample;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.TimeSeries;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.WriteRequest;
 import org.junit.jupiter.api.Test;
+import org.xerial.snappy.Snappy;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,6 +60,8 @@ class TimeSeriesPerTypeAclIT extends BaseGraphServerTest {
   private static final String SCOPED_PWD      = "tsscopeduser1";
   private static final String RESTRICTED_TYPE = "SecretMetrics";
   private static final String AUTHORIZED_TYPE = "PublicMetrics";
+  private static final String RESTRICTED_TAG  = "secret_host";
+  private static final String AUTHORIZED_TAG  = "public_host";
 
   private String lastResponseBody = "";
 
@@ -57,10 +69,16 @@ class TimeSeriesPerTypeAclIT extends BaseGraphServerTest {
   void perTypeAclEnforcedOnEveryTimeSeriesPath() throws Exception {
     testEachServer((serverIndex) -> {
       // Types must exist BEFORE the scoped user's per-type map is built, so the map segments the restricted one.
+      // Each type carries a DIFFERENT tag column name, so the discovery endpoints (PromQL labels/series,
+      // Grafana metadata) can be checked for leaking the denied type's schema and not just its samples.
+      command(serverIndex, "CREATE TIMESERIES TYPE " + RESTRICTED_TYPE
+          + " TIMESTAMP ts TAGS (" + RESTRICTED_TAG + " STRING) FIELDS (value DOUBLE)");
+      command(serverIndex, "CREATE TIMESERIES TYPE " + AUTHORIZED_TYPE
+          + " TIMESTAMP ts TAGS (" + AUTHORIZED_TAG + " STRING) FIELDS (value DOUBLE)");
       for (final String typeName : new String[] { RESTRICTED_TYPE, AUTHORIZED_TYPE }) {
-        command(serverIndex, "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts FIELDS (value DOUBLE)");
-        command(serverIndex, "INSERT INTO " + typeName + " SET ts = 1000, value = 42.0");
-        command(serverIndex, "INSERT INTO " + typeName + " SET ts = 2000, value = 1337.0");
+        final String tag = RESTRICTED_TYPE.equals(typeName) ? RESTRICTED_TAG : AUTHORIZED_TAG;
+        command(serverIndex, "INSERT INTO " + typeName + " SET ts = 1000, " + tag + " = 'a', value = 42.0");
+        command(serverIndex, "INSERT INTO " + typeName + " SET ts = 2000, " + tag + " = 'a', value = 1337.0");
       }
 
       createScopedUser(serverIndex);
@@ -94,6 +112,8 @@ class TimeSeriesPerTypeAclIT extends BaseGraphServerTest {
 
         assertThat(getStatus(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/latest?type=" + RESTRICTED_TYPE, auth))
             .as("the TimeSeries latest endpoint must apply the same per-type check").isEqualTo(403);
+        assertThat(getStatus(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/latest?type=" + AUTHORIZED_TYPE, auth))
+            .as("the same endpoint on an authorized type must still work: %s", lastResponseBody).isEqualTo(200);
 
         assertThat(postTextStatus(serverIndex,
             "/api/v1/ts/" + getDatabaseName() + "/write?precision=ms", auth, RESTRICTED_TYPE + " value=-1.0 9999"))
@@ -108,6 +128,10 @@ class TimeSeriesPerTypeAclIT extends BaseGraphServerTest {
             new JSONObject().put("targets", new JSONArray().put(
                 new JSONObject().put("refId", "A").put("type", RESTRICTED_TYPE))).toString()))
             .as("the Grafana query endpoint must apply the same per-type check").isEqualTo(403);
+        assertThat(postJsonStatus(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/grafana/query", auth,
+            new JSONObject().put("targets", new JSONArray().put(
+                new JSONObject().put("refId", "A").put("type", AUTHORIZED_TYPE))).toString()))
+            .as("the same endpoint on an authorized type must still work: %s", lastResponseBody).isEqualTo(200);
 
         final JSONObject metadata = new JSONObject(
             getBody(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/grafana/metadata", auth));
@@ -122,6 +146,32 @@ class TimeSeriesPerTypeAclIT extends BaseGraphServerTest {
         assertThat(getStatus(serverIndex,
             "/api/v1/ts/" + getDatabaseName() + "/prom/api/v1/query?query=" + RESTRICTED_TYPE, auth))
             .as("PromQL must not be a side door onto a denied TimeSeries type").isEqualTo(403);
+        assertThat(getStatus(serverIndex,
+            "/api/v1/ts/" + getDatabaseName() + "/prom/api/v1/query?query=" + AUTHORIZED_TYPE, auth))
+            .as("PromQL on an authorized type must still work: %s", lastResponseBody).isEqualTo(200);
+
+        final JSONObject labels = new JSONObject(getBody(serverIndex,
+            "/api/v1/ts/" + getDatabaseName() + "/prom/api/v1/labels", auth));
+        assertThat(labels.getJSONArray("data").toList())
+            .as("a denied type's tag names must not be discoverable through PromQL labels")
+            .doesNotContain(RESTRICTED_TAG).contains(AUTHORIZED_TAG);
+
+        assertThat(new JSONObject(getBody(serverIndex, "/api/v1/ts/" + getDatabaseName()
+            + "/prom/api/v1/series?match[]=" + RESTRICTED_TYPE, auth)).getJSONArray("data").toList())
+            .as("a denied type's series must not be listed").isEmpty();
+        assertThat(new JSONObject(getBody(serverIndex, "/api/v1/ts/" + getDatabaseName()
+            + "/prom/api/v1/series?match[]=" + AUTHORIZED_TYPE, auth)).getJSONArray("data").toList())
+            .as("an authorized type's series must still be listed").isNotEmpty();
+
+        // --- Prometheus remote write / read ---
+        assertThat(postPromWrite(serverIndex, auth, RESTRICTED_TYPE))
+            .as("Prometheus remote write into a denied type must be rejected").isEqualTo(403);
+        assertThat(postPromWrite(serverIndex, auth, AUTHORIZED_TYPE))
+            .as("Prometheus remote write into an authorized type must still work").isEqualTo(204);
+        assertThat(postPromRead(serverIndex, auth, RESTRICTED_TYPE))
+            .as("Prometheus remote read of a denied type must be rejected").isEqualTo(403);
+        assertThat(postPromRead(serverIndex, auth, AUTHORIZED_TYPE))
+            .as("Prometheus remote read of an authorized type must still work").isEqualTo(200);
 
         final JSONObject labelValues = new JSONObject(getBody(serverIndex,
             "/api/v1/ts/" + getDatabaseName() + "/prom/api/v1/label/__name__/values", auth));
@@ -133,7 +183,7 @@ class TimeSeriesPerTypeAclIT extends BaseGraphServerTest {
         assertThat(countSamples(serverIndex, RESTRICTED_TYPE))
             .as("no sample may have been written to the denied type").isEqualTo(2);
         assertThat(countSamples(serverIndex, AUTHORIZED_TYPE))
-            .as("the authorized line-protocol write must have been persisted").isEqualTo(3);
+            .as("the authorized line-protocol and remote-write samples must have been persisted").isEqualTo(4);
       } finally {
         deleteUser(serverIndex, SCOPED_USER);
       }
@@ -245,6 +295,35 @@ class TimeSeriesPerTypeAclIT extends BaseGraphServerTest {
     try {
       assertThat(connection.getResponseCode()).isEqualTo(200);
       return new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int postPromWrite(final int serverIndex, final String auth, final String metric) throws Exception {
+    final WriteRequest request = new WriteRequest(List.of(new TimeSeries(
+        List.of(new Label("__name__", metric)), List.of(new Sample(-1.0, 8888)))));
+    return postBinary(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/prom/write", auth,
+        Snappy.compress(request.encode()));
+  }
+
+  private int postPromRead(final int serverIndex, final String auth, final String metric) throws Exception {
+    final ReadRequest request = new ReadRequest(
+        List.of(new Query(0, 5000, List.of(new LabelMatcher(MatchType.EQ, "__name__", metric)))));
+    return postBinary(serverIndex, "/api/v1/ts/" + getDatabaseName() + "/prom/read", auth,
+        Snappy.compress(request.encode()));
+  }
+
+  private int postBinary(final int serverIndex, final String path, final String auth, final byte[] body)
+      throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "POST", path, auth);
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/x-protobuf");
+    connection.setRequestProperty("Content-Encoding", "snappy");
+    connection.getOutputStream().write(body);
+    connection.connect();
+    try {
+      return statusOf(connection);
     } finally {
       connection.disconnect();
     }


### PR DESCRIPTION
## Problem

A TimeSeries type owns no record bucket: its samples live in its own `TimeSeriesEngine`, and `LocalTimeSeriesType` never calls `addBucket()`. The permission map a group's `types` ACL is compiled into is keyed by bucket/file id, so a TimeSeries type gets no entry in it and `requestAccessOnFile()` falls back to allow. A type-name-keyed map and a `checkPermissionsOnType()` primitive already exist, but only two call sites used them - the plain scan (`FetchFromTimeSeriesStep`) and the `count(*)` shortcut.

Every other path that reaches the samples on a user's behalf was ungated:

| Path | Access | Where |
| --- | --- | --- |
| `ts.timeBucket` push-down aggregation | read | `AggregateFromTimeSeriesStep` |
| `INSERT INTO <tsType>` | create | `SaveElementStep` |
| `async().appendSamples(...)` | create | `DatabaseAsyncExecutorImpl` |
| PromQL instant/matrix selectors | read | `PromQLEvaluator` (also behind `promql()` SQL and `/prom/api/v1/query[_range]`) |
| `POST /api/v1/ts/{db}/query`, `GET .../latest` | read | TimeSeries handlers |
| `POST /api/v1/ts/{db}/write` (line protocol) | create | TimeSeries handler |
| `POST /api/v1/ts/{db}/prom/write` and `/prom/read` | create / read | Prometheus handlers |
| `POST /api/v1/ts/{db}/grafana/query` | read | Grafana handler |
| Grafana metadata, PromQL labels / label values / series | read (discovery) | listing handlers |

The consequence is that a group with an explicit `types.<TsType>.access: []` deny - and equally the bundled `readonly` and catch-all `*` policies - restricted a normal document type correctly while leaving the TimeSeries type readable and writable.

## Fix

Rather than repeating a check at ~15 call sites (which is what let this drift out of sync in the first place), `LocalTimeSeriesType` now owns the check and exposes it as the accessor every user-driven path already had to call:

- `getEngine(SecurityDatabaseUser.ACCESS)` and `requireEngine(SecurityDatabaseUser.ACCESS)` verify the per-type ACL *before* looking at the engine, so a denied caller also cannot distinguish an available engine from an unavailable one.
- The unchecked `getEngine()` / `requireEngine()` stay, now documented as engine-internal only (schema load/save, `CHECK DATABASE`, the maintenance scheduler). Opting out of the check is a deliberate, greppable act; a new call site that wants the engine on behalf of a user sees the gated overload first.
- `FetchFromTimeSeriesStep`'s open-coded `SecurityHelper.checkAccessOnType(...)` collapses into the same accessor, so there is one implementation instead of two.
- `SecurityHelper.canAccessType(DatabaseInternal, DocumentType, ACCESS)` is a new non-throwing overload that resolves the bound principal itself, for the listing handlers.

**Denial semantics**, deliberately split:

- An endpoint that names one type answers `403`. On `POST /grafana/query` that fails the whole request rather than emitting a per-target error frame, because an error frame would confirm the type exists to a caller denied on it. On `/prom/read` it is a `403` rather than an empty result, because an empty result is how a *non-existent* metric answers and conflating the two invites probing.
- An endpoint that enumerates types (Grafana metadata, PromQL labels, label values, series) omits what the caller cannot read, exactly as `SELECT FROM schema:types` does. A discovery API legitimately spans many metrics, and hiding is both non-leaky and non-breaking there.

## On the reported "silent configuration acceptance"

The report also suggests rejecting a `types` entry whose name does not resolve to a schema type. That is deliberately **not** done here: group and API-token policies are server-scoped and declarative, so a policy written before its type exists (or before the database is created) is a normal, supported workflow, and validating existence at save time would break it and race with schema changes. The actionable half of that concern - that the saved policy was *inert* - is what this PR fixes: a `types` entry on a TimeSeries type now enforces.

## Tests

- `engine/.../PerTypeAclTimeSeriesPathsTest` - aggregation push-down, INSERT, async append, PromQL, plus the already-covered plain scan as a control. Each denial is paired with the same operation on a second, authorized TimeSeries type, so a green run cannot be a blanket lockout.
- `server/.../security/TimeSeriesPerTypeAclIT` - the reported scenario end to end over HTTP with a real group policy: SQL read / aggregate / insert, the TimeSeries query, latest and line-protocol write endpoints, Grafana query and metadata, PromQL query and label values, and a final root-side count proving nothing was written to the denied type.

Both were verified **red** against the unmodified code before the fix (main-code changes reverted, tests kept) and green after.

Regression runs: 360 engine tests (`*TimeSeries*`, `*PerTypeAcl*`, `*PromQL*`, `*Prometheus*`, `*Grafana*`, `*Security*`), 112 server TimeSeries/Prometheus/Grafana tests, 140 `com.arcadedb.server.security.**` tests - all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enforced per-type permissions for time-series reads and writes across SQL, PromQL, Prometheus, Grafana, and HTTP APIs.
  * Restricted users cannot access time-series data or metadata, including labels, tags, and series information.
  * Unauthorized requests return appropriate access errors, while inaccessible types are omitted from discovery results.
* **Bug Fixes**
  * Prevented unauthorized inserts and sample appends, including partial writes.
  * Confirmed through expanded coverage that restricted data is neither exposed nor persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->