### PR TITLE
Vector graph persist keeps the caller's transaction, strict page parse on compaction, explicit instance for Java method functions, gRPC admin double-terminate guard

### DIFF
--- a/bolt/src/test/java/com/arcadedb/bolt/Issue7058BoltVectorSustainedWritesIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue7058BoltVectorSustainedWritesIT.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7058: with an {@code LSM_VECTOR} index on the written property, sustained
+ * {@code MERGE ... SET n = $props} writes over Bolt failed with {@code Neo.ClientError.Transaction.TransactionNotFound:
+ * Transaction not begun}, while the identical workload passed once the vector index was dropped. The failure was
+ * scale-dependent: a handful of writes per database completed, hundreds did not.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7058BoltVectorSustainedWritesIT extends BaseGraphServerTest {
+
+  private static final int DIMENSIONS = 384;
+  private static final int WRITES     = 400;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+  }
+
+  private void createSchema(final String typeName) {
+    final Database db = getServerDatabase(0, getDatabaseName());
+    db.command("sql", "CREATE VERTEX TYPE " + typeName);
+    db.command("sql", "CREATE PROPERTY " + typeName + ".uuid STRING");
+    db.command("sql", "CREATE PROPERTY " + typeName + ".name STRING");
+    db.command("sql", "CREATE PROPERTY " + typeName + ".name_embedding ARRAY_OF_FLOATS");
+    db.command("sql", "CREATE INDEX ON " + typeName + " (uuid) NOTUNIQUE");
+    db.command("sql", "CREATE INDEX ON " + typeName + " (name_embedding) LSM_VECTOR METADATA {dimensions: " + DIMENSIONS
+        + ", similarity: 'COSINE'}");
+  }
+
+  private static Map<String, Object> props(final Random random, final int i) {
+    final List<Double> embedding = new ArrayList<>(DIMENSIONS);
+    for (int d = 0; d < DIMENSIONS; d++)
+      embedding.add(random.nextDouble());
+    final Map<String, Object> props = new HashMap<>();
+    props.put("uuid", "uuid-" + i);
+    props.put("name", "entity " + i);
+    props.put("name_embedding", embedding);
+    return props;
+  }
+
+  @Test
+  void sustainedAutocommitMergeWritesSucceedWithAVectorIndex() {
+    final String typeName = "Entity7058A";
+    createSchema(typeName);
+    final Random random = new Random(7058);
+
+    try (final Driver driver = getDriver(); final Session session = driver.session(
+        SessionConfig.forDatabase(getDatabaseName()))) {
+      for (int i = 0; i < WRITES; i++) {
+        final Map<String, Object> props = props(random, i);
+        session.run("MERGE (n:" + typeName + " {uuid: $uuid}) SET n:" + typeName + " SET n = $props",
+            Map.of("uuid", props.get("uuid"), "props", props)).consume();
+      }
+
+      assertThat(session.run("MATCH (n:" + typeName + ") RETURN count(n) AS c").single().get("c").asLong()).isEqualTo(WRITES);
+    }
+  }
+
+  @Test
+  void sustainedManagedTransactionMergeWritesSucceedWithAVectorIndex() {
+    final String typeName = "Entity7058B";
+    createSchema(typeName);
+    final Random random = new Random(7058);
+
+    try (final Driver driver = getDriver(); final Session session = driver.session(
+        SessionConfig.forDatabase(getDatabaseName()))) {
+      for (int i = 0; i < WRITES; i++) {
+        final Map<String, Object> props = props(random, i);
+        session.executeWrite(tx -> tx.run("MERGE (n:" + typeName + " {uuid: $uuid}) SET n:" + typeName + " SET n = $props",
+            Map.of("uuid", props.get("uuid"), "props", props)).consume());
+      }
+
+      assertThat(session.run("MATCH (n:" + typeName + ") RETURN count(n) AS c").single().get("c").asLong()).isEqualTo(WRITES);
+    }
+  }
+
+  /**
+   * The reporter's workload carries a {@code SET n:<labels>} clause: with more than one label per node the vertex is
+   * moved to a composite type that is created on the fly the first time its label combination shows up, and every
+   * index of the parent type, the vector one included, is propagated to it.
+   */
+  @Test
+  void sustainedMultiLabelMergeWritesSucceedWithAVectorIndex() {
+    final String typeName = "Entity7058C";
+    createSchema(typeName);
+    final String[] secondaryLabels = { "Person7058C", "Organization7058C", "Location7058C", "Event7058C", "Topic7058C" };
+    final Database db = getServerDatabase(0, getDatabaseName());
+    for (final String label : secondaryLabels)
+      db.command("sql", "CREATE VERTEX TYPE " + label);
+    final Random random = new Random(7058);
+
+    try (final Driver driver = getDriver(); final Session session = driver.session(
+        SessionConfig.forDatabase(getDatabaseName()))) {
+      for (int i = 0; i < WRITES; i++) {
+        final Map<String, Object> props = props(random, i);
+        final String labels = typeName + ":" + secondaryLabels[i % secondaryLabels.length];
+        session.executeWrite(tx -> tx.run("MERGE (n:" + typeName + " {uuid: $uuid}) SET n:" + labels + " SET n = $props",
+            Map.of("uuid", props.get("uuid"), "props", props)).consume());
+      }
+
+      assertThat(session.run("MATCH (n:" + typeName + ") RETURN count(n) AS c").single().get("c").asLong()).isEqualTo(WRITES);
+    }
+  }
+
+  /** All the writes inside ONE explicit transaction, the way a driver's {@code begin_transaction()} loop does it. */
+  @Test
+  void manyMergeWritesInOneExplicitTransactionSucceedWithAVectorIndex() {
+    final String typeName = "Entity7058D";
+    createSchema(typeName);
+    final Random random = new Random(7058);
+
+    try (final Driver driver = getDriver(); final Session session = driver.session(
+        SessionConfig.forDatabase(getDatabaseName()))) {
+      try (final Transaction tx = session.beginTransaction()) {
+        for (int i = 0; i < WRITES; i++) {
+          final Map<String, Object> props = props(random, i);
+          tx.run("MERGE (n:" + typeName + " {uuid: $uuid}) SET n:" + typeName + " SET n = $props",
+              Map.of("uuid", props.get("uuid"), "props", props)).consume();
+        }
+        tx.commit();
+      }
+
+      assertThat(session.run("MATCH (n:" + typeName + ") RETURN count(n) AS c").single().get("c").asLong()).isEqualTo(WRITES);
+    }
+  }
+
+  /**
+   * A similarity search inside the same explicit transaction as the writes: the first search after a batch of writes
+   * rebuilds the graph synchronously on the calling thread, and that rebuild must not touch the caller's transaction.
+   */
+  @Test
+  void vectorSearchInsideAnExplicitTransactionKeepsTheTransactionOpen() {
+    final String typeName = "Entity7058E";
+    createSchema(typeName);
+    final Random random = new Random(7058);
+
+    try (final Driver driver = getDriver(); final Session session = driver.session(
+        SessionConfig.forDatabase(getDatabaseName()))) {
+      for (int i = 0; i < 50; i++) {
+        final Map<String, Object> props = props(random, i);
+        session.executeWrite(tx -> tx.run("MERGE (n:" + typeName + " {uuid: $uuid}) SET n = $props",
+            Map.of("uuid", props.get("uuid"), "props", props)).consume());
+      }
+
+      final List<Double> query = new ArrayList<>(DIMENSIONS);
+      for (int d = 0; d < DIMENSIONS; d++)
+        query.add(random.nextDouble());
+
+      try (final Transaction tx = session.beginTransaction()) {
+        final Map<String, Object> props = props(random, 1000);
+        tx.run("MERGE (n:" + typeName + " {uuid: $uuid}) SET n = $props", Map.of("uuid", props.get("uuid"), "props", props)).consume();
+        final long found = tx.run("CALL db.index.vector.queryNodes('" + typeName + "[name_embedding]', 5, $q) YIELD node RETURN count(node) AS c",
+            Map.of("q", query)).single().get("c").asLong();
+        assertThat(found).isGreaterThan(0);
+        tx.commit();
+      }
+
+      assertThat(session.run("MATCH (n:" + typeName + ") RETURN count(n) AS c").single().get("c").asLong()).isEqualTo(51);
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -61,18 +61,18 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
   /**
    * Creates a function bound to a single Java method.
    *
-   * @param instance Java object against where to invoke the method
+   * @param instance Java object against where to invoke the method; required when the method is not static, ignored
+   *                 (may be {@code null}) when it is
    * @param method   Java Method object to invoke
    *
-   * @throws NoSuchMethodException
-   * @throws InvocationTargetException
-   * @throws InstantiationException
-   * @throws IllegalAccessException
+   * @throws IllegalArgumentException when {@code method} is not static and no instance is supplied. The declaring
+   *                                  class is never instantiated on the caller's behalf (issue #7046): whether a
+   *                                  class gets constructed, and how, is the registration site's decision, as
+   *                                  {@link JavaClassFunctionLibraryDefinition} makes it for a whole class
    */
-  public JavaMethodFunctionDefinition(final Object instance, final Method method)
-      throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-    this.instance = Modifier.isStatic(method.getModifiers()) ? null : instance != null ? instance : method.getDeclaringClass().getConstructor().newInstance();
+  public JavaMethodFunctionDefinition(final Object instance, final Method method) {
     this.methods = List.of(method);
+    this.instance = instanceFor(instance, this.methods);
   }
 
   /**
@@ -80,13 +80,11 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
    *
    * @param method static method to execute
    *
-   * @throws NoSuchMethodException
-   * @throws InvocationTargetException
-   * @throws InstantiationException
-   * @throws IllegalAccessException
+   * @throws IllegalArgumentException when {@code method} is not static: see
+   *                                  {@link #JavaMethodFunctionDefinition(Object, Method)} for the form that takes
+   *                                  the instance to invoke it on
    */
-  public JavaMethodFunctionDefinition(final Method method)
-      throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+  public JavaMethodFunctionDefinition(final Method method) {
     this(null, method);
   }
 
@@ -97,16 +95,37 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
    *
    * @param instance Java object against where to invoke the non-static overloads, or {@code null} if all of them are static
    * @param methods  the overloads, all sharing the same method name
+   *
+   * @throws IllegalArgumentException when an overload is not static and no instance is supplied
    */
   public JavaMethodFunctionDefinition(final Object instance, final List<Method> methods) {
     if (methods.isEmpty())
       throw new IllegalArgumentException("At least one method is required");
-    this.instance = instance;
+    this.instance = instanceFor(instance, methods);
     // Sorted so which overload names an error message (getName(), or the "expected/received" and ambiguity
     // messages) is deterministic, rather than depending on the JVM's unspecified getDeclaredMethods() order.
     this.methods = methods.stream()
         .sorted(Comparator.<Method>comparingInt(Method::getParameterCount).thenComparing(m -> Arrays.toString(m.getParameterTypes())))
         .toList();
+  }
+
+  /**
+   * The receiver the methods are invoked on: {@code instance} when any of them needs one, {@code null} when all of
+   * them are static (a receiver is ignored by {@link Method#invoke} for a static method, so there is no point in
+   * holding on to one). A non-static method with no instance is refused here rather than served by instantiating
+   * its declaring class: constructing an arbitrary class as a side effect of registering a function is not a
+   * contract a registration site can be expected to know about (issue #7046).
+   */
+  private static Object instanceFor(final Object instance, final List<Method> methods) {
+    boolean needsInstance = false;
+    for (final Method method : methods)
+      if (!Modifier.isStatic(method.getModifiers())) {
+        if (instance == null)
+          throw new IllegalArgumentException(
+              "Method '" + method + "' is not static: an instance to invoke it on is required");
+        needsInstance = true;
+      }
+    return needsInstance ? instance : null;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionLibraryDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionLibraryDefinition.java
@@ -21,10 +21,19 @@ import com.arcadedb.function.FunctionLibraryDefinition;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Set;
 
 /**
- * Function library that allows invocation of functions written in Java language.
+ * Function library that allows invocation of functions written in Java language: a single method, exposed under the
+ * library name.
+ * <p>
+ * A method that is not static is invoked on an instance. The instance-less constructors create one HERE, at the
+ * registration site, through the public no-arg constructor of the declaring class - the same choice
+ * {@link JavaClassFunctionLibraryDefinition} makes for a whole class - and that is the only place it happens:
+ * {@link JavaMethodFunctionDefinition} itself never instantiates anything (issue #7046). To invoke the method on an
+ * object of the caller's choosing, one that carries state or dependencies, register it through
+ * {@link #JavaMethodFunctionLibraryDefinition(String, Object, Method)}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -33,16 +42,44 @@ public class JavaMethodFunctionLibraryDefinition implements FunctionLibraryDefin
   private final Method                       method;
   private final JavaMethodFunctionDefinition function;
 
+  /**
+   * Exposes a method under a library named after its declaring class and its name. A non-static method is invoked on
+   * a new instance of its declaring class, created through the public no-arg constructor.
+   */
   public JavaMethodFunctionLibraryDefinition(final Method method)
       throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     this(method.getDeclaringClass() + "::" + method.getName(), method);
   }
 
+  /**
+   * Exposes a method under {@code libraryName}. A non-static method is invoked on a new instance of its declaring
+   * class, created through the public no-arg constructor.
+   *
+   * @throws NoSuchMethodException     when the method is not static and its class has no public no-arg constructor
+   * @throws InstantiationException    when the method is not static and its class cannot be instantiated
+   * @throws IllegalAccessException    when the method is not static and its constructor is not accessible
+   * @throws InvocationTargetException when the method is not static and its constructor throws
+   */
   public JavaMethodFunctionLibraryDefinition(final String libraryName, final Method method)
       throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+    this(libraryName, Modifier.isStatic(method.getModifiers()) ? null : method.getDeclaringClass().getConstructor().newInstance(),
+        method);
+  }
+
+  /**
+   * Exposes a method under {@code libraryName}, invoked on {@code instance} when it is not static.
+   *
+   * @param libraryName the library name the function is registered under
+   * @param instance    the object to invoke the method on; required when the method is not static, ignored (may be
+   *                    {@code null}) when it is
+   * @param method      the method to expose
+   *
+   * @throws IllegalArgumentException when {@code method} is not static and {@code instance} is {@code null}
+   */
+  public JavaMethodFunctionLibraryDefinition(final String libraryName, final Object instance, final Method method) {
     this.method = method;
     this.libraryName = libraryName;
-    this.function = new JavaMethodFunctionDefinition(method);
+    this.function = new JavaMethodFunctionDefinition(instance, method);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3290,6 +3290,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // Rollback on error - the persist transaction only, and only while it is still the current one (see
           // the begin above): once it is committed, or popped by a commit that failed, "current" is the caller's.
           final TransactionContext openedHere = persistTransaction[0];
+          // Captured before the rollback: afterwards "current" is the caller's transaction, whose status says
+          // nothing about the persist that failed.
+          final TransactionContext.STATUS persistStatus = openedHere != null ? openedHere.getStatus() : null;
           if (openedHere != null && openedHere.isActive() && database.getTransaction() == openedHere) {
             try {
               database.rollback();
@@ -3327,7 +3330,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
               indexName,
               totalNodes,
               metadata.storeVectorsInGraph,
-              database.getTransaction().getStatus(),
+              persistStatus,
               e.getClass().getSimpleName(),
               e.getMessage(),
               e);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2404,9 +2404,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // A tombstone carries the SAME id as the entry it kills, which is why ties must go to the later entry: dropping
     // tombstones here (as this loop used to do) left every deleted RID in the live set, so the next rebuild put the
     // deleted vectors back into the graph and into the location index.
+    // Strict when compacting (issue #7045): a page the parser cannot read to the end is cut short - every entry from
+    // the failing one to the end of that page silently missing from the result - and a rebuild survives that thanks
+    // to the recovery fallbacks below. A compaction does not: it rewrites the data file from this very set and then
+    // reclaims the source, so a truncated set here would be shipped as the whole live set and the vectors it lacks
+    // would be gone for good. Fail the compaction instead, before any file is created or replaced.
     if (compactedSubIndex != null) {
       LSMVectorIndexPageParser.parsePages(database, compactedSubIndex.getFileId(), compactedSubIndex.getTotalPages(),
-          getPageSize(), true, entry -> {
+          getPageSize(), true, compactDataFile, entry -> {
             totalEntriesRead[0]++;
             if (entry.deleted)
               filteredDeletedVectors[0]++;
@@ -2415,7 +2420,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
     }
 
     // Read from mutable index (its entries are newer than the compacted ones)
-    LSMVectorIndexPageParser.parsePages(database, getFileId(), getTotalPages(), getPageSize(), false, entry -> {
+    LSMVectorIndexPageParser.parsePages(database, getFileId(), getTotalPages(), getPageSize(), false, compactDataFile,
+        entry -> {
       totalEntriesRead[0]++;
       if (entry.deleted)
         filteredDeletedVectors[0]++;
@@ -3171,16 +3177,24 @@ public class LSMVectorIndex implements Index, IndexInternal {
         if (effectiveGraphCallback != null)
           effectiveGraphCallback.onGraphBuildProgress("persisting", 0, totalNodes, 0);
 
-        // Start a dedicated transaction for graph persistence with chunked commits
-        long chunkSizeMB = getTxChunkSize();
+        // Start a dedicated transaction for graph persistence with chunked commits. ALWAYS one of its own, nested
+        // when the calling thread already holds one (issue #7058): the graph is derived state computed from
+        // committed pages, so it commits on its own terms, and the transaction a caller opened around the search
+        // (or the DDL) that triggered this rebuild has to be left exactly as it was found - neither committed on
+        // its behalf nor switched to WAL-less. Committing it from here was what turned a similarity search inside
+        // an explicit Bolt transaction into a COMMIT failing with "Transaction not begun": the search rebuilt the
+        // graph synchronously, this step committed the session's transaction, and the client's own COMMIT then
+        // found nothing left to commit.
+        //
+        // The transaction opened here is tracked by identity, and re-tracked after every chunk commit, so the
+        // rollback in the catch below can only ever target THIS transaction: a nested commit that failed has
+        // already been popped, and rolling back "whatever is current" at that point would roll back the caller's.
+        final long chunkSizeMB = getTxChunkSize();
 
-        final boolean startedTransaction = !database.isTransactionActive();
-        if (startedTransaction) {
-          database.begin();
-          database.getTransaction().setUseWAL(false);
-        } else {
-          database.getTransaction().setUseWAL(false);
-        }
+        final TransactionContext[] persistTransaction = new TransactionContext[1];
+        database.begin();
+        persistTransaction[0] = database.getTransaction();
+        persistTransaction[0].setUseWAL(false);
 
         final ChunkCommitCallback chunkCallback = bytesWritten -> {
           LogManager.instance().log(this, Level.INFO,
@@ -3191,7 +3205,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
           // Start new transaction and disable WAL
           database.begin();
-          database.getTransaction().setUseWAL(false);
+          persistTransaction[0] = database.getTransaction();
+          persistTransaction[0].setUseWAL(false);
         };
 
         // Flipped the moment the manifest certifies the committed pages. Everything after that point - the
@@ -3209,16 +3224,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
           }
 
           // Commit the transaction to persist graph pages
-          if (startedTransaction) {
-            database.commit();
-            LogManager.instance().log(this, Level.FINE, "Vector graph persisted and committed for index: %s",
-                indexName);
-          } else {
-            database.commit();
-            LogManager.instance()
-                .log(this, Level.FINE, "Vector graph persisted (transaction managed by caller) for index: %s",
-                    indexName);
-          }
+          database.commit();
+          persistTransaction[0] = null;
+          LogManager.instance().log(this, Level.FINE, "Vector graph persisted and committed for index: %s",
+              indexName);
 
           // Only now that the pages are committed may the manifest vouch for them (issue #6106). Written after the
           // commit and never before: a manifest that outlived a persist which did not complete would be the one
@@ -3278,8 +3287,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // so a build that died mid-persist left a dangling transaction and a manifest that still vouched for
           // whatever the pages happened to hold (issue #6503).
           //
-          // Rollback on error
-          if (startedTransaction) {
+          // Rollback on error - the persist transaction only, and only while it is still the current one (see
+          // the begin above): once it is committed, or popped by a commit that failed, "current" is the caller's.
+          final TransactionContext openedHere = persistTransaction[0];
+          if (openedHere != null && openedHere.isActive() && database.getTransaction() == openedHere) {
             try {
               database.rollback();
             } catch (final Exception rollbackEx) {

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3189,6 +3189,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // The transaction opened here is tracked by identity, and re-tracked after every chunk commit, so the
         // rollback in the catch below can only ever target THIS transaction: a nested commit that failed has
         // already been popped, and rolling back "whatever is current" at that point would roll back the caller's.
+        // Re-tracked rather than assumed stable: with no caller transaction the thread's single TransactionContext
+        // is reused across begin()/commit() cycles (nothing to pop), with one it is a fresh object every time.
         final long chunkSizeMB = getTxChunkSize();
 
         final TransactionContext[] persistTransaction = new TransactionContext[1];

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexPageParser.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexPageParser.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.BasePage;
 import com.arcadedb.engine.PageId;
+import com.arcadedb.index.IndexException;
 import com.arcadedb.log.LogManager;
 
 import java.util.ArrayList;
@@ -64,7 +65,8 @@ class LSMVectorIndexPageParser {
   }
 
   /**
-   * Parse all vector entries from a range of pages in a file.
+   * Parse all vector entries from a range of pages in a file, leniently: a page that cannot be parsed to the end is
+   * logged and cut short, and the parse moves on to the next page. See the strict overload for what that costs.
    *
    * @param database    The database instance
    * @param fileId      The file ID to read from
@@ -72,14 +74,41 @@ class LSMVectorIndexPageParser {
    * @param pageSize    Page size in bytes
    * @param isCompacted Whether this is a compacted index file
    * @param consumer    Consumer to process each parsed entry
+   *
    * @return Number of entries parsed
    */
   static int parsePages(final DatabaseInternal database, final int fileId, final int totalPages,
       final int pageSize, final boolean isCompacted, final Consumer<VectorEntry> consumer) {
+    return parsePages(database, fileId, totalPages, pageSize, isCompacted, false, consumer);
+  }
+
+  /**
+   * Parse all vector entries from a range of pages in a file.
+   *
+   * @param database    The database instance
+   * @param fileId      The file ID to read from
+   * @param totalPages  Number of pages to read
+   * @param pageSize    Page size in bytes
+   * @param isCompacted Whether this is a compacted index file
+   * @param strict      When true, a page that cannot be parsed to the end fails the whole parse with an
+   *                    {@link IndexException} instead of being cut short. A parse failure at entry {@code i} of a page
+   *                    leaves entries {@code i..n} of that page out of the result, and nothing downstream can tell a
+   *                    truncated result from a complete one - so a caller about to treat it as the complete live set
+   *                    (compaction, which reclaims the source file right after) must not get one (issue #7045). The
+   *                    lenient mode is for the load and rebuild paths, which have recovery fallbacks of their own
+   * @param consumer    Consumer to process each parsed entry
+   *
+   * @return Number of entries parsed
+   */
+  static int parsePages(final DatabaseInternal database, final int fileId, final int totalPages,
+      final int pageSize, final boolean isCompacted, final boolean strict, final Consumer<VectorEntry> consumer) {
 
     int entriesRead = 0;
 
     for (int pageNum = 0; pageNum < totalPages; pageNum++) {
+      // Declared outside the try so the failure report can say which entry stopped the parse and how many were lost.
+      int numberOfEntries = 0;
+      int entryIndex = 0;
       try {
         final PageId pageId = new PageId(database, fileId, pageNum);
         final BasePage page = database.getPageManager().getImmutablePage(pageId, pageSize, false, false);
@@ -87,7 +116,7 @@ class LSMVectorIndexPageParser {
         if (page == null)
           continue;
 
-        final int numberOfEntries = page.readInt(LSMVectorIndex.OFFSET_NUM_ENTRIES);
+        numberOfEntries = page.readInt(LSMVectorIndex.OFFSET_NUM_ENTRIES);
         if (numberOfEntries == 0)
           continue;
 
@@ -99,7 +128,7 @@ class LSMVectorIndexPageParser {
 
         // Parse entries
         int currentOffset = headerSize;
-        for (int i = 0; i < numberOfEntries; i++) {
+        for (; entryIndex < numberOfEntries; entryIndex++) {
           final int entryStartOffset = currentOffset;
           final long entryFileOffset = pageStartOffset + BasePage.PAGE_HEADER_SIZE + currentOffset;
 
@@ -136,8 +165,14 @@ class LSMVectorIndexPageParser {
           entriesRead++;
         }
       } catch (final Exception e) {
-        LogManager.instance().log(LSMVectorIndexPageParser.class, Level.WARNING,
-            "Error parsing page %d in file %d: %s", pageNum, fileId, e.getMessage());
+        // Entries entryIndex..numberOfEntries-1 of this page are not in the result: say so, because a caller that
+        // only sees the count has no way to tell a page cut short from a page that was complete.
+        final String message = String.format(
+            "Error parsing page %d in file %d at entry %d of %d (entries %d to %d of the page not read): %s", pageNum,
+            fileId, entryIndex, numberOfEntries, entryIndex, numberOfEntries - 1, e.getMessage());
+        if (strict)
+          throw new IndexException(message, e);
+        LogManager.instance().log(LSMVectorIndexPageParser.class, Level.WARNING, message);
       }
     }
 

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -25,6 +25,8 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -159,6 +161,69 @@ class JavaFunctionTest extends TestHelper {
     database.getSchema().unregisterFunctionLibrary("math");
     database.getSchema()
             .registerFunctionLibrary(new JavaMethodFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class.getMethod("sum", Integer.TYPE, Integer.TYPE)));
+  }
+
+  public static class Counter {
+    private int count = 0;
+
+    public int next() {
+      return ++count;
+    }
+  }
+
+  /**
+   * Issue #7046: {@link JavaMethodFunctionDefinition} refuses a non-static method registered without an instance
+   * rather than instantiating its declaring class behind the registration site's back.
+   */
+  @Test
+  void nonStaticMethodWithoutAnInstanceIsRejected() throws Exception {
+    final Method next = Counter.class.getMethod("next");
+
+    assertThatThrownBy(() -> new JavaMethodFunctionDefinition(next))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("not static");
+    assertThatThrownBy(() -> new JavaMethodFunctionDefinition(null, next))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("not static");
+    assertThatThrownBy(() -> new JavaMethodFunctionDefinition(null, List.of(next)))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("not static");
+    assertThatThrownBy(() -> new JavaMethodFunctionLibraryDefinition("counter", null, next))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("not static");
+  }
+
+  /** Issue #7046: the instance a registration supplies is the one the method is invoked on, and it keeps its state. */
+  @Test
+  void nonStaticMethodIsInvokedOnTheSuppliedInstance() throws Exception {
+    final Counter counter = new Counter();
+    database.getSchema().registerFunctionLibrary(
+        new JavaMethodFunctionLibraryDefinition("counter", counter, Counter.class.getMethod("next")));
+
+    assertThat(database.getSchema().getFunction("counter", "next").execute()).isEqualTo(1);
+    assertThat(database.getSchema().getFunction("counter", "next").execute()).isEqualTo(2);
+    assertThat(counter.count).isEqualTo(2);
+  }
+
+  /**
+   * Issue #7046: the instance-less library form still serves a non-static method, but the instance it invokes it on
+   * is created by the library - the registration site - and not by the function definition.
+   */
+  @Test
+  void instanceLessLibraryFormInstantiatesAtTheRegistrationSite() throws Exception {
+    final JavaMethodFunctionLibraryDefinition library = new JavaMethodFunctionLibraryDefinition("counter",
+        Counter.class.getMethod("next"));
+    assertThat(library.getFunction("next").execute()).isEqualTo(1);
+    assertThat(library.getFunction("next").execute()).isEqualTo(2);
+
+    // Each library gets an instance of its own, so two registrations of the same method never share state.
+    final JavaMethodFunctionLibraryDefinition another = new JavaMethodFunctionLibraryDefinition("counter2",
+        Counter.class.getMethod("next"));
+    assertThat(another.getFunction("next").execute()).isEqualTo(1);
+  }
+
+  /** A static method needs no instance, and one passed anyway is neither required nor an error. */
+  @Test
+  void staticMethodNeedsNoInstance() throws Exception {
+    final Method boom = Sum.class.getMethod("boom");
+    assertThat(new JavaMethodFunctionDefinition(boom).getName()).contains("boom");
+    assertThat(new JavaMethodFunctionDefinition(new Sum(), boom).getName()).contains("boom");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7045TruncatedPageCompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7045TruncatedPageCompactionTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #7045: a parse failure in the middle of a vector index page dropped every entry from the
+ * failing one to the end of that page, silently, and a compaction then rewrote the data file from that truncated
+ * set and reclaimed the source - so the vectors it lacked were gone from every later search while the index kept
+ * reporting itself healthy. The parse is now strict when it feeds a compaction: the failure propagates, the
+ * compaction is aborted before any file is created or replaced, and the lenient load/rebuild paths keep their
+ * recovery fallbacks.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7045TruncatedPageCompactionTest {
+  private static final String DB_PATH     = "./target/databases/Issue7045TruncatedPageCompactionTest";
+  private static final int    DIMENSIONS  = 8;
+  private static final int    NUM_VECTORS = 300;
+
+  @AfterEach
+  void cleanUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void compactionAbortsInsteadOfShippingATruncatedLiveSet() throws Exception {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    final Random rng = new Random(7045);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.create();
+      try {
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, 100_000);
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 0);
+
+        db.transaction(() -> {
+          final DocumentType t = db.getSchema().createDocumentType("Doc");
+          t.createProperty("id", Type.INTEGER);
+          t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+        });
+        db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
+            + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\" }");
+
+        for (int batch = 0; batch < 3; batch++) {
+          final int from = batch * NUM_VECTORS / 3;
+          db.transaction(() -> {
+            for (int i = from; i < from + NUM_VECTORS / 3; i++)
+              db.newDocument("Doc").set("id", i).set("embedding", randomVector(rng)).save();
+          });
+        }
+
+        final DatabaseInternal internal = (DatabaseInternal) db;
+        final LSMVectorIndex lsm = vectorIndex(db);
+        final int fileIdBefore = lsm.getFileId();
+        final int totalPages = lsm.getTotalPages();
+        final int pageSize = lsm.getPageSize();
+
+        assertThat(parse(internal, fileIdBefore, totalPages, pageSize, false))
+            .as("precondition: every entry is readable before the corruption").hasSize(NUM_VECTORS);
+
+        final int corruptedEntry = NUM_VECTORS / 2;
+        corruptEntry(internal, fileIdBefore, pageSize, corruptedEntry);
+
+        // The lenient parse is what the issue describes: the page is cut short at the corrupted entry and the parse
+        // reports fewer entries than the page holds, with nothing but a WARNING to tell.
+        final int lenientlyParsed = parse(internal, fileIdBefore, totalPages, pageSize, false).size();
+        assertThat(lenientlyParsed).as("the corruption must cut the page short, or this test proves nothing")
+            .isLessThan(NUM_VECTORS);
+
+        // The strict parse, the one a compaction runs, must refuse instead.
+        assertThatThrownBy(() -> parse(internal, fileIdBefore, totalPages, pageSize, true))
+            .isInstanceOf(IndexException.class)
+            .hasMessageContaining("page 0")
+            .hasMessageContaining("of the page not read");
+
+        // And the compaction itself must abort, leaving the source file - and every vector in it - in place.
+        assertThat(lsm.scheduleCompaction()).isTrue();
+        assertThatThrownBy(lsm::compact)
+            .as("a compaction fed a truncated live set must fail rather than reclaim the source file")
+            .hasStackTraceContaining("Error parsing page 0");
+
+        assertThat(lsm.getFileId()).as("the source data file must not have been replaced").isEqualTo(fileIdBefore);
+        assertThat(lsm.countEntries()).as("no vector may have been dropped by the aborted compaction")
+            .isEqualTo(NUM_VECTORS);
+        assertThat(lsm.scheduleCompaction()).as("the aborted compaction must hand its scheduling slot back")
+            .isTrue();
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static List<LSMVectorIndexPageParser.VectorEntry> parse(final DatabaseInternal db, final int fileId,
+      final int totalPages, final int pageSize, final boolean strict) {
+    final List<LSMVectorIndexPageParser.VectorEntry> entries = new ArrayList<>();
+    LSMVectorIndexPageParser.parsePages(db, fileId, totalPages, pageSize, false, strict, entries::add);
+    return entries;
+  }
+
+  /**
+   * Corrupts entry {@code entryIndex} of page 0 the way a damaged page would: its quantization type byte claims an
+   * INT8 payload as long as the whole page, so the parse of the next entry starts past the end of the page.
+   */
+  private static void corruptEntry(final DatabaseInternal db, final int fileId, final int pageSize, final int entryIndex) {
+    db.transaction(() -> {
+      final MutablePage page;
+      try {
+        page = db.getTransaction().getPageToModify(new PageId(db, fileId, 0), pageSize, false);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+      assertThat(page.readInt(LSMVectorIndex.OFFSET_NUM_ENTRIES)).as("every entry must be on page 0")
+          .isEqualTo(NUM_VECTORS);
+
+      int offset = LSMVectorIndex.HEADER_BASE_SIZE;
+      for (int i = 0; i < entryIndex; i++) {
+        offset = skipIdsAndDeletedFlag(page, offset);
+        offset = LSMVectorIndexPageParser.skipQuantizationData(page, offset);
+      }
+      offset = skipIdsAndDeletedFlag(page, offset);
+      page.writeByte(offset, (byte) VectorQuantizationType.INT8.ordinal());
+      page.writeInt(offset + 1, pageSize);
+    });
+  }
+
+  private static int skipIdsAndDeletedFlag(final MutablePage page, int offset) {
+    offset += (int) page.readNumberAndSize(offset)[1]; // vector id
+    offset += (int) page.readNumberAndSize(offset)[1]; // bucket id
+    offset += (int) page.readNumberAndSize(offset)[1]; // position
+    return offset + 1; // deleted flag
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+    return (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+  }
+
+  private static float[] randomVector(final Random rng) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (float) rng.nextGaussian();
+    return v;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7058SearchInsideTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7058SearchInsideTransactionTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for issue #7058: a similarity search issued inside an explicit transaction, after writes to the
+ * index, rebuilds the graph synchronously on the calling thread, and the persist step of that rebuild used to commit
+ * whatever transaction the thread held - the caller's - and to switch it to WAL-less first. Over Bolt that surfaced
+ * as the client's own COMMIT failing with {@code Neo.ClientError.Transaction.TransactionNotFound: Transaction not
+ * begun}. The persist now runs in a transaction of its own, nested when the caller holds one, and leaves the
+ * caller's untouched.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7058SearchInsideTransactionTest {
+  private static final String DB_PATH     = "./target/databases/Issue7058SearchInsideTransactionTest";
+  private static final int    DIMENSIONS  = 16;
+  private static final int    NUM_VECTORS = 50;
+
+  @AfterEach
+  void cleanUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void searchInsideAnExplicitTransactionLeavesTheTransactionOpenAndUntouched() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    final Random rng = new Random(7058);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.create();
+      try {
+        // Keep the background rebuild machinery out of the picture: the rebuild under test is the synchronous one
+        // the first search after a batch of writes performs on the calling thread.
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, 100_000);
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 0);
+
+        db.transaction(() -> {
+          final DocumentType t = db.getSchema().createDocumentType("Doc");
+          t.createProperty("id", Type.INTEGER);
+          t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+        });
+        db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
+            + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\" }");
+
+        db.transaction(() -> {
+          for (int i = 0; i < NUM_VECTORS; i++)
+            db.newDocument("Doc").set("id", i).set("embedding", randomVector(rng)).save();
+        });
+
+        final LSMVectorIndex lsm = vectorIndex(db);
+        assertThat(lsm.getStats().get("graphNodeCount")).as("precondition: no graph built yet, so the search below rebuilds it")
+            .isEqualTo(0L);
+
+        db.begin();
+        // Uncommitted work in the caller's transaction, the same shape as the reporter's MERGE before the search.
+        db.newDocument("Doc").set("id", NUM_VECTORS).set("embedding", randomVector(rng)).save();
+        final boolean useWAL = ((DatabaseInternal) db).getTransaction().isUseWAL();
+
+        assertThat(lsm.findNeighborsFromVector(randomVector(new Random(3)), 5, 64)).isNotEmpty();
+
+        assertThat(db.isTransactionActive())
+            .as("the graph rebuild the search triggered must not commit the caller's transaction")
+            .isTrue();
+        assertThat(((DatabaseInternal) db).getTransaction().isUseWAL())
+            .as("the graph rebuild must not switch the caller's transaction to WAL-less either")
+            .isEqualTo(useWAL);
+        assertThatCode(db::commit).as("the caller's COMMIT must still find its transaction").doesNotThrowAnyException();
+
+        assertThat(db.countType("Doc", true)).isEqualTo(NUM_VECTORS + 1);
+        assertThat(lsm.getStats().get("graphNodeCount"))
+            .as("the graph must have been built and persisted all the same, in a transaction of its own")
+            .isEqualTo((long) NUM_VECTORS);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+    return (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+  }
+
+  private static float[] randomVector(final Random rng) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (float) rng.nextGaussian();
+    return v;
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -33,6 +33,7 @@ import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.server.security.credential.CredentialsValidator;
 import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 
 import java.util.ArrayList;
@@ -60,24 +61,18 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   // ------------------------------------------------------------------------------------
 
   @Override
-  public void ping(PingRequest req, StreamObserver<PingResponse> resp) {
-    try {
+  public void ping(final PingRequest req, final StreamObserver<PingResponse> resp) {
+    respond(resp, "ping", () -> {
       // If you want ping to be open, comment out the next line
       authenticate(req.getCredentials());
 
-      PingResponse out = PingResponse.newBuilder().setOk(true).setServerTimeMs(System.currentTimeMillis()).build();
-      resp.onNext(out);
-      resp.onCompleted();
-    } catch (SecurityException se) {
-      resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
-    } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("ping: " + e.getMessage()).asException());
-    }
+      return PingResponse.newBuilder().setOk(true).setServerTimeMs(System.currentTimeMillis()).build();
+    });
   }
 
   @Override
-  public void getServerInfo(GetServerInfoRequest req, StreamObserver<GetServerInfoResponse> resp) {
-    try {
+  public void getServerInfo(final GetServerInfoRequest req, final StreamObserver<GetServerInfoResponse> resp) {
+    respond(resp, "getServerInfo", () -> {
       authenticate(req.getCredentials());
 
       final String version = getServerVersion();
@@ -89,76 +84,48 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       final int binaryPort = getBinaryPort();
 
       final List<String> dbNames = new ArrayList<>(getDatabaseNames());
-      int dbCount = dbNames.size();
+      final int dbCount = dbNames.size();
 
-      GetServerInfoResponse out = GetServerInfoResponse.newBuilder().setVersion(version)
+      return GetServerInfoResponse.newBuilder().setVersion(version)
           .setEdition("CE") // adjust if you expose edition
           .setStartTimeMs(startMs).setUptimeMs(uptime).setHttpPort(httpPort).setGrpcPort(grpcPort).setBinaryPort(binaryPort)
           .setDatabasesCount(dbCount).build();
-
-      resp.onNext(out);
-      resp.onCompleted();
-    } catch (SecurityException se) {
-      resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
-    } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("getServerInfo: " + e.getMessage()).asException());
-    }
+    });
   }
 
   @Override
-  public void listDatabases(ListDatabasesRequest req, StreamObserver<ListDatabasesResponse> resp) {
-
-    try {
-
+  public void listDatabases(final ListDatabasesRequest req, final StreamObserver<ListDatabasesResponse> resp) {
+    respond(resp, "listDatabases", () -> {
       authenticate(req.getCredentials());
 
-      ArrayList<String> names = new ArrayList<>(getDatabaseNames());
+      final ArrayList<String> names = new ArrayList<>(getDatabaseNames());
       names.sort(String.CASE_INSENSITIVE_ORDER);
 
-      resp.onNext(ListDatabasesResponse.newBuilder().addAllDatabases(names).build());
-      resp.onCompleted();
-    } catch (SecurityException se) {
-      resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
-    } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("listDatabases: " + e.getMessage()).asException());
-    }
+      return ListDatabasesResponse.newBuilder().addAllDatabases(names).build();
+    });
   }
 
   @Override
-  public void existsDatabase(ExistsDatabaseRequest req, StreamObserver<ExistsDatabaseResponse> resp) {
-
-    try {
-
+  public void existsDatabase(final ExistsDatabaseRequest req, final StreamObserver<ExistsDatabaseResponse> resp) {
+    respond(resp, "existsDatabase", () -> {
       authenticate(req.getCredentials());
 
       final String name = req.getName(); // proto should define 'name' for the DB
 
-      boolean exists = containsDatabaseIgnoreCase(name);
-
-      resp.onNext(ExistsDatabaseResponse.newBuilder().setExists(exists).build());
-      resp.onCompleted();
-    } catch (SecurityException se) {
-      resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
-    } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("existsDatabase: " + e.getMessage()).asException());
-    }
+      return ExistsDatabaseResponse.newBuilder().setExists(containsDatabaseIgnoreCase(name)).build();
+    });
   }
 
   @Override
-  public void createDatabase(CreateDatabaseRequest req, StreamObserver<CreateDatabaseResponse> resp) {
-
-    try {
+  public void createDatabase(final CreateDatabaseRequest req, final StreamObserver<CreateDatabaseResponse> resp) {
+    respond(resp, "createDatabase", () -> {
       requireServerAdmin(authenticate(req.getCredentials()));
 
       final String name = req.getName(); // DB name in proto
       final String type = req.getType(); // "graph" or "document" (logical)
 
-      if (containsDatabaseIgnoreCase(name)) {
-
-        resp.onNext(CreateDatabaseResponse.newBuilder().build());
-        resp.onCompleted();
-        return;
-      }
+      if (containsDatabaseIgnoreCase(name))
+        return CreateDatabaseResponse.newBuilder().build();
 
       // Physical creation (READ_WRITE is the common default)
       createDatabasePhysical(name);
@@ -175,65 +142,38 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
             s.createEdgeType("E");
         });
       }
-      resp.onNext(CreateDatabaseResponse.newBuilder().build());
-      resp.onCompleted();
-    } catch (AdminAuthorizationException ae) {
-      resp.onError(Status.PERMISSION_DENIED.withDescription(ae.getMessage()).asException());
-    } catch (SecurityException se) {
-      resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
-    } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("createDatabase: " + e.getMessage()).asException());
-    }
+      return CreateDatabaseResponse.newBuilder().build();
+    });
   }
 
   @Override
-  public void dropDatabase(DropDatabaseRequest req, StreamObserver<DropDatabaseResponse> resp) {
-
-    try {
-
+  public void dropDatabase(final DropDatabaseRequest req, final StreamObserver<DropDatabaseResponse> resp) {
+    respond(resp, "dropDatabase", () -> {
       requireServerAdmin(authenticate(req.getCredentials()));
 
       final String name = req.getName();
 
-      if (!containsDatabaseIgnoreCase(name)) {
-        resp.onNext(DropDatabaseResponse.newBuilder().build());
-        resp.onCompleted();
-        return;
-      }
+      if (containsDatabaseIgnoreCase(name))
+        dropDatabasePhysical(name);
 
-      dropDatabasePhysical(name);
-
-      resp.onNext(DropDatabaseResponse.newBuilder().build());
-      resp.onCompleted();
-    } catch (AdminAuthorizationException ae) {
-      resp.onError(Status.PERMISSION_DENIED.withDescription(ae.getMessage()).asException());
-    } catch (SecurityException se) {
-      resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
-    } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("dropDatabase: " + e.getMessage()).asException());
-    }
+      return DropDatabaseResponse.newBuilder().build();
+    });
   }
 
   @Override
-  public void getDatabaseInfo(GetDatabaseInfoRequest req, StreamObserver<GetDatabaseInfoResponse> resp) {
-
-    try {
-
+  public void getDatabaseInfo(final GetDatabaseInfoRequest req, final StreamObserver<GetDatabaseInfoResponse> resp) {
+    respond(resp, "getDatabaseInfo", () -> {
       authenticate(req.getCredentials());
 
       final String name = req.getName();
 
-      if (!containsDatabaseIgnoreCase(name)) {
-        resp.onError(Status.NOT_FOUND.withDescription("Database not found: " + name).asException());
-        return;
-      }
+      if (!containsDatabaseIgnoreCase(name))
+        throw Status.NOT_FOUND.withDescription("Database not found: " + name).asException();
 
       // Use getDatabase which returns a shared ServerDatabase - don't close it
       final Database db = openDatabase(name);
-      if (db == null) {
-        resp.onError(Status.NOT_FOUND.withDescription("Database not found: " + name).asException());
-        return;
-      }
+      if (db == null)
+        throw Status.NOT_FOUND.withDescription("Database not found: " + name).asException();
 
       final Schema schema = db.getSchema();
 
@@ -253,7 +193,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       }
 
       // Approximate record count (fast-ish; adjust to your needs)
-      long records = approximateRecordCount(db);
+      final long records = approximateRecordCount(db);
 
       // Infer db kind: "graph" if any vertex type exists
       String type = "document";
@@ -266,18 +206,11 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
         // Keep default "document" type if schema inspection fails
       }
 
-      GetDatabaseInfoResponse out = GetDatabaseInfoResponse.newBuilder()
+      return GetDatabaseInfoResponse.newBuilder()
           .setDatabase(name)
           .setClasses(classes).setIndexes(indexes).setRecords(records).setType(type)
           .build();
-
-      resp.onNext(out);
-      resp.onCompleted();
-    } catch (SecurityException se) {
-      resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
-    } catch (Exception e) {
-      resp.onError(Status.INTERNAL.withDescription("getDatabaseInfo: " + e.getMessage()).asException());
-    }
+    });
   }
 
   @Override
@@ -301,6 +234,30 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   // ------------------------------------------------------------------------------------
   // Helpers
   // ------------------------------------------------------------------------------------
+
+  /**
+   * Every unary handler of this service goes through here so the call is terminated exactly once (issue #7035):
+   * the same {@code responded} guard {@link ArcadeDbGrpcService} carries inline, applied by {@link GrpcUnaryCall}.
+   * {@code operation} prefixes the description of an unexpected failure, as the inline catch blocks used to.
+   */
+  private static <T> void respond(final StreamObserver<T> resp, final String operation, final GrpcUnaryCall.Body<T> body) {
+    GrpcUnaryCall.respond(resp, body, e -> toStatus(operation, e));
+  }
+
+  /**
+   * Maps a handler failure to the status the client receives. A {@link StatusException} raised by the body (the
+   * NOT_FOUND of {@code getDatabaseInfo}) is sent as it is; the authorization exception is checked before the
+   * authentication one because it is the more specific outcome, not because of any inheritance between the two.
+   */
+  private static StatusException toStatus(final String operation, final Exception e) {
+    if (e instanceof StatusException se)
+      return se;
+    if (e instanceof AdminAuthorizationException)
+      return Status.PERMISSION_DENIED.withDescription(e.getMessage()).asException();
+    if (e instanceof SecurityException)
+      return Status.UNAUTHENTICATED.withDescription(e.getMessage()).asException();
+    return Status.INTERNAL.withDescription(operation + ": " + e.getMessage()).asException();
+  }
 
   // Defense-in-depth: GrpcAuthInterceptor already authenticates these body credentials centrally
   // before the call reaches this handler. This handler-side check is intentionally kept (do not

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -134,7 +134,7 @@ public class GrpcServerPlugin implements ServerPlugin {
 
       registerShutdownHook();
 
-    } catch (IOException e) {
+    } catch (final IOException | RuntimeException e) {
       LogManager.instance().log(this, Level.SEVERE, "Failed to start gRPC server", e);
       // Issue #6756 (1): ArcadeDBServer.start() deliberately does not call stopService() on a plugin
       // whose startService() threw, so a partially-started server (the service/reaper created by
@@ -142,7 +142,13 @@ public class GrpcServerPlugin implements ServerPlugin {
       // standard server left behind when the xDS server fails afterward) would otherwise leak with no
       // teardown path. stopService() is idempotent (guarded by the "stopped" CAS), so this is safe even
       // when nothing was actually started yet.
+      //
+      // RuntimeException too, not only IOException (issue #7035): a runtime failure out of build() or start(),
+      // or inside startXdsServer() in "both" mode, left the same partially-started server behind with the same
+      // missing teardown. A RuntimeException keeps its own type on the way out; only the checked one is wrapped.
       stopService();
+      if (e instanceof RuntimeException re)
+        throw re;
       throw new RuntimeException("Failed to start gRPC server", e);
     }
   }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -134,23 +134,28 @@ public class GrpcServerPlugin implements ServerPlugin {
 
       registerShutdownHook();
 
-    } catch (final IOException | RuntimeException e) {
-      LogManager.instance().log(this, Level.SEVERE, "Failed to start gRPC server", e);
-      // Issue #6756 (1): ArcadeDBServer.start() deliberately does not call stopService() on a plugin
-      // whose startService() threw, so a partially-started server (the service/reaper created by
-      // configureServer() before the failing build().start(), or - in "both" mode - a fully running
-      // standard server left behind when the xDS server fails afterward) would otherwise leak with no
-      // teardown path. stopService() is idempotent (guarded by the "stopped" CAS), so this is safe even
-      // when nothing was actually started yet.
-      //
-      // RuntimeException too, not only IOException (issue #7035): a runtime failure out of build() or start(),
-      // or inside startXdsServer() in "both" mode, left the same partially-started server behind with the same
-      // missing teardown. A RuntimeException keeps its own type on the way out; only the checked one is wrapped.
-      stopService();
-      if (e instanceof RuntimeException re)
-        throw re;
+    } catch (final IOException e) {
+      stopAfterFailedStart(e);
       throw new RuntimeException("Failed to start gRPC server", e);
+    } catch (final RuntimeException e) {
+      // A runtime failure out of build() or start(), or inside startXdsServer() in "both" mode, left the same
+      // partially-started server behind as the IOException did, with the same missing teardown (issue #7035). It
+      // keeps its own type on the way out; only the checked exception is wrapped.
+      stopAfterFailedStart(e);
+      throw e;
     }
+  }
+
+  /**
+   * Issue #6756 (1): ArcadeDBServer.start() deliberately does not call stopService() on a plugin whose
+   * startService() threw, so a partially-started server (the service/reaper created by configureServer() before the
+   * failing build().start(), or - in "both" mode - a fully running standard server left behind when the xDS server
+   * fails afterward) would otherwise leak with no teardown path. stopService() is idempotent (guarded by the
+   * "stopped" CAS), so this is safe even when nothing was actually started yet.
+   */
+  private void stopAfterFailedStart(final Exception e) {
+    LogManager.instance().log(this, Level.SEVERE, "Failed to start gRPC server", e);
+    stopService();
   }
 
   private void startStandardServer(ContextConfiguration config) throws IOException {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcUnaryCall.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcUnaryCall.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.log.LogManager;
+import io.grpc.StatusException;
+import io.grpc.stub.StreamObserver;
+
+import java.util.function.Function;
+import java.util.logging.Level;
+
+/**
+ * Terminates a unary gRPC call exactly once. The handler body computes the response; this helper hands it to the
+ * observer and closes the call, and it maps a failure to {@code onError} only while the call has not been answered
+ * yet.
+ * <p>
+ * The guard is the point (issues #6192 and #6756): a client cancel landing between {@code onNext} and
+ * {@code onCompleted} makes {@code onCompleted()} throw, and a handler that catches that and calls {@code onError}
+ * on the already-closed call lets an {@code IllegalStateException} ("call already closed") escape instead of the
+ * cancel being absorbed. The flag is set before {@code onCompleted()}, not after: once {@code onNext} has delivered
+ * the response the call must never fall through to {@code onError}, whatever {@code onCompleted()} itself does.
+ * <p>
+ * {@link ArcadeDbGrpcService} carries the same guard inline in every handler, because its error mapping is
+ * per-handler and threaded through the transaction registry; this helper is for the handlers whose shape is
+ * "authenticate, compute, answer", so the next one added cannot be added without the guard.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class GrpcUnaryCall {
+  /** The body of a unary handler: computes the response, or throws. */
+  interface Body<T> {
+    T call() throws Exception;
+  }
+
+  private GrpcUnaryCall() {
+  }
+
+  /**
+   * Runs {@code body} and delivers its result to {@code resp}. A failure raised by the body is mapped through
+   * {@code errorMapper} and sent with {@code onError}; a failure raised by the observer once the response has been
+   * delivered is logged and swallowed, since the call is already terminated from the caller's point of view.
+   *
+   * @param resp        the observer of the unary call
+   * @param body        the handler body
+   * @param errorMapper maps a failure of the body to the status the client receives
+   */
+  static <T> void respond(final StreamObserver<T> resp, final Body<T> body,
+      final Function<Exception, StatusException> errorMapper) {
+    boolean responded = false;
+    try {
+      final T out = body.call();
+      resp.onNext(out);
+      responded = true;
+      resp.onCompleted();
+    } catch (final Exception e) {
+      if (responded)
+        LogManager.instance().log(GrpcUnaryCall.class, Level.FINE,
+            "Unary call already answered when its completion failed (client cancelled?): %s", e.getMessage());
+      else
+        resp.onError(errorMapper.apply(e));
+    }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7035AdminServiceDoubleTerminateGuardTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7035AdminServiceDoubleTerminateGuardTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.credential.DefaultCredentialsValidator;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Regression test for issue #7035: the {@code responded} guard issue #6756 added to every unary handler of
+ * {@link ArcadeDbGrpcService} was never applied to its sibling {@link ArcadeDbGrpcAdminService}, registered on the
+ * same server by the same plugin, whose seven handlers kept the pre-fix shape. A client cancel landing between
+ * {@code onNext} and {@code onCompleted} makes {@code onCompleted()} throw, and the catch block then called
+ * {@code onError} on an already-closed call.
+ * <p>
+ * Same technique as {@code Issue6756DoubleTerminateGuardTest}: each handler is called directly against a real
+ * service bound to the test server, with a mocked observer whose {@code onCompleted()} throws, and {@code onError}
+ * must never be invoked afterward.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7035AdminServiceDoubleTerminateGuardTest extends BaseGraphServerTest {
+  private static final String CREATED_DATABASE = "Issue7035Created";
+  private static final String DROPPED_DATABASE = "Issue7035Dropped";
+
+  private ArcadeDbGrpcAdminService service;
+
+  @BeforeEach
+  void setupService() {
+    service = new ArcadeDbGrpcAdminService(getServer(0), new DefaultCredentialsValidator());
+  }
+
+  @AfterEach
+  void dropCreatedDatabases() {
+    for (final String name : new String[] { CREATED_DATABASE, DROPPED_DATABASE })
+      if (getServer(0).existsDatabase(name)) {
+        getServer(0).getDatabase(name).getEmbedded().drop();
+        getServer(0).removeDatabase(name);
+      }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private static <T> StreamObserver<T> observerWhoseCompletionThrows() {
+    @SuppressWarnings("unchecked")
+    final StreamObserver<T> resp = mock(StreamObserver.class);
+    doThrow(new RuntimeException("call already closed")).when(resp).onCompleted();
+    return resp;
+  }
+
+  /**
+   * Proves onCompleted() was actually reached (not skipped by an early return) - the configured throw alone does
+   * not distinguish "invoked and threw" from "never invoked" - and that the throw was absorbed.
+   */
+  private static <T> void assertTerminatedOnce(final StreamObserver<T> resp) {
+    verify(resp).onNext(any());
+    verify(resp).onCompleted();
+    verify(resp, never()).onError(any());
+  }
+
+  @Test
+  void pingDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final StreamObserver<PingResponse> resp = observerWhoseCompletionThrows();
+    service.ping(PingRequest.newBuilder().setCredentials(credentials()).build(), resp);
+    assertTerminatedOnce(resp);
+  }
+
+  @Test
+  void getServerInfoDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final StreamObserver<GetServerInfoResponse> resp = observerWhoseCompletionThrows();
+    service.getServerInfo(GetServerInfoRequest.newBuilder().setCredentials(credentials()).build(), resp);
+    assertTerminatedOnce(resp);
+  }
+
+  @Test
+  void listDatabasesDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final StreamObserver<ListDatabasesResponse> resp = observerWhoseCompletionThrows();
+    service.listDatabases(ListDatabasesRequest.newBuilder().setCredentials(credentials()).build(), resp);
+    assertTerminatedOnce(resp);
+  }
+
+  @Test
+  void existsDatabaseDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final StreamObserver<ExistsDatabaseResponse> resp = observerWhoseCompletionThrows();
+    service.existsDatabase(
+        ExistsDatabaseRequest.newBuilder().setCredentials(credentials()).setName(getDatabaseName()).build(), resp);
+    assertTerminatedOnce(resp);
+  }
+
+  @Test
+  void createDatabaseDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final StreamObserver<CreateDatabaseResponse> resp = observerWhoseCompletionThrows();
+    service.createDatabase(
+        CreateDatabaseRequest.newBuilder().setCredentials(credentials()).setName(CREATED_DATABASE).setType("graph").build(),
+        resp);
+    assertTerminatedOnce(resp);
+  }
+
+  @Test
+  void dropDatabaseDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    getServer(0).createDatabase(DROPPED_DATABASE, ComponentFile.MODE.READ_WRITE);
+
+    final StreamObserver<DropDatabaseResponse> resp = observerWhoseCompletionThrows();
+    service.dropDatabase(
+        DropDatabaseRequest.newBuilder().setCredentials(credentials()).setName(DROPPED_DATABASE).build(), resp);
+    assertTerminatedOnce(resp);
+  }
+
+  @Test
+  void getDatabaseInfoDoesNotDoubleTerminateWhenOnCompletedThrows() {
+    final StreamObserver<GetDatabaseInfoResponse> resp = observerWhoseCompletionThrows();
+    service.getDatabaseInfo(
+        GetDatabaseInfoRequest.newBuilder().setCredentials(credentials()).setName(getDatabaseName()).build(), resp);
+    assertTerminatedOnce(resp);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7035StartServiceRuntimeFailureCleanupTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7035StartServiceRuntimeFailureCleanupTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for the second residue of issue #7035: {@code GrpcServerPlugin.startService()}'s cleanup added by
+ * issue #6756 caught {@code IOException} only, so a runtime failure out of the server build - after
+ * {@code configureServer()} had already created the service and started its idle-transaction reaper - still
+ * escaped without {@code stopService()}, leaking both. The catch now covers runtime failures too, and rethrows them
+ * with their own type.
+ * <p>
+ * The failure is injected at {@code getMaxMetadataSizeBytes()}, which {@code startStandardServer()} asks right after
+ * {@code configureServer()} and right before {@code build().start()}: the same point in the sequence a runtime
+ * failure of the builder would land on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7035StartServiceRuntimeFailureCleanupTest {
+
+  @TempDir
+  Path tempDir;
+
+  private GrpcServerPlugin plugin;
+
+  @AfterEach
+  void cleanup() {
+    if (plugin != null)
+      plugin.stopService();
+  }
+
+  @Test
+  void runtimeFailureWhileBuildingTheServerStopsTheLeakedServiceAndReaper() throws IOException {
+    final int freePort;
+    try (final ServerSocket probe = new ServerSocket(0)) {
+      freePort = probe.getLocalPort();
+    }
+
+    plugin = new GrpcServerPlugin() {
+      @Override
+      int getMaxMetadataSizeBytes(final ContextConfiguration config) {
+        throw new IllegalStateException("simulated runtime failure while building the gRPC server");
+      }
+    };
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.GRPC_PORT.getKey(), String.valueOf(freePort));
+    when(mockServer.getRootPath()).thenReturn(tempDir.toString());
+    when(mockServer.getConfiguration()).thenReturn(config);
+    plugin.configure(mockServer, config);
+
+    assertThatThrownBy(plugin::startService)
+        .as("a runtime failure keeps its own type on the way out")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("simulated runtime failure");
+
+    final ArcadeDbGrpcService service = plugin.getService();
+    assertThat(service).as("the service must have been constructed before the failure, or this proves nothing").isNotNull();
+    assertThat(service.isIdleReaperShutdown())
+        .as("the idle-transaction reaper thread must not leak past a failed startService()").isTrue();
+  }
+}


### PR DESCRIPTION
Fixes #7058, fixes #7046, fixes #7045, fixes #7035.

## #7058 - `Transaction not begun` on Bolt with an `LSM_VECTOR` index

Reproduced with a similarity search issued inside an explicit Bolt transaction after a batch of writes: the first search after writes rebuilds the graph synchronously on the calling thread, and the persist step of that rebuild (`LSMVectorIndex`, graph persistence after `buildGraphFromScratch`) committed **whatever transaction the thread held** - the session's - after switching it to WAL-less. The client's own `COMMIT` then found no transaction and failed with `Neo.ClientError.Transaction.TransactionNotFound: Transaction not begun`. The pure write workload of the report does not reproduce on its own (five Bolt variants are in the new IT: autocommit, managed transactions, one big transaction, multi-label `SET n:<labels>`, and the search-in-transaction one that fails on `main`).

Fix: the graph persist always runs in a transaction of its own, nested when the caller already holds one. The graph is derived state computed from committed pages, so it commits on its own terms; the caller's transaction is left exactly as found (not committed, WAL setting untouched). The rollback on failure is bound to the persist transaction by identity, so a nested commit that failed - already popped - can never turn into a rollback of the caller's.

## #7045 - truncated page parse shipped as the compaction's live set

`LSMVectorIndexPageParser.parsePages` gained a `strict` mode: a page that cannot be parsed to the end fails the parse with an `IndexException` naming the page, the failing entry and the entries lost, instead of being cut short with a WARNING. `buildGraphFromScratch` passes `strict = compactDataFile`, so a compaction aborts before any file is created or replaced (the scheduling slot is handed back), while the load and rebuild paths keep the lenient parse and their recovery fallbacks. The lenient message now also says how many entries of the page were not read.

## #7046 - `JavaMethodFunctionDefinition` auto-instantiated the declaring class

`JavaMethodFunctionDefinition` never instantiates anything any more: a non-static method registered without an instance is refused with `IllegalArgumentException` (all three constructors). The convenience moves to the registration site, as the issue suggested: `JavaMethodFunctionLibraryDefinition`'s instance-less constructors create the instance explicitly - the same choice `JavaClassFunctionLibraryDefinition` already makes for a whole class - so the documented usage keeps working, and a new `JavaMethodFunctionLibraryDefinition(String, Object, Method)` overload invokes the method on an instance of the caller's choosing. Docs updated in the arcadedb-docs repo (committed locally, not pushed).

## #7035 - `responded` guard missing from `ArcadeDbGrpcAdminService`

All seven admin handlers now go through `GrpcUnaryCall.respond(...)`, a small helper that terminates a unary call exactly once (flag set before `onCompleted()`, `onError` only while unanswered), with the admin service's own status mapping (`StatusException` pass-through, `PERMISSION_DENIED`, `UNAUTHENTICATED`, `INTERNAL` with the operation prefix). The second residue is covered too: `GrpcServerPlugin.startService()` now calls `stopService()` on a `RuntimeException` as well as on `IOException`, rethrowing the runtime failure with its own type.

## Tests

- `Issue7058BoltVectorSustainedWritesIT` (bolt) and `Issue7058SearchInsideTransactionTest` (engine)
- `Issue7045TruncatedPageCompactionTest` (engine): corrupts one entry mid-page, checks the lenient parse is cut short, the strict one refuses, and `compact()` aborts leaving the source file and every vector in place
- `JavaFunctionTest`: refusal of the instance-less forms, invocation on the supplied instance, instantiation at the library registration site
- `Issue7035AdminServiceDoubleTerminateGuardTest` and `Issue7035StartServiceRuntimeFailureCleanupTest` (grpcw)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector index compaction safety when pages are truncated or corrupted, preventing data replacement or vector loss.
  * Preserved active transactions and transaction settings during vector searches and graph persistence.
  * Improved gRPC error reporting, startup cleanup, and response handling to prevent duplicate termination errors.
  * Improved validation and instance handling for Java functions, including static and non-static methods.

* **Tests**
  * Added regression coverage for vector indexes, Java functions, and gRPC service reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->