### PR TITLE
Fix remote client: batch re-send after a failed flush, existsBucket source, transaction retry guards (#7031, #7030)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaBucketsStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaBucketsStep.java
@@ -18,10 +18,13 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.schema.Schema;
+import com.arcadedb.security.SecurityDatabaseUser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,10 +54,21 @@ public class FetchFromSchemaBucketsStep extends AbstractExecutionStep {
       try {
         final Schema schema = context.getDatabase().getSchema();
 
+        final SecurityDatabaseUser currentUser = currentUser(context);
+
         final List<String> orderedBuckets = schema.getBuckets().stream().map(x -> x.getName()).sorted(String::compareToIgnoreCase)
             .collect(Collectors.toList());
         for (final String bucketName : orderedBuckets) {
           final Bucket bucket = schema.getBucketByName(bucketName);
+
+          // Hide buckets the current user cannot read instead of throwing, the same way schema:types hides
+          // restricted types (issue #4238): countBucket() below checks the same permission and throws on the
+          // first denied bucket, which aborted the whole listing - and with it every remote-client call that
+          // goes through it - for a user allowed to see all the others. A null user (embedded usage, or no
+          // security context) sees everything, and so does a bucket the security map does not cover.
+          if (currentUser != null && !currentUser.requestAccessOnFile(bucket.getFileId(),
+              SecurityDatabaseUser.ACCESS.READ_RECORD))
+            continue;
 
           final ResultInternal r = new ResultInternal(context.getDatabase());
           result.add(r);
@@ -96,6 +110,12 @@ public class FetchFromSchemaBucketsStep extends AbstractExecutionStep {
         cursor = 0;
       }
     };
+  }
+
+  private static SecurityDatabaseUser currentUser(final CommandContext context) {
+    final DatabaseInternal database = (DatabaseInternal) context.getDatabase();
+    final DatabaseContext.DatabaseContextTL dbContext = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
+    return dbContext != null ? dbContext.getCurrentUser() : null;
   }
 
   @Override

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -242,8 +242,22 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
         return createdNewTx;
 
       } catch (final NeedRetryException | DuplicatedKeyException e) {
+        // #661 (issue #7030 ported the guard here from LocalDatabase.transaction()): when we joined a
+        // transaction owned by the caller (createdNewTx == false) we must NOT retry here. The retry would
+        // re-run the block inside the caller's still-open transaction, which then accumulates the partial
+        // effects of the failed attempt on top of the ones the caller made before the call, without ever
+        // being told; and re-running against the same conflicted state cannot succeed anyway. Propagate the
+        // exception so the real transaction owner retries the whole logical unit with fresh bindings.
+        if (!createdNewTx)
+          throw e;
+
         // RETRY
         lastException = e;
+        // Close the server-side transaction before the next attempt: leaving it open keeps its locks until the
+        // server times it out, so attempt N+1 would contend with the locks of attempt N and be MORE likely to
+        // need a retry, not less (issue #7030). A failure raised by commit() has already ended the session
+        // (commit() clears the session id in its finally), so this only fires when the block itself failed.
+        rollbackQuietly();
         setSessionId(null);
         // The tx (server-side) is gone: reset records created in it so a retry/re-save inserts cleanly (issue #4562)
         resetCreatedRecordsIdentity();
@@ -252,6 +266,9 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
           error.call(e);
 
       } catch (final Exception e) {
+        // Same as above: the transaction this attempt left open on the server is never going to be committed,
+        // so release it now instead of holding its locks until the server-side timeout (issue #7030).
+        rollbackQuietly();
         setSessionId(null);
         resetCreatedRecordsIdentity();
 
@@ -412,6 +429,25 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
     } finally {
       resetCreatedRecordsIdentity();
       setSessionId(null);
+    }
+  }
+
+  /**
+   * Rolls back the server-side transaction, if one is still open, without ever throwing. Used on the failure paths
+   * of {@link #transaction(TransactionScope, boolean, int, OkCallback, ErrorCallback)}, where the exception being
+   * handled is the one the caller has to see: a rollback that fails on its way out (the session is already gone
+   * server-side, the connection is broken) must not replace it, and there is nothing left to do about it anyway
+   * since the server releases the transaction on its own timeout. Issue #7030.
+   */
+  private void rollbackQuietly() {
+    if (!isTransactionActive())
+      return;
+
+    try {
+      rollback();
+    } catch (final Exception e) {
+      LogManager.instance()
+          .log(this, Level.FINE, "Error on rolling back the transaction of a failed attempt (ignored)", e);
     }
   }
 

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -78,6 +78,11 @@ public class RemoteGraphBatch implements AutoCloseable {
   private         int                 itemsInBuffer;
   protected       boolean             hasEdges;
   protected       boolean             closed;
+  /**
+   * Raised while a flush is in flight and left raised if that flush does not complete, so the payload of a failed
+   * flush is never re-sent on this class' own initiative (issue #7031).
+   */
+  protected       boolean             failed;
 
   // --- Aggregated result across all flushes ---
   protected long totalVerticesCreated;
@@ -198,10 +203,31 @@ public class RemoteGraphBatch implements AutoCloseable {
    * any flushed vertices is stored for resolving future edge references.
    * This method can be called explicitly; it is also called automatically
    * when the buffer reaches the {@code flushEvery} threshold.
+   * <p>
+   * A flush that does not complete leaves the batch failed: the payload it was carrying is dropped rather than
+   * kept for the next flush, and every later flush on this instance - including the implicit one from
+   * {@link #close()}, which runs during exception unwinding when the batch is used in a try-with-resources -
+   * refuses to run. Re-sending would be a decision this class cannot make: each flush is an independent request
+   * the server does not remember, so a failure that is a response the client never saw (a socket reset after the
+   * server committed, a proxy timeout) is indistinguishable here from a server-side rejection, and re-sending
+   * the first kind creates every record of that payload a second time. Only the caller knows whether its load is
+   * idempotent, so only the caller can retry - by building a new batch and replaying the records itself
+   * (issue #7031).
+   *
+   * @throws IllegalStateException if a previous flush on this batch failed
    */
   public void flush() {
+    if (failed)
+      throw new IllegalStateException(
+          "Batch cannot be flushed because a previous flush failed: its payload was dropped and this batch cannot "
+              + "be reused. Retrying the load, if it is safe to repeat, requires a new batch");
+
     if (buffer.isEmpty())
       return;
+
+    // Raised BEFORE the request and lowered only once the payload is fully accounted for: anything thrown in
+    // between - by the send, or by the response handling below - leaves the batch failed.
+    failed = true;
 
     queryParams.put("ordinalBase", Integer.toString(bufferOrdinalBase));
 
@@ -239,6 +265,7 @@ public class RemoteGraphBatch implements AutoCloseable {
     buffer.setLength(0);
     itemsInBuffer = 0;
     bufferOrdinalBase = vertexCounter;
+    failed = false;
   }
 
   /**
@@ -253,12 +280,23 @@ public class RemoteGraphBatch implements AutoCloseable {
   /**
    * Flushes any remaining buffered records to the server.
    * This method is idempotent - calling it multiple times has no additional effect.
+   * <p>
+   * A batch whose flush failed closes without sending anything: the payload of the failed flush was already
+   * dropped, and the exception the caller is unwinding with is the one it has to see, not a second one raised
+   * from here (issue #7031).
    */
   @Override
   public void close() {
     if (closed)
       return;
     closed = true;
+    if (failed) {
+      // Release the payload the failed flush was carrying: nothing can send it any more.
+      buffer.setLength(0);
+      buffer.trimToSize();
+      itemsInBuffer = 0;
+      return;
+    }
     flush();
   }
 

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -92,9 +92,15 @@ public class RemoteSchema implements Schema {
     return found;
   }
 
+  /**
+   * Answers from {@code schema:buckets}, the database's bucket list, and not from the buckets attached to the types
+   * in {@code schema:types}: a bucket exists as soon as it is created, whether or not any type uses it, so asking the
+   * type list answered {@code false} for a standalone bucket - including one the caller had just created through this
+   * same API (issue #7031).
+   */
   @Override
   public boolean existsBucket(final String bucketName) {
-    return remoteDatabase.command("sql", "select from schema:types where :name IN buckets", Map.of("name", bucketName)).hasNext();
+    return remoteDatabase.command("sql", "select from schema:buckets where name = :name", Map.of("name", bucketName)).hasNext();
   }
 
   @Override

--- a/server/src/test/java/com/arcadedb/remote/Issue7030RemoteTransactionRetryIT.java
+++ b/server/src/test/java/com/arcadedb/remote/Issue7030RemoteTransactionRetryIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote;
+
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #7030: {@link RemoteDatabase#transaction} was missing the two guards
+ * {@code LocalDatabase.transaction()} has - it retried a transaction owned by the caller (the guard issue #661
+ * established), and it never rolled back a failed attempt before starting the next one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7030RemoteTransactionRetryIT extends BaseGraphServerTest {
+  private static final String DATABASE_NAME = "remote-tx-7030";
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return false;
+  }
+
+  @BeforeEach
+  public void beginTest() {
+    super.beginTest();
+    final RemoteServer server = new RemoteServer("127.0.0.1", 2480, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+    if (!server.exists(DATABASE_NAME))
+      server.create(DATABASE_NAME);
+  }
+
+  @AfterEach
+  public void endTest() {
+    final RemoteServer server = new RemoteServer("127.0.0.1", 2480, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+    if (server.exists(DATABASE_NAME))
+      server.drop(DATABASE_NAME);
+    super.endTest();
+  }
+
+  /**
+   * The bug: joining a transaction the caller owns and then hitting a {@link NeedRetryException} re-ran the block
+   * inside that still-open transaction, which silently accumulated the partial effects of every failed attempt.
+   * The block must run once and the exception must reach the owner of the transaction.
+   */
+  @Test
+  void aJoinedTransactionIsNotRetried() {
+    try (final RollbackCountingDatabase database = newDatabase()) {
+      database.command("sql", "CREATE DOCUMENT TYPE Person");
+
+      final AtomicInteger executions = new AtomicInteger();
+
+      database.begin();
+      try {
+        assertThatThrownBy(() -> database.transaction(() -> {
+          executions.incrementAndGet();
+          throw new NeedRetryException("simulated conflict");
+        }, true, 5)).isInstanceOf(NeedRetryException.class).hasMessageContaining("simulated conflict");
+
+        assertThat(executions.get()).as("a transaction owned by the caller must not be retried").isEqualTo(1);
+        assertThat(database.rollbacks.get()).as("the caller's transaction must not be rolled back from here").isZero();
+        assertThat(database.isTransactionActive()).as("the caller's transaction must still be open").isTrue();
+      } finally {
+        if (database.isTransactionActive())
+          database.rollback();
+      }
+    }
+  }
+
+  /**
+   * The bug: a failed attempt left its server-side transaction open, so the next attempt contended with the locks
+   * of the previous one until the server timed it out. Each failed attempt must be rolled back before the retry.
+   */
+  @Test
+  void everyFailedAttemptIsRolledBackBeforeTheRetry() {
+    try (final RollbackCountingDatabase database = newDatabase()) {
+      database.command("sql", "CREATE DOCUMENT TYPE Person");
+
+      final AtomicInteger executions = new AtomicInteger();
+
+      final boolean createdNewTx = database.transaction(() -> {
+        database.newDocument("Person").set("name", "Alice").save();
+        if (executions.incrementAndGet() < 3)
+          throw new NeedRetryException("simulated conflict");
+      }, false, 5);
+
+      assertThat(createdNewTx).isTrue();
+      assertThat(executions.get()).isEqualTo(3);
+      assertThat(database.rollbacks.get()).as("each of the two failed attempts must be rolled back").isEqualTo(2);
+      assertThat(database.countType("Person", false)).as("only the attempt that committed must leave a record")
+          .isEqualTo(1);
+    }
+  }
+
+  /**
+   * The same on the arm that gives up: an exception the retry loop does not handle still has to release the
+   * server-side transaction on the way out instead of leaving it open until its timeout.
+   */
+  @Test
+  void aFatalFailureRollsBackBeforeRethrowing() {
+    try (final RollbackCountingDatabase database = newDatabase()) {
+      database.command("sql", "CREATE DOCUMENT TYPE Person");
+
+      assertThatThrownBy(() -> database.transaction(() -> {
+        database.newDocument("Person").set("name", "Alice").save();
+        throw new IllegalArgumentException("fatal");
+      }, false, 5)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("fatal");
+
+      assertThat(database.rollbacks.get()).isEqualTo(1);
+      assertThat(database.isTransactionActive()).isFalse();
+      assertThat(database.countType("Person", false)).isZero();
+    }
+  }
+
+  private RollbackCountingDatabase newDatabase() {
+    return new RollbackCountingDatabase("127.0.0.1", 2480, DATABASE_NAME, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  /**
+   * Counts the {@code POST /rollback} the retry loop issues, which is what tells a failed attempt that released
+   * its server-side transaction from one that abandoned it.
+   */
+  private static class RollbackCountingDatabase extends RemoteDatabase {
+    final AtomicInteger rollbacks = new AtomicInteger();
+
+    RollbackCountingDatabase(final String server, final int port, final String databaseName, final String userName,
+        final String userPassword) {
+      super(server, port, databaseName, userName, userPassword);
+    }
+
+    @Override
+    public void rollback() {
+      rollbacks.incrementAndGet();
+      super.rollback();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/remote/Issue7031RemoteClientIT.java
+++ b/server/src/test/java/com/arcadedb/remote/Issue7031RemoteClientIT.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote;
+
+import com.arcadedb.exception.ArcadeDBException;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #7031: a failed {@link RemoteGraphBatch#flush()} must not leave its payload buffered
+ * for {@link RemoteGraphBatch#close()} to send a second time, and {@link RemoteSchema#existsBucket(String)} must
+ * answer from the bucket list rather than from the buckets attached to the types.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7031RemoteClientIT extends BaseGraphServerTest {
+  private static final String DATABASE_NAME = "remote-client-7031";
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return false;
+  }
+
+  @BeforeEach
+  public void beginTest() {
+    super.beginTest();
+    final RemoteServer server = new RemoteServer("127.0.0.1", 2480, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+    if (!server.exists(DATABASE_NAME))
+      server.create(DATABASE_NAME);
+  }
+
+  @AfterEach
+  public void endTest() {
+    final RemoteServer server = new RemoteServer("127.0.0.1", 2480, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+    if (server.exists(DATABASE_NAME))
+      server.drop(DATABASE_NAME);
+    super.endTest();
+  }
+
+  /**
+   * The bug: an interior auto-flush failed inside {@code createVertex()}, the buffer kept its payload, and the
+   * {@code close()} of the try-with-resources sent the very same payload again. When the failure was a response
+   * the client never saw rather than a server-side rejection, that second send created every record twice.
+   */
+  @Test
+  void failedInteriorFlushIsNotResentOnClose() {
+    try (final RecordingBatchDatabase database = newRecordingDatabase()) {
+      database.command("sql", "CREATE VERTEX TYPE Person");
+
+      database.failNextSend = true;
+
+      assertThatThrownBy(() -> {
+        try (final RemoteGraphBatch batch = database.batch().withFlushEvery(2).build()) {
+          batch.createVertex("Person", "name", "Alice");
+          // Trips the auto-flush, which fails.
+          batch.createVertex("Person", "name", "Bob");
+          batch.createVertex("Person", "name", "Carl");
+        }
+      }).isInstanceOf(ArcadeDBException.class).hasMessageContaining("simulated");
+
+      assertThat(database.sentPayloads).as("the payload of the failed flush must not be sent a second time").hasSize(1);
+      assertThat(database.sentPayloads.getFirst()).contains("Alice").contains("Bob");
+    }
+  }
+
+  /**
+   * The same for an explicit {@code flush()}: the failure is the caller's to handle, and the {@code close()} that
+   * follows must not quietly repeat the attempt (nor raise a second failure on top of the real one).
+   */
+  @Test
+  void failedExplicitFlushLeavesTheBatchUnusableAndClosesQuietly() {
+    try (final RecordingBatchDatabase database = newRecordingDatabase()) {
+      database.command("sql", "CREATE VERTEX TYPE Person");
+
+      final RemoteGraphBatch batch = database.batch().build();
+      batch.createVertex("Person", "name", "Alice");
+
+      database.failNextSend = true;
+      assertThatThrownBy(batch::flush).isInstanceOf(ArcadeDBException.class).hasMessageContaining("simulated");
+
+      // Even if the transport recovers, the batch must not decide on its own to send that payload again.
+      database.failNextSend = false;
+      assertThatThrownBy(batch::flush).isInstanceOf(IllegalStateException.class).hasMessageContaining("previous flush failed");
+
+      assertThatNoException().isThrownBy(batch::close);
+      assertThat(database.sentPayloads).hasSize(1);
+
+      // Nothing was created: the only request the client made is the one that failed.
+      assertThat(countOf(database, "Person")).isZero();
+    }
+  }
+
+  /**
+   * A batch that never fails keeps working exactly as before: the buffered records are sent by {@code close()}.
+   */
+  @Test
+  void successfulBatchStillFlushesOnClose() {
+    try (final RecordingBatchDatabase database = newRecordingDatabase()) {
+      database.command("sql", "CREATE VERTEX TYPE Person");
+
+      try (final RemoteGraphBatch batch = database.batch().build()) {
+        batch.createVertex("Person", "name", "Alice");
+        batch.createVertex("Person", "name", "Bob");
+      }
+
+      assertThat(database.sentPayloads).hasSize(1);
+      assertThat(countOf(database, "Person")).isEqualTo(2);
+    }
+  }
+
+  /**
+   * The bug: {@code existsBucket()} resolved the name against {@code schema:types}, so a bucket attached to no
+   * type - including one just created through this same API - answered {@code false}.
+   */
+  @Test
+  void existsBucketSeesABucketAttachedToNoType() {
+    try (final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, DATABASE_NAME, "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)) {
+
+      assertThat(database.getSchema().existsBucket("standalone")).isFalse();
+
+      database.getSchema().createBucket("standalone");
+      assertThat(database.getSchema().existsBucket("standalone")).isTrue();
+
+      // A bucket that belongs to a type keeps answering true, and an unknown name still answers false.
+      database.command("sql", "CREATE DOCUMENT TYPE Person BUCKETS 1");
+      assertThat(database.getSchema().existsBucket("Person_0")).isTrue();
+      assertThat(database.getSchema().existsBucket("NotThere")).isFalse();
+
+      database.getSchema().dropBucket("standalone");
+      assertThat(database.getSchema().existsBucket("standalone")).isFalse();
+    }
+  }
+
+  private RecordingBatchDatabase newRecordingDatabase() {
+    return new RecordingBatchDatabase("127.0.0.1", 2480, DATABASE_NAME, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private static long countOf(final RemoteDatabase database, final String typeName) {
+    return database.countType(typeName, false);
+  }
+
+  /**
+   * Records every payload handed to the {@code /batch} endpoint and can fail the next one, which is how a
+   * response the client never sees - a socket reset after the server committed, a proxy timeout - reaches this
+   * class: indistinguishable, from here, from a server-side rejection.
+   */
+  private static class RecordingBatchDatabase extends RemoteDatabase {
+    final List<String> sentPayloads = new ArrayList<>();
+    boolean failNextSend = false;
+
+    RecordingBatchDatabase(final String server, final int port, final String databaseName, final String userName,
+        final String userPassword) {
+      super(server, port, databaseName, userName, userPassword);
+    }
+
+    @Override
+    JSONObject sendBatch(final String content, final Map<String, String> queryParams) {
+      sentPayloads.add(content);
+      if (failNextSend)
+        throw new ArcadeDBException("simulated failure of the batch request");
+      return super.sendBatch(content, queryParams);
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/RemoteSchemaPartialAccessIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/RemoteSchemaPartialAccessIT.java
@@ -117,6 +117,46 @@ class RemoteSchemaPartialAccessIT {
     }
   }
 
+  /**
+   * Issue #7031: {@code existsBucket()} now answers from {@code schema:buckets}, which walks every bucket of the
+   * database and counts its records - and so threw {@link SecurityException} on the first bucket the user cannot
+   * read, failing the call instead of answering it. Buckets the caller cannot read are hidden from that listing,
+   * exactly as restricted types are hidden from {@code schema:types} (issue #4238).
+   */
+  @Test
+  void existsBucketAnswersWhenUserLacksReadRecordOnSomeBuckets() {
+    SECURITY.createUser(new JSONObject().put("name", USER).put("password", SECURITY.encodePassword(PWD))
+        .put("databases", new JSONObject().put(DATABASE_NAME, new JSONArray(new String[] { "readerOfDocuments" }))));
+
+    try {
+      final DatabaseInternal database = SERVER.getDatabase(DATABASE_NAME);
+      database.getSchema().getOrCreateVertexType("AllowedDocument");
+      database.getSchema().getOrCreateVertexType("RestrictedVertex");
+
+      final String[] address = HostUtil.parseHostAddress(SERVER.getHttpServer().getListeningAddress(),
+          HostUtil.CLIENT_DEFAULT_PORT);
+
+      final RemoteDatabase remote = new RemoteDatabase(address[0], Integer.parseInt(address[1]), DATABASE_NAME, USER, PWD);
+
+      assertThat(remote.getSchema().existsBucket("AllowedDocument_0")).isTrue();
+      assertThat(remote.getSchema().existsBucket("RestrictedVertex_0")).isFalse();
+      assertThat(remote.getSchema().existsBucket("NotThere")).isFalse();
+
+      // Sanity: root continues to see every bucket.
+      final RemoteDatabase rootRemote = new RemoteDatabase(address[0], Integer.parseInt(address[1]), DATABASE_NAME, "root",
+          "dD5ed08c");
+      assertThat(rootRemote.getSchema().existsBucket("AllowedDocument_0")).isTrue();
+      assertThat(rootRemote.getSchema().existsBucket("RestrictedVertex_0")).isTrue();
+    } finally {
+      final DatabaseInternal database = SERVER.getDatabase(DATABASE_NAME);
+      if (database.getSchema().existsType("RestrictedVertex"))
+        database.getSchema().dropType("RestrictedVertex");
+      if (database.getSchema().existsType("AllowedDocument"))
+        database.getSchema().dropType("AllowedDocument");
+      SECURITY.dropUser(USER);
+    }
+  }
+
   @BeforeAll
   static void beforeAll() {
     FileUtils.deleteRecursively(new File("./target/config"));


### PR DESCRIPTION
Fixes #7031 and #7030 - three defects in the remote client, plus the server-side listing one of them now depends on.

## #7031 part 1 - `RemoteGraphBatch.flush()` re-sent a failed payload on `close()`

`flush()` cleared its buffer only on the success path, so a flush that threw left the payload buffered and the `close()` that followed - directly, or from try-with-resources during exception unwinding - sent it again.

When the failure was a response the client never saw rather than a server-side rejection (a socket reset after the server committed, a proxy timeout), the records were already created and that second send created every one of them twice. Each flush is an independent request the server does not remember, so the client cannot tell the two cases apart and must not decide to re-send on its own initiative.

The issue suggested clearing the buffer in a `finally` **or** marking the batch failed. The second is the better half of that choice and this PR takes it, because a bare `finally` drops the payload silently: a caller that catches the flush failure and keeps going gets a batch that looks usable and is quietly missing records. Instead `flush()` raises a `failed` flag before the request and lowers it only once the payload is fully accounted for - so anything thrown in between, including the `idMappingOmitted` check that runs after the send succeeded, leaves it raised. A later `flush()` then fails fast with an explanation, and `close()` releases the payload without sending anything and without raising a second exception on top of the one the caller is unwinding with. Retrying, if the load is safe to repeat, stays the caller's decision and needs a new batch.

`RemoteGrpcGraphBatch` already handles the same hazard this way on its own transport ("the buffer is handed over before anything that can fail"), so the two loaders now agree.

## #7031 part 2 - `RemoteSchema.existsBucket()` answered from `schema:types`

It resolved the name against the type list, so a bucket attached to no type - including one the caller had just created through this same API - answered `false`. It now asks `schema:buckets`.

That listing counts the records of every bucket, and `countBucket()` throws `SecurityException` on the first bucket the current user cannot read, which aborted the whole listing rather than answering the question. `FetchFromSchemaBucketsStep` now hides buckets the caller cannot read, exactly as `FetchFromSchemaTypesStep` has hidden restricted types since #4238; without this, `existsBucket()` throws for any non-root user with a per-type ACL (and so does Studio's bucket list, which runs the same query). A `null` user - embedded usage, no security context - and a bucket the security map does not cover both keep seeing everything, so nothing changes for the unrestricted case.

Sourcing `RemoteSchema.reload()`'s bucket cache from `schema:buckets` as well was considered and rejected: it would add a second round trip to every schema reload for a cache only the deprecated `getBucketByName*()` accessors read.

## #7030 - `RemoteDatabase.transaction()` missing two guards `LocalDatabase` has

- **Retrying a transaction the caller owns.** `transaction(block, true)` that joined an outer transaction and then hit a `NeedRetryException` re-ran the block inside the caller's still-open transaction, which accumulated the partial effects of every failed attempt without the owner ever being told. That is the guard #661 established locally; the block now runs once and the exception reaches the transaction's owner.
- **No rollback before the retry.** Each failed attempt left its server-side transaction open holding its locks until the server timed it out, so attempt N+1 contended with the locks of attempt N - making a `NeedRetryException` more likely, not less. Both catch arms now roll back first.

The rollback goes through a small helper rather than a bare `rollback()` call: on these paths the exception being handled is the one the caller has to see, and a rollback that fails on its way out (session already gone server-side, connection broken) must not replace it. The order matters too - `setSessionId(null)` runs *after* the rollback, since clearing it first would make `isTransactionActive()` false and turn the rollback into a no-op.

Extracting the shared retry policy so the two implementations cannot drift again, as the issue suggests, is worth doing but is a larger refactor of both call sites (the local one carries the `#4959`/`#5061` duplicated-key logic and the retry delays, neither of which exists remotely); it is deliberately left out of this fix.

## Tests

- `Issue7031RemoteClientIT` - a failed interior auto-flush is not re-sent by `close()`, a failed explicit `flush()` leaves the batch unusable and closes quietly, a successful batch still flushes on close, and `existsBucket()` sees a bucket attached to no type.
- `Issue7030RemoteTransactionRetryIT` - a joined transaction is not retried and the caller's transaction survives, every failed attempt is rolled back before the retry, and the fatal arm rolls back before rethrowing.
- `RemoteSchemaPartialAccessIT` - a new case for `existsBucket()` under a partial-access ACL, alongside the existing #4238 one.

Each of the seven new/changed test methods was confirmed to fail against the unfixed sources. Also re-ran `RemoteGraphBatchIT`, `RemoteSchemaIT`, `RemoteDatabaseIT`, `RemoteDatabaseJavaApiIT`, `RemoteTypesIT`, `Issue5279Remote*`, `Issue2590UniqueConstraintUpdateIT`, `Issue1515IT`, `Issue4267CountTypeIT`, `RemoteMaterializedViewIT` (46 + 19 green) and the engine tests covering `schema:buckets` (`ExternalPropertyTest`, `SQLExecutorAdditionalCoverageTest`, 106 green).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema bucket visibility now respects read permissions, while users without security rules retain existing visibility.
  * Standalone buckets are correctly recognized by schema checks.
  * Remote transaction failures now roll back safely and avoid retrying caller-owned transactions.
  * Failed remote graph batch flushes are no longer retried during close, preventing duplicate submissions and leaving failed batches unusable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->