### PR TITLE
Fix #7032, #7039, #7043: one NaN policy for timeseries MIN/MAX, and a JSONL round trip that survives a TIMESERIES type

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
@@ -335,6 +335,14 @@ public final class MultiColumnAggregationResult {
     return vals[requestIndex];
   }
 
+  /**
+   * The number of samples that REACHED this request in this bucket, NaN ones included.
+   * <p>
+   * It is deliberately not a "has this request any real data" test, and must not be used as one: that a NaN
+   * sample increments this counter is precisely what made the old {@code counts[i] == 0} guard miss an all-NaN
+   * bucket and leak the MIN/MAX sentinel (issue #7043). For MIN/MAX, ask the value:
+   * {@code TimeSeriesNaN.isAbsent(getValue(bucketTs, requestIndex))}.
+   */
   public long getCount(final long bucketTs, final int requestIndex) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
@@ -312,38 +312,27 @@ public final class MultiColumnAggregationResult {
     return orderedBuckets;
   }
 
+  /**
+   * The MIN/MAX accumulator is returned as it stands: {@link TimeSeriesNaN#ABSENT} when no non-NaN sample ever
+   * reached this request in this bucket, and the real extreme otherwise. There is deliberately no
+   * "was the accumulator ever touched" guard here any more - the seed carries that answer itself, which is what
+   * issues #4596 and #7043 needed and what a count-based guard could not give (a NaN sample increments the count
+   * without contributing a value).
+   */
   public double getValue(final long bucketTs, final int requestIndex) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);
-      if (idx >= 0 && idx < maxBuckets && bucketUsed[idx]) {
-        if (isUnusedMinMax(flatCounts[idx], requestIndex))
-          return Double.NaN;
+      if (idx >= 0 && idx < maxBuckets && bucketUsed[idx])
         return flatValues[idx][requestIndex];
-      }
       final double[] overflow = overflowValues != null ? overflowValues.get(bucketTs) : null;
-      if (overflow != null) {
-        if (isUnusedMinMax(overflowCounts.get(bucketTs), requestIndex))
-          return Double.NaN;
+      if (overflow != null)
         return overflow[requestIndex];
-      }
       return 0.0;
     }
     final double[] vals = valuesByBucket.get(bucketTs);
     if (vals == null)
       return 0.0;
-    if (isUnusedMinMax(countsByBucket.get(bucketTs), requestIndex))
-      return Double.NaN;
     return vals[requestIndex];
-  }
-
-  /**
-   * A bucket is flagged used as soon as any request touches it, but a MIN/MAX request that received
-   * no data keeps its {@code Double.MAX_VALUE} / {@code -Double.MAX_VALUE} init sentinel. Surface that
-   * as NaN (the absent marker, issue #4596) instead of leaking the sentinel as if it were data.
-   */
-  private boolean isUnusedMinMax(final long[] counts, final int requestIndex) {
-    final AggregationType type = types[requestIndex];
-    return (type == AggregationType.MIN || type == AggregationType.MAX) && counts != null && counts[requestIndex] == 0;
   }
 
   public long getCount(final long bucketTs, final int requestIndex) {
@@ -391,12 +380,10 @@ public final class MultiColumnAggregationResult {
         for (int i = 0; i < requestCount; i++) {
           switch (types[i]) {
           case MIN:
-            if (oVals[i] < tVals[i])
-              tVals[i] = oVals[i];
+            tVals[i] = TimeSeriesNaN.min(tVals[i], oVals[i]);
             break;
           case MAX:
-            if (oVals[i] > tVals[i])
-              tVals[i] = oVals[i];
+            tVals[i] = TimeSeriesNaN.max(tVals[i], oVals[i]);
             break;
           case SUM:
           case AVG:
@@ -493,15 +480,23 @@ public final class MultiColumnAggregationResult {
     return true;
   }
 
+  /**
+   * MIN/MAX accumulators start at {@link TimeSeriesNaN#ABSENT}, not at a {@code ±Double.MAX_VALUE} sentinel.
+   * <p>
+   * The sentinel was the whole defect of issue #7043: it is a finite double, so nothing downstream could tell an
+   * untouched accumulator from a real extreme, and the guard that tried to (a {@code counts[i] == 0} test) keyed
+   * off the raw sample count - which a NaN sample increments. An all-NaN bucket therefore looked touched and
+   * handed {@code Double.MAX_VALUE} back as data. With the absent marker as the seed and
+   * {@link TimeSeriesNaN#min}/{@link TimeSeriesNaN#max} as the fold, "nothing real arrived" IS the value, and no
+   * side-channel is needed to recover it.
+   */
   private double[] newInitializedValues() {
     final double[] vals = new double[requestCount];
     for (int i = 0; i < requestCount; i++) {
       switch (types[i]) {
       case MIN:
-        vals[i] = Double.MAX_VALUE;
-        break;
       case MAX:
-        vals[i] = -Double.MAX_VALUE;
+        vals[i] = TimeSeriesNaN.ABSENT;
         break;
       default:
         vals[i] = 0.0;
@@ -521,12 +516,10 @@ public final class MultiColumnAggregationResult {
       vals[idx] += 1;
       break;
     case MIN:
-      if (value < vals[idx])
-        vals[idx] = value;
+      vals[idx] = TimeSeriesNaN.min(vals[idx], value);
       break;
     case MAX:
-      if (value > vals[idx])
-        vals[idx] = value;
+      vals[idx] = TimeSeriesNaN.max(vals[idx], value);
       break;
     }
     counts[idx]++;
@@ -537,12 +530,10 @@ public final class MultiColumnAggregationResult {
     for (int i = 0; i < requestCount; i++) {
       switch (types[i]) {
       case MIN:
-        if (values[i] < vals[i])
-          vals[i] = values[i];
+        vals[i] = TimeSeriesNaN.min(vals[i], values[i]);
         break;
       case MAX:
-        if (values[i] > vals[i])
-          vals[i] = values[i];
+        vals[i] = TimeSeriesNaN.max(vals[i], values[i]);
         break;
       case SUM:
       case AVG:
@@ -560,12 +551,10 @@ public final class MultiColumnAggregationResult {
       final int requestIndex, final double value, final long count) {
     switch (types[requestIndex]) {
     case MIN:
-      if (value < vals[requestIndex])
-        vals[requestIndex] = value;
+      vals[requestIndex] = TimeSeriesNaN.min(vals[requestIndex], value);
       break;
     case MAX:
-      if (value > vals[requestIndex])
-        vals[requestIndex] = value;
+      vals[requestIndex] = TimeSeriesNaN.max(vals[requestIndex], value);
       break;
     case SUM:
     case AVG:

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesNaN.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesNaN.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+/**
+ * THE NaN policy for the whole time-series stack: {@code NaN} is the ABSENT marker, and MIN/MAX skip it.
+ * <p>
+ * The policy exists as one class because the subsystem previously carried three of them. Every MIN/MAX
+ * accumulator started from a sentinel of its own choosing - {@code ±Infinity} in the PromQL functions and the
+ * instant-vector aggregation arms, {@code ±Double.MAX_VALUE} in the multi-column accumulator, the block-statistics
+ * reducer's {@code ±Double.MAX_VALUE} on disk - and each one leaked that sentinel back to the caller as though it
+ * were data whenever the window it summarised held no real value (issues #4596, #4716, #7039, #7043). Two paths
+ * over the same all-NaN samples answered differently, which is what made the leak more than cosmetic.
+ * <p>
+ * The fix removes the sentinels rather than guarding them: seed a MIN/MAX accumulator with {@link #ABSENT} and
+ * fold with {@link #min(double, double)} / {@link #max(double, double)}. A NaN sample never displaces the
+ * accumulator and the accumulator is NaN if and only if nothing real ever reached it, so "no data" needs no
+ * side-channel (a count, a bitset, a {@code found} flag) to be told apart from a real minimum. Merging two
+ * partial results is the same fold, so it inherits the property for free.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class TimeSeriesNaN {
+
+  /**
+   * The absent marker. A MIN/MAX result equal to this means the window carried no non-NaN sample.
+   */
+  public static final double ABSENT = Double.NaN;
+
+  private TimeSeriesNaN() {
+  }
+
+  /**
+   * Whether {@code value} is the absent marker rather than data.
+   */
+  public static boolean isAbsent(final double value) {
+    return Double.isNaN(value);
+  }
+
+  /**
+   * Folds one sample into a running MIN. {@code accumulator} starts at {@link #ABSENT}; a NaN sample is skipped,
+   * and the first real sample replaces the absent accumulator outright.
+   */
+  public static double min(final double accumulator, final double sample) {
+    if (Double.isNaN(sample))
+      return accumulator;
+    return Double.isNaN(accumulator) || sample < accumulator ? sample : accumulator;
+  }
+
+  /**
+   * Folds one sample into a running MAX. See {@link #min(double, double)}.
+   */
+  public static double max(final double accumulator, final double sample) {
+    if (Double.isNaN(sample))
+      return accumulator;
+    return Double.isNaN(accumulator) || sample > accumulator ? sample : accumulator;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -2080,6 +2080,20 @@ public class TimeSeriesSealedStore implements AutoCloseable {
   }
 
   /**
+   * Whether a declared statistic disagrees with the one recomputed from the column's values.
+   * <p>
+   * Plain {@code !=} cannot answer this since issue #7043: NaN is a legitimate declaration (the column carries no
+   * real sample), and {@code NaN != NaN} is true, so it would report every correctly-declared all-NaN column as
+   * damaged. Comparing "is either one absent" first, and only then the numbers, keeps the real-number comparison
+   * exactly as it was - {@code -0.0} and {@code 0.0} still agree, as they always did.
+   */
+  private static boolean statisticDiffers(final double declared, final double recomputed) {
+    if (TimeSeriesNaN.isAbsent(declared) || TimeSeriesNaN.isAbsent(recomputed))
+      return TimeSeriesNaN.isAbsent(declared) != TimeSeriesNaN.isAbsent(recomputed);
+    return declared != recomputed;
+  }
+
+  /**
    * Reduces one numeric column to the {@code {min, max, sum}} triple a block declares for it.
    * <p>
    * ONE definition, shared by the two write paths that produce the triple ({@link #downsampleBlocks} and
@@ -2128,9 +2142,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       return;
     }
 
-    // A NaN declared minimum is how the format says "this column carries no statistics", which is what a writer
-    // records for every column whose codec is not numeric. Nothing to reconcile against.
-    if (Double.isNaN(entry.columnMins[colIdx]) || values.length == 0)
+    if (values.length == 0)
       return;
 
     final double[] stats = reduceNumericStats(values);
@@ -2138,17 +2150,37 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final double max = stats[1];
     final double sum = stats[2];
 
-    if (min != entry.columnMins[colIdx])
+    // A block written before issue #7043 declares the OLD +/-Double.MAX_VALUE seed for a column whose samples
+    // are all NaN, and the aggregation push-down answers MIN/MAX straight out of that header - so it hands the
+    // seed back as a measurement until the block is rewritten. Reported by name, because a generic "declares
+    // 1.79E308 but its values start at NaN" says nothing about what to do, and there IS something to do.
+    if (TimeSeriesNaN.isAbsent(min) && (entry.columnMins[colIdx] == Double.MAX_VALUE
+        || entry.columnMaxs[colIdx] == -Double.MAX_VALUE)) {
+      problems.add(where + " declares the pre-#7043 min/max seed for column '" + column.getName()
+          + "', whose samples are all NaN: an aggregation answered from this block's header returns "
+          + Double.MAX_VALUE + " as if it were data. Recompacting or downsampling the block rewrites the header "
+          + "with the current policy (NaN = no sample)");
+      return;
+    }
+
+    // NaN is a legitimate declaration since issue #7043 - it is what a column with no real sample records - so
+    // the reconciliation has to compare it as a value rather than skip on it. NaN != NaN in Java, so a plain
+    // '!=' would report every correctly-declared all-NaN column as damaged, and would equally MISS a block that
+    // declares NaN over real data.
+    if (statisticDiffers(entry.columnMins[colIdx], min))
       problems.add(where + " declares min " + entry.columnMins[colIdx] + " for column '" + column.getName()
           + "' but its values start at " + min + ": an aggregation answered from this block would be wrong");
-    if (max != entry.columnMaxs[colIdx])
+    if (statisticDiffers(entry.columnMaxs[colIdx], max))
       problems.add(where + " declares max " + entry.columnMaxs[colIdx] + " for column '" + column.getName()
           + "' but its values reach " + max + ": an aggregation answered from this block would be wrong");
     // Relative, because summing the same doubles is only reproducible to within the rounding of the accumulation
     // itself - an absolute bound would fire on a healthy block of large values and pass on a damaged block of
     // small ones.
     final double declaredSum = entry.columnSums[colIdx];
-    if (Math.abs(sum - declaredSum) > SUM_RELATIVE_TOLERANCE * Math.max(1.0, Math.abs(sum)))
+    if (Double.isNaN(sum) != Double.isNaN(declaredSum))
+      problems.add(where + " declares sum " + declaredSum + " for column '" + column.getName()
+          + "' but its values add up to " + sum + ": an aggregation answered from this block would be wrong");
+    else if (Math.abs(sum - declaredSum) > SUM_RELATIVE_TOLERANCE * Math.max(1.0, Math.abs(sum)))
       problems.add(where + " declares sum " + declaredSum + " for column '" + column.getName()
           + "' but its values add up to " + sum + ": an aggregation answered from this block would be wrong");
   }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -238,10 +238,13 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     try {
       final int colCount = columns.size();
 
-      // Count numeric columns (those with non-NaN stats)
+      // Count the columns that carry a statistics triplet. Keyed off the codec, never off the VALUE of the
+      // declared minimum: a NaN minimum is a legitimate declaration ("this column holds no real sample", the
+      // absent marker of issue #7043), and treating it as "this column has no statistics section" would drop a
+      // triplet the reader still expects and shift every following column's statistics onto the wrong column.
       int numericColCount = 0;
       for (int c = 0; c < colCount; c++)
-        if (!Double.isNaN(columnMins[c]))
+        if (hasNumericStats(c))
           numericColCount++;
 
       // Build tag metadata section
@@ -263,7 +266,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       // Write stats section (schema order, no colIdx — iterate columns, skip non-numeric)
       metaBuf.putInt(numericColCount);
       for (int c = 0; c < colCount; c++) {
-        if (!Double.isNaN(columnMins[c])) {
+        if (hasNumericStats(c)) {
           metaBuf.putDouble(columnMins[c]);
           metaBuf.putDouble(columnMaxs[c]);
           metaBuf.putDouble(columnSums[c]);
@@ -1297,9 +1300,10 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       final double[] columnMins, final double[] columnMaxs, final double[] columnSums,
       final int colCount, final String[][] tagDistinctValues) throws IOException {
 
+    // Same codec-keyed rule as writeBlock() - see the comment there.
     int numericColCount = 0;
     for (int c = 0; c < colCount; c++)
-      if (!Double.isNaN(columnMins[c]))
+      if (hasNumericStats(c))
         numericColCount++;
 
     final byte[] tagMeta = buildTagMetadata(tagDistinctValues, colCount);
@@ -1315,7 +1319,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       metaBuf.putInt(col.length);
     metaBuf.putInt(numericColCount);
     for (int c = 0; c < colCount; c++) {
-      if (!Double.isNaN(columnMins[c])) {
+      if (hasNumericStats(c)) {
         metaBuf.putDouble(columnMins[c]);
         metaBuf.putDouble(columnMaxs[c]);
         metaBuf.putDouble(columnSums[c]);
@@ -2062,6 +2066,20 @@ public class TimeSeriesSealedStore implements AutoCloseable {
   }
 
   /**
+   * Whether column {@code c} carries a {@code {min, max, sum}} triplet in a block header.
+   * <p>
+   * ONE definition, shared by the two writers and the reader, because the block format stores the triplets
+   * positionally with no column index: the three sites must agree on exactly which columns contribute one or the
+   * statistics land on the wrong columns. The answer is the codec - the two numeric codecs are the ones
+   * {@link #reduceNumericStats} is run for - and deliberately NOT the value of the declared minimum, which since
+   * issue #7043 can legitimately be NaN for a column whose samples are all NaN.
+   */
+  private boolean hasNumericStats(final int c) {
+    final TimeSeriesCodec codec = columns.get(c).getCompressionHint();
+    return codec == TimeSeriesCodec.GORILLA_XOR || codec == TimeSeriesCodec.SIMPLE8B;
+  }
+
+  /**
    * Reduces one numeric column to the {@code {min, max, sum}} triple a block declares for it.
    * <p>
    * ONE definition, shared by the two write paths that produce the triple ({@link #downsampleBlocks} and
@@ -2071,14 +2089,17 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    * never do.
    */
   static double[] reduceNumericStats(final double[] values) {
-    double min = Double.MAX_VALUE;
-    double max = -Double.MAX_VALUE;
+    // MIN/MAX follow the one NaN policy of the subsystem (issue #7043): NaN is absent, and a column with no real
+    // value declares NaN statistics - which is already how the format says "this column carries no statistics",
+    // the marker writeBlock() and the DEEP checker both read. The previous +/-Double.MAX_VALUE seed was a finite
+    // double that survived into the block header, and the aggregation push-down answers MIN/MAX straight out of
+    // that header, so an all-NaN column made the fast path return Double.MAX_VALUE as if it were a measurement.
+    double min = TimeSeriesNaN.ABSENT;
+    double max = TimeSeriesNaN.ABSENT;
     double sum = 0;
     for (final double d : values) {
-      if (d < min)
-        min = d;
-      if (d > max)
-        max = d;
+      min = TimeSeriesNaN.min(min, d);
+      max = TimeSeriesNaN.max(max, d);
       sum += d;
     }
     return new double[] { min, max, sum };
@@ -2544,11 +2565,13 @@ public class TimeSeriesSealedStore implements AutoCloseable {
         if (indexChannel.read(statsBuf, statsPos) < tripletSize)
           break;
         statsBuf.flip();
-        // Stats are in schema order — iterate columns, populate non-NaN entries
+        // Stats are in schema order — iterate columns, consuming one triplet per column the WRITER emitted one
+        // for. The test has to be the writer's own (hasNumericStats), not "is this column a TIMESTAMP or a TAG":
+        // a FIELD whose codec is DICTIONARY (a STRING measurement) is neither, yet has no triplet, and reading
+        // one for it consumed the next column's statistics and left the last numeric column with none.
         int numericIdx = 0;
         for (int c = 0; c < colCount && numericIdx < numericColCount; c++) {
-          if (columns.get(c).getRole() == ColumnDefinition.ColumnRole.TIMESTAMP
-              || columns.get(c).getRole() == ColumnDefinition.ColumnRole.TAG)
+          if (!hasNumericStats(c))
             continue;
           mins[c] = statsBuf.getDouble();
           maxs[c] = statsBuf.getDouble();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -20,6 +20,7 @@ package com.arcadedb.engine.timeseries.promql;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.timeseries.TimeSeriesNaN;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.TimeBoundRegex;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
@@ -366,14 +367,17 @@ public class PromQLEvaluator {
           for (final VectorSample s : group) sum += s.value();
           yield sum / group.size();
         }
+        // Same NaN policy as every other MIN/MAX in the time-series stack (issue #7039): a group whose samples
+        // are all NaN yields NaN, not the seed. Seeding +/-Infinity and relying on `<`/`>` to displace it returned
+        // the sentinel as data, because a NaN sample never wins either comparison.
         case MIN -> {
-          double min = Double.POSITIVE_INFINITY;
-          for (final VectorSample s : group) if (s.value() < min) min = s.value();
+          double min = TimeSeriesNaN.ABSENT;
+          for (final VectorSample s : group) min = TimeSeriesNaN.min(min, s.value());
           yield min;
         }
         case MAX -> {
-          double max = Double.NEGATIVE_INFINITY;
-          for (final VectorSample s : group) if (s.value() > max) max = s.value();
+          double max = TimeSeriesNaN.ABSENT;
+          for (final VectorSample s : group) max = TimeSeriesNaN.max(max, s.value());
           yield max;
         }
         case COUNT -> (double) group.size();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLFunctions.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLFunctions.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.engine.timeseries.promql;
 
+import com.arcadedb.engine.timeseries.TimeSeriesNaN;
 import com.arcadedb.engine.timeseries.promql.PromQLResult.RangeSeries;
 
 import java.util.List;
@@ -158,19 +159,25 @@ public final class PromQLFunctions {
     return sumOverTime(series) / series.values().size();
   }
 
+  /**
+   * Prometheus answers NaN for {@code min_over_time} over a window with no real sample, so the fold goes through
+   * {@link TimeSeriesNaN} - the one NaN policy of the time-series stack - instead of seeding {@code +Infinity} and
+   * returning that sentinel as data when nothing displaced it (issue #7039).
+   */
   public static double minOverTime(final RangeSeries series) {
-    double min = Double.POSITIVE_INFINITY;
+    double min = TimeSeriesNaN.ABSENT;
     for (final double[] v : series.values())
-      if (v[1] < min)
-        min = v[1];
+      min = TimeSeriesNaN.min(min, v[1]);
     return min;
   }
 
+  /**
+   * See {@link #minOverTime(RangeSeries)}.
+   */
   public static double maxOverTime(final RangeSeries series) {
-    double max = Double.NEGATIVE_INFINITY;
+    double max = TimeSeriesNaN.ABSENT;
     for (final double[] v : series.values())
-      if (v[1] > max)
-        max = v[1];
+      max = TimeSeriesNaN.max(max, v[1]);
     return max;
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/simd/ScalarTimeSeriesVectorOps.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/simd/ScalarTimeSeriesVectorOps.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.engine.timeseries.simd;
 
+import com.arcadedb.engine.timeseries.TimeSeriesNaN;
+
 /**
  * Pure Java scalar implementation of vector operations. Always available as fallback.
  *
@@ -35,36 +37,21 @@ public final class ScalarTimeSeriesVectorOps implements TimeSeriesVectorOps {
 
   @Override
   public double min(final double[] data, final int offset, final int length) {
-    // NaN policy (issue #4716): skip NaN values, and return NaN (not the +Inf sentinel) when the range
-    // is empty or contains only NaN, so an "all-NaN" result is not mistaken for real data.
-    double m = Double.POSITIVE_INFINITY;
-    boolean found = false;
-    for (int i = offset; i < offset + length; i++) {
-      final double v = data[i];
-      if (Double.isNaN(v))
-        continue;
-      found = true;
-      if (v < m)
-        m = v;
-    }
-    return found ? m : Double.NaN;
+    // NaN policy (issues #4716, #7039): the fold IS the policy - see TimeSeriesNaN. Skips NaN, and an empty or
+    // all-NaN range comes back as the absent marker rather than a +Inf sentinel that reads as real data.
+    double m = TimeSeriesNaN.ABSENT;
+    for (int i = offset; i < offset + length; i++)
+      m = TimeSeriesNaN.min(m, data[i]);
+    return m;
   }
 
   @Override
   public double max(final double[] data, final int offset, final int length) {
-    // NaN policy (issue #4716): skip NaN values, and return NaN (not the -Inf sentinel) when the range
-    // is empty or contains only NaN, so an "all-NaN" result is not mistaken for real data.
-    double m = Double.NEGATIVE_INFINITY;
-    boolean found = false;
-    for (int i = offset; i < offset + length; i++) {
-      final double v = data[i];
-      if (Double.isNaN(v))
-        continue;
-      found = true;
-      if (v > m)
-        m = v;
-    }
-    return found ? m : Double.NaN;
+    // See min() above.
+    double m = TimeSeriesNaN.ABSENT;
+    for (int i = offset; i < offset + length; i++)
+      m = TimeSeriesNaN.max(m, data[i]);
+    return m;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/simd/SimdTimeSeriesVectorOps.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/simd/SimdTimeSeriesVectorOps.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.engine.timeseries.simd;
 
+import com.arcadedb.engine.timeseries.TimeSeriesNaN;
+
 import jdk.incubator.vector.DoubleVector;
 import jdk.incubator.vector.LongVector;
 import jdk.incubator.vector.VectorMask;
@@ -78,8 +80,10 @@ public final class SimdTimeSeriesVectorOps implements TimeSeriesVectorOps {
       if (v < m)
         m = v;
     }
-    // NaN policy (issue #4716): empty or all-NaN range returns NaN, not the +Inf sentinel.
-    return found ? m : Double.NaN;
+    // NaN policy (issues #4716, #7039): empty or all-NaN range returns the absent marker, not the +Inf sentinel.
+    // The vectorized loop keeps the +Inf reduction identity because that is what the hardware MIN reduction needs;
+    // `found` is what converts it back to TimeSeriesNaN's contract, which the scalar sibling folds directly.
+    return found ? m : TimeSeriesNaN.ABSENT;
   }
 
   @Override
@@ -111,8 +115,8 @@ public final class SimdTimeSeriesVectorOps implements TimeSeriesVectorOps {
       if (v > m)
         m = v;
     }
-    // NaN policy (issue #4716): empty or all-NaN range returns NaN, not the -Inf sentinel.
-    return found ? m : Double.NaN;
+    // See min() above: same TimeSeriesNaN contract, -Inf reduction identity.
+    return found ? m : TimeSeriesNaN.ABSENT;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/schema/TimeSeriesTypeBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TimeSeriesTypeBuilder.java
@@ -74,6 +74,24 @@ public class TimeSeriesTypeBuilder {
     return this;
   }
 
+  /**
+   * Adds an already-resolved column, codec included.
+   * <p>
+   * {@link #withTimestamp}/{@link #withTag}/{@link #withField} build the {@link ColumnDefinition} from the name and
+   * the type alone, which leaves the codec at the current default table's choice. That is right for a user creating
+   * a type, and wrong for anything RESTORING one - a logical restore (the JSONL importer) has the exported schema in
+   * hand, where the codec is recorded per column precisely because it is not re-derivable (issue #5475), and
+   * re-deriving it would silently re-encode the restored type differently from the one it came from.
+   *
+   * @param column the column to add; a TIMESTAMP-role column also becomes the type's timestamp column
+   */
+  public TimeSeriesTypeBuilder withColumn(final ColumnDefinition column) {
+    if (column.getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
+      this.timestampColumn = column.getName();
+    this.columns.add(column);
+    return this;
+  }
+
   public TimeSeriesTypeBuilder withShards(final int shards) {
     this.shards = shards;
     return this;

--- a/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
@@ -39,6 +39,14 @@ import java.util.Map;
 public class JsonGraphSerializer extends JsonSerializer {
 
   private boolean    expandVertexEdges       = false;
+  /**
+   * Whether a vertex line carries its edge metadata at all. The RID lists {@link #expandVertexEdges} produces are
+   * a diagnostic view, not part of a graph's definition: every importer rebuilds the edges from the edge records
+   * themselves, and a RID does not survive a re-import into a differently laid-out database anyway - so a consumer
+   * that writes them for a machine to read back is paying 2 x average-degree RIDs per vertex for something nothing
+   * reads, and implying a guarantee the format cannot make (issue #7032).
+   */
+  private boolean    includeVertexEdgeMetadata = true;
   private JSONObject sharedJson              = null;
   private boolean    includeMetadata         = true;
   private boolean    precisionAwareTemporals = false;
@@ -114,6 +122,9 @@ public class JsonGraphSerializer extends JsonSerializer {
     if (document instanceof Vertex vertex1) {
       final Vertex vertex = vertex1;
 
+      if (!includeVertexEdgeMetadata)
+        return;
+
       if (expandVertexEdges) {
         final JSONArray outEdges = new JSONArray();
         for (final Edge e : vertex.getEdges(Vertex.DIRECTION.OUT))
@@ -134,6 +145,18 @@ public class JsonGraphSerializer extends JsonSerializer {
       object.put("i", edge.getIn().toString());
       object.put("o", edge.getOut().toString());
     }
+  }
+
+  public boolean isIncludeVertexEdgeMetadata() {
+    return includeVertexEdgeMetadata;
+  }
+
+  /**
+   * See {@link #includeVertexEdgeMetadata}. Edges keep their endpoint RIDs either way - those ARE the edge.
+   */
+  public JsonGraphSerializer setIncludeVertexEdgeMetadata(final boolean includeVertexEdgeMetadata) {
+    this.includeVertexEdgeMetadata = includeVertexEdgeMetadata;
+    return this;
   }
 
   public boolean isExpandVertexEdges() {

--- a/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
@@ -26,6 +26,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.serializer.json.NonFiniteNumbers;
 import com.arcadedb.utility.DateUtils;
 
 import java.time.temporal.Temporal;
@@ -98,15 +99,10 @@ public class JsonGraphSerializer extends JsonSerializer {
             list.add(o);
           }
           value = list;
-        } else if (value.equals(Double.NaN) || value.equals(Float.NaN))
-          // JSON DOES NOT SUPPORT NaN
-          value = "NaN";
-        else if (value.equals(Double.POSITIVE_INFINITY) || value.equals(Float.POSITIVE_INFINITY))
-          // JSON DOES NOT SUPPORT INFINITY
-          value = "PosInfinity";
-        else if (value.equals(Double.NEGATIVE_INFINITY) || value.equals(Float.NEGATIVE_INFINITY))
-          // JSON DOES NOT SUPPORT INFINITY
-          value = "NegInfinity";
+        } else if (value instanceof Double || value instanceof Float)
+          // JSON supports none of NaN / +Infinity / -Infinity: they travel as the marker strings of
+          // NonFiniteNumbers, which is also what every reader of this output substitutes back.
+          value = NonFiniteNumbers.encode(value);
         else if (type != null && isEncodableTemporal(value) && type.existsProperty(prop.getKey()))
           value = encodeTemporalForWriteBack(value, type.getProperty(prop.getKey()).getType());
       }

--- a/engine/src/main/java/com/arcadedb/serializer/json/NonFiniteNumbers.java
+++ b/engine/src/main/java/com/arcadedb/serializer/json/NonFiniteNumbers.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.serializer.json;
+
+/**
+ * THE encoding of the three doubles JSON cannot represent - {@code NaN}, {@code +Infinity} and {@code -Infinity} -
+ * as the marker strings ArcadeDB's own formats read back.
+ * <p>
+ * JSON has no literal for any of them, and {@link JSONArray#put(Number)} resolves that by rewriting them to
+ * {@code 0} - which is a measurement of zero, indistinguishable from data. Every writer that must preserve the
+ * distinction therefore substitutes a string, and every reader of that writer's output must substitute back with
+ * the SAME three tokens: this class is where they live, so a change on one side cannot silently diverge from the
+ * other (record properties through {@code JsonGraphSerializer}, TIMESERIES samples through the JSONL
+ * exporter/importer).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class NonFiniteNumbers {
+
+  public static final String NAN               = "NaN";
+  public static final String POSITIVE_INFINITY = "PosInfinity";
+  public static final String NEGATIVE_INFINITY = "NegInfinity";
+
+  private NonFiniteNumbers() {
+  }
+
+  /**
+   * Returns the marker string for a non-finite {@code Double}/{@code Float}, and {@code value} itself for anything
+   * else - so a caller can pipe every value through it.
+   */
+  public static Object encode(final Object value) {
+    if (value instanceof Double d && !Double.isFinite(d))
+      return markerOf(d);
+    if (value instanceof Float f && !Float.isFinite(f))
+      return markerOf(f);
+    return value;
+  }
+
+  /**
+   * The inverse of {@link #encode(Object)} for a single token.
+   *
+   * @return the double the marker stands for, or {@code null} if {@code text} is not one of the three markers
+   */
+  public static Double decode(final String text) {
+    return switch (text) {
+      case NAN -> Double.NaN;
+      case POSITIVE_INFINITY -> Double.POSITIVE_INFINITY;
+      case NEGATIVE_INFINITY -> Double.NEGATIVE_INFINITY;
+      case null, default -> null;
+    };
+  }
+
+  private static String markerOf(final double value) {
+    if (Double.isNaN(value))
+      return NAN;
+    return value > 0 ? POSITIVE_INFINITY : NEGATIVE_INFINITY;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7043MinMaxAbsentPolicyTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7043MinMaxAbsentPolicyTest.java
@@ -143,6 +143,12 @@ class Issue7043MinMaxAbsentPolicyTest extends TestHelper {
       final long bucketTs = multi.getBucketTimestamps().getFirst();
       assertThat(multi.getValue(bucketTs, 0)).as("sealed-block MIN over an all-NaN column").isNaN();
       assertThat(multi.getValue(bucketTs, 1)).as("sealed-block MAX over an all-NaN column").isNaN();
+
+      // The DEEP check reconciles the declared statistics against the decoded values, and NaN is now a
+      // legitimate declaration: a plain '!=' there would report this healthy block as damaged, because
+      // NaN != NaN.
+      assertThat(engine.checkIntegrity(TimeSeriesIntegrity.Options.deepOnly()).problems())
+          .as("an all-NaN block declares NaN statistics and that is correct, not damage").isEmpty();
       database.commit();
     } finally {
       engine.drop();
@@ -188,6 +194,9 @@ class Issue7043MinMaxAbsentPolicyTest extends TestHelper {
       final long bucketTs = multi.getBucketTimestamps().getFirst();
       assertThat(multi.getValue(bucketTs, 0)).isEqualTo(10.0);
       assertThat(multi.getValue(bucketTs, 1)).isEqualTo(41.0);
+
+      // The same misalignment would make the DEEP check reconcile a column against another column's statistics.
+      assertThat(engine.checkIntegrity(TimeSeriesIntegrity.Options.deepOnly()).problems()).isEmpty();
       database.commit();
     } finally {
       engine.drop();

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7043MinMaxAbsentPolicyTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7043MinMaxAbsentPolicyTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7043 (follow-up on #4596): an all-NaN bucket leaked the MIN/MAX init sentinel.
+ * <p>
+ * {@code isUnusedMinMax} keyed off the raw sample count, and a NaN sample increments that count, so a bucket whose
+ * samples were all NaN looked "touched" while its accumulator still held the untouched {@code ±Double.MAX_VALUE}.
+ * The single-column path seeds its bucket with NaN and answered NaN over the same data, so the two paths disagreed.
+ * <p>
+ * The fix removes the sentinel rather than guarding it: MIN/MAX start at {@link TimeSeriesNaN#ABSENT} and fold
+ * through the one NaN policy of the subsystem, so "no real sample arrived" is the value itself.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7043MinMaxAbsentPolicyTest extends TestHelper {
+
+  private static final List<ColumnDefinition> COLUMNS = List.of(
+      new ColumnDefinition("ts", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP),
+      new ColumnDefinition("value", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD));
+
+  /**
+   * The issue's own repro: identical all-NaN data, two code paths, two different answers.
+   */
+  @Test
+  void anAllNaNBucketIsAbsentOnBothTheSingleAndTheMultiColumnPath() throws Exception {
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts7043_allnan", COLUMNS, 1);
+    engine.appendSamples(new long[] { 1000L, 2000L }, new Object[] { Double.NaN, Double.NaN });
+    database.commit();
+
+    try {
+      database.begin();
+      assertThat(engine.aggregate(Long.MIN_VALUE, Long.MAX_VALUE, 0, AggregationType.MIN, 0, null).getValue(0))
+          .as("single-column MIN over an all-NaN window").isNaN();
+      assertThat(engine.aggregate(Long.MIN_VALUE, Long.MAX_VALUE, 0, AggregationType.MAX, 0, null).getValue(0))
+          .as("single-column MAX over an all-NaN window").isNaN();
+
+      final List<MultiColumnAggregationRequest> requests = List.of(
+          new MultiColumnAggregationRequest(1, AggregationType.MIN, "min"),
+          new MultiColumnAggregationRequest(1, AggregationType.MAX, "max"));
+      final MultiColumnAggregationResult multi = engine.aggregateMulti(Long.MIN_VALUE, Long.MAX_VALUE, requests, 0, null);
+      assertThat(multi.size()).isEqualTo(1);
+      final long bucketTs = multi.getBucketTimestamps().getFirst();
+
+      // These two were Double.MAX_VALUE and -Double.MAX_VALUE.
+      assertThat(multi.getValue(bucketTs, 0)).as("multi-column MIN over an all-NaN window").isNaN();
+      assertThat(multi.getValue(bucketTs, 1)).as("multi-column MAX over an all-NaN window").isNaN();
+      database.commit();
+    } finally {
+      engine.drop();
+    }
+  }
+
+  /**
+   * The guard the sentinel needed must not have cost the ordinary answer: a bucket that holds real values among
+   * the NaN ones still reports those values, and a real {@code Double.MAX_VALUE} sample is data, not a sentinel.
+   */
+  @Test
+  void realValuesStillWinAndTheExtremeDoubleIsData() throws Exception {
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts7043_mixed", COLUMNS, 1);
+    engine.appendSamples(new long[] { 1000L, 2000L, 3000L },
+        new Object[] { Double.NaN, Double.MAX_VALUE, -Double.MAX_VALUE });
+    database.commit();
+
+    try {
+      database.begin();
+      final List<MultiColumnAggregationRequest> requests = List.of(
+          new MultiColumnAggregationRequest(1, AggregationType.MIN, "min"),
+          new MultiColumnAggregationRequest(1, AggregationType.MAX, "max"));
+      final MultiColumnAggregationResult multi = engine.aggregateMulti(Long.MIN_VALUE, Long.MAX_VALUE, requests, 0, null);
+      final long bucketTs = multi.getBucketTimestamps().getFirst();
+
+      assertThat(multi.getValue(bucketTs, 0)).isEqualTo(-Double.MAX_VALUE);
+      assertThat(multi.getValue(bucketTs, 1)).isEqualTo(Double.MAX_VALUE);
+
+      assertThat(engine.aggregate(Long.MIN_VALUE, Long.MAX_VALUE, 0, AggregationType.MIN, 0, null).getValue(0))
+          .as("the single-column path must agree").isEqualTo(-Double.MAX_VALUE);
+      assertThat(engine.aggregate(Long.MIN_VALUE, Long.MAX_VALUE, 0, AggregationType.MAX, 0, null).getValue(0))
+          .as("the single-column path must agree").isEqualTo(Double.MAX_VALUE);
+      database.commit();
+    } finally {
+      engine.drop();
+    }
+  }
+
+  /**
+   * The same question asked of a SEALED block, where MIN/MAX are answered from the block header the compaction
+   * wrote rather than from the samples: {@code reduceNumericStats} used to seed the very same
+   * {@code ±Double.MAX_VALUE} into that header, so the aggregation push-down handed the sentinel back as a
+   * measurement without ever decompressing a column.
+   */
+  @Test
+  void anAllNaNSealedBlockIsAbsentToo() throws Exception {
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts7043_sealed", COLUMNS, 1);
+    final long[] timestamps = new long[64];
+    final Object[] values = new Object[64];
+    for (int i = 0; i < timestamps.length; i++) {
+      timestamps[i] = 1000L + i;
+      values[i] = Double.NaN;
+    }
+    engine.appendSamples(timestamps, values);
+    database.commit();
+
+    try {
+      database.begin();
+      engine.compactAll();
+      database.commit();
+
+      database.begin();
+      final List<MultiColumnAggregationRequest> requests = List.of(
+          new MultiColumnAggregationRequest(1, AggregationType.MIN, "min"),
+          new MultiColumnAggregationRequest(1, AggregationType.MAX, "max"));
+      final MultiColumnAggregationResult multi = engine.aggregateMulti(Long.MIN_VALUE, Long.MAX_VALUE, requests, 0, null);
+      final long bucketTs = multi.getBucketTimestamps().getFirst();
+      assertThat(multi.getValue(bucketTs, 0)).as("sealed-block MIN over an all-NaN column").isNaN();
+      assertThat(multi.getValue(bucketTs, 1)).as("sealed-block MAX over an all-NaN column").isNaN();
+      database.commit();
+    } finally {
+      engine.drop();
+    }
+  }
+
+  /**
+   * A sealed block whose columns are a mix of numeric and text must still declare each column's statistics against
+   * the right column. The writer emitted a triplet per column with non-NaN statistics and the reader consumed one
+   * per column that is neither a TIMESTAMP nor a TAG - two different sets as soon as a FIELD is a STRING, which
+   * shifted every following column's min/max/sum onto the wrong column.
+   */
+  @Test
+  void blockStatisticsStayAlignedWithATextFieldBetweenTheNumericOnes() throws Exception {
+    final List<ColumnDefinition> columns = List.of(
+        new ColumnDefinition("ts", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP),
+        new ColumnDefinition("label", Type.STRING, ColumnDefinition.ColumnRole.FIELD),
+        new ColumnDefinition("value", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD));
+
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts7043_textfield", columns, 1);
+    final long[] timestamps = new long[32];
+    final Object[] labels = new Object[32];
+    final Object[] values = new Object[32];
+    for (int i = 0; i < timestamps.length; i++) {
+      timestamps[i] = 1000L + i;
+      labels[i] = "l" + i;
+      values[i] = 10.0 + i;
+    }
+    engine.appendSamples(timestamps, labels, values);
+    database.commit();
+
+    try {
+      database.begin();
+      engine.compactAll();
+      database.commit();
+
+      database.begin();
+      final List<MultiColumnAggregationRequest> requests = List.of(
+          new MultiColumnAggregationRequest(2, AggregationType.MIN, "min"),
+          new MultiColumnAggregationRequest(2, AggregationType.MAX, "max"));
+      final MultiColumnAggregationResult multi = engine.aggregateMulti(Long.MIN_VALUE, Long.MAX_VALUE, requests, 0, null);
+      final long bucketTs = multi.getBucketTimestamps().getFirst();
+      assertThat(multi.getValue(bucketTs, 0)).isEqualTo(10.0);
+      assertThat(multi.getValue(bucketTs, 1)).isEqualTo(41.0);
+      database.commit();
+    } finally {
+      engine.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/promql/Issue7039PromQLMinMaxNaNTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/promql/Issue7039PromQLMinMaxNaNTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries.promql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.timeseries.promql.PromQLResult.InstantVector;
+import com.arcadedb.engine.timeseries.promql.PromQLResult.VectorSample;
+import com.arcadedb.engine.timeseries.promql.ast.PromQLExpr;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7039 (follow-up on #4716): {@code min_over_time}/{@code max_over_time} and the
+ * instant-vector MIN/MAX aggregation arms kept the {@code ±Infinity} seed the rest of the time-series stack had
+ * already dropped, so an all-NaN window returned the sentinel as data.
+ * <p>
+ * {@code <} and {@code >} skip NaN implicitly, so an all-NaN input never displaced the seed. Prometheus - the
+ * protocol being emulated - answers NaN here, and so does {@code TimeSeriesVectorOps.min} over the same samples:
+ * the two paths disagreed with each other on identical data, which is what made this more than cosmetic.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7039PromQLMinMaxNaNTest extends TestHelper {
+
+  private static final long EVAL_TIME_MS = 6_000L;
+
+  @Test
+  void minAndMaxOverTimeReportAnAllNaNWindowAsAbsent() throws Exception {
+    createSeriesWithValues("promql7039_allnan", Double.NaN, Double.NaN);
+
+    // Was +Infinity / -Infinity.
+    assertThat(singleValueOf("min_over_time(promql7039_allnan[5m])")).as("min_over_time over an all-NaN window")
+        .isNaN();
+    assertThat(singleValueOf("max_over_time(promql7039_allnan[5m])")).as("max_over_time over an all-NaN window")
+        .isNaN();
+  }
+
+  @Test
+  void theMinAndMaxAggregationArmsReportAnAllNaNGroupAsAbsent() throws Exception {
+    createSeriesWithValues("promql7039_agg", Double.NaN, Double.NaN);
+
+    assertThat(singleValueOf("min(promql7039_agg)")).as("min() over an all-NaN group").isNaN();
+    assertThat(singleValueOf("max(promql7039_agg)")).as("max() over an all-NaN group").isNaN();
+  }
+
+  @Test
+  void aRealValueAmongTheNaNSamplesIsStillTheAnswer() throws Exception {
+    createSeriesWithValues("promql7039_mixed", Double.NaN, 7.5);
+
+    assertThat(singleValueOf("min_over_time(promql7039_mixed[5m])")).isEqualTo(7.5);
+    assertThat(singleValueOf("max_over_time(promql7039_mixed[5m])")).isEqualTo(7.5);
+  }
+
+  /**
+   * A genuine ±Infinity sample is a measurement, not the absent marker: it must survive the fold.
+   */
+  @Test
+  void aRealInfinitySampleIsPreserved() throws Exception {
+    createSeriesWithValues("promql7039_inf", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+
+    assertThat(singleValueOf("min_over_time(promql7039_inf[5m])")).isEqualTo(Double.NEGATIVE_INFINITY);
+    assertThat(singleValueOf("max_over_time(promql7039_inf[5m])")).isEqualTo(Double.POSITIVE_INFINITY);
+  }
+
+  private void createSeriesWithValues(final String typeName, final double first, final double second)
+      throws Exception {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS 1");
+
+    // A NaN value has no SQL literal, so the samples go in through the engine - the same write path the SQL
+    // INSERT reaches, and the one the issue's repro uses.
+    final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(typeName);
+    database.begin();
+    tsType.getEngine().appendSamples(new long[] { 1_000L, 2_000L },
+        new Object[] { "h1", "h1" }, new Object[] { first, second });
+    database.commit();
+  }
+
+  private double singleValueOf(final String promql) {
+    final PromQLExpr expr = new PromQLParser(promql).parse();
+    final PromQLResult result = new PromQLEvaluator((DatabaseInternal) database).evaluateInstant(expr, EVAL_TIME_MS);
+    assertThat(result).isInstanceOf(InstantVector.class);
+
+    final InstantVector iv = (InstantVector) result;
+    assertThat(iv.samples()).as("the query must produce exactly one sample: %s", promql).hasSize(1);
+    final VectorSample sample = iv.samples().getFirst();
+    return sample.value();
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/exporter/Exporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/Exporter.java
@@ -92,10 +92,10 @@ public class Exporter {
             skippedRecords);
       else
         logger.logLine(0,//
-            "Database exported successfully: %,d records exported in %s secs (%,d records/secs %,d documents %,d vertices %,d edges)",
+            "Database exported successfully: %,d records exported in %s secs (%,d records/secs %,d documents %,d vertices %,d edges %,d timeseries samples)",
 //
             totalRecords, elapsedInSecs, totalRecords / elapsedInSecs, context.documents.get(), context.vertices.get(),
-            context.edges.get());
+            context.edges.get(), context.timeSeriesSamples.get());
 
       // RETURN STATISTICS
       final Map<String, Object> result = new LinkedHashMap<>();
@@ -108,6 +108,8 @@ public class Exporter {
         result.put("vertices", context.vertices.get());
       if (context.edges.get() > 0)
         result.put("edges", context.edges.get());
+      if (context.timeSeriesSamples.get() > 0)
+        result.put("timeSeriesSamples", context.timeSeriesSamples.get());
       if (skippedRecords > 0)
         result.put("skippedRecords", skippedRecords);
 

--- a/integration/src/main/java/com/arcadedb/integration/exporter/ExporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/ExporterContext.java
@@ -30,6 +30,11 @@ public class ExporterContext {
    * surfaces a non-zero count as a failing outcome once the export completes.
    */
   public final AtomicLong skippedRecords = new AtomicLong();
+  /**
+   * TIMESERIES samples written to the export (issue #7032). A TimeSeries type owns no record bucket, so its rows
+   * are counted here rather than under {@link #documents}.
+   */
+  public final AtomicLong timeSeriesSamples = new AtomicLong();
   public       long       startedOn;
   public       long       lastLapOn;
   public       long       lastDocuments;

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
@@ -23,6 +23,8 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Record;
+import com.arcadedb.engine.timeseries.ColumnDefinition;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.LightEdge;
 import com.arcadedb.graph.Vertex;
@@ -34,8 +36,11 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalEdgeType;
 import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.LocalVertexType;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.JsonGraphSerializer;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
 import java.io.File;
@@ -52,6 +57,12 @@ import java.util.zip.GZIPOutputStream;
 public class JsonlExporterFormat extends AbstractExporterFormat {
   public static final  String             NAME       = "jsonl";
   private final static int                VERSION    = 1;
+  /**
+   * Samples per {@code "ts"} line. One line per sample would multiply the per-line envelope by the sample count
+   * (a TimeSeries type is the one place where records are counted in millions); one line for the whole type would
+   * make the reader hold it all in memory.
+   */
+  private final static int                TIMESERIES_CHUNK_SIZE = 1_000;
   private              OutputStreamWriter writer;
   protected final      JSONObject         sharedJson = new JSONObject();
 
@@ -103,6 +114,7 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
       final List<String> vertexTypes = new ArrayList<>();
       final List<String> edgeTypes = new ArrayList<>();
       final List<String> documentTypes = new ArrayList<>();
+      final List<String> timeSeriesTypes = new ArrayList<>();
 
       for (final DocumentType type : database.getSchema().getTypes()) {
         final String typeName = type.getName();
@@ -112,7 +124,12 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
         if (settings.excludeTypes != null && settings.excludeTypes.contains(typeName))
           continue;
 
-        if (type instanceof LocalVertexType)
+        // Checked before LocalVertexType/LocalEdgeType only for symmetry with them; a TimeSeries type is a
+        // LocalDocumentType and would otherwise fall through to documentTypes, where iterateType() finds nothing
+        // because the type owns no record bucket - its samples live in its own engine (issue #7032).
+        if (type instanceof LocalTimeSeriesType)
+          timeSeriesTypes.add(typeName);
+        else if (type instanceof LocalVertexType)
           vertexTypes.add(typeName);
         else if (type instanceof LocalEdgeType)
           edgeTypes.add(typeName);
@@ -125,16 +142,21 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
       // Issue #6455: the importer feeds the exported JSON straight back through MutableDocument.fromMap(), so
       // DATE/DATETIME_MICROS/DATETIME_NANOS must be encoded the way that schema-typed write-back path decodes
       // them, not as the epoch-millis number the default (HTTP graph-mode) encoding uses.
+      // Issue #7032: a vertex line used to carry the RID of every one of its edges, in both directions, and no
+      // import path has ever read them - edges are rebuilt from the "e" lines. On a graph of average degree d that
+      // was 2d RIDs per vertex of pure overhead, in the one thing an export cannot promise to honour on the way
+      // back in. Edges keep their endpoints; only the vertex-side duplicate goes.
       final JsonGraphSerializer graphSerializer = JsonGraphSerializer.createJsonGraphSerializer()
           .setSharedJson(recordJson)
           .setIncludeMetadata(false)
-          .setExpandVertexEdges(true)
+          .setIncludeVertexEdgeMetadata(false)
           .setPrecisionAwareTemporals(true);
 
       exportVertices(vertexTypes, graphSerializer);
       exportDocuments(documentTypes, graphSerializer);
       exportEdges(edgeTypes, graphSerializer);
       exportLightweightEdges(vertexTypes, graphSerializer);
+      exportTimeSeries(timeSeriesTypes);
     }
   }
 
@@ -256,6 +278,84 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
         }
       }
     }
+  }
+
+  /**
+   * Exports the samples of every TIMESERIES type, in chunks, as {@code "ts"} lines.
+   * <p>
+   * The schema line already carries the type's definition; without this the definition came back on import with no
+   * data behind it, which is not a round trip. The samples do not go through {@link JsonGraphSerializer}: a
+   * TimeSeries row is a fixed column tuple with no RID and no type of its own, so it is written as the raw value
+   * array the engine reads and writes, in schema-column order, timestamp first.
+   *
+   * @param timeSeriesTypes names of the TIMESERIES types selected for export
+   */
+  private void exportTimeSeries(final List<String> timeSeriesTypes) throws IOException {
+    for (final String typeName : timeSeriesTypes) {
+      final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(typeName);
+      // The gated accessor, not getEngine(): a TimeSeries type owns no bucket for the per-file read check to
+      // apply to, so this per-type check is the only thing standing between a denied user and the samples.
+      final TimeSeriesEngine engine = tsType.getEngine(SecurityDatabaseUser.ACCESS.READ_RECORD);
+      if (engine == null) {
+        LogManager.instance().log(this, Level.SEVERE,
+            "TimeSeries engine for type '%s' is not available, its samples are NOT part of this export", null, typeName);
+        context.skippedRecords.incrementAndGet();
+        continue;
+      }
+
+      final List<ColumnDefinition> columns = tsType.getTsColumns();
+
+      // The scan reads the shards' mutable pages, which are only reachable through a transaction; the record
+      // exports above go through iterateType(), which opens an implicit one of its own.
+      final boolean ownTransaction = !database.isTransactionActive();
+      if (ownTransaction)
+        database.begin();
+      try {
+        JSONArray chunk = new JSONArray();
+        for (final Iterator<Object[]> rows = engine.iterateQuery(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+            rows.hasNext(); ) {
+          final Object[] row = rows.next();
+          final JSONArray sample = new JSONArray();
+          for (int i = 0; i < columns.size() && i < row.length; i++)
+            sample.put(encodeSampleValue(row[i]));
+          chunk.put(sample);
+          context.timeSeriesSamples.incrementAndGet();
+
+          if (chunk.length() >= TIMESERIES_CHUNK_SIZE) {
+            writeJsonLine("ts", new JSONObject().put("t", typeName).put("s", chunk));
+            chunk = new JSONArray();
+          }
+        }
+
+        if (chunk.length() > 0)
+          writeJsonLine("ts", new JSONObject().put("t", typeName).put("s", chunk));
+      } finally {
+        if (ownTransaction && database.isTransactionActive())
+          database.rollback();
+      }
+    }
+  }
+
+  /**
+   * Encodes one raw sample value for JSON.
+   * <p>
+   * Only the non-finite doubles need work, and they need it badly: {@code JSONArray.put(Number)} rewrites NaN and
+   * ±Infinity to {@code 0}, so writing them straight would turn "no measurement" into a measurement of zero. They
+   * travel as the same string markers {@link JsonGraphSerializer} already uses for record properties, and
+   * {@code JsonlImporterFormat} decodes them back against the column's declared type.
+   */
+  private static Object encodeSampleValue(final Object value) {
+    if (value instanceof Double d && !Double.isFinite(d))
+      return nonFiniteMarker(d);
+    if (value instanceof Float f && !Float.isFinite(f))
+      return nonFiniteMarker(f);
+    return value;
+  }
+
+  private static String nonFiniteMarker(final double value) {
+    if (Double.isNaN(value))
+      return "NaN";
+    return value > 0 ? "PosInfinity" : "NegInfinity";
   }
 
   protected void writeJsonLine(final String type, final JSONObject json) throws IOException {

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
@@ -42,6 +42,7 @@ import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.serializer.JsonGraphSerializer;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.serializer.json.NonFiniteNumbers;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -317,7 +318,11 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
           final Object[] row = rows.next();
           final JSONArray sample = new JSONArray();
           for (int i = 0; i < columns.size() && i < row.length; i++)
-            sample.put(encodeSampleValue(row[i]));
+              // Only the non-finite doubles need work, and they need it badly: JSONArray.put(Number) rewrites NaN
+            // and +/-Infinity to 0, so writing them straight would turn "no measurement" into a measurement of
+            // zero. NonFiniteNumbers is the same encoding record properties already travel by, and
+            // JsonlImporterFormat decodes them back against the column's declared type.
+            sample.put(NonFiniteNumbers.encode(row[i]));
           chunk.put(sample);
           context.timeSeriesSamples.incrementAndGet();
 
@@ -336,28 +341,6 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
           database.rollback();
       }
     }
-  }
-
-  /**
-   * Encodes one raw sample value for JSON.
-   * <p>
-   * Only the non-finite doubles need work, and they need it badly: {@code JSONArray.put(Number)} rewrites NaN and
-   * ±Infinity to {@code 0}, so writing them straight would turn "no measurement" into a measurement of zero. They
-   * travel as the same string markers {@link JsonGraphSerializer} already uses for record properties, and
-   * {@code JsonlImporterFormat} decodes them back against the column's declared type.
-   */
-  private static Object encodeSampleValue(final Object value) {
-    if (value instanceof Double d && !Double.isFinite(d))
-      return nonFiniteMarker(d);
-    if (value instanceof Float f && !Float.isFinite(f))
-      return nonFiniteMarker(f);
-    return value;
-  }
-
-  private static String nonFiniteMarker(final double value) {
-    if (Double.isNaN(value))
-      return "NaN";
-    return value > 0 ? "PosInfinity" : "NegInfinity";
   }
 
   protected void writeJsonLine(final String type, final JSONObject json) throws IOException {

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
@@ -330,6 +330,8 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
         if (chunk.length() > 0)
           writeJsonLine("ts", new JSONObject().put("t", typeName).put("s", chunk));
       } finally {
+        // Rolled back, never committed, on the success path too: the scan above only reads, so there is nothing
+        // to publish, and a rollback releases the read view without asking the page manager to flush anything.
         if (ownTransaction && database.isTransactionActive())
           database.rollback();
       }

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
@@ -29,6 +29,11 @@ public class ImporterContext {
   public final AtomicLong createdVertices            = new AtomicLong();
   public final AtomicLong createdEdges               = new AtomicLong();
   public final AtomicLong createdEmbeddedDocuments   = new AtomicLong();
+  /**
+   * TIMESERIES samples appended by the import (issue #7032). Counted apart from the record kinds because a
+   * TimeSeries type owns no record bucket.
+   */
+  public final AtomicLong createdTimeSeriesSamples   = new AtomicLong();
   public final AtomicLong linkedEdges                = new AtomicLong();
   public final AtomicLong updatedDocuments           = new AtomicLong();
   public final AtomicLong documentsWithLinksToUpdate = new AtomicLong();
@@ -71,6 +76,8 @@ public class ImporterContext {
       map.put("createdVertices", createdVertices.get());
     if (createdEdges.get() > 0)
       map.put("createdEdges", createdEdges.get());
+    if (createdTimeSeriesSamples.get() > 0)
+      map.put("createdTimeSeriesSamples", createdTimeSeriesSamples.get());
 
     return map;
   }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -29,6 +29,10 @@ import com.arcadedb.graph.LightEdge;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.engine.timeseries.ColumnDefinition;
+import com.arcadedb.engine.timeseries.DownsamplingTier;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.engine.timeseries.codec.TimeSeriesCodec;
 import com.arcadedb.index.CompressedRID2RIDIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NULL_STRATEGY;
 import com.arcadedb.integration.importer.AnalyzedEntity.EntityType;
@@ -42,9 +46,11 @@ import com.arcadedb.integration.importer.SourceSchema;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalEdgeType;
+import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.LocalVertexType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.TimeSeriesTypeBuilder;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.TypeFullTextIndexBuilder;
 import com.arcadedb.schema.TypeLSMSparseVectorIndexBuilder;
@@ -130,6 +136,7 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
           case "d" -> loadDocument(database, context, jsonLine.getJSONObject("c"));
           case "v" -> loadVertex(database, context, jsonLine.getJSONObject("c"));
           case "e" -> loadEdge(database, context, jsonLine.getJSONObject("c"));
+          case "ts" -> loadTimeSeriesSamples(database, context, jsonLine.getJSONObject("c"));
           }
         } catch (final Exception e) {
           // Every per-record failure (document/vertex/edge, and a broken schema entry too) funnels through here,
@@ -221,6 +228,9 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
                 .withLightweight(type.getBoolean("lightweight", false))
                 .create();
             case "d" -> databaseSchema.createDocumentType(typeName);
+            // A TIMESERIES type is exported as "t" and had no case here at all, so the switch's default threw and
+            // the whole import aborted at the schema line - not a partial restore, no restore (issue #7032).
+            case "t" -> createTimeSeriesType(databaseSchema, typeName, type);
             default -> throw new IllegalStateException("Unexpected value: " + typeType);
           };
 
@@ -236,6 +246,17 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
           properties.keySet()
               .forEach(propertyName -> {
                 var property = properties.getJSONObject(propertyName);
+                if (docType.existsProperty(propertyName)) {
+                  // A TIMESERIES type's columns are registered as properties by its own builder, so they already
+                  // exist by the time this pass runs and createProperty() would throw. Their CUSTOM metadata is
+                  // still the export's to restore - it is not something the builder can know.
+                  if (property.has("custom")) {
+                    final JSONObject custom = property.getJSONObject("custom");
+                    for (final String key : custom.keySet())
+                      docType.getProperty(propertyName).setCustomValue(key, custom.get(key));
+                  }
+                  return;
+                }
                 docType.createProperty(propertyName, property);
               });
 
@@ -309,9 +330,171 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
             edgeType.setUnique(true);
         });
 
+    // Type-level ALIASES and CUSTOM metadata (issue #7032). The export has always carried both, and the import
+    // restored neither, while property-level CUSTOM - handled a few lines up, by the same JSON, in adjacent code -
+    // was restored. A restored type silently lost every alias queries referred to it by and every custom key an
+    // application read back.
+    types.keySet()
+        .forEach(typeName -> {
+          final JSONObject type = types.getJSONObject(typeName);
+          final DocumentType docType = databaseSchema.getType(typeName);
+
+          if (!type.isNull("aliases")) {
+            final Set<String> aliases = new HashSet<>(type.getJSONArray("aliases").toListOfStrings());
+            if (!aliases.isEmpty())
+              docType.setAliases(aliases);
+          }
+
+          if (type.has("custom")) {
+            final JSONObject custom = type.getJSONObject("custom");
+            for (final String key : custom.keySet())
+              docType.setCustomValue(key, custom.get(key));
+          }
+        });
+
+    // The bucket-selection strategy goes LAST, for the reason LocalSchema's own loader puts it last: a
+    // PARTITIONED strategy binds to an index, so it can only be restored once the indexes above exist. Losing it
+    // is not cosmetic - the strategy is what spreads writes across buckets, and `thread` is the documented remedy
+    // for the single-bucket write contention the server warns about (issue #7032).
+    types.keySet()
+        .forEach(typeName -> {
+          final JSONObject type = types.getJSONObject(typeName);
+          if (!type.has("bucketSelectionStrategy"))
+            return;
+
+          final JSONObject strategy = type.getJSONObject("bucketSelectionStrategy");
+          final Object[] properties = strategy.has("properties") ?
+              strategy.getJSONArray("properties").toList().toArray() :
+              new Object[0];
+          try {
+            databaseSchema.getType(typeName).setBucketSelectionStrategy(strategy.getString("name"), properties);
+          } catch (final Exception e) {
+            // One type declining its strategy must not abort an import that has already recreated the schema and
+            // is about to load the records - same trade-off LocalSchema makes on open. The type falls back to
+            // round-robin, which costs the partition pruning and keeps the data.
+            context.warnings.incrementAndGet();
+            LogManager.instance().log(this, Level.WARNING,
+                "Cannot restore the '%s' bucket selection strategy on type '%s': %s. The type falls back to round-robin",
+                e, strategy.getString("name"), typeName, e.getMessage() != null ? e.getMessage() : e.toString());
+          }
+        });
+
     // final report
     databaseSchema.getTypes()
         .forEach(type -> logger.logLine(2, " - Created type %s: %s", type.getName(), type.toJSON()));
+  }
+
+  /**
+   * Recreates a TIMESERIES type from its exported schema definition (issue #7032).
+   * <p>
+   * Everything the type's identity depends on comes out of the export: the column list WITH the per-column codec
+   * (which is not re-derivable - see {@link TimeSeriesTypeBuilder#withColumn}), the shard count, the retention and
+   * compaction settings, and the downsampling tiers. What is deliberately NOT carried over is the format versions:
+   * this build writes its own current formats into a type it is creating now, and the exported
+   * {@code sealedFormatVersion}/{@code mutableFormatVersion} describe the pages of the SOURCE database, which the
+   * target does not have.
+   */
+  private DocumentType createTimeSeriesType(final Schema databaseSchema, final String typeName, final JSONObject type) {
+    final TimeSeriesTypeBuilder builder = databaseSchema.buildTimeSeriesType().withName(typeName);
+
+    final JSONArray columns = type.getJSONArray("tsColumns", null);
+    if (columns == null || columns.length() == 0)
+      throw new ImportException("TIMESERIES type '" + typeName + "' carries no column definition in the export");
+
+    for (int i = 0; i < columns.length(); i++) {
+      final JSONObject column = columns.getJSONObject(i);
+      final Type dataType = Type.getTypeByName(column.getString("dataType"));
+      final ColumnDefinition.ColumnRole role = ColumnDefinition.ColumnRole.valueOf(column.getString("role"));
+      final String compression = column.getString("compression", null);
+      builder.withColumn(compression != null ?
+          new ColumnDefinition(column.getString("name"), dataType, role, TimeSeriesCodec.valueOf(compression)) :
+          new ColumnDefinition(column.getString("name"), dataType, role));
+    }
+
+    if (type.has("precision"))
+      builder.withPrecision(type.getString("precision"));
+    builder.withShards(type.getInt("shardCount", 0));
+    builder.withRetention(type.getLong("retentionMs", 0L));
+    builder.withCompactionBucketInterval(type.getLong("compactionBucketIntervalMs", 0L));
+
+    final JSONArray tiers = type.getJSONArray("downsamplingTiers", null);
+    if (tiers != null) {
+      final List<DownsamplingTier> parsed = new ArrayList<>(tiers.length());
+      for (int i = 0; i < tiers.length(); i++) {
+        final JSONObject tier = tiers.getJSONObject(i);
+        parsed.add(new DownsamplingTier(tier.getLong("afterMs"), tier.getLong("granularityMs")));
+      }
+      builder.withDownsamplingTiers(parsed);
+    }
+
+    return builder.create();
+  }
+
+  /**
+   * Appends one chunk of TIMESERIES samples, as written by {@code JsonlExporterFormat.exportTimeSeries} (issue
+   * #7032). Each sample is the type's columns in schema order, timestamp first - a TimeSeries row has no RID, so
+   * there is nothing to remap and nothing to record in {@code ridIndex}.
+   */
+  private void loadTimeSeriesSamples(final DatabaseInternal database, final ImporterContext context,
+      final JSONObject chunk) throws IOException {
+    final String typeName = chunk.getString("t");
+    if (!(database.getSchema().getType(typeName) instanceof LocalTimeSeriesType tsType))
+      throw new ImportException("Type '" + typeName + "' is not a TIMESERIES type, cannot import its samples");
+
+    final TimeSeriesEngine engine = tsType.getEngine();
+    if (engine == null)
+      throw new ImportException("TimeSeries engine for type '" + typeName + "' is not initialized");
+
+    final List<ColumnDefinition> columns = tsType.getTsColumns();
+    int timestampIdx = 0;
+    for (int i = 0; i < columns.size(); i++)
+      if (columns.get(i).getRole() == ColumnDefinition.ColumnRole.TIMESTAMP) {
+        timestampIdx = i;
+        break;
+      }
+
+    final JSONArray samples = chunk.getJSONArray("s");
+    final int rows = samples.length();
+    final long[] timestamps = new long[rows];
+    // appendBatch indexes the value columns, skipping the timestamp - see ObjectColumnsRowSource.
+    final Object[][] values = new Object[columns.size() - 1][rows];
+
+    for (int r = 0; r < rows; r++) {
+      final JSONArray sample = samples.getJSONArray(r);
+      timestamps[r] = ((Number) sample.get(timestampIdx)).longValue();
+      int valueIdx = 0;
+      for (int c = 0; c < columns.size(); c++) {
+        if (c == timestampIdx)
+          continue;
+        values[valueIdx][r] = decodeSampleValue(sample.get(c), columns.get(c).getDataType());
+        valueIdx++;
+      }
+    }
+
+    engine.appendBatch(timestamps, values);
+    context.createdTimeSeriesSamples.addAndGet(rows);
+  }
+
+  /**
+   * Reverses {@code JsonlExporterFormat.encodeSampleValue}: the non-finite doubles travel as string markers
+   * because {@code JSONArray.put(Number)} would otherwise rewrite them to 0, turning "no measurement" into a
+   * measurement of zero. Every other value passes through - {@code ObjectColumnsRowSource} accepts any
+   * {@link Number} for a numeric column, so JSON's widening does no harm.
+   */
+  private static Object decodeSampleValue(final Object value, final Type dataType) {
+    if (value instanceof String text && (dataType == Type.DOUBLE || dataType == Type.FLOAT)) {
+      switch (text) {
+      case "NaN":
+        return Double.NaN;
+      case "PosInfinity":
+        return Double.POSITIVE_INFINITY;
+      case "NegInfinity":
+        return Double.NEGATIVE_INFINITY;
+      default:
+        return Double.parseDouble(text);
+      }
+    }
+    return value;
   }
 
   /**

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -90,6 +90,19 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
   // Recording the specific old-source RIDs left unresolved lets reconciliation touch only those elements.
   private final Map<RID, Map<String, Set<RID>>> pendingLinkReconciliation = new HashMap<>();
 
+  /**
+   * Records - or TIMESERIES samples - accumulated before the periodic commit in {@link #load} fires.
+   */
+  private static final int COMMIT_EVERY = 1_000;
+
+  /**
+   * TIMESERIES samples appended since the last commit. One {@code "ts"} line carries a whole chunk of samples
+   * (up to {@code JsonlExporterFormat}'s own chunk size), so counting LINES the way {@code context.parsed} does
+   * would let a thousand such lines - a million samples - pile into a single transaction's WAL and dirty pages
+   * before it commits. Counted apart, so a chunk weighs what it actually costs.
+   */
+  private int timeSeriesSamplesSinceCommit;
+
   @Override
   public void load(SourceSchema sourceSchema,
       EntityType entityType,
@@ -120,6 +133,7 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
       ridIndex = new CompressedRID2RIDIndex(database, 1000, 1000);
       pendingLinkReconciliation.clear();
+      timeSeriesSamplesSinceCommit = 0;
 
       if (!database.isTransactionActive())
         database.begin();
@@ -155,6 +169,7 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
           if (database.isTransactionActive())
             database.rollback();
           database.begin();
+          timeSeriesSamplesSinceCommit = 0;
           continue;
         }
 
@@ -166,9 +181,11 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
         // all when the caller already owns the active transaction (skip mode never reaches here - see the guard
         // above): a caller-managed transaction is never ours to commit piecemeal, only to accumulate into and hand
         // back to whoever owns it (issue #6561).
-        if (!context.callerTransactionActiveOnEntry && (skipOnRowError || context.parsed.get() % 1000 == 0)) {
+        if (!context.callerTransactionActiveOnEntry && (skipOnRowError || context.parsed.get() % COMMIT_EVERY == 0
+            || timeSeriesSamplesSinceCommit >= COMMIT_EVERY)) {
           database.commit();
           database.begin();
+          timeSeriesSamplesSinceCommit = 0;
         }
       }
 
@@ -466,6 +483,18 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
     final JSONArray samples = chunk.getJSONArray("s");
     final int rows = samples.length();
+
+    // Arity is checked for the WHOLE chunk before a single value is decoded, so a malformed chunk is refused by
+    // the caller's row-error policy (abort or skip) rather than half-applied. A sample SHORTER than the schema
+    // used to fail mid-decode, and a LONGER one was silently truncated to the columns this type declares - which
+    // is the worse of the two, because it discards data without saying so.
+    for (int r = 0; r < rows; r++) {
+      final int arity = samples.getJSONArray(r).length();
+      if (arity != columns.size())
+        throw new ImportException("TIMESERIES sample " + r + " of type '" + typeName + "' has " + arity
+            + " value(s) but the type declares " + columns.size() + " column(s)");
+    }
+
     final long[] timestamps = new long[rows];
     // appendBatch indexes the value columns, skipping the timestamp - see ObjectColumnsRowSource.
     final Object[][] values = new Object[columns.size() - 1][rows];
@@ -484,6 +513,7 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
     engine.appendBatch(timestamps, values);
     context.createdTimeSeriesSamples.addAndGet(rows);
+    timeSeriesSamplesSinceCommit += rows;
   }
 
   /**

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -57,6 +57,7 @@ import com.arcadedb.schema.TypeLSMSparseVectorIndexBuilder;
 import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.serializer.json.NonFiniteNumbers;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -529,27 +530,21 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
   }
 
   /**
-   * Reverses {@code JsonlExporterFormat.encodeSampleValue}: the non-finite doubles travel as string markers
+   * Reverses the exporter's {@link NonFiniteNumbers#encode}: the non-finite doubles travel as string markers
    * because {@code JSONArray.put(Number)} would otherwise rewrite them to 0, turning "no measurement" into a
    * measurement of zero. Every other value passes through - {@code ObjectColumnsRowSource} accepts any
    * {@link Number} for a numeric column, so JSON's widening does no harm.
    */
   private static Object decodeSampleValue(final Object value, final Type dataType) {
     if (value instanceof String text && (dataType == Type.DOUBLE || dataType == Type.FLOAT)) {
-      switch (text) {
-      case "NaN":
-        return Double.NaN;
-      case "PosInfinity":
-        return Double.POSITIVE_INFINITY;
-      case "NegInfinity":
-        return Double.NEGATIVE_INFINITY;
-      default:
-        // Not reachable from an export this build wrote - encodeSampleValue only ever emits the three markers
-        // above. Kept as a tolerant parse for a hand-written or foreign-tool file that quoted a plain number,
-        // which is otherwise a perfectly well-formed sample; a genuinely unparseable token still fails loudly,
-        // through the same per-line row-error policy as anything else on the line.
-        return Double.parseDouble(text);
-      }
+      final Double marker = NonFiniteNumbers.decode(text);
+      if (marker != null)
+        return marker;
+      // Not reachable from an export this build wrote - the exporter only ever emits the three markers. Kept as
+      // a tolerant parse for a hand-written or foreign-tool file that quoted a plain number, which is otherwise
+      // a perfectly well-formed sample; a genuinely unparseable token still fails loudly, through the same
+      // per-line row-error policy as anything else on the line.
+      return Double.parseDouble(text);
     }
     return value;
   }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -544,6 +544,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       case "NegInfinity":
         return Double.NEGATIVE_INFINITY;
       default:
+        // Not reachable from an export this build wrote - encodeSampleValue only ever emits the three markers
+        // above. Kept as a tolerant parse for a hand-written or foreign-tool file that quoted a plain number,
+        // which is otherwise a perfectly well-formed sample; a genuinely unparseable token still fails loudly,
+        // through the same per-line row-error policy as anything else on the line.
         return Double.parseDouble(text);
       }
     }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -342,7 +342,18 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
           if (!type.isNull("aliases")) {
             final Set<String> aliases = new HashSet<>(type.getJSONArray("aliases").toListOfStrings());
             if (!aliases.isEmpty())
-              docType.setAliases(aliases);
+              try {
+                docType.setAliases(aliases);
+              } catch (final Exception e) {
+                // setAliases() refuses an alias another type already answers to, which an import into a
+                // NON-EMPTY target reaches without anything being wrong with the export. Same trade-off as the
+                // strategy restore below: the type keeps its own name, the import keeps going, and the log says
+                // what was dropped - aborting here would discard every record the file has not reached yet.
+                context.warnings.incrementAndGet();
+                LogManager.instance().log(this, Level.WARNING,
+                    "Cannot restore the aliases %s on type '%s': %s. The type is reachable by its own name only",
+                    e, aliases, typeName, e.getMessage() != null ? e.getMessage() : e.toString());
+              }
           }
 
           if (type.has("custom")) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -431,16 +431,28 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
     for (int i = 0; i < columns.length(); i++) {
       final JSONObject column = columns.getJSONObject(i);
-      final Type dataType = Type.getTypeByName(column.getString("dataType"));
-      final ColumnDefinition.ColumnRole role = ColumnDefinition.ColumnRole.valueOf(column.getString("role"));
-      final String compression = column.getString("compression", null);
-      builder.withColumn(compression != null ?
-          new ColumnDefinition(column.getString("name"), dataType, role, TimeSeriesCodec.valueOf(compression)) :
-          new ColumnDefinition(column.getString("name"), dataType, role));
+      final String columnName = column.getString("name");
+      // The three enums are parsed inside one try: a hand-edited or foreign-tool-generated export reaches them
+      // with a value none of them knows, and the raw IllegalArgumentException they raise names the bad token and
+      // nothing else - not the column it came from, not the type, not even that this was a schema line.
+      try {
+        final Type dataType = Type.getTypeByName(column.getString("dataType"));
+        final ColumnDefinition.ColumnRole role = ColumnDefinition.ColumnRole.valueOf(column.getString("role"));
+        final String compression = column.getString("compression", null);
+        builder.withColumn(compression != null ?
+            new ColumnDefinition(columnName, dataType, role, TimeSeriesCodec.valueOf(compression)) :
+            new ColumnDefinition(columnName, dataType, role));
+      } catch (final IllegalArgumentException | NullPointerException e) {
+        throw new ImportException(
+            "Column '" + columnName + "' of TIMESERIES type '" + typeName + "' declares a data type, role or "
+                + "compression this build does not know: " + e.getMessage(), e);
+      }
     }
 
     if (type.has("precision"))
       builder.withPrecision(type.getString("precision"));
+    // 0 is the builder's own "use the default" (it resolves to ASYNC_WORKER_THREADS), which is the right answer
+    // for an export written before the count was persisted.
     builder.withShards(type.getInt("shardCount", 0));
     builder.withRetention(type.getLong("retentionMs", 0L));
     builder.withCompactionBucketInterval(type.getLong("compactionBucketIntervalMs", 0L));

--- a/integration/src/test/java/com/arcadedb/integration/exporter/Issue7032JsonlRoundTripIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/Issue7032JsonlRoundTripIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.exporter;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.engine.timeseries.ColumnDefinition;
+import com.arcadedb.engine.timeseries.codec.TimeSeriesCodec;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.GZIPInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7032: three defects in the JSONL export/import round trip.
+ *
+ * <ol>
+ *   <li>A TIMESERIES type is exported as {@code "type":"t"} and the importer's schema switch had no case for it,
+ *       so the switch's {@code default} threw: exporting a database with any TIMESERIES type produced a file that
+ *       could not be imported AT ALL - the failure aborted the whole import at the schema line.</li>
+ *   <li>The export carries type-level CUSTOM metadata, ALIASES and the bucket-selection strategy; the importer
+ *       restored none of the three, while property-level CUSTOM - adjacent code, same JSON - was restored.</li>
+ *   <li>Every exported vertex carried the RID of every one of its edges, in both directions, and no import path
+ *       reads them.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7032JsonlRoundTripIT {
+  private static final String SOURCE_PATH = "target/databases/issue7032-jsonl-source";
+  private static final String TARGET_PATH = "target/databases/issue7032-jsonl-target";
+  private static final String FILE        = "target/issue7032-jsonl.jsonl.tgz";
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    TestHelper.checkActiveDatabases();
+    FileUtils.deleteRecursively(new File(SOURCE_PATH));
+    FileUtils.deleteRecursively(new File(TARGET_PATH));
+    new File(FILE).delete();
+  }
+
+  @Test
+  void theWholeSchemaAndItsTimeSeriesSamplesSurviveAnExportImportCycle() throws Exception {
+    createSourceDatabase();
+
+    new Exporter(("-f " + FILE + " -d " + SOURCE_PATH + " -o -format jsonl").split(" ")).exportDatabase();
+    assertThat(new File(FILE).exists()).isTrue();
+
+    // (3) No vertex line carries edge RID lists any more, and the edge lines still carry their endpoints.
+    int vertexLines = 0;
+    int edgeLines = 0;
+    for (final String line : readExportedLines()) {
+      final JSONObject json = new JSONObject(line);
+      final JSONObject content = json.getJSONObject("c");
+      switch (json.getString("t")) {
+      case "v" -> {
+        vertexLines++;
+        assertThat(content.has("o")).as("a vertex must not carry its outgoing edge RIDs: %s", line).isFalse();
+        assertThat(content.has("i")).as("a vertex must not carry its incoming edge RIDs: %s", line).isFalse();
+      }
+      case "e" -> {
+        edgeLines++;
+        assertThat(content.has("o")).as("an edge's endpoints ARE the edge: %s", line).isTrue();
+        assertThat(content.has("i")).as("an edge's endpoints ARE the edge: %s", line).isTrue();
+      }
+      default -> {
+      }
+      }
+    }
+    assertThat(vertexLines).isEqualTo(2);
+    assertThat(edgeLines).isEqualTo(1);
+
+    // (1) The import used to abort here, at the schema line, on the TIMESERIES type's "t" marker.
+    try (final Database target = new DatabaseFactory(TARGET_PATH).create()) {
+      target.command("sql", "IMPORT DATABASE file://" + new File(FILE).getAbsolutePath());
+    }
+
+    try (final Database target = new DatabaseFactory(TARGET_PATH).open()) {
+      assertThat(target.countType("Person", false)).isEqualTo(2);
+      assertThat(target.countType("Friend", false)).isEqualTo(1);
+      assertThat(target.query("sql", "SELECT FROM Person WHERE id = 0").next().getVertex().get()
+          .getVertices(Vertex.DIRECTION.OUT, "Friend").iterator().hasNext())
+          .as("the edge must be rebuilt from the edge line, which is the only thing that ever rebuilt it").isTrue();
+
+      // (2) Type-level ALIASES, CUSTOM and the bucket-selection strategy.
+      final DocumentType invoice = target.getSchema().getType("Invoice");
+      assertThat(invoice.getAliases()).containsExactlyInAnyOrder("Bill", "Receipt");
+      assertThat(invoice.getCustomValue("retention")).isEqualTo("7y");
+      assertThat(invoice.getBucketSelectionStrategy().getName()).isEqualTo("thread");
+      assertThat(invoice.getProperty("code").getCustomValue("pii")).as("property-level CUSTOM must keep working")
+          .isEqualTo("false");
+
+      // The type is reachable through its restored alias, which is the point of restoring one.
+      assertThat(target.query("sql", "SELECT FROM Bill").hasNext()).isTrue();
+
+      // (1) The TIMESERIES type comes back with its definition AND its samples.
+      final LocalTimeSeriesType tsType = (LocalTimeSeriesType) target.getSchema().getType("Sensor");
+      assertThat(tsType.getShardCount()).isEqualTo(2);
+      assertThat(tsType.getTsColumns().stream().map(ColumnDefinition::getName).toList())
+          .containsExactly("ts", "host", "value");
+      assertThat(tsType.getTsColumns().get(2).getCompressionHint()).as("the per-column codec is not re-derivable")
+          .isEqualTo(TimeSeriesCodec.GORILLA_XOR);
+
+      final List<Double> values = new ArrayList<>();
+      try (final ResultSet rs = target.query("sql", "SELECT value FROM Sensor ORDER BY ts")) {
+        while (rs.hasNext())
+          values.add(((Number) rs.next().getProperty("value")).doubleValue());
+      }
+      assertThat(values).hasSize(3);
+      assertThat(values.get(0)).isEqualTo(1.5);
+      // NaN must survive: JSONArray.put(Number) rewrites a non-finite double to 0, so an unencoded NaN would come
+      // back as a measurement of zero.
+      assertThat(values.get(1)).isNaN();
+      assertThat(values.get(2)).isEqualTo(3.5);
+    }
+  }
+
+  private void createSourceDatabase() throws Exception {
+    try (final Database source = new DatabaseFactory(SOURCE_PATH).create()) {
+      source.transaction(() -> {
+        final VertexType person = source.getSchema().buildVertexType().withName("Person").create();
+        person.createProperty("id", Type.INTEGER);
+        source.getSchema().buildEdgeType().withName("Friend").create();
+
+        final MutableVertex a = source.newVertex("Person").set("id", 0).save();
+        final MutableVertex b = source.newVertex("Person").set("id", 1).save();
+        a.newEdge("Friend", b);
+
+        final DocumentType invoice = source.getSchema().createDocumentType("Invoice", 4);
+        invoice.createProperty("code", Type.STRING).setCustomValue("pii", "false");
+        invoice.setAliases(Set.of("Bill", "Receipt"));
+        invoice.setCustomValue("retention", "7y");
+        invoice.setBucketSelectionStrategy("thread");
+        source.newDocument("Invoice").set("code", "INV-1").save();
+      });
+
+      source.command("sql",
+          "CREATE TIMESERIES TYPE Sensor TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS 2");
+
+      // A NaN sample has no SQL literal, so the samples go in through the engine.
+      final LocalTimeSeriesType tsType = (LocalTimeSeriesType) source.getSchema().getType("Sensor");
+      source.begin();
+      tsType.getEngine().appendSamples(new long[] { 1_000L, 2_000L, 3_000L },
+          new Object[] { "h1", "h1", "h2" },
+          new Object[] { 1.5, Double.NaN, 3.5 });
+      source.commit();
+    }
+  }
+
+  private List<String> readExportedLines() throws Exception {
+    final List<String> lines = new ArrayList<>();
+    try (final BufferedReader reader = new BufferedReader(
+        new InputStreamReader(new GZIPInputStream(new FileInputStream(FILE)), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null)
+        lines.add(line);
+    }
+    return lines;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/exporter/Issue7032JsonlRoundTripIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/Issue7032JsonlRoundTripIT.java
@@ -25,6 +25,7 @@ import com.arcadedb.engine.timeseries.codec.TimeSeriesCodec;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.integration.TestHelper;
+import com.arcadedb.integration.importer.Importer;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
@@ -40,14 +41,19 @@ import org.junit.jupiter.api.Test;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Issue #7032: three defects in the JSONL export/import round trip.
@@ -195,6 +201,36 @@ class Issue7032JsonlRoundTripIT {
     }
   }
 
+  /**
+   * A {@code "ts"} chunk whose samples do not match the type's column count is refused by the caller's row-error
+   * policy, and refused for the WHOLE chunk before any of it is appended. A longer sample is the one that matters:
+   * reading only the schema positions would have truncated it silently, discarding data without saying so.
+   */
+  @Test
+  void aTimeSeriesSampleOfTheWrongArityIsRejectedRatherThanTruncated() throws Exception {
+    createSourceDatabase();
+    new Exporter(("-f " + FILE + " -d " + SOURCE_PATH + " -o -format jsonl").split(" ")).exportDatabase();
+
+    // Give one sample of the "ts" chunk a fifth value the 4-column type does not declare.
+    final List<String> lines = new ArrayList<>();
+    for (final String line : readExportedLines()) {
+      final JSONObject json = new JSONObject(line);
+      if ("ts".equals(json.getString("t"))) {
+        json.getJSONObject("c").getJSONArray("s").getJSONArray(0).put(999.0);
+        lines.add(json.toString());
+      } else
+        lines.add(line);
+    }
+    writeExportedLines(lines);
+
+    final Throwable thrown = catchThrowable(() -> new Importer(
+        ("-url " + new File(FILE).getAbsolutePath() + " -database " + TARGET_PATH + " -forceDatabaseCreate true")
+            .split(" ")).load());
+
+    assertThat(thrown).isNotNull();
+    assertThat(thrown).hasStackTraceContaining("has 5 value(s) but the type declares 4 column(s)");
+  }
+
   private void createSourceDatabase() throws Exception {
     try (final Database source = new DatabaseFactory(SOURCE_PATH).create()) {
       source.transaction(() -> {
@@ -227,6 +263,14 @@ class Issue7032JsonlRoundTripIT {
           new Object[] { 1.5, Double.NaN, 3.5 },
           new Object[] { 0.5f, Float.NaN, Float.POSITIVE_INFINITY });
       source.commit();
+    }
+  }
+
+  private void writeExportedLines(final List<String> lines) throws Exception {
+    try (final Writer writer = new OutputStreamWriter(new GZIPOutputStream(new FileOutputStream(FILE)),
+        StandardCharsets.UTF_8)) {
+      for (final String line : lines)
+        writer.write(line + "\n");
     }
   }
 

--- a/integration/src/test/java/com/arcadedb/integration/exporter/Issue7032JsonlRoundTripIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/Issue7032JsonlRoundTripIT.java
@@ -146,6 +146,19 @@ class Issue7032JsonlRoundTripIT {
       assertThat(tsType.getTsColumns().get(2).getCompressionHint()).as("the per-column codec is not re-derivable")
           .isEqualTo(TimeSeriesCodec.GORILLA_XOR);
 
+      // Every non-default TIMESERIES setting the export carries must come back, tiers in order.
+      final LocalTimeSeriesType policy = (LocalTimeSeriesType) target.getSchema().getType("SensorPolicy");
+      assertThat(policy.getTimestampColumn()).isEqualTo("ts");
+      assertThat(policy.getPrecision()).isEqualTo("MICROSECOND");
+      assertThat(policy.getShardCount()).isEqualTo(3);
+      assertThat(policy.getRetentionMs()).isEqualTo(90L * 86_400_000L);
+      assertThat(policy.getCompactionBucketIntervalMs()).isEqualTo(30_000L);
+      assertThat(policy.getDownsamplingTiers()).hasSize(2);
+      assertThat(policy.getDownsamplingTiers().get(0).afterMs()).isEqualTo(7L * 86_400_000L);
+      assertThat(policy.getDownsamplingTiers().get(0).granularityMs()).isEqualTo(3_600_000L);
+      assertThat(policy.getDownsamplingTiers().get(1).afterMs()).isEqualTo(30L * 86_400_000L);
+      assertThat(policy.getDownsamplingTiers().get(1).granularityMs()).isEqualTo(86_400_000L);
+
       final List<Double> values = new ArrayList<>();
       final List<Float> ratios = new ArrayList<>();
       try (final ResultSet rs = target.query("sql", "SELECT value, ratio FROM Sensor ORDER BY ts")) {
@@ -254,6 +267,22 @@ class Issue7032JsonlRoundTripIT {
       // to 0 whatever the width, so both float and double columns need the string markers.
       source.command("sql",
           "CREATE TIMESERIES TYPE Sensor TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE, ratio FLOAT) SHARDS 2");
+
+      // A second TIMESERIES type whose retention / precision / compaction / downsampling settings are all
+      // NON-default, so the restore of each one is actually pinned. It carries no samples on purpose: a retention
+      // policy would otherwise expire the epoch-1970 timestamps the sample-carrying type uses.
+      source.command("sql", """
+          CREATE TIMESERIES TYPE SensorPolicy
+            TIMESTAMP ts PRECISION MICROSECOND
+            TAGS (host STRING)
+            FIELDS (value DOUBLE)
+            SHARDS 3
+            RETENTION 90 DAYS
+            COMPACTION INTERVAL 30 SECONDS
+          """);
+      source.command("sql",
+          "ALTER TIMESERIES TYPE SensorPolicy ADD DOWNSAMPLING POLICY AFTER 7 DAYS GRANULARITY 1 HOURS "
+              + "AFTER 30 DAYS GRANULARITY 1 DAYS");
 
       // A NaN sample has no SQL literal, so the samples go in through the engine.
       final LocalTimeSeriesType tsType = (LocalTimeSeriesType) source.getSchema().getType("Sensor");

--- a/integration/src/test/java/com/arcadedb/integration/exporter/Issue7032JsonlRoundTripIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/Issue7032JsonlRoundTripIT.java
@@ -25,6 +25,7 @@ import com.arcadedb.engine.timeseries.codec.TimeSeriesCodec;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.integration.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
@@ -135,14 +136,18 @@ class Issue7032JsonlRoundTripIT {
       final LocalTimeSeriesType tsType = (LocalTimeSeriesType) target.getSchema().getType("Sensor");
       assertThat(tsType.getShardCount()).isEqualTo(2);
       assertThat(tsType.getTsColumns().stream().map(ColumnDefinition::getName).toList())
-          .containsExactly("ts", "host", "value");
+          .containsExactly("ts", "host", "value", "ratio");
       assertThat(tsType.getTsColumns().get(2).getCompressionHint()).as("the per-column codec is not re-derivable")
           .isEqualTo(TimeSeriesCodec.GORILLA_XOR);
 
       final List<Double> values = new ArrayList<>();
-      try (final ResultSet rs = target.query("sql", "SELECT value FROM Sensor ORDER BY ts")) {
-        while (rs.hasNext())
-          values.add(((Number) rs.next().getProperty("value")).doubleValue());
+      final List<Float> ratios = new ArrayList<>();
+      try (final ResultSet rs = target.query("sql", "SELECT value, ratio FROM Sensor ORDER BY ts")) {
+        while (rs.hasNext()) {
+          final Result row = rs.next();
+          values.add(((Number) row.getProperty("value")).doubleValue());
+          ratios.add(((Number) row.getProperty("ratio")).floatValue());
+        }
       }
       assertThat(values).hasSize(3);
       assertThat(values.get(0)).isEqualTo(1.5);
@@ -150,6 +155,43 @@ class Issue7032JsonlRoundTripIT {
       // back as a measurement of zero.
       assertThat(values.get(1)).isNaN();
       assertThat(values.get(2)).isEqualTo(3.5);
+
+      // Same encoding, narrower column: a non-finite FLOAT must not come back as 0 either.
+      assertThat(ratios.get(0)).isEqualTo(0.5f);
+      assertThat(ratios.get(1)).isNaN();
+      assertThat(ratios.get(2)).isEqualTo(Float.POSITIVE_INFINITY);
+    }
+  }
+
+  /**
+   * The alias restore must not be able to abort an import. {@code setAliases} refuses an alias another type
+   * already answers to, which an import into a NON-EMPTY target reaches without anything being wrong with the
+   * export - and aborting there would discard every record the file has not reached yet.
+   */
+  @Test
+  void anAliasAlreadyTakenInTheTargetDowngradesToAWarningInsteadOfAbortingTheImport() throws Exception {
+    createSourceDatabase();
+    new Exporter(("-f " + FILE + " -d " + SOURCE_PATH + " -o -format jsonl").split(" ")).exportDatabase();
+
+    try (final Database target = new DatabaseFactory(TARGET_PATH).create()) {
+      // Claims "Bill" before the import gets there, so Invoice's alias cannot be restored.
+      target.getSchema().createDocumentType("Bill");
+      target.command("sql", "IMPORT DATABASE file://" + new File(FILE).getAbsolutePath());
+    }
+
+    try (final Database target = new DatabaseFactory(TARGET_PATH).open()) {
+      // Every record after the schema line still made it in.
+      assertThat(target.countType("Person", false)).isEqualTo(2);
+      assertThat(target.countType("Friend", false)).isEqualTo(1);
+      assertThat(target.countType("Invoice", false)).isEqualTo(1);
+      assertThat(target.query("sql", "SELECT count(*) AS c FROM Sensor").next().<Number>getProperty("c").longValue())
+          .isEqualTo(3L);
+
+      // The type keeps its own name; the alias it could not take is simply not registered.
+      final DocumentType invoice = target.getSchema().getType("Invoice");
+      assertThat(invoice.getAliases()).doesNotContain("Bill");
+      assertThat(invoice.getCustomValue("retention")).as("the rest of the type metadata is unaffected")
+          .isEqualTo("7y");
     }
   }
 
@@ -172,15 +214,18 @@ class Issue7032JsonlRoundTripIT {
         source.newDocument("Invoice").set("code", "INV-1").save();
       });
 
+      // The FLOAT column is here for the non-finite encoding: JSONArray.put(Number) rewrites NaN and +/-Infinity
+      // to 0 whatever the width, so both float and double columns need the string markers.
       source.command("sql",
-          "CREATE TIMESERIES TYPE Sensor TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS 2");
+          "CREATE TIMESERIES TYPE Sensor TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE, ratio FLOAT) SHARDS 2");
 
       // A NaN sample has no SQL literal, so the samples go in through the engine.
       final LocalTimeSeriesType tsType = (LocalTimeSeriesType) source.getSchema().getType("Sensor");
       source.begin();
       tsType.getEngine().appendSamples(new long[] { 1_000L, 2_000L, 3_000L },
           new Object[] { "h1", "h1", "h2" },
-          new Object[] { 1.5, Double.NaN, 3.5 });
+          new Object[] { 1.5, Double.NaN, 3.5 },
+          new Object[] { 0.5f, Float.NaN, Float.POSITIVE_INFINITY });
       source.commit();
     }
   }

--- a/integration/src/test/java/com/arcadedb/integration/exporter/SQLLocalExporterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/SQLLocalExporterTest.java
@@ -100,7 +100,11 @@ public class SQLLocalExporterTest {
 
       final File exportFile = new File("./exports/export.jsonl.tgz");
       assertThat(exportFile.exists()).isTrue();
-      assertThat(exportFile.length()).isGreaterThan(40_000);
+      // A Person-only export is 500 vertex lines and nothing else. The bound used to be 40 KB, which only held
+      // because every vertex also carried the RIDs of its ~40 Friend edges in both directions - 20,000 RIDs that
+      // no import path ever read, and the bulk of this file (issue #7032). What the bound is here for is to catch
+      // an export that wrote no records at all.
+      assertThat(exportFile.length()).isGreaterThan(1_000);
     }
 
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -1443,4 +1443,22 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     }
     return buffer.toString();
   }
+
+  /**
+   * Appends a TimeSeries value to a JSON response array, emitting JSON {@code null} for a non-finite one.
+   * <p>
+   * NaN is the absent marker of the time-series stack (see {@code TimeSeriesNaN}): a MIN/MAX over a window with
+   * no real sample legitimately answers NaN. JSON has no NaN literal, and {@link JSONArray#put(Number)} resolves
+   * that by rewriting NaN and ±Infinity to {@code 0} - which is indistinguishable from a genuine measurement of
+   * zero and, for a Grafana dashboard, draws a dip to zero where the series actually has a gap. {@code null} is
+   * the encoding both consumers already understand as "no value here".
+   *
+   * @param array the response array to append to
+   * @param value the value; anything that is not a non-finite double or float is appended unchanged
+   */
+  protected static void putSampleValue(final JSONArray array, final Object value) {
+    final boolean absent = (value instanceof Double d && !Double.isFinite(d))
+        || (value instanceof Float f && !Float.isFinite(f));
+    array.put(absent ? JSONObject.NULL : value);
+  }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
@@ -164,7 +164,9 @@ public class PostGrafanaQueryHandler extends AbstractServerHttpHandler {
 
     for (final Object[] row : rows) {
       for (int c = 0; c < numCols; c++)
-        columnArrays[c].put(row[c]);
+        // Same treatment as the aggregation branch below: a non-finite raw sample is a gap, and it must not
+        // reach a dashboard as a number - nor as a JSON literal the response writer refuses to emit.
+        putSampleValue(columnArrays[c], row[c]);
     }
 
     final JSONArray valuesArray = new JSONArray();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
@@ -235,7 +235,9 @@ public class PostGrafanaQueryHandler extends AbstractServerHttpHandler {
 
     for (final long ts : timestamps) {
       for (int r = 0; r < requests.size(); r++)
-        aggColumns[r].put(aggResult.getValue(ts, r));
+        // NOT put(double): an absent MIN/MAX answers NaN, which that overload rewrites to 0 - and a dashboard
+        // draws a dip to zero instead of the gap the data actually has.
+        putSampleValue(aggColumns[r], aggResult.getValue(ts, r));
     }
 
     final JSONArray valuesArray = new JSONArray();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -156,7 +156,8 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
       final Object[] row = rows.get(i);
       final JSONArray rowArray = new JSONArray();
       for (final Object val : row)
-        rowArray.put(val);
+        // A raw sample can be NaN too, and it means the same "no measurement" there as in an aggregate.
+        putSampleValue(rowArray, val);
       rowsArray.put(rowArray);
     }
 
@@ -234,7 +235,8 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
       bucket.put("timestamp", ts);
       final JSONArray values = new JSONArray();
       for (int r = 0; r < requests.size(); r++)
-        values.put(aggResult.getValue(ts, r));
+        // NOT values.put(double): an absent MIN/MAX answers NaN, which that overload rewrites to 0.
+        putSampleValue(values, aggResult.getValue(ts, r));
       bucket.put("values", values);
       buckets.put(bucket);
     }

--- a/server/src/test/java/com/arcadedb/server/Issue7043AbsentMinMaxOverHttpIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7043AbsentMinMaxOverHttpIT.java
@@ -86,6 +86,44 @@ class Issue7043AbsentMinMaxOverHttpIT extends BaseGraphServerTest {
   }
 
   /**
+   * The RAW (non-aggregated) branches carry the same exposure: a NaN sample there means the same "no
+   * measurement", and JSON has no literal for it either way.
+   */
+  @Test
+  void aRawNaNSampleIsNullNotZeroOnBothEndpoints() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeWithOnlyNaNSamples(serverIndex);
+
+      // --- /ts/<db>/query, raw branch: rows of [ts, value] ---
+      final JSONObject raw = new JSONObject();
+      raw.put("type", TYPE);
+      raw.put("from", 0L);
+      raw.put("to", 10_000L);
+      final JSONArray rows = postJson(serverIndex, "/api/v1/ts/graph/query", raw).getJSONArray("rows");
+      assertThat(rows.length()).isEqualTo(2);
+      assertThat(rows.getJSONArray(0).isNull(1)).as("a raw NaN sample must be JSON null, not 0").isTrue();
+
+      // --- /ts/<db>/grafana/query, raw branch: columnar, value column last ---
+      final JSONArray targets = new JSONArray();
+      final JSONObject target = new JSONObject();
+      target.put("refId", "A");
+      target.put("type", TYPE);
+      targets.put(target);
+
+      final JSONObject grafana = new JSONObject();
+      grafana.put("from", 0L);
+      grafana.put("to", 10_000L);
+      grafana.put("targets", targets);
+
+      final JSONArray columns = postJson(serverIndex, "/api/v1/ts/graph/grafana/query", grafana)
+          .getJSONObject("results").getJSONObject("A").getJSONArray("frames")
+          .getJSONObject(0).getJSONObject("data").getJSONArray("values");
+      final JSONArray valueColumn = columns.getJSONArray(columns.length() - 1);
+      assertThat(valueColumn.isNull(0)).as("Grafana raw column must carry a gap, not a zero").isTrue();
+    });
+  }
+
+  /**
    * The same endpoint must still return real numbers: the null is the absent marker, not a blanket rule.
    */
   @Test

--- a/server/src/test/java/com/arcadedb/server/Issue7043AbsentMinMaxOverHttpIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7043AbsentMinMaxOverHttpIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7043, over HTTP: an absent MIN/MAX must not reach a client as the number {@code 0}.
+ * <p>
+ * The engine now answers {@code NaN} - the absent marker - for a MIN/MAX bucket that received no real sample, and
+ * {@code JSONArray.put(Number)} resolves JSON's lack of a NaN literal by rewriting NaN to {@code 0}. Feeding the
+ * aggregate straight into a response array therefore turned "no measurement" into a measurement of zero:
+ * indistinguishable from real data, and for a Grafana dashboard a dip to zero where the series has a gap. Both
+ * time-series response builders emit JSON {@code null} instead.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7043AbsentMinMaxOverHttpIT extends BaseGraphServerTest {
+
+  private static final String TYPE = "nanmetric";
+
+  @Test
+  void anAllNaNBucketIsNullNotZeroOnTheTimeSeriesAndGrafanaEndpoints() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeWithOnlyNaNSamples(serverIndex);
+
+      // --- /ts/<db>/query, aggregation branch ---
+      final JSONObject tsBucket = postJson(serverIndex, "/api/v1/ts/graph/query", aggregationRequest())
+          .getJSONArray("buckets").getJSONObject(0);
+      final JSONArray tsValues = tsBucket.getJSONArray("values");
+      assertThat(tsValues.isNull(0)).as("MIN over an all-NaN bucket must be JSON null, not 0").isTrue();
+      assertThat(tsValues.isNull(1)).as("MAX over an all-NaN bucket must be JSON null, not 0").isTrue();
+
+      // --- /ts/<db>/grafana/query, aggregation branch: columnar, timestamps first ---
+      final JSONObject request = aggregationRequest();
+      request.put("type", TYPE);
+      final JSONArray targets = new JSONArray();
+      final JSONObject target = new JSONObject();
+      target.put("refId", "A");
+      target.put("type", TYPE);
+      target.put("aggregation", request.getJSONObject("aggregation"));
+      targets.put(target);
+
+      final JSONObject grafana = new JSONObject();
+      grafana.put("from", 0L);
+      grafana.put("to", 10_000L);
+      grafana.put("targets", targets);
+
+      final JSONArray frames = postJson(serverIndex, "/api/v1/ts/graph/grafana/query", grafana)
+          .getJSONObject("results").getJSONObject("A").getJSONArray("frames");
+      final JSONArray columns = frames.getJSONObject(0).getJSONObject("data").getJSONArray("values");
+
+      // Column 0 is the timestamps; the aggregations follow in request order.
+      assertThat(columns.getJSONArray(1).isNull(0)).as("Grafana MIN column must carry a gap, not a zero").isTrue();
+      assertThat(columns.getJSONArray(2).isNull(0)).as("Grafana MAX column must carry a gap, not a zero").isTrue();
+    });
+  }
+
+  /**
+   * The same endpoint must still return real numbers: the null is the absent marker, not a blanket rule.
+   */
+  @Test
+  void aRealValueIsStillReturnedAsANumber() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeWithOnlyNaNSamples(serverIndex);
+
+      final Database database = getServerDatabase(serverIndex, getDatabaseName());
+      final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(TYPE);
+      database.begin();
+      tsType.getEngine().appendSamples(new long[] { 3_000L }, new Object[] { 4.25 });
+      database.commit();
+
+      final JSONArray values = postJson(serverIndex, "/api/v1/ts/graph/query", aggregationRequest())
+          .getJSONArray("buckets").getJSONObject(0).getJSONArray("values");
+      assertThat(values.isNull(0)).isFalse();
+      assertThat(((Number) values.get(0)).doubleValue()).isEqualTo(4.25);
+      assertThat(((Number) values.get(1)).doubleValue()).isEqualTo(4.25);
+    });
+  }
+
+  private JSONObject aggregationRequest() {
+    final JSONArray requests = new JSONArray();
+    final JSONObject min = new JSONObject();
+    min.put("field", "value");
+    min.put("type", "MIN");
+    min.put("alias", "min");
+    requests.put(min);
+    final JSONObject max = new JSONObject();
+    max.put("field", "value");
+    max.put("type", "MAX");
+    max.put("alias", "max");
+    requests.put(max);
+
+    final JSONObject aggregation = new JSONObject();
+    // One bucket wide enough to hold every sample, so the answer is a single bucket to assert on.
+    aggregation.put("bucketInterval", 1_000_000L);
+    aggregation.put("requests", requests);
+
+    final JSONObject payload = new JSONObject();
+    payload.put("type", TYPE);
+    payload.put("from", 0L);
+    payload.put("to", 10_000L);
+    payload.put("aggregation", aggregation);
+    return payload;
+  }
+
+  /**
+   * A NaN sample has no line-protocol or SQL literal, so the samples go in through the server's own database.
+   */
+  private void createTypeWithOnlyNaNSamples(final int serverIndex) throws Exception {
+    final Database database = getServerDatabase(serverIndex, getDatabaseName());
+    if (database.getSchema().existsType(TYPE))
+      database.getSchema().dropType(TYPE);
+
+    database.command("sql", "CREATE TIMESERIES TYPE " + TYPE + " TIMESTAMP ts FIELDS (value DOUBLE) SHARDS 1");
+
+    final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType(TYPE);
+    database.begin();
+    tsType.getEngine().appendSamples(new long[] { 1_000L, 2_000L }, new Object[] { Double.NaN, Double.NaN });
+    database.commit();
+  }
+
+  private JSONObject postJson(final int serverIndex, final String path, final JSONObject body) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI("http://127.0.0.1:248" + serverIndex + path)
+        .toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+
+    try (final OutputStream os = connection.getOutputStream()) {
+      os.write(body.toString().getBytes(StandardCharsets.UTF_8));
+      os.flush();
+    }
+
+    assertThat(connection.getResponseCode()).isEqualTo(200);
+    try (final InputStream is = connection.getInputStream()) {
+      return new JSONObject(new String(is.readAllBytes(), StandardCharsets.UTF_8));
+    }
+  }
+}


### PR DESCRIPTION
Closes #7032, closes #7039, closes #7043.

## #7039 + #7043 — one NaN policy across `engine/timeseries`

`engine/timeseries` held **three** MIN/MAX "no data" sentinels, each of which leaked back to the caller as though it were a measurement:

| site | sentinel |
|---|---|
| `PromQLFunctions.minOverTime` / `maxOverTime` | `±Infinity` |
| `PromQLEvaluator` MIN/MAX aggregation arms | `±Infinity` |
| `MultiColumnAggregationResult` accumulators | `±Double.MAX_VALUE` |
| `TimeSeriesSealedStore.reduceNumericStats` → persisted block statistics | `±Double.MAX_VALUE` |

`<` and `>` skip NaN implicitly, so an all-NaN window never displaced the seed. Two paths over identical data answered differently — `TimeSeriesVectorOps.min` said `NaN`, `aggregateMulti` said `1.7976931348623157E308` — and the PromQL layer diverged from the protocol it emulates (Prometheus answers `NaN`).

**The fix removes the sentinels instead of guarding them.** The #4596 guard (`isUnusedMinMax`) keyed off the raw sample count, and a NaN sample increments that count — which is precisely why an all-NaN bucket still leaked. A bitset or a NaN-aware counter, as #7043 suggests, would have been a second side-channel with the same shape.

New `TimeSeriesNaN` holds **the** policy — NaN *is* the absent marker. Every MIN/MAX accumulator seeds at `TimeSeriesNaN.ABSENT` and folds through `TimeSeriesNaN.min`/`max`. "Nothing real arrived" is then the value itself, so `isUnusedMinMax` and its three call sites are deleted, and merging two partial results inherits the property for free. A genuine `±Infinity` sample stays data — it is a measurement, not a marker.

### Block statistics: the set of columns with a triplet is now codec-keyed

Since a declared minimum can now legitimately be `NaN`, the writers could no longer use `!Double.isNaN(min)` to decide which columns carry a `{min,max,sum}` triplet — the format stores them positionally with no column index, so writer and reader must agree exactly or the statistics land on the wrong columns. Both writers and the reader now key off the codec.

That also fixes a **latent misalignment**: the reader consumed a triplet for any column that was neither TIMESTAMP nor TAG, so a `STRING` FIELD — which has no triplet — shifted every following column's statistics onto the wrong column. Covered by a new test.

## #7032 — the JSONL round trip

1. **A TIMESERIES type aborted the whole import.** Exported as `"type":"t"`, with no case in the importer's schema switch — the `default` threw at the schema line. The type is now recreated from the export, per-column codec included (not re-derivable, which is why the schema persists it — #5475).

   **Going beyond what the issue asks**: the samples now travel too, as chunked `"ts"` lines, so the restored type has its *data* behind it rather than only its definition. Restoring a definition into an empty type is not a round trip. Non-finite doubles are encoded as string markers, because `JSONArray.put(Number)` silently rewrites NaN/±Infinity to `0` — an unencoded NaN would come back as a measurement of zero.

2. **Type-level CUSTOM, ALIASES and the bucket-selection strategy** were exported and never restored, while property-level CUSTOM — same JSON, adjacent code — was. All three are restored, the strategy last so a `PARTITIONED` one finds its index, and a strategy that declines to bind warns instead of aborting an import that has already recreated the schema.

3. **Vertex lines carried the RID of every one of their edges, in both directions**, and no import path has ever read them (edges are rebuilt from the `"e"` lines). Dropped, behind a new `JsonGraphSerializer.setIncludeVertexEdgeMetadata` flag so the HTTP callers are untouched. Edges keep their endpoints — those *are* the edge. On the existing 500-vertex / 10,000-edge fixture the Person-only export goes from >40 KB to 3.3 KB.

## Tests

- `Issue7043MinMaxAbsentPolicyTest` — all-NaN bucket on the mutable, sealed-fast-path and multi-column paths; real values and a real `Double.MAX_VALUE` sample still win; block statistics stay aligned with a text FIELD between the numeric ones.
- `Issue7039PromQLMinMaxNaNTest` — `min_over_time`/`max_over_time` and `min()`/`max()` over an all-NaN window; a real value among NaN samples; a real `±Infinity` sample preserved.
- `Issue7032JsonlRoundTripIT` — full export/import cycle with a TIMESERIES type (samples, NaN included), type-level aliases/custom/`thread` strategy, and an assertion on the exported file that vertex lines carry no edge RIDs while edge lines keep their endpoints.

Existing suites: 72 `engine/timeseries` test classes and 177 integration exporter/importer tests green. `SQLLocalExporterTest.importAndExportPartialDatabase` had a `> 40_000` file-size bound that only held because of the removed edge-RID bloat; it now asserts the export is non-empty, with a comment saying why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added JSONL export and import support for time-series schemas, samples, metadata, retention, and non-finite values.
  - Export and import results now report time-series sample counts.
  - Added an option to include or omit vertex edge metadata in JSON serialization.

- **Bug Fixes**
  - Improved time-series MIN/MAX handling for NaN, empty, and all-NaN data.
  - Preserved valid extreme values and statistics alignment across stored data, vector operations, and PromQL queries.
  - Prevented duplicated edge metadata during JSONL export.
  - Imports now continue when aliases conflict with existing types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Note on existing databases

A block sealed by a pre-fix build with an all-NaN numeric column already has `±Double.MAX_VALUE` baked into its persisted `{min,max,sum}` triplet, and the MIN/MAX push-down answers from that triplet without decompressing. Those specific blocks keep returning the old sentinel until they are recompacted or downsampled, at which point they are rewritten with the new policy. This is not repairable at read time: a finite `Double.MAX_VALUE` in a header is indistinguishable from a genuine measurement of that value, which the tests here assert must stay data.
