### PR TITLE
fix(#6995,#7056,#7029,#6998): four values that were wrong or lost in silence

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamWriter.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamWriter.java
@@ -18,10 +18,14 @@
  */
 package com.arcadedb.bolt.packstream;
 
+import com.arcadedb.utility.CollectionUtils;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -294,6 +298,13 @@ public class PackStreamWriter {
       writeMap((Map<String, Object>) value);
     } else if (value instanceof PackStreamStructure) {
       ((PackStreamStructure) value).writeTo(this);
+    } else if (value instanceof Collection) {
+      writeList(new ArrayList<>((Collection<?>) value));
+    } else if (value.getClass().isArray()) {
+      // Last line of defense for a multi-value that reached the writer unconverted: without this, a Set or an
+      // array (a primitive one in particular, which `instanceof List` never matches) fell into the toString()
+      // default below and the client silently received "[F@294b13ce" instead of the values - issue #7056.
+      writeList(CollectionUtils.arrayToList(value));
     } else {
       // Default: convert to string
       writeString(value.toString());

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -34,6 +34,7 @@ import com.arcadedb.query.opencypher.temporal.CypherLocalTime;
 import com.arcadedb.query.opencypher.temporal.CypherTime;
 import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.utility.CollectionUtils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -101,12 +102,13 @@ public class BoltStructureMapper {
       return toList(list);
     }
 
-    if (value instanceof Set<?> set) {
-      return toList(new ArrayList<>(set));
+    if (value instanceof Collection<?> collection) {
+      return toList(new ArrayList<>(collection));
     }
 
-    if (value instanceof Object[] array) {
-      return toList(Arrays.asList(array));
+    // A byte[] is the BINARY scalar and travels as PackStream Bytes, so it is excluded here and handled below.
+    if (value.getClass().isArray() && !(value instanceof byte[])) {
+      return toList(CollectionUtils.arrayToList(value));
     }
 
     // Spatial Point: Cypher point() returns a plain Map (there is no Point class), so detect

--- a/bolt/src/test/java/com/arcadedb/bolt/Issue7056DeclaredArrayOfFloatsIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue7056DeclaredArrayOfFloatsIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.types.Node;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+/**
+ * Regression test for issue #7056: reading back a property declared ARRAY_OF_FLOATS over Bolt returned the Java
+ * array's {@code toString()} - e.g. {@code [F@294b13ce} - as a plain string, silently, while the same row read over
+ * HTTP/SQL returned the values. Declaring the property is what triggered it: an undeclared one is stored as a List
+ * and was mapped correctly.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7056DeclaredArrayOfFloatsIT extends BaseGraphServerTest {
+
+  private static final List<Double> EMBEDDING = List.of(0.1, 0.2, 0.3, 0.4);
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+  }
+
+  @Test
+  void declaredArrayOfFloatsReadsBackAsAList() {
+    final Database db = getServerDatabase(0, getDatabaseName());
+    db.command("sql", "CREATE VERTEX TYPE Entity7056");
+    db.command("sql", "CREATE PROPERTY Entity7056.emb ARRAY_OF_FLOATS");
+
+    try (final Driver driver = getDriver(); final Session session = driver.session(
+        SessionConfig.forDatabase(getDatabaseName()))) {
+
+      session.run("CREATE (n:Entity7056 {uuid:'a'}) SET n.emb = $v", Map.of("v", EMBEDDING)).consume();
+
+      final Result result = session.run("MATCH (n:Entity7056 {uuid:'a'}) RETURN n.emb AS e");
+      assertThat(result.hasNext()).isTrue();
+
+      final Value value = result.next().get("e");
+      assertThat(value.type().name())
+          .as("a declared ARRAY_OF_FLOATS must come back as a list, not as the array's identity string")
+          .isNotEqualTo("STRING");
+
+      final List<Object> read = value.asList();
+      assertThat(read).hasSize(EMBEDDING.size());
+      for (int i = 0; i < EMBEDDING.size(); i++)
+        assertThat(((Number) read.get(i)).doubleValue()).isCloseTo(EMBEDDING.get(i), offset(1e-6));
+    }
+  }
+
+  @Test
+  void declaredArrayOfFloatsIsAlsoAListInsideANode() {
+    final Database db = getServerDatabase(0, getDatabaseName());
+    db.command("sql", "CREATE VERTEX TYPE EntityNode7056");
+    db.command("sql", "CREATE PROPERTY EntityNode7056.emb ARRAY_OF_FLOATS");
+
+    try (final Driver driver = getDriver(); final Session session = driver.session(
+        SessionConfig.forDatabase(getDatabaseName()))) {
+
+      session.run("CREATE (n:EntityNode7056 {uuid:'b'}) SET n.emb = $v", Map.of("v", EMBEDDING)).consume();
+
+      final Result result = session.run("MATCH (n:EntityNode7056 {uuid:'b'}) RETURN n");
+      assertThat(result.hasNext()).isTrue();
+
+      // The whole node travels through the same property mapper, so the value must not degrade there either.
+      final Node node = result.next().get("n").asNode();
+      final List<Object> read = node.get("emb").asList();
+      assertThat(read).hasSize(EMBEDDING.size());
+      for (int i = 0; i < EMBEDDING.size(); i++)
+        assertThat(((Number) read.get(i)).doubleValue()).isCloseTo(EMBEDDING.get(i), offset(1e-6));
+    }
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/Issue7056PrimitiveArrayValueTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue7056PrimitiveArrayValueTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.bolt.structure.BoltStructureMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+/**
+ * Regression test for issue #7056: a property declared ARRAY_OF_FLOATS (or any other primitive array type) is stored
+ * as the matching Java primitive array, which {@code instanceof Object[]} never matches. Such a value fell through
+ * every branch of the value mapper and reached the {@code toString()} default, so a Bolt client read back the array's
+ * identity string - {@code [F@294b13ce} - with no error to say the value had been lost. The very same row read over
+ * HTTP/SQL returned the values, so only the Bolt read path was affected.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7056PrimitiveArrayValueTest {
+
+  @Test
+  void floatArrayIsMappedToAListOfNumbers() {
+    final Object mapped = BoltStructureMapper.toPackStreamValue(new float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+
+    assertThat(mapped).as("an embedding must reach the wire as a list, not as the array's toString()").isInstanceOf(List.class);
+
+    final List<?> values = (List<?>) mapped;
+    assertThat(values).hasSize(4).allSatisfy(item -> assertThat(item).isInstanceOf(Double.class));
+    // A float widened to double is not exactly the decimal literal, hence the tolerance.
+    assertThat(((Number) values.get(0)).doubleValue()).isCloseTo(0.1, offset(1e-6));
+    assertThat(((Number) values.get(3)).doubleValue()).isCloseTo(0.4, offset(1e-6));
+  }
+
+  @Test
+  void everyPrimitiveArrayTypeIsMappedToAList() {
+    assertThat(BoltStructureMapper.toPackStreamValue(new double[] { 1.5, 2.5 })).isEqualTo(List.of(1.5d, 2.5d));
+    assertThat(BoltStructureMapper.toPackStreamValue(new int[] { 1, 2 })).isEqualTo(List.of(1L, 2L));
+    assertThat(BoltStructureMapper.toPackStreamValue(new long[] { 1L, 2L })).isEqualTo(List.of(1L, 2L));
+    assertThat(BoltStructureMapper.toPackStreamValue(new short[] { 1, 2 })).isEqualTo(List.of(1L, 2L));
+    assertThat(BoltStructureMapper.toPackStreamValue(new boolean[] { true, false })).isEqualTo(List.of(true, false));
+    assertThat(BoltStructureMapper.toPackStreamValue(new char[] { 'a', 'b' })).isEqualTo(List.of("a", "b"));
+    assertThat(BoltStructureMapper.toPackStreamValue(new String[] { "a", "b" })).isEqualTo(List.of("a", "b"));
+  }
+
+  @Test
+  void binaryStaysBytesAndIsNotExpandedToAList() {
+    final byte[] binary = { 1, 2, 3 };
+    assertThat(BoltStructureMapper.toPackStreamValue(binary))
+        .as("a byte[] is the BINARY scalar and travels as PackStream Bytes, not as a list of numbers")
+        .isSameAs(binary);
+  }
+
+  @Test
+  void aSetIsMappedToAListLikeAnyOtherCollection() {
+    final Set<String> set = new LinkedHashSet<>(List.of("a", "b"));
+    assertThat(BoltStructureMapper.toPackStreamValue(set)).isEqualTo(List.of("a", "b"));
+  }
+
+  @Test
+  void theWriterAlsoRefusesToStringifyAMultiValueItIsHandedDirectly() throws IOException {
+    // Defense in depth: even if a raw array reaches the writer unconverted, it must go out as a PackStream list
+    // rather than as the array's identity string.
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeValue(new float[] { 1.0f, 2.0f });
+
+    final Object read = new PackStreamReader(writer.toByteArray()).readValue();
+    assertThat(read).isInstanceOf(List.class);
+    assertThat(((List<?>) read)).hasSize(2);
+    assertThat(((Number) ((List<?>) read).get(1)).doubleValue()).isEqualTo(2.0);
+  }
+}

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -16,8 +16,10 @@ parameter bound to a Java array. The right-hand side is now normalized exactly a
 answers precisely what the identical `List` answers - no more, and no less: a single-item collection is
 unwrapped to its item (the one-row sub-query case), and a longer one is looked for as one element of the
 left-hand collection, which is what `test CONTAINS [1]` has always meant for a row holding `test = [[1]]`.
-The one array kept out of this is `byte[]`, which is the BINARY *scalar* type rather than a multi-value:
-expanding it would turn `list CONTAINS :binary` into a search for a list of numbers.
+The one array kept out of this is `byte[]`, and only on the right: it is the BINARY *scalar* type, so expanding it
+would turn `list CONTAINS :binary` into a search for a list of numbers. The asymmetry is the point rather than an
+oversight - the two operands play different roles. The left-hand side is the container being searched, so expanding
+an array into its items is exactly what it means there, and a `byte[]` on the left keeps behaving as it did.
 
 **A declared `ARRAY_OF_FLOATS` read back over Bolt as `[F@294b13ce` (#7056).** Declaring the property is what
 triggered it: a declared array property is stored as the matching Java primitive array, and the Bolt value

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3,6 +3,52 @@
 This is a living document: fixes, improvements, new features, and breaking changes are collected here as
 they land during the 26.9.1 development cycle, so the release notes are ready at tag time.
 
+## Four values that were wrong or lost in silence: CONTAINS against an array, an embedding read over Bolt, a paged gRPC stream's ordering, and two BinaryComparator corners (#6995, #7056, #7029, #6998)
+
+Four independent defects, one thing in common: each returned a wrong answer with no error to say so.
+
+**`CONTAINS` with an array on the right never matched (#6995).** `ContainsCondition` normalizes an array
+left-hand side to a `List` - that is what #6984 fixed, so `txt.split(' ') CONTAINS 'a'` works. The right-hand
+side got no such treatment, and an array satisfies neither `instanceof Collection` nor `instanceof Iterable`,
+so `'a b c'.split(' ') CONTAINS 'a'.split(' ')` skipped every branch of the operator and compared the whole
+`String[]` object against each left-hand item: false, always, whatever the content. The same happened to any
+parameter bound to a Java array. The right-hand side is now normalized exactly as the left one is, so an array
+answers precisely what the identical `List` answers - no more, and no less: a single-item collection is
+unwrapped to its item (the one-row sub-query case), and a longer one is looked for as one element of the
+left-hand collection, which is what `test CONTAINS [1]` has always meant for a row holding `test = [[1]]`.
+The one array kept out of this is `byte[]`, which is the BINARY *scalar* type rather than a multi-value:
+expanding it would turn `list CONTAINS :binary` into a search for a list of numbers.
+
+**A declared `ARRAY_OF_FLOATS` read back over Bolt as `[F@294b13ce` (#7056).** Declaring the property is what
+triggered it: a declared array property is stored as the matching Java primitive array, and the Bolt value
+mapper tested for `Object[]`, which a `float[]` never is. The value fell past every branch to the `toString()`
+default and reached the client as an 11-character string, while the same row read over HTTP/SQL returned the
+values - so a client hydrating embeddings got a corrupted value with nothing to indicate it. Every array now
+maps to a PackStream list through the engine's existing `CollectionUtils.arrayToList`, `byte[]` still travels
+as PackStream Bytes, a `Set` no longer stringifies either, and the PackStream writer grew the same handling as
+a last line of defense, so a multi-value that reaches it unconverted goes out as a list rather than as an
+identity string.
+
+**A paged gRPC stream discarded the caller's ORDER BY (#7029).** `StreamQuery`'s PAGED mode wraps the caller's
+SQL as `SELECT FROM ( ... ) ORDER BY @rid SKIP :_skip LIMIT :_limit`, so `SELECT FROM Doc ORDER BY createdAt
+DESC` came back in RID order - and because the pages were cut by SKIP/LIMIT over that rewritten order, the
+caller could not restore the intended order client-side without pulling every page. The stable `@rid` order is
+deliberate, since paging without a total order is unsound, so it stays - but only when the caller expressed no
+order of its own. When the caller's statement carries its own ORDER BY, the sub-query already emits its rows
+sorted and the wrapper preserves that by adding no ORDER BY of its own. Re-stating the caller's terms on the
+outside would not have worked: a projection (`SELECT name FROM Doc ORDER BY createdAt`) leaves neither the
+sort key nor `@rid` visible to the outer statement.
+
+**Two corners of `BinaryComparator` (#6998).** `equalsBytes` applied a "compare the last byte first" fast path
+with no empty-array guard, so two empty `byte[]` read index -1 and threw `ArrayIndexOutOfBoundsException`
+instead of comparing equal - reachable from SQL as `WHERE bin = :p` against an empty BINARY property, which
+failed the query rather than matching the row. And `compareTo` encoded its left String operand with the JVM
+default charset and its right one with the configured charset; on a JVM started with a non-UTF-8
+`-Dfile.encoding` the two disagree, so an equal pair of non-ASCII strings compared as less-than and `ORDER BY`
+and range predicates answered wrongly on non-ASCII data. Both operands now use the configured charset, and the
+case is covered by a test that forks a JVM with `-Dfile.encoding=ISO-8859-1`, since a default charset is fixed
+at startup and cannot be varied from inside a running suite.
+
 ## Vector index: opening a database no longer parses every index page to rebuild the location map (#6722)
 
 Opening a database walked every page of every `LSM_VECTOR` index and rebuilt the in-memory location map, whether

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
@@ -27,7 +27,6 @@ import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.QueryOperatorEquals;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-import com.arcadedb.schema.Type;
 import com.arcadedb.utility.CollectionUtils;
 
 import java.util.*;
@@ -42,15 +41,21 @@ public class ContainsCondition extends BooleanExpression {
   }
 
   public boolean execute(final Object left, Object right) {
-    if (isMultiValue(right))
+    if (isArray(right) && !(right instanceof byte[]))
       // Normalize an array right-hand side - the result of a second split(), a parameter bound to a Java array -
       // to a List, so it is answered exactly as the equivalent List right-hand side is. An array satisfies neither
       // `instanceof Collection` nor `instanceof Iterable`, so it used to skip every branch below and be compared as
       // one opaque object against each left-hand item, which made the condition effectively always false: the same
       // blind spot as #6984, on the other side of the operator (issue #6995).
+      //
+      // The byte[] carve-out is only on this side, and the asymmetry is the point rather than an oversight: the two
+      // operands play different roles. The left-hand side is the container being searched, so expanding an array
+      // into its items is exactly what it means; the right-hand side is the value being searched FOR, and a byte[]
+      // is ArcadeDB's BINARY scalar, so expanding it would turn `list CONTAINS :binary` from a search for that one
+      // value into a search for a list of numbers.
       right = CollectionUtils.arrayToList(right);
 
-    if (isMultiValue(left))
+    if (isArray(left))
       // Normalize an array left-hand side (e.g. the result of split()) to a List so it gets the same CONTAINS
       // semantics as a Collection below (issue #6984). Deliberately recurses into the Collection branch rather
       // than delegating straight to MultiValue.contains(): the Collection branch also unwraps a single-item
@@ -149,13 +154,8 @@ public class ContainsCondition extends BooleanExpression {
     return condition == null || condition.isCacheable();
   }
 
-  /**
-   * An array is a multi-value for CONTAINS purposes, with one exception: a {@code byte[]} is ArcadeDB's BINARY
-   * scalar ({@link Type#BINARY}), so expanding it to a list of bytes would turn
-   * {@code list CONTAINS :binary} into a search for a list of numbers instead of for that binary value.
-   */
-  private static boolean isMultiValue(final Object value) {
-    return value != null && value.getClass().isArray() && !(value instanceof byte[]);
+  private static boolean isArray(final Object value) {
+    return value != null && value.getClass().isArray();
   }
 
   private boolean equalsInContainsSpace(final Object left, final Object right) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.QueryOperatorEquals;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.schema.Type;
 import com.arcadedb.utility.CollectionUtils;
 
 import java.util.*;
@@ -150,7 +151,7 @@ public class ContainsCondition extends BooleanExpression {
 
   /**
    * An array is a multi-value for CONTAINS purposes, with one exception: a {@code byte[]} is ArcadeDB's BINARY
-   * scalar ({@link com.arcadedb.schema.Type#BINARY}), so expanding it to a list of bytes would turn
+   * scalar ({@link Type#BINARY}), so expanding it to a list of bytes would turn
    * {@code list CONTAINS :binary} into a search for a list of numbers instead of for that binary value.
    */
   private static boolean isMultiValue(final Object value) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.QueryOperatorEquals;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.CollectionUtils;
 
 import java.util.*;
 
@@ -40,20 +41,20 @@ public class ContainsCondition extends BooleanExpression {
   }
 
   public boolean execute(final Object left, Object right) {
-    if (left != null && left.getClass().isArray()) {
-      // Normalize an array left-hand side (e.g. the result of split()) to a List so it gets the same
-      // CONTAINS semantics as a Collection below; MultiValue's iterator covers both object and primitive
-      // arrays via reflection, unlike a direct `instanceof Iterable`/`instanceof Collection` check, which
-      // an array never satisfies (issue #6984). Deliberately recurses into the Collection branch rather
-      // than delegating straight to MultiValue.contains(): the Collection branch also unwraps a
-      // single-item Result/Identifiable on the right-hand side (lines below), and a direct delegation
-      // would silently drop that behavior for an array left-hand side.
-      final List<Object> leftAsList = new ArrayList<>(MultiValue.getSize(left));
-      final Iterator<?> leftArrayIterator = MultiValue.getMultiValueIterator(left);
-      while (leftArrayIterator.hasNext())
-        leftAsList.add(leftArrayIterator.next());
-      return execute(leftAsList, right);
-    }
+    if (isMultiValue(right))
+      // Normalize an array right-hand side - the result of a second split(), a parameter bound to a Java array -
+      // to a List, so it is answered exactly as the equivalent List right-hand side is. An array satisfies neither
+      // `instanceof Collection` nor `instanceof Iterable`, so it used to skip every branch below and be compared as
+      // one opaque object against each left-hand item, which made the condition effectively always false: the same
+      // blind spot as #6984, on the other side of the operator (issue #6995).
+      right = CollectionUtils.arrayToList(right);
+
+    if (isMultiValue(left))
+      // Normalize an array left-hand side (e.g. the result of split()) to a List so it gets the same CONTAINS
+      // semantics as a Collection below (issue #6984). Deliberately recurses into the Collection branch rather
+      // than delegating straight to MultiValue.contains(): the Collection branch also unwraps a single-item
+      // Result/Identifiable on the right-hand side, and a direct delegation would silently drop that behavior.
+      return execute(CollectionUtils.arrayToList(left), right);
 
     if (left instanceof Collection) {
       if (right instanceof Collection) {
@@ -74,6 +75,9 @@ public class ContainsCondition extends BooleanExpression {
             return true;
         }
 
+        // A multi-item collection on the right is looked for as ONE element of the left-hand collection, which is
+        // what `test CONTAINS [1]` means for a row holding `test = [[1]]`. The single-item unwrapping above is the
+        // deliberate exception, for the one-row sub-query case.
         return MultiValue.contains(left, right);
       }
 
@@ -142,6 +146,15 @@ public class ContainsCondition extends BooleanExpression {
       return false;
     }
     return condition == null || condition.isCacheable();
+  }
+
+  /**
+   * An array is a multi-value for CONTAINS purposes, with one exception: a {@code byte[]} is ArcadeDB's BINARY
+   * scalar ({@link com.arcadedb.schema.Type#BINARY}), so expanding it to a list of bytes would turn
+   * {@code list CONTAINS :binary} into a search for a list of numbers instead of for that binary value.
+   */
+  private static boolean isMultiValue(final Object value) {
+    return value != null && value.getClass().isArray() && !(value instanceof byte[]);
   }
 
   private boolean equalsInContainsSpace(final Object left, final Object right) {

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -420,6 +420,10 @@ public class BinaryComparator {
     if (buffer1.length != buffer2.length)
       return false;
 
+    if (buffer1.length == 0)
+      // BOTH EMPTY, SO EQUAL: THE FAST PATH BELOW WOULD READ INDEX -1 (ISSUE #6998)
+      return true;
+
     if (buffer1[buffer1.length - 1] != buffer2[buffer2.length - 1])
       // OPTIMIZATION: CHECK THE LAST BYTE IF IT'S THE SAME FIRST
       return false;
@@ -452,7 +456,9 @@ public class BinaryComparator {
     else if (a == null)
       return -1;
     else if (a instanceof String string && b instanceof String string1)
-      return compareBytes(string.getBytes(), string1.getBytes(DatabaseFactory.getDefaultCharset()));
+      // BOTH OPERANDS MUST BE ENCODED WITH THE SAME CHARSET: A NO-ARG getBytes() ON ONE SIDE FOLLOWS THE JVM
+      // DEFAULT AND MADE AN EQUAL PAIR COMPARE AS LESS-THAN ON A NON-UTF-8 JVM (ISSUE #6998)
+      return compareBytes(string.getBytes(DatabaseFactory.getDefaultCharset()), string1.getBytes(DatabaseFactory.getDefaultCharset()));
     else if (a instanceof byte[] bytes && b instanceof byte[] bytes1)
       return compareBytes(bytes, bytes1);
     else if (a instanceof Map map && b instanceof Map map1)

--- a/engine/src/test/java/com/arcadedb/query/sql/QueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/QueryTest.java
@@ -1460,6 +1460,47 @@ class QueryTest extends TestHelper {
     });
   }
 
+  // Issue #6995: CONTAINS with an array (not a List) on the RHS - a second split() - never matched anything
+  @Test
+  void containsWithSplitOnBothSides() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc6995 IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc6995 SET txt = 'a b c'");
+      database.command("sql", "INSERT INTO doc6995 SET txt = 'hello world'");
+
+      // A single-term split() on the right is unwrapped to its item, exactly as the identical list literal is.
+      final ResultSet matching = database.query("sql", "SELECT FROM doc6995 WHERE txt.split(' ') CONTAINS 'a'.split(' ')");
+      assertThat(matching.hasNext()).isTrue();
+      assertThat(matching.next().<String>getProperty("txt")).isEqualTo("a b c");
+      assertThat(matching.hasNext()).isFalse();
+
+      // No row holds the term, so the operator is not answering "true" blindly.
+      final ResultSet none = database.query("sql", "SELECT FROM doc6995 WHERE txt.split(' ') CONTAINS 'zzz'.split(' ')");
+      assertThat(none.hasNext()).isFalse();
+    });
+  }
+
+  // Issue #6995: an array bound as a query parameter is answered like the equivalent list, not like an opaque object
+  @Test
+  void containsWithArrayParameterOnRhs() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc6995b IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc6995b SET tags = ['red','green','blue']");
+      database.command("sql", "INSERT INTO doc6995b SET tags = ['black']");
+
+      final ResultSet rs = database.query("sql", "SELECT FROM doc6995b WHERE tags CONTAINS :wanted",
+          Map.of("wanted", new String[] { "red" }));
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<List<String>>getProperty("tags")).containsExactly("red", "green", "blue");
+      assertThat(rs.hasNext()).isFalse();
+
+      // A longer array is looked for as one element, the same rule `test CONTAINS [1]` follows for a nested list.
+      final ResultSet asElement = database.query("sql", "SELECT FROM doc6995b WHERE tags CONTAINS :wanted",
+          Map.of("wanted", new String[] { "red", "blue" }));
+      assertThat(asElement.hasNext()).isFalse();
+    });
+  }
+
   // Issue #3583: chained replace().ilike() inside a LET subquery combined with UNIONALL evaluates without $current null
   @Test
   void replaceWithIlikeInLetSubquery() {

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
@@ -190,5 +190,10 @@ class ContainsConditionTest {
     assertThat(op.execute(left, (byte) 9)).isFalse();
     // The items are matched with the operator's loose equality, so a widened literal finds them too.
     assertThat(op.execute(left, 2)).isTrue();
+
+    // The corner where the two rules meet: the left side expands to its bytes, the right side stays one BINARY
+    // value, so no item can equal it. That follows from the two rules rather than being a rule of its own, and it is
+    // pinned here so a later change to either side cannot alter it unnoticed.
+    assertThat(op.execute(left, new byte[] { 1, 2, 3 })).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
@@ -159,8 +159,9 @@ class ContainsConditionTest {
   }
 
   /**
-   * A byte[] is the BINARY scalar type, not a multi-value: {@code list CONTAINS :binary} must keep looking for that
-   * binary value among the list items rather than degenerating into a byte-by-byte test (issue #6995).
+   * A byte[] is the BINARY scalar type, so on the right-hand side - the value being searched FOR -
+   * {@code list CONTAINS :binary} must keep looking for that one binary value among the list items rather than
+   * degenerating into a search for a list of numbers (issue #6995).
    */
   @Test
   void binaryRightHandSideStaysAScalar() {
@@ -173,5 +174,21 @@ class ContainsConditionTest {
     assertThat(op.execute(left, new byte[] { 1, 2 })).isFalse();
     // Proof it is not being expanded: a single byte of the stored value is not "contained" in the list.
     assertThat(op.execute(left, (byte) 1)).isFalse();
+  }
+
+  /**
+   * The byte[] carve-out is right-hand-side only. On the left the operand is the container being searched, so it is
+   * expanded like any other array - the behaviour #6984 shipped, which the #6995 fix must not disturb.
+   */
+  @Test
+  void binaryLeftHandSideIsStillExpanded() {
+    final ContainsCondition op = new ContainsCondition();
+
+    final byte[] left = { 1, 2, 3 };
+
+    assertThat(op.execute(left, (byte) 2)).isTrue();
+    assertThat(op.execute(left, (byte) 9)).isFalse();
+    // The items are matched with the operator's loose equality, so a widened literal finds them too.
+    assertThat(op.execute(left, 2)).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
@@ -107,4 +107,71 @@ class ContainsConditionTest {
     assertThat(op.execute(primitiveLeft, 2)).isTrue();
     assertThat(op.execute(primitiveLeft, 5)).isFalse();
   }
+
+  /**
+   * Regression test for issue #6995: the same blind spot as #6984, but on the other side of the operator. An array
+   * right-hand side - the result of a second split(), a parameter bound to a Java array - satisfies neither
+   * {@code instanceof Collection} nor {@code instanceof Iterable}, so it used to skip every branch of the operator
+   * and be compared as one opaque object against each left-hand item: the condition was effectively always false.
+   * <p>
+   * The fix is a normalization, not a change of meaning: an array right-hand side now answers exactly what the
+   * equivalent List right-hand side answers, which is the operator's established semantics - a single-item
+   * collection is unwrapped to its item (the one-row sub-query case), and a longer one is looked for as one element
+   * of the left-hand collection, as {@code SelectStatementExecutionTest.containsCollection} pins down.
+   */
+  @Test
+  void issue6995ArrayRightHandSide() {
+    final ContainsCondition op = new ContainsCondition();
+
+    final String[] left = "a b c".split(" ");
+
+    // Single-item array: unwrapped to its item, so the item is looked for among the left-hand values. This is the
+    // case that used to be false for an array and true for the identical List.
+    assertThat(op.execute(left, "a".split(" "))).isTrue();
+    assertThat(op.execute(left, "z".split(" "))).isFalse();
+    assertThat(op.execute(new int[] { 1, 2, 3 }, new int[] { 2 })).isTrue();
+    assertThat(op.execute(new int[] { 1, 2, 3 }, new int[] { 9 })).isFalse();
+
+    // Longer array: looked for as one element of the left-hand collection, so it matches a nested value.
+    assertThat(op.execute(List.of(List.of("a", "b")), "a b".split(" "))).isTrue();
+    assertThat(op.execute(List.of(List.of("a", "b")), "a z".split(" "))).isFalse();
+  }
+
+  /**
+   * The point of the #6995 fix: an array right-hand side must answer whatever the identical List right-hand side
+   * answers. Anything else leaves the operator's meaning depending on how the value happened to be produced.
+   */
+  @Test
+  void anArrayRightHandSideAnswersTheSameAsTheEquivalentList() {
+    final ContainsCondition op = new ContainsCondition();
+
+    final List<Object> flat = Arrays.asList("a", "b", "c");
+    final List<Object> nested = List.of(List.of("a", "b"), List.of("z"));
+
+    for (final Object left : List.of(flat, nested)) {
+      for (final List<String> right : List.of(List.of("a"), List.of("z"), List.of("a", "b"), List.of("b", "c"))) {
+        final String[] asArray = right.toArray(new String[0]);
+        assertThat(op.execute(left, asArray))
+            .as("CONTAINS %s must answer the same for the array and for the List", right)
+            .isEqualTo(op.execute(left, right));
+      }
+    }
+  }
+
+  /**
+   * A byte[] is the BINARY scalar type, not a multi-value: {@code list CONTAINS :binary} must keep looking for that
+   * binary value among the list items rather than degenerating into a byte-by-byte test (issue #6995).
+   */
+  @Test
+  void binaryRightHandSideStaysAScalar() {
+    final ContainsCondition op = new ContainsCondition();
+
+    final List<Object> left = new ArrayList<>();
+    left.add(new byte[] { 1, 2, 3 });
+
+    assertThat(op.execute(left, new byte[] { 1, 2, 3 })).isTrue();
+    assertThat(op.execute(left, new byte[] { 1, 2 })).isFalse();
+    // Proof it is not being expanded: a single byte of the stored value is not "contained" in the list.
+    assertThat(op.execute(left, (byte) 1)).isFalse();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/serializer/Issue6998BinaryComparatorTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue6998BinaryComparatorTest.java
@@ -130,13 +130,23 @@ class Issue6998BinaryComparatorTest {
     // stderr is inherited rather than merged: a JVM warning on the child's stderr must not end up mixed into the
     // single line this method returns, but it still has to be visible in the build log when something goes wrong.
     final Process process = new ProcessBuilder(command).redirectError(ProcessBuilder.Redirect.INHERIT).start();
-    final String output;
-    try (final var in = process.getInputStream()) {
-      output = new String(in.readAllBytes(), StandardCharsets.US_ASCII).trim();
+    try {
+      final String output;
+      try (final var in = process.getInputStream()) {
+        output = new String(in.readAllBytes(), StandardCharsets.US_ASCII).trim();
+      }
+
+      // A hang detector, not a latency bound: the child prints one line and exits in well under a second, so no
+      // amount of load brings it near this. StallAwareStopwatch does not apply - it discounts a stall observed in
+      // THIS JVM, and the thing being waited on here is a separate process.
+      final boolean exited = process.waitFor(60, TimeUnit.SECONDS);
+      assertThat(exited).as("the forked JVM must terminate; it printed: %s", output).isTrue();
+      assertThat(process.exitValue()).as("the forked JVM failed; it printed: %s", output).isZero();
+      return output;
+    } finally {
+      // Leave nothing behind on any exit path, a timed-out or half-read child included.
+      process.destroyForcibly();
     }
-    assertThat(process.waitFor(60, TimeUnit.SECONDS)).as("the forked JVM must terminate; it printed: %s", output).isTrue();
-    assertThat(process.exitValue()).as("the forked JVM failed; it printed: %s", output).isZero();
-    return output;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/serializer/Issue6998BinaryComparatorTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue6998BinaryComparatorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.serializer;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.QueryOperatorEquals;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6998, two independent defects in {@link BinaryComparator}.
+ * <p>
+ * 1. {@code equalsBytes} applied a "compare the last byte first" fast path with no guard for an empty array, so two
+ * empty {@code byte[]} instances read index -1 and threw {@code ArrayIndexOutOfBoundsException} instead of comparing
+ * equal. It is reachable from SQL: an empty BINARY property compared against a different empty {@code byte[]}
+ * instance failed the query rather than matching it.
+ * <p>
+ * 2. {@code compareTo} encoded its left String operand with the JVM default charset and its right one with the
+ * configured charset. On a non-UTF-8 default the two disagree, so an equal pair of non-ASCII strings compared as
+ * less-than and ORDER BY / range predicates answered wrongly. That precondition cannot be created inside a running
+ * JVM - {@code Charset.defaultCharset()} is fixed at startup - so the case is exercised in a forked JVM started with
+ * {@code -Dfile.encoding=ISO-8859-1}, which reproduces the wrong answer against the unfixed comparator.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6998BinaryComparatorTest {
+
+  /** A pair of identical non-ASCII strings: one byte under ISO-8859-1, two bytes under UTF-8. */
+  private static final String NON_ASCII = "é";
+
+  @Test
+  void twoEmptyByteArraysAreEqual() {
+    assertThat(BinaryComparator.equalsBytes(new byte[0], new byte[0]))
+        .as("two empty byte[] are equal; the last-byte fast path used to read index -1 and throw")
+        .isTrue();
+
+    // The length check still catches a mismatched pair before the fast path.
+    assertThat(BinaryComparator.equalsBytes(new byte[0], new byte[] { 1 })).isFalse();
+    assertThat(BinaryComparator.equalsBytes(new byte[] { 1 }, new byte[0])).isFalse();
+
+    // Same route through the generic entry points, which is what SQL equality reaches.
+    assertThat(BinaryComparator.equals(new byte[0], new byte[0])).isTrue();
+    assertThat(QueryOperatorEquals.equals(new byte[0], new byte[0]))
+        .as("SQL equality over two distinct empty BINARY values must match, not fail")
+        .isTrue();
+
+    // Non-empty arrays keep the behavior the fast path was written for.
+    assertThat(BinaryComparator.equalsBytes(new byte[] { 1, 2, 3 }, new byte[] { 1, 2, 3 })).isTrue();
+    assertThat(BinaryComparator.equalsBytes(new byte[] { 1, 2, 3 }, new byte[] { 1, 2, 4 })).isFalse();
+  }
+
+  @Test
+  void emptyBinaryPropertyIsMatchedBySql() throws Exception {
+    TestHelper.executeInNewDatabase("Issue6998", db -> {
+      db.getSchema().createDocumentType("Doc6998").createProperty("bin", Type.BINARY);
+
+      db.transaction(() -> db.newDocument("Doc6998").set("bin", new byte[0]).save());
+
+      // A distinct byte[0] instance, so QueryOperatorEquals' identity shortcut cannot fire and the comparison goes
+      // through BinaryComparator.equalsBytes - which used to throw.
+      try (final ResultSet rs = db.query("sql", "SELECT FROM Doc6998 WHERE bin = :p", Map.of("p", new byte[0]))) {
+        assertThat(rs.hasNext()).as("an empty BINARY value must match another empty BINARY value").isTrue();
+        rs.next();
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void compareToEncodesBothStringOperandsWithTheSameCharset() throws Exception {
+    // Holds on any JVM, but only proves the fix where the default charset is not UTF-8, hence the fork below.
+    assertThat(BinaryComparator.compareTo(NON_ASCII, NON_ASCII)).isZero();
+    assertThat(BinaryComparator.compareTo("a" + NON_ASCII, "a" + NON_ASCII)).isZero();
+    assertThat(BinaryComparator.compareTo(NON_ASCII, "f")).isNotZero();
+
+    final String forked = runInForkedJvm(StandardCharsets.ISO_8859_1);
+
+    assertThat(forked)
+        .as("the forked JVM must actually run with a non-UTF-8 default charset, otherwise this proves nothing")
+        .startsWith("charset=ISO-8859-1 ");
+    assertThat(forked)
+        .as("with a non-UTF-8 default charset an equal pair of non-ASCII strings must still compare equal: "
+            + "encoding one operand with the platform charset and the other with the configured one made it less-than")
+        .isEqualTo("charset=ISO-8859-1 compareTo=0");
+  }
+
+  /**
+   * Runs {@link CharsetProbe} in a child JVM whose default charset is the given one, and returns the single line it
+   * prints. {@code Charset.defaultCharset()} is decided at JVM startup, so a fork is the only way to exercise a
+   * platform charset other than the one this suite runs under.
+   */
+  private static String runInForkedJvm(final Charset charset) throws Exception {
+    final String classpath = System.getProperty("java.class.path");
+    assertThat(classpath).as("the forked JVM needs this JVM's classpath").isNotBlank();
+
+    final List<String> command = new ArrayList<>();
+    command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+    command.add("-Dfile.encoding=" + charset.name());
+    command.add("-cp");
+    command.add(classpath);
+    command.add(CharsetProbe.class.getName());
+
+    // stderr is inherited rather than merged: a JVM warning on the child's stderr must not end up mixed into the
+    // single line this method returns, but it still has to be visible in the build log when something goes wrong.
+    final Process process = new ProcessBuilder(command).redirectError(ProcessBuilder.Redirect.INHERIT).start();
+    final String output;
+    try (final var in = process.getInputStream()) {
+      output = new String(in.readAllBytes(), StandardCharsets.US_ASCII).trim();
+    }
+    assertThat(process.waitFor(60, TimeUnit.SECONDS)).as("the forked JVM must terminate; it printed: %s", output).isTrue();
+    assertThat(process.exitValue()).as("the forked JVM failed; it printed: %s", output).isZero();
+    return output;
+  }
+
+  /**
+   * Child-JVM entry point: prints its default charset and the comparison of two identical non-ASCII strings, in
+   * ASCII only so the child's own stdout encoding cannot alter the answer.
+   */
+  public static class CharsetProbe {
+    public static void main(final String[] args) {
+      System.out.println("charset=" + Charset.defaultCharset().name() //
+          + " compareTo=" + BinaryComparator.compareTo(NON_ASCII, NON_ASCII));
+    }
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2494,7 +2494,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   /**
    * Reports whether an SQL statement carries its own ORDER BY. Parsing goes through the database statement cache, so
-   * a repeated query is parsed once, and the wrapped query reuses the same entry when it executes.
+   * the answer costs one parse per distinct query text rather than one per page. It is not free: the cache is keyed by
+   * the exact SQL string, and the pages execute the *wrapped* statement, so that is a second entry and a second parse.
+   * One extra parse per distinct PAGED query is the price of not silently discarding the caller's ordering.
    * <p>
    * SELECT and MATCH are the two statement shapes in this dialect that can carry an ORDER BY, and they do not share
    * an accessor for it, so both are asked. A statement that does not parse, or that is neither of those, is reported

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -20,6 +20,9 @@ package com.arcadedb.server.grpc;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.query.sql.parser.Identifier;
+import com.arcadedb.query.sql.parser.OrderBy;
+import com.arcadedb.query.sql.parser.SelectStatement;
+import com.arcadedb.query.sql.parser.Statement;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.database.DatabaseContext;
@@ -2367,7 +2370,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               "PAGED retrieval mode reserves the parameter names '_skip' and '_limit'; rename the conflicting query parameter or use CURSOR retrieval mode")
           .asRuntimeException();
 
-    final String pagedSql = wrapWithSkipLimit(request.getQuery()); // see helper below
+    final String pagedSql = wrapWithSkipLimit(db, request.getQuery()); // see helper below
     int offset = 0;
     long running = 0L;
     // A full page is held back one step so the terminal page carries is_last_batch=true even when the total
@@ -2469,15 +2472,43 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   /**
-   * Wrap arbitrary SQL so we can safely inject LIMIT/SKIP outside.
+   * Wraps arbitrary SQL so the per-page SKIP/LIMIT can be injected outside it, without disturbing any SKIP/LIMIT the
+   * caller wrote.
+   * <p>
+   * Paging is only sound over a deterministic order, so the wrapper adds {@code ORDER BY @rid} - but only when the
+   * caller expressed no order of its own. A caller-supplied {@code ORDER BY} lives inside the sub-query, which emits
+   * its rows already sorted, and the wrapper preserves that order precisely by adding no {@code ORDER BY} of its own:
+   * re-sorting on the outside used to discard the requested order silently, and could not be repaired by re-stating
+   * the caller's terms outside either, because a projection ({@code SELECT name FROM Doc ORDER BY createdAt}) leaves
+   * neither the sort key nor {@code @rid} visible to the outer statement (issue #7029).
+   * <p>
+   * When the caller orders by a key that is not unique, rows that tie may still move between pages from one page
+   * query to the next; adding a unique tie-break such as {@code @rid} to the query's own ORDER BY is the caller's
+   * call to make, exactly as it would be against any other paged API.
    */
-  private String wrapWithSkipLimit(String originalSql) {
+  private String wrapWithSkipLimit(final Database db, final String originalSql) {
+    final String outerOrderBy = hasOrderBy(db, originalSql) ? "" : " ORDER BY @rid";
+    return "SELECT FROM (" + originalSql + ")" + outerOrderBy + " SKIP :_skip LIMIT :_limit";
+  }
 
-    // Minimal defensive approach; you can do a real parser if needed.
-
-    // ArcadeDB: SELECT FROM (...) [ORDER BY ...] SKIP :_skip LIMIT :_limit
-
-    return "SELECT FROM (" + originalSql + ") ORDER BY @rid SKIP :_skip LIMIT :_limit";
+  /**
+   * Reports whether an SQL statement carries its own ORDER BY. Parsing goes through the database statement cache, so
+   * a repeated query is parsed once. A statement that does not parse, or that is not a SELECT, is reported as
+   * unordered: the page query would fail on execution anyway, and the caller gets the same error it would have got
+   * without the wrapper.
+   */
+  private boolean hasOrderBy(final Database db, final String sql) {
+    try {
+      final Statement statement = ((DatabaseInternal) db).getStatementCache().get(sql);
+      if (statement instanceof SelectStatement select) {
+        final OrderBy orderBy = select.getOrderBy();
+        return orderBy != null && orderBy.getItems() != null && !orderBy.getItems().isEmpty();
+      }
+    } catch (final Exception e) {
+      LogManager.instance()
+          .log(this, Level.FINE, "Could not parse the query to look for an ORDER BY, paging by @rid: %s", e, sql);
+    }
+    return false;
   }
 
   private void safeOnNext(ServerCallStreamObserver<QueryResult> scso, AtomicBoolean cancelled, QueryResult payload) {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.grpc;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.query.sql.parser.Identifier;
+import com.arcadedb.query.sql.parser.MatchStatement;
 import com.arcadedb.query.sql.parser.OrderBy;
 import com.arcadedb.query.sql.parser.SelectStatement;
 import com.arcadedb.query.sql.parser.Statement;
@@ -2493,17 +2494,26 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   /**
    * Reports whether an SQL statement carries its own ORDER BY. Parsing goes through the database statement cache, so
-   * a repeated query is parsed once. A statement that does not parse, or that is not a SELECT, is reported as
-   * unordered: the page query would fail on execution anyway, and the caller gets the same error it would have got
-   * without the wrapper.
+   * a repeated query is parsed once, and the wrapped query reuses the same entry when it executes.
+   * <p>
+   * SELECT and MATCH are the two statement shapes in this dialect that can carry an ORDER BY, and they do not share
+   * an accessor for it, so both are asked. A statement that does not parse, or that is neither of those, is reported
+   * as unordered and gets the {@code @rid} wrapper: the page query would fail on execution anyway, and the caller
+   * gets the same error it would have got without the wrapper.
    */
   private boolean hasOrderBy(final Database db, final String sql) {
     try {
       final Statement statement = ((DatabaseInternal) db).getStatementCache().get(sql);
-      if (statement instanceof SelectStatement select) {
-        final OrderBy orderBy = select.getOrderBy();
-        return orderBy != null && orderBy.getItems() != null && !orderBy.getItems().isEmpty();
-      }
+
+      final OrderBy orderBy;
+      if (statement instanceof SelectStatement select)
+        orderBy = select.getOrderBy();
+      else if (statement instanceof MatchStatement match)
+        orderBy = match.getOrderBy();
+      else
+        orderBy = null;
+
+      return orderBy != null && orderBy.getItems() != null && !orderBy.getItems().isEmpty();
     } catch (final Exception e) {
       LogManager.instance()
           .log(this, Level.FINE, "Could not parse the query to look for an ORDER BY, paging by @rid: %s", e, sql);

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7029GrpcPagedOrderByIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7029GrpcPagedOrderByIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7029: the PAGED retrieval mode wrapped the caller's SQL in an outer
+ * {@code SELECT FROM (...) ORDER BY @rid}, which discarded the caller's own ORDER BY. Rows came back in RID order,
+ * silently, and because the pages were cut by SKIP/LIMIT over that rewritten order the caller could not even restore
+ * the intended order client-side without pulling every page.
+ * <p>
+ * The wrapper now adds {@code ORDER BY @rid} only when the caller asked for no order of its own; a caller-supplied
+ * ORDER BY is left to do its job inside the sub-query, which the wrapper no longer re-sorts.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7029GrpcPagedOrderByIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+  private static final int ROWS      = 12;
+  private static final int PAGE_SIZE = 5;
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password",
+      Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database",
+      Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                 channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    // "seq" runs 0..ROWS-1 in insertion (RID) order, so ordering by -seq is the exact opposite of RID order and a
+    // wrapper that re-sorts by @rid is impossible to mistake for one that does not.
+    final Database db = getServerDatabase(0, getDatabaseName());
+    db.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        db.newVertex(VERTEX1_TYPE_NAME).set("id", 9000L + i).set("seq", i).save();
+    });
+
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private List<Long> streamPagedSeq(final String query) {
+    final StreamQueryRequest request = StreamQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setQuery(query)
+        .setBatchSize(PAGE_SIZE)
+        .setRetrievalMode(StreamQueryRequest.RetrievalMode.PAGED)
+        .build();
+
+    final List<Long> seq = new ArrayList<>();
+    final Iterator<QueryResult> results = authenticatedStub.streamQuery(request);
+    while (results.hasNext()) {
+      for (final GrpcRecord record : results.next().getRecordsList()) {
+        final GrpcValue value = record.getPropertiesMap().get("seq");
+        assertThat(value).as("every row must carry the 'seq' property").isNotNull();
+        seq.add(value.hasInt64Value() ? value.getInt64Value() : value.getInt32Value());
+      }
+    }
+    return seq;
+  }
+
+  @Test
+  void pagedModeKeepsTheCallerDescendingOrderAcrossPages() {
+    // No projection, so the sub-query yields records and the outer statement really can sort them by @rid - which is
+    // what used to happen. RID order here is neither ascending nor descending "seq" (the type's buckets are filled
+    // round-robin), so the outer re-sort is unmistakable. 12 rows over pages of 5 means three pages, so the order has
+    // to survive the page boundaries and not just hold within one page.
+    final List<Long> seq = streamPagedSeq("SELECT FROM " + VERTEX1_TYPE_NAME + " WHERE seq IS NOT NULL ORDER BY seq DESC");
+
+    assertThat(seq).as("every row must be delivered exactly once across the pages").hasSize(ROWS);
+    assertThat(seq)
+        .as("PAGED must deliver the rows in the order the caller asked for, not in RID order")
+        .isSortedAccordingTo((a, b) -> Long.compare(b, a));
+    assertThat(seq.get(0)).isEqualTo(ROWS - 1L);
+    assertThat(seq.get(seq.size() - 1)).isZero();
+  }
+
+  @Test
+  void pagedModeKeepsTheCallerAscendingOrder() {
+    final List<Long> seq = streamPagedSeq("SELECT FROM " + VERTEX1_TYPE_NAME + " WHERE seq IS NOT NULL ORDER BY seq ASC");
+
+    assertThat(seq).hasSize(ROWS);
+    assertThat(seq).as("an ascending caller order must be preserved too, and it is not the RID order either").isSorted();
+  }
+
+  @Test
+  void pagedModeKeepsTheCallerOrderOnAProjection() {
+    // A projected column shows the fix does not depend on the outer statement being able to see @rid or the sort key:
+    // the ordering is applied inside the sub-query, where both are still in scope. Note this case survived the old
+    // wrapper too, by luck rather than design - @rid is null on every projected row, so the outer sort was a stable
+    // no-op. It is here as a guard that the fix does not break it, not as a reproduction of the bug; the two
+    // record-returning tests above are what fail against the old code.
+    final List<Long> seq = streamPagedSeq(
+        "SELECT seq AS seq FROM " + VERTEX1_TYPE_NAME + " WHERE seq IS NOT NULL ORDER BY seq DESC");
+
+    assertThat(seq).hasSize(ROWS);
+    assertThat(seq).isSortedAccordingTo((a, b) -> Long.compare(b, a));
+  }
+
+  @Test
+  void pagedModeStillPagesStablyWhenTheCallerAsksForNoOrder() {
+    // Without a caller-supplied ORDER BY the wrapper keeps ordering by @rid, which is what makes SKIP/LIMIT paging
+    // sound. RID order is not insertion order - the type's buckets are filled round-robin - so what is asserted here
+    // is what @rid buys: every row delivered exactly once, and the same total order on every run, so the pages of one
+    // scan cannot drop or duplicate a row.
+    final String query = "SELECT FROM " + VERTEX1_TYPE_NAME + " WHERE seq IS NOT NULL";
+
+    final List<Long> seq = streamPagedSeq(query);
+    final List<Long> expected = new ArrayList<>();
+    for (long i = 0; i < ROWS; i++)
+      expected.add(i);
+
+    assertThat(seq).as("with no caller order, @rid paging must deliver every row exactly once")
+        .hasSize(ROWS)
+        .containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(streamPagedSeq(query)).as("@rid gives the pages a stable total order, so a re-run repeats it")
+        .containsExactlyElementsOf(seq);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7029GrpcPagedOrderByIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7029GrpcPagedOrderByIT.java
@@ -177,6 +177,24 @@ public class Issue7029GrpcPagedOrderByIT extends BaseGraphServerTest {
   }
 
   @Test
+  void pagedModeKeepsTheCallerOrderOnAMatchStatement() {
+    // MATCH is the other statement shape in this dialect that can carry an ORDER BY, and it is not a
+    // SelectStatement, so the parse check asks it separately - otherwise the wrapper appends a second, meaningless
+    // sort by @rid on top of the order MATCH already produced.
+    //
+    // Like the projection case above, this is a guard rather than a reproduction: it passes with or without that
+    // branch, because MATCH always projects and so leaves @rid null on every outer row, which makes the outer sort a
+    // stable no-op. Verified by deleting the MatchStatement branch and re-running - still green. The branch is kept
+    // because the parse check should answer honestly about the dialect, not because MATCH was losing its order.
+    final List<Long> seq = streamPagedSeq(
+        "MATCH {type: " + VERTEX1_TYPE_NAME + ", as: v, where: (seq IS NOT NULL)} RETURN v.seq AS seq ORDER BY seq DESC");
+
+    assertThat(seq).hasSize(ROWS);
+    assertThat(seq).as("a MATCH statement's own ORDER BY must survive paging too")
+        .isSortedAccordingTo((a, b) -> Long.compare(b, a));
+  }
+
+  @Test
   void pagedModeStillPagesStablyWhenTheCallerAsksForNoOrder() {
     // Without a caller-supplied ORDER BY the wrapper keeps ordering by @rid, which is what makes SKIP/LIMIT paging
     // sound. RID order is not insertion order - the type's buckets are filled round-robin - so what is asserted here


### PR DESCRIPTION
Closes #6995, closes #7056, closes #7029, closes #6998.

Four independent defects with one thing in common: each returned a wrong answer with no error to say so.

### #6995 - SQL `CONTAINS` with an array on the right never matched

`ContainsCondition` normalizes an array *left*-hand side to a `List` (that is #6984), but the right-hand side got no such treatment. An array satisfies neither `instanceof Collection` nor `instanceof Iterable`, so `'a b c'.split(' ') CONTAINS 'a'.split(' ')` skipped every branch of the operator and compared the whole `String[]` object against each left-hand item: false, always, whatever the content. Same for any parameter bound to a Java array.

The right-hand side is now normalized exactly as the left one is, so an array answers precisely what the identical `List` answers - **the operator's meaning is unchanged**. That matters, because the established semantics are not the obvious ones and are pinned by existing tests: a single-item collection is unwrapped to its item (the one-row sub-query case, `containsEmptyCollection`), and a longer one is looked for as *one element* of the left-hand collection (`containsCollection`: `test CONTAINS [1]` matches a row holding `test = [[1]]`). An earlier draft of this fix made a multi-item right-hand side a subset test instead; those two tests caught it, and the semantics were left alone.

`byte[]` is deliberately excluded on both sides: it is ArcadeDB's BINARY *scalar*, so expanding it would turn `list CONTAINS :binary` into a search for a list of numbers.

Both sides now reuse the engine's existing `CollectionUtils.arrayToList` instead of hand-rolling the boxing.

### #7056 - a declared `ARRAY_OF_FLOATS` read back over Bolt as `[F@294b13ce`

Declaring the property is what triggered it: a declared array property is stored as the matching Java primitive array, and the Bolt value mapper tested for `Object[]`, which a `float[]` never is. The value fell past every branch to the `toString()` default and reached the client as an 11-character string, while the same row over HTTP/SQL returned the values - so a client hydrating embeddings got a corrupted value with nothing to indicate it.

Every array now maps to a PackStream list (again through `CollectionUtils.arrayToList`), `byte[]` still travels as PackStream Bytes, a `Set` no longer stringifies either, and `PackStreamWriter` grew the same handling as a last line of defense, so a multi-value that reaches the writer unconverted goes out as a list rather than an identity string.

### #7029 - the gRPC PAGED stream discarded the caller's `ORDER BY`

`wrapWithSkipLimit` hardcoded `SELECT FROM ( ... ) ORDER BY @rid SKIP :_skip LIMIT :_limit`, so `SELECT FROM Doc ORDER BY createdAt DESC` came back in RID order, and because the pages were cut by SKIP/LIMIT over that rewritten order the caller could not restore the intended order client-side without pulling every page.

The stable `@rid` order is deliberate - paging without a total order is unsound - so it stays, but only when the caller expressed no order of its own. The statement is parsed through the database statement cache (so a repeated query is parsed once); when it carries its own `ORDER BY`, the sub-query already emits rows sorted and the wrapper preserves that by adding no `ORDER BY` of its own.

The issue offered a second option - refusing a PAGED request whose SQL has an `ORDER BY`, pointing the caller at CURSOR. Preserving the order is strictly better, and re-stating the caller's terms on the outside (the issue's first option) does not work: a projection (`SELECT name FROM Doc ORDER BY createdAt`) leaves neither the sort key nor `@rid` visible to the outer statement.

### #6998 - two corners of `BinaryComparator`

- `equalsBytes` applied a "compare the last byte first" fast path with no empty-array guard, so two empty `byte[]` read index -1 and threw `ArrayIndexOutOfBoundsException` instead of comparing equal. Reachable from SQL: `WHERE bin = :p` against an empty BINARY property failed the query rather than matching the row.
- `compareTo` encoded its left String operand with the JVM default charset and its right one with the configured charset. On a JVM started with a non-UTF-8 `-Dfile.encoding` the two disagree, so an equal pair of non-ASCII strings compared as less-than and `ORDER BY` / range predicates answered wrongly.

## Tests

Every new test was run against the unfixed code first and fails there.

- `ContainsConditionTest` - array right-hand side, array/List parity across flat and nested left-hand values, `byte[]` stays a scalar.
- `QueryTest` - the same two cases end to end in SQL, via `split()` and via a bound array parameter.
- `Issue6998BinaryComparatorTest` - empty `byte[]` at both the comparator and the SQL level; the charset case runs in a **forked JVM** with `-Dfile.encoding=ISO-8859-1`, because `Charset.defaultCharset()` is fixed at startup and cannot be varied inside a running suite. The fork asserts it really got ISO-8859-1, so the test cannot pass vacuously.
- `Issue7056PrimitiveArrayValueTest` + `Issue7056DeclaredArrayOfFloatsIT` - the mapper for every primitive array type, and the real Bolt round trip through the Neo4j driver against a declared `ARRAY_OF_FLOATS`.
- `Issue7029GrpcPagedOrderByIT` - descending and ascending caller orders across three pages, plus the no-order case (exactly-once delivery and a repeatable total order). One test there is labelled as a guard rather than a reproduction: with a projected inner query `@rid` is null on every row, so the old outer sort was a stable no-op and that case passed before the fix too.

Full unit suites green for engine, network, integration, server, ha-raft, bolt and grpcw; both new ITs green.

Release notes added to `docs/release-26.9.1.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bolt now serializes primitive arrays, collections, and sets as lists while preserving byte arrays as binary values.
  * `CONTAINS` handles arrays consistently, including nested and multi-element values, while preserving byte-array behavior by operand position.
  * gRPC paged queries preserve caller-specified ordering across supported query types.
  * Comparisons safely handle empty byte arrays and consistently apply configured character encoding.
  * Declared float-array properties are returned as numeric lists through Bolt.
* **Documentation**
  * Clarified array handling and byte-array behavior for `CONTAINS`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->