### PR TITLE
fix(ci): stop the issue classifier losing its own label write to a flag-order denial (#7077) [skip ci]

### DIFF
--- a/.github/workflows/classify-issue.yml
+++ b/.github/workflows/classify-issue.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Classify the issue and apply labels
+      - name: Decide which labels fit
         id: classify
         uses: anthropics/claude-code-action@e8c2d7c16c018cf1e694711c1c07a5f5db2b5eb1 # v1.0.208
         with:
@@ -195,21 +195,132 @@ jobs:
           # for them unless they are allow-listed here. This is the case the input documents
           # ("workflows with very limited permissions, e.g. issue labeling"), and it is only
           # honoured because github_token above is set. The issue body is untrusted input, so
-          # the tool allow-list below is the containment: read this one issue, read the label
-          # list, add labels to this one issue. Nothing else.
+          # the tool allow-list below is the containment: read this one issue and read the
+          # label list. Nothing else - the labelling itself is a separate step that only ever
+          # adds labels which already exist, to this one issue.
           allowed_non_write_users: "*"
           prompt: |
             REPO: ${{ github.repository }}
 
-            classify the issue ${{ github.event.issue.number }} labeling it
+            Classify GitHub issue ${{ github.event.issue.number }} of that repository.
 
-            Read the issue with `gh issue view`, list the labels that already exist in the
-            repository with `gh label list`, and apply the ones that fit with
-            `gh issue edit ${{ github.event.issue.number }} --add-label "..."`.
-            Only use labels that already exist; never create new ones. Do not remove
-            existing labels, and do not touch the `high_priority` label, which the
-            sponsor job owns.
-          # Both gh patterns are pinned to this issue's number, and the edit pattern to
-          # --add-label, so an injected instruction in the issue body cannot retitle, close,
-          # reassign, or relabel any other issue in the repository.
-          claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh issue view ${{ github.event.issue.number }}:*),Bash(gh label list:*),Bash(gh issue edit ${{ github.event.issue.number }} --add-label:*)"'
+            Read the issue with `gh issue view ${{ github.event.issue.number }}` and list the
+            labels that already exist in the repository with `gh label list`. Decide which of
+            the existing labels fit the issue. Never invent a label that does not already
+            exist, and never pick `high_priority`, which the sponsor job owns.
+
+            Do not try to edit the issue: you have no permission to do so, and another step
+            applies your decision. Instead, end your reply with one final line, exactly:
+
+            LABELS: <comma-separated label names>
+
+            Use `LABELS: none` if no existing label fits. That line must be the last line of
+            your reply and must contain nothing else.
+          # Read-only, and both patterns are pinned: this issue's number, and the repository
+          # label list. Claude gets no write tool at all, so an injected instruction in the
+          # issue body cannot retitle, close, reassign, or relabel anything. Note the pin has
+          # to sit at the very end of the allowed prefix, because Claude routinely appends
+          # flags of its own (`--repo <owner/name>`, `--json ...`) and any pattern that pins
+          # something *after* the issue number stops matching when it does.
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh issue view ${{ github.event.issue.number }}:*),Bash(gh label list:*)"'
+
+      - name: Apply the labels Claude chose
+        if: steps.classify.outputs.execution_file != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          EXECUTION_FILE: ${{ steps.classify.outputs.execution_file }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          RESERVED_LABEL: high_priority
+        with:
+          script: |
+            const fs = require("fs");
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const reserved = process.env.RESERVED_LABEL.toLowerCase();
+
+            const audit = (msg) => core.info(`classify-issue: issue=${issueNumber}, ${msg}`);
+
+            // The execution log is the JSON array of SDK messages. The final `result` message
+            // carries Claude's last reply; fall back to the last assistant text block.
+            let text = "";
+            try {
+              const raw = JSON.parse(fs.readFileSync(process.env.EXECUTION_FILE, "utf8"));
+              const messages = Array.isArray(raw) ? raw : [raw];
+              for (const m of messages) {
+                if (m?.type === "result" && typeof m.result === "string") text = m.result;
+                else if (m?.type === "assistant" && Array.isArray(m.message?.content)) {
+                  for (const c of m.message.content)
+                    if (c?.type === "text" && typeof c.text === "string") text = c.text;
+                }
+              }
+            } catch (err) {
+              core.warning(`classify-issue: unreadable execution file: ${err.message}`);
+              audit("action=errored");
+              return;
+            }
+
+            // Last LABELS: line wins, so a line quoted from the issue body earlier in the
+            // reply cannot outrank the decision Claude ends on.
+            const matches = [...text.matchAll(/^\s*LABELS:\s*(.*)$/gim)];
+            if (matches.length === 0) {
+              audit("action=no_decision");
+              return;
+            }
+            const requested = matches[matches.length - 1][1]
+              .split(",")
+              .map((s) => s.trim().replace(/^[`"']|[`"']$/g, ""))
+              .filter((s) => s.length > 0 && s.toLowerCase() !== "none");
+            if (requested.length === 0) {
+              audit("action=none_chosen");
+              return;
+            }
+
+            // Only labels that already exist may be applied, matched case-insensitively and
+            // mapped back to their canonical name. This is what keeps a hallucinated or
+            // injected name from reaching the API at all.
+            let existing;
+            try {
+              existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              });
+            } catch (err) {
+              core.warning(`classify-issue: listLabelsForRepo failed: ${err.message}`);
+              audit(`requested=${requested.join("|")}, action=errored`);
+              return;
+            }
+            const canonical = new Map(existing.map((l) => [l.name.toLowerCase(), l.name]));
+
+            const seen = new Set();
+            const labels = [];
+            const dropped = [];
+            for (const name of requested) {
+              const key = name.toLowerCase();
+              if (key === reserved || !canonical.has(key) || seen.has(key)) {
+                dropped.push(name);
+                continue;
+              }
+              seen.add(key);
+              labels.push(canonical.get(key));
+            }
+
+            const tail =
+              `requested=${requested.join("|")}, applied=${labels.join("|") || "-"}, ` +
+              `dropped=${dropped.join("|") || "-"}`;
+            if (labels.length === 0) {
+              audit(`${tail}, action=skipped`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels,
+              });
+              audit(`${tail}, action=labeled`);
+            } catch (err) {
+              core.warning(`classify-issue: addLabels failed: ${err.message}`);
+              audit(`${tail}, action=errored`);
+            }


### PR DESCRIPTION
## The bug

`Classify Issues and Label Sponsors` runs green and labels nothing. [Run 33645627413](https://github.com/ArcadeData/arcadedb/actions/runs/33645627413/job/100299507289) is the reported case: job `classify-issue` succeeded, #7059 came out unlabelled, and the SDK result line reads `"permission_denials_count": 2`.

The allow-list is a **prefix** match:

```
Bash(gh issue edit 7059 --add-label:*)
```

The prompt opens with `REPO: ArcadeData/arcadedb`, so Claude reaches for `--repo`. Reproduced locally with the workflow's exact prompt and allow-list:

| command Claude actually ran | verdict |
| --- | --- |
| `gh issue view 7059 --repo ArcadeData/arcadedb --json ... 2>&1` | allowed |
| `gh label list --repo ArcadeData/arcadedb --limit 100 2>&1` | allowed |
| `gh issue edit 7059 --repo ArcadeData/arcadedb --add-label "bug" --add-label "opencypher" 2>&1` | **denied** |

The two read patterns pin a prefix that nothing can be pushed in front of, so extra flags land harmlessly at the end. The write pattern pins `--add-label` *after* the issue number, and `--repo` slots into exactly that gap. A denial is not an error, so Claude finishes by describing the labels it would have applied and the job exits 0.

It is not a constant failure, which is what made it look intermittent: the runs with `permission_denials_count: 0` are the ones that labelled (#7052, #7049), and 1-3 denials is the rest of today's issues.

## The fix

Claude gets **no write tool at all**.

1. **Decide which labels fit** - read-only (`gh issue view <n>:*`, `gh label list:*`). The prompt asks it to end its reply with one line, `LABELS: a, b` (or `LABELS: none`).
2. **Apply the labels Claude chose** - `actions/github-script` reads `steps.classify.outputs.execution_file`, takes the **last** `LABELS:` line, intersects it case-insensitively with the repository's real labels (mapping back to the canonical name), drops `high_priority`, and calls `addLabels` on this one issue.

This is tighter containment than the version it replaces, not looser. Previously an injected instruction in the untrusted issue body had a write command within reach, pinned to one issue but free in its arguments. Now the only writer is a step with a hard-coded issue number that can apply nothing but a label which already exists. And the fragility is gone with it: the surviving allow patterns cannot be broken by a flag Claude decides to add.

## Verification

- **The new prompt, run locally against #7059 with the new read-only allow-list**: `permission_denials: []`, reply ends `LABELS: bug, opencypher`.
- **The apply step, exercised in a stub harness** (github-script body extracted from the YAML, GitHub API stubbed) across 10 cases:

| case | result |
| --- | --- |
| real execution log from the local run | applies `bug`, `opencypher` |
| hallucinated label `totally-made-up` | dropped, `bug` still applied |
| `high_priority` requested | dropped, `bug` still applied |
| `LABELS: none` | `action=none_chosen`, no call |
| no `LABELS:` line at all | `action=no_decision`, no call |
| `Bug, ` + backtick-quoted `sql`, `bug` | applies `bug` and the repo's canonical `SQL`, duplicate dropped |
| decoy `LABELS:` line earlier in the reply | last line wins |
| execution file missing | warning, `action=errored`, no call |
| `listLabelsForRepo` throws | warning, `action=errored`, no call |
| no result message, assistant text only | falls back to the last text block |

  The harness initially shared one temp file across the cases, so every case read the last one written and all ten "passed" for the wrong reason. Fixed to a file per case before the table above was taken.
- `actionlint` clean.

Every outcome logs one audit line, `classify-issue: issue=<n>, requested=..., applied=..., dropped=..., action=...`, next to the existing `sponsor-priority:` lines.

## Not in this PR

#7057, #7058 and #7059 are still unlabelled from the broken runs; they need labelling by hand or a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014N5M3Dp4d32Kr8tTBNCBAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue classification now applies only valid, canonical repository labels.
  * Prevents duplicate labels and excludes the reserved sponsor label.
  * Improved handling and logging for empty, malformed, skipped, and unsuccessful classification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->