### PR TITLE
fix(#6992): filter PairHashJoinOp CSR build anchors by label

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOp.java
@@ -114,21 +114,15 @@ public final class PairHashJoinOp implements CountOp {
     final NeighborView arm1View = arm1SingleHop ? provider.getNeighborView(arm1Directions[0], arm1EdgeTypes[0]) : null;
     final NeighborView arm2View = arm2SingleHop ? provider.getNeighborView(arm2Directions[0], arm2EdgeTypes[0]) : null;
 
-    // Every NeighborView build path below needs arm1's view; none of them runs without it. The label filter of
-    // EITHER arm needs the bucket of a node id, so the table is built once here for both, rather than inside
-    // the branch that first wanted it - arm1's filter used to be dropped by all three of those paths precisely
-    // because the table was owned by the arm2 branch (issue #6304).
-    final int[] bucketIds;
-    if (arm1View != null && (arm1Buckets != null || arm2Buckets != null)) {
-      bucketIds = new int[nodeIdUpperBound];
-      for (int v = 0; v < nodeIdUpperBound; v++) {
-        guard.checkPeriodically(v);
-        if (!provider.isNodeLive(v))
-          continue;
-        bucketIds[v] = provider.getRID(v).getBucketId();
-      }
-    } else
-      bucketIds = null;
+    // Every CSR build path needs the build anchor's bucket. Endpoint label filters use the same lookup, so build
+    // it once rather than resolving RIDs in each hot loop.
+    final int[] bucketIds = new int[nodeIdUpperBound];
+    for (int v = 0; v < nodeIdUpperBound; v++) {
+      guard.checkPeriodically(v);
+      if (!provider.isNodeLive(v))
+        continue;
+      bucketIds[v] = provider.getRID(v).getBucketId();
+    }
 
     // A single-hop arm's only label filter sits on its endpoint, which is the one hop it has. arm1 is single-hop
     // wherever arm1View exists, and the multi-hop arm1 case never reaches a path that reads this.
@@ -150,21 +144,23 @@ public final class PairHashJoinOp implements CountOp {
       }
 
       if (allArm2Views) {
-        return buildAndProbeInline(provider, arm1View, arm1Filter, arm2Views, arm2Buckets, probeView,
+        return buildAndProbeInline(provider, buildBuckets, arm1View, arm1Filter, arm2Views, arm2Buckets, probeView,
             nodeIdUpperBound, bucketIds, guard);
       }
     }
 
     // FALLBACK: HashMap build + probe (for cases without full NeighborView coverage)
     if (arm1View != null && arm2View != null) {
-      buildWithViews(provider, arm1View, arm1Filter, arm2View, arm2Buckets != null ? arm2Buckets[0] : null,
+      buildWithViews(provider, buildBuckets, arm1View, arm1Filter,
+          arm2View, arm2Buckets != null ? arm2Buckets[0] : null,
           pairCounts, nodeIdUpperBound, bucketIds, guard);
     } else if (arm1View != null) {
-      buildWithArm1View(arm1View, arm1Filter, provider, arm2Buckets, pairCounts, nodeIdUpperBound, bucketIds, guard);
+      buildWithArm1View(buildBuckets, arm1View, arm1Filter, provider, arm2Buckets,
+          pairCounts, nodeIdUpperBound, bucketIds, guard);
     } else {
       for (int startId = 0; startId < nodeIdUpperBound; startId++) {
         guard.check();
-        if (!provider.isNodeLive(startId))
+        if (!provider.isNodeLive(startId) || !buildBuckets.contains(bucketIds[startId]))
           continue;
         final int[] ep1Ids = CSRCountUtils.walkArm(provider, startId, arm1EdgeTypes, arm1Directions, arm1Buckets);
         if (ep1Ids.length == 0)
@@ -265,7 +261,8 @@ public final class PairHashJoinOp implements CountOp {
    * When arm2 has exactly 2 hops (the Q2 case), fuses the arm2 walk with the probe
    * check inline to avoid allocating an intermediate int[] per build node.
    */
-  private long buildAndProbeInline(final GraphTraversalProvider provider, final NeighborView arm1View,
+  private long buildAndProbeInline(final GraphTraversalProvider provider, final IntHashSet buildBuckets,
+      final NeighborView arm1View,
       final IntHashSet arm1Filter,
       final NeighborView[] arm2Views, final IntHashSet[] arm2Buckets, final NeighborView probeView,
       final int nodeIdUpperBound, final int[] bucketIds, final WorkGuard guard) {
@@ -283,7 +280,7 @@ public final class PairHashJoinOp implements CountOp {
       for (int startId = 0; startId < nodeIdUpperBound; startId++) {
         // The build node's own cost is O(arm1 x arm2 x log d), so a per-anchor check is what bounds it.
         guard.check();
-        if (!provider.isNodeLive(startId))
+        if (!provider.isNodeLive(startId) || !buildBuckets.contains(bucketIds[startId]))
           continue;
         final int a1Start = arm1View.offset(startId);
         final int a1End = arm1View.offsetEnd(startId);
@@ -324,7 +321,7 @@ public final class PairHashJoinOp implements CountOp {
     // GENERAL PATH: allocate arm2 endpoints array per build node
     for (int startId = 0; startId < nodeIdUpperBound; startId++) {
       guard.check();
-      if (!provider.isNodeLive(startId))
+      if (!provider.isNodeLive(startId) || !buildBuckets.contains(bucketIds[startId]))
         continue;
       final int a1Start = arm1View.offset(startId);
       final int a1End = arm1View.offsetEnd(startId);
@@ -357,7 +354,8 @@ public final class PairHashJoinOp implements CountOp {
    * The two endpoint filters are the labels the pattern put on the shared variables; dropping one does not make
    * the join cheaper, it makes it count endpoints the pattern excluded (issue #6304).
    */
-  private void buildWithViews(final GraphTraversalProvider provider, final NeighborView arm1View,
+  private void buildWithViews(final GraphTraversalProvider provider, final IntHashSet buildBuckets,
+      final NeighborView arm1View,
       final IntHashSet arm1Filter,
       final NeighborView arm2View, final IntHashSet arm2Filter, final LongLongHashMap pairCounts,
       final int nodeIdUpperBound, final int[] bucketIds, final WorkGuard guard) {
@@ -365,7 +363,7 @@ public final class PairHashJoinOp implements CountOp {
     final int[] arm2Nbrs = arm2View.neighbors();
     for (int startId = 0; startId < nodeIdUpperBound; startId++) {
       guard.check();
-      if (!provider.isNodeLive(startId))
+      if (!provider.isNodeLive(startId) || !buildBuckets.contains(bucketIds[startId]))
         continue;
       final int a1Start = arm1View.offset(startId);
       final int a1End = arm1View.offsetEnd(startId);
@@ -391,7 +389,8 @@ public final class PairHashJoinOp implements CountOp {
    * Uses pre-fetched NeighborViews for arm2 hops to avoid per-node getNeighborIds calls.
    * For Q2: arm1=HAS_CREATOR OUT (Comment→Person), arm2=REPLY_OF+HAS_CREATOR (Comment→Post→Person).
    */
-  private void buildWithArm1View(final NeighborView arm1View, final IntHashSet arm1Filter,
+  private void buildWithArm1View(final IntHashSet buildBuckets, final NeighborView arm1View,
+      final IntHashSet arm1Filter,
       final GraphTraversalProvider provider, final IntHashSet[] arm2Buckets, final LongLongHashMap pairCounts,
       final int nodeIdUpperBound, final int[] bucketIds, final WorkGuard guard) {
     final int[] arm1Nbrs = arm1View.neighbors();
@@ -406,7 +405,7 @@ public final class PairHashJoinOp implements CountOp {
 
     for (int startId = 0; startId < nodeIdUpperBound; startId++) {
       guard.check();
-      if (!provider.isNodeLive(startId))
+      if (!provider.isNodeLive(startId) || !buildBuckets.contains(bucketIds[startId]))
         continue;
       final int a1Start = arm1View.offset(startId);
       final int a1End = arm1View.offsetEnd(startId);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherPairJoinBuildStartLabelIssue6992Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherPairJoinBuildStartLabelIssue6992Test.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.NeighborView;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Regression coverage for issue #6992: CSR pair joins must restrict build anchors to their declared label. */
+class CypherPairJoinBuildStartLabelIssue6992Test extends TestHelper {
+  private static final String MATCH =
+      "MATCH (left)-[:PROBE]->(right), (left)<-[:ARM_1]-(build:Build)-[:ARM_2]->(right)";
+  private static final String TWO_HOP_MATCH =
+      "MATCH (left)-[:PROBE]->(right), " +
+          "(left)<-[:ARM_1]-(build:Build)-[:ARM_2_FIRST]->(middle)-[:ARM_2_SECOND]->(right)";
+
+  private RID outsideBuildRid;
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Build");
+      database.getSchema().createVertexType("Other");
+      database.getSchema().createVertexType("Endpoint");
+      database.getSchema().createVertexType("Intermediate");
+      database.getSchema().createEdgeType("ARM_1");
+      database.getSchema().createEdgeType("ARM_2");
+      database.getSchema().createEdgeType("ARM_2_FIRST");
+      database.getSchema().createEdgeType("ARM_2_SECOND");
+      database.getSchema().createEdgeType("PROBE");
+
+      final MutableVertex build = database.newVertex("Build").save();
+      final MutableVertex outsideBuild = database.newVertex("Other").save();
+      final MutableVertex left = database.newVertex("Endpoint").save();
+      final MutableVertex right = database.newVertex("Endpoint").save();
+      final MutableVertex middle = database.newVertex("Intermediate").save();
+
+      build.newEdge("ARM_1", left).save();
+      build.newEdge("ARM_2", right).save();
+      outsideBuild.newEdge("ARM_1", left).save();
+      outsideBuild.newEdge("ARM_2", right).save();
+      build.newEdge("ARM_2_FIRST", middle).save();
+      outsideBuild.newEdge("ARM_2_FIRST", middle).save();
+      middle.newEdge("ARM_2_SECOND", right).save();
+      left.newEdge("PROBE", right).save();
+
+      outsideBuildRid = outsideBuild.getIdentity();
+    });
+  }
+
+  @Test
+  void buildStartLabelExcludesOtherLiveTypesWhenAllCsrViewsAreAvailable() {
+    assertCountWithAllViews(MATCH);
+  }
+
+  @Test
+  void buildStartLabelExcludesOtherLiveTypesOnTheFusedTwoHopPath() {
+    assertCountWithAllViews(TWO_HOP_MATCH);
+  }
+
+  private void assertCountWithAllViews(final String matchClause) {
+    assertThat(explainOf(matchClause + " RETURN count(*) AS c")).contains("COUNT PAIR JOIN");
+    assertThat(rowCountOf(matchClause + " RETURN build")).as("materialized pipeline").isEqualTo(1);
+    assertThat(scalarOf(matchClause + " RETURN count(*) AS c")).as("OLTP").isEqualTo(1L);
+
+    final GraphAnalyticalView view = newViewOverFixture();
+    try {
+      final int outsideBuildId = view.getNodeId(outsideBuildRid);
+      assertThat(outsideBuildId).isGreaterThanOrEqualTo(0);
+      assertThat(view.isNodeLive(outsideBuildId)).isTrue();
+      assertThat(scalarOf(matchClause + " RETURN count(*) AS c")).as("CSR").isEqualTo(1L);
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void buildStartLabelExcludesOtherLiveTypesWhenIndividualCsrViewsAreUnavailable() {
+    assertThat(rowCountOf(MATCH + " RETURN build")).as("materialized pipeline").isEqualTo(1);
+    assertThat(scalarOf(MATCH + " RETURN count(*) AS c")).as("OLTP").isEqualTo(1L);
+
+    assertCountWithHiddenView("PROBE");
+    assertCountWithHiddenView("ARM_2");
+    assertCountWithHiddenView("ARM_1");
+  }
+
+  private void assertCountWithHiddenView(final String hiddenEdgeType) {
+    final GraphAnalyticalView view = newViewOverFixture();
+    final GraphTraversalProvider hiddenView = new ViewHidingProvider(view, hiddenEdgeType);
+    try {
+      GraphTraversalProviderRegistry.unregister(database, view);
+      GraphTraversalProviderRegistry.register(database, hiddenView);
+      assertThat(scalarOf(MATCH + " RETURN count(*) AS c"))
+          .as("CSR without %s NeighborView", hiddenEdgeType)
+          .isEqualTo(1L);
+    } finally {
+      GraphTraversalProviderRegistry.unregister(database, hiddenView);
+      GraphTraversalProviderRegistry.register(database, view);
+      view.drop();
+    }
+  }
+
+  private GraphAnalyticalView newViewOverFixture() {
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("issue-6992")
+        .withVertexTypes("Build", "Other", "Endpoint", "Intermediate")
+        .withEdgeTypes("ARM_1", "ARM_2", "ARM_2_FIRST", "ARM_2_SECOND", "PROBE")
+        .build();
+    assertThat(GraphTraversalProviderRegistry.awaitAll(database, 30, TimeUnit.SECONDS)).isTrue();
+    assertThat(GraphTraversalProviderRegistry.findProvider(database,
+        "ARM_1", "ARM_2", "ARM_2_FIRST", "ARM_2_SECOND", "PROBE")).isNotNull();
+    return view;
+  }
+
+  private long scalarOf(final String query) {
+    final List<Long> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        values.add(((Number) rs.next().getProperty("c")).longValue());
+    }
+    assertThat(values).as(query).hasSize(1);
+    return values.get(0);
+  }
+
+  private int rowCountOf(final String query) {
+    int count = 0;
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private String explainOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+
+  /** Keeps all graph data available while making one zero-copy adjacency view unavailable. */
+  private record ViewHidingProvider(GraphAnalyticalView delegate, String hiddenEdgeType)
+      implements GraphTraversalProvider {
+
+    @Override
+    public NeighborView getNeighborView(final Vertex.DIRECTION direction, final String... edgeTypes) {
+      if (edgeTypes != null)
+        for (final String edgeType : edgeTypes)
+          if (hiddenEdgeType.equals(edgeType))
+            return null;
+      return delegate.getNeighborView(direction, edgeTypes);
+    }
+
+    @Override
+    public int getNodeCount() {
+      return delegate.getNodeCount();
+    }
+
+    @Override
+    public int getNodeIdUpperBound() {
+      return delegate.getNodeIdUpperBound();
+    }
+
+    @Override
+    public boolean isNodeLive(final int nodeId) {
+      return delegate.isNodeLive(nodeId);
+    }
+
+    @Override
+    public boolean isReady() {
+      return delegate.isReady();
+    }
+
+    @Override
+    public String getName() {
+      return delegate.getName();
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return delegate.coversVertexType(typeName);
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return delegate.coversEdgeType(edgeTypeName);
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return delegate.getNodeId(rid);
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return delegate.getRID(nodeId);
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return delegate.getNeighborIds(nodeId, direction, edgeTypes);
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return delegate.countEdges(nodeId, direction, edgeTypes);
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+        final String... edgeTypes) {
+      return delegate.isConnectedTo(nodeA, nodeB, direction, edgeTypes);
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return delegate.getProperty(nodeId, propertyName);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherPairJoinBuildStartLabelIssue6992Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherPairJoinBuildStartLabelIssue6992Test.java
@@ -113,15 +113,54 @@ class CypherPairJoinBuildStartLabelIssue6992Test extends TestHelper {
     assertCountWithHiddenView("ARM_1");
   }
 
+  /**
+   * The filter must not be narrower than the label either: a subtype of the build label is an anchor on every
+   * path, exactly as OLTP's polymorphic type iteration already treats it.
+   */
+  @Test
+  void buildStartLabelKeepsSubtypeAnchorsOnEveryCsrPath() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("SubBuild").addSuperType("Build");
+      final MutableVertex subBuild = database.newVertex("SubBuild").save();
+      final Vertex left = database.query("sql", "SELECT FROM Endpoint WHERE out('PROBE').size() > 0").next()
+          .getElement().get().asVertex();
+      final Vertex right = left.getVertices(Vertex.DIRECTION.OUT, "PROBE").iterator().next();
+      final Vertex middle = database.query("sql", "SELECT FROM Intermediate").next().getElement().get().asVertex();
+      subBuild.newEdge("ARM_1", left).save();
+      subBuild.newEdge("ARM_2", right).save();
+      subBuild.newEdge("ARM_2_FIRST", middle).save();
+    });
+
+    for (final String matchClause : new String[] { MATCH, TWO_HOP_MATCH }) {
+      assertThat(rowCountOf(matchClause + " RETURN build")).as("materialized pipeline").isEqualTo(2);
+      assertThat(scalarOf(matchClause + " RETURN count(*) AS c")).as("OLTP").isEqualTo(2L);
+      final GraphAnalyticalView view = newViewOverFixture("SubBuild");
+      try {
+        assertThat(scalarOf(matchClause + " RETURN count(*) AS c")).as("CSR").isEqualTo(2L);
+      } finally {
+        view.drop();
+      }
+    }
+
+    assertCountWithHiddenView("PROBE", 2L, "SubBuild");
+    assertCountWithHiddenView("ARM_2", 2L, "SubBuild");
+    assertCountWithHiddenView("ARM_1", 2L, "SubBuild");
+  }
+
   private void assertCountWithHiddenView(final String hiddenEdgeType) {
-    final GraphAnalyticalView view = newViewOverFixture();
+    assertCountWithHiddenView(hiddenEdgeType, 1L);
+  }
+
+  private void assertCountWithHiddenView(final String hiddenEdgeType, final long expected,
+      final String... extraVertexTypes) {
+    final GraphAnalyticalView view = newViewOverFixture(extraVertexTypes);
     final GraphTraversalProvider hiddenView = new ViewHidingProvider(view, hiddenEdgeType);
     try {
       GraphTraversalProviderRegistry.unregister(database, view);
       GraphTraversalProviderRegistry.register(database, hiddenView);
       assertThat(scalarOf(MATCH + " RETURN count(*) AS c"))
           .as("CSR without %s NeighborView", hiddenEdgeType)
-          .isEqualTo(1L);
+          .isEqualTo(expected);
     } finally {
       GraphTraversalProviderRegistry.unregister(database, hiddenView);
       GraphTraversalProviderRegistry.register(database, view);
@@ -129,10 +168,12 @@ class CypherPairJoinBuildStartLabelIssue6992Test extends TestHelper {
     }
   }
 
-  private GraphAnalyticalView newViewOverFixture() {
+  private GraphAnalyticalView newViewOverFixture(final String... extraVertexTypes) {
+    final List<String> vertexTypes = new ArrayList<>(List.of("Build", "Other", "Endpoint", "Intermediate"));
+    vertexTypes.addAll(List.of(extraVertexTypes));
     final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
         .withName("issue-6992")
-        .withVertexTypes("Build", "Other", "Endpoint", "Intermediate")
+        .withVertexTypes(vertexTypes.toArray(new String[0]))
         .withEdgeTypes("ARM_1", "ARM_2", "ARM_2_FIRST", "ARM_2_SECOND", "PROBE")
         .build();
     assertThat(GraphTraversalProviderRegistry.awaitAll(database, 30, TimeUnit.SECONDS)).isTrue();


### PR DESCRIPTION
## Summary

- build a node-ID-to-bucket lookup for every live CSR node so build anchors can be checked consistently
- apply `buildStartLabel` filtering to all CSR build strategies, including the fused two-hop inline path
- add a real `GraphAnalyticalView` regression with a live out-of-label anchor and cross-check CSR counts against OLTP and materialized query results

## Testing

- `mvn -pl engine test -Dtest=CypherPairJoinBuildStartLabelIssue6992Test,CypherPairJoinLabelFilterIssue6304Test,PairHashJoinOpSparseNodeIdsTest`

Fixes #6992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Cypher pair-join results when queries use a starting `Build` label.
  - Ensured consistent filtering across materialized, OLTP, and CSR execution modes.
  - Fixed fused multi-hop joins and cases where some graph adjacency views are unavailable.
  - Preserved endpoint and intermediate-label filtering while applying starting-label constraints consistently.

- **Tests**
  - Added regression coverage for labeled vertices and edges, multi-hop joins, multiple execution modes, and limited adjacency availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->