### PR TITLE
fix(#7054): resolve a lifted sub-query alias against the record shape CONTAINS hands over

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -49,6 +49,7 @@ import com.arcadedb.query.sql.parser.FromClause;
 import com.arcadedb.query.sql.parser.FromItem;
 import com.arcadedb.query.sql.parser.FunctionCall;
 import com.arcadedb.query.sql.parser.GeOperator;
+import com.arcadedb.query.sql.parser.GeneratedAlias;
 import com.arcadedb.query.sql.parser.GroupBy;
 import com.arcadedb.query.sql.parser.GtOperator;
 import com.arcadedb.query.sql.parser.Identifier;
@@ -945,7 +946,7 @@ public class SelectExecutionPlanner {
           } else {
             continue;
           }
-          final Identifier newAlias = new Identifier("_$$$ORDER_BY_ALIAS$$$_" + (nextAliasCount++));
+          final Identifier newAlias = new Identifier(GeneratedAlias.PREFIX + "ORDER_BY_ALIAS$$$_" + (nextAliasCount++));
           newProj.setAlias(newAlias);
           item.setAlias(newAlias.getStringValue());
           item.expression = null;
@@ -1072,7 +1073,7 @@ public class SelectExecutionPlanner {
       if (!found) {
         final ProjectionItem newItem = new ProjectionItem();
         newItem.setExpression(exp);
-        final Identifier groupByAlias = new Identifier("_$$$GROUP_BY_ALIAS$$$_" + (nextAliasCount++));
+        final Identifier groupByAlias = new Identifier(GeneratedAlias.PREFIX + "GROUP_BY_ALIAS$$$_" + (nextAliasCount++));
         newItem.setAlias(groupByAlias);
         if (info.preAggregateProjection == null) {
           info.preAggregateProjection = new Projection();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AggregateProjectionSplit.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AggregateProjectionSplit.java
@@ -47,7 +47,7 @@ import java.util.List;
  */
 public class AggregateProjectionSplit {
 
-  protected static final String GENERATED_ALIAS_PREFIX = "_$$$OALIAS$$$_";
+  protected static final String GENERATED_ALIAS_PREFIX = GeneratedAlias.PREFIX + "OALIAS$$$_";
   protected              int    nextAliasId            = 0;
 
   protected List<ProjectionItem> preAggregate = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GeneratedAlias.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GeneratedAlias.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+/**
+ * The one spelling every alias the planner invents for itself has to start with.
+ * <p>
+ * The planner rewrites a statement into one the executor can run, and in doing so it names things the user never
+ * wrote: the LET a lifted sub-query is moved into ({@link SubQueryCollector}), the projection an aggregate is split
+ * across ({@link AggregateProjectionSplit}), the column an ORDER BY or GROUP BY term is materialized as. Those names
+ * then travel with the query and have to be resolved again at execution time - and the code doing the resolving has to
+ * tell them apart from a property the record might actually own, which it can only do by the prefix. Hence one
+ * constant rather than four independent string literals: an alias generator that picked its own prefix would compile,
+ * run, and silently resolve to nothing (issue #7054).
+ * <p>
+ * The prefix is deliberately unspellable as a property name in practice, so the test is a prefix match and nothing
+ * more.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class GeneratedAlias {
+  /** Every planner-generated alias begins with this; nothing a user can write does. */
+  public static final String PREFIX = "_$$$";
+
+  private GeneratedAlias() {
+  }
+
+  /** Whether {@code name} is an alias the planner generated for itself rather than a name the user wrote. */
+  public static boolean is(final String name) {
+    return name != null && name.startsWith(PREFIX);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SubQueryCollector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SubQueryCollector.java
@@ -44,7 +44,7 @@ import java.util.Map;
  */
 public class SubQueryCollector {
 
-  protected static final String GENERATED_ALIAS_PREFIX = "_$$$SUBQUERY$$$_";
+  protected static final String GENERATED_ALIAS_PREFIX = GeneratedAlias.PREFIX + "SUBQUERY$$$_";
   protected              int    nextAliasId            = 0;
 
   protected final Map<Identifier, Statement> subQueries = new LinkedHashMap<>();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
@@ -72,14 +72,31 @@ public class SuffixIdentifier extends SimpleNode {
     }
   }
 
+  /**
+   * Whether {@code name} names a context variable rather than a property of the record being evaluated: a user-visible
+   * {@code $variable}, or one of the {@code _$$$...} aliases the planner generates when it lifts a sub-query out of an
+   * expression ({@link SubQueryCollector}) or splits an aggregate projection ({@link AggregateProjectionSplit}) into a
+   * LET clause. No record can own a property under either spelling, so the context is the only place such a name can be
+   * resolved from - and every overload of {@code execute()} has to agree on that, or the same condition answers
+   * differently depending on whether the row reaching it happens to be a {@link Result} or an {@link Identifiable}
+   * (issue #7054: {@code $nested CONTAINS (@rid IN (SELECT ...))} hands each item over as an Identifiable, so the
+   * lifted sub-query resolved to null and the condition was never true).
+   */
+  private static boolean isContextVariable(final String name) {
+    return name.startsWith("$") || name.startsWith("_$$$");
+  }
+
   public Object execute(final Identifiable currentRecord, final CommandContext context) {
     if (star) {
       return currentRecord;
     }
     if (identifier != null) {
       final String varName = identifier.getStringValue();
-      if (context != null && varName.startsWith("$") && context.getVariable(varName) != null)
-        return context.getVariable(varName);
+      if (context != null && isContextVariable(varName)) {
+        final Object ctxVar = context.getVariable(varName);
+        if (ctxVar != null)
+          return ctxVar;
+      }
 
       if (currentRecord != null) {
         final Record record = currentRecord.getRecord();
@@ -130,7 +147,7 @@ public class SuffixIdentifier extends SimpleNode {
       if (currentRecord != null && varName.startsWith("$") && currentRecord.getMetadataKeys().contains(varName)) {
         return currentRecord.getMetadata(varName);
       }
-      if (context != null && (varName.startsWith("$") || varName.startsWith("_$$$"))) {
+      if (context != null && isContextVariable(varName)) {
         final Object ctxVar = context.getVariable(varName);
         if (ctxVar != null) {
           return ctxVar;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
@@ -190,8 +190,15 @@ public class SuffixIdentifier extends SimpleNode {
       if (context != null && "$parent".equalsIgnoreCase(varName))
         return context.getParent();
 
-      if (context != null && context.getVariable(varName) != null)
-        return context.getVariable(varName);
+      // Same predicate as the other two overloads, and for the same reason. Without it this one asked the context about
+      // EVERY name, so a plain map key was shadowed by any context variable that happened to share it: `$m.name` with a
+      // `LET $name = ...` in scope answered the variable instead of the map entry, and a database global variable could
+      // shadow a key with no LET involved at all.
+      if (context != null && isContextVariable(varName)) {
+        final Object ctxVar = context.getVariable(varName);
+        if (ctxVar != null)
+          return ctxVar;
+      }
 
       if (currentRecord != null)
         return currentRecord.get(varName);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
@@ -73,17 +73,21 @@ public class SuffixIdentifier extends SimpleNode {
   }
 
   /**
-   * Whether {@code name} names a context variable rather than a property of the record being evaluated: a user-visible
-   * {@code $variable}, or one of the {@code _$$$...} aliases the planner generates when it lifts a sub-query out of an
-   * expression ({@link SubQueryCollector}) or splits an aggregate projection ({@link AggregateProjectionSplit}) into a
-   * LET clause. No record can own a property under either spelling, so the context is the only place such a name can be
-   * resolved from - and every overload of {@code execute()} has to agree on that, or the same condition answers
-   * differently depending on whether the row reaching it happens to be a {@link Result} or an {@link Identifiable}
-   * (issue #7054: {@code $nested CONTAINS (@rid IN (SELECT ...))} hands each item over as an Identifiable, so the
-   * lifted sub-query resolved to null and the condition was never true).
+   * Whether {@code name} names a context variable rather than a property of the value being evaluated: a user-visible
+   * {@code $variable}, or a {@link GeneratedAlias} the planner invented for itself.
+   * <p>
+   * Every overload of {@code execute()} has to agree on this, or the same condition answers differently depending on
+   * the shape the value reaching it happens to have. Both directions have already gone wrong (issue #7054):
+   * <ul>
+   * <li>the {@link Identifiable} overload asked the context only about {@code $} names, so a lifted sub-query's alias
+   * resolved to null and {@code $nested CONTAINS (@rid IN (SELECT ...))} was never true - {@code CONTAINS} hands each
+   * item over as an Identifiable when the collection holds records;
+   * <li>the {@link Map} overload asked the context about EVERY name, so a plain map key was shadowed by any context
+   * variable that happened to share it.
+   * </ul>
    */
   private static boolean isContextVariable(final String name) {
-    return name.startsWith("$") || name.startsWith("_$$$");
+    return name.startsWith("$") || GeneratedAlias.is(name);
   }
 
   public Object execute(final Identifiable currentRecord, final CommandContext context) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SubQueryAliasInNestedConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SubQueryAliasInNestedConditionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins a sub-query used inside a condition that is evaluated against something other than the row being filtered -
+ * {@code $nested CONTAINS (<condition>)}, where the condition sees each ITEM of {@code $nested} - which used to answer
+ * nothing while the same condition written with a literal answered correctly (issue #7054, second report).
+ * <p>
+ * The planner lifts every sub-query into a LET and leaves a generated {@code _$$$SUBQUERY$$$_N} alias behind, so the
+ * inner condition reads that alias from the command context. {@code CONTAINS} hands each item over as an
+ * {@code Identifiable} when the collection holds records, and the identifier resolution for that shape only knew about
+ * user-visible {@code $variable} names: the generated alias resolved to null, the {@code IN} then had nothing to test
+ * against, and the whole condition was silently never true.
+ * <p>
+ * Every case therefore checks the sub-query spelling against the equivalent spelling that never went through the alias
+ * (a literal, or an explicit LET variable), so the two cannot drift apart again.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SubQueryAliasInNestedConditionTest extends TestHelper {
+
+  private static final String SELECT_NESTED =
+      "SELECT $nested.name AS names FROM AllSuppliers LET $nested = outE('RelSupplier').inV('Supplier') WHERE code = 'A1' ";
+
+  private String s1Rid;
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("Supplier").createProperty("name", Type.STRING);
+    database.getSchema().createVertexType("TopSuppliers").createProperty("name", Type.STRING);
+    database.getSchema().getType("TopSuppliers").createProperty("target_rid", Type.LINK);
+    database.getSchema().createVertexType("AllSuppliers").createProperty("code", Type.STRING);
+    database.getSchema().createEdgeType("RelSupplier");
+
+    database.transaction(() -> {
+      for (final String name : new String[] { "S1", "S2", "S3" }) {
+        database.command("sql", "INSERT INTO Supplier SET name = '" + name + "'");
+        database.command("sql", "INSERT INTO TopSuppliers SET name = '" + name + "', target_rid = (SELECT @rid FROM Supplier "
+            + "WHERE name = '" + name + "')");
+      }
+      database.command("sql", "INSERT INTO AllSuppliers SET code = 'A1'");
+      // A1 is linked to S1 and S2, so a condition that fails to discriminate is visible as an over-match, not only as
+      // the empty answer the report was about.
+      database.command("sql", "CREATE EDGE RelSupplier FROM (SELECT FROM AllSuppliers WHERE code = 'A1') TO "
+          + "(SELECT FROM Supplier WHERE name IN ['S1', 'S2'])");
+    });
+
+    s1Rid = database.query("sql", "SELECT @rid AS rid FROM Supplier WHERE name = 'S1'").next().getProperty("rid").toString();
+  }
+
+  @Test
+  void ridInSubQueryInsideContainsMatchesTheLinkedRecord() {
+    assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid IN (SELECT target_rid FROM TopSuppliers "
+        + "WHERE name = 'S1'))")).containsExactly("S1", "S2");
+  }
+
+  @Test
+  void ridInSubQueryInsideContainsAnswersLikeTheLiteralSpelling() {
+    assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid IN (SELECT target_rid FROM TopSuppliers "
+        + "WHERE name = 'S1'))"))
+        .isEqualTo(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid IN [" + s1Rid + "])"));
+  }
+
+  @Test
+  void ridInSubQueryInsideContainsAnswersLikeAnExplicitLetVariable() {
+    assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid IN (SELECT target_rid FROM TopSuppliers "
+        + "WHERE name = 'S1'))"))
+        .isEqualTo(nestedNames("SELECT $nested.name AS names FROM AllSuppliers LET $top = (SELECT target_rid FROM "
+            + "TopSuppliers WHERE name = 'S1'), $nested = outE('RelSupplier').inV('Supplier') WHERE code = 'A1' "
+            + "AND $nested CONTAINS (@rid IN $top)"));
+  }
+
+  @Test
+  void aSubQueryInsideContainsIsNotJustAboutRids() {
+    // The gap was in identifier resolution, not in the RID-address optimization, so a plain property comparison against
+    // a lifted sub-query has to work too.
+    assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (name IN (SELECT name FROM TopSuppliers "
+        + "WHERE name = 'S1'))")).containsExactly("S1", "S2");
+  }
+
+  @Test
+  void aSubQueryInsideContainsThatMatchesNothingStillExcludesTheRow() {
+    assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid IN (SELECT target_rid FROM TopSuppliers "
+        + "WHERE name = 'nobody'))")).isEmpty();
+  }
+
+  @Test
+  void aSubQueryInsideContainsThatMatchesNoLinkedItemExcludesTheRow() {
+    // S3 exists, but A1 is not linked to it: the condition has to be false because no ITEM matches, which is a
+    // different thing from the sub-query being empty.
+    assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid IN (SELECT target_rid FROM TopSuppliers "
+        + "WHERE name = 'S3'))")).isEmpty();
+  }
+
+  @Test
+  void aNegatedSubQueryInsideContainsIsTheComplement() {
+    // At least one linked supplier is NOT S1 - S2 is - so the row stays.
+    assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid NOT IN (SELECT target_rid FROM TopSuppliers "
+        + "WHERE name = 'S1'))")).containsExactly("S1", "S2");
+    // ...while no linked supplier is outside {S1, S2}.
+    assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid NOT IN (SELECT target_rid FROM TopSuppliers "
+        + "WHERE name IN ['S1', 'S2']))")).isEmpty();
+  }
+
+  /** The names the single AllSuppliers row projects, or an empty list when the WHERE clause excluded it. */
+  private List<String> nestedNames(final String query) {
+    final List<String> names = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext()) {
+        final Object value = rs.next().getProperty("names");
+        if (value instanceof Iterable<?> iterable)
+          for (final Object name : iterable)
+            names.add((String) name);
+        else if (value != null)
+          names.add((String) value);
+      }
+    }
+    names.sort(null);
+    return names;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SubQueryAliasInNestedConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SubQueryAliasInNestedConditionTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,6 +42,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * Every case therefore checks the sub-query spelling against the equivalent spelling that never went through the alias
  * (a literal, or an explicit LET variable), so the two cannot drift apart again.
+ * <p>
+ * The last case covers the third overload, which walks a MAP value: it had the opposite half of the same defect, asking
+ * the context about every name instead of only the ones the context can own, so a plain map key was shadowed by any
+ * context variable that happened to share it. All three now decide "context or record?" the same way.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -58,6 +63,7 @@ class SubQueryAliasInNestedConditionTest extends TestHelper {
     database.getSchema().getType("TopSuppliers").createProperty("target_rid", Type.LINK);
     database.getSchema().createVertexType("AllSuppliers").createProperty("code", Type.STRING);
     database.getSchema().createEdgeType("RelSupplier");
+    database.getSchema().createDocumentType("Holder").createProperty("attrs", Type.MAP);
 
     database.transaction(() -> {
       for (final String name : new String[] { "S1", "S2", "S3" }) {
@@ -70,6 +76,8 @@ class SubQueryAliasInNestedConditionTest extends TestHelper {
       // the empty answer the report was about.
       database.command("sql", "CREATE EDGE RelSupplier FROM (SELECT FROM AllSuppliers WHERE code = 'A1') TO "
           + "(SELECT FROM Supplier WHERE name IN ['S1', 'S2'])");
+      // A map whose key collides with a plausible LET variable name.
+      database.newDocument("Holder").set("attrs", Map.of("name", "FROM_MAP")).save();
     });
 
     try (final ResultSet rs = database.query("sql", "SELECT @rid AS rid FROM Supplier WHERE name = 'S1'")) {
@@ -129,6 +137,24 @@ class SubQueryAliasInNestedConditionTest extends TestHelper {
     // ...while no linked supplier is outside {S1, S2}.
     assertThat(nestedNames(SELECT_NESTED + "AND $nested CONTAINS (@rid NOT IN (SELECT target_rid FROM TopSuppliers "
         + "WHERE name IN ['S1', 'S2']))")).isEmpty();
+  }
+
+  @Test
+  void aMapKeyIsNotShadowedByAContextVariableOfTheSameName() {
+    // The third place that had to decide "context variable or property of the row?" is the overload that walks a MAP
+    // value, and it used to ask the context about every name rather than only the ones the context can own. A `LET
+    // $name` therefore hijacked the map's own `name` key.
+    assertThat(single("SELECT $m.name AS v FROM Holder LET $m = attrs")).isEqualTo("FROM_MAP");
+    assertThat(single("SELECT $m.name AS v FROM Holder LET $name = 'SHADOW', $m = attrs")).isEqualTo("FROM_MAP");
+    assertThat(single("SELECT $m.name AS v FROM Holder LET $name = 'SHADOW', $m = attrs WHERE $m.name = 'FROM_MAP'"))
+        .isEqualTo("FROM_MAP");
+  }
+
+  /** The single value the query projects under {@code v}, or null when it returned no row. */
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      return rs.hasNext() ? rs.next().getProperty("v") : null;
+    }
   }
 
   /** The names the single AllSuppliers row projects, or an empty list when the WHERE clause excluded it. */

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SubQueryAliasInNestedConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SubQueryAliasInNestedConditionTest.java
@@ -72,7 +72,9 @@ class SubQueryAliasInNestedConditionTest extends TestHelper {
           + "(SELECT FROM Supplier WHERE name IN ['S1', 'S2'])");
     });
 
-    s1Rid = database.query("sql", "SELECT @rid AS rid FROM Supplier WHERE name = 'S1'").next().getProperty("rid").toString();
+    try (final ResultSet rs = database.query("sql", "SELECT @rid AS rid FROM Supplier WHERE name = 'S1'")) {
+      s1Rid = rs.next().getProperty("rid").toString();
+    }
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #7060, for the second case reported on #7054.

## Problem

```sql
SELECT $nested.name
FROM AllSuppliers
LET $nested = outE('RelSupplier').inV('Supplier')
WHERE code = 'A1'
AND $nested CONTAINS (@rid IN (SELECT target_rid FROM TopSuppliers WHERE name = 'S1'))
```

returns nothing, while the same condition spelled with a RID literal - `$nested CONTAINS (@rid IN [#1:0])` - returns the expected row.

## Cause

The planner lifts every sub-query into a LET and leaves a generated `_$$$SUBQUERY$$$_N` alias in its place, so the nested condition has to read that alias from the command context.

`CONTAINS` evaluates its inner condition once per item of the collection, and hands each item over as an `Identifiable` when the collection holds records. `SuffixIdentifier.execute(Identifiable, ...)` resolved only names starting with `$` from the context, so the generated alias fell through to a property lookup on the record - which no record can answer. The `IN` then had nothing to test against and the condition was never true.

The `Result` overload of the same method has always known about the alias, which is why the identical query works as soon as the collection holds anything other than records, and why an explicit `LET $top = (SELECT ...) ... $nested CONTAINS (@rid IN $top)` works today.

The gap was never about `@rid`: a plain `name IN (SELECT name ...)` inside `CONTAINS` was equally dead.

## Fix

Both overloads now share a single predicate for "this name is resolved against the context, not against the record", so they cannot disagree again. It is a widening only: a name under either spelling cannot be a record property, so nothing that resolved before resolves differently now.

## Tests

New `SubQueryAliasInNestedConditionTest` (engine, 7 cases). Each sub-query spelling is checked against the equivalent spelling that never goes through the alias - a RID literal, or an explicit LET variable - so the two paths cannot drift apart. Coverage: the reported repro, the non-RID sibling, an empty sub-query, a sub-query matching a record that is not linked, and `NOT IN`. 5 of the 7 fail on `main`.

Green locally: `engine` 14194 tests, `server` 906, `network` 461 - 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query handling for generated context variables, including correct fallback to record and result properties.
  * Fixed sub-queries used within `CONTAINS` conditions over linked records, including RID and property comparisons.
  * Prevented context variables from incorrectly overriding ordinary map keys.
  * Improved consistency when identifying planner-generated query aliases.

* **Tests**
  * Added coverage for nested sub-query comparisons, empty and nonmatching results, negated conditions, and explicit variables.
  * Expanded validation for generated context variables, map-property resolution, and linked-record query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->