### PR TITLE
fix(#7059): interpolate Cypher dynamic labels instead of naming a type after the expression

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -614,6 +614,61 @@ public final class Labels {
   }
 
   /**
+   * Appends the label(s) a Cypher 25 dynamic label expression - {@code SET n:$(expr)}, {@code REMOVE n:$(expr)} -
+   * evaluated to, validating each one as a name a type can actually be created under.
+   * <p>
+   * The contract on the value follows Neo4j: a string is one label, a list (or array) of strings is that many
+   * labels, and {@code null} contributes nothing. Anything else is refused rather than coerced.
+   * <p>
+   * The write clauses validate where the read clauses ({@code MatchNodeStep} and friends) deliberately do not:
+   * a nonsense label in a pattern matches nothing and is harmless, whereas the same value on a write path becomes
+   * a <i>vertex type</i>. Issue #7059 is what happens without the check - the source text {@code $(node.labels)}
+   * was itself turned into a type, and the schema corruption only surfaced when a client read those nodes back.
+   * {@code toString()}-ing a number or a map into a type name would land in exactly the same place, so the value
+   * has to be a usable label or the statement fails.
+   *
+   * @param target the list to append to
+   * @param value  the value the dynamic label expression evaluated to
+   * @param clause the clause name to name in the error message, e.g. {@code "SET"}
+   *
+   * @throws CommandSemanticException when the value, or an entry of it, cannot be used as a label
+   */
+  public static void appendDynamicLabels(final List<String> target, final Object value, final String clause) {
+    if (value == null)
+      return;
+
+    if (value instanceof Iterable<?> iterable) {
+      for (final Object item : iterable)
+        if (item != null)
+          target.add(requireUsableLabel(item, clause));
+      return;
+    }
+
+    if (value instanceof Object[] array) {
+      for (final Object item : array)
+        if (item != null)
+          target.add(requireUsableLabel(item, clause));
+      return;
+    }
+
+    target.add(requireUsableLabel(value, clause));
+  }
+
+  private static String requireUsableLabel(final Object value, final String clause) {
+    if (!(value instanceof String label))
+      throw new CommandSemanticException("A dynamic label expression in " + clause + " must evaluate to a string or a "
+          + "list of strings, but it evaluated to " + value.getClass().getSimpleName() + " (" + value + ")");
+    if (label.isBlank())
+      throw new CommandSemanticException(
+          "A dynamic label expression in " + clause + " evaluated to a blank label, which is not a usable type name");
+    if (label.contains(LABEL_SEPARATOR))
+      throw new CommandSemanticException("A dynamic label expression in " + clause + " evaluated to '" + label
+          + "', but '" + LABEL_SEPARATOR + "' is reserved as the separator between the labels of a composite type "
+          + "and cannot appear inside a single label");
+    return label;
+  }
+
+  /**
    * Ensures composite type exists, creating it if necessary.
    * Returns the type name to use for creating vertices.
    * <p>

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RemoveClause.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RemoveClause.java
@@ -27,7 +27,8 @@ import java.util.List;
  * <p>
  * Examples:
  * - REMOVE n.property - removes a property from a node
- * - REMOVE n:Label - removes a label from a node (not yet supported)
+ * - REMOVE n:Label - removes a label from a node
+ * - REMOVE n:$(expr) - removes the label(s) the expression yields (Cypher 25 dynamic label)
  */
 public class RemoveClause {
   private final List<RemoveItem> items;
@@ -53,7 +54,7 @@ public class RemoveClause {
      */
     public enum RemoveType {
       PROPERTY,   // Remove a property from node/edge
-      LABELS      // Remove labels from a node (not yet implemented)
+      LABELS      // Remove labels from a node
     }
 
     private final RemoveType type;
@@ -61,6 +62,7 @@ public class RemoveClause {
     private final String property;  // For PROPERTY type
     private final Expression keyExpression;  // For dynamic PROPERTY type: REMOVE n[keyExpr]
     private final List<String> labels;  // For LABELS type
+    private final List<Expression> labelExpressions;  // For LABELS type: REMOVE n:$(expr)
 
     /**
      * Constructor for property removal.
@@ -74,6 +76,7 @@ public class RemoveClause {
       this.property = property;
       this.keyExpression = null;
       this.labels = null;
+      this.labelExpressions = List.of();
     }
 
     /**
@@ -89,6 +92,7 @@ public class RemoveClause {
       this.property = null;
       this.keyExpression = keyExpression;
       this.labels = null;
+      this.labelExpressions = List.of();
     }
 
     /**
@@ -98,11 +102,24 @@ public class RemoveClause {
      * @param labels   the labels to remove
      */
     public RemoveItem(final String variable, final List<String> labels) {
+      this(variable, labels, List.of());
+    }
+
+    /**
+     * Constructor for label removal with Cypher 25 dynamic labels: {@code REMOVE n:Static:$(expr)}. Each expression
+     * in {@code labelExpressions} is evaluated per row and contributes the label (or list of labels) it yields.
+     *
+     * @param variable         the variable name (node)
+     * @param labels           the statically written labels to remove
+     * @param labelExpressions the {@code $(expr)} labels to resolve per row
+     */
+    public RemoveItem(final String variable, final List<String> labels, final List<Expression> labelExpressions) {
       this.type = RemoveType.LABELS;
       this.variable = variable;
       this.property = null;
       this.keyExpression = null;
       this.labels = labels;
+      this.labelExpressions = labelExpressions != null ? labelExpressions : List.of();
     }
 
     public RemoveType getType() {
@@ -125,12 +142,26 @@ public class RemoveClause {
       return labels;
     }
 
+    /** The Cypher 25 {@code $(expr)} labels of this item, evaluated per row. Never null; empty when there are none. */
+    public List<Expression> getLabelExpressions() {
+      return labelExpressions;
+    }
+
+    public boolean hasLabelExpressions() {
+      return !labelExpressions.isEmpty();
+    }
+
     @Override
     public String toString() {
       if (type == RemoveType.PROPERTY) {
         return keyExpression != null ? variable + "[" + keyExpression + "]" : variable + "." + property;
       } else {
-        return variable + ":" + String.join(":", labels);
+        final StringBuilder sb = new StringBuilder(variable);
+        for (final String label : labels)
+          sb.append(':').append(label);
+        for (final Expression labelExpression : labelExpressions)
+          sb.append(":$(").append(labelExpression).append(')');
+        return sb.toString();
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/SetClause.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/SetClause.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
+import com.arcadedb.query.opencypher.Labels;
+
 import java.util.List;
 
 /**
@@ -111,7 +113,7 @@ public class SetClause {
      * Label assignment with Cypher 25 dynamic labels: {@code SET n:Static:$(expr)}. The static labels are known at
      * parse time; each expression in {@code labelExpressions} is evaluated per row and contributes the label (or
      * list of labels) it yields. Labels are a set, so the two lists are merged without preserving the order they
-     * were written in - {@link com.arcadedb.query.opencypher.Labels#ensureCompositeType} sorts them anyway.
+     * were written in - {@link Labels#ensureCompositeType} sorts them anyway.
      */
     public SetItem(final String variable, final List<String> labels, final List<Expression> labelExpressions) {
       this.variable = variable;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/SetClause.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/SetClause.java
@@ -29,6 +29,7 @@ import java.util.List;
  * - SET n = {name: 'Alice', age: 30}
  * - SET n += {name: 'Alice'}
  * - SET n:Label
+ * - SET n:$(expr)   (Cypher 25 dynamic label)
  */
 public class SetClause {
   private final List<SetItem> items;
@@ -63,6 +64,7 @@ public class SetClause {
     private final Expression targetExpression;
     private final SetType type;
     private final List<String> labels;
+    private final List<Expression> labelExpressions;
 
     /** Property assignment: SET n.prop = value */
     public SetItem(final String variable, final String property, final Expression valueExpression) {
@@ -73,6 +75,7 @@ public class SetClause {
       this.targetExpression = null;
       this.type = SetType.PROPERTY;
       this.labels = null;
+      this.labelExpressions = List.of();
     }
 
     /** Property assignment with expression target: SET (CASE ... THEN n END).prop = value */
@@ -84,6 +87,7 @@ public class SetClause {
       this.valueExpression = valueExpression;
       this.type = SetType.PROPERTY;
       this.labels = null;
+      this.labelExpressions = List.of();
     }
 
     /** Map replacement (SET n = expr) or map merge (SET n += expr) */
@@ -95,10 +99,21 @@ public class SetClause {
       this.targetExpression = null;
       this.type = type;
       this.labels = null;
+      this.labelExpressions = List.of();
     }
 
     /** Label assignment: SET n:Label */
     public SetItem(final String variable, final List<String> labels) {
+      this(variable, labels, List.of());
+    }
+
+    /**
+     * Label assignment with Cypher 25 dynamic labels: {@code SET n:Static:$(expr)}. The static labels are known at
+     * parse time; each expression in {@code labelExpressions} is evaluated per row and contributes the label (or
+     * list of labels) it yields. Labels are a set, so the two lists are merged without preserving the order they
+     * were written in - {@link com.arcadedb.query.opencypher.Labels#ensureCompositeType} sorts them anyway.
+     */
+    public SetItem(final String variable, final List<String> labels, final List<Expression> labelExpressions) {
       this.variable = variable;
       this.property = null;
       this.keyExpression = null;
@@ -106,6 +121,7 @@ public class SetClause {
       this.targetExpression = null;
       this.type = SetType.LABELS;
       this.labels = labels;
+      this.labelExpressions = labelExpressions != null ? labelExpressions : List.of();
     }
 
     /**
@@ -123,6 +139,7 @@ public class SetClause {
       this.targetExpression = targetExpression;
       this.type = SetType.PROPERTY;
       this.labels = null;
+      this.labelExpressions = List.of();
     }
 
     public String getVariable() {
@@ -151,6 +168,15 @@ public class SetClause {
 
     public List<String> getLabels() {
       return labels;
+    }
+
+    /** The Cypher 25 {@code $(expr)} labels of this item, evaluated per row. Never null; empty when there are none. */
+    public List<Expression> getLabelExpressions() {
+      return labelExpressions;
+    }
+
+    public boolean hasLabelExpressions() {
+      return !labelExpressions.isEmpty();
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -5152,14 +5152,18 @@ public class CypherExecutionPlan {
           return true;
         break;
       case SET:
+        // A Cypher 25 dynamic label - SET n:$(expr) - is a right-hand side like any other, so it counts as a read
+        // of the graph when its expression does (issue #7059).
         for (final SetClause.SetItem setItem : ((SetClause) innerClause.getClause()).getItems())
           if (expressionReadsGraph(setItem.getValueExpression()) || expressionReadsGraph(setItem.getKeyExpression())
-              || expressionReadsGraph(setItem.getTargetExpression()))
+              || expressionReadsGraph(setItem.getTargetExpression())
+              || expressionsReadGraph(setItem.getLabelExpressions()))
             return true;
         break;
       case REMOVE:
         for (final RemoveClause.RemoveItem removeItem : ((RemoveClause) innerClause.getClause()).getItems())
-          if (expressionReadsGraph(removeItem.getKeyExpression()))
+          if (expressionReadsGraph(removeItem.getKeyExpression())
+              || expressionsReadGraph(removeItem.getLabelExpressions()))
             return true;
         break;
       case DELETE:

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -5122,10 +5122,42 @@ public class CypherExecutionPlan {
         if (expressionReadsGraph(((UnwindClause) laterClause.getClause()).getListExpression()))
           return true;
         break;
+      case SET:
+        if (setItemsReadGraph(laterClause.getTypedClause()))
+          return true;
+        break;
+      case REMOVE:
+        if (removeItemsReadGraph(laterClause.getTypedClause()))
+          return true;
+        break;
       default:
         break;
       }
     }
+    return false;
+  }
+
+  /**
+   * Tells whether a SET clause reads the graph. Every right-hand side counts - the assigned value, an expression
+   * target, a dynamic property key, and a Cypher 25 dynamic label ({@code SET n:$(expr)}, issue #7059) - because
+   * each is evaluated per row against the live graph. Shared by {@link #graphReadFollows(List, int)} and
+   * {@link #foreachBodyReadsGraph(ForeachClause)} so a SET is classified the same wherever it sits.
+   */
+  private boolean setItemsReadGraph(final SetClause setClause) {
+    for (final SetClause.SetItem setItem : setClause.getItems())
+      if (expressionReadsGraph(setItem.getValueExpression()) || expressionReadsGraph(setItem.getKeyExpression())
+          || expressionReadsGraph(setItem.getTargetExpression())
+          || expressionsReadGraph(setItem.getLabelExpressions()))
+        return true;
+    return false;
+  }
+
+  /** {@link #setItemsReadGraph(SetClause)}, for the dynamic key and dynamic label of a REMOVE clause. */
+  private boolean removeItemsReadGraph(final RemoveClause removeClause) {
+    for (final RemoveClause.RemoveItem removeItem : removeClause.getItems())
+      if (expressionReadsGraph(removeItem.getKeyExpression())
+          || expressionsReadGraph(removeItem.getLabelExpressions()))
+        return true;
     return false;
   }
 
@@ -5152,19 +5184,12 @@ public class CypherExecutionPlan {
           return true;
         break;
       case SET:
-        // A Cypher 25 dynamic label - SET n:$(expr) - is a right-hand side like any other, so it counts as a read
-        // of the graph when its expression does (issue #7059).
-        for (final SetClause.SetItem setItem : ((SetClause) innerClause.getClause()).getItems())
-          if (expressionReadsGraph(setItem.getValueExpression()) || expressionReadsGraph(setItem.getKeyExpression())
-              || expressionReadsGraph(setItem.getTargetExpression())
-              || expressionsReadGraph(setItem.getLabelExpressions()))
-            return true;
+        if (setItemsReadGraph(innerClause.getTypedClause()))
+          return true;
         break;
       case REMOVE:
-        for (final RemoveClause.RemoveItem removeItem : ((RemoveClause) innerClause.getClause()).getItems())
-          if (expressionReadsGraph(removeItem.getKeyExpression())
-              || expressionsReadGraph(removeItem.getLabelExpressions()))
-            return true;
+        if (removeItemsReadGraph(innerClause.getTypedClause()))
+          return true;
         break;
       case DELETE:
         for (final Expression deleteExpression : ((DeleteClause) innerClause.getClause()).getExpressions())

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
@@ -174,6 +174,8 @@ public final class CypherVariableUsage {
             if (item.getTargetExpression() != null
                 && expressionReferencesVariable(item.getTargetExpression(), variable))
               return true;
+            if (labelExpressionsReferenceVariable(item.getLabelExpressions(), variable))
+              return true;
           }
           break;
         }
@@ -183,7 +185,8 @@ public final class CypherVariableUsage {
           // and became a no-op unless the edge was also projected through WITH (issue #5013).
           final RemoveClause rc = entry.getTypedClause();
           for (final RemoveClause.RemoveItem item : rc.getItems())
-            if (variable.equals(item.getVariable()))
+            if (variable.equals(item.getVariable())
+                || labelExpressionsReferenceVariable(item.getLabelExpressions(), variable))
               return true;
           break;
         }
@@ -287,13 +290,16 @@ public final class CypherVariableUsage {
             if (item.getTargetExpression() != null
                 && expressionReferencesVariable(item.getTargetExpression(), variable))
               return true;
+            if (labelExpressionsReferenceVariable(item.getLabelExpressions(), variable))
+              return true;
           }
           break;
         }
         case REMOVE: {
           final RemoveClause rc = inner.getTypedClause();
           for (final RemoveClause.RemoveItem item : rc.getItems())
-            if (variable.equals(item.getVariable()))
+            if (variable.equals(item.getVariable())
+                || labelExpressionsReferenceVariable(item.getLabelExpressions(), variable))
               return true;
           break;
         }
@@ -376,13 +382,16 @@ public final class CypherVariableUsage {
           if (item.getTargetExpression() != null
               && expressionReferencesVariable(item.getTargetExpression(), variable))
             return true;
+          if (labelExpressionsReferenceVariable(item.getLabelExpressions(), variable))
+            return true;
         }
         break;
       }
       case REMOVE: {
         final RemoveClause rc = entry.getTypedClause();
         for (final RemoveClause.RemoveItem item : rc.getItems())
-          if (variable.equals(item.getVariable()))
+          if (variable.equals(item.getVariable())
+              || labelExpressionsReferenceVariable(item.getLabelExpressions(), variable))
             return true;
         break;
       }
@@ -467,6 +476,20 @@ public final class CypherVariableUsage {
     final VariableReferenceFinder finder = new VariableReferenceFinder(variable);
     CypherExpressionWalker.walk(expression, finder);
     return finder.found;
+  }
+
+  /**
+   * A Cypher 25 dynamic label - {@code SET n:$(r.kind)} / {@code REMOVE n:$(r.kind)} - can be the only place a
+   * binding is read. Missing it here would drop that binding exactly the way issues #5137 and #5013 dropped an edge
+   * read solely from a SET value or a REMOVE target, and the label expression would then quietly evaluate to null
+   * instead of naming a label (issue #7059).
+   */
+  private static boolean labelExpressionsReferenceVariable(final List<Expression> labelExpressions,
+      final String variable) {
+    for (int i = 0; i < labelExpressions.size(); i++)
+      if (expressionReferencesVariable(labelExpressions.get(i), variable))
+        return true;
+    return false;
   }
 
   /** {@link #expressionReferencesVariable(Expression, String)}, for a WHERE-clause predicate. */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -24,6 +24,7 @@ import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
+import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.RemoveClause;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.DeletedEntityMarker;
@@ -246,6 +247,22 @@ public class RemoveStep extends AbstractExecutionStep {
   }
 
   /**
+   * Resolves the labels this item removes: the statically written ones, plus whatever each Cypher 25
+   * {@code $(expression)} label evaluates to against the current row. Before issue #7059 the parser dropped the
+   * dynamic labels entirely, so {@code REMOVE n:$(x)} was a silent no-op.
+   */
+  private List<String> resolveLabels(final RemoveClause.RemoveItem item, final Result result) {
+    if (!item.hasLabelExpressions())
+      return item.getLabels();
+
+    final List<String> resolved = new ArrayList<>(item.getLabels().size() + item.getLabelExpressions().size());
+    resolved.addAll(item.getLabels());
+    for (final Expression labelExpression : item.getLabelExpressions())
+      Labels.appendDynamicLabels(resolved, evaluator.evaluate(labelExpression, result, context), "REMOVE");
+    return resolved;
+  }
+
+  /**
    * Removes labels from a vertex by changing its type.
    * Creates a new vertex with the reduced label set and migrates properties/edges.
    */
@@ -271,7 +288,9 @@ public class RemoveStep extends AbstractExecutionStep {
     // instead of with Entity), while keeping every implied label would flatten the hierarchy (issue #6363).
     final DocumentType currentType = vertex.getType();
     final Schema schema = context.getDatabase().getSchema();
-    final List<String> labelsToRemove = item.getLabels();
+    final List<String> labelsToRemove = resolveLabels(item, result);
+    if (labelsToRemove.isEmpty())
+      return;
     final List<String> remainingLabels = Labels.remainingLabels(schema, vertex, labelsToRemove);
 
     // Count the labels the vertex actually carries - a label it does not have is a no-op, exactly as in Neo4j, and

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -165,11 +165,30 @@ public class RemoveStep extends AbstractExecutionStep {
         context.getDatabase().begin();
       }
 
-      for (final RemoveClause.RemoveItem item : removeClause.getItems()) {
+      // Phase 1: read every right-hand side against the pre-clause state, before any write of this clause
+      // lands. A clause assigns simultaneously in Cypher, so `REMOVE n.kind, n:$(n.kind)` must name the label
+      // from the property value the clause is about to remove, not from the hole it leaves. This mirrors the
+      // phase-1/phase-2 split SetClauseApplier already performs (issue #5190).
+      final List<RemoveClause.RemoveItem> items = removeClause.getItems();
+      // Allocated only for a clause that actually names a label: the overwhelmingly common REMOVE is
+      // property-only, and this runs once per row.
+      Object[] labels = null;
+      for (int i = 0; i < items.size(); i++) {
+        final RemoveClause.RemoveItem item = items.get(i);
+        if (item.getType() == RemoveClause.RemoveItem.RemoveType.LABELS) {
+          if (labels == null)
+            labels = new Object[items.size()];
+          labels[i] = resolveLabels(item, result);
+        }
+      }
+
+      // Phase 2: apply in source order, each label removal working off its phase-1 list.
+      for (int i = 0; i < items.size(); i++) {
+        final RemoveClause.RemoveItem item = items.get(i);
         if (item.getType() == RemoveClause.RemoveItem.RemoveType.PROPERTY)
           removeProperty(item, result);
         else if (item.getType() == RemoveClause.RemoveItem.RemoveType.LABELS)
-          removeLabels(item, result, replacements);
+          removeLabels(item, result, replacements, asLabelList(labels[i]));
       }
 
       // Commit transaction if we started it
@@ -246,6 +265,12 @@ public class RemoveStep extends AbstractExecutionStep {
     RowAliases.propagateUpdate(result, doc, mutableDoc);
   }
 
+  /** The phase-1 label list, cast back from the {@code Object[]} the snapshot is held in. */
+  @SuppressWarnings("unchecked")
+  private static List<String> asLabelList(final Object phase1Value) {
+    return (List<String>) phase1Value;
+  }
+
   /**
    * Resolves the labels this item removes: the statically written ones, plus whatever each Cypher 25
    * {@code $(expression)} label evaluates to against the current row. Before issue #7059 the parser dropped the
@@ -267,7 +292,7 @@ public class RemoveStep extends AbstractExecutionStep {
    * Creates a new vertex with the reduced label set and migrates properties/edges.
    */
   private void removeLabels(final RemoveClause.RemoveItem item, final Result result,
-      final LabelReplacements replacements) {
+      final LabelReplacements replacements, final List<String> labelsToRemove) {
     final String variable = item.getVariable();
     final Object obj = result.getProperty(variable);
     // #5795: reject a label removal targeting a node deleted earlier in the same query instead
@@ -288,7 +313,6 @@ public class RemoveStep extends AbstractExecutionStep {
     // instead of with Entity), while keeping every implied label would flatten the hierarchy (issue #6363).
     final DocumentType currentType = vertex.getType();
     final Schema schema = context.getDatabase().getSchema();
-    final List<String> labelsToRemove = resolveLabels(item, result);
     if (labelsToRemove.isEmpty())
       return;
     final List<String> remainingLabels = Labels.remainingLabels(schema, vertex, labelsToRemove);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetClauseApplier.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
+import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.executor.CypherValues;
 import com.arcadedb.query.opencypher.executor.DeletedEntityMarker;
@@ -177,6 +178,10 @@ public final class SetClauseApplier {
             item.getType() == SetClause.SetType.REPLACE_MAP ? "=" : "+=");
         break;
       case LABELS:
+        // A Cypher 25 dynamic label - SET n:$(expr) - is a read of the row, so it is answered from the pre-clause
+        // state like every other right-hand side, and it is validated here so an unusable label rejects the clause
+        // before any of it has been written (issue #7059).
+        values[i] = resolveLabels(item, result);
         break;
       }
     }
@@ -195,7 +200,7 @@ public final class SetClauseApplier {
         applyMergeMap(item, result, writtenDocs, asPropertyMap(values[i]));
         break;
       case LABELS:
-        applyLabels(item, result, writtenDocs, labelReplacements);
+        applyLabels(item, result, writtenDocs, labelReplacements, asLabelList(values[i]));
         break;
       }
     }
@@ -447,8 +452,31 @@ public final class SetClauseApplier {
       ((ResultInternal) result).setProperty(variable, mutable);
   }
 
+  /**
+   * Resolves the labels this item writes: the statically written ones, plus whatever each Cypher 25
+   * {@code $(expression)} label evaluates to against the current row. A dynamic expression may yield a single label
+   * or a list of them, and a value that is not usable as a type name is refused rather than {@code toString()}-ed
+   * into one - see {@link Labels#appendDynamicLabels}.
+   */
+  private List<String> resolveLabels(final SetClause.SetItem item, final Result result) {
+    if (!item.hasLabelExpressions())
+      return item.getLabels();
+
+    final List<String> resolved = new ArrayList<>(item.getLabels().size() + item.getLabelExpressions().size());
+    resolved.addAll(item.getLabels());
+    for (final Expression labelExpression : item.getLabelExpressions())
+      Labels.appendDynamicLabels(resolved, evaluator.evaluate(labelExpression, result, context), "SET");
+    return resolved;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> asLabelList(final Object value) {
+    return (List<String>) value;
+  }
+
   private void applyLabels(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final LabelReplacements labelReplacements) {
+      final Map<RID, MutableDocument> writtenDocs, final LabelReplacements labelReplacements,
+      final List<String> labelsToAdd) {
     final Object obj = result.getProperty(item.getVariable());
     // #5795: reject a label write targeting a node deleted earlier in the same query instead of silently no-op'ing.
     DeletedEntityMarker.checkNotDeleted(obj);
@@ -475,7 +503,7 @@ public final class SetClauseApplier {
     final DocumentType currentType = vertex.getType();
     final List<String> allLabels = new ArrayList<>(Labels.getOwnLabels(vertex));
     int newLabelsCount = 0;
-    for (final String label : item.getLabels())
+    for (final String label : labelsToAdd)
       if (!currentType.instanceOf(label) && !allLabels.contains(label)) {
         allLabels.add(label);
         newLabelsCount++;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -726,27 +726,17 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
         final Expression valueExpr = expressionBuilder.parseExpression(addCtx.expression());
         items.add(new SetClause.SetItem(variable, valueExpr, SetClause.SetType.MERGE_MAP));
       } else if (itemCtx instanceof Cypher25Parser.SetLabelsContext labelsCtx) {
-        // SET n:Label — add labels
-        final String variable = labelsCtx.variable().getText();
-        final String labelsText = labelsCtx.nodeLabels().getText();
-        final String cleanText = labelsText.replaceAll("^:+", "");
-        final String[] parts = cleanText.split("[:&|]+");
+        // SET n:Label / SET n:$(expr) — add labels
         final List<String> labelList = new ArrayList<>();
-        for (final String part : parts)
-          if (!part.isEmpty())
-            labelList.add(stripBackticks(part));
-        items.add(new SetClause.SetItem(variable, labelList));
+        final List<Expression> labelExpressions = new ArrayList<>();
+        collectNodeLabels(labelsCtx.nodeLabels(), labelList, labelExpressions);
+        items.add(new SetClause.SetItem(labelsCtx.variable().getText(), labelList, labelExpressions));
       } else if (itemCtx instanceof Cypher25Parser.SetLabelsIsContext labelsIsCtx) {
-        // SET n IS Label — add labels (IS syntax)
-        final String variable = labelsIsCtx.variable().getText();
-        final String labelsText = labelsIsCtx.nodeLabelsIs().getText();
-        final String cleanText = labelsText.replaceAll("^\\s*IS\\s+", "").replaceAll("^:+", "");
-        final String[] parts = cleanText.split("[:&|]+");
+        // SET n IS Label / SET n IS $(expr) — add labels (IS syntax)
         final List<String> labelList = new ArrayList<>();
-        for (final String part : parts)
-          if (!part.isEmpty())
-            labelList.add(stripBackticks(part));
-        items.add(new SetClause.SetItem(variable, labelList));
+        final List<Expression> labelExpressions = new ArrayList<>();
+        collectNodeLabelsIs(labelsIsCtx.nodeLabelsIs(), labelList, labelExpressions);
+        items.add(new SetClause.SetItem(labelsIsCtx.variable().getText(), labelList, labelExpressions));
       }
     }
 
@@ -764,6 +754,45 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
     }
 
     return new DeleteClause(variables, expressions, detach);
+  }
+
+  /**
+   * Splits a {@code nodeLabels} subtree - the label list of a {@code SET n:...} or {@code REMOVE n:...} item - into
+   * the statically written label names and the Cypher 25 {@code $(expression)} labels that have to be resolved per
+   * row.
+   * <p>
+   * Both clauses used to reduce this whole subtree to {@code getText()} and split the result on {@code [:&|]},
+   * which turned the source text of a dynamic label into a label of its own: {@code SET n:$(node.labels)} created a
+   * vertex type literally named {@code $(node.labels)} and attached it to the node, corrupting schema and data with
+   * no error at write time (issue #7059). {@code REMOVE} had the mirror-image defect - it read {@code labelType()}
+   * alone, so a dynamic label was dropped from the AST and the clause silently did nothing.
+   * <p>
+   * Static and dynamic labels are collected into two lists rather than one interleaved sequence because labels are
+   * a set: the composite type name is built from the sorted union either way.
+   */
+  private void collectNodeLabels(final Cypher25Parser.NodeLabelsContext ctx, final List<String> labels,
+      final List<Expression> labelExpressions) {
+    for (final Cypher25Parser.LabelTypeContext labelType : ctx.labelType())
+      labels.add(stripBackticks(labelType.symbolicNameString().getText()));
+    for (final Cypher25Parser.DynamicLabelTypeContext dynamicLabel : ctx.dynamicLabelType())
+      labelExpressions.add(expressionBuilder.parseExpression(dynamicLabel.dynamicExpression().expression()));
+  }
+
+  /**
+   * The {@code IS} spelling of {@link #collectNodeLabels}: {@code SET n IS Label:Other} / {@code SET n IS $(expr)}.
+   * The grammar puts the first label outside the repetition ({@code IS (symbolicNameString | dynamicExpression)
+   * (labelType | dynamicLabelType)*}), so it is read separately.
+   */
+  private void collectNodeLabelsIs(final Cypher25Parser.NodeLabelsIsContext ctx, final List<String> labels,
+      final List<Expression> labelExpressions) {
+    if (ctx.symbolicNameString() != null)
+      labels.add(stripBackticks(ctx.symbolicNameString().getText()));
+    if (ctx.dynamicExpression() != null)
+      labelExpressions.add(expressionBuilder.parseExpression(ctx.dynamicExpression().expression()));
+    for (final Cypher25Parser.LabelTypeContext labelType : ctx.labelType())
+      labels.add(stripBackticks(labelType.symbolicNameString().getText()));
+    for (final Cypher25Parser.DynamicLabelTypeContext dynamicLabel : ctx.dynamicLabelType())
+      labelExpressions.add(expressionBuilder.parseExpression(dynamicLabel.dynamicExpression().expression()));
   }
 
   public RemoveClause visitRemoveClause(final Cypher25Parser.RemoveClauseContext ctx) {
@@ -786,15 +815,21 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
         final String variable = dynPropExpr.expression1().getText();
         final Expression keyExpr = expressionBuilder.parseExpression(dynPropExpr.dynamicProperty().expression());
         items.add(new RemoveClause.RemoveItem(variable, keyExpr));
-      } else if (itemCtx instanceof Cypher25Parser.RemoveLabelsContext) {
-        final Cypher25Parser.RemoveLabelsContext labelsCtx = (Cypher25Parser.RemoveLabelsContext) itemCtx;
-        final String variable = stripBackticks(labelsCtx.variable().getText());
+      } else if (itemCtx instanceof Cypher25Parser.RemoveLabelsContext labelsCtx) {
+        // REMOVE n:Label / REMOVE n:$(expr)
         final List<String> labels = new ArrayList<>();
-        for (final Cypher25Parser.LabelTypeContext lt : labelsCtx.nodeLabels().labelType())
-          labels.add(stripBackticks(lt.symbolicNameString().getText()));
-        items.add(new RemoveClause.RemoveItem(variable, labels));
+        final List<Expression> labelExpressions = new ArrayList<>();
+        collectNodeLabels(labelsCtx.nodeLabels(), labels, labelExpressions);
+        items.add(new RemoveClause.RemoveItem(stripBackticks(labelsCtx.variable().getText()), labels, labelExpressions));
+      } else if (itemCtx instanceof Cypher25Parser.RemoveLabelsIsContext labelsIsCtx) {
+        // REMOVE n IS Label / REMOVE n IS $(expr) — the IS spelling was previously dropped on the floor, so the
+        // whole clause silently did nothing.
+        final List<String> labels = new ArrayList<>();
+        final List<Expression> labelExpressions = new ArrayList<>();
+        collectNodeLabelsIs(labelsIsCtx.nodeLabelsIs(), labels, labelExpressions);
+        items.add(
+            new RemoveClause.RemoveItem(stripBackticks(labelsIsCtx.variable().getText()), labels, labelExpressions));
       }
-      // TODO: Handle RemoveLabelsIs
     }
 
     return new RemoveClause(items);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -730,13 +730,13 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
         final List<String> labelList = new ArrayList<>();
         final List<Expression> labelExpressions = new ArrayList<>();
         collectNodeLabels(labelsCtx.nodeLabels(), labelList, labelExpressions);
-        items.add(new SetClause.SetItem(labelsCtx.variable().getText(), labelList, labelExpressions));
+        items.add(new SetClause.SetItem(stripBackticks(labelsCtx.variable().getText()), labelList, labelExpressions));
       } else if (itemCtx instanceof Cypher25Parser.SetLabelsIsContext labelsIsCtx) {
         // SET n IS Label / SET n IS $(expr) — add labels (IS syntax)
         final List<String> labelList = new ArrayList<>();
         final List<Expression> labelExpressions = new ArrayList<>();
         collectNodeLabelsIs(labelsIsCtx.nodeLabelsIs(), labelList, labelExpressions);
-        items.add(new SetClause.SetItem(labelsIsCtx.variable().getText(), labelList, labelExpressions));
+        items.add(new SetClause.SetItem(stripBackticks(labelsIsCtx.variable().getText()), labelList, labelExpressions));
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -383,6 +383,9 @@ public final class CypherExpressionWalker {
       walk(item.getTargetExpression(), visitor);
       walk(item.getKeyExpression(), visitor);
       walk(item.getValueExpression(), visitor);
+      // A Cypher 25 dynamic label - SET n:$(expr) - is a read of the row like any other right-hand side, so every
+      // visitor that reasons about what a SET reads has to see it too (issue #7059).
+      walkAll(item.getLabelExpressions(), visitor);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherDynamicLabelSetIssue7059Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherDynamicLabelSetIssue7059Test.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7059: Neo4j 5 dynamic-label syntax {@code SET n:$(expression)} was parsed by the grammar
+ * but never interpolated. {@code CypherASTBuilder.visitSetClause} flattened the whole {@code nodeLabels}
+ * subtree with {@code getText()} and split the result on {@code [:&|]}, so the <i>source text</i> of the
+ * expression became the label: a vertex type literally named {@code $(node.labels)} was created and
+ * attached to every affected node, with no error at write time.
+ * <p>
+ * {@code visitRemoveClause} carried the mirror-image defect with the opposite symptom - it iterated
+ * {@code nodeLabels().labelType()} only, so a dynamic label was silently dropped and {@code REMOVE n:$(x)}
+ * was a no-op.
+ * <p>
+ * Node <i>patterns</i> already resolved {@code $(expr)} labels per row, so the gap was confined to the
+ * two write clauses.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class CypherDynamicLabelSetIssue7059Test extends TestHelper {
+
+  /** The exact shape graphiti emits for bulk node saves. */
+  @Test
+  void bulkMergeWithDynamicLabelAppliesTheInterpolatedLabel() {
+    final List<Map<String, Object>> nodes = List.of(
+        Map.of("uuid", "a", "labels", "Finding", "name", "x"),
+        Map.of("uuid", "b", "labels", "Finding", "name", "y"));
+
+    database.transaction(() -> database.command("opencypher", """
+        UNWIND $nodes AS node
+        MERGE (n:Entity {uuid: node.uuid})
+        SET n:$(node.labels)
+        SET n = node
+        RETURN n.uuid
+        """, Map.of("nodes", nodes)).close());
+
+    // No junk type named after the uninterpolated expression, in any composite position.
+    assertThat(schemaTypeNames()).noneMatch(name -> name.contains("$("));
+
+    // Both nodes carry Entity AND the interpolated Finding label.
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity) RETURN n.uuid AS uuid, labels(n) AS l ORDER BY uuid");
+    final List<String> uuids = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      uuids.add(row.getProperty("uuid"));
+      final List<String> labels = row.getProperty("l");
+      assertThat(labels).containsExactlyInAnyOrder("Entity", "Finding");
+    }
+    assertThat(uuids).containsExactly("a", "b");
+  }
+
+  /** A dynamic label reachable through the {@code Finding} label proves the type really was created. */
+  @Test
+  void theInterpolatedLabelIsMatchable() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Entity {uuid: 'a'})").close();
+      database.command("opencypher", "MATCH (n:Entity {uuid: 'a'}) SET n:$($label)", Map.of("label", "Finding")).close();
+    });
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Finding) RETURN count(n) AS c");
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(1L);
+  }
+
+  /** A dynamic label expression may yield a list: every entry becomes a label, as in a node pattern. */
+  @Test
+  void aListValuedDynamicLabelAddsEveryLabel() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Entity {uuid: 'a'})").close();
+      database.command("opencypher", "MATCH (n:Entity {uuid: 'a'}) SET n:$($labels)",
+          Map.of("labels", List.of("Finding", "Claim"))).close();
+    });
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l");
+    assertThat(rs.next().<List<String>>getProperty("l")).containsExactlyInAnyOrder("Entity", "Finding", "Claim");
+    assertThat(schemaTypeNames()).noneMatch(name -> name.contains("$("));
+  }
+
+  /** Static and dynamic labels mix in one SET item, in either order. */
+  @Test
+  void staticAndDynamicLabelsCombineInOneSetItem() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Entity {uuid: 'a'})").close();
+      database.command("opencypher", "MATCH (n:Entity {uuid: 'a'}) SET n:Audited:$($label):Reviewed",
+          Map.of("label", "Finding")).close();
+    });
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l");
+    assertThat(rs.next().<List<String>>getProperty("l"))
+        .containsExactlyInAnyOrder("Entity", "Audited", "Finding", "Reviewed");
+  }
+
+  /** The {@code IS} spelling of the same syntax: {@code SET n IS $(expr)}. */
+  @Test
+  void theIsSpellingInterpolatesToo() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Entity {uuid: 'a'})").close();
+      database.command("opencypher", "MATCH (n:Entity {uuid: 'a'}) SET n IS $($label)", Map.of("label", "Finding")).close();
+    });
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l");
+    assertThat(rs.next().<List<String>>getProperty("l")).containsExactlyInAnyOrder("Entity", "Finding");
+    assertThat(schemaTypeNames()).noneMatch(name -> name.contains("$("));
+  }
+
+  /** REMOVE had the opposite symptom - the dynamic label was dropped from the AST, so the clause no-op'd. */
+  @Test
+  void removeWithADynamicLabelActuallyRemovesIt() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Entity:Finding {uuid: 'a'})").close();
+      database.command("opencypher", "MATCH (n:Entity {uuid: 'a'}) REMOVE n:$($label)", Map.of("label", "Finding")).close();
+    });
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l");
+    assertThat(rs.next().<List<String>>getProperty("l")).containsExactly("Entity");
+  }
+
+  /** A per-row expression, not just a parameter: each row contributes its own label. */
+  @Test
+  void theExpressionIsEvaluatedPerRow() {
+    database.transaction(() -> database.command("opencypher", """
+        UNWIND [{uuid: 'a', labels: 'Finding'}, {uuid: 'b', labels: 'Claim'}] AS node
+        CREATE (n:Entity {uuid: node.uuid})
+        SET n:$(node.labels)
+        """).close());
+
+    assertThat(database.query("opencypher", "MATCH (n:Finding) RETURN count(n) AS c").next().<Long>getProperty("c"))
+        .isEqualTo(1L);
+    assertThat(database.query("opencypher", "MATCH (n:Claim) RETURN count(n) AS c").next().<Long>getProperty("c"))
+        .isEqualTo(1L);
+    assertThat(schemaTypeNames()).noneMatch(name -> name.contains("$("));
+  }
+
+  /**
+   * A label expression that resolves to something that is not a usable label name is rejected rather
+   * than {@code toString()}-ed into a junk type: silently creating a type named {@code 42} or {@code {a=1}}
+   * is the same class of schema corruption this issue is about.
+   */
+  @Test
+  void anUnusableDynamicLabelValueIsRejected() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Entity {uuid: 'a'})").close());
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher",
+        "MATCH (n:Entity {uuid: 'a'}) SET n:$($label)", Map.of("label", 42)).close()))
+        .hasMessageContaining("label");
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher",
+        "MATCH (n:Entity {uuid: 'a'}) SET n:$($label)", Map.of("label", "")).close()))
+        .hasMessageContaining("label");
+
+    assertThat(schemaTypeNames()).noneMatch(name -> name.equals("42"));
+  }
+
+  /** A dynamic label that evaluates to null contributes nothing, matching the read-path contract. */
+  @Test
+  void aNullDynamicLabelContributesNothing() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Entity {uuid: 'a'})").close();
+      database.command("opencypher", "MATCH (n:Entity {uuid: 'a'}) SET n:$(n.missing)").close();
+    });
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l");
+    assertThat(rs.next().<List<String>>getProperty("l")).containsExactly("Entity");
+  }
+
+  /**
+   * The label expression can be the <i>only</i> place a binding is read. {@code CypherVariableUsage} decides which
+   * bindings a write clause keeps alive, and it looked at the SET target and the value/target expressions only - so
+   * an edge read solely from a dynamic label would have been dropped, the expression would have evaluated to null,
+   * and the clause would have silently written nothing. Issues #5137 and #5013 are the same defect on the other
+   * right-hand sides.
+   */
+  @Test
+  void anEdgeReadOnlyByTheLabelExpressionStaysBound() {
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:Entity {uuid: 'a'})-[:LINK {kind: 'Finding'}]->(b:Entity {uuid: 'b'})").close());
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (a:Entity {uuid: 'a'})-[r:LINK]->(b) SET a:$(r.kind)").close());
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l");
+    assertThat(rs.next().<List<String>>getProperty("l")).containsExactlyInAnyOrder("Entity", "Finding");
+  }
+
+  /** The same, for the REMOVE side. */
+  @Test
+  void anEdgeReadOnlyByTheRemoveLabelExpressionStaysBound() {
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:Entity:Finding {uuid: 'a'})-[:LINK {kind: 'Finding'}]->(b:Entity {uuid: 'b'})").close());
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (a:Entity {uuid: 'a'})-[r:LINK]->(b) REMOVE a:$(r.kind)").close());
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l");
+    assertThat(rs.next().<List<String>>getProperty("l")).containsExactly("Entity");
+  }
+
+  /**
+   * SET is a simultaneous assignment: every right-hand side reads the state the clause began with, so a label
+   * expression reading a property the same clause overwrites must still see the pre-clause value (issue #5190).
+   */
+  @Test
+  void theLabelExpressionReadsThePreClauseState() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Entity {uuid: 'a', kind: 'Finding'})").close());
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (n:Entity {uuid: 'a'}) SET n.kind = 'Claim', n:$(n.kind)").close());
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l, n.kind AS k");
+    final Result row = rs.next();
+    assertThat(row.<List<String>>getProperty("l")).containsExactlyInAnyOrder("Entity", "Finding");
+    assertThat(row.<String>getProperty("k")).isEqualTo("Claim");
+  }
+
+  /** A dynamic label carrying the composite-type separator would decompose into two labels on read-back. */
+  @Test
+  void aDynamicLabelCarryingTheCompositeSeparatorIsRejected() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Entity {uuid: 'a'})").close());
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher",
+        "MATCH (n:Entity {uuid: 'a'}) SET n:$($label)", Map.of("label", "A~B")).close()))
+        .hasMessageContaining("label");
+
+    assertThat(schemaTypeNames()).doesNotContain("A~B");
+  }
+
+  private List<String> schemaTypeNames() {
+    return database.getSchema().getTypes().stream().map(t -> t.getName()).toList();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherDynamicLabelSetIssue7059Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherDynamicLabelSetIssue7059Test.java
@@ -252,6 +252,43 @@ class CypherDynamicLabelSetIssue7059Test extends TestHelper {
     assertThat(schemaTypeNames()).doesNotContain("A~B");
   }
 
+  /**
+   * The REMOVE counterpart of {@link #theLabelExpressionReadsThePreClauseState()}. A clause assigns
+   * simultaneously in Cypher, so a label expression reading a property the same clause removes must still
+   * see the pre-clause value - {@code RemoveStep} applied its items in source order, so the property was
+   * already gone and the expression evaluated to null, making the label removal a silent no-op.
+   */
+  @Test
+  void theRemoveLabelExpressionReadsThePreClauseState() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Entity {uuid: 'a', kind: 'Finding'})").close();
+      database.command("opencypher", "MATCH (n:Entity {uuid: 'a'}) SET n:$(n.kind)").close();
+    });
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (n:Entity {uuid: 'a'}) REMOVE n.kind, n:$(n.kind)").close());
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l, n.kind AS k");
+    final Result row = rs.next();
+    assertThat(row.<List<String>>getProperty("l")).containsExactly("Entity");
+    assertThat(row.<String>getProperty("k")).isNull();
+  }
+
+  /**
+   * {@code visitNodePattern} strips the backticks off an escaped variable, and so does the REMOVE side of
+   * this clause pair, so a SET that keeps them cannot find the row value and drops the label write.
+   */
+  @Test
+  void aBacktickEscapedVariableAcceptsADynamicLabel() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Entity {uuid: 'a'})").close());
+
+    database.transaction(() -> database.command("opencypher",
+        "MATCH (`my node`:Entity {uuid: 'a'}) SET `my node`:$($label)", Map.of("label", "Finding")).close());
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Entity {uuid: 'a'}) RETURN labels(n) AS l");
+    assertThat(rs.next().<List<String>>getProperty("l")).containsExactlyInAnyOrder("Entity", "Finding");
+  }
+
   private List<String> schemaTypeNames() {
     return database.getSchema().getTypes().stream().map(t -> t.getName()).toList();
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherForeachEagerReadIssue6922Test.java
@@ -381,6 +381,39 @@ class CypherForeachEagerReadIssue6922Test {
     }
   }
 
+  @Test
+  void aDynamicLabelExpressionInALaterSetArmsEagerness() {
+    // A Cypher 25 dynamic label (issue #7059) is a right-hand side evaluated per row against the live
+    // graph, exactly like the RETURN and WITH expressions above. graphReadFollows() classified a later
+    // clause by its type alone and let SET fall through its default branch, so the FOREACH kept
+    // streaming and each row's label was chosen by the pull batch it was produced in.
+    database.transaction(() -> database.command("opencypher", "UNWIND range(1, 250) AS i CREATE (:Marker {i: i})").close());
+
+    // MATCH precedes the FOREACH, so it is not what arms eagerness here.
+    final List<Object> rows = queryColumn("""
+        MATCH (m:Marker)
+        FOREACH (j IN range(0, 1) | CREATE (:L1 {j: j}))
+        SET m:$('N' + toString(count { MATCH (n:L1) }))
+        RETURN m.i AS value""", "value");
+
+    assertThat(rows).hasSize(250);
+    assertThat(countOf("L1")).isEqualTo(500L);
+    assertThat(dynamicLabelsApplied())
+        .as("every row must name the label from the complete post-FOREACH graph")
+        .containsExactly("N500");
+  }
+
+  /** The {@code N<count>} labels the dynamic-label SET above actually attached, deduplicated. */
+  private List<String> dynamicLabelsApplied() {
+    final List<String> applied = new ArrayList<>();
+    final ResultSet resultSet = database.query("opencypher", "MATCH (m:Marker) RETURN labels(m) AS l");
+    while (resultSet.hasNext())
+      for (final String label : resultSet.next().<List<String>>getProperty("l"))
+        if (label.startsWith("N") && !applied.contains(label))
+          applied.add(label);
+    return applied;
+  }
+
   private List<Object> queryColumn(final String cypher, final String column) {
     final List<Object> values = new ArrayList<>();
     database.transaction(() -> {


### PR DESCRIPTION
Closes #7059

## Problem

Neo4j 5 dynamic-label syntax `SET n:$(expression)` is parsed by the grammar but was never interpolated. ArcadeDB created a vertex type whose name is the **literal source text** `$(node.labels)` and attached it to the affected nodes. Nothing was raised at write time; the corruption surfaced only when a client read those nodes back and found an invalid label:

```sql
SELECT name FROM schema:types
-- '$(node.labels)', '$(node.labels)~Entity', 'Entity', ...
```

This is the query [graphiti](https://github.com/getzep/graphiti) emits for bulk node saves, so any Neo4j-compatible client using dynamic labels hits it: ingesting one episode appears to succeed, then the next episode's deduplication reads those nodes back, rejects the label, and the pipeline stops.

## Root cause

The grammar already models dynamic labels, and node *patterns* already evaluate them (`NodePattern.getDynamicLabels()`, resolved per row by `MatchNodeStep` / `ExpandPathStep` / `QuantifiedPathStep`):

```
nodeLabels       : (labelType | dynamicLabelType)+ ;
nodeLabelsIs     : IS (symbolicNameString | dynamicExpression) (labelType | dynamicLabelType)* ;
dynamicLabelType : COLON dynamicExpression ;
dynamicExpression: DOLLAR LPAREN expression RPAREN ;
```

The two **write** clauses never looked at that parse tree. `CypherASTBuilder.visitSetClause` reduced the whole `nodeLabels` subtree to one flat string and split it:

```java
final String labelsText = labelsCtx.nodeLabels().getText();   // ":$(node.labels)"
final String cleanText  = labelsText.replaceAll("^:+", "");   // "$(node.labels)"
final String[] parts    = cleanText.split("[:&|]+");          // ["$(node.labels)"]
```

so the source text of the expression became the label name. The `IS` spelling was worse still: `SET n IS $(x)` produced a label literally named `IS$($label)`.

`visitRemoveClause` carried the mirror-image defect with the opposite symptom — it iterated `nodeLabels().labelType()` only, so a dynamic label was dropped from the AST and `REMOVE n:$(x)` was a silent no-op.

## Fix

1. `SetClause.SetItem` / `RemoveClause.RemoveItem` carry a `List<Expression> labelExpressions` alongside the static `List<String> labels`.
2. `CypherASTBuilder` walks the `labelType` / `dynamicLabelType` children instead of flattening `getText()`, parsing each `$(expr)` into an `Expression`. Two shared collectors cover both the plain and the `IS` spelling, for both clauses.
3. `Labels.appendDynamicLabels(...)` resolves a value per row: a string is one label, a list or array of strings is that many, `null` contributes nothing — the same contract the read paths already implement.
4. `SetClauseApplier` resolves labels in **phase 1**, so a dynamic label reads the pre-clause state like every other right-hand side (`SET n.kind = 'Claim', n:$(n.kind)` uses the old `kind`, per openCypher's simultaneous-assignment rule, issue #5190), and an unusable label rejects the clause before any of it has been written. `RemoveStep` does the same, in a phase 1 of its own added in review (see the follow-up section: it originally applied its items in source order and got this wrong).
5. A value that is not a usable type name is **refused**, not `toString()`-ed into one: a non-string (Neo4j raises a type mismatch here too), a blank string, or a string containing `~`, which is the composite-type separator and would decompose into two labels on read-back. The read paths stay lenient on purpose — a nonsense label in a *pattern* matches nothing and is harmless, whereas the same value on a *write* path becomes a vertex type. That asymmetry is documented on the helper.

## Adjacent defects the same change closes

- **`REMOVE n IS Label` was dropped on the floor.** `visitRemoveClause` carried a `// TODO: Handle RemoveLabelsIs`, so the whole clause silently did nothing. The `IS` collector handles it.
- **A binding read only by a label expression was pruned.** `CypherVariableUsage` decides which bindings a write clause keeps alive, and it looked at the SET target and the value/target expressions only. `MATCH (a)-[r]->(b) SET a:$(r.kind)` would have dropped `r`, the expression would have evaluated to null, and the clause would have written nothing — the same defect as issues #5137 and #5013 on the other right-hand sides. Both new liveness tests were verified to go red with this hook neutered, so they are armed rather than passing incidentally.
- **`FOREACH` eager-read detection** (`CypherExecutionPlan.foreachBodyReadsGraph`, issue #6922) did not count a label expression as a graph read.
- **`CypherExpressionWalker.walkSet`** did not visit label expressions, so every visitor reasoning about what a SET reads was blind to them.

## Deliberately out of scope

- `CypherSemanticValidator`'s undefined-variable scope check still ignores label expressions. It already ignores `getKeyExpression()` and `getTargetExpression()` on SET items and skips REMOVE entirely ("complex to validate"); tightening one of the four in isolation would be inconsistent and risks rejecting queries that work today.
- `CypherVariableUsage` and `CypherExecutionPlan` still ignore `RemoveItem.getKeyExpression()` (`REMOVE n[r.k]`), a pre-existing gap of the same shape.

## Test plan

New regression test `CypherDynamicLabelSetIssue7059Test` — 13 tests, **all 13 red before the fix**:

- [x] the exact graphiti bulk-save query (`UNWIND` + `MERGE` + `SET n:$(node.labels)`) applies `Finding`, and no type name contains `$(`
- [x] the interpolated label is matchable (`MATCH (n:Finding)`), proving the type was really created
- [x] a list-valued expression adds every label
- [x] static and dynamic labels mix in one item (`SET n:Audited:$($label):Reviewed`)
- [x] the `IS` spelling interpolates (`SET n IS $($label)`)
- [x] `REMOVE n:$($label)` actually removes it
- [x] the expression is evaluated per row, not once
- [x] a non-string and a blank value are rejected, and no junk type is left behind
- [x] a value containing the composite separator `~` is rejected
- [x] a null-valued expression contributes nothing
- [x] an edge read *only* by the SET label expression stays bound
- [x] an edge read *only* by the REMOVE label expression stays bound
- [x] the label expression reads the pre-clause state

Regression runs (isolated worktree, isolated `-Dmaven.repo.local`):

| Suite | Result |
|---|---|
| `com.arcadedb.query.opencypher.**` | **9244 run, 0 failures** |
| openCypher TCK (`-Dsurefire.includes=**/*Suite.java`) | **3897 scenarios, 0 failures** |
| full `engine` module (`-DexcludedGroups=benchmark,vector,slow`) | 14200 run, 1 unrelated flake |

The one failure in the full-module run is `SQLMethodPrecisionTest.zonedDateTime` (`expected: Millis but was: Seconds`), a clock-resolution flake the test itself documents — *"NANOS COULD END WITH 000 AND THEREFORE THE TEST WON'T PASS, RETRY MULTIPLE TIME IN CASE"*. It exercises `SQLMethodPrecision` on `ZonedDateTime.now()` and touches no Cypher code; it passes 3/3 standalone in this worktree.

## Review follow-up (900f541f52)

Three defects found by review, each reproduced before being fixed.

**REMOVE did not assign simultaneously.** `RemoveStep.applyRemoveOperations` looped over its items in source order, so `REMOVE n.kind, n:$(n.kind)` resolved the label *after* `removeProperty` had saved the removal and propagated it to the row binding: the expression evaluated to null and the label removal became a silent no-op, leaving `["Entity", "Finding"]` where the SET analogue is explicitly tested to use the pre-clause value. It now snapshots every label list in a phase 1 and applies the writes in a phase 2, mirroring `SetClauseApplier`. The phase-1 array is allocated only for a clause that names a label, since a property-only REMOVE is the common case and this runs once per row.

**The FOREACH eager-read detector was blind to a later top-level SET or REMOVE.** `graphReadFollows()` classified a later clause by type alone, so both fell through its `default` branch. With

```cypher
MATCH (m:Marker)                                  -- 250 pre-created, before the FOREACH so it arms nothing
FOREACH (j IN range(0, 1) | CREATE (:L1 {j: j}))  -- 500 nodes total
SET m:$('N' + toString(count { MATCH (n:L1) }))
RETURN m.i AS value
```

the 250 rows carried `N200`, `N400` and `N500` — the pull-batch signature from #6922, one label per batch rather than one per graph. The SET/REMOVE checks `foreachBodyReadsGraph` already carried are now `setItemsReadGraph`/`removeItemsReadGraph`, called from both places, so a write clause is classified the same wherever it sits. This also closes the identical hole for a SET **value**, **target** or **key** expression (`SET n.x = count { ... }` after a FOREACH), which predates the dynamic-label work.

**The SET label branches kept the backticks on an escaped variable.** `visitNodePattern` strips them and so do this PR's REMOVE branches, so ``MATCH (`my node`:Entity) SET `my node`:$($label)`` could not find the row value and dropped the label write, returning `["Entity"]`. Pre-existing — the pre-refactor code did not strip the variable either — but the asymmetry now sat inside one clause pair.

Plus one nit: `Labels` is imported rather than named fully qualified in a `SetClause` Javadoc link.

**Deliberately not changed.** `CypherVariableUsage.labelExpressionsReferenceVariable`'s indexed loop, flagged as inconsistent with the enhanced-`for` in this PR's other new helpers. An indexed loop over a `List` allocates no `Iterator`, which is what the project's performance rule asks for; if the inconsistency is worth resolving the other two should become indexed, and that is a separate sweep. `RemoveStep.removeLabels`'s redundant `isEmpty()` guard also stays, as the reviewer suggested.

**Verification after the follow-up:** 3 new regression tests (2 in `CypherDynamicLabelSetIssue7059Test`, 1 in `CypherForeachEagerReadIssue6922Test`), all three red before their fix with the symptoms above. Full engine module **14203 / 0 failures**, openCypher package **9247 / 0**, openCypher TCK **3897 scenarios / 0**. The `SQLMethodPrecisionTest.zonedDateTime` flake noted above did not recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJBD77PbMSvPmV11G8qiGS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic Cypher 25 labels in `SET` and `REMOVE` clauses using `$(expression)` syntax.
  * Supports string, list, iterable, and array-based label values, including combinations with static labels.
  * Dynamic labels are evaluated per row and work across `FOREACH`, subqueries, and bulk operations.

* **Bug Fixes**
  * Correctly handles null or empty values and rejects invalid label formats without creating unintended schema types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
