### PR TITLE
Fix HA follow-ups: cluster status membership (#7040), bootstrap seeding race (#7011), wedged Raft log writer (#7037), exporter raw casts (#7041)

### DIFF
--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -40,7 +40,7 @@ The shutdown trigger has a counterintuitive consequence when reproducing durabil
 
 ## Peer-list filtering is duplicated across three methods
 
-`RaftHAServer` iterates `raftGroup.getPeers()` and applies its own copy of the leader-exclusion criterion in three places:
+`RaftHAServer` applies its own copy of the leader-exclusion criterion in three places:
 
 - `getStats()` - feeds `ha.network.replicas` in `/api/v1/server?mode=cluster`
 - `getReplicaAddresses()` - feeds `ha.replicaAddresses` in the same response
@@ -48,7 +48,7 @@ The shutdown trigger has a counterintuitive consequence when reproducing durabil
 
 Each has its own local `excludeId` derivation (`leaderId != null ? leaderId : localPeerId`, or the leader directly). They are not factored into a shared helper, so a fix applied to one silently leaves the others wrong and the cluster API response internally inconsistent.
 
-**Any change to what "replica" means must be applied to all three.** Grep `RaftHAServer.java` for `getPeers()` before claiming such a fix is complete. This has already caused one incomplete fix that review caught.
+**Any change to what "replica" means must be applied to all three.** This has already caused one incomplete fix that review caught, twice: the second time (#7040) `/api/v1/cluster` learned to tell a declared peer from a member of the live Raft configuration while these three still iterated the static `raftGroup.getPeers()`. Since then the membership itself comes from one place - `ClusterMembership.of(raftGroup.getPeers(), getLivePeers()).configuredPeers()`, read through `RaftHAServer.configuredPeers()` - and `GetClusterHandler` reads the same reconciliation. Grep `RaftHAServer.java` for `raftGroup.getPeers()` before claiming such a fix is complete: the only legitimate direct readers left are the ones that want the *declared* list on purpose (`getConfiguredServers()`, the presence matrix, the membership reconciliation itself).
 
 ## Anything that commits must hold the WRAPPED database instance, not the inner one
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -828,6 +828,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
   /**
    * Ratis reports a log write failure here from the segmented log worker thread. Cheap and non-blocking by
    * contract; the recovery runs on the {@link HealthMonitor} thread, driven by {@link #getRaftLogFailure()}.
+   * <p>
+   * The check-then-set on {@link #raftLogFailure} is not atomic and does not need to be: Ratis runs one
+   * {@code SegmentedRaftLogWorker} thread per division and every {@code notifyLogFailed} call for this state
+   * machine comes from it, in order. The field is volatile only so the monitor thread sees the mark promptly.
    */
   @Override
   public void notifyLogFailed(final Throwable cause, final LogEntryProto failedEntry) {
@@ -2750,11 +2754,21 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // stood at sampling time, and everyone else's snapshot comes from this copy. Writes accepted between the
     // sample and this apply legitimately move it past the baseline; refusing it here poisoned the leader of a
     // cluster that seeded its databases right after election, and the cluster never converged.
-    if (originatedLocally && localLastTxId >= chosenLastTxId) {
-      LogManager.instance().log(this, Level.INFO,
-          "Database '%s' is the bootstrap source on this node (local lastTxId=%d, baseline lastTxId=%d): the local copy "
-              + "is the baseline, nothing to verify",
-          dbName, localLastTxId, chosenLastTxId);
+    if (originatedLocally) {
+      if (localLastTxId >= chosenLastTxId)
+        LogManager.instance().log(this, Level.INFO,
+            "Database '%s' is the bootstrap source on this node (local lastTxId=%d, baseline lastTxId=%d): the local copy "
+                + "is the baseline, nothing to verify",
+            dbName, localLastTxId, chosenLastTxId);
+      else
+        // A committed transaction id never moves backwards, so the source's copy cannot sit behind the baseline it
+        // sampled from that same copy. Should it ever happen (a database replaced under the running server), the
+        // copy is still the one every other peer installs from: keep it and say so, rather than fall through to
+        // the mismatch branch and have this node reinstall from itself.
+        LogManager.instance().log(this, Level.WARNING,
+            "Database '%s' is the bootstrap source on this node but its local lastTxId=%d is BELOW the baseline "
+                + "lastTxId=%d it sampled; keeping the local copy, which is what the other peers install from",
+            dbName, localLastTxId, chosenLastTxId);
       return;
     }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -160,6 +160,31 @@ public class ArcadeStateMachine extends BaseStateMachine {
   private volatile ArcadeDBServer server;
   private volatile RaftHAServer   raftHAServer;
 
+  /**
+   * The first persistent Raft log write failure Ratis reported through {@link #notifyLogFailed}, or {@code null}
+   * while the log writer is healthy (issue #7037). Once the segmented log worker hits an I/O error - {@code No
+   * space left on device} being the reported one - Ratis marks the log failed at that index and fails every later
+   * append with {@code RaftLogIOException: Log already failed at index N}, while the division stays {@code RUNNING}:
+   * no lifecycle state, lag or divergence check can see it, so the state machine keeps the mark and the
+   * {@link HealthMonitor} restarts the server in place once the volume has room again. Set once per state-machine
+   * lifetime: a restart builds a fresh state machine, which is what clears it.
+   */
+  private volatile RaftLogFailure raftLogFailure;
+  /**
+   * The Ratis {@code StateMachineUpdater} thread, recorded on every apply so callers that reach
+   * {@link SnapshotInstaller} from an entry apply can tell they are on it (issue #7037): a snapshot request
+   * blocks until that same thread takes it, so it must not be issued from there.
+   */
+  private volatile Thread         applyThread;
+
+  /** A persistent Raft log write failure: the failed entry's index ({@code -1} for a whole segment) and the cause. */
+  public record RaftLogFailure(long index, String cause, long timestamp) {
+    /** One-line description for logs and the health monitor. */
+    public String describe() {
+      return (index >= 0 ? "at index " + index : "on a log segment") + ": " + cause;
+    }
+  }
+
   /** Multiplier applied to HA_ELECTION_TIMEOUT_MAX when flooring the watchdog timeout. */
   static final int WATCHDOG_ELECTION_TIMEOUT_MULTIPLIER = 4;
 
@@ -800,12 +825,42 @@ public class ArcadeStateMachine extends BaseStateMachine {
         .build();
   }
 
+  /**
+   * Ratis reports a log write failure here from the segmented log worker thread. Cheap and non-blocking by
+   * contract; the recovery runs on the {@link HealthMonitor} thread, driven by {@link #getRaftLogFailure()}.
+   */
+  @Override
+  public void notifyLogFailed(final Throwable cause, final LogEntryProto failedEntry) {
+    super.notifyLogFailed(cause, failedEntry);
+    // Ratis reports every later task against the same pinned exception: the first failure is the one that matters.
+    if (raftLogFailure != null)
+      return;
+    final long index = failedEntry != null ? failedEntry.getIndex() : -1L;
+    final String message = cause != null ? cause.toString() : "unknown cause";
+    raftLogFailure = new RaftLogFailure(index, message, System.currentTimeMillis());
+    LogManager.instance().log(this, Level.SEVERE,
+        "Raft log write failed %s. Ratis has marked the log failed: every later append is rejected until the server "
+            + "is restarted. The health monitor will restart it in place once the Raft storage volume has room "
+            + "again (issue #7037)", cause, index >= 0 ? "at index " + index : "on a log segment");
+  }
+
+  /** The first persistent Raft log write failure, or {@code null} while the log writer is healthy (issue #7037). */
+  public RaftLogFailure getRaftLogFailure() {
+    return raftLogFailure;
+  }
+
+  /** Whether the current thread is the Ratis apply thread this state machine last applied an entry on. */
+  boolean isApplyThread() {
+    return Thread.currentThread() == applyThread;
+  }
+
   @Override
   public CompletableFuture<Message> applyTransaction(final TransactionContext trx) {
     final LogEntryProto entry = trx.getLogEntry();
     final ByteString data = entry.getStateMachineLogEntry().getLogData();
     final TermIndex termIndex = TermIndex.valueOf(entry);
     final long index = termIndex.getIndex();
+    applyThread = Thread.currentThread();
 
     // Refuse to apply once a prior entry tripped the critical-error halt. Continuing would
     // operate on the inconsistent in-memory state left behind by the failed apply and cascade
@@ -847,7 +902,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
         case INSTALL_DATABASE_ENTRY -> applyInstallDatabaseEntry(decoded);
         case DROP_DATABASE_ENTRY -> applyDropDatabaseEntry(decoded);
         case SECURITY_USERS_ENTRY -> applySecurityUsersEntry(decoded);
-        case BOOTSTRAP_FINGERPRINT_ENTRY -> applyBootstrapFingerprintEntry(decoded, index);
+        case BOOTSTRAP_FINGERPRINT_ENTRY -> applyBootstrapFingerprintEntry(decoded, index, originatedLocally);
         }
       });
 
@@ -2569,11 +2624,35 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * </ul>
    * The committed baseline is recorded in {@link #bootstrapBaselines} for status export and tests.
    * <p>
+   * Two rules keep the protocol honest on a cluster that starts taking writes while it is being born (issue
+   * #7011: the formation-time election samples whatever local databases exist at collect time, and the
+   * application typically creates and seeds its databases right after leader election):
+   * <ul>
+   *   <li><b>Superseded baseline.</b> A database that an application entry earlier in the log already
+   *       created or mutated on this node has its whole history inside the Raft log: the baseline sampled for
+   *       it is stale by construction and replication, not bootstrap, is what keeps the copies in step. The
+   *       entry is ignored for that database. The decision keys on this database's persisted applied index
+   *       being below the entry's index, which is the same on every peer because the log order is, so every
+   *       peer ignores or honours the same entry.</li>
+   *   <li><b>Bootstrap source.</b> The peer that committed the entry sampled the baseline from its own copy,
+   *       which is the copy the snapshot ships to everyone else. Its copy advancing past the sampled
+   *       {@code lastTxId} between the sample and the local apply (18 ms in the report) is the expected
+   *       outcome, not a fresher stray copy, so the overwrite refusal does not apply to it: the refusal is
+   *       only meaningful on a peer that did not source the baseline.</li>
+   * </ul>
+   * Neither rule is reachable on a genuine first formation - no application entry precedes the baseline
+   * there, and the source's copy equals the baseline - so the #4800 and #6124 guarantees are unchanged.
+   * <p>
    * Package-private (not private) so ArcadeStateMachineBootstrapMismatchTest can exercise the
    * install-failure recovery path directly instead of via reflection.
+   *
+   * @param originatedLocally whether this node submitted the entry, i.e. is the elected bootstrap source
+   *                          (see {@link #startTransaction}); {@code false} on replay, where the
+   *                          per-database replay-skip below settles the question instead
    */
   // @VisibleForTesting
-  void applyBootstrapFingerprintEntry(final RaftLogEntryCodec.DecodedEntry decoded, final long index) {
+  void applyBootstrapFingerprintEntry(final RaftLogEntryCodec.DecodedEntry decoded, final long index,
+      final boolean originatedLocally) {
     final String dbName = decoded.databaseName();
     final String chosenFingerprint = decoded.bootstrapFingerprint();
     final long chosenLastTxId = decoded.bootstrapLastTxId();
@@ -2583,6 +2662,21 @@ public class ArcadeStateMachine extends BaseStateMachine {
           dbName, chosenFingerprint);
       return;
     }
+
+    final long persistedApplied = readPersistedAppliedIndex(dbName);
+    if (persistedApplied >= 0 && persistedApplied < index) {
+      // Superseded (issue #7011): an application entry for this database was applied before this baseline was
+      // committed, so the database was created or mutated through Raft on this cluster and its copies are
+      // kept in step by replication. Honouring the baseline would either refuse the copy as "fresher" (it is
+      // not: it is the replicated state) or reinstall it from a snapshot the following entries then re-apply.
+      // The baseline is not recorded: it describes a state this cluster never adopted.
+      LogManager.instance().log(this, Level.INFO,
+          "Bootstrap baseline for '%s' (lastTxId=%d) ignored: the database already has Raft history on this node "
+              + "(applied index %d precedes the baseline at index %d), so replication keeps it in step",
+          dbName, chosenLastTxId, persistedApplied, index);
+      return;
+    }
+
     recordBootstrapBaseline(dbName, new BootstrapBaseline(chosenFingerprint, chosenLastTxId));
 
     // Re-application during log replay on restart: if we've persisted an applied index at or
@@ -2605,7 +2699,6 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // data loss, just a SEVERE log line); a genuinely-behind copy re-installs from the leader, which
     // is the correct action anyway. From the first post-upgrade apply onwards the per-database map is
     // authoritative.
-    final long persistedApplied = readPersistedAppliedIndex(dbName);
     if (persistedApplied >= index) {
       HALog.log(this, HALog.BASIC,
           "Bootstrap baseline for '%s' already applied (persistedAppliedIndex=%d >= entryIndex=%d); skipping verification",
@@ -2650,6 +2743,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.INFO,
           "Database '%s' bootstrapped locally (lastTxId=%d, fingerprint matches cluster baseline)",
           dbName, chosenLastTxId);
+      return;
+    }
+
+    // The bootstrap source (issue #7011): this node committed the entry, so the baseline IS its own copy as it
+    // stood at sampling time, and everyone else's snapshot comes from this copy. Writes accepted between the
+    // sample and this apply legitimately move it past the baseline; refusing it here poisoned the leader of a
+    // cluster that seeded its databases right after election, and the cluster never converged.
+    if (originatedLocally && localLastTxId >= chosenLastTxId) {
+      LogManager.instance().log(this, Level.INFO,
+          "Database '%s' is the bootstrap source on this node (local lastTxId=%d, baseline lastTxId=%d): the local copy "
+              + "is the baseline, nothing to verify",
+          dbName, localLastTxId, chosenLastTxId);
       return;
     }
 
@@ -2737,6 +2842,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
                 + "the HealthMonitor backstop will retry once the server is available", null, dbName);
       }
     }
+  }
+
+  /** Test convenience: applies the entry as a peer that did not source the baseline. */
+  // @VisibleForTesting
+  void applyBootstrapFingerprintEntry(final RaftLogEntryCodec.DecodedEntry decoded, final long index) {
+    applyBootstrapFingerprintEntry(decoded, index, false);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2652,7 +2652,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
    *
    * @param originatedLocally whether this node submitted the entry, i.e. is the elected bootstrap source
    *                          (see {@link #startTransaction}); {@code false} on replay, where the
-   *                          per-database replay-skip below settles the question instead
+   *                          per-database replay-skip below settles the question instead. The marker is set
+   *                          only on the node whose own client submitted the request, which is always the
+   *                          source: {@code BootstrapElection} never commits on behalf of a remote source -
+   *                          it transfers leadership to it and that node commits the entry once it leads
    */
   // @VisibleForTesting
   void applyBootstrapFingerprintEntry(final RaftLogEntryCodec.DecodedEntry decoded, final long index,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
@@ -105,6 +105,8 @@ public class ClusterAlerts {
    */
   public static JSONArray scan(final ArcadeDBServer server, final ArcadeStateMachine stateMachine,
       final List<FollowerSample> followerSamples, final Set<String> visibleDatabases) {
+    // No membership check here on purpose: reconciling the declared list against the live Raft configuration
+    // needs the RaftHAServer, which only the HA cluster endpoint holds. Callers that have it pass it explicitly.
     return scan(server, stateMachine, followerSamples, visibleDatabases, null, null);
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
@@ -105,6 +105,20 @@ public class ClusterAlerts {
    */
   public static JSONArray scan(final ArcadeDBServer server, final ArcadeStateMachine stateMachine,
       final List<FollowerSample> followerSamples, final Set<String> visibleDatabases) {
+    return scan(server, stateMachine, followerSamples, visibleDatabases, null, null);
+  }
+
+  /**
+   * Scan overload that also flags a divergence between the declared peer list and the live Raft configuration
+   * (issue #7040). Pass {@code null} for {@code membership} when HA is unavailable; {@code localPeerId} names
+   * this node so the alert can escalate when it is this node that the configuration no longer contains.
+   * <p>
+   * Node-scoped like the lagging-follower alert: it names peers, never databases, so {@code visibleDatabases}
+   * does not apply to it.
+   */
+  public static JSONArray scan(final ArcadeDBServer server, final ArcadeStateMachine stateMachine,
+      final List<FollowerSample> followerSamples, final Set<String> visibleDatabases,
+      final ClusterMembership membership, final String localPeerId) {
     final JSONArray alerts = new JSONArray();
     checkSingleBucketTypes(server, alerts, visibleDatabases);
     if (stateMachine != null) {
@@ -113,7 +127,65 @@ public class ClusterAlerts {
       checkBootstrapDivergedDatabases(stateMachine, alerts, visibleDatabases);
     }
     addLaggingFollowerAlert(followerSamples, alerts);
+    if (membership != null)
+      addMembershipDivergenceAlert(membership.notInConfiguration(), membership.notInServerList(), localPeerId, alerts);
     return alerts;
+  }
+
+  /**
+   * Pure alert builder (package-private for unit testing): appends the membership-divergence alert iff the
+   * declared peer list and the live Raft configuration differ (issue #7040).
+   * <p>
+   * A declared peer missing from the configuration is the condition #5275 asked to surface: the leader does not
+   * replicate to it and it cannot vote, so the cluster runs with less failover margin than the operator believes,
+   * and until #5275 a Kubernetes restart could shrink the configuration silently. It is {@code warning} in
+   * general and {@code critical} when the missing peer is this node, which then serves nothing until it rejoins.
+   * A committed member the list does not declare is only {@code info}: it was added deliberately through the
+   * management API, but a restart of this node will not know it, so the operator should update the list.
+   */
+  static void addMembershipDivergenceAlert(final List<String> notInConfiguration, final List<String> notInServerList,
+      final String localPeerId, final JSONArray alerts) {
+    if (notInConfiguration != null && !notInConfiguration.isEmpty()) {
+      final boolean localExcluded = localPeerId != null && notInConfiguration.contains(localPeerId);
+      final JSONArray names = new JSONArray();
+      for (final String name : notInConfiguration)
+        names.put(name);
+
+      alerts.put(new JSONObject()
+          .put("id", "peers-not-in-configuration")
+          .put("severity", localExcluded ? SEVERITY_CRITICAL : SEVERITY_WARNING)
+          .put("title", localExcluded ? "This node is not in the Raft configuration"
+              : "Declared peer(s) are not in the Raft configuration")
+          .put("message", (localExcluded ? "This node (" + localPeerId + ") is declared in arcadedb.ha.serverList but the "
+              + "live Raft configuration does not contain it: it cannot vote, the leader does not replicate to it, and it "
+              + "serves no traffic until it rejoins. "
+              : "")
+              + notInConfiguration.size() + " declared peer(s) are not in the live Raft configuration: " + notInConfiguration
+              + ". They are not replicated to and do not count toward the quorum, so the cluster is running with less "
+              + "failover margin than the server list suggests. Reachable through DELETE /api/v1/cluster/peer/{id}, or on a "
+              + "cluster shrunk by a build predating #5275 before the peer restarted.")
+          .put("recommendation", "Re-add the peer with POST /api/v1/cluster/peer (a peer running with "
+              + "arcadedb.ha.k8s=true re-adds itself on restart), or remove it from arcadedb.ha.serverList on every node "
+              + "if the removal was intended.")
+          .put("details", new JSONObject().put("peers", names)));
+    }
+
+    if (notInServerList != null && !notInServerList.isEmpty()) {
+      final JSONArray names = new JSONArray();
+      for (final String name : notInServerList)
+        names.put(name);
+
+      alerts.put(new JSONObject()
+          .put("id", "peers-not-in-server-list")
+          .put("severity", SEVERITY_INFO)
+          .put("title", "Configuration member(s) not declared in the server list")
+          .put("message", notInServerList.size() + " member(s) of the live Raft configuration are not declared in this "
+              + "node's arcadedb.ha.serverList: " + notInServerList + ". They replicate normally, but this node will not "
+              + "know them after a restart until the configuration is read back from Raft storage.")
+          .put("recommendation", "Add the peer(s) to arcadedb.ha.serverList on every node so the declared list and the "
+              + "cluster agree.")
+          .put("details", new JSONObject().put("peers", names)));
+    }
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMembership.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMembership.java
@@ -42,7 +42,14 @@ import java.util.Set;
  * operator declared plus every peer the cluster committed - and says for each whether it is in the configuration.
  * <p>
  * Pure value: the order of {@link #peers()} is the static order first (stable across polls, the order the operator
- * wrote), then the live-only peers in configuration order.
+ * wrote), then the live-only peers in configuration order. For an id present in both lists the <b>live</b> entry
+ * is kept: its address is the one the cluster committed and dials, and a peer that rejoined at a new address under
+ * its old id would otherwise be reported at the declared, stale one.
+ * <p>
+ * {@link #configuredPeers()} is the view every "which peers are members" consumer in {@link RaftHAServer} reads -
+ * the server stats, the replica address list and the client routing table - so a peer the configuration dropped
+ * disappears from all of them at once instead of from the one that happened to be fixed (see the module's
+ * {@code CLAUDE.md}, "Peer-list filtering").
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -75,7 +82,8 @@ final class ClusterMembership {
     final List<String> notInServerList = new ArrayList<>();
     for (final RaftPeer peer : livePeers) {
       configured.add(peer.getId());
-      if (byId.putIfAbsent(peer.getId(), peer) == null)
+      // put() keeps the declared position (LinkedHashMap does not reorder on replace) and takes the live entry.
+      if (byId.put(peer.getId(), peer) == null)
         notInServerList.add(peer.getId().toString());
     }
 
@@ -91,6 +99,15 @@ final class ClusterMembership {
   /** Every peer known to this node: the static list first, then the peers only the live configuration holds. */
   List<RaftPeer> peers() {
     return peers;
+  }
+
+  /** The members of the live Raft configuration, in the order of {@link #peers()}. */
+  List<RaftPeer> configuredPeers() {
+    final List<RaftPeer> result = new ArrayList<>(configured.size());
+    for (final RaftPeer peer : peers)
+      if (configured.contains(peer.getId()))
+        result.add(peer);
+    return result;
   }
 
   /** Whether {@code peerId} is a member of the live Raft configuration. */

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMembership.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMembership.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The reconciliation of the two peer lists a node knows about: the <b>static</b> group built once at startup from
+ * {@code arcadedb.ha.serverList}, and the <b>live</b> Raft configuration, which membership changes ({@code DELETE
+ * /api/v1/cluster/peer/<id>}, {@code POST /api/v1/cluster/peer}, a shrink by a pre-#5275 build) move away from it
+ * over the node's lifetime.
+ * <p>
+ * {@code /api/v1/cluster} used to build its peer list from the static group alone and label every entry
+ * {@code FOLLOWER}, so a peer removed from the live configuration kept reading as a healthy member with an address,
+ * indistinguishable from a working one (issue #7040). The status endpoint now reports the union - every peer the
+ * operator declared plus every peer the cluster committed - and says for each whether it is in the configuration.
+ * <p>
+ * Pure value: the order of {@link #peers()} is the static order first (stable across polls, the order the operator
+ * wrote), then the live-only peers in configuration order.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class ClusterMembership {
+  private final List<RaftPeer>   peers;
+  private final Set<RaftPeerId>  configured;
+  private final List<String>     notInConfiguration;
+  private final List<String>     notInServerList;
+
+  private ClusterMembership(final List<RaftPeer> peers, final Set<RaftPeerId> configured,
+      final List<String> notInConfiguration, final List<String> notInServerList) {
+    this.peers = peers;
+    this.configured = configured;
+    this.notInConfiguration = notInConfiguration;
+    this.notInServerList = notInServerList;
+  }
+
+  /**
+   * Reconciles the static group against the live configuration.
+   *
+   * @param staticPeers the peers of {@code arcadedb.ha.serverList}, in declaration order
+   * @param livePeers   the peers of the current Raft configuration
+   */
+  static ClusterMembership of(final Collection<RaftPeer> staticPeers, final Collection<RaftPeer> livePeers) {
+    final Map<RaftPeerId, RaftPeer> byId = new LinkedHashMap<>();
+    for (final RaftPeer peer : staticPeers)
+      byId.put(peer.getId(), peer);
+
+    final Set<RaftPeerId> configured = new HashSet<>();
+    final List<String> notInServerList = new ArrayList<>();
+    for (final RaftPeer peer : livePeers) {
+      configured.add(peer.getId());
+      if (byId.putIfAbsent(peer.getId(), peer) == null)
+        notInServerList.add(peer.getId().toString());
+    }
+
+    final List<String> notInConfiguration = new ArrayList<>();
+    for (final RaftPeer peer : staticPeers)
+      if (!configured.contains(peer.getId()))
+        notInConfiguration.add(peer.getId().toString());
+
+    return new ClusterMembership(Collections.unmodifiableList(new ArrayList<>(byId.values())), configured,
+        Collections.unmodifiableList(notInConfiguration), Collections.unmodifiableList(notInServerList));
+  }
+
+  /** Every peer known to this node: the static list first, then the peers only the live configuration holds. */
+  List<RaftPeer> peers() {
+    return peers;
+  }
+
+  /** Whether {@code peerId} is a member of the live Raft configuration. */
+  boolean isInConfiguration(final RaftPeerId peerId) {
+    return configured.contains(peerId);
+  }
+
+  /** Ids of the declared peers that the live configuration no longer contains, in declaration order. */
+  List<String> notInConfiguration() {
+    return notInConfiguration;
+  }
+
+  /** Ids of the committed members that {@code arcadedb.ha.serverList} does not declare, in configuration order. */
+  List<String> notInServerList() {
+    return notInServerList;
+  }
+
+  /** Whether the two lists differ at all. */
+  boolean diverged() {
+    return !notInConfiguration.isEmpty() || !notInServerList.isEmpty();
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -57,6 +57,12 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
 
   private final RaftHAPlugin plugin;
 
+  /**
+   * {@code role} of a peer that {@code arcadedb.ha.serverList} declares but the live Raft configuration does not
+   * contain (issue #7040). The other two values are {@code LEADER} and {@code FOLLOWER}.
+   */
+  static final String ROLE_NOT_IN_CONFIGURATION = "NOT_IN_CONFIGURATION";
+
   public GetClusterHandler(final HttpServer httpServer, final RaftHAPlugin plugin) {
     super(httpServer);
     this.plugin = plugin;
@@ -126,12 +132,22 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
     // peer only if no other peer resolves to it, so asking per peer would resolve the group once per peer.
     final Map<RaftPeerId, RaftHAServer.PeerHttpEndpoint> httpEndpoints = raftHAServer.getPeerHttpEndpoints();
 
+    // The static group is what the operator declared; the live configuration is what the cluster committed. A
+    // peer removed from the configuration (DELETE /api/v1/cluster/peer/<id>, or a shrink by a pre-#5275 build)
+    // used to keep reading here as a healthy FOLLOWER with an address, because only the static list was consulted
+    // (issue #7040). Report both: every known peer, each flagged with its membership, so monitoring built on this
+    // endpoint can tell a working member from a peer the cluster no longer counts on.
+    final ClusterMembership membership = ClusterMembership.of(raftHAServer.getRaftGroup().getPeers(),
+        raftHAServer.getLivePeers());
+
     final JSONArray peers = new JSONArray();
-    for (final RaftPeer peer : raftHAServer.getRaftGroup().getPeers()) {
+    for (final RaftPeer peer : membership.peers()) {
       final JSONObject peerJson = new JSONObject();
       final String peerId = peer.getId().toString();
       peerJson.put("id", peerId);
       peerJson.put("address", peer.getAddress());
+      final boolean inConfiguration = membership.isInConfiguration(peer.getId());
+      peerJson.put("inConfiguration", inConfiguration);
       // Both fields are written only when they have something to say: a peer whose endpoint cannot be resolved
       // carries neither, and a correctly declared cluster carries no flag.
       final RaftHAServer.PeerHttpEndpoint httpEndpoint = httpEndpoints.get(peer.getId());
@@ -142,7 +158,9 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
       }
 
       final boolean peerIsLeader = leaderId != null && peer.getId().equals(leaderId);
-      peerJson.put("role", peerIsLeader ? "LEADER" : "FOLLOWER");
+      // A peer outside the configuration is not a follower: the leader does not replicate to it and it cannot
+      // vote. Naming that state in the role keeps a consumer that only reads roles from mistaking it for one.
+      peerJson.put("role", peerIsLeader ? "LEADER" : inConfiguration ? "FOLLOWER" : ROLE_NOT_IN_CONFIGURATION);
 
       final HAReplicationStatsProvider.FollowerSample health = followerHealth.get(peerId);
       if (!peerIsLeader && health != null) {
@@ -212,8 +230,11 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
     // leader). Surfaced in Studio's HA panel so operators see actionable warnings without log-grepping.
     // Scoped like the database list above, because the alert payloads name databases and, for the
     // single-bucket check, their type names too.
+    // The membership divergence is a cluster-level condition: the only one on this endpoint that nothing else
+    // flags, and the one an operator most needs told rather than left to diff the peer list by eye (issue #7040).
     response.put("alerts",
-        ClusterAlerts.scan(httpServer.getServer(), stateMachine, followerSamples, authorizedDatabases));
+        ClusterAlerts.scan(httpServer.getServer(), stateMachine, followerSamples, authorizedDatabases, membership,
+            localPeerId.toString()));
 
     return new ExecutionResponse(200, response.toString());
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -154,9 +154,10 @@ public final class HealthMonitor {
   private static final long REFORMAT_EPISODE_RESET_MULTIPLIER = 5L;
 
   /**
-   * Log-writer recovery (issue #7037): restarts fired more than this long after the previous one start a new
-   * episode, so a volume that fills again much later is recovered again instead of hitting a budget spent on an
-   * old incident. Package-private for tests.
+   * Log-writer recovery (issue #7037): once the log writer has been healthy for this long after a recovery, the
+   * incident is over and the restart budget re-arms, so a volume that fills again much later is recovered again
+   * instead of hitting a budget spent on an old incident. A failure that never clears never re-arms it.
+   * Package-private for tests.
    */
   static final long LOG_FAILURE_EPISODE_RESET_MS = 10L * 60_000L;
 
@@ -188,10 +189,11 @@ public final class HealthMonitor {
   private          int                      crashRestartStreak          = 0;
   private          boolean                  crashLoopReformatTried       = false;
   private          boolean                  crashLoopEscalated           = false;
-  // Log-writer recovery (#7037): in-place restarts fired in the current failure episode, when the last one
-  // fired, when the "deferred" line was last logged, and whether the budget for this episode is spent (logged once).
+  // Log-writer recovery (#7037): in-place restarts fired in the current failure episode, since when the writer
+  // has been observed healthy again after them (-1 = not yet, or no episode), when the "deferred" line was last
+  // logged, and whether the budget for this episode is spent (logged once).
   private          int                      logFailureRestarts           = 0;
-  private          long                     lastLogFailureRestartMs      = -1;
+  private          long                     logFailureClearSinceMs       = -1;
   private          long                     lastLogFailureDeferredWarnMs = -1;
   private          boolean                  logFailureEscalated          = false;
   // Injectable for deterministic tests; defaults to the system clock.
@@ -292,7 +294,7 @@ public final class HealthMonitor {
       handleFailedLogWriter(logFailure);
       return;
     }
-    logFailureEscalated = false;
+    noteLogWriterHealthy();
     // checkStaleFollower (lag: commit - applied > threshold) and checkStuckFollower (divergence:
     // commit == applied) are mutually exclusive by construction, so at most one arms per tick.
     checkStaleFollower();
@@ -372,6 +374,7 @@ public final class HealthMonitor {
    */
   private void handleFailedLogWriter(final String failure) {
     final long now = clock.getAsLong();
+    logFailureClearSinceMs = -1; // the incident is ongoing: the healthy streak, if any, is over
 
     if (!target.isRaftStorageWritable()) {
       if (lastLogFailureDeferredWarnMs < 0 || now - lastLogFailureDeferredWarnMs >= LOG_FAILURE_DEFERRED_WARNING_THROTTLE_MS) {
@@ -384,30 +387,44 @@ public final class HealthMonitor {
       return;
     }
 
-    if (logFailureRestarts > 0 && now - lastLogFailureRestartMs >= LOG_FAILURE_EPISODE_RESET_MS) {
-      logFailureRestarts = 0;
-      logFailureEscalated = false;
-    }
-
     if (crashLoopRestartThreshold > 0 && logFailureRestarts >= crashLoopRestartThreshold) {
       if (!logFailureEscalated) {
         logFailureEscalated = true;
         LogManager.instance().log(this, Level.SEVERE,
             "Raft log writer failed again (%s) after %d in-place restarts with free space available; the failure is "
-                + "not about space. Giving up automatic restart for %d minutes - operator intervention required "
-                + "(check the Raft storage volume for I/O errors or permission changes)",
-            failure, logFailureRestarts, LOG_FAILURE_EPISODE_RESET_MS / 60_000L);
+                + "not about space. Giving up automatic restart - operator intervention required (check the Raft "
+                + "storage volume for I/O errors or permission changes)",
+            failure, logFailureRestarts);
       }
       return;
     }
 
     logFailureRestarts++;
-    lastLogFailureRestartMs = now;
     LogManager.instance().log(this, Level.WARNING,
         "Raft log writer failed %s; the Raft storage volume has room again, restarting Ratis in place to resume "
             + "replication (attempt %d, issue #7037)", failure, logFailureRestarts);
     target.restartRatisIfNeeded();
     resetStreaksAfterRestart();
+  }
+
+  /**
+   * Healthy log writer observed. The restart budget of a past incident re-arms only once the writer has stayed
+   * healthy for {@link #LOG_FAILURE_EPISODE_RESET_MS}: a restart clears the mark (fresh state machine), so a
+   * failure that comes straight back is the same incident and keeps consuming the same budget, while one that
+   * returns much later is a new incident. A budget exhausted while the failure persists is never re-armed by
+   * time alone.
+   */
+  private void noteLogWriterHealthy() {
+    if (logFailureRestarts == 0)
+      return;
+    final long now = clock.getAsLong();
+    if (logFailureClearSinceMs < 0)
+      logFailureClearSinceMs = now;
+    else if (now - logFailureClearSinceMs >= LOG_FAILURE_EPISODE_RESET_MS) {
+      logFailureRestarts = 0;
+      logFailureClearSinceMs = -1;
+      logFailureEscalated = false;
+    }
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -113,6 +113,29 @@ public final class HealthMonitor {
     }
 
     /**
+     * Describes a persistent Raft log write failure on this node, or returns {@code null} while the log writer
+     * is healthy (issue #7037). Once Ratis's log worker hits an I/O error ({@code No space left on device} being
+     * the reported one) it marks the log failed at that index and rejects every later append with
+     * {@code RaftLogIOException: Log already failed}, while the division stays {@code RUNNING} - so none of the
+     * lifecycle, lag or divergence checks can see it, and without this hook the node stays wedged until an
+     * operator restarts it. Implementations must return {@code null} when the state cannot be read.
+     */
+    default String getRaftLogFailure() {
+      return null;
+    }
+
+    /**
+     * Whether the Raft storage volume currently has enough free space for the log writer to resume after an
+     * in-place restart. A restart on a still-full volume fails the same way at once, so the monitor defers it
+     * until the periodic log compaction (or the operator) has freed room. Implementations that cannot read the
+     * volume must return {@code true}: the restart is then bounded by the crash-loop budget rather than never
+     * attempted.
+     */
+    default boolean isRaftStorageWritable() {
+      return true;
+    }
+
+    /**
      * Re-verifies, against the leader, every database this node kept through the bootstrap
      * "local is fresher, refuse to overwrite" guard (issue #6124), clearing the mark once the two
      * copies match and otherwise re-raising an operator-visible alert. No-op when no database took that
@@ -129,6 +152,16 @@ public final class HealthMonitor {
   // How long (as a multiple of the recovery duration) the follower must look healthy before a prior
   // reformat episode is considered resolved and the bounded reformat budget re-arms.
   private static final long REFORMAT_EPISODE_RESET_MULTIPLIER = 5L;
+
+  /**
+   * Log-writer recovery (issue #7037): restarts fired more than this long after the previous one start a new
+   * episode, so a volume that fills again much later is recovered again instead of hitting a budget spent on an
+   * old incident. Package-private for tests.
+   */
+  static final long LOG_FAILURE_EPISODE_RESET_MS = 10L * 60_000L;
+
+  /** At most one "deferred: volume still full" line per this window, matching the compaction scheduler's throttle. */
+  static final long LOG_FAILURE_DEFERRED_WARNING_THROTTLE_MS = 60_000L;
 
   private final    HealthTarget             target;
   private final    long                     intervalMs;
@@ -155,6 +188,12 @@ public final class HealthMonitor {
   private          int                      crashRestartStreak          = 0;
   private          boolean                  crashLoopReformatTried       = false;
   private          boolean                  crashLoopEscalated           = false;
+  // Log-writer recovery (#7037): in-place restarts fired in the current failure episode, when the last one
+  // fired, when the "deferred" line was last logged, and whether the budget for this episode is spent (logged once).
+  private          int                      logFailureRestarts           = 0;
+  private          long                     lastLogFailureRestartMs      = -1;
+  private          long                     lastLogFailureDeferredWarnMs = -1;
+  private          boolean                  logFailureEscalated          = false;
   // Injectable for deterministic tests; defaults to the system clock.
   private          LongSupplier             clock                       = System::currentTimeMillis;
 
@@ -245,6 +284,15 @@ public final class HealthMonitor {
     crashRestartStreak = 0;
     crashLoopReformatTried = false;
     crashLoopEscalated = false;
+    // A wedged log writer keeps the lifecycle RUNNING, so it is checked here, after the lifecycle branch and
+    // before the follower checks: a node that rejects every append is behind for a reason neither a snapshot
+    // re-arm nor a storage reformat can fix (issue #7037).
+    final String logFailure = target.getRaftLogFailure();
+    if (logFailure != null) {
+      handleFailedLogWriter(logFailure);
+      return;
+    }
+    logFailureEscalated = false;
     // checkStaleFollower (lag: commit - applied > threshold) and checkStuckFollower (divergence:
     // commit == applied) are mutually exclusive by construction, so at most one arms per tick.
     checkStaleFollower();
@@ -304,6 +352,60 @@ public final class HealthMonitor {
     }
 
     HALog.log(this, HALog.BASIC, "Health monitor detected Ratis %s state, attempting recovery", state);
+    target.restartRatisIfNeeded();
+    resetStreaksAfterRestart();
+  }
+
+  /**
+   * Recovers a node whose Raft log writer failed persistently (issue #7037, follow-up to #5345). Ratis never
+   * recovers the writer by itself: the first I/O error pins a {@code RaftLogIOException} that every later task
+   * throws, and only a fresh server clears it. The recovery is a plain in-place {@code RECOVER} restart, the
+   * same one the CLOSED/EXCEPTION branch uses, with two guards:
+   * <ul>
+   *   <li>it waits for the Raft storage volume to have room ({@link HealthTarget#isRaftStorageWritable()}),
+   *       because a restart on a still-full volume wedges again at the first append. The periodic compaction
+   *       (#5345) is what frees the room; until then a throttled SEVERE says the restart is deferred;</li>
+   *   <li>it is bounded per episode by the same {@code crashLoopRestartThreshold} the lifecycle branch uses, so
+   *       a failure that is not about space (a dying disk, a permission change) does not restart the server on
+   *       every tick forever. The budget re-arms after {@link #LOG_FAILURE_EPISODE_RESET_MS} of quiet.</li>
+   * </ul>
+   */
+  private void handleFailedLogWriter(final String failure) {
+    final long now = clock.getAsLong();
+
+    if (!target.isRaftStorageWritable()) {
+      if (lastLogFailureDeferredWarnMs < 0 || now - lastLogFailureDeferredWarnMs >= LOG_FAILURE_DEFERRED_WARNING_THROTTLE_MS) {
+        lastLogFailureDeferredWarnMs = now;
+        LogManager.instance().log(this, Level.SEVERE,
+            "Raft log writer failed %s and the Raft storage volume is still short of space: this node rejects every "
+                + "append until restarted. Deferring the in-place restart until the periodic log compaction "
+                + "(arcadedb.ha.snapshotInterval) or the operator frees room on the volume (issue #7037)", failure);
+      }
+      return;
+    }
+
+    if (logFailureRestarts > 0 && now - lastLogFailureRestartMs >= LOG_FAILURE_EPISODE_RESET_MS) {
+      logFailureRestarts = 0;
+      logFailureEscalated = false;
+    }
+
+    if (crashLoopRestartThreshold > 0 && logFailureRestarts >= crashLoopRestartThreshold) {
+      if (!logFailureEscalated) {
+        logFailureEscalated = true;
+        LogManager.instance().log(this, Level.SEVERE,
+            "Raft log writer failed again (%s) after %d in-place restarts with free space available; the failure is "
+                + "not about space. Giving up automatic restart for %d minutes - operator intervention required "
+                + "(check the Raft storage volume for I/O errors or permission changes)",
+            failure, logFailureRestarts, LOG_FAILURE_EPISODE_RESET_MS / 60_000L);
+      }
+      return;
+    }
+
+    logFailureRestarts++;
+    lastLogFailureRestartMs = now;
+    LogManager.instance().log(this, Level.WARNING,
+        "Raft log writer failed %s; the Raft storage volume has room again, restarting Ratis in place to resume "
+            + "replication (attempt %d, issue #7037)", failure, logFailureRestarts);
     target.restartRatisIfNeeded();
     resetStreaksAfterRestart();
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -371,6 +371,9 @@ public final class HealthMonitor {
    *       a failure that is not about space (a dying disk, a permission change) does not restart the server on
    *       every tick forever. The budget re-arms after {@link #LOG_FAILURE_EPISODE_RESET_MS} of quiet.</li>
    * </ul>
+   * The two budgets are deliberately separate counters sharing one threshold: a CLOSED/EXCEPTION lifecycle and a
+   * failed log writer are different incidents with different exits (a reformat escalation for the first, a
+   * free-space gate for the second), and a node that goes through both in a row has had two incidents, not one.
    */
   private void handleFailedLogWriter(final String failure) {
     final long now = clock.getAsLong();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterStatusExporter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterStatusExporter.java
@@ -44,6 +44,14 @@ class RaftClusterStatusExporter {
   private static final int LAG_MONITOR_INITIAL_DELAY_SECS = 5;
   private static final int LAG_MONITOR_INTERVAL_SECS      = 5;
 
+  /**
+   * LAG column value for a follower whose match index could not be read consistently on this tick (issue
+   * #7041). Distinct from {@code "0"} and from the blank the leader row carries: the operator is told the
+   * number is unavailable rather than shown a fabricated one. Excluded from the stable signature like every
+   * other LAG value, so a transient unknown never re-emits the table.
+   */
+  static final String LAG_UNKNOWN = "?";
+
   private final    RaftHAServer   haServer;
   private final    ClusterMonitor clusterMonitor;
   private volatile int            lastStableSignature;
@@ -52,14 +60,6 @@ class RaftClusterStatusExporter {
     this.haServer = haServer;
     this.clusterMonitor = clusterMonitor;
   }
-
-  /**
-   * LAG column value for a follower whose match index could not be read consistently on this tick (issue
-   * #7041). Distinct from {@code "0"} and from the blank the leader row carries: the operator is told the
-   * number is unavailable rather than shown a fabricated one. Excluded from the stable signature like every
-   * other LAG value, so a transient unknown never re-emits the table.
-   */
-  static final String LAG_UNKNOWN = "?";
 
   /**
    * One follower's replication state as read from a {@link RaftHAServer#getFollowerStates()} entry. The

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterStatusExporter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterStatusExporter.java
@@ -53,6 +53,38 @@ class RaftClusterStatusExporter {
     this.clusterMonitor = clusterMonitor;
   }
 
+  /**
+   * LAG column value for a follower whose match index could not be read consistently on this tick (issue
+   * #7041). Distinct from {@code "0"} and from the blank the leader row carries: the operator is told the
+   * number is unavailable rather than shown a fabricated one. Excluded from the stable signature like every
+   * other LAG value, so a transient unknown never re-emits the table.
+   */
+  static final String LAG_UNKNOWN = "?";
+
+  /**
+   * One follower's replication state as read from a {@link RaftHAServer#getFollowerStates()} entry. The
+   * match index is optional: a degraded entry (membership changed while the indices were being read, issue
+   * #4842) carries none, and {@code matchIndexKnown} says so, because Ratis's own {@code -1} means
+   * "never appended" and cannot double as "unknown".
+   */
+  static final class FollowerReplicationState {
+    final long    matchIndex;
+    final boolean matchIndexKnown;
+    final long    lastRpcMs;
+
+    FollowerReplicationState(final long matchIndex, final boolean matchIndexKnown, final long lastRpcMs) {
+      this.matchIndex = matchIndex;
+      this.matchIndexKnown = matchIndexKnown;
+      this.lastRpcMs = lastRpcMs;
+    }
+
+    static FollowerReplicationState of(final Map<String, Object> state) {
+      return new FollowerReplicationState(RaftHAServer.followerStateIndex(state, "matchIndex"),
+          RaftHAServer.hasFollowerStateIndex(state, "matchIndex"),
+          RaftHAServer.followerStateIndex(state, "lastRpcElapsedMs"));
+    }
+  }
+
   // -- Cluster Configuration Printing --
 
   /**
@@ -141,14 +173,13 @@ class RaftClusterStatusExporter {
     if (peers.isEmpty())
       return null;
 
-    // Collect follower replication state (only available on leader)
-    final Map<String, long[]> followerState = new HashMap<>();
-    for (final Map<String, Object> f : haServer.getFollowerStates()) {
-      final String peerId = (String) f.get("peerId");
-      final long matchIndex = (Long) f.get("matchIndex");
-      final long lastRpcMs = (Long) f.get("lastRpcElapsedMs");
-      followerState.put(peerId, new long[] { matchIndex, lastRpcMs });
-    }
+    // Collect follower replication state (only available on leader). The entries are read defensively
+    // (issue #7041): while membership is changing, getFollowerStates() degrades to entries without a
+    // match index rather than misattributing one, and a raw cast on that entry used to throw inside the
+    // catch-all above and suppress the whole table. Such a peer keeps its row, with the lag marked unknown.
+    final Map<String, FollowerReplicationState> followerState = new HashMap<>();
+    for (final Map<String, Object> f : haServer.getFollowerStates())
+      followerState.put((String) f.get("peerId"), FollowerReplicationState.of(f));
 
     // Measured leader->follower replication RTT per follower (issue #5314): the real appendEntries/
     // heartbeat round-trip, load-independent, distinct from the LAST CONTACT staleness figure below.
@@ -167,15 +198,18 @@ class RaftClusterStatusExporter {
       String lastContactStr = "";
       String statusStr = "";
       if (!isPeerLeader) {
-        final long[] state = followerState.get(peerId);
+        final FollowerReplicationState state = followerState.get(peerId);
         if (state != null) {
-          final long lag = commitIndex - state[0];
-          lagStr = lag > 0 ? String.valueOf(lag) : "0";
+          if (state.matchIndexKnown) {
+            final long lag = commitIndex - state.matchIndex;
+            lagStr = lag > 0 ? String.valueOf(lag) : "0";
+          } else
+            lagStr = LAG_UNKNOWN;
           // LAST CONTACT = time since the leader last heard from this follower (issue #5314). On an idle
           // cluster it just tracks the heartbeat cadence, and it is most useful precisely when it grows
           // large (an election is imminent as it nears electionTimeoutMin), so it is always shown - it is
           // not, and never was, the network latency the old "LATENCY" header implied.
-          lastContactStr = state[1] + " ms";
+          lastContactStr = state.lastRpcMs + " ms";
         }
         final RaftHAServer.ReplicationLatency rtt = rttByPeer.get(peerId);
         if (rtt != null)
@@ -315,9 +349,20 @@ class RaftClusterStatusExporter {
       if (!haServer.isLeader())
         return;
       clusterMonitor.updateLeaderCommitIndex(haServer.getCommitIndex());
-      for (final var fs : haServer.getFollowerStates())
-        clusterMonitor.updateReplicaMatchIndex((String) fs.get("peerId"), (Long) fs.get("matchIndex"),
-            (Long) fs.get("lastRpcElapsedMs"));
+      for (final Map<String, Object> fs : haServer.getFollowerStates()) {
+        final FollowerReplicationState state = FollowerReplicationState.of(fs);
+        // A degraded entry (issue #4842) carries no match index. Feeding the monitor a placeholder would
+        // classify the peer from a number Ratis never reported - -1 is its never-appended sentinel and would
+        // read as a dead replication path - and the raw cast it replaces aborted the whole tick (issue
+        // #7041). Leave this peer's classification as it was and carry on with the others.
+        if (!state.matchIndexKnown) {
+          LogManager.instance().log(this, Level.FINE,
+              "Replica lag tick: match index of '%s' unavailable while membership is changing; keeping its last classification",
+              fs.get("peerId"));
+          continue;
+        }
+        clusterMonitor.updateReplicaMatchIndex((String) fs.get("peerId"), state.matchIndex, state.lastRpcMs);
+      }
       // Issue #5304: with the per-replica classifications refreshed, re-emit the CLUSTER CONFIGURATION
       // table when the stable picture (membership, roles, statuses, term) changed since the last
       // emission, so the logged view converges instead of freezing on the election-time snapshot.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -195,7 +195,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // still copies it to a local before use so a concurrent reassignment cannot null it mid-method.
   private volatile RaftServer                raftServer;
   private          RaftClient                raftClient;
-  private          RaftProperties            raftProperties;
+  private volatile RaftProperties            raftProperties;
   private volatile RaftTransactionBroker     transactionBroker;
   private          RaftClusterStatusExporter statusExporter;
   private          ScheduledExecutorService  lagMonitorExecutor;
@@ -3651,7 +3651,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * config-derived and constant for the server's lifetime, and re-running its {@code exists()} probes
    * on every tick is pointless I/O. The ancestor walk stays per-call because its result legitimately
    * changes once Ratis creates the directory. Shared by the compaction scheduler's disk-pressure probe and
-   * the log-writer recovery's free-space gate (issue #7037), so the two cannot disagree on the volume.
+   * the log-writer recovery's free-space gate (issue #7037), so the two cannot disagree on the volume; the walk
+   * itself is {@link SnapshotInstaller#nearestExistingAncestor}, the same one the snapshot space check uses.
    */
   private File raftStorageVolume() {
     File dir = cachedRaftStorageDir;
@@ -3659,9 +3660,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       dir = getRaftStorageDir();
       cachedRaftStorageDir = dir;
     }
-    while (dir != null && !dir.exists())
-      dir = dir.getParentFile();
-    return dir;
+    return SnapshotInstaller.nearestExistingAncestor(dir);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1350,9 +1350,30 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
+   * Whether free space on the Raft storage volume is below {@code arcadedb.ha.raftStorageMinFreeSpacePerc}. The
+   * same arithmetic as the compaction scheduler's disk-pressure probe; {@code false} when the check is disabled
+   * (0) or the volume cannot be sized, so pressure is never guessed.
+   */
+  boolean isRaftStorageUnderPressure() {
+    final int minFreeSpacePerc = configuration.getValueAsInteger(GlobalConfiguration.HA_RAFT_STORAGE_MIN_FREE_SPACE_PERC);
+    if (minFreeSpacePerc <= 0)
+      return false;
+    final File volume = raftStorageVolume();
+    if (volume == null)
+      return false;
+    final long total = volume.getTotalSpace();
+    final long usable = volume.getUsableSpace();
+    return total > 0 && usable >= 0 && (double) usable / (double) total * 100.0 < minFreeSpacePerc;
+  }
+
+  /**
    * Forces a local Raft snapshot with the smallest creation gap Ratis accepts, so every log segment below the
    * applied index becomes purgeable before a database snapshot is written onto the same volume (issue #7037).
    * Best-effort: a refused or timed-out request only means the segments stay until the next periodic tick.
+   * <p>
+   * Only when the Raft storage volume is actually under pressure (below {@code arcadedb.ha.raftStorageMinFreeSpacePerc},
+   * the same threshold the periodic compaction escalates on): an ordinary resync on a volume with room must not pay a
+   * round trip to the {@code StateMachineUpdater} for a purge that has nothing to reclaim.
    * <p>
    * A snapshot request is fulfilled by the {@code StateMachineUpdater} thread, and only while the state machine is
    * {@code RUNNING}, so it is skipped when it could not be served promptly: on the apply thread itself (a request
@@ -1361,6 +1382,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * the scheduler's 30s one, because the install it precedes must not queue behind a long entry apply.
    */
   void compactRaftLogBeforeSnapshotInstall(final String databaseName) {
+    if (!isRaftStorageUnderPressure())
+      return;
     final ArcadeStateMachine sm = stateMachine;
     if (sm == null || sm.isApplyThread() || sm.getLifeCycleState() != LifeCycle.State.RUNNING) {
       LogManager.instance().log(this, Level.FINE,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -139,6 +139,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // Generous: the request is served on the state-machine updater thread, which may be busy applying a
   // backlog, and a timeout here only skips one compaction tick.
   private static final long SNAPSHOT_REQUEST_TIMEOUT_MS = 30_000L;
+  /** Budget of the log purge that precedes a database snapshot install (issue #7037): "not now" beats waiting. */
+  private static final long PRE_INSTALL_SNAPSHOT_REQUEST_TIMEOUT_MS = 5_000L;
 
   private final    ArcadeDBServer          arcadeServer;
   private final    ContextConfiguration    configuration;
@@ -1319,6 +1321,58 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   @Override
   public void restartRatisIfNeeded() {
     restartRatis(false);
+  }
+
+  @Override
+  public String getRaftLogFailure() {
+    final ArcadeStateMachine sm = stateMachine;
+    if (sm == null)
+      return null;
+    final ArcadeStateMachine.RaftLogFailure failure = sm.getRaftLogFailure();
+    return failure != null ? failure.describe() : null;
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * "Enough" is two log segments ({@code arcadedb.ha.logSegmentSize}): Ratis rolls the open segment and
+   * preallocates the next on recovery, so with less than that the restarted writer fails at the first append.
+   */
+  @Override
+  public boolean isRaftStorageWritable() {
+    final File volume = raftStorageVolume();
+    if (volume == null)
+      return true; // volume unknown: never guess "full" from it, let the restart budget bound the attempts
+    final RaftProperties properties = raftProperties;
+    final long segmentSize = properties != null ? RaftServerConfigKeys.Log.segmentSizeMax(properties).getSize()
+        : RaftServerConfigKeys.Log.SEGMENT_SIZE_MAX_DEFAULT.getSize();
+    return volume.getUsableSpace() >= 2L * segmentSize;
+  }
+
+  /**
+   * Forces a local Raft snapshot with the smallest creation gap Ratis accepts, so every log segment below the
+   * applied index becomes purgeable before a database snapshot is written onto the same volume (issue #7037).
+   * Best-effort: a refused or timed-out request only means the segments stay until the next periodic tick.
+   * <p>
+   * A snapshot request is fulfilled by the {@code StateMachineUpdater} thread, and only while the state machine is
+   * {@code RUNNING}, so it is skipped when it could not be served promptly: on the apply thread itself (a request
+   * issued from an entry apply would wait on itself), while the state machine is paused or reloading (a
+   * leader-driven install, which purges the log by itself once it lands), and it carries a short budget rather than
+   * the scheduler's 30s one, because the install it precedes must not queue behind a long entry apply.
+   */
+  void compactRaftLogBeforeSnapshotInstall(final String databaseName) {
+    final ArcadeStateMachine sm = stateMachine;
+    if (sm == null || sm.isApplyThread() || sm.getLifeCycleState() != LifeCycle.State.RUNNING) {
+      LogManager.instance().log(this, Level.FINE,
+          "Skipping the Raft log purge before installing '%s': the state machine cannot serve a snapshot request now",
+          databaseName);
+      return;
+    }
+    final long index = takeLocalSnapshot(RaftLogCompactionScheduler.DISK_PRESSURE_CREATION_GAP,
+        PRE_INSTALL_SNAPSHOT_REQUEST_TIMEOUT_MS);
+    if (index >= 0)
+      HALog.log(this, HALog.BASIC, "Raft log purged up to index %d before installing the snapshot of '%s'", index,
+          databaseName);
   }
 
   /**
@@ -3100,9 +3154,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final List<HAReplicationStatsProvider.FollowerSample> samples = new ArrayList<>(followers.size());
     for (final Map<String, Object> follower : followers) {
       final String peerId = (String) follower.get("peerId");
-      final long matchIndex = follower.get("matchIndex") instanceof Number n ? n.longValue() : -1;
-      final long nextIndex = follower.get("nextIndex") instanceof Number n ? n.longValue() : -1;
-      final long lastContactMs = follower.get("lastRpcElapsedMs") instanceof Number n ? n.longValue() : -1;
+      final long matchIndex = followerStateIndex(follower, "matchIndex");
+      final long nextIndex = followerStateIndex(follower, "nextIndex");
+      final long lastContactMs = followerStateIndex(follower, "lastRpcElapsedMs");
       final long lag = commitIndex >= 0 && matchIndex >= 0 ? Math.max(0L, commitIndex - matchIndex) : -1;
       final String status = clusterMonitor != null ? clusterMonitor.getReplicaStatus(peerId).name() : "UNKNOWN";
       final long laggingForMs = clusterMonitor != null ? clusterMonitor.getReplicaLaggingForMs(peerId) : 0;
@@ -3110,6 +3164,27 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
           peerId, matchIndex, nextIndex, lag, lastContactMs, status, laggingForMs));
     }
     return samples;
+  }
+
+  /**
+   * Reads one index of a {@link #getFollowerStates()} entry, or {@code -1} when the entry does not carry it.
+   * <p>
+   * The match/next index keys are deliberately absent from the degraded entries
+   * {@link #degradedFollowerStates} builds when membership churned faster than a consistent snapshot could
+   * be taken (issue #4842). Every consumer must therefore read them through this method rather than with a
+   * raw {@code (Long)} cast: the cast unboxes the missing value into a {@code NullPointerException}, and
+   * because the consumers run inside catch-alls the failure did not crash anything - it silently dropped
+   * the whole cluster-configuration table and aborted the lag-monitor tick, precisely while membership was
+   * changing (issue #7041). Callers that need to tell "unknown" from Ratis's own {@code -1} never-appended
+   * sentinel check {@link #hasFollowerStateIndex} first.
+   */
+  static long followerStateIndex(final Map<String, Object> state, final String key) {
+    return state.get(key) instanceof Number n ? n.longValue() : -1L;
+  }
+
+  /** Whether a {@link #getFollowerStates()} entry carries {@code key} at all (see {@link #followerStateIndex}). */
+  static boolean hasFollowerStateIndex(final Map<String, Object> state, final String key) {
+    return state.get(key) instanceof Number;
   }
 
   /**
@@ -3565,26 +3640,28 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       return dir != null ? dir.getAbsolutePath() : "<unknown>";
     }
 
-    /**
-     * The Raft storage directory, or its nearest existing ancestor. {@code File.getUsableSpace()}
-     * returns 0 for a path that does not exist, which would otherwise read as "disk full" during the
-     * window between server start and Ratis creating the directory.
-     * <p>
-     * The configured directory itself is resolved once and cached: {@code resolveRaftStorageDir} is
-     * config-derived and constant for the server's lifetime, and re-running its {@code exists()} probes
-     * on every tick is pointless I/O. The ancestor walk stays per-call because its result legitimately
-     * changes once Ratis creates the directory.
-     */
-    private File raftStorageVolume() {
-      File dir = cachedRaftStorageDir;
-      if (dir == null) {
-        dir = getRaftStorageDir();
-        cachedRaftStorageDir = dir;
-      }
-      while (dir != null && !dir.exists())
-        dir = dir.getParentFile();
-      return dir;
+  }
+
+  /**
+   * The Raft storage directory, or its nearest existing ancestor. {@code File.getUsableSpace()}
+   * returns 0 for a path that does not exist, which would otherwise read as "disk full" during the
+   * window between server start and Ratis creating the directory.
+   * <p>
+   * The configured directory itself is resolved once and cached: {@code resolveRaftStorageDir} is
+   * config-derived and constant for the server's lifetime, and re-running its {@code exists()} probes
+   * on every tick is pointless I/O. The ancestor walk stays per-call because its result legitimately
+   * changes once Ratis creates the directory. Shared by the compaction scheduler's disk-pressure probe and
+   * the log-writer recovery's free-space gate (issue #7037), so the two cannot disagree on the volume.
+   */
+  private File raftStorageVolume() {
+    File dir = cachedRaftStorageDir;
+    if (dir == null) {
+      dir = getRaftStorageDir();
+      cachedRaftStorageDir = dir;
     }
+    while (dir != null && !dir.exists())
+      dir = dir.getParentFile();
+    return dir;
   }
 
   /**
@@ -3607,6 +3684,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * @return the resulting snapshot index, or -1 when no snapshot was taken
    */
   long takeLocalSnapshot(final long creationGap) {
+    return takeLocalSnapshot(creationGap, SNAPSHOT_REQUEST_TIMEOUT_MS);
+  }
+
+  /**
+   * {@link #takeLocalSnapshot(long)} with an explicit request timeout. Ratis fulfils the request on its
+   * {@code StateMachineUpdater} thread the next time that thread is free, so a caller that cannot afford to wait
+   * behind a long entry apply passes a short budget and treats the timeout as "not now".
+   */
+  long takeLocalSnapshot(final long creationGap, final long timeoutMs) {
     final RaftServer server = raftServer;
     if (server == null || shutdownRequested)
       return -1L;
@@ -3616,7 +3702,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     try {
       final RaftClientReply reply = server.snapshotManagement(
           SnapshotManagementRequest.newCreate(snapshotClientId, localPeerId, raftGroup.getGroupId(),
-              snapshotCallId.incrementAndGet(), SNAPSHOT_REQUEST_TIMEOUT_MS, creationGap));
+              snapshotCallId.incrementAndGet(), timeoutMs, creationGap));
       if (reply == null || !reply.isSuccess()) {
         LogManager.instance().log(this, Level.FINE, "Local Raft snapshot request was not successful: %s", reply);
         return -1L;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1810,6 +1810,17 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     return display != null ? display : leaderId.toString();
   }
 
+  /**
+   * The peers every "who are the members" consumer reports: the declared server list reconciled against the live
+   * Raft configuration (issue #7040). A peer the configuration dropped is not a replica - the leader does not
+   * replicate to it and a client must not be routed to it - and a peer added at runtime is one even though the
+   * server list does not declare it. {@link #getStats()}, {@link #getReplicaAddresses()} and
+   * {@link #routingTableFor} all read this, so the three views cannot disagree about membership.
+   */
+  private List<RaftPeer> configuredPeers() {
+    return ClusterMembership.of(raftGroup.getPeers(), getLivePeers()).configuredPeers();
+  }
+
   public Map<String, Object> getStats() {
     final Map<String, Object> stats = new HashMap<>();
     stats.put("localPeerId", localPeerId.toString());
@@ -1827,7 +1838,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final RaftPeerId statsLeaderId = getLeaderId();
     final RaftPeerId statsExcludeId = statsLeaderId != null ? statsLeaderId : localPeerId;
     final List<Map<String, String>> replicas = new ArrayList<>();
-    for (final RaftPeer peer : raftGroup.getPeers()) {
+    for (final RaftPeer peer : configuredPeers()) {
       if (!peer.getId().equals(statsExcludeId)) {
         final Map<String, String> replicaInfo = new HashMap<>();
         replicaInfo.put("id", peer.getId().toString());
@@ -1846,7 +1857,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final RaftPeerId leaderId = getLeaderId();
     final RaftPeerId excludeId = leaderId != null ? leaderId : localPeerId;
     final StringBuilder sb = new StringBuilder();
-    for (final RaftPeer peer : raftGroup.getPeers()) {
+    for (final RaftPeer peer : configuredPeers()) {
       if (!peer.getId().equals(excludeId)) {
         final String httpAddr = resolveHttpAddress(peer);
         if (httpAddr != null) {
@@ -1864,9 +1875,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * from one {@link #getLeaderId()} read, so a concurrent leader change cannot make the writer and reader sets
    * mutually inconsistent. Returns {@code null} when no leader is known, the leader has no resolvable
    * address for that protocol, or that address cannot be told apart from a follower's (see
-   * {@link #selectUnambiguousRouting}). Readers reflect the configured cluster membership, matching
-   * {@link #getReplicaAddresses()}; peers whose address cannot be resolved, or resolved to an address another
-   * peer claims too, are skipped.
+   * {@link #selectUnambiguousRouting}). Readers reflect the live cluster membership ({@link #configuredPeers()}),
+   * matching {@link #getReplicaAddresses()}: a peer the configuration dropped is never handed to a client as a
+   * read target (issue #7040). Peers whose address cannot be resolved, or resolved to an address another peer
+   * claims too, are skipped.
    * <p>
    * The ambiguity filter is deliberately confined to the client-routing view and is <b>not</b> applied to the
    * HTTP addresses behind {@link #getReplicaAddresses()} or {@code getStats()}: those feed cluster reporting
@@ -1896,15 +1908,16 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (writer == null)
       return null;
 
-    final Collection<RaftPeer> peers = raftGroup.getPeers();
+    final Collection<RaftPeer> peers = configuredPeers();
 
     // Index 0 is always the writer, so one pair of arrays carries the whole view and the ambiguity check can
     // see the leader and the followers at once. A peer that resolves to nothing is skipped, exactly as before.
     //
-    // The +1 is not slack: raftGroup is final and holds the peers HA_SERVER_LIST was parsed into, while the
-    // leader comes from live Ratis state, so a leader that joined at runtime (addPeer, the Kubernetes
-    // auto-join) is not in getPeers() and the writer occupies a slot beyond it. Sizing to peers.size() would
-    // put an ArrayIndexOutOfBoundsException on the Bolt ROUTE path in exactly that window.
+    // The +1 is not slack: the leader comes from live Ratis state read separately from the membership above,
+    // and getLivePeers() falls back to the declared list when the division cannot be read, so a leader that
+    // joined at runtime (addPeer, the Kubernetes auto-join) can be absent from `peers` and the writer occupies
+    // a slot beyond it. Sizing to peers.size() would put an ArrayIndexOutOfBoundsException on the Bolt ROUTE
+    // path in exactly that window.
     final String[] addresses = new String[peers.size() + 1];
     final boolean[] fromConfig = new boolean[addresses.length];
     // Carried alongside so the warning can name the peers that collided rather than only say that some did

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -466,6 +466,11 @@ public class SnapshotHttpHandler implements HttpHandler {
           }
         });
 
+    // Tell the follower how much it is about to extract (issue #7037) before the response is committed by the
+    // first body byte, so a follower short of space refuses at once instead of failing mid-extraction.
+    exchange.getResponseHeaders().put(new HttpString(SnapshotManager.UNCOMPRESSED_BYTES_HEADER),
+        String.valueOf(estimateUncompressedBytes(db, snapshot)));
+
     try (final OutputStream rawOut = exchange.getOutputStream();
         final OutputStream out = new ProgressTrackingOutputStream(rawOut, lastProgressMs);
         final ZipOutputStream zipOut = new ZipOutputStream(out)) {
@@ -576,6 +581,39 @@ public class SnapshotHttpHandler implements HttpHandler {
    * receives rather than a separate re-read of the file. Skipped files (absent or symlink) contribute no
    * manifest entry, matching what is sent.
    */
+  /**
+   * Uncompressed bytes of the files {@link #serveSnapshotZip} is about to stream: the same file set, sized the same
+   * way (a page-snapshot file is its page count times its page size, everything else its on-disk length). An
+   * estimate rather than a promise - a fallback-path file can still grow before it is read - which is all the
+   * follower's up-front space check needs (issue #7037). Package-private for unit testing.
+   */
+  static long estimateUncompressedBytes(final DatabaseInternal db, final PageSnapshot snapshot) {
+    long total = 0L;
+
+    final File configFile = ((LocalDatabase) db.getEmbedded()).getConfigurationFile();
+    if (configFile.exists())
+      total += configFile.length();
+
+    final File schemaFile = ((LocalSchema) db.getSchema()).getConfigurationFile();
+    if (schemaFile.exists())
+      total += schemaFile.length();
+
+    if (snapshot != null)
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+        total += file.size();
+    else
+      for (final ComponentFile file : new ArrayList<>(db.getFileManager().getFiles()))
+        if (file != null)
+          total += file.getOSFile().length();
+
+    final File[] sealedFiles = new File(db.getDatabasePath()).listFiles((d, name) -> name.endsWith(".ts.sealed"));
+    if (sealedFiles != null)
+      for (final File sealedFile : sealedFiles)
+        total += sealedFile.length();
+
+    return total + Long.BYTES; // the last-tx-id marker
+  }
+
   private void addFileToZip(final ZipOutputStream zipOut, final File inputFile,
       final List<SnapshotManager.ManifestEntry> manifest) throws Exception {
     if (!inputFile.exists())

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -883,11 +883,29 @@ public final class SnapshotInstaller {
     if (volume == null)
       return;
     final long usable = volume.getUsableSpace();
-    if (usable < requiredBytes)
+    final long needed = withAllocationReserve(requiredBytes);
+    if (usable < needed)
       throw new IOException("Insufficient space to install the snapshot of '" + databaseName + "': it inflates to "
-          + requiredBytes + " bytes but the volume of '" + volume.getAbsolutePath() + "' has " + usable
-          + " usable. Free space on the volume (the Raft log is purged before every install; see "
-          + "arcadedb.ha.snapshotInterval) and the install is retried");
+          + requiredBytes + " bytes (" + needed + " with the allocation reserve) but the volume of '"
+          + volume.getAbsolutePath() + "' has " + usable + " usable. Free space on the volume (the Raft log is purged "
+          + "before every install; see arcadedb.ha.snapshotInterval) and the install is retried");
+  }
+
+  /**
+   * Reserve added on top of the advertised payload before it is compared with the usable space: the payload is the
+   * logical size, and the extraction also pays per-file block rounding, directory metadata and the durability
+   * markers, and the swap keeps the previous copy in {@code .snapshot-backup} until it is dropped. A payload the
+   * volume can hold only to the byte would still run out mid-extraction, which is the failure the check exists to
+   * turn into an early, clear one. Package-private for tests.
+   */
+  static final int  SPACE_RESERVE_PERCENT   = 5;
+  static final long SPACE_RESERVE_MIN_BYTES = 16L * 1024 * 1024;
+
+  /** {@code requiredBytes} plus the allocation reserve, saturating at {@link Long#MAX_VALUE}. */
+  static long withAllocationReserve(final long requiredBytes) {
+    final long reserve = Math.max(requiredBytes / 100L * SPACE_RESERVE_PERCENT, SPACE_RESERVE_MIN_BYTES);
+    final long needed = requiredBytes + reserve;
+    return needed < requiredBytes ? Long.MAX_VALUE : needed;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -770,7 +770,7 @@ public final class SnapshotInstaller {
 
       final String snapshotUrl = (https ? "https://" : "http://") + endpoint + "/api/v1/ha/snapshot/" + databaseName;
       try {
-        downloadSnapshot(snapshotNewDir, snapshotUrl, clusterToken, https, server);
+        downloadSnapshot(databaseName, snapshotNewDir, snapshotUrl, clusterToken, https, server);
         return; // Success
       } catch (final IOException e) {
         lastException = e;
@@ -784,7 +784,7 @@ public final class SnapshotInstaller {
         lastException);
   }
 
-  private static void downloadSnapshot(final Path targetDir, final String snapshotUrl,
+  private static void downloadSnapshot(final String databaseName, final Path targetDir, final String snapshotUrl,
       final String clusterToken, final boolean https, final ArcadeDBServer server) throws IOException {
 
     HALog.log(SnapshotInstaller.class, HALog.BASIC, "Downloading snapshot from %s", snapshotUrl);
@@ -828,7 +828,7 @@ public final class SnapshotInstaller {
       // not fit, after the whole transfer, and leave a follower already short of space with a partial staging
       // directory to clean up. A leader predating #7037 omits the header and the check is skipped.
       checkUsableSpace(targetDir, parseUncompressedBytes(connection.getHeaderField(SnapshotManager.UNCOMPRESSED_BYTES_HEADER)),
-          targetDir.getFileName() != null ? targetDir.getFileName().toString() : "snapshot");
+          databaseName);
 
       final CountingInputStream rawCounter = new CountingInputStream(connection.getInputStream());
       InputStream source = rawCounter;
@@ -877,9 +877,7 @@ public final class SnapshotInstaller {
   static void checkUsableSpace(final Path targetDir, final long requiredBytes, final String databaseName) throws IOException {
     if (requiredBytes <= 0)
       return;
-    File volume = targetDir.toAbsolutePath().toFile();
-    while (volume != null && !volume.exists())
-      volume = volume.getParentFile();
+    final File volume = nearestExistingAncestor(targetDir.toAbsolutePath().toFile());
     if (volume == null)
       return;
     final long usable = volume.getUsableSpace();
@@ -889,6 +887,19 @@ public final class SnapshotInstaller {
           + requiredBytes + " bytes (" + needed + " with the allocation reserve) but the volume of '"
           + volume.getAbsolutePath() + "' has " + usable + " usable. Free space on the volume (the Raft log is purged "
           + "before every install; see arcadedb.ha.snapshotInterval) and the install is retried");
+  }
+
+  /**
+   * {@code path} itself when it exists, otherwise its nearest existing ancestor, or {@code null} when none does.
+   * {@code File.getUsableSpace()} and {@code getTotalSpace()} answer 0 for a path that does not exist, which would
+   * read as "disk full" for a directory that is about to be created (a staging directory, the Raft storage
+   * directory before Ratis creates it), so every free-space probe resolves its volume through this one walk.
+   */
+  static File nearestExistingAncestor(final File path) {
+    File dir = path;
+    while (dir != null && !dir.exists())
+      dir = dir.getParentFile();
+    return dir;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -894,9 +894,11 @@ public final class SnapshotInstaller {
    * {@code File.getUsableSpace()} and {@code getTotalSpace()} answer 0 for a path that does not exist, which would
    * read as "disk full" for a directory that is about to be created (a staging directory, the Raft storage
    * directory before Ratis creates it), so every free-space probe resolves its volume through this one walk.
+   * The walk runs on the absolute form: a relative path's parent chain ends at {@code null} where its components
+   * run out, before ever reaching the working directory that exists.
    */
   static File nearestExistingAncestor(final File path) {
-    File dir = path;
+    File dir = path.getAbsoluteFile();
     while (dir != null && !dir.exists())
       dir = dir.getParentFile();
     return dir;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -216,6 +216,12 @@ public final class SnapshotInstaller {
       final int maxRetries = server.getConfiguration().getValueAsInteger(GlobalConfiguration.HA_SNAPSHOT_INSTALL_RETRIES);
       final long retryBaseMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_INSTALL_RETRY_BASE_MS);
 
+      // PHASE 0 - MAKE ROOM (issue #7037). This install is the self-heal for a diverged follower, and the volume
+      // it writes onto may be the one the Raft log just filled: purge the local log first so the segments below
+      // the applied index are reclaimable, then let the download refuse up front (see downloadSnapshot) rather
+      // than fail with "No space left on device" halfway through the extraction.
+      purgeRaftLogBeforeInstall(databaseName, server);
+
       // PHASE 1 - DOWNLOAD into .snapshot-new with the live database STILL OPEN. The historical behaviour
       // closed it up-front, so any download failure (leader unreachable, network blip) left it closed and
       // deregistered with no recovery. Staging first means we touch the live files only on success.
@@ -817,6 +823,13 @@ public final class SnapshotInstaller {
       // acceptance for backward compatibility during a rolling upgrade.
       final boolean manifestRequired = "1".equals(connection.getHeaderField(SnapshotManager.MANIFEST_HEADER));
 
+      // A leader on #7037 or later says how many bytes the archive inflates to. Refuse before reading the body
+      // when the target volume cannot hold them: the extraction would otherwise fail on the last file it could
+      // not fit, after the whole transfer, and leave a follower already short of space with a partial staging
+      // directory to clean up. A leader predating #7037 omits the header and the check is skipped.
+      checkUsableSpace(targetDir, parseUncompressedBytes(connection.getHeaderField(SnapshotManager.UNCOMPRESSED_BYTES_HEADER)),
+          targetDir.getFileName() != null ? targetDir.getFileName().toString() : "snapshot");
+
       final CountingInputStream rawCounter = new CountingInputStream(connection.getInputStream());
       InputStream source = rawCounter;
       final boolean progressLogging = server == null
@@ -832,6 +845,49 @@ public final class SnapshotInstaller {
     } finally {
       connection.disconnect();
     }
+  }
+
+  /**
+   * Asks the local Raft server to snapshot and purge its log before a database snapshot is written (issue #7037).
+   * No-op without Raft HA (unit tests, the non-Raft install callers) and best-effort otherwise: the purge only
+   * makes the space reclaimable, it is not a precondition of the install.
+   */
+  private static void purgeRaftLogBeforeInstall(final String databaseName, final ArcadeDBServer server) {
+    if (server != null && server.getHA() instanceof RaftHAPlugin plugin && plugin.getRaftHAServer() != null)
+      plugin.getRaftHAServer().compactRaftLogBeforeSnapshotInstall(databaseName);
+  }
+
+  /** Parses the {@link SnapshotManager#UNCOMPRESSED_BYTES_HEADER} value; absent or malformed reads as unknown ({@code -1}). */
+  static long parseUncompressedBytes(final String header) {
+    if (header == null || header.isEmpty())
+      return -1L;
+    try {
+      return Long.parseLong(header.trim());
+    } catch (final NumberFormatException e) {
+      return -1L;
+    }
+  }
+
+  /**
+   * Refuses an install whose files cannot fit on the volume hosting {@code targetDir} (issue #7037). The volume is
+   * the target directory or its nearest existing ancestor, because {@code getUsableSpace()} answers 0 for a path
+   * that does not exist yet. An unknown size ({@code <= 0}) or an unresolvable volume never refuses: the check
+   * turns a certain failure into a clear early one, it does not add a new way to fail. Package-private for tests.
+   */
+  static void checkUsableSpace(final Path targetDir, final long requiredBytes, final String databaseName) throws IOException {
+    if (requiredBytes <= 0)
+      return;
+    File volume = targetDir.toAbsolutePath().toFile();
+    while (volume != null && !volume.exists())
+      volume = volume.getParentFile();
+    if (volume == null)
+      return;
+    final long usable = volume.getUsableSpace();
+    if (usable < requiredBytes)
+      throw new IOException("Insufficient space to install the snapshot of '" + databaseName + "': it inflates to "
+          + requiredBytes + " bytes but the volume of '" + volume.getAbsolutePath() + "' has " + usable
+          + " usable. Free space on the volume (the Raft log is purged before every install; see "
+          + "arcadedb.ha.snapshotInterval) and the install is retried");
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -217,9 +217,9 @@ public final class SnapshotInstaller {
       final long retryBaseMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_INSTALL_RETRY_BASE_MS);
 
       // PHASE 0 - MAKE ROOM (issue #7037). This install is the self-heal for a diverged follower, and the volume
-      // it writes onto may be the one the Raft log just filled: purge the local log first so the segments below
-      // the applied index are reclaimable, then let the download refuse up front (see downloadSnapshot) rather
-      // than fail with "No space left on device" halfway through the extraction.
+      // it writes onto may be the one the Raft log just filled: when that volume is under pressure, purge the local
+      // log first so the segments below the applied index are reclaimable, then let the download refuse up front
+      // (see downloadSnapshot) rather than fail with "No space left on device" halfway through the extraction.
       purgeRaftLogBeforeInstall(databaseName, server);
 
       // PHASE 1 - DOWNLOAD into .snapshot-new with the live database STILL OPEN. The historical behaviour
@@ -848,9 +848,9 @@ public final class SnapshotInstaller {
   }
 
   /**
-   * Asks the local Raft server to snapshot and purge its log before a database snapshot is written (issue #7037).
-   * No-op without Raft HA (unit tests, the non-Raft install callers) and best-effort otherwise: the purge only
-   * makes the space reclaimable, it is not a precondition of the install.
+   * Asks the local Raft server to snapshot and purge its log before a database snapshot is written (issue #7037),
+   * when its storage volume is under pressure. No-op without Raft HA (unit tests, the non-Raft install callers) and
+   * best-effort otherwise: the purge only makes the space reclaimable, it is not a precondition of the install.
    */
   private static void purgeRaftLogBeforeInstall(final String databaseName, final ArcadeDBServer server) {
     if (server != null && server.getHA() instanceof RaftHAPlugin plugin && plugin.getRaftHAServer() != null)
@@ -886,7 +886,8 @@ public final class SnapshotInstaller {
       throw new IOException("Insufficient space to install the snapshot of '" + databaseName + "': it inflates to "
           + requiredBytes + " bytes (" + needed + " with the allocation reserve) but the volume of '"
           + volume.getAbsolutePath() + "' has " + usable + " usable. Free space on the volume (the Raft log is purged "
-          + "before every install; see arcadedb.ha.snapshotInterval) and the install is retried");
+          + "before an install when its volume is under pressure; see arcadedb.ha.snapshotInterval and "
+          + "arcadedb.ha.raftStorageMinFreeSpacePerc) and the install is retried");
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
@@ -72,6 +72,12 @@ public final class SnapshotManager {
    * skips manifest verification, preserving backward compatibility.
    */
   public static final String MANIFEST_HEADER = "X-ArcadeDB-Snapshot-Manifest";
+  /**
+   * Response header carrying the uncompressed byte count of the files the snapshot ships (issue #7037), so the
+   * follower can refuse the download up front when its volume cannot hold them instead of failing with {@code No
+   * space left on device} halfway through the extraction. A leader predating #7037 omits it and the check is skipped.
+   */
+  public static final String UNCOMPRESSED_BYTES_HEADER = "X-ArcadeDB-Snapshot-Uncompressed-Bytes";
 
   /**
    * One file recorded in a snapshot manifest: the entry name, its uncompressed byte size and its CRC32.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7011BootstrapSourceRaceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7011BootstrapSourceRaceTest.java
@@ -114,6 +114,23 @@ class Issue7011BootstrapSourceRaceTest {
   }
 
   /**
+   * The source never falls through to the mismatch branch, whatever its copy reads: a baseline above the local
+   * transaction id is impossible for the copy it was sampled from, and the answer is still "keep the copy".
+   */
+  @Test
+  void theBootstrapSourceKeepsItsCopyEvenBehindItsOwnBaseline() {
+    final ArcadeStateMachine sm = newStateMachine();
+    final RaftLogEntryCodec.DecodedEntry aheadOfLocal = RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.encodeBootstrapFingerprintEntry(DB, "0".repeat(64), localDb.getLastTransactionId() + 100));
+
+    sm.applyBootstrapFingerprintEntry(aheadOfLocal, 3L, true);
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+    assertThat(localDb.isOpen()).as("the copy is kept open, not closed for a reinstall from itself").isTrue();
+    assertThat(sm.getBootstrapBaseline(DB)).isNotNull();
+  }
+
+  /**
    * Regression guard for the #6124 behaviour this fix must not weaken: a peer that did NOT source the baseline and
    * holds a fresher copy with no Raft history is still refused and marked diverged.
    */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7011BootstrapSourceRaceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7011BootstrapSourceRaceTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.BootstrapFingerprint;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #7011: the formation-time bootstrap election racing the leader's own database creation
+ * and seeding.
+ * <p>
+ * The election samples every local database at collect time, so a database the leader created milliseconds
+ * earlier is baselined at {@code lastTxId=0}; by the time the leader's own state machine applies the committed
+ * {@code BOOTSTRAP_FINGERPRINT_ENTRY} the seeding has advanced the copy, and the "local is fresher, refusing to
+ * overwrite" guard fired on the very peer that sourced the baseline. Two apply-side rules close it deterministically:
+ * the bootstrap source is exempt from the refusal (its copy IS the baseline), and a baseline for a database that
+ * already has Raft history on the node is superseded and ignored on every peer alike.
+ * <p>
+ * Same harness as {@code ArcadeStateMachineBootstrapDivergenceTest}: a real unstarted {@link ArcadeDBServer} and a
+ * real {@link LocalDatabase}, no mocking framework.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7011BootstrapSourceRaceTest {
+
+  private static final String DB = "config-db";
+
+  @TempDir
+  private Path           serverDir;
+  private ArcadeDBServer server;
+  private LocalDatabase  localDb;
+  private String         dbPath;
+
+  @BeforeEach
+  void setUp() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+    server = new ArcadeDBServer(config);
+
+    dbPath = serverDir.resolve(DB).toString();
+    localDb = (LocalDatabase) new DatabaseFactory(dbPath).create();
+    // The application seeds the database right after creating it: the copy moves past the sampled baseline.
+    localDb.getSchema().createDocumentType("Seed");
+    localDb.transaction(() -> localDb.newDocument("Seed").set("k", 1).save());
+    server.registerDatabase(DB, localDb);
+    assertThat(localDb.getLastTransactionId()).isGreaterThan(0);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (localDb != null && localDb.isOpen())
+      localDb.close();
+    if (dbPath != null)
+      FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  private ArcadeStateMachine newStateMachine() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(server);
+    return sm;
+  }
+
+  /** The baseline the election sampled when the database was still empty. */
+  private RaftLogEntryCodec.DecodedEntry emptyBaseline() {
+    return RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeBootstrapFingerprintEntry(DB, "0".repeat(64), 0L));
+  }
+
+  /**
+   * The reported failure: the leader that committed the baseline applies it after its own seeding advanced the
+   * copy. The source's copy is the baseline by definition, so the refusal must not fire on it.
+   */
+  @Test
+  void theBootstrapSourceIsNotPoisonedByItsOwnConcurrentWrites() {
+    final ArcadeStateMachine sm = newStateMachine();
+
+    sm.applyBootstrapFingerprintEntry(emptyBaseline(), 3L, true);
+
+    assertThat(sm.getBootstrapUnreconciledDatabases())
+        .as("the source's copy advancing past the sampled baseline is the expected outcome, not divergence")
+        .isEmpty();
+    assertThat(sm.getBootstrapBaseline(DB)).as("the committed baseline is still recorded for status export").isNotNull();
+    assertThat(sm.getBootstrapBaseline(DB).lastTxId()).isZero();
+    assertThat(localDb.isOpen()).isTrue();
+  }
+
+  /**
+   * Regression guard for the #6124 behaviour this fix must not weaken: a peer that did NOT source the baseline and
+   * holds a fresher copy with no Raft history is still refused and marked diverged.
+   */
+  @Test
+  void aNonSourcePeerWithAFresherStrayCopyIsStillRefused() {
+    final ArcadeStateMachine sm = newStateMachine();
+
+    sm.applyBootstrapFingerprintEntry(emptyBaseline(), 3L, false);
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).containsExactly(DB);
+  }
+
+  /**
+   * A database that an application entry earlier in the log already touched on this node has its history inside
+   * the Raft log: the baseline sampled for it is stale by construction and must be ignored, not refused. This is
+   * what keeps a follower that acquired the database through replication from being marked diverged, and it is
+   * decided from the log order, so every peer reaches the same verdict.
+   */
+  @Test
+  void aBaselineCommittedAfterTheDatabaseGotRaftHistoryIsSuperseded() {
+    final ArcadeStateMachine sm = newStateMachine();
+    // A schema/tx entry for this database applied at index 2, then the baseline lands at index 3.
+    sm.writePersistedAppliedIndex(2L, DB);
+
+    sm.applyBootstrapFingerprintEntry(emptyBaseline(), 3L, false);
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).as("replication, not bootstrap, owns this database").isEmpty();
+    assertThat(sm.getBootstrapBaseline(DB)).as("a baseline the cluster never adopted is not recorded").isNull();
+    assertThat(localDb.isOpen()).isTrue();
+  }
+
+  /**
+   * The superseded rule is per database: history on ANOTHER database does not suppress this one's baseline.
+   */
+  @Test
+  void historyOnAnotherDatabaseDoesNotSupersedeThisBaseline() {
+    final ArcadeStateMachine sm = newStateMachine();
+    sm.writePersistedAppliedIndex(2L, "other-db");
+
+    sm.applyBootstrapFingerprintEntry(emptyBaseline(), 3L, false);
+
+    assertThat(sm.getBootstrapBaseline(DB)).isNotNull();
+    assertThat(sm.getBootstrapUnreconciledDatabases()).containsExactly(DB);
+  }
+
+  /**
+   * A genuine first formation is untouched: the source's copy equals the baseline and no history precedes it.
+   */
+  @Test
+  void aMatchingBaselineOnTheSourceIsBootstrappedLocally() {
+    final ArcadeStateMachine sm = newStateMachine();
+    final RaftLogEntryCodec.DecodedEntry matching = RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeBootstrapFingerprintEntry(
+        DB, BootstrapFingerprint.compute(new File(dbPath)), localDb.getLastTransactionId()));
+
+    sm.applyBootstrapFingerprintEntry(matching, 3L, true);
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+    assertThat(sm.getBootstrapBaseline(DB)).isNotNull();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037LogWriterRecoveryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037LogWriterRecoveryTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.proto.RaftProtos.LogEntryProto;
+import org.apache.ratis.util.LifeCycle;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #7037 (follow-up to #5345): a follower whose Raft log writer failed persistently -
+ * {@code No space left on device} being the reported cause - stays {@code RUNNING} while rejecting every append,
+ * and nothing recovered it without an operator restart. The state machine now keeps the failure Ratis reports
+ * through {@code notifyLogFailed}, and the health monitor restarts the server in place once the volume has room,
+ * bounded per episode so a failure that is not about space does not restart the node on every tick forever.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7037LogWriterRecoveryTest {
+
+  /** A target whose log writer failure and volume state the test drives; a restart clears the failure unless pinned. */
+  static final class FakeTarget implements HealthMonitor.HealthTarget {
+    final    AtomicInteger restarts        = new AtomicInteger();
+    volatile String        logFailure      = null;
+    volatile boolean       storageWritable = true;
+    volatile boolean       failureSurvivesRestart = false;
+
+    @Override
+    public LifeCycle.State getRaftLifeCycleState() {
+      return LifeCycle.State.RUNNING;
+    }
+
+    @Override
+    public boolean isShutdownRequested() {
+      return false;
+    }
+
+    @Override
+    public void restartRatisIfNeeded() {
+      restarts.incrementAndGet();
+      if (!failureSurvivesRestart)
+        logFailure = null; // a restart builds a fresh state machine, which is what clears the mark
+    }
+
+    @Override
+    public String getRaftLogFailure() {
+      return logFailure;
+    }
+
+    @Override
+    public boolean isRaftStorageWritable() {
+      return storageWritable;
+    }
+  }
+
+  private static HealthMonitor monitor(final FakeTarget target, final int restartThreshold, final AtomicLong clock) {
+    final HealthMonitor monitor = new HealthMonitor(target, 1000L, 0L, 0L, false, 0, restartThreshold);
+    monitor.setClock(clock::get);
+    return monitor;
+  }
+
+  @Test
+  void healthyLogWriterNeverRestarts() {
+    final FakeTarget target = new FakeTarget();
+    final HealthMonitor monitor = monitor(target, 10, new AtomicLong(1_000L));
+
+    monitor.tick();
+    monitor.tick();
+
+    assertThat(target.restarts.get()).isZero();
+  }
+
+  @Test
+  void restartIsDeferredWhileTheVolumeIsStillFullAndFiredOnceItHasRoom() {
+    final FakeTarget target = new FakeTarget();
+    final AtomicLong clock = new AtomicLong(1_000L);
+    final HealthMonitor monitor = monitor(target, 10, clock);
+
+    target.logFailure = "at index 4946: java.io.IOException: No space left on device";
+    target.storageWritable = false;
+    monitor.tick();
+    monitor.tick();
+    assertThat(target.restarts.get()).as("a restart on a full volume wedges again at the first append").isZero();
+
+    // The periodic compaction freed the segments below the applied index.
+    target.storageWritable = true;
+    monitor.tick();
+    assertThat(target.restarts.get()).isEqualTo(1);
+    assertThat(target.logFailure).isNull();
+
+    monitor.tick();
+    assertThat(target.restarts.get()).as("the fresh state machine carries no failure: nothing more to do").isEqualTo(1);
+  }
+
+  @Test
+  void restartsAreBoundedPerEpisodeWhenTheFailureIsNotAboutSpace() {
+    final FakeTarget target = new FakeTarget();
+    final AtomicLong clock = new AtomicLong(1_000L);
+    final HealthMonitor monitor = monitor(target, 2, clock);
+
+    target.logFailure = "at index 12: java.io.IOException: Input/output error";
+    target.failureSurvivesRestart = true; // a dying disk: every restart fails the same way
+
+    for (int i = 0; i < 6; i++) {
+      monitor.tick();
+      clock.addAndGet(1_000L);
+    }
+    assertThat(target.restarts.get()).as("the crash-loop budget bounds the in-place restarts").isEqualTo(2);
+
+    // After a quiet window the episode is over and recovery is attempted again.
+    clock.addAndGet(HealthMonitor.LOG_FAILURE_EPISODE_RESET_MS);
+    monitor.tick();
+    assertThat(target.restarts.get()).isEqualTo(3);
+  }
+
+  @Test
+  void aZeroThresholdKeepsTheLegacyUnboundedBehaviour() {
+    final FakeTarget target = new FakeTarget();
+    final HealthMonitor monitor = monitor(target, 0, new AtomicLong(1_000L));
+
+    target.logFailure = "at index 12: java.io.IOException: Input/output error";
+    target.failureSurvivesRestart = true;
+    for (int i = 0; i < 4; i++)
+      monitor.tick();
+
+    assertThat(target.restarts.get()).isEqualTo(4);
+  }
+
+  @Test
+  void stateMachineKeepsTheFirstFailureRatisReports() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    assertThat(sm.getRaftLogFailure()).isNull();
+
+    sm.notifyLogFailed(new IOException("No space left on device"), LogEntryProto.newBuilder().setTerm(3).setIndex(4946).build());
+    final ArcadeStateMachine.RaftLogFailure first = sm.getRaftLogFailure();
+    assertThat(first).isNotNull();
+    assertThat(first.index()).isEqualTo(4946L);
+    assertThat(first.describe()).contains("at index 4946").contains("No space left on device");
+
+    // Ratis reports every later task against the pinned exception; the first failure is the one that matters.
+    sm.notifyLogFailed(new IOException("Log already failed at index 4946"), LogEntryProto.newBuilder().setTerm(3).setIndex(4947).build());
+    assertThat(sm.getRaftLogFailure()).isSameAs(first);
+
+    // A whole-segment failure carries no entry.
+    final ArcadeStateMachine other = new ArcadeStateMachine();
+    other.notifyLogFailed(new IOException("No space left on device"), null);
+    assertThat(other.getRaftLogFailure().index()).isEqualTo(-1L);
+    assertThat(other.getRaftLogFailure().describe()).startsWith("on a log segment");
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037LogWriterRecoveryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037LogWriterRecoveryTest.java
@@ -128,10 +128,44 @@ class Issue7037LogWriterRecoveryTest {
     }
     assertThat(target.restarts.get()).as("the crash-loop budget bounds the in-place restarts").isEqualTo(2);
 
-    // After a quiet window the episode is over and recovery is attempted again.
-    clock.addAndGet(HealthMonitor.LOG_FAILURE_EPISODE_RESET_MS);
+    // Time alone never re-arms an incident that is still going on: the failure is present on every tick.
+    clock.addAndGet(2 * HealthMonitor.LOG_FAILURE_EPISODE_RESET_MS);
+    monitor.tick();
+    monitor.tick();
+    assertThat(target.restarts.get()).as("a persisting failure keeps the exhausted budget exhausted").isEqualTo(2);
+  }
+
+  @Test
+  void budgetReArmsOnlyAfterTheWriterHasBeenHealthyForTheResetWindow() {
+    final FakeTarget target = new FakeTarget();
+    final AtomicLong clock = new AtomicLong(1_000L);
+    final HealthMonitor monitor = monitor(target, 2, clock);
+
+    // Two incidents in quick succession: each restart clears the mark, the disk fills again right away.
+    for (int i = 0; i < 2; i++) {
+      target.logFailure = "at index " + i + ": java.io.IOException: No space left on device";
+      monitor.tick();
+      clock.addAndGet(1_000L);
+    }
+    assertThat(target.restarts.get()).isEqualTo(2);
+
+    // The failure comes back within the window: same incident, budget spent, no restart.
+    target.logFailure = "at index 9: java.io.IOException: No space left on device";
+    monitor.tick();
+    assertThat(target.restarts.get()).isEqualTo(2);
+    target.logFailure = null; // an operator restart cleared it
+
+    // The writer stays healthy for the whole window: the incident is over.
+    for (int i = 0; i < 3; i++) {
+      monitor.tick();
+      clock.addAndGet(HealthMonitor.LOG_FAILURE_EPISODE_RESET_MS / 2);
+    }
+
+    // A new incident much later is recovered again.
+    target.logFailure = "at index 40: java.io.IOException: No space left on device";
     monitor.tick();
     assertThat(target.restarts.get()).isEqualTo(3);
+    assertThat(target.logFailure).isNull();
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037SnapshotInstallSpaceCheckTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037SnapshotInstallSpaceCheckTest.java
@@ -86,6 +86,13 @@ class Issue7037SnapshotInstallSpaceCheckTest {
   }
 
   @Test
+  void theVolumeIsTheNearestExistingAncestor(@TempDir final Path tempDir) {
+    assertThat(SnapshotInstaller.nearestExistingAncestor(tempDir.toFile())).isEqualTo(tempDir.toFile());
+    assertThat(SnapshotInstaller.nearestExistingAncestor(tempDir.resolve("db").resolve(".snapshot-new").toFile()))
+        .isEqualTo(tempDir.toFile());
+  }
+
+  @Test
   void theReserveCoversAllocationOverheadAndSaturates() {
     assertThat(SnapshotInstaller.withAllocationReserve(1L)).isEqualTo(1L + SnapshotInstaller.SPACE_RESERVE_MIN_BYTES);
     final long oneGb = 1L << 30;
@@ -119,7 +126,7 @@ class Issue7037SnapshotInstallSpaceCheckTest {
 
     assertThatThrownBy(() -> SnapshotInstaller.downloadWithRetry("testdb", snapshotDir, "localhost:" + port, null, 0, 10))
         .isInstanceOf(IOException.class)
-        .rootCause().hasMessageContaining("Insufficient space");
+        .rootCause().hasMessageContaining("Insufficient space to install the snapshot of 'testdb'");
     assertThat(calls.get()).isEqualTo(1);
     assertThat(snapshotDir.resolve("data.dat")).as("nothing was extracted").doesNotExist();
   }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037SnapshotInstallSpaceCheckTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037SnapshotInstallSpaceCheckTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.utility.FileUtils;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #7037: the snapshot self-heal checks usable space before it downloads. The leader
+ * advertises the uncompressed size of the archive in a response header; a follower whose volume cannot hold it
+ * refuses before reading the body instead of failing with {@code No space left on device} after the whole transfer.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7037SnapshotInstallSpaceCheckTest {
+
+  private HttpServer httpServer;
+  private int        port;
+
+  @BeforeEach
+  void startServer() throws IOException {
+    httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+    port = httpServer.getAddress().getPort();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (httpServer != null)
+      httpServer.stop(0);
+  }
+
+  @Test
+  void refusesWhenTheVolumeCannotHoldTheInflatedArchive(@TempDir final Path tempDir) {
+    assertThatThrownBy(() -> SnapshotInstaller.checkUsableSpace(tempDir, Long.MAX_VALUE, "big"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Insufficient space to install the snapshot of 'big'")
+        .hasMessageContaining(String.valueOf(Long.MAX_VALUE));
+  }
+
+  @Test
+  void acceptsWhatFitsAndNeverRefusesAnUnknownSize(@TempDir final Path tempDir) {
+    assertThatCode(() -> SnapshotInstaller.checkUsableSpace(tempDir, 1L, "small")).doesNotThrowAnyException();
+    assertThatCode(() -> SnapshotInstaller.checkUsableSpace(tempDir, 0L, "unknown")).doesNotThrowAnyException();
+    assertThatCode(() -> SnapshotInstaller.checkUsableSpace(tempDir, -1L, "unknown")).doesNotThrowAnyException();
+    // The staging directory does not exist yet when the check runs: the nearest existing ancestor is the volume.
+    assertThatCode(() -> SnapshotInstaller.checkUsableSpace(tempDir.resolve("db").resolve(".snapshot-new"), 1L, "db"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void headerParsingTreatsAbsentOrMalformedAsUnknown() {
+    assertThat(SnapshotInstaller.parseUncompressedBytes(null)).isEqualTo(-1L);
+    assertThat(SnapshotInstaller.parseUncompressedBytes("")).isEqualTo(-1L);
+    assertThat(SnapshotInstaller.parseUncompressedBytes("lots")).isEqualTo(-1L);
+    assertThat(SnapshotInstaller.parseUncompressedBytes(" 4096 ")).isEqualTo(4096L);
+  }
+
+  @Test
+  void downloadRefusesBeforeReadingTheBodyWhenTheLeaderAdvertisesMoreThanFits(@TempDir final Path tempDir) throws Exception {
+    final AtomicInteger calls = new AtomicInteger();
+    httpServer.createContext("/api/v1/ha/snapshot/testdb", exchange -> {
+      calls.incrementAndGet();
+      final byte[] zip = zipWith("data.dat", "hello");
+      exchange.getResponseHeaders().add(SnapshotManager.UNCOMPRESSED_BYTES_HEADER, String.valueOf(Long.MAX_VALUE));
+      exchange.sendResponseHeaders(200, zip.length);
+      exchange.getResponseBody().write(zip);
+      exchange.close();
+    });
+    httpServer.start();
+
+    final Path snapshotDir = tempDir.resolve(".snapshot-new");
+    Files.createDirectories(snapshotDir);
+
+    assertThatThrownBy(() -> SnapshotInstaller.downloadWithRetry("testdb", snapshotDir, "localhost:" + port, null, 0, 10))
+        .isInstanceOf(IOException.class)
+        .rootCause().hasMessageContaining("Insufficient space");
+    assertThat(calls.get()).isEqualTo(1);
+    assertThat(snapshotDir.resolve("data.dat")).as("nothing was extracted").doesNotExist();
+  }
+
+  @Test
+  void downloadProceedsWhenTheAdvertisedSizeFits(@TempDir final Path tempDir) throws Exception {
+    httpServer.createContext("/api/v1/ha/snapshot/testdb", exchange -> {
+      final byte[] zip = zipWith("data.dat", "hello");
+      exchange.getResponseHeaders().add(SnapshotManager.UNCOMPRESSED_BYTES_HEADER, "5");
+      exchange.sendResponseHeaders(200, zip.length);
+      exchange.getResponseBody().write(zip);
+      exchange.close();
+    });
+    httpServer.start();
+
+    final Path snapshotDir = tempDir.resolve(".snapshot-new");
+    Files.createDirectories(snapshotDir);
+
+    SnapshotInstaller.downloadWithRetry("testdb", snapshotDir, "localhost:" + port, null, 0, 10);
+
+    assertThat(Files.readString(snapshotDir.resolve("data.dat"))).isEqualTo("hello");
+  }
+
+  @Test
+  void leaderEstimateCoversEveryShippedFile() {
+    final String path = "./target/databases/issue7037-estimate";
+    FileUtils.deleteRecursively(new File(path));
+    final Database db = new DatabaseFactory(path).create();
+    try {
+      db.getSchema().createDocumentType("Doc");
+      db.transaction(() -> {
+        for (int i = 0; i < 100; i++)
+          db.newDocument("Doc").set("id", i).set("payload", "x".repeat(200)).save();
+      });
+
+      final long estimate = SnapshotHttpHandler.estimateUncompressedBytes((DatabaseInternal) db, null);
+
+      // The archive ships the registered page files (not the WAL, which the install discards), so that is the floor.
+      long pageFiles = 0L;
+      for (final ComponentFile file : ((DatabaseInternal) db).getFileManager().getFiles())
+        if (file != null)
+          pageFiles += file.getOSFile().length();
+      assertThat(pageFiles).isGreaterThan(0L);
+      assertThat(estimate).as("the estimate covers every page file plus the schema and configuration")
+          .isGreaterThan(pageFiles);
+    } finally {
+      db.drop();
+      FileUtils.deleteRecursively(new File(path));
+    }
+  }
+
+  private static byte[] zipWith(final String name, final String content) throws IOException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (final ZipOutputStream zip = new ZipOutputStream(baos)) {
+      zip.putNextEntry(new ZipEntry(name));
+      zip.write(content.getBytes());
+      zip.closeEntry();
+    }
+    return baos.toByteArray();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037SnapshotInstallSpaceCheckTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037SnapshotInstallSpaceCheckTest.java
@@ -86,6 +86,14 @@ class Issue7037SnapshotInstallSpaceCheckTest {
   }
 
   @Test
+  void theReserveCoversAllocationOverheadAndSaturates() {
+    assertThat(SnapshotInstaller.withAllocationReserve(1L)).isEqualTo(1L + SnapshotInstaller.SPACE_RESERVE_MIN_BYTES);
+    final long oneGb = 1L << 30;
+    assertThat(SnapshotInstaller.withAllocationReserve(oneGb)).isEqualTo(oneGb + oneGb / 100L * SnapshotInstaller.SPACE_RESERVE_PERCENT);
+    assertThat(SnapshotInstaller.withAllocationReserve(Long.MAX_VALUE)).isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
   void headerParsingTreatsAbsentOrMalformedAsUnknown() {
     assertThat(SnapshotInstaller.parseUncompressedBytes(null)).isEqualTo(-1L);
     assertThat(SnapshotInstaller.parseUncompressedBytes("")).isEqualTo(-1L);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037SnapshotInstallSpaceCheckTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7037SnapshotInstallSpaceCheckTest.java
@@ -90,6 +90,10 @@ class Issue7037SnapshotInstallSpaceCheckTest {
     assertThat(SnapshotInstaller.nearestExistingAncestor(tempDir.toFile())).isEqualTo(tempDir.toFile());
     assertThat(SnapshotInstaller.nearestExistingAncestor(tempDir.resolve("db").resolve(".snapshot-new").toFile()))
         .isEqualTo(tempDir.toFile());
+    // A relative path (arcadedb.ha.raftStorageDirectory=raft/storage-n1) must reach the working directory instead
+    // of running out of components and answering "unknown volume".
+    assertThat(SnapshotInstaller.nearestExistingAncestor(new File("issue7037-missing/raft-storage-n1")))
+        .isEqualTo(new File("").getAbsoluteFile());
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7040ClusterMembershipTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7040ClusterMembershipTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for issue #7040 (follow-up to #5275): the reconciliation of the declared peer list against the live
+ * Raft configuration, and the alert built from their divergence. The end-to-end shape of {@code /api/v1/cluster}
+ * after a peer removal is covered by {@link Issue7040RemovedPeerStatusIT}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7040ClusterMembershipTest {
+
+  private static final RaftPeer A = peer("a");
+  private static final RaftPeer B = peer("b");
+  private static final RaftPeer C = peer("c");
+  private static final RaftPeer D = peer("d");
+
+  @Test
+  void identicalListsAreNotDiverged() {
+    final ClusterMembership membership = ClusterMembership.of(List.of(A, B, C), List.of(C, A, B));
+
+    assertThat(membership.diverged()).isFalse();
+    assertThat(membership.notInConfiguration()).isEmpty();
+    assertThat(membership.notInServerList()).isEmpty();
+    assertThat(membership.peers()).as("declaration order is kept, whatever order the configuration reports")
+        .containsExactly(A, B, C);
+    for (final RaftPeer peer : List.of(A, B, C))
+      assertThat(membership.isInConfiguration(peer.getId())).isTrue();
+  }
+
+  @Test
+  void removedPeerStaysListedButIsMarkedOutOfConfiguration() {
+    final ClusterMembership membership = ClusterMembership.of(List.of(A, B, C), List.of(A, B));
+
+    assertThat(membership.diverged()).isTrue();
+    assertThat(membership.peers()).as("the removed peer is still reported, never silently dropped").containsExactly(A, B, C);
+    assertThat(membership.isInConfiguration(C.getId())).isFalse();
+    assertThat(membership.isInConfiguration(A.getId())).isTrue();
+    assertThat(membership.notInConfiguration()).containsExactly("c");
+    assertThat(membership.notInServerList()).isEmpty();
+  }
+
+  @Test
+  void dynamicallyAddedPeerIsAppendedAfterTheDeclaredOnes() {
+    final ClusterMembership membership = ClusterMembership.of(List.of(A, B), List.of(D, A, B));
+
+    assertThat(membership.peers()).containsExactly(A, B, D);
+    assertThat(membership.isInConfiguration(D.getId())).isTrue();
+    assertThat(membership.notInServerList()).containsExactly("d");
+    assertThat(membership.notInConfiguration()).isEmpty();
+  }
+
+  @Test
+  void alertNamesTheDeclaredPeersMissingFromTheConfiguration() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addMembershipDivergenceAlert(List.of("c"), List.of(), "a", alerts);
+
+    assertThat(alerts.length()).isEqualTo(1);
+    final JSONObject alert = alerts.getJSONObject(0);
+    assertThat(alert.getString("id")).isEqualTo("peers-not-in-configuration");
+    assertThat(alert.getString("severity")).isEqualTo(ClusterAlerts.SEVERITY_WARNING);
+    assertThat(alert.getString("message")).contains("c");
+    assertThat(alert.getJSONObject("details").getJSONArray("peers").toList()).containsExactly("c");
+  }
+
+  @Test
+  void alertIsCriticalWhenThisNodeIsTheOneMissing() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addMembershipDivergenceAlert(List.of("a", "c"), List.of(), "a", alerts);
+
+    final JSONObject alert = alerts.getJSONObject(0);
+    assertThat(alert.getString("severity")).isEqualTo(ClusterAlerts.SEVERITY_CRITICAL);
+    assertThat(alert.getString("title")).contains("This node");
+  }
+
+  @Test
+  void undeclaredMemberIsOnlyInformational() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addMembershipDivergenceAlert(List.of(), List.of("d"), "a", alerts);
+
+    assertThat(alerts.length()).isEqualTo(1);
+    final JSONObject alert = alerts.getJSONObject(0);
+    assertThat(alert.getString("id")).isEqualTo("peers-not-in-server-list");
+    assertThat(alert.getString("severity")).isEqualTo(ClusterAlerts.SEVERITY_INFO);
+  }
+
+  @Test
+  void noAlertWithoutDivergence() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addMembershipDivergenceAlert(List.of(), List.of(), "a", alerts);
+    ClusterAlerts.addMembershipDivergenceAlert(null, null, null, alerts);
+
+    assertThat(alerts.length()).isZero();
+  }
+
+  private static RaftPeer peer(final String id) {
+    return RaftPeer.newBuilder().setId(RaftPeerId.valueOf(id)).setAddress(id + ":2434").build();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7040ClusterMembershipTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7040ClusterMembershipTest.java
@@ -78,6 +78,26 @@ class Issue7040ClusterMembershipTest {
   }
 
   @Test
+  void configuredPeersDropTheRemovedAndKeepTheRuntimeAdded() {
+    final ClusterMembership membership = ClusterMembership.of(List.of(A, B, C), List.of(A, D, B));
+
+    assertThat(membership.configuredPeers()).as("declared order first, runtime-added last, removed dropped")
+        .containsExactly(A, B, D);
+    assertThat(membership.peers()).containsExactly(A, B, C, D);
+  }
+
+  @Test
+  void theLiveEntryWinsForAPeerPresentInBothLists() {
+    final RaftPeer rejoined = RaftPeer.newBuilder().setId(B.getId()).setAddress("b-new:2434").build();
+    final ClusterMembership membership = ClusterMembership.of(List.of(A, B), List.of(A, rejoined));
+
+    assertThat(membership.peers()).containsExactly(A, rejoined);
+    assertThat(membership.peers().get(1).getAddress()).as("the address the cluster committed, not the declared one")
+        .isEqualTo("b-new:2434");
+    assertThat(membership.diverged()).isFalse();
+  }
+
+  @Test
   void alertNamesTheDeclaredPeersMissingFromTheConfiguration() {
     final JSONArray alerts = new JSONArray();
     ClusterAlerts.addMembershipDivergenceAlert(List.of("c"), List.of(), "a", alerts);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7040RemovedPeerStatusIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7040RemovedPeerStatusIT.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -100,6 +101,14 @@ class Issue7040RemovedPeerStatusIT extends BaseRaftHATest {
     assertThat(membershipAlert).as("the divergence is told to the operator, not left to diff by eye").isNotNull();
     assertThat(membershipAlert.getString("severity")).isEqualTo(ClusterAlerts.SEVERITY_WARNING);
     assertThat(membershipAlert.getJSONObject("details").getJSONArray("peers").toList()).containsExactly(removedPeerId);
+
+    // The sibling views agree (module CLAUDE.md, "Peer-list filtering"): the removed peer is no replica in the server
+    // stats, nor in the replica address list a client or a peer-to-peer transfer would dial.
+    final List<?> replicas = (List<?>) leaderRaft.getStats().get("replicas");
+    for (final Object replica : replicas)
+      assertThat(((Map<?, ?>) replica).get("id")).isNotEqualTo(removedPeerId);
+    assertThat(replicas).hasSize(1);
+    assertThat(leaderRaft.getReplicaAddresses()).doesNotContain("localhost:" + (2480 + removedIndex));
 
     // A follower that is still a member sees the same picture: the live configuration is committed cluster-wide.
     final int otherFollower = (leaderIndex + 2) % getServerCount();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7040RemovedPeerStatusIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7040RemovedPeerStatusIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7040 (follow-up to #5275): after a peer is removed from the live Raft configuration,
+ * {@code /api/v1/cluster} used to keep reporting it as a healthy {@code FOLLOWER} with an address, because the peer
+ * list was built from the static group only. It must now flag the peer as out of the configuration and raise the
+ * membership alert, while the members still in the configuration read as before.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7040RemovedPeerStatusIT extends BaseRaftHATest {
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Test
+  void removedPeerIsReportedOutOfConfigurationWithAnAlert() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).isGreaterThanOrEqualTo(0);
+    final int removedIndex = (leaderIndex + 1) % getServerCount();
+    final String removedPeerId = peerIdForIndex(removedIndex);
+
+    final RaftHAServer leaderRaft = getRaftPlugin(leaderIndex).getRaftHAServer();
+    assertThat(leaderRaft.getLivePeers()).hasSize(3);
+
+    // Before the removal every declared peer is a member: no flag, no alert.
+    final JSONObject before = queryClusterEndpoint(leaderIndex);
+    assertThat(before.getJSONArray("peers").length()).isEqualTo(3);
+    for (int i = 0; i < 3; i++) {
+      final JSONObject peer = before.getJSONArray("peers").getJSONObject(i);
+      assertThat(peer.getBoolean("inConfiguration")).isTrue();
+      assertThat(peer.getString("role")).isIn("LEADER", "FOLLOWER");
+    }
+    assertThat(alertIds(before)).doesNotContain("peers-not-in-configuration");
+
+    // The reported scenario: the peer is dropped from the committed configuration while it is down.
+    getServer(removedIndex).stop();
+    leaderRaft.removePeer(removedPeerId, true);
+    Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(leaderRaft.getLivePeers()).hasSize(2));
+
+    final JSONObject after = queryClusterEndpoint(leaderIndex);
+    final JSONArray peers = after.getJSONArray("peers");
+    assertThat(peers.length()).as("the removed peer stays listed: it is still declared").isEqualTo(3);
+
+    boolean removedSeen = false;
+    for (int i = 0; i < peers.length(); i++) {
+      final JSONObject peer = peers.getJSONObject(i);
+      if (removedPeerId.equals(peer.getString("id"))) {
+        removedSeen = true;
+        assertThat(peer.getBoolean("inConfiguration")).isFalse();
+        assertThat(peer.getString("role")).isEqualTo(GetClusterHandler.ROLE_NOT_IN_CONFIGURATION);
+      } else {
+        assertThat(peer.getBoolean("inConfiguration")).isTrue();
+        assertThat(peer.getString("role")).isIn("LEADER", "FOLLOWER");
+      }
+    }
+    assertThat(removedSeen).isTrue();
+
+    final JSONArray alerts = after.getJSONArray("alerts");
+    JSONObject membershipAlert = null;
+    for (int i = 0; i < alerts.length(); i++)
+      if ("peers-not-in-configuration".equals(alerts.getJSONObject(i).getString("id")))
+        membershipAlert = alerts.getJSONObject(i);
+    assertThat(membershipAlert).as("the divergence is told to the operator, not left to diff by eye").isNotNull();
+    assertThat(membershipAlert.getString("severity")).isEqualTo(ClusterAlerts.SEVERITY_WARNING);
+    assertThat(membershipAlert.getJSONObject("details").getJSONArray("peers").toList()).containsExactly(removedPeerId);
+
+    // A follower that is still a member sees the same picture: the live configuration is committed cluster-wide.
+    final int otherFollower = (leaderIndex + 2) % getServerCount();
+    final JSONObject fromFollower = queryClusterEndpoint(otherFollower);
+    assertThat(alertIds(fromFollower)).contains("peers-not-in-configuration");
+  }
+
+  private static List<String> alertIds(final JSONObject response) {
+    final List<String> ids = new ArrayList<>();
+    final JSONArray alerts = response.getJSONArray("alerts");
+    for (int i = 0; i < alerts.length(); i++)
+      ids.add(alerts.getJSONObject(i).getString("id"));
+    return ids;
+  }
+
+  private JSONObject queryClusterEndpoint(final int serverIndex) throws Exception {
+    final int httpPort = 2480 + serverIndex;
+    final URL url = new URL("http://localhost:" + httpPort + "/api/v1/cluster");
+    final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestMethod("GET");
+    conn.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8)));
+    try {
+      assertThat(conn.getResponseCode()).isEqualTo(200);
+      return new JSONObject(new String(conn.getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+    } finally {
+      conn.disconnect();
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7041DegradedFollowerStateTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7041DegradedFollowerStateTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for issue #7041 (follow-up to #4842).
+ * <p>
+ * When membership changes while the leader reads its follower indices, {@link RaftHAServer#getFollowerStates()}
+ * degrades to entries WITHOUT a {@code matchIndex} rather than attributing an index to the wrong peer. The
+ * exporter unboxed that key with a raw {@code (Long)} cast at two sites, both inside catch-alls, so the
+ * {@code NullPointerException} never surfaced: the CLUSTER CONFIGURATION table was silently suppressed and the
+ * lag-monitor tick aborted before the remaining followers were classified - exactly while membership churned.
+ * <p>
+ * Drives the exporter against a mocked {@link RaftHAServer} that answers with one degraded and one complete
+ * follower entry, the shape {@link RaftHAServer#degradedFollowerStates} produces.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7041DegradedFollowerStateTest {
+
+  private static final RaftPeerId LEADER   = RaftPeerId.valueOf("leader");
+  private static final RaftPeerId DEGRADED = RaftPeerId.valueOf("degraded");
+  private static final RaftPeerId HEALTHY  = RaftPeerId.valueOf("healthy");
+
+  /** Exporter with the log-emission seam captured; data collection runs exactly as in production. */
+  private static final class CapturingExporter extends RaftClusterStatusExporter {
+    private final List<String> emitted = new ArrayList<>();
+
+    CapturingExporter(final RaftHAServer haServer, final ClusterMonitor clusterMonitor) {
+      super(haServer, clusterMonitor);
+    }
+
+    @Override
+    void emit(final String output) {
+      emitted.add(output);
+    }
+  }
+
+  private RaftHAServer   haServer;
+  private ClusterMonitor clusterMonitor;
+
+  @BeforeEach
+  void setUp() {
+    haServer = mock(RaftHAServer.class);
+    clusterMonitor = new ClusterMonitor(10L);
+
+    when(haServer.isLeader()).thenReturn(true);
+    when(haServer.getLeaderId()).thenReturn(LEADER);
+    when(haServer.getCurrentTerm()).thenReturn(7L);
+    when(haServer.getCommitIndex()).thenReturn(100L);
+    when(haServer.getConfiguredServers()).thenReturn(3);
+    when(haServer.getReplicationLatencies()).thenReturn(Map.of());
+    when(haServer.getStateMachine()).thenReturn(null);
+    when(haServer.getLivePeers()).thenReturn(List.of(peer(LEADER), peer(DEGRADED), peer(HEALTHY)));
+
+    // The degraded entry comes first so the old raw cast aborted the loop BEFORE the healthy peer was read.
+    when(haServer.getFollowerStates()).thenReturn(List.of(degradedState(DEGRADED, 12L), completeState(HEALTHY, 100L, 3L)));
+  }
+
+  @Test
+  void degradedFollowerKeepsItsRowWithUnknownLagInsteadOfSuppressingTheTable() {
+    final CapturingExporter exporter = new CapturingExporter(haServer, clusterMonitor);
+
+    exporter.printClusterConfiguration();
+
+    assertThat(exporter.emitted).as("the table must be emitted even though one entry has no match index").hasSize(1);
+    final String table = exporter.emitted.get(0);
+    assertThat(table).contains("CLUSTER CONFIGURATION (term=7, commitIndex=100)");
+    assertThat(table).contains("degraded");
+    assertThat(table).contains("healthy");
+
+    final String degradedRow = rowOf(table, "degraded");
+    assertThat(degradedRow).as("lag is reported as unknown, not as a number Ratis never gave").contains("| " + RaftClusterStatusExporter.LAG_UNKNOWN + " ");
+    assertThat(degradedRow).as("last contact is still known for a degraded entry").contains("12 ms");
+
+    final String healthyRow = rowOf(table, "healthy");
+    assertThat(healthyRow).contains("| 0 ").contains("3 ms");
+  }
+
+  @Test
+  void lagTickSkipsTheDegradedFollowerAndStillClassifiesTheOthers() {
+    final CapturingExporter exporter = new CapturingExporter(haServer, clusterMonitor);
+
+    exporter.checkReplicaLag();
+
+    assertThat(clusterMonitor.getReplicaStatus(HEALTHY.toString()))
+        .as("the tick must reach the followers listed after the degraded one")
+        .isEqualTo(ClusterMonitor.ReplicaStatus.HEALTHY);
+    assertThat(clusterMonitor.getReplicaStatus(DEGRADED.toString()))
+        .as("a peer whose index is unknown keeps its previous classification rather than one derived from a placeholder")
+        .isEqualTo(ClusterMonitor.ReplicaStatus.UNKNOWN);
+    assertThat(exporter.emitted).as("the tick re-emits the table it used to lose").hasSize(1);
+  }
+
+  @Test
+  void followerStateIndexReadsAbsentKeysAsUnknown() {
+    final Map<String, Object> degraded = degradedState(DEGRADED, 5L);
+    assertThat(RaftHAServer.hasFollowerStateIndex(degraded, "matchIndex")).isFalse();
+    assertThat(RaftHAServer.followerStateIndex(degraded, "matchIndex")).isEqualTo(-1L);
+    assertThat(RaftHAServer.followerStateIndex(degraded, "lastRpcElapsedMs")).isEqualTo(5L);
+
+    final Map<String, Object> complete = completeState(HEALTHY, 42L, 1L);
+    assertThat(RaftHAServer.hasFollowerStateIndex(complete, "matchIndex")).isTrue();
+    assertThat(RaftHAServer.followerStateIndex(complete, "matchIndex")).isEqualTo(42L);
+  }
+
+  private static RaftPeer peer(final RaftPeerId id) {
+    return RaftPeer.newBuilder().setId(id).setAddress(id + ":2434").build();
+  }
+
+  /** Same shape as {@link RaftHAServer#degradedFollowerStates}: peer id and last-RPC elapsed only. */
+  private static Map<String, Object> degradedState(final RaftPeerId id, final long lastRpcElapsedMs) {
+    final Map<String, Object> state = new LinkedHashMap<>();
+    state.put("peerId", id.toString());
+    state.put("lastRpcElapsedMs", lastRpcElapsedMs);
+    return state;
+  }
+
+  private static Map<String, Object> completeState(final RaftPeerId id, final long matchIndex, final long lastRpcElapsedMs) {
+    final Map<String, Object> state = degradedState(id, lastRpcElapsedMs);
+    state.put("matchIndex", matchIndex);
+    state.put("nextIndex", matchIndex + 1);
+    return state;
+  }
+
+  private static String rowOf(final String table, final String peerId) {
+    for (final String line : table.split("\n"))
+      if (line.startsWith("| " + peerId + " "))
+        return line;
+    throw new AssertionError("No row for '" + peerId + "' in:\n" + table);
+  }
+}

--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -29,12 +29,18 @@ function renderClusterData(data) {
   var leaderId = data.leaderId;
   var localPeerId = data.localPeerId;
 
-  // Determine local role
-  var localRole = isLeader ? "LEADER" : "FOLLOWER";
+  // Determine local role from the local peer's own entry, so a node the live Raft configuration no longer
+  // contains reads NOT IN CONFIGURATION here as well as on its card (issue #7040).
+  var localPeer = null;
+  for (var p = 0; p < (data.peers || []).length; p++)
+    if (data.peers[p].id === localPeerId)
+      localPeer = data.peers[p];
+  var localOutOfConfiguration = !isLeader && localPeer != null && localPeer.inConfiguration === false;
+  var localRole = isLeader ? "LEADER" : (localOutOfConfiguration ? "NOT IN CONFIGURATION" : "FOLLOWER");
   $("#clusterRoleBadge")
     .text(localRole)
-    .removeClass("bg-success bg-warning bg-secondary bg-primary")
-    .addClass(isLeader ? "bg-success" : "bg-primary");
+    .removeClass("bg-success bg-warning bg-secondary bg-primary bg-danger")
+    .addClass(isLeader ? "bg-success" : (localOutOfConfiguration ? "bg-danger" : "bg-primary"));
 
   var healthy = leaderId != null && leaderId !== "";
   $("#clusterHealthBadge")

--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -498,9 +498,13 @@ function renderNodeCards(data) {
     var isLocal = peer.id === data.localPeerId;
 
     var borderColor = isLeader ? "var(--color-brand)" : "var(--border-light)";
+    // A declared peer the live Raft configuration no longer contains is not a follower: the leader does not
+    // replicate to it and it cannot vote (issue #7040). Show it as such instead of as a healthy member.
     var roleBadge = isLeader
       ? '<span class="badge bg-success">LEADER</span>'
-      : '<span class="badge bg-secondary">FOLLOWER</span>';
+      : (peer.inConfiguration === false
+        ? '<span class="badge bg-danger">NOT IN CONFIGURATION</span>'
+        : '<span class="badge bg-secondary">FOLLOWER</span>');
     var localBadge = isLocal ? ' <span class="badge bg-info" style="font-size:0.6rem;">LOCAL</span>' : '';
 
     // replicaStatus is only sent for followers and only by a leader's status export.
@@ -583,9 +587,12 @@ function renderPeerManagement(data) {
     var peer = peers[i];
     var isLeader = peer.role === "LEADER";
     var isLocal = peer.id === data.localPeerId;
+    var inConfiguration = peer.inConfiguration !== false;
     var roleBadge = isLeader
       ? '<span class="badge bg-success" style="font-size:0.65rem;">LEADER</span>'
-      : '<span class="badge bg-secondary" style="font-size:0.65rem;">FOLLOWER</span>';
+      : (inConfiguration
+        ? '<span class="badge bg-secondary" style="font-size:0.65rem;">FOLLOWER</span>'
+        : '<span class="badge bg-danger" style="font-size:0.65rem;">NOT IN CONFIGURATION</span>');
     var localTag = isLocal ? ' <span class="badge bg-info" style="font-size:0.6rem;">LOCAL</span>' : '';
     var statusBadge = (!isLeader && peer.replicaStatus)
       ? ' <span class="badge ' + replicaStatusStyle(peer.replicaStatus).badge + '" style="font-size:0.6rem;">' + escapeHtml(peer.replicaStatus) + '</span>'
@@ -594,8 +601,9 @@ function renderPeerManagement(data) {
     // Remove button only when local is leader and target is a follower. The leader cannot remove
     // itself: it must step down (or use Leave Cluster) so the resulting Raft config is valid.
     // JSON.stringify + &quot; escaping keeps any characters in peer.id safe inside the attribute.
+    // A peer already outside the configuration has nothing left to remove (issue #7040).
     var removeBtn = "";
-    if (canManage && !isLeader) {
+    if (canManage && !isLeader && inConfiguration) {
       var idAttr = JSON.stringify(peer.id).replace(/"/g, "&quot;");
       removeBtn = '<button class="btn btn-sm btn-outline-danger" style="font-size:0.7rem; padding:1px 8px;" '
         + 'onclick="removePeer(' + idAttr + ')" title="Remove peer from the cluster">'


### PR DESCRIPTION
Four HA follow-ups that came out of re-validating earlier fixes against `main`, plus the analysis of a fifth that needs a design decision before any code.

Fixes #7040, fixes #7011, fixes #7037, fixes #7041. Related: #6965 (analysis only, see below).

## #7041 - `RaftClusterStatusExporter` raw-casts the follower indices

`getFollowerStates()` degrades to entries **without** a `matchIndex` when membership changes while the indices are read (#4842). Two exporter sites still unboxed the key with `(Long)`, both inside catch-alls, so the NPE never surfaced: the CLUSTER CONFIGURATION table was silently suppressed and the lag tick aborted before the remaining followers were classified, exactly while membership churned.

- One shared reader on `RaftHAServer` (`followerStateIndex` / `hasFollowerStateIndex`) replaces every ad-hoc `instanceof Number` and every raw cast, so the degraded shape has one consumer contract instead of two.
- The table keeps the degraded peer's row with `LAG = ?` (its last contact is still known); `-1` could not stand in for "unknown" because it is Ratis's own never-appended sentinel and `ClusterMonitor` classifies from it.
- The lag tick skips only that peer and classifies the others; its previous classification is kept rather than derived from a placeholder.

## #7040 - `/api/v1/cluster` built its peer list from the static group

A peer removed from the live Raft configuration read as a healthy `FOLLOWER` with an address. The response now reconciles the two lists (`ClusterMembership`): every declared peer plus every committed member, each with `inConfiguration`; a declared peer outside the configuration gets `role: NOT_IN_CONFIGURATION`, and the divergence raises `peers-not-in-configuration` (`critical` when it is the answering node itself, `warning` otherwise) and, for a member added at runtime but not declared, the informational `peers-not-in-server-list`. Studio shows the state as a red badge and hides the remove button for a peer that is already out.

The issue offered "build from `getLivePeers()`" as one option; that would have silently dropped the removed peer from the list, which is the opposite of surfacing it. Reporting the union with the flag keeps the operator's declared view and tells them where it diverges.

## #7011 - cold-boot bootstrap election races the leader's own seeding

The formation-time election samples whatever databases exist at collect time. A database the leader created milliseconds earlier is baselined at `lastTxId=0`; by the time the leader's state machine applies the committed baseline its own seeding has moved the copy on, and the "local is fresher, refusing to overwrite" guard fired on the very peer that sourced the baseline. Two apply-side rules close it deterministically, on every peer alike:

- **Superseded baseline**: a database that already has Raft history on the node (its per-database applied index precedes the baseline's index) is owned by replication, not bootstrap; the baseline is ignored and not recorded. Same verdict on every peer because the log order is the same.
- **Bootstrap source**: the peer that committed the entry (`originatedLocally`, from the same origin marker the TX path uses) sampled the baseline from its own copy, so that copy advancing past the sample is the expected outcome and the refusal does not apply to it.

Neither rule is reachable on a genuine first formation, so #4800 / #6124 are unchanged (the divergence tests still pass). The reporter's reflection-based workaround (draining `runBootstrapIfEligible()` before the first database access) is no longer needed.

## #7037 - a follower wedged by a full disk had no recovery path

- `ArcadeStateMachine` now overrides Ratis's `notifyLogFailed` and keeps the first persistent log-write failure. `HealthMonitor` checks it on every tick (the division stays `RUNNING`, so nothing else could see it) and restarts Ratis in place - but only once the Raft storage volume has room for two log segments again, which the periodic compaction from #5345 provides; until then it logs a throttled SEVERE. The in-place restarts are bounded per incident by `arcadedb.ha.ratisRestartMaxRetries` and re-arm after ten quiet minutes, so a failure that is not about space does not restart the node on every tick.
- `SnapshotInstaller.install` purges the local Raft log first (skipped on the apply thread and while the state machine is paused, where the request could not be served, and with a 5 s budget so it never queues an install behind a long apply) and refuses the download up front when the volume cannot hold the archive: the leader now advertises the inflated size in `X-ArcadeDB-Snapshot-Uncompressed-Bytes`; a leader predating this header skips the check.

## #6965 - page-level conflict repair silently undoes a replica's increments (not fixed here)

Root cause confirmed as in the issue thread: `TransactionManager.applyChangesInternal` writes replicated page deltas without the per-file commit lock, so the leader's own phase 2 (`validateAndBumpVersions` ... `publishPages`) and the state machine's apply of a replica entry to the same page interleave. Taking the lock in the apply path alone is not sufficient: two deltas validated against the same base version are then merged region by region at "equal version" on every node (that is the #4926 torn-write repair semantics), which is consistent but still a lost update whenever the two intervals overlap, e.g. when a varint-encoded counter changes size and the slot table moves. The correct behaviour - the second writer gets a `NeedRetryException` - needs conflict detection at a point with a total order: the apply, with the leader's phase 2 running at its own log position and a whole-entry skip on conflict, plus a way to tell "replayed after a crash" from "second delta on the same base" (today indistinguishable by version alone). That is a change to the replication conflict model, tracked separately; this PR does not touch that path.

## Tests

- `Issue7041DegradedFollowerStateTest` (table emitted with `?`, tick continues, shared reader)
- `Issue7040ClusterMembershipTest` (reconciliation + alert builder) and `Issue7040RemovedPeerStatusIT` (3-node cluster, peer removed while down, endpoint on leader and follower)
- `Issue7011BootstrapSourceRaceTest` (source exemption, superseded rule, per-database scope, #6124 refusal kept)
- `Issue7037LogWriterRecoveryTest` (deferred while full, restart once with room, bounded per episode, state-machine mark) and `Issue7037SnapshotInstallSpaceCheckTest` (space check, header parsing, refusal before the body, leader estimate)
- ha-raft unit suite green locally; docs updated in arcadedb-docs (`ha.adoc`, `settings.adoc`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cluster views identify peers missing from the live Raft configuration with a clear “NOT IN CONFIGURATION” status.
  - Membership differences generate more informative cluster alerts.
  - Snapshot transfers advertise their uncompressed size and validate available storage before installation.
  - Persistent Raft log-write failures support automatic, storage-aware recovery.
  - Local Raft log compaction improves snapshot installation performance.

- **Bug Fixes**
  - Degraded follower status no longer disrupts cluster metrics; unavailable lag is shown as unknown.
  - Bootstrap handling better preserves valid local data and avoids stale baseline conflicts.
  - Removed peers are excluded from replica statistics and routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->