### PR TITLE
fix(#7057): one node, one row from a vector search

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -37,6 +37,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -173,13 +174,22 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       throw new CommandSQLParsingException("Index '" + typeIndex.getName() + "' has no bucket indexes");
     }
 
-    // Filter bucket indexes if a specific type was requested
+    // Filter bucket indexes if a specific type was requested, and search each bucket at most once.
+    // TypeIndex.addIndexOnBucket appends without checking, so a schema carrying two entries for the same bucket and
+    // property - a stale definition left beside the one that replaced it - attaches both. The two describe the same
+    // records, so searching both returns every record twice (issue #7057).
     final List<LSMVectorIndex> vectorIndexes = new ArrayList<>();
+    final IntHashSet searchedBucketIds = new IntHashSet();
     for (final IndexInternal bucketIndex : bucketIndexes) {
       if (bucketIndex instanceof LSMVectorIndex lsmIndex) {
-        if (allowedBucketIds == null || allowedBucketIds.contains(bucketIndex.getAssociatedBucketId())) {
-          vectorIndexes.add(lsmIndex);
-        }
+        final int bucketId = bucketIndex.getAssociatedBucketId();
+        if (allowedBucketIds != null && !allowedBucketIds.contains(bucketId))
+          continue;
+        // A negative id means the sub-index is not bound to a bucket, which cannot be deduplicated by bucket and is
+        // left alone rather than collapsed onto whatever else reports the same sentinel.
+        if (bucketId >= 0 && !searchedBucketIds.add(bucketId))
+          continue;
+        vectorIndexes.add(lsmIndex);
       }
     }
 
@@ -272,6 +282,10 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
 
     final ArrayList<Object> result = new ArrayList<>();
     final GroupAdmissionState groups = groupBy != null ? new GroupAdmissionState(limit, groupSize) : null;
+    // One record, one row. This list is the concatenation of one search per index, so a record offered by more than
+    // one of them would otherwise take two of the caller's `limit` slots - and, under groupBy, two slots of its own
+    // group's cap (issue #7057). The list is already sorted, so the sighting kept is the nearest one.
+    final RidHashSet emitted = new RidHashSet(Math.max(limit, 16));
 
     for (final Pair<RID, Float> neighbor : allNeighbors) {
       // Stop conditions:
@@ -291,6 +305,9 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
         break;
 
       final RID rid = neighbor.getFirst();
+      if (!emitted.add(rid))
+        continue;
+
       final Document record;
       try {
         record = (Document) db.lookupByRID(rid, true);

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -175,8 +175,8 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
     }
 
     // Filter bucket indexes if a specific type was requested, and visit each sub-index at most once. See
-    // VectorUtils.collectVectorSubIndexes for why the same sub-index can be listed twice (issue #7057).
-    final List<LSMVectorIndex> vectorIndexes = VectorUtils.collectVectorSubIndexes(bucketIndexes,
+    // VectorUtils.collectSubIndexesOnce for why the same sub-index can be listed twice (issue #7057).
+    final List<LSMVectorIndex> vectorIndexes = VectorUtils.collectSubIndexesOnce(bucketIndexes, LSMVectorIndex.class,
         allowedBucketIds == null ? null : allowedBucketIds::contains);
 
     if (vectorIndexes.isEmpty()) {

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -271,7 +271,15 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
     // One record, one row. This list is the concatenation of one search per index, so a record offered by more than
     // one of them would otherwise take two of the caller's `limit` slots - and, under groupBy, two slots of its own
     // group's cap (issue #7057). The list is already sorted, so the sighting kept is the nearest one.
-    final RidHashSet emitted = new RidHashSet(Math.max(limit, 16));
+    //
+    // Sized from the candidates actually fetched, never from `limit`. On the non-grouped path `limit` is the raw
+    // caller-supplied k, checked only for `<= 0` - the MAX_FETCH_CANDIDATES budget above guards the grouped path
+    // alone. RidHashSet allocates an int[] and a long[] of the next power of two up front, so sizing off k would
+    // let `vector.neighbors(idx, v, 100000000)` claim ~1.5GB before looking at a single record, and a k near
+    // Integer.MAX_VALUE would overflow the rounding to a negative capacity and throw NegativeArraySizeException.
+    // That is the hazard issue #5924 already closed one layer down, where findNeighborsFromVector clamps k against
+    // the real candidate count; allNeighbors.size() is that clamp having already happened, per index and summed.
+    final RidHashSet emitted = new RidHashSet(Math.min(limit, allNeighbors.size()));
 
     for (final Pair<RID, Float> neighbor : allNeighbors) {
       // Stop conditions:

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -174,24 +174,10 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       throw new CommandSQLParsingException("Index '" + typeIndex.getName() + "' has no bucket indexes");
     }
 
-    // Filter bucket indexes if a specific type was requested, and search each bucket at most once.
-    // TypeIndex.addIndexOnBucket appends without checking, so a schema carrying two entries for the same bucket and
-    // property - a stale definition left beside the one that replaced it - attaches both. The two describe the same
-    // records, so searching both returns every record twice (issue #7057).
-    final List<LSMVectorIndex> vectorIndexes = new ArrayList<>();
-    final IntHashSet searchedBucketIds = new IntHashSet();
-    for (final IndexInternal bucketIndex : bucketIndexes) {
-      if (bucketIndex instanceof LSMVectorIndex lsmIndex) {
-        final int bucketId = bucketIndex.getAssociatedBucketId();
-        if (allowedBucketIds != null && !allowedBucketIds.contains(bucketId))
-          continue;
-        // A negative id means the sub-index is not bound to a bucket, which cannot be deduplicated by bucket and is
-        // left alone rather than collapsed onto whatever else reports the same sentinel.
-        if (bucketId >= 0 && !searchedBucketIds.add(bucketId))
-          continue;
-        vectorIndexes.add(lsmIndex);
-      }
-    }
+    // Filter bucket indexes if a specific type was requested, and visit each sub-index at most once. See
+    // VectorUtils.collectVectorSubIndexes for why the same sub-index can be listed twice (issue #7057).
+    final List<LSMVectorIndex> vectorIndexes = VectorUtils.collectVectorSubIndexes(bucketIndexes,
+        allowedBucketIds == null ? null : allowedBucketIds::contains);
 
     if (vectorIndexes.isEmpty()) {
       if (allowedBucketIds != null) {

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
@@ -37,6 +37,7 @@ import com.arcadedb.index.vector.VectorUtils;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.IntHashSet;
+import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -178,18 +179,15 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
     if (specifiedTypeName != null)
       allowedBucketIds = narrowAllowedBucketIdsByPartitionHint(allowedBucketIds, specifiedTypeName, context);
 
-    final var bucketIndexes = typeIndex.getIndexesOnBuckets();
-    final List<LSMSparseVectorIndex> result = new ArrayList<>();
+    final IndexInternal[] bucketIndexes = typeIndex.getIndexesOnBuckets();
     if (bucketIndexes == null)
-      return result;
+      return new ArrayList<>();
 
-    for (final IndexInternal bucketIndex : bucketIndexes) {
-      if (bucketIndex instanceof LSMSparseVectorIndex sparseIndex) {
-        if (allowedBucketIds.isEmpty() || allowedBucketIds.contains(bucketIndex.getAssociatedBucketId()))
-          result.add(sparseIndex);
-      }
-    }
-    return result;
+    // Each sub-index visited at most once. See VectorUtils.collectSubIndexesOnce for why the same sub-index can be
+    // listed twice and why the guard is on identity rather than on the bucket id (issue #7057).
+    final IntHashSet allowed = allowedBucketIds;
+    return VectorUtils.collectSubIndexesOnce(bucketIndexes, LSMSparseVectorIndex.class,
+        allowed.isEmpty() ? null : allowed::contains);
   }
 
   private Object executeWithIndexes(final List<LSMSparseVectorIndex> indexes, final int[] queryIndices,
@@ -320,6 +318,12 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
     // per-group constraint and this admission is idempotent. For multi-bucket grouping, per-bucket
     // results may share group keys; this loop collapses them to the global per-group winners.
     final GroupAdmissionState groups = groupBy != null ? new GroupAdmissionState(k, groupSize) : null;
+    // One record, one row. `merged` is the concatenation of one search per sub-index, so a record offered by more
+    // than one of them would otherwise take two of the caller's k slots - and, under groupBy, two slots of its own
+    // group's cap (issue #7057). Sized from the candidates actually fetched, never from k: k is caller-supplied and
+    // RidHashSet allocates its backing arrays up front, so sizing off k would let a huge k claim gigabytes, and one
+    // near Integer.MAX_VALUE overflow the power-of-two rounding to a negative capacity.
+    final RidHashSet emitted = new RidHashSet(Math.min(k, merged.size()));
 
     for (final RidScore neighbor : merged) {
       if (groupBy == null) {
@@ -333,6 +337,9 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
       // whose score is below minScore, every subsequent one will too - break out of the loop.
       if (neighbor.score() < minScore)
         break;
+
+      if (!emitted.add(neighbor.rid()))
+        continue;
 
       final Document record;
       try {

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
@@ -18,14 +18,17 @@
  */
 package com.arcadedb.index.vector;
 
+import com.arcadedb.index.IndexInternal;
 import com.arcadedb.log.LogManager;
 import io.github.jbellis.jvector.vector.VectorUtil;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntPredicate;
 import java.util.logging.Level;
 
 import static io.github.jbellis.jvector.vector.VectorUtil.cosine;
@@ -568,5 +571,51 @@ public final class VectorUtils {
   public static void validateSameDimension(final float[] v1, final float[] v2) {
     if (v1.length != v2.length)
       throw new IllegalArgumentException("Vectors must have the same dimension, found: " + v1.length + " and " + v2.length);
+  }
+  /**
+   * Collects the vector sub-indexes of a type index that a search should visit, each one at most once.
+   * <p>
+   * Both vector entry points - {@code db.index.vector.queryNodes} and the {@code vector.neighbors} SQL function -
+   * run one search per sub-index and merge the answers, so a sub-index reached twice contributes its records twice
+   * (issue #7057). {@link com.arcadedb.index.TypeIndex#addIndexOnBucket} appends without checking, so the same
+   * sub-index really can appear twice in {@code bucketIndexes}.
+   * </p>
+   * <p>
+   * The guard is deliberately on the sub-index <em>identity</em> rather than on its bucket id. Dropping a repeat of
+   * an index already collected cannot change the answer - it is the same object, searched with the same arguments.
+   * Dropping a <em>different</em> index that happens to share a bucket id could: nothing orders
+   * {@code indexesOnBuckets}, so "keep the first" would be "keep whichever the schema file listed first", and if
+   * that one were the stale half of a duplicated schema entry the search would silently answer from stale data.
+   * Two different indexes on one bucket are therefore both searched, and the caller's own per-record deduplication
+   * reduces them to one row apiece - which returns the union at its nearest distance and hides nothing.
+   * </p>
+   *
+   * @param bucketIndexes the type index's sub-indexes, as returned by {@code TypeIndex.getIndexesOnBuckets()}
+   * @param bucketAllowed tests a sub-index's associated bucket id; {@code null} accepts every bucket
+   *
+   * @return the vector sub-indexes to search, in the order given, with no index listed twice
+   */
+  public static List<LSMVectorIndex> collectVectorSubIndexes(final IndexInternal[] bucketIndexes,
+      final IntPredicate bucketAllowed) {
+    final List<LSMVectorIndex> vectorIndexes = new ArrayList<>(bucketIndexes.length);
+    for (final IndexInternal bucketIndex : bucketIndexes) {
+      if (!(bucketIndex instanceof final LSMVectorIndex lsmIndex))
+        continue;
+      if (bucketAllowed != null && !bucketAllowed.test(bucketIndex.getAssociatedBucketId()))
+        continue;
+      // A linear scan, not a hash set: this list holds one entry per bucket of one type, so it is a handful of
+      // reference comparisons on a path that is about to run a graph search per entry.
+      if (containsSame(vectorIndexes, lsmIndex))
+        continue;
+      vectorIndexes.add(lsmIndex);
+    }
+    return vectorIndexes;
+  }
+
+  private static boolean containsSame(final List<LSMVectorIndex> collected, final LSMVectorIndex candidate) {
+    for (int i = 0; i < collected.size(); i++)
+      if (collected.get(i) == candidate)
+        return true;
+    return false;
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
@@ -573,12 +573,12 @@ public final class VectorUtils {
       throw new IllegalArgumentException("Vectors must have the same dimension, found: " + v1.length + " and " + v2.length);
   }
   /**
-   * Collects the vector sub-indexes of a type index that a search should visit, each one at most once.
+   * Collects the sub-indexes of a type index that a search should visit, each one at most once.
    * <p>
-   * Both vector entry points - {@code db.index.vector.queryNodes} and the {@code vector.neighbors} SQL function -
-   * run one search per sub-index and merge the answers, so a sub-index reached twice contributes its records twice
-   * (issue #7057). {@link com.arcadedb.index.TypeIndex#addIndexOnBucket} appends without checking, so the same
-   * sub-index really can appear twice in {@code bucketIndexes}.
+   * All three vector entry points - {@code db.index.vector.queryNodes}, {@code vector.neighbors} and
+   * {@code vector.sparseNeighbors} - run one search per sub-index and merge the answers, so a sub-index reached
+   * twice contributes its records twice (issue #7057). {@link com.arcadedb.index.TypeIndex#addIndexOnBucket}
+   * appends without checking, so the same sub-index really can appear twice in {@code bucketIndexes}.
    * </p>
    * <p>
    * The guard is deliberately on the sub-index <em>identity</em> rather than on its bucket id. Dropping a repeat of
@@ -591,28 +591,30 @@ public final class VectorUtils {
    * </p>
    *
    * @param bucketIndexes the type index's sub-indexes, as returned by {@code TypeIndex.getIndexesOnBuckets()}
+   * @param indexType     the sub-index implementation to collect; anything else is ignored
    * @param bucketAllowed tests a sub-index's associated bucket id; {@code null} accepts every bucket
    *
-   * @return the vector sub-indexes to search, in the order given, with no index listed twice
+   * @return the sub-indexes to search, in the order given, with no index listed twice
    */
-  public static List<LSMVectorIndex> collectVectorSubIndexes(final IndexInternal[] bucketIndexes,
-      final IntPredicate bucketAllowed) {
-    final List<LSMVectorIndex> vectorIndexes = new ArrayList<>(bucketIndexes.length);
+  public static <T extends IndexInternal> List<T> collectSubIndexesOnce(final IndexInternal[] bucketIndexes,
+      final Class<T> indexType, final IntPredicate bucketAllowed) {
+    final List<T> subIndexes = new ArrayList<>(bucketIndexes.length);
     for (final IndexInternal bucketIndex : bucketIndexes) {
-      if (!(bucketIndex instanceof final LSMVectorIndex lsmIndex))
+      if (!indexType.isInstance(bucketIndex))
         continue;
       if (bucketAllowed != null && !bucketAllowed.test(bucketIndex.getAssociatedBucketId()))
         continue;
-      // A linear scan, not a hash set: this list holds one entry per bucket of one type, so it is a handful of
-      // reference comparisons on a path that is about to run a graph search per entry.
-      if (containsSame(vectorIndexes, lsmIndex))
+      // A linear scan, not a hash set: this list holds one entry per bucket of one type - a handful - on a path that
+      // is about to run a whole index search per entry. A type with a bucket fan-out large enough to make the scan
+      // matter would make the searches themselves matter far more first.
+      if (containsSame(subIndexes, bucketIndex))
         continue;
-      vectorIndexes.add(lsmIndex);
+      subIndexes.add(indexType.cast(bucketIndex));
     }
-    return vectorIndexes;
+    return subIndexes;
   }
 
-  private static boolean containsSame(final List<LSMVectorIndex> collected, final LSMVectorIndex candidate) {
+  private static boolean containsSame(final List<? extends IndexInternal> collected, final IndexInternal candidate) {
     for (int i = 0; i < collected.size(); i++)
       if (collected.get(i) == candidate)
         return true;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
@@ -26,12 +26,12 @@ import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.vector.LSMVectorIndex;
+import com.arcadedb.index.vector.VectorUtils;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.schema.DocumentType;
-import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.Pair;
 import com.arcadedb.utility.RidHashSet;
@@ -233,34 +233,17 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
   }
 
   /**
-   * Collects the vector sub-indexes to search, at most one per bucket.
-   * <p>
-   * {@link TypeIndex#addIndexOnBucket} appends without checking, and a schema carrying two entries for the same
-   * bucket and property - a stale definition left beside the one that replaced it - attaches both. The two describe
-   * the same records, so searching both returns every record twice: k rows holding k/2 distinct nodes, which is
-   * issue #7057. Only the first sub-index on a bucket is searched; a second one can contribute nothing the first
-   * did not already have, so this removes the wasted search rather than merely cleaning up after it.
-   * </p>
+   * Resolves the vector sub-indexes to search. See
+   * {@link VectorUtils#collectVectorSubIndexes(IndexInternal[], java.util.function.IntPredicate)} for why the same
+   * sub-index can be listed twice and why the guard is on identity rather than on the bucket id (issue #7057).
    */
   private List<LSMVectorIndex> filterVectorIndexes(final TypeIndex typeIndex, final Set<Integer> allowedBucketIds) {
-    final var bucketIndexes = typeIndex.getIndexesOnBuckets();
+    final IndexInternal[] bucketIndexes = typeIndex.getIndexesOnBuckets();
     if (bucketIndexes == null || bucketIndexes.length == 0)
       throw new CommandSQLParsingException("Index '" + typeIndex.getName() + "' has no bucket indexes");
 
-    final List<LSMVectorIndex> vectorIndexes = new ArrayList<>();
-    final IntHashSet searchedBucketIds = new IntHashSet();
-    for (final IndexInternal bucketIndex : bucketIndexes) {
-      if (bucketIndex instanceof LSMVectorIndex lsmIndex) {
-        final int bucketId = bucketIndex.getAssociatedBucketId();
-        if (allowedBucketIds != null && !allowedBucketIds.contains(bucketId))
-          continue;
-        // A negative id means the sub-index is not bound to a bucket, which cannot be deduplicated by bucket and is
-        // left alone rather than collapsed onto whatever else reports the same sentinel.
-        if (bucketId >= 0 && !searchedBucketIds.add(bucketId))
-          continue;
-        vectorIndexes.add(lsmIndex);
-      }
-    }
+    final List<LSMVectorIndex> vectorIndexes = VectorUtils.collectVectorSubIndexes(bucketIndexes,
+        allowedBucketIds == null ? null : allowedBucketIds::contains);
 
     if (vectorIndexes.isEmpty())
       throw new CommandSQLParsingException("Index '" + typeIndex.getName() + "' is not a vector index");

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
@@ -31,8 +31,10 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.RidHashSet;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
 import java.math.BigDecimal;
@@ -130,8 +132,19 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
     final int resultCount = Math.min(limit, allNeighbors.size());
     final List<Result> results = new ArrayList<>(resultCount);
 
-    for (int i = 0; i < resultCount; i++) {
-      final Pair<RID, Float> neighbor = allNeighbors.get(i);
+    // One node, one row: the Neo4j procedure this mirrors promises k rows carrying k DISTINCT nodes, and every
+    // consumer taking the top k relies on it. Nothing upstream can promise it on its own - this list is the
+    // concatenation of one search per resolved index, and a single record can be offered by more than one of them
+    // (issue #7057). Deduplicating here, after the sort, keeps each node at its NEAREST distance and lets the walk
+    // continue past a repeat, so a k that was silently halved comes back full instead of merely unduplicated.
+    final RidHashSet emitted = new RidHashSet(Math.max(resultCount, 16));
+
+    for (final Pair<RID, Float> neighbor : allNeighbors) {
+      if (results.size() == resultCount)
+        break;
+      if (!emitted.add(neighbor.getFirst()))
+        continue;
+
       final Document record = neighbor.getFirst().asDocument();
       final float distance = neighbor.getSecond();
 
@@ -219,16 +232,34 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
             (directIndex != null ? directIndex.getClass().getSimpleName() : "null") + ")");
   }
 
+  /**
+   * Collects the vector sub-indexes to search, at most one per bucket.
+   * <p>
+   * {@link TypeIndex#addIndexOnBucket} appends without checking, and a schema carrying two entries for the same
+   * bucket and property - a stale definition left beside the one that replaced it - attaches both. The two describe
+   * the same records, so searching both returns every record twice: k rows holding k/2 distinct nodes, which is
+   * issue #7057. Only the first sub-index on a bucket is searched; a second one can contribute nothing the first
+   * did not already have, so this removes the wasted search rather than merely cleaning up after it.
+   * </p>
+   */
   private List<LSMVectorIndex> filterVectorIndexes(final TypeIndex typeIndex, final Set<Integer> allowedBucketIds) {
     final var bucketIndexes = typeIndex.getIndexesOnBuckets();
     if (bucketIndexes == null || bucketIndexes.length == 0)
       throw new CommandSQLParsingException("Index '" + typeIndex.getName() + "' has no bucket indexes");
 
     final List<LSMVectorIndex> vectorIndexes = new ArrayList<>();
+    final IntHashSet searchedBucketIds = new IntHashSet();
     for (final IndexInternal bucketIndex : bucketIndexes) {
-      if (bucketIndex instanceof LSMVectorIndex lsmIndex)
-        if (allowedBucketIds == null || allowedBucketIds.contains(bucketIndex.getAssociatedBucketId()))
-          vectorIndexes.add(lsmIndex);
+      if (bucketIndex instanceof LSMVectorIndex lsmIndex) {
+        final int bucketId = bucketIndex.getAssociatedBucketId();
+        if (allowedBucketIds != null && !allowedBucketIds.contains(bucketId))
+          continue;
+        // A negative id means the sub-index is not bound to a bucket, which cannot be deduplicated by bucket and is
+        // left alone rather than collapsed onto whatever else reports the same sentinel.
+        if (bucketId >= 0 && !searchedBucketIds.add(bucketId))
+          continue;
+        vectorIndexes.add(lsmIndex);
+      }
     }
 
     if (vectorIndexes.isEmpty())

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
@@ -234,7 +234,7 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
 
   /**
    * Resolves the vector sub-indexes to search. See
-   * {@link VectorUtils#collectVectorSubIndexes(IndexInternal[], java.util.function.IntPredicate)} for why the same
+   * {@link VectorUtils#collectSubIndexesOnce(IndexInternal[], Class, java.util.function.IntPredicate)} for why the same
    * sub-index can be listed twice and why the guard is on identity rather than on the bucket id (issue #7057).
    */
   private List<LSMVectorIndex> filterVectorIndexes(final TypeIndex typeIndex, final Set<Integer> allowedBucketIds) {
@@ -242,7 +242,7 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
     if (bucketIndexes == null || bucketIndexes.length == 0)
       throw new CommandSQLParsingException("Index '" + typeIndex.getName() + "' has no bucket indexes");
 
-    final List<LSMVectorIndex> vectorIndexes = VectorUtils.collectVectorSubIndexes(bucketIndexes,
+    final List<LSMVectorIndex> vectorIndexes = VectorUtils.collectSubIndexesOnce(bucketIndexes, LSMVectorIndex.class,
         allowedBucketIds == null ? null : allowedBucketIds::contains);
 
     if (vectorIndexes.isEmpty())

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
@@ -137,7 +137,7 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
     // concatenation of one search per resolved index, and a single record can be offered by more than one of them
     // (issue #7057). Deduplicating here, after the sort, keeps each node at its NEAREST distance and lets the walk
     // continue past a repeat, so a k that was silently halved comes back full instead of merely unduplicated.
-    final RidHashSet emitted = new RidHashSet(Math.max(resultCount, 16));
+    final RidHashSet emitted = new RidHashSet(resultCount);
 
     for (final Pair<RID, Float> neighbor : allNeighbors) {
       if (results.size() == resultCount)

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SparseNeighborsDuplicateSubIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SparseNeighborsDuplicateSubIndexTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7057 for the third vector entry point. {@code vector.sparseNeighbors} fans out over the type's sparse
+ * sub-indexes exactly the way {@code db.index.vector.queryNodes} and {@code vector.neighbors} do - one search per
+ * sub-index, concatenate, sort, truncate at k - and so duplicated the same way when a sub-index was listed twice.
+ * It is also reachable through {@code vector.fuse}, which takes both functions as pluggable input sources.
+ */
+class SparseNeighborsDuplicateSubIndexTest extends TestHelper {
+  private static final String TYPE_NAME = "SparseDoc";
+  private static final int    DOCS      = 60;
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("uuid", Type.STRING);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(50)
+          .create();
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < DOCS; i++) {
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("uuid", "d" + i);
+        doc.set("tokens", new int[] { i % 50, (i + 7) % 50, (i + 13) % 50 });
+        doc.set("weights", new float[] { 1.0f, 0.5f, 0.25f });
+        doc.save();
+      }
+    });
+  }
+
+  @Test
+  void sparseNeighborsReturnsDistinctRecordsWhenTheSameSubIndexIsAttachedTwice() {
+    final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME)
+        .getPolymorphicIndexByProperties("tokens", "weights");
+    final IndexInternal[] before = typeIndex.getIndexesOnBuckets();
+    for (final IndexInternal bucketIndex : before)
+      typeIndex.addIndexOnBucket(bucketIndex);
+
+    assertThat(typeIndex.getIndexesOnBuckets())
+        .as("the fixture has to actually plant the multiplicity, or the assertion below cannot fail")
+        .hasSize(before.length * 2);
+
+    final List<String> uuids = topK(6);
+
+    assertThat(uuids).hasSize(6);
+    assertThat(new LinkedHashSet<>(uuids)).as("rows %s must all be distinct records", uuids).hasSize(6);
+  }
+
+  /** Control: the ordinary path is untouched. */
+  @Test
+  void sparseNeighborsStillAnswersWithoutTheDuplication() {
+    final List<String> uuids = topK(6);
+
+    assertThat(uuids).hasSize(6);
+    assertThat(new LinkedHashSet<>(uuids)).hasSize(6);
+  }
+
+  private List<String> topK(final int k) {
+    final List<String> uuids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        TYPE_NAME + "[tokens,weights]", new int[] { 3, 10, 16 }, new float[] { 1.0f, 0.5f, 0.25f }, k)) {
+      while (rs.hasNext())
+        uuids.add(rs.next().getProperty("uuid"));
+    }
+    return uuids;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SparseNeighborsDuplicateSubIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SparseNeighborsDuplicateSubIndexTest.java
@@ -87,6 +87,20 @@ class SparseNeighborsDuplicateSubIndexTest extends TestHelper {
     assertThat(new LinkedHashSet<>(uuids)).as("rows %s must all be distinct records", uuids).hasSize(6);
   }
 
+  /**
+   * The sparse counterpart of {@code vectorNeighborsSurvivesAnUnboundedLimit}: k is caller-supplied and only
+   * checked for {@code <= 0}, and {@code RidHashSet} allocates its backing arrays up front, so the dedup set has to
+   * be sized from the candidates actually fetched. Sized from k, {@link Integer#MAX_VALUE} rounds up to a negative
+   * capacity and throws {@code NegativeArraySizeException} before a single record is read.
+   */
+  @Test
+  void sparseNeighborsSurvivesAnUnboundedLimit() {
+    final List<String> uuids = topK(Integer.MAX_VALUE);
+
+    assertThat(uuids).isNotEmpty();
+    assertThat(new LinkedHashSet<>(uuids)).hasSameSizeAs(uuids);
+  }
+
   /** Control: the ordinary path is untouched. */
   @Test
   void sparseNeighborsStillAnswersWithoutTheDuplication() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java
@@ -53,6 +53,7 @@ class CypherVectorQueryNodesDuplicateTest extends TestHelper {
       database.command("sql", "CREATE VERTEX TYPE Entity IF NOT EXISTS");
       database.command("sql", "CREATE PROPERTY Entity.uuid IF NOT EXISTS STRING");
       database.command("sql", "CREATE PROPERTY Entity.name_embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE PROPERTY Entity.grp IF NOT EXISTS STRING");
       database.command("sql", "CREATE INDEX IF NOT EXISTS ON Entity (uuid) UNIQUE");
       database.command("sql", """
           CREATE INDEX IF NOT EXISTS ON Entity (name_embedding) LSM_VECTOR
@@ -65,7 +66,7 @@ class CypherVectorQueryNodesDuplicateTest extends TestHelper {
 
     database.transaction(() -> {
       for (int i = 0; i < NODES; i++)
-        database.newVertex("Entity").set("uuid", "u" + i).set("name_embedding", vector(i)).save();
+        database.newVertex("Entity").set("uuid", "u" + i).set("grp", "g" + (i % 20)).set("name_embedding", vector(i)).save();
     });
   }
 
@@ -157,6 +158,32 @@ class CypherVectorQueryNodesDuplicateTest extends TestHelper {
 
     assertThat(uuids).hasSize(NODES);
     assertThat(new LinkedHashSet<>(uuids)).hasSize(NODES);
+  }
+
+  /**
+   * {@code groupBy} plus a duplicated sub-index. The dedup runs before {@code GroupAdmissionState.admit}, so a
+   * record offered twice gets exactly one admission decision against its group's cap. Without it the two copies
+   * take both slots of a {@code groupSize: 2} group between them - the same record twice, and the group's genuine
+   * second member locked out of an answer it had earned.
+   */
+  @Test
+  void vectorNeighborsGroupCapIsNotSpentTwiceOnOneRecord() {
+    final TypeIndex typeIndex = database.getSchema().getType("Entity").getPolymorphicIndexByProperties("name_embedding");
+    for (final IndexInternal bucketIndex : typeIndex.getIndexesOnBuckets())
+      typeIndex.addIndexOnBucket(bucketIndex);
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("v", vector(3));
+
+    final List<String> uuids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql",
+        "SELECT expand(vector.neighbors('Entity[name_embedding]', :v, 3, { groupBy: 'grp', groupSize: 2 }))", params)) {
+      while (rs.hasNext())
+        uuids.add(rs.next().getProperty("uuid"));
+    }
+
+    assertThat(uuids).isNotEmpty();
+    assertThat(new LinkedHashSet<>(uuids)).as("rows %s must all be distinct records", uuids).hasSameSizeAs(uuids);
   }
 
   /** The ordinary case: nothing anomalous, and the answer must stay exactly what it was. */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java
@@ -135,6 +135,30 @@ class CypherVectorQueryNodesDuplicateTest extends TestHelper {
     assertThat(new LinkedHashSet<>(uuids)).as("rows %s must all be distinct records", uuids).hasSize(6);
   }
 
+  /**
+   * A huge {@code k} must be answered from the records that exist, not sized for. On the non-grouped path
+   * {@code limit} is the raw caller-supplied value - checked only for {@code <= 0}, since the
+   * {@code MAX_FETCH_CANDIDATES} budget guards the grouped path alone - and the per-record dedup set has to be
+   * sized from the candidates actually fetched. Sizing it from {@code k} would have {@code RidHashSet} round
+   * {@link Integer#MAX_VALUE} up to a negative capacity and throw {@code NegativeArraySizeException} before a
+   * single record was read, and a merely large {@code k} claim gigabytes for an index holding a hundred rows.
+   */
+  @Test
+  void vectorNeighborsSurvivesAnUnboundedLimit() {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("v", vector(3));
+
+    final List<String> uuids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql",
+        "SELECT expand(vector.neighbors('Entity[name_embedding]', :v, " + Integer.MAX_VALUE + "))", params)) {
+      while (rs.hasNext())
+        uuids.add(rs.next().getProperty("uuid"));
+    }
+
+    assertThat(uuids).hasSize(NODES);
+    assertThat(new LinkedHashSet<>(uuids)).hasSize(NODES);
+  }
+
   /** The ordinary case: nothing anomalous, and the answer must stay exactly what it was. */
   @Test
   void queryNodesStillReturnsTheNearestNodesInOrder() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java
@@ -71,9 +71,12 @@ class CypherVectorQueryNodesDuplicateTest extends TestHelper {
 
   /**
    * The reported shape. A type whose {@link TypeIndex} carries the same bucket sub-index twice - which
-   * {@link TypeIndex#addIndexOnBucket} accepts without complaint, and which a schema holding a stale definition
-   * beside the one that replaced it produces - made the procedure search the same records twice and concatenate the
-   * two answers. Before the fix this returned the issue's numbers exactly: 6 rows, 3 distinct.
+   * {@link TypeIndex#addIndexOnBucket} accepts without complaint - made the procedure search the same records twice
+   * and concatenate the two answers. Before the fix this returned the issue's numbers exactly: 6 rows, 3 distinct.
+   * <p>
+   * The same sub-index, not two different ones on one bucket: the schema rejects a second index over an
+   * already-indexed property set outright ("A type holds one index per property set"), so listing one index twice is
+   * the only multiplicity this fan-out can actually meet.
    */
   @Test
   void queryNodesReturnsDistinctNodesWhenTheSameSubIndexIsAttachedTwice() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7057: {@code db.index.vector.queryNodes} returned every matching node twice, so asking for {@code k} rows
+ * yielded {@code k} rows carrying only {@code k / 2} distinct nodes - silently halving the candidates any consumer
+ * taking the top {@code k} received, and pinning measured recall at exactly 0.50.
+ * <p>
+ * The procedure concatenates one search per vector sub-index of the type and truncates the merged list at {@code k}.
+ * Nothing in that pipeline promised one row per node: not the merge, and not the graph walk feeding it, where a RID
+ * owning more than one live vector id owns one graph ordinal per id.
+ */
+class CypherVectorQueryNodesDuplicateTest extends TestHelper {
+  private static final int DIMENSIONS = 16;
+  private static final int NODES      = 100;
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Entity IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY Entity.uuid IF NOT EXISTS STRING");
+      database.command("sql", "CREATE PROPERTY Entity.name_embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX IF NOT EXISTS ON Entity (uuid) UNIQUE");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON Entity (name_embedding) LSM_VECTOR
+          METADATA {
+            dimensions: 16,
+            similarity: 'COSINE',
+            idPropertyName: 'uuid'
+          }""");
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < NODES; i++)
+        database.newVertex("Entity").set("uuid", "u" + i).set("name_embedding", vector(i)).save();
+    });
+  }
+
+  /**
+   * The reported shape. A type whose {@link TypeIndex} carries the same bucket sub-index twice - which
+   * {@link TypeIndex#addIndexOnBucket} accepts without complaint, and which a schema holding a stale definition
+   * beside the one that replaced it produces - made the procedure search the same records twice and concatenate the
+   * two answers. Before the fix this returned the issue's numbers exactly: 6 rows, 3 distinct.
+   */
+  @Test
+  void queryNodesReturnsDistinctNodesWhenTheSameSubIndexIsAttachedTwice() {
+    final TypeIndex typeIndex = database.getSchema().getType("Entity").getPolymorphicIndexByProperties("name_embedding");
+    final IndexInternal[] before = typeIndex.getIndexesOnBuckets();
+    for (final IndexInternal bucketIndex : before)
+      typeIndex.addIndexOnBucket(bucketIndex);
+
+    assertThat(typeIndex.getIndexesOnBuckets())
+        .as("the fixture has to actually plant the multiplicity, or the assertions below cannot fail")
+        .hasSize(before.length * 2);
+
+    assertDistinctTopK(6);
+    assertDistinctTopK(10);
+  }
+
+  /**
+   * The dedup has to keep the NEAREST sighting of a node, not an arbitrary one, and it has to keep the order: the
+   * doubled schema must produce exactly the answer the healthy one does, row for row and score for score.
+   */
+  @Test
+  void queryNodesAnswerIsUnchangedByTheDuplicatedSubIndex() {
+    final List<String> healthy = queryTopK(vector(3), 8);
+    final List<Double> healthyScores = scoresTopK(vector(3), 8);
+
+    final TypeIndex typeIndex = database.getSchema().getType("Entity").getPolymorphicIndexByProperties("name_embedding");
+    for (final IndexInternal bucketIndex : typeIndex.getIndexesOnBuckets())
+      typeIndex.addIndexOnBucket(bucketIndex);
+
+    assertThat(queryTopK(vector(3), 8)).isEqualTo(healthy);
+    assertThat(scoresTopK(vector(3), 8)).isEqualTo(healthyScores);
+  }
+
+  /**
+   * {@code vector.neighbors} is the ArcadeDB-native entry point onto the same fan-out over the type's vector
+   * sub-indexes, and it duplicated for the same reason. Fixing only the Neo4j-compatible procedure would leave the
+   * SQL function - and {@code CALL vector.neighbors(...)} from Cypher - returning each record twice.
+   */
+  @Test
+  void vectorNeighborsReturnsDistinctRecordsWhenTheSameSubIndexIsAttachedTwice() {
+    final TypeIndex typeIndex = database.getSchema().getType("Entity").getPolymorphicIndexByProperties("name_embedding");
+    for (final IndexInternal bucketIndex : typeIndex.getIndexesOnBuckets())
+      typeIndex.addIndexOnBucket(bucketIndex);
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("v", vector(3));
+
+    final List<String> uuids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql",
+        "SELECT expand(vector.neighbors('Entity[name_embedding]', :v, 6))", params)) {
+      while (rs.hasNext())
+        uuids.add(rs.next().getProperty("uuid"));
+    }
+
+    assertThat(uuids).hasSize(6);
+    assertThat(new LinkedHashSet<>(uuids)).as("rows %s must all be distinct records", uuids).hasSize(6);
+  }
+
+  /** The ordinary case: nothing anomalous, and the answer must stay exactly what it was. */
+  @Test
+  void queryNodesStillReturnsTheNearestNodesInOrder() {
+    final List<String> hits = queryTopK(vector(3), 5);
+
+    assertThat(hits).hasSize(5);
+    assertThat(hits.getFirst()).isEqualTo("u3");
+    assertThat(new LinkedHashSet<>(hits)).hasSize(5);
+  }
+
+  private void assertDistinctTopK(final int k) {
+    final List<String> rows = queryTopK(vector(3), k);
+    final Set<String> distinct = new LinkedHashSet<>(rows);
+
+    assertThat(rows).as("k rows were requested and %d nodes exist", NODES).hasSize(k);
+    assertThat(distinct).as("rows %s must all be distinct nodes", rows).hasSize(k);
+  }
+
+  private List<Double> scoresTopK(final float[] queryVector, final int k) {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("v", queryVector);
+    params.put("k", k);
+
+    final List<Double> scores = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "CALL db.index.vector.queryNodes('Entity[name_embedding]', $k, $v) YIELD node AS n, score RETURN score AS s",
+        params)) {
+      while (rs.hasNext())
+        scores.add(((Number) rs.next().getProperty("s")).doubleValue());
+    }
+    return scores;
+  }
+
+  private List<String> queryTopK(final float[] queryVector, final int k) {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("v", queryVector);
+    params.put("k", k);
+
+    final List<String> uuids = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "CALL db.index.vector.queryNodes('Entity[name_embedding]', $k, $v) YIELD node AS n, score RETURN n.uuid AS u",
+        params)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        uuids.add(row.getProperty("u"));
+      }
+    }
+    return uuids;
+  }
+
+  private static float[] vector(final int i) {
+    final float[] v = new float[DIMENSIONS];
+    v[i % DIMENSIONS] = 1.0f;
+    v[(i + 1) % DIMENSIONS] = 0.1f + (i % 7) * 0.01f;
+    v[(i + 2) % DIMENSIONS] = 0.05f + (i % 5) * 0.02f;
+    return v;
+  }
+}


### PR DESCRIPTION
Closes #7057

## The symptom

`CALL db.index.vector.queryNodes('Entity[name_embedding]', 6, $v)` returned **6 rows carrying only 3 distinct nodes**. Silent: top-1 was still correct, so the only visible trace was recall pinned at exactly 0.50 - any consumer taking the top `k` received half the candidates it asked for.

## Root cause

Both vector-search entry points fan out over the type's vector sub-indexes, run one search per sub-index, concatenate the answers, sort by distance and truncate at `k`:

- `DbIndexVectorQueryNodes.execute()` - the Neo4j-compatible procedure
- `SQLFunctionVectorNeighbors.executeWithLSMVectorIndexes()` - the ArcadeDB-native `vector.neighbors`, and therefore `CALL vector.neighbors(...)` from Cypher too

Neither step ever promised one row per record. That held only because the fan-out normally visits each bucket once, and a record lives in exactly one bucket.

`TypeIndex.addIndexOnBucket` appends without checking, so a type can end up with two sub-indexes attached to the **same** bucket - a stale schema definition left beside the one that replaced it. The two describe the same records, so the fan-out searched the same records twice and the merged list held every record twice. After the truncation at `k` that is exactly the reported shape: `k` rows, `k/2` distinct nodes, the two copies of each node adjacent because the sort is by distance and they share it.

Reproduced verbatim, including the issue's own numbers:

```
rows=6 distinct=3 [u3, u3, u67, u67, u19, u19]
```

## The fix

Two changes, applied identically to both entry points:

1. **Search each bucket at most once.** The sub-index filter keeps the first vector sub-index per associated bucket id. A second sub-index on the same bucket can contribute nothing the first did not already have, so this removes the redundant search rather than only cleaning up after it. A sub-index reporting a negative (unbound) bucket id is left alone rather than collapsed onto the sentinel.
2. **One record, one row.** The merge loop deduplicates by RID. The list is already sorted ascending by distance, so the sighting kept is the **nearest** one, and the loop continues past a repeat instead of spending a result slot on it - so a `k` that was silently halved comes back *full*, not merely unduplicated. Under `groupBy` this also stops one record spending two slots of its own group's cap.

Both use the project's primitive-backed `IntHashSet` / `RidHashSet` rather than boxing sets.

## What was deliberately NOT changed

`LSMVectorIndex.findNeighborsFromVector`'s graph-walk extraction loop has no RID dedup either, and `VectorLocationIndex` genuinely models a RID as owning an `int[]` of live vector ids - two writes to one record's vector inside a single transaction leave two live ids behind (confirmed: `activeVectors=200` for 100 records).

A guard was written for it and then reverted, because it is **unreachable**: every search calls `rebuildGraphBeforeSearch()` first, and the rebuild folds the duplicate ids back to one before the walk can see them (`totalVectors` drops 200 -> 100 on the first search). Adding a per-search `RidHashSet` allocation to the primary search path to guard a state that cannot occur would cost the hot path for nothing, and could not be covered by a test that is able to fail. Recorded here so the next reader does not have to rediscover it.

## Test plan

New: `engine/src/test/java/com/arcadedb/query/opencypher/CypherVectorQueryNodesDuplicateTest.java`

| test | asserts | without the fix |
|---|---|---|
| `queryNodesReturnsDistinctNodesWhenTheSameSubIndexIsAttachedTwice` | `k` rows, `k` distinct, for k=6 and k=10 | **FAILS** - `Expected size: 6 but was: 3` |
| `queryNodesAnswerIsUnchangedByTheDuplicatedSubIndex` | the doubled schema returns the healthy answer row for row **and** score for score | **FAILS** - `["u3","u3","u67","u67","u19","u19","u99","u99"]` |
| `vectorNeighborsReturnsDistinctRecordsWhenTheSameSubIndexIsAttachedTwice` | the SQL function is fixed too | **FAILS** - `Expected size: 6 but was: 3` |
| `queryNodesStillReturnsTheNearestNodesInOrder` | control: the ordinary path is untouched | passes both ways |

The fixture plants the multiplicity through the public `TypeIndex.addIndexOnBucket` and **asserts the plant landed** before asserting anything about the query - a fixture that silently failed to double the sub-index would make the whole class pass for the wrong reason.

Verification (all with an isolated `-Dmaven.repo.local`):

- [x] `mvn -o -pl engine test -Dtest=CypherVectorQueryNodesDuplicateTest` - 4/4 green with the fix; 3 of the 4 red without it (the control stays green both ways)
- [x] `mvn -o -pl engine test -Dtest='*Vector*'` - **697 tests, 0 failures**
- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.query.opencypher.**'` - **9245 tests, 0 failures**, 98 skipped
- [x] `mvn -o -pl engine test -Dtest='com.arcadedb.query.sql.functions.**,com.arcadedb.query.select.**,com.arcadedb.index.**,com.arcadedb.function.**'` - **2977 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJBD77PbMSvPmV11G8qiGS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vector and sparse-vector searches returning duplicate records when sub-indexes are repeated.
  * Ensured results contain distinct records, remain correctly ordered, and honor requested limits.
  * Improved handling of very large result limits without unnecessary allocation.
  * Preserved correct filtering of applicable vector indexes during searches.

* **Tests**
  * Added coverage for duplicate sub-index scenarios across vector, sparse-vector, and nearest-neighbor queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->