### PR TITLE
Fix full-text field qualifiers, MATCH NOT rendering, STRING UTF-8 order, importer delimiter override and super type unlink (#7000, #6999, #6997, #6946, #6935)

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -509,7 +509,10 @@ public class FullTextQueryExecutor {
    */
   private float boostFor(final String field) {
     if (!isUnqualified(field) && metadata != null)
-      return metadata.getFieldBoost(field);
+      // A per-field boost is declared under the property name the index carries ({@code keywords by item_boost}), the
+      // same spelling the direct get() path looks up: the qualifier has to be resolved here too or a BY ITEM property's
+      // boost is silently dropped by SEARCH_INDEX while CONTAINSTEXT applies it (issue #7000 review follow-up)
+      return metadata.getFieldBoost(storedField(field));
     return 1.0f;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -49,7 +49,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -543,9 +542,8 @@ public class FullTextQueryExecutor {
     final String field = query.getTerm().field();
     final String text = query.getTerm().text();
 
-    // For field-specific queries (e.g., "title:java"), prepend field name
-    // Multi-property indexes store tokens as "fieldName:token"
-    final String searchKey = isUnqualified(field) ? text : field + ":" + text;
+    // For field-specific queries (e.g., "title:java"), prepend the stored field name (see buildSearchKey)
+    final String searchKey = buildSearchKey(field, text);
 
     recordScoringToken(searchKey, boostFor(field));
     if (tokensOnly)
@@ -569,25 +567,28 @@ public class FullTextQueryExecutor {
   private void collectPhraseMatches(final PhraseQuery query, final Map<RID, AtomicInteger> scoreMap) {
     // For phrase queries, all terms must match in the same document
     // Note: We can't verify word order without position indexing, so we just require all terms.
-    // Phrase terms are matched/scored against the unprefixed token, so the configured per-field boost is NOT applied to phrase
-    // terms (an enclosing caret boost still applies via currentBoost). They are recorded with boost 1.0 accordingly.
+    // Every phrase term is looked up under the SAME key a single-term query would use (buildSearchKey), so a phrase
+    // qualified to a field stays within that field and takes that field's boost; looking the terms up by their bare
+    // text matched the phrase across every indexed property while the single-term form of the same query was correctly
+    // restricted (issue #7000).
     final Term[] terms = query.getTerms();
     if (terms.length == 0)
       return;
 
     if (tokensOnly) {
       for (final Term term : terms)
-        recordScoringToken(term.text(), 1.0f);
+        recordScoringToken(buildSearchKey(term.field(), term.text()), boostFor(term.field()));
       return;
     }
 
     Map<RID, AtomicInteger> intersection = null;
 
     for (final Term term : terms) {
-      recordScoringToken(term.text(), 1.0f);
+      final String searchKey = buildSearchKey(term.field(), term.text());
+      recordScoringToken(searchKey, boostFor(term.field()));
       final Map<RID, AtomicInteger> termMatches = new HashMap<>();
       long df = 0L;
-      try (final IndexCursor cursor = index.getPostings(term.text())) {
+      try (final IndexCursor cursor = index.getPostings(searchKey)) {
         while (cursor.hasNext()) {
           final RID rid = cursor.next().getIdentity();
           // Deletion markers carry a negative bucket id and must not inflate the document frequency.
@@ -596,7 +597,7 @@ public class FullTextQueryExecutor {
           termMatches.put(rid, new AtomicInteger(1));
         }
       }
-      recordDocumentFrequency(term.text(), df);
+      recordDocumentFrequency(searchKey, df);
 
       if (intersection == null) {
         intersection = termMatches;
@@ -614,7 +615,7 @@ public class FullTextQueryExecutor {
 
   private void collectPrefixMatches(final PrefixQuery query, final Map<RID, AtomicInteger> scoreMap) {
     final String field = query.getPrefix().field();
-    final String prefix = normalizeText(query.getPrefix().text());
+    final String prefix = normalizeText(field, query.getPrefix().text());
     if (prefix.isEmpty())
       return;
 
@@ -624,14 +625,14 @@ public class FullTextQueryExecutor {
 
   private void collectWildcardMatches(final WildcardQuery query, final Map<RID, AtomicInteger> scoreMap) {
     final String field = query.getTerm().field();
-    final String pattern = normalizeText(query.getTerm().text());
+    final String pattern = normalizeText(field, query.getTerm().text());
     if (pattern.isEmpty())
       return;
 
     // Compute the literal prefix (everything up to the first wildcard char)
     final String literalPrefix = extractLiteralPrefix(pattern);
     final String searchPrefix = buildSearchKey(field, literalPrefix);
-    final String fieldPrefix = !isUnqualified(field) ? field + ":" : "";
+    final String fieldPrefix = fieldPrefix(field);
     final Pattern regex = wildcardToRegex(pattern);
     // A sequence of several *'s (translated to .* by wildcardToRegex, same shape as %  in SQL LIKE) reproduces
     // catastrophic backtracking without needing grouping/alternation/nested quantifiers - issue #5886 follow-up.
@@ -664,14 +665,14 @@ public class FullTextQueryExecutor {
 
   private void collectFuzzyMatches(final FuzzyQuery query, final Map<RID, AtomicInteger> scoreMap) {
     final String field = query.getTerm().field();
-    final String term = normalizeText(query.getTerm().text());
+    final String term = normalizeText(field, query.getTerm().text());
     if (term.isEmpty())
       return;
 
     final int maxEdits = query.getMaxEdits();
     final int prefixLen = Math.min(query.getPrefixLength(), term.length());
     final String requiredPrefix = term.substring(0, prefixLen);
-    final String fieldPrefix = !isUnqualified(field) ? field + ":" : "";
+    final String fieldPrefix = fieldPrefix(field);
     final String searchPrefix = fieldPrefix + requiredPrefix;
 
     iterateAndMatch(searchPrefix.isEmpty() ? null : searchPrefix, key -> {
@@ -686,7 +687,7 @@ public class FullTextQueryExecutor {
 
   private void collectRegexpMatches(final RegexpQuery query, final Map<RID, AtomicInteger> scoreMap) {
     final String field = query.getRegexp().field();
-    final String regexText = normalizeText(query.getRegexp().text());
+    final String regexText = normalizeText(field, query.getRegexp().text());
     if (regexText.isEmpty())
       return;
 
@@ -697,7 +698,7 @@ public class FullTextQueryExecutor {
       return;
     }
 
-    final String fieldPrefix = !isUnqualified(field) ? field + ":" : "";
+    final String fieldPrefix = fieldPrefix(field);
     // A user-supplied regexp query (/pattern/ syntax) is matched against every token in what is, absent a literal
     // prefix, a full index scan (issue #5886) - one shared deadline for the whole scan, not a fresh one per token,
     // otherwise a crafted index could still tie the thread up for token count * regexTimeout.
@@ -757,19 +758,61 @@ public class FullTextQueryExecutor {
 
   /**
    * Builds the index search key by prefixing the field name when needed. Multi-property indexes store entries as
-   * {@code fieldName:token}; unqualified terms (see {@link #isUnqualified(String)}) target the unprefixed tokens.
+   * {@code fieldName:token}; unqualified terms (see {@link #isUnqualified(String)}) target the unprefixed tokens. The
+   * prefix is the field name in the spelling the postings use (see {@link #fieldPrefix(String)}), which is the ONLY way
+   * a key may be built on the query side: every collector goes through here or through {@code fieldPrefix}, so the
+   * read path cannot derive a key the write path never stored (issue #7000).
    */
   private String buildSearchKey(final String field, final String text) {
-    return isUnqualified(field) ? text : field + ":" + text;
+    return fieldPrefix(field) + text;
   }
 
   /**
-   * Normalizes a wildcard / fuzzy / regex term to lowercase to match how the analyzer stored the tokens.
-   * The Lucene QueryParser does not pass these terms through the analyzer; without normalization, queries
-   * like {@code Hell*} would never match the lower-cased indexed tokens.
+   * The {@code fieldName:} prefix a qualified clause has to match, or the empty string for an unqualified one. The name
+   * is resolved to the spelling {@link LSMTreeFullTextIndex#put} used, which for a property indexed with a modifier is
+   * the modifier-qualified one ({@code keywords by item}) rather than the base name a query can write ({@code keywords}),
+   * so a {@code BY ITEM} property is reachable by its declared name (issue #7000). A qualifier that names no indexed
+   * property is kept verbatim, and matches nothing, as before.
    */
-  private static String normalizeText(final String text) {
-    return text == null ? "" : text.toLowerCase(Locale.ROOT);
+  private String fieldPrefix(final String field) {
+    if (isUnqualified(field))
+      return "";
+    final String storedField = storedFieldFor(propertyNames, field);
+    return (storedField != null ? storedField : field) + ":";
+  }
+
+  /**
+   * Answers the indexed property a query qualifier names, in the spelling the POSTINGS use, or {@code null} when the
+   * qualifier names no indexed property. Kept next to {@link #isUnqualified(List, String)} because it is the other half
+   * of the same rule, consulted by both full-text query paths: this executor and the direct {@code get()} lookup in
+   * {@link LSMTreeFullTextIndex#parseQueryTerms}.
+   * <p>
+   * The two spellings differ for a property indexed with a modifier: {@link LSMTreeFullTextIndex#put} prefixes tokens
+   * with the index's own property name ({@code obj.hd by item}) while a query can only write the base name
+   * ({@code obj.hd}) - the modified one carries spaces and would not survive the parser. Matching on the base name and
+   * answering with the stored one is what lets a field-qualified lookup reach those postings at all. The direct path
+   * had this rule and the executor did not, which is issue #7000's second defect.
+   */
+  static String storedFieldFor(final List<String> propertyNames, final String qualifier) {
+    if (propertyNames == null || qualifier == null)
+      return null;
+    for (final String property : propertyNames)
+      if (property.equals(qualifier) || Index.basePropertyName(property).equals(qualifier))
+        return property;
+    return null;
+  }
+
+  /**
+   * Normalizes a wildcard / fuzzy / regexp term the way the analyzer normalizes the tokens it stores, so both sides
+   * fold identically whatever the analyzer: lower-casing for the standard analyzer, nothing at all for a
+   * case-preserving one such as {@code WhitespaceAnalyzer}, where an unconditional {@code toLowerCase} turned
+   * {@code Fo*} into a prefix the stored {@code Foo} could never match (issue #7000). This is also what the Lucene
+   * QueryParser itself does for the prefix, wildcard and fuzzy forms; the regexp form it hands over untouched.
+   */
+  private String normalizeText(final String field, final String text) {
+    if (text == null || text.isEmpty())
+      return "";
+    return analyzer.normalize(isUnqualified(field) ? DEFAULT_FIELD : field, text).utf8ToString();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -775,10 +775,17 @@ public class FullTextQueryExecutor {
    * property is kept verbatim, and matches nothing, as before.
    */
   private String fieldPrefix(final String field) {
-    if (isUnqualified(field))
-      return "";
+    return isUnqualified(field) ? "" : storedField(field) + ":";
+  }
+
+  /**
+   * The spelling of a qualified field the postings use, or the qualifier itself when it names no indexed property. The
+   * one resolution shared by key building and analyzer normalization, so the two cannot disagree on which field a
+   * clause is about.
+   */
+  private String storedField(final String field) {
     final String storedField = storedFieldFor(propertyNames, field);
-    return (storedField != null ? storedField : field) + ":";
+    return storedField != null ? storedField : field;
   }
 
   /**
@@ -812,7 +819,9 @@ public class FullTextQueryExecutor {
   private String normalizeText(final String field, final String text) {
     if (text == null || text.isEmpty())
       return "";
-    return analyzer.normalize(isUnqualified(field) ? DEFAULT_FIELD : field, text).utf8ToString();
+    // The field is resolved to its stored spelling, like the key prefix is: an analyzer that folds per field has to be
+    // asked about the same field the write path tokenized under, or the two sides drift apart again.
+    return analyzer.normalize(isUnqualified(field) ? DEFAULT_FIELD : storedField(field), text).utf8ToString();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -618,7 +618,7 @@ public class FullTextQueryExecutor {
 
   private void collectPrefixMatches(final PrefixQuery query, final Map<RID, AtomicInteger> scoreMap) {
     final String field = query.getPrefix().field();
-    final String prefix = normalizeText(field, query.getPrefix().text());
+    final String prefix = normalizeText(query.getPrefix().text());
     if (prefix.isEmpty())
       return;
 
@@ -628,7 +628,7 @@ public class FullTextQueryExecutor {
 
   private void collectWildcardMatches(final WildcardQuery query, final Map<RID, AtomicInteger> scoreMap) {
     final String field = query.getTerm().field();
-    final String pattern = normalizeText(field, query.getTerm().text());
+    final String pattern = normalizeText(query.getTerm().text());
     if (pattern.isEmpty())
       return;
 
@@ -668,7 +668,7 @@ public class FullTextQueryExecutor {
 
   private void collectFuzzyMatches(final FuzzyQuery query, final Map<RID, AtomicInteger> scoreMap) {
     final String field = query.getTerm().field();
-    final String term = normalizeText(field, query.getTerm().text());
+    final String term = normalizeText(query.getTerm().text());
     if (term.isEmpty())
       return;
 
@@ -690,7 +690,7 @@ public class FullTextQueryExecutor {
 
   private void collectRegexpMatches(final RegexpQuery query, final Map<RID, AtomicInteger> scoreMap) {
     final String field = query.getRegexp().field();
-    final String regexText = normalizeText(field, query.getRegexp().text());
+    final String regexText = normalizeText(query.getRegexp().text());
     if (regexText.isEmpty())
       return;
 
@@ -819,12 +819,13 @@ public class FullTextQueryExecutor {
    * {@code Fo*} into a prefix the stored {@code Foo} could never match (issue #7000). This is also what the Lucene
    * QueryParser itself does for the prefix, wildcard and fuzzy forms; the regexp form it hands over untouched.
    */
-  private String normalizeText(final String field, final String text) {
+  private String normalizeText(final String text) {
     if (text == null || text.isEmpty())
       return "";
-    // The field is resolved to its stored spelling, like the key prefix is: an analyzer that folds per field has to be
-    // asked about the same field the write path tokenized under, or the two sides drift apart again.
-    return analyzer.normalize(isUnqualified(field) ? DEFAULT_FIELD : storedField(field), text).utf8ToString();
+    // Normalized under the one field name the write path tokenizes every property under (LSMTreeFullTextIndex.tokenize),
+    // not under the query's qualifier: a field-aware analyzer folds by that name, and the stored tokens are what the
+    // pattern has to match.
+    return analyzer.normalize(LSMTreeFullTextIndex.ANALYZED_FIELD, text).utf8ToString();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -89,6 +89,14 @@ import java.util.logging.Level;
  * the query result will be the TreeMap ordered by score, so if the query has a limit, only the first X items will be returned ordered by score desc
  */
 public class LSMTreeFullTextIndex implements Index, IndexInternal {
+  /**
+   * The Lucene field name every stored token is analyzed under, whatever property it comes from. A field-aware analyzer
+   * decides how to fold text by this name, so the query side normalizes a non-exact term under the same one (see
+   * {@code FullTextQueryExecutor.normalizeText}) rather than under the query's own qualifier, or the two sides would fold
+   * differently (issue #7000).
+   */
+  static final String ANALYZED_FIELD = "contents";
+
   /** Max query terms detailed in an EXPLAIN/PROFILE scoring breakdown (each costs one posting scan); beyond it the output is truncated. */
   private static final int MAX_EXPLAIN_TERMS = 64;
 
@@ -1595,7 +1603,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * Tokenizes a single non-null value with the analyzer and appends the resulting tokens to {@code tokens}.
    */
   private static void tokenize(final Analyzer analyzer, final Object value, final List<String> tokens) {
-    final TokenStream tokenizer = analyzer.tokenStream("contents", value.toString());
+    final TokenStream tokenizer = analyzer.tokenStream(ANALYZED_FIELD, value.toString());
     try {
       tokenizer.reset();
       final CharTermAttribute termAttribute = tokenizer.getAttribute(CharTermAttribute.class);

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -292,24 +292,6 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * Answers the indexed property a query qualifier names, in the spelling the POSTINGS use, or {@code null} when the
-   * qualifier names no indexed property.
-   * <p>
-   * The two spellings differ for a property indexed with a modifier: {@link #put} prefixes tokens with the index's own
-   * property name ({@code obj.hd by item}) while a query can only write the base name ({@code obj.hd}) - the modified one
-   * carries spaces and would not survive the whitespace split. Matching on the base name and answering with the stored one
-   * is what lets a field-qualified lookup reach those postings at all.
-   */
-  private static String storedFieldFor(final List<String> propertyNames, final String qualifier) {
-    if (propertyNames == null || qualifier == null)
-      return null;
-    for (final String property : propertyNames)
-      if (property.equals(qualifier) || Index.basePropertyName(property).equals(qualifier))
-        return property;
-    return null;
-  }
-
-  /**
    * Prefixes every whitespace-separated part of {@code text} with {@code field:}, the form {@link #parseQueryTerms}
    * recognises as a field qualifier. A part that already carries a colon keeps it as literal text: only the FIRST colon
    * separates the qualifier, so {@code jira:1234} under field {@code title} becomes {@code title:jira:1234} and is
@@ -1002,7 +984,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       // Check for field:value pattern
       final int colonIdx = part.indexOf(':');
       final String storedField = colonIdx > 0 && colonIdx < part.length() - 1 ?
-          storedFieldFor(propertyNames, part.substring(0, colonIdx)) :
+          FullTextQueryExecutor.storedFieldFor(propertyNames, part.substring(0, colonIdx)) :
           null;
       if (storedField != null) {
         // Field-prefixed term: qualified only where qualified keys are stored, i.e. on a multi-property index

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -407,6 +407,33 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   }
 
   /**
+   * Splits the patterns of a MATCH statement into the positive ones and those a {@code NOT} keyword precedes, by walking
+   * the parse tree in order and letting a {@code NOT} token flag the pattern that follows it.
+   * <p>
+   * The grammar is {@code MATCH matchExpression (COMMA NOT? matchExpression)*}, so the {@code NOT} tokens form a
+   * sparse list: the i-th {@code NOT} is not the one that precedes the i-th pattern unless every negative pattern
+   * comes last. Indexing {@code NOT(i - 1)} flagged the wrong pattern as soon as a negative pattern was followed by a
+   * positive one ({@code MATCH {as:a}, NOT {as:a}-X->{}, {as:a}-Y->{as:b} RETURN a} negated the Y hop instead of the X
+   * hop), and made the rendered text (issue #6999) a different statement from the one that was parsed.
+   */
+  private void collectMatchExpressions(final SQLParser.MatchStatementContext ctx, final List<MatchExpression> matchExpressions,
+      final List<MatchExpression> notMatchExpressions) {
+    if (ctx.children == null)
+      return;
+
+    boolean negated = false;
+    for (final ParseTree child : ctx.children) {
+      if (child instanceof TerminalNode terminal) {
+        if (terminal.getSymbol().getType() == SQLParser.NOT)
+          negated = true;
+      } else if (child instanceof SQLParser.MatchExpressionContext exprCtx) {
+        (negated ? notMatchExpressions : matchExpressions).add((MatchExpression) visit(exprCtx));
+        negated = false;
+      }
+    }
+  }
+
+  /**
    * MATCH statement rule visitor (for matchStatement grammar rule).
    * This is called when visiting a matchStatement rule directly (e.g., from subqueries).
    */
@@ -417,20 +444,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Parse match expressions (both positive and negative patterns)
     final List<MatchExpression> matchExpressions = new ArrayList<>();
     final List<MatchExpression> notMatchExpressions = new ArrayList<>();
-
-    if (CollectionUtils.isNotEmpty(ctx.matchExpression())) {
-      for (int i = 0; i < ctx.matchExpression().size(); i++) {
-        final SQLParser.MatchExpressionContext exprCtx = ctx.matchExpression(i);
-        final MatchExpression matchExpr = (MatchExpression) visit(exprCtx);
-
-        // Check if this is a NOT expression (only possible for non-first expressions)
-        if (i > 0 && ctx.NOT(i - 1) != null) {
-          notMatchExpressions.add(matchExpr);
-        } else {
-          matchExpressions.add(matchExpr);
-        }
-      }
-    }
+    collectMatchExpressions(ctx, matchExpressions, notMatchExpressions);
 
     stmt.setMatchExpressions(matchExpressions);
     stmt.setNotMatchExpressions(notMatchExpressions);
@@ -516,20 +530,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Parse match expressions (both positive and negative patterns)
     final List<MatchExpression> matchExpressions = new ArrayList<>();
     final List<MatchExpression> notMatchExpressions = new ArrayList<>();
-
-    if (CollectionUtils.isNotEmpty(matchCtx.matchExpression())) {
-      for (int i = 0; i < matchCtx.matchExpression().size(); i++) {
-        final SQLParser.MatchExpressionContext exprCtx = matchCtx.matchExpression(i);
-        final MatchExpression matchExpr = (MatchExpression) visit(exprCtx);
-
-        // Check if this is a NOT expression (only possible for non-first expressions)
-        if (i > 0 && matchCtx.NOT(i - 1) != null) {
-          notMatchExpressions.add(matchExpr);
-        } else {
-          matchExpressions.add(matchExpr);
-        }
-      }
-    }
+    collectMatchExpressions(matchCtx, matchExpressions, notMatchExpressions);
 
     stmt.setMatchExpressions(matchExpressions);
     stmt.setNotMatchExpressions(notMatchExpressions);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchStatement.java
@@ -324,6 +324,15 @@ public class MatchStatement extends Statement {
       expr.toString(params, builder);
       first = false;
     }
+    // THE NEGATIVE PATTERNS ARE RENDERED TOO, EACH PREFIXED WITH ", NOT ": THE GRAMMAR ACCEPTS THEM ANYWHERE AFTER THE
+    // FIRST PATTERN AND THE BUILDER SPLITS THEM INTO THEIR OWN LIST, SO EMITTING THEM AFTER THE POSITIVE ONES IS THE
+    // SAME STATEMENT. LEAVING THEM OUT SILENTLY WIDENED ANYTHING THAT ROUND-TRIPS A MATCH THROUGH ITS TEXT, SUCH AS A
+    // MATERIALIZED VIEW (ISSUE #6999)
+    if (notMatchExpressions != null)
+      for (final MatchExpression expr : this.notMatchExpressions) {
+        builder.append(", NOT ");
+        expr.toString(params, builder);
+      }
     builder.append(" RETURN ");
     if (returnDistinct) {
       builder.append("DISTINCT ");

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -2024,6 +2024,10 @@ public class LocalDocumentType implements DocumentType {
    * the polymorphic caches of its sub types, in that order, then does the same up every super type, whose caches are
    * derived from this one. Each list is published as a fresh unmodifiable copy, the same copy-on-write contract the
    * lock-free readers of the two volatile fields rely on (issue #6678).
+   * <p>
+   * The order is load-bearing: a type's cache is read by its super types and never by its sub types, so this type is
+   * rebuilt BEFORE the walk goes up, and the sub types' caches it reads are already final because the change that
+   * triggered the rebuild happened above them. Rebuilding a super type first would read this type's stale cache.
    */
   private void rebuildPolymorphicBucketsCache() {
     final List<Bucket> polymorphicBuckets = new ArrayList<>(buckets);

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -203,16 +203,11 @@ public class LocalDocumentType implements DocumentType {
   public DocumentType removeSuperType(final DocumentType superType) {
     checkForSchemaMutation();
     recordFileChanges(() -> {
-      if (!superTypes.remove(superType))
+      if (!superTypes.contains(superType))
         // ALREADY REMOVED SUPER TYPE
         return null;
 
-      ((LocalDocumentType) superType).subTypes.remove(this);
-
-      // TODO: CHECK THE EDGE CASE WHERE THE SAME TYPE IS INHERITED ON MULTIPLE LEVEL AND YOU DON'T NEED TO REMOVE THE BUCKETS
-      // UPDATE THE LIST OF POLYMORPHIC BUCKETS TREE
-      ((LocalDocumentType) superType).updatePolymorphicBucketsCache(false, buckets, bucketIds);
-
+      unlinkSuperType((LocalDocumentType) superType);
       return null;
     });
     return this;
@@ -2006,18 +2001,47 @@ public class LocalDocumentType implements DocumentType {
   }
 
   /**
-   * Undoes the in-memory linkage {@link #addSuperType(DocumentType, boolean)} applies before it propagates the super
-   * type's indexes, so a propagation that fails leaves the type exactly as unlinked as it found it and the next
-   * attempt is a real attempt rather than an early return.
-   *
-   * @param linkedBuckets   the very lists handed to {@code updatePolymorphicBucketsCache} on the way in - the caches
-   *                        are replaced rather than mutated, so removing anything else would not be symmetric
+   * The mirror image of {@link #linkSuperType}: severs the link in both directions, then has the former super type
+   * rebuild its polymorphic bucket caches from what is still linked to it. Used by {@link #removeSuperType(DocumentType)}
+   * and by {@link #addSuperTypeInternal} to hand a failed linkage back, so the two cannot drift apart.
+   * <p>
+   * The caches are REBUILT rather than subtracted from. Linking contributed this type's whole polymorphic subtree, so a
+   * subtraction has to withdraw the same subtree, and withdrawing only the type's own buckets left every grandchild
+   * visible in {@code SELECT FROM <ancestor>} after the link was gone (issue #6935). A subtraction of the subtree is not
+   * right either: a bucket the former super type still reaches through another path (a diamond, where the subtree is
+   * also linked to it directly or through a sibling) would be withdrawn although it still belongs there. Recomputing
+   * from the surviving links is the only answer that is correct in both shapes, and a schema change is rare enough that
+   * its O(tree) cost is not worth a cheaper rule that is wrong in one of them.
    */
-  private void unlinkSuperType(final LocalDocumentType superType, final List<Bucket> linkedBuckets,
-      final List<Integer> linkedBucketIds) {
+  private void unlinkSuperType(final LocalDocumentType superType) {
     superTypes.remove(superType);
     superType.subTypes.remove(this);
-    superType.updatePolymorphicBucketsCache(false, linkedBuckets, linkedBucketIds);
+    superType.rebuildPolymorphicBucketsCache();
+  }
+
+  /**
+   * Recomputes {@link #cachedPolymorphicBuckets} and {@link #cachedPolymorphicBucketIds} from this type's own buckets and
+   * the polymorphic caches of its sub types, in that order, then does the same up every super type, whose caches are
+   * derived from this one. Each list is published as a fresh unmodifiable copy, the same copy-on-write contract the
+   * lock-free readers of the two volatile fields rely on (issue #6678).
+   */
+  private void rebuildPolymorphicBucketsCache() {
+    final List<Bucket> polymorphicBuckets = new ArrayList<>(buckets);
+    final List<Integer> polymorphicBucketIds = new ArrayList<>(bucketIds);
+    // A DIAMOND HANDS THE SAME BUCKET OVER THROUGH MORE THAN ONE SUB TYPE: IT IS LISTED ONCE
+    final Set<Bucket> seen = new HashSet<>(buckets);
+    for (final LocalDocumentType subType : subTypes)
+      for (final Bucket bucket : subType.cachedPolymorphicBuckets)
+        if (seen.add(bucket)) {
+          polymorphicBuckets.add(bucket);
+          polymorphicBucketIds.add(bucket.getFileId());
+        }
+
+    cachedPolymorphicBuckets = Collections.unmodifiableList(polymorphicBuckets);
+    cachedPolymorphicBucketIds = Collections.unmodifiableList(polymorphicBucketIds);
+
+    for (final LocalDocumentType superType : superTypes)
+      superType.rebuildPolymorphicBucketsCache();
   }
 
   DocumentType addSuperType(final DocumentType superType, final boolean createIndexes) {
@@ -2075,12 +2099,7 @@ public class LocalDocumentType implements DocumentType {
     recordFileChanges(() -> {
       final LocalDocumentType embeddedSuperType = (LocalDocumentType) superType;
 
-      // The lists are captured because the fields are REPLACED rather than mutated, and unlinkSuperType has to hand
-      // back exactly what was handed over.
-      final List<Bucket>  linkedBuckets   = cachedPolymorphicBuckets;
-      final List<Integer> linkedBucketIds = cachedPolymorphicBucketIds;
-
-      linkSuperType(embeddedSuperType, linkedBuckets, linkedBucketIds);
+      linkSuperType(embeddedSuperType);
 
       // EVERYTHING THAT FOLLOWS THE LINKAGE IS GUARDED BY IT. Every step below can still refuse - a paired external
       // bucket that cannot be created, an index propagation that hits a duplicate, an inherited partition the
@@ -2110,7 +2129,7 @@ public class LocalDocumentType implements DocumentType {
         //
         // The paired external buckets ensureExternalBucketsRecursive may have created are deliberately left: they are
         // additive, idempotent, and reused by the next attempt.
-        unlinkSuperType(embeddedSuperType, linkedBuckets, linkedBucketIds);
+        unlinkSuperType(embeddedSuperType);
         throw e;
       }
 
@@ -2120,17 +2139,13 @@ public class LocalDocumentType implements DocumentType {
 
   /**
    * The in-memory linkage, and nothing else: the three lines {@link #unlinkSuperType} undoes, kept next to it so the
-   * two stay symmetric.
-   *
-   * @param linkedBuckets the caches captured by the caller, which are the very lists {@code unlinkSuperType} has to
-   *                      hand back - the fields are replaced rather than mutated, so re-reading them later would
-   *                      remove something else
+   * two stay symmetric. The super type receives this type's whole polymorphic subtree, which is what a polymorphic read
+   * on it has to reach from now on.
    */
-  private void linkSuperType(final LocalDocumentType superType, final List<Bucket> linkedBuckets,
-      final List<Integer> linkedBucketIds) {
+  private void linkSuperType(final LocalDocumentType superType) {
     superTypes.add(superType);
     superType.subTypes.add(this);
-    superType.updatePolymorphicBucketsCache(true, linkedBuckets, linkedBucketIds);
+    superType.updatePolymorphicBucketsCache(true, cachedPolymorphicBuckets, cachedPolymorphicBucketIds);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -488,6 +488,11 @@ public class BinaryComparator {
    * sidesteps the two {@code byte[]} allocations that encoding both operands cost on every comparison, which the index
    * cursor pays once per key while it walks a range. Both sides used to encode with
    * {@link DatabaseFactory#getDefaultCharset()}, which is UTF-8 (issue #6998): the invariant this relies on.
+   * <p>
+   * The remap is only right for well-formed UTF-16. An isolated surrogate has no code point: the encoder writes the
+   * replacement byte {@code '?'} for it, which sorts below almost everything, while the remap would sort it above the
+   * whole BMP. So when the first difference sits on or right after a surrogate that is not part of a pair, the pages'
+   * own encoding is compared instead - the rare path, and the only one that allocates.
    */
   public static int compareStrings(final String a, final String b) {
     final int aLength = a.length();
@@ -497,6 +502,9 @@ public class BinaryComparator {
       int ca = a.charAt(i);
       int cb = b.charAt(i);
       if (ca != cb) {
+        if (isolatedSurrogateAround(a, i) || isolatedSurrogateAround(b, i))
+          return compareBytes(a.getBytes(DatabaseFactory.getDefaultCharset()), b.getBytes(DatabaseFactory.getDefaultCharset()));
+
         if (ca >= 0xD800 && cb >= 0xD800) {
           // BOTH UNITS ARE IN THE SURROGATE-OR-ABOVE REGION, THE ONLY PLACE THE TWO ORDERS DISAGREE: MOVE THE SURROGATE
           // BLOCK ABOVE THE REST OF THE BMP, WHERE THE 4-BYTE UTF-8 FORM OF WHAT IT ENCODES SORTS
@@ -507,6 +515,20 @@ public class BinaryComparator {
       }
     }
     return aLength - bLength;
+  }
+
+  /**
+   * True when the unit at {@code i} is a surrogate without its partner, or when the unit before it is a high surrogate
+   * that this unit does not complete: both shapes are encoded as a replacement byte rather than as the code point the
+   * UTF-16-as-UTF-8 remap assumes.
+   */
+  private static boolean isolatedSurrogateAround(final String s, final int i) {
+    final char c = s.charAt(i);
+    if (Character.isHighSurrogate(c))
+      return i + 1 >= s.length() || !Character.isLowSurrogate(s.charAt(i + 1));
+    if (Character.isLowSurrogate(c))
+      return i == 0 || !Character.isHighSurrogate(s.charAt(i - 1));
+    return i > 0 && Character.isHighSurrogate(s.charAt(i - 1));
   }
 
   public static int compareBytes(final byte[] buffer1, final byte[] buffer2) {

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -92,7 +92,12 @@ public class BinaryComparator {
         return -compare(value2, type2, value1, type1);
 
       default:
-        return ((String) value1).compareTo(value2.toString());
+        // TWO STRINGS ARE ORDERED THE WAY THE PAGES ORDER THEM - BY UNSIGNED UTF-8 BYTES, NOT BY UTF-16 CODE UNITS.
+        // String.compareTo() disagrees with the page order for any non-BMP character (a surrogate pair, 0xD800-0xDBFF
+        // lead unit, but a 0xF0-0xF4 lead byte) against a BMP character above U+E000, so the range cursor's stop
+        // condition, which compares the un-encoded bounds through here, ended a scan before emitting anything
+        // (issue #6997)
+        return compareStrings((String) value1, value2.toString());
       }
     }
 
@@ -456,9 +461,7 @@ public class BinaryComparator {
     else if (a == null)
       return -1;
     else if (a instanceof String string && b instanceof String string1)
-      // BOTH OPERANDS MUST BE ENCODED WITH THE SAME CHARSET: A NO-ARG getBytes() ON ONE SIDE FOLLOWS THE JVM
-      // DEFAULT AND MADE AN EQUAL PAIR COMPARE AS LESS-THAN ON A NON-UTF-8 JVM (ISSUE #6998)
-      return compareBytes(string.getBytes(DatabaseFactory.getDefaultCharset()), string1.getBytes(DatabaseFactory.getDefaultCharset()));
+      return compareStrings(string, string1);
     else if (a instanceof byte[] bytes && b instanceof byte[] bytes1)
       return compareBytes(bytes, bytes1);
     else if (a instanceof Map map && b instanceof Map map1)
@@ -471,6 +474,39 @@ public class BinaryComparator {
       return DateUtils.dateTimeToTimestampInferringStringPrecision(a, ChronoUnit.NANOS)
           .compareTo(DateUtils.dateTimeToTimestampInferringStringPrecision(b, ChronoUnit.NANOS));
     return ((Comparable<Object>) a).compareTo(b);
+  }
+
+  /**
+   * Orders two strings exactly as the unsigned UTF-8 encodings the LSM pages hold would order them, without encoding
+   * either: UTF-8 byte order is Unicode code point order, and the only place UTF-16 code unit order departs from it is
+   * the surrogate block ({@code 0xD800-0xDFFF}), which UTF-16 places BELOW {@code 0xE000-0xFFFF} while the code points
+   * it encodes ({@code U+10000} and above) sort ABOVE every BMP character. The first differing pair of units is
+   * therefore remapped so that the two blocks swap places, which is all it takes to sort UTF-16 as UTF-8.
+   * <p>
+   * This is the one ordering for a String pair, shared by {@link #compare(Object, byte, Object, byte)} and
+   * {@link #compareTo(Object, Object)} so the two entry points cannot answer differently again (issue #6997). It also
+   * sidesteps the two {@code byte[]} allocations that encoding both operands cost on every comparison, which the index
+   * cursor pays once per key while it walks a range. Both sides used to encode with
+   * {@link DatabaseFactory#getDefaultCharset()}, which is UTF-8 (issue #6998): the invariant this relies on.
+   */
+  public static int compareStrings(final String a, final String b) {
+    final int aLength = a.length();
+    final int bLength = b.length();
+    final int length = Math.min(aLength, bLength);
+    for (int i = 0; i < length; i++) {
+      int ca = a.charAt(i);
+      int cb = b.charAt(i);
+      if (ca != cb) {
+        if (ca >= 0xD800 && cb >= 0xD800) {
+          // BOTH UNITS ARE IN THE SURROGATE-OR-ABOVE REGION, THE ONLY PLACE THE TWO ORDERS DISAGREE: MOVE THE SURROGATE
+          // BLOCK ABOVE THE REST OF THE BMP, WHERE THE 4-BYTE UTF-8 FORM OF WHAT IT ENCODES SORTS
+          ca += ca >= 0xE000 ? -0x800 : 0x2000;
+          cb += cb >= 0xE000 ? -0x800 : 0x2000;
+        }
+        return ca - cb;
+      }
+    }
+    return aLength - bLength;
   }
 
   public static int compareBytes(final byte[] buffer1, final byte[] buffer2) {

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue7000FieldQualifiedFullTextTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue7000FieldQualifiedFullTextTest.java
@@ -23,6 +23,11 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.LowerCaseFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -186,6 +191,54 @@ class Issue7000FieldQualifiedFullTextTest extends TestHelper {
       assertThat(rs.hasNext()).isFalse();
       return ((Number) result.getProperty("$score")).floatValue();
     }
+  }
+
+  /**
+   * Folds every token it stores (lower case), but only normalizes a query pattern the same way when asked under the field
+   * the write path tokenizes under: under any other field name the pattern is left as it is.
+   */
+  public static final class FieldAwareAnalyzer extends Analyzer {
+    @Override
+    protected TokenStreamComponents createComponents(final String fieldName) {
+      final Tokenizer source = new WhitespaceTokenizer();
+      return new TokenStreamComponents(source, new LowerCaseFilter(source));
+    }
+
+    @Override
+    protected TokenStream normalize(final String fieldName, final TokenStream in) {
+      return LSMTreeFullTextIndex.ANALYZED_FIELD.equals(fieldName) ? new LowerCaseFilter(in) : in;
+    }
+  }
+
+  /**
+   * The write path analyzes every property under one Lucene field name. A field-aware analyzer folds by that name, so
+   * the query side has to normalize a non-exact term under the same one rather than under the query's own qualifier, or
+   * the pattern is folded differently from the tokens it has to match.
+   */
+  @Test
+  void nonExactTermsAreNormalizedUnderTheFieldTheWritePathTokenizesUnder() {
+    final DocumentType doc = database.getSchema().createDocumentType("Doc");
+    doc.createProperty("content", Type.STRING);
+    doc.createProperty("extra", Type.STRING);
+    database.command("sql", "CREATE INDEX Doc_ft ON Doc (content, extra) FULL_TEXT METADATA {\"analyzer\": \""
+        + FieldAwareAnalyzer.class.getName() + "\"}");
+
+    database.transaction(() -> database.newDocument("Doc").set("content", "Foo Bar").set("extra", "none").save());
+
+    // THE STORED TOKENS ARE LOWER CASE, WHATEVER THE PROPERTY
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'content:foo') = true")).containsExactly("Foo Bar");
+
+    // A MIXED-CASE PATTERN REACHES THEM ONLY IF IT IS FOLDED UNDER THE FIELD THE WRITE PATH USED
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'content:Fo*') = true")).as("prefix")
+        .containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'content:F?o') = true")).as("wildcard")
+        .containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'content:Fooo~1') = true")).as("fuzzy")
+        .containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'content:/Fo+/') = true")).as("regexp")
+        .containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'Fo*') = true")).as("unqualified prefix")
+        .containsExactly("Foo Bar");
   }
 
   private List<String> titles(final String query) {

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue7000FieldQualifiedFullTextTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue7000FieldQualifiedFullTextTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7000: the full-text query path and the indexing path derived the posting key and the
+ * term normalization independently, and drifted apart in three places.
+ * <ol>
+ *   <li>a field-qualified PHRASE query looked every term up by its bare text, so {@code title:"..."} also matched a
+ *   document carrying the phrase only in {@code body};</li>
+ *   <li>a field qualifier on a multi-property index was used verbatim, while the postings of a {@code BY ITEM}
+ *   property are prefixed with the modifier-qualified name the index declares, so {@code keywords:x} never matched;</li>
+ *   <li>wildcard, prefix, fuzzy and regexp terms were unconditionally lower-cased, while the postings are produced by
+ *   the configured analyzer, so on a case-preserving analyzer {@code Fo*} could never reach the stored {@code Foo}.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7000FieldQualifiedFullTextTest extends TestHelper {
+
+  @Test
+  void fieldQualifiedPhraseIsRestrictedToItsField() {
+    final DocumentType article = database.getSchema().createDocumentType("Article");
+    article.createProperty("title", Type.STRING);
+    article.createProperty("body", Type.STRING);
+    database.command("sql", "CREATE INDEX Article_ft ON Article (title, body) FULL_TEXT");
+
+    database.transaction(() -> {
+      database.newDocument("Article").set("title", "Java Programming").set("body", "An introduction to the language").save();
+      database.newDocument("Article").set("title", "Python Guide")
+          .set("body", "Java programming is what the other article is about").save();
+    });
+
+    // THE SINGLE-TERM FORM IS RESTRICTED TO THE FIELD...
+    assertThat(titles("SELECT title FROM Article WHERE SEARCH_INDEX('Article_ft', 'title:java') = true"))
+        .containsExactly("Java Programming");
+
+    // ...AND THE PHRASE FORM OF THE SAME QUERY MUST BE TOO
+    assertThat(titles("SELECT title FROM Article WHERE SEARCH_INDEX('Article_ft', 'title:\"java programming\"') = true"))
+        .as("a phrase qualified to 'title' must not match a document carrying the phrase only in 'body'")
+        .containsExactly("Java Programming");
+
+    // THE UNQUALIFIED PHRASE STILL SEES BOTH FIELDS
+    assertThat(titles("SELECT title FROM Article WHERE SEARCH_INDEX('Article_ft', '\"java programming\"') = true"))
+        .containsExactlyInAnyOrder("Java Programming", "Python Guide");
+
+    // A PHRASE QUALIFIED TO THE OTHER FIELD REACHES THE OTHER DOCUMENT ONLY
+    assertThat(titles("SELECT title FROM Article WHERE SEARCH_INDEX('Article_ft', 'body:\"java programming\"') = true"))
+        .containsExactly("Python Guide");
+  }
+
+  @Test
+  void fieldQualifiedClauseReachesAByItemProperty() {
+    final DocumentType metadata = database.getSchema().createDocumentType("Metadata");
+    metadata.createProperty("title", Type.STRING);
+    metadata.createProperty("keywords", Type.LIST);
+    database.command("sql", "CREATE INDEX Metadata_ft ON Metadata (title, keywords BY ITEM) FULL_TEXT");
+
+    database.transaction(() -> {
+      database.newDocument("Metadata").set("title", "First").set("keywords", List.of("graph", "database")).save();
+      database.newDocument("Metadata").set("title", "Second graph").set("keywords", List.of("vector")).save();
+    });
+
+    // THE UNQUALIFIED QUERY MATCHES BOTH (ONE BY KEYWORD, ONE BY TITLE)...
+    assertThat(titles("SELECT title FROM Metadata WHERE SEARCH_INDEX('Metadata_ft', 'graph') = true"))
+        .containsExactlyInAnyOrder("First", "Second graph");
+
+    // ...AND THE QUALIFIED ONE MUST REACH THE BY ITEM PROPERTY BY ITS DECLARED NAME
+    assertThat(titles("SELECT title FROM Metadata WHERE SEARCH_INDEX('Metadata_ft', 'keywords:graph') = true"))
+        .as("a 'keywords:' qualifier must reach the postings of the 'keywords BY ITEM' property")
+        .containsExactly("First");
+    assertThat(titles("SELECT title FROM Metadata WHERE SEARCH_INDEX('Metadata_ft', 'keywords:gra*') = true"))
+        .as("the same rule applies to the prefix form")
+        .containsExactly("First");
+    assertThat(titles("SELECT title FROM Metadata WHERE SEARCH_INDEX('Metadata_ft', 'title:graph') = true"))
+        .containsExactly("Second graph");
+
+    // THE DIRECT LOOKUP PATH (CONTAINSTEXT) ALREADY RESOLVED THE QUALIFIER: THE TWO PATHS MUST AGREE
+    assertThat(titles("SELECT title FROM Metadata WHERE keywords CONTAINSTEXT 'graph'")).containsExactly("First");
+  }
+
+  @Test
+  void nonExactTermsAreNormalizedByTheAnalyzerNotLowerCased() {
+    final DocumentType doc = database.getSchema().createDocumentType("Doc");
+    doc.createProperty("content", Type.STRING);
+    database.command("sql", "CREATE INDEX Doc_ft ON Doc (content) FULL_TEXT METADATA {\"analyzer\": "
+        + "\"org.apache.lucene.analysis.core.WhitespaceAnalyzer\"}");
+
+    database.transaction(() -> {
+      database.newDocument("Doc").set("content", "Foo Bar").save();
+      database.newDocument("Doc").set("content", "foo baz").save();
+    });
+
+    // EXACT TERMS GO THROUGH THE ANALYZER ON BOTH SIDES, SO THEY ARE CASE-SENSITIVE HERE
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'Foo') = true")).containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'foo') = true")).containsExactly("foo baz");
+
+    // THE NON-EXACT FORMS MUST FOLD THE SAME WAY THE ANALYZER DOES, I.E. NOT AT ALL FOR A WHITESPACE ANALYZER
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'Fo*') = true"))
+        .as("prefix: the stored token is 'Foo', a query folded to 'fo*' can never reach it").containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'F?o') = true"))
+        .as("wildcard").containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'Fooo~1') = true"))
+        .as("fuzzy").containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', '/Fo+/') = true"))
+        .as("regexp").containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'fo*') = true"))
+        .as("a lower-case prefix reaches the lower-case token only").containsExactly("foo baz");
+  }
+
+  @Test
+  void nonExactTermsStillFoldOnTheDefaultAnalyzer() {
+    final DocumentType doc = database.getSchema().createDocumentType("Doc");
+    doc.createProperty("content", Type.STRING);
+    database.command("sql", "CREATE INDEX Doc_ft ON Doc (content) FULL_TEXT");
+
+    database.transaction(() -> database.newDocument("Doc").set("content", "Foo Bar").save());
+
+    // GUARD AGAINST OVER-FIXING: THE STANDARD ANALYZER LOWER-CASES, SO A MIXED-CASE PATTERN MUST STILL MATCH
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'Fo*') = true")).containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'F?o') = true")).containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'Fooo~1') = true")).containsExactly("Foo Bar");
+    assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', '/Fo+/') = true")).containsExactly("Foo Bar");
+  }
+
+  private List<String> titles(final String query) {
+    return column(query, "title");
+  }
+
+  private List<String> contents(final String query) {
+    return column(query, "content");
+  }
+
+  private List<String> column(final String query, final String property) {
+    final List<String> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        values.add(rs.next().getProperty(property));
+    }
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue7000FieldQualifiedFullTextTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue7000FieldQualifiedFullTextTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.index.fulltext;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
@@ -106,6 +107,33 @@ class Issue7000FieldQualifiedFullTextTest extends TestHelper {
     assertThat(titles("SELECT title FROM Metadata WHERE keywords CONTAINSTEXT 'graph'")).containsExactly("First");
   }
 
+  /**
+   * A per-field boost is declared under the property name the index carries, which for a BY ITEM property is the
+   * modifier-qualified one: the executor has to look the boost up under that spelling too, or SEARCH_INDEX drops it
+   * while the direct CONTAINSTEXT path applies it.
+   */
+  @Test
+  void aBoostOnAByItemPropertyReachesTheFieldQualifiedQuery() {
+    final DocumentType metadata = database.getSchema().createDocumentType("Metadata");
+    metadata.createProperty("name", Type.STRING);
+    metadata.createProperty("title", Type.STRING);
+    metadata.createProperty("keywords", Type.LIST);
+    database.command("sql", "CREATE INDEX Metadata_ft ON Metadata (title, keywords BY ITEM) FULL_TEXT METADATA "
+        + "{\"similarity\": \"BM25\", \"keywords by item_boost\": 5.0}");
+
+    // THE TWO DOCUMENTS ARE SYMMETRIC (ONE TOKEN PER FIELD), SO ONLY THE BOOST CAN TELL THEIR SCORES APART
+    database.transaction(() -> {
+      database.newDocument("Metadata").set("name", "inTitle").set("title", "java").set("keywords", List.of("other")).save();
+      database.newDocument("Metadata").set("name", "inKeywords").set("title", "other").set("keywords", List.of("java")).save();
+    });
+
+    final float keywordScore = score("SELECT name, $score FROM Metadata WHERE SEARCH_INDEX('Metadata_ft', 'keywords:java') = true",
+        "inKeywords");
+    final float titleScore = score("SELECT name, $score FROM Metadata WHERE SEARCH_INDEX('Metadata_ft', 'title:java') = true",
+        "inTitle");
+    assertThat(keywordScore).as("the boosted BY ITEM field must outscore the unboosted one").isGreaterThan(titleScore);
+  }
+
   @Test
   void nonExactTermsAreNormalizedByTheAnalyzerNotLowerCased() {
     final DocumentType doc = database.getSchema().createDocumentType("Doc");
@@ -148,6 +176,16 @@ class Issue7000FieldQualifiedFullTextTest extends TestHelper {
     assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'F?o') = true")).containsExactly("Foo Bar");
     assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', 'Fooo~1') = true")).containsExactly("Foo Bar");
     assertThat(contents("SELECT content FROM Doc WHERE SEARCH_INDEX('Doc_ft', '/Fo+/') = true")).containsExactly("Foo Bar");
+  }
+
+  private float score(final String query, final String expectedName) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result result = rs.next();
+      assertThat(result.<String>getProperty("name")).isEqualTo(expectedName);
+      assertThat(rs.hasNext()).isFalse();
+      return ((Number) result.getProperty("$score")).floatValue();
+    }
   }
 
   private List<String> titles(final String query) {

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6999MatchStatementNotPatternToStringTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6999MatchStatementNotPatternToStringTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.antlr.SQLAntlrParser;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6999: {@code MatchStatement.toString()} rendered the positive patterns only, so anything
+ * that round-trips a MATCH through its text (a materialized view, a continuous aggregate, the statement cache) silently
+ * lost every {@code NOT} pattern and widened its result set.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6999MatchStatementNotPatternToStringTest extends TestHelper {
+
+  /** The documented shape: a friend-of-a-friend who is not already a direct friend. */
+  private static final String QUERY = "MATCH {as: a, type: Person}-Friend->{as: b}-Friend->{as: c}, NOT {as: a}-Friend->{as: c} "
+      + "RETURN a.name AS name";
+
+  @Test
+  void toStringRendersTheNotPatterns() {
+    final SQLAntlrParser parser = new SQLAntlrParser(null);
+    final MatchStatement original = (MatchStatement) parser.parse(QUERY);
+    assertThat(original.getNotMatchExpressions()).hasSize(1);
+
+    final String rendered = original.toString();
+    assertThat(rendered).as("the rendered text must carry the negative pattern").contains(", NOT ");
+
+    final MatchStatement reparsed = (MatchStatement) parser.parse(rendered);
+    assertThat(reparsed.getNotMatchExpressions()).as("the NOT pattern must survive a parse/render/parse round trip").hasSize(1);
+    assertThat(reparsed).isEqualTo(original);
+    assertThat(reparsed.toString()).isEqualTo(rendered);
+  }
+
+  /**
+   * A negative pattern followed by a positive one: the AST builder indexed the sparse list of NOT tokens by pattern
+   * position, so it negated the wrong pattern in this shape, and the text it rendered was a different statement.
+   */
+  @Test
+  void aNotPatternFollowedByAPositiveOneIsAssignedToTheRightPattern() {
+    final SQLAntlrParser parser = new SQLAntlrParser(null);
+    final MatchStatement original = (MatchStatement) parser.parse(
+        "MATCH {as: p, type: Person}, NOT {as: p}-Friend->{as: q}, {as: p}-Knows->{as: k}, NOT {as: p}-Blocks->{as: b} RETURN p");
+
+    assertThat(original.getMatchExpressions()).hasSize(2);
+    assertThat(original.getMatchExpressions().get(1).toString()).contains("Knows");
+    assertThat(original.getNotMatchExpressions()).hasSize(2);
+    assertThat(original.getNotMatchExpressions().get(0).toString()).contains("Friend");
+    assertThat(original.getNotMatchExpressions().get(1).toString()).contains("Blocks");
+
+    final String rendered = original.toString();
+    final MatchStatement reparsed = (MatchStatement) parser.parse(rendered);
+    assertThat(reparsed.getMatchExpressions()).hasSize(2);
+    assertThat(reparsed.getNotMatchExpressions()).hasSize(2);
+    assertThat(reparsed).isEqualTo(original);
+    assertThat(reparsed.toString()).isEqualTo(rendered);
+  }
+
+  @Test
+  void theReRenderedStatementReturnsTheSameRowsAsTheOriginal() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("Friend");
+
+    database.transaction(() -> {
+      // ALICE -> BOB -> CAROL, WITH NO DIRECT ALICE -> CAROL EDGE
+      final MutableVertex alice = database.newVertex("Person").set("name", "Alice").save();
+      final MutableVertex bob = database.newVertex("Person").set("name", "Bob").save();
+      final MutableVertex carol = database.newVertex("Person").set("name", "Carol").save();
+      alice.newEdge("Friend", bob).save();
+      bob.newEdge("Friend", carol).save();
+      // DAVE -> EVE -> FRANK, AND DAVE IS ALREADY A DIRECT FRIEND OF FRANK
+      final MutableVertex dave = database.newVertex("Person").set("name", "Dave").save();
+      final MutableVertex eve = database.newVertex("Person").set("name", "Eve").save();
+      final MutableVertex frank = database.newVertex("Person").set("name", "Frank").save();
+      dave.newEdge("Friend", eve).save();
+      eve.newEdge("Friend", frank).save();
+      dave.newEdge("Friend", frank).save();
+    });
+
+    assertThat(names(QUERY)).as("only the chain with no direct edge survives the NOT pattern").containsExactly("Alice");
+
+    final String rendered = new SQLAntlrParser(null).parse(QUERY).toString();
+    assertThat(names(rendered)).as("the re-rendered statement must keep the negative filter; without it Dave is back")
+        .containsExactly("Alice");
+  }
+
+  private List<String> names(final String query) {
+    final List<String> names = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+    }
+    return names;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue6935RemoveSuperTypeGrandchildTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6935RemoveSuperTypeGrandchildTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6935: {@code removeSuperType} withdrew only the type's OWN buckets from the former
+ * ancestor's polymorphic cache, while linking had contributed the whole polymorphic subtree. A grandchild's buckets
+ * therefore stayed in the ancestor after the link was severed, and {@code SELECT FROM <ancestor>} kept returning the
+ * grandchild's records. A two-level hierarchy hid it because for a leaf type the two lists coincide.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6935RemoveSuperTypeGrandchildTest extends TestHelper {
+
+  @Test
+  void removingTheMiddleLinkWithdrawsTheGrandchildFromTheAncestor() {
+    database.command("sql", "CREATE DOCUMENT TYPE A2");
+    database.command("sql", "CREATE DOCUMENT TYPE B2 EXTENDS A2");
+    database.command("sql", "CREATE DOCUMENT TYPE C2 EXTENDS B2");
+    database.transaction(() -> database.command("sql", "INSERT INTO C2 SET n = 1"));
+
+    final DocumentType a2 = database.getSchema().getType("A2");
+    final DocumentType b2 = database.getSchema().getType("B2");
+    final DocumentType c2 = database.getSchema().getType("C2");
+    final List<Bucket> c2Buckets = c2.getBuckets(false);
+
+    assertThat(count("A2")).isEqualTo(1);
+    assertThat(a2.getBuckets(true)).containsAll(c2Buckets);
+
+    b2.removeSuperType("A2");
+
+    assertThat(a2.getSubTypes()).isEmpty();
+    assertThat(b2.getSuperTypes()).isEmpty();
+    assertThat(a2.getBuckets(true)).as("A2 has no relationship with C2 any more").doesNotContainAnyElementsOf(c2Buckets);
+    assertThat(a2.getBucketIds(true)).doesNotContainAnyElementsOf(c2.getBucketIds(false));
+    assertThat(count("A2")).as("a polymorphic scan of A2 must not read C2's bucket").isZero();
+
+    // B2 STILL SEES ITS OWN SUBTREE
+    assertThat(b2.getBuckets(true)).containsAll(c2Buckets);
+    assertThat(count("B2")).isEqualTo(1);
+    assertThat(count("C2")).isEqualTo(1);
+
+    // AND RE-LINKING BRINGS THE WHOLE SUBTREE BACK, ONCE
+    b2.addSuperType("A2");
+    assertThat(a2.getBuckets(true)).containsAll(c2Buckets).doesNotHaveDuplicates();
+    assertThat(count("A2")).isEqualTo(1);
+  }
+
+  @Test
+  void removingOneLinkOfADiamondKeepsTheBucketsStillReachableThroughTheOther() {
+    // C3 EXTENDS BOTH B3 AND A3, AND B3 EXTENDS A3: SEVERING B3 -> A3 MUST NOT BLIND A3 TO C3, WHICH IS STILL ITS SUBTYPE
+    database.command("sql", "CREATE DOCUMENT TYPE A3");
+    database.command("sql", "CREATE DOCUMENT TYPE B3 EXTENDS A3");
+    database.command("sql", "CREATE DOCUMENT TYPE C3 EXTENDS B3, A3");
+    database.transaction(() -> database.command("sql", "INSERT INTO C3 SET n = 1"));
+
+    final DocumentType a3 = database.getSchema().getType("A3");
+    final DocumentType b3 = database.getSchema().getType("B3");
+    final DocumentType c3 = database.getSchema().getType("C3");
+
+    assertThat(a3.getBuckets(true)).containsAll(c3.getBuckets(false)).doesNotHaveDuplicates();
+    assertThat(count("A3")).isEqualTo(1);
+
+    b3.removeSuperType("A3");
+
+    assertThat(a3.getSubTypes()).containsExactly(c3);
+    assertThat(a3.getBuckets(true)).as("C3 still extends A3 directly").containsAll(c3.getBuckets(false));
+    assertThat(a3.getBuckets(true)).doesNotContainAnyElementsOf(b3.getBuckets(false));
+    assertThat(count("A3")).isEqualTo(1);
+
+    c3.removeSuperType("A3");
+    assertThat(a3.getBuckets(true)).doesNotContainAnyElementsOf(c3.getBuckets(false));
+    assertThat(count("A3")).isZero();
+  }
+
+  @Test
+  void theCacheSurvivesAReopen() {
+    database.command("sql", "CREATE DOCUMENT TYPE A4");
+    database.command("sql", "CREATE DOCUMENT TYPE B4 EXTENDS A4");
+    database.command("sql", "CREATE DOCUMENT TYPE C4 EXTENDS B4");
+    database.transaction(() -> database.command("sql", "INSERT INTO C4 SET n = 1"));
+
+    database.getSchema().getType("B4").removeSuperType("A4");
+    assertThat(count("A4")).isZero();
+
+    reopenDatabase();
+    assertThat(count("A4")).isZero();
+    assertThat(count("B4")).isEqualTo(1);
+  }
+
+  private long count(final String typeName) {
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM " + typeName)) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue6935RemoveSuperTypeGrandchildTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6935RemoveSuperTypeGrandchildTest.java
@@ -113,9 +113,10 @@ class Issue6935RemoveSuperTypeGrandchildTest extends TestHelper {
     assertThat(count("B4")).isEqualTo(1);
   }
 
+  /** Enumerates the rows a polymorphic scan of the type returns, so the assertion sees the bucket list and not a counter. */
   private long count(final String typeName) {
-    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM " + typeName)) {
-      return ((Number) rs.next().getProperty("c")).longValue();
+    try (final ResultSet rs = database.query("sql", "SELECT FROM " + typeName)) {
+      return rs.stream().count();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/serializer/Issue6997BinaryComparatorUtf8OrderTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue6997BinaryComparatorUtf8OrderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.serializer;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6997: {@link BinaryComparator#compare(Object, byte, Object, byte)} ordered two STRINGs by
+ * UTF-16 code units ({@code String.compareTo}) while the LSM pages, {@code lookupInPage} and the sibling
+ * {@link BinaryComparator#compareTo(Object, Object)} order them by unsigned UTF-8 bytes. The two orders disagree for any
+ * pair of a non-BMP character (a surrogate pair, {@code 0xD800-0xDBFF} lead unit, {@code 0xF0-0xF4} lead byte) and a
+ * BMP character above {@code U+E000}, so an indexed range scan whose stop bound sits on the wrong side of the disagreement
+ * stopped before emitting anything.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6997BinaryComparatorUtf8OrderTest extends TestHelper {
+
+  /** U+FF21 FULLWIDTH LATIN CAPITAL LETTER A: one UTF-16 unit above every surrogate, three UTF-8 bytes. */
+  private static final String FULLWIDTH_A = "Ａ";
+  /** U+1F600 GRINNING FACE: a surrogate pair in UTF-16, four UTF-8 bytes. */
+  private static final String EMOJI       = new String(Character.toChars(0x1F600));
+
+  @Test
+  void bothEntryPointsAgreeWithTheUtf8ByteOrder() {
+    final BinaryComparator comparator = new BinaryComparator();
+
+    // THE PREMISE: THE TWO ORDERS REALLY DISAGREE ON THIS PAIR
+    assertThat(FULLWIDTH_A.compareTo(EMOJI)).isGreaterThan(0);
+    assertThat(BinaryComparator.compareTo(FULLWIDTH_A, EMOJI)).isLessThan(0);
+
+    assertThat(comparator.compare(FULLWIDTH_A, BinaryTypes.TYPE_STRING, EMOJI, BinaryTypes.TYPE_STRING))
+        .as("compare() must order two STRINGs the way the pages do: unsigned UTF-8 bytes").isLessThan(0);
+    assertThat(comparator.compare(EMOJI, BinaryTypes.TYPE_STRING, FULLWIDTH_A, BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    assertThat(comparator.compare(EMOJI, BinaryTypes.TYPE_STRING, EMOJI, BinaryTypes.TYPE_STRING)).isZero();
+
+    // THE ORDERS AGREE ON EVERYTHING ELSE, AND SO MUST THE FIX
+    assertThat(comparator.compare("2", BinaryTypes.TYPE_STRING, "10", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    assertThat(comparator.compare("abc", BinaryTypes.TYPE_STRING, "abd", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare("ab", BinaryTypes.TYPE_STRING, "abc", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare("abc", BinaryTypes.TYPE_STRING, "ab", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    assertThat(comparator.compare("", BinaryTypes.TYPE_STRING, "", BinaryTypes.TYPE_STRING)).isZero();
+    assertThat(comparator.compare("é", BinaryTypes.TYPE_STRING, "z", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    assertThat(comparator.compare("", BinaryTypes.TYPE_STRING, "퟿", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    // A NON-STRING type2 STILL FALLS BACK TO ITS toString() FORM
+    assertThat(comparator.compare("#1:0", BinaryTypes.TYPE_STRING, "#1:0", BinaryTypes.TYPE_COMPRESSED_RID)).isZero();
+  }
+
+  @Test
+  void indexedRangeScanOverABmpAndANonBmpKeyReturnsBothRows() {
+    final DocumentType type = database.getSchema().createDocumentType("S");
+    type.createProperty("k", Type.STRING);
+    type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "k");
+
+    database.transaction(() -> {
+      database.newDocument("S").set("k", FULLWIDTH_A).save();
+      database.newDocument("S").set("k", EMOJI).save();
+    });
+
+    assertThat(keys("SELECT k FROM S", Map.of())).hasSize(2);
+
+    assertThat(keys("SELECT k FROM S WHERE k <= :bound", Map.of("bound", EMOJI)))
+        .as("both keys sort at or below the emoji in UTF-8 order").containsExactlyInAnyOrder(FULLWIDTH_A, EMOJI);
+    assertThat(keys("SELECT k FROM S WHERE k >= :bound", Map.of("bound", FULLWIDTH_A)))
+        .containsExactlyInAnyOrder(FULLWIDTH_A, EMOJI);
+    assertThat(keys("SELECT k FROM S WHERE k < :bound", Map.of("bound", EMOJI))).containsExactly(FULLWIDTH_A);
+    assertThat(keys("SELECT k FROM S WHERE k > :bound", Map.of("bound", FULLWIDTH_A))).containsExactly(EMOJI);
+    assertThat(keys("SELECT k FROM S WHERE k BETWEEN :from AND :to", Map.of("from", FULLWIDTH_A, "to", EMOJI)))
+        .containsExactlyInAnyOrder(FULLWIDTH_A, EMOJI);
+    assertThat(keys("SELECT k FROM S WHERE k > :bound", Map.of("bound", EMOJI))).isEmpty();
+  }
+
+  private List<String> keys(final String query, final Map<String, Object> params) {
+    final List<String> keys = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query, params)) {
+      while (rs.hasNext())
+        keys.add(rs.next().getProperty("k"));
+    }
+    return keys;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/serializer/Issue6997BinaryComparatorUtf8OrderTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue6997BinaryComparatorUtf8OrderTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +72,36 @@ class Issue6997BinaryComparatorUtf8OrderTest extends TestHelper {
     assertThat(comparator.compare("", BinaryTypes.TYPE_STRING, "퟿", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
     // A NON-STRING type2 STILL FALLS BACK TO ITS toString() FORM
     assertThat(comparator.compare("#1:0", BinaryTypes.TYPE_STRING, "#1:0", BinaryTypes.TYPE_COMPRESSED_RID)).isZero();
+  }
+
+  /**
+   * An isolated surrogate has no code point, so the encoder writes a replacement byte for it and the UTF-16-as-UTF-8
+   * remap no longer describes what the pages hold. Every shape of malformed input must still agree with the encoded
+   * order, which is the order the pages use.
+   */
+  @Test
+  void isolatedSurrogatesFollowTheEncodedOrder() {
+    final String loneHigh = "\uD800";
+    final String loneLow = "\uDC00";
+    final String nonCharacter = "\uFFFE";
+    final String[] samples = { loneHigh, loneLow, nonCharacter, EMOJI, FULLWIDTH_A, "a", "", "a" + loneHigh, loneHigh + "a",
+        loneLow + "a", "a" + loneLow, EMOJI + "a", "a" + EMOJI, loneHigh + EMOJI, EMOJI + loneHigh, loneHigh + loneHigh,
+        loneHigh + nonCharacter, "\uD800\uD800\uDC00", "\uD800\uDC00\uDC00" };
+
+    for (final String a : samples)
+      for (final String b : samples) {
+        final int expected = Integer.signum(BinaryComparator.compareBytes(a.getBytes(StandardCharsets.UTF_8),
+            b.getBytes(StandardCharsets.UTF_8)));
+        assertThat(Integer.signum(BinaryComparator.compareStrings(a, b)))
+            .as("'%s' vs '%s' must follow the unsigned UTF-8 order of the encodings", escape(a), escape(b)).isEqualTo(expected);
+      }
+  }
+
+  private static String escape(final String s) {
+    final StringBuilder out = new StringBuilder();
+    for (final char c : s.toCharArray())
+      out.append(c < 0x80 ? String.valueOf(c) : String.format("\\u%04X", (int) c));
+    return out.toString();
   }
 
   @Test

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -218,6 +218,24 @@ public class SourceDiscovery {
     return stream;
   }
 
+  /**
+   * Records a separator detected by sniffing the source content, unless the user already supplied a delimiter: a guess
+   * never overrides an explicit choice. The one place every detection site goes through, so a new site cannot fall
+   * back to the unconditional write that overwrote the user's {@code -delimiter} / {@code WITH delimiter = ...} whenever
+   * the file extension did not short-circuit detection (issue #6946, the sibling of #6811). A discarded guess is logged
+   * so the "best separator candidate" line just above it does not read as authoritative.
+   */
+  static void applyDetectedDelimiter(final ImporterSettings settings, final char detected) {
+    final Object userDelimiter = settings.options.get("delimiter");
+    if (userDelimiter != null) {
+      if (!userDelimiter.toString().equals(String.valueOf(detected)))
+        LogManager.instance().log(SourceDiscovery.class, Level.INFO,
+            "Detected separator '%s' discarded: using the delimiter '%s' explicitly set by the user", detected, userDelimiter);
+      return;
+    }
+    settings.options.put("delimiter", String.valueOf(detected));
+  }
+
   private FormatImporter analyzeSourceContent(final Parser parser, final AnalyzedEntity.EntityType entityType,
       final ImporterSettings settings,
       final ConsoleLogger logger) throws IOException {
@@ -258,12 +276,15 @@ public class SourceDiscovery {
       throw new IllegalArgumentException("entityType '" + entityType + "' not supported");
     }
 
+    // THE USER'S DELIMITER IS SETTLED HERE, ONCE, BEFORE ANY DETECTION RUNS: THE PER-ENTITY DELIMITER IS AN OVERRIDE
+    // OF THE GENERIC `delimiter` OPTION, NOT A MANDATORY VALUE, SO AN ABSENT ONE LEAVES THE OPTION ALONE (CLOBBERING IT
+    // WITH NULL MADE EVERY NON-COMMA CSV UNIMPORTABLE, ISSUE #6811). FROM HERE ON `settings.options` HOLDS THE USER'S
+    // CHOICE, WHICH EVERY DETECTED SEPARATOR BELOW HAS TO YIELD TO THROUGH applyDetectedDelimiter() (ISSUE #6946)
+    if (knownDelimiter != null)
+      settings.options.put("delimiter", knownDelimiter);
+
     if (knownFileType != null) {
       if ("csv".equalsIgnoreCase(knownFileType)) {
-        // NEVER OVERWRITE THE USER'S `delimiter` OPTION WITH NULL: THE PER-ENTITY DELIMITER IS AN OVERRIDE, NOT A
-        // MANDATORY VALUE, AND CLOBBERING IT MADE EVERY NON-COMMA CSV UNIMPORTABLE (ISSUE #6811)
-        if (knownDelimiter != null)
-          settings.options.put("delimiter", knownDelimiter);
         return new CSVImporterFormat();
       } else if ("json".equalsIgnoreCase(knownFileType)) {
         return new JSONImporterFormat();
@@ -353,7 +374,10 @@ public class SourceDiscovery {
 
         final Map.Entry<Character, AtomicInteger> bestSeparator = list.getFirst();
 
-        if (bestSeparator.getKey() == ' ') {
+        // A DELIMITER THE USER SUPPLIED SETTLES THE QUESTION THE SNIFFING IS ASKING: THE FILE IS DELIMITED TEXT WITH
+        // THAT DELIMITER, SO THE SPACE-SEPARATED VECTOR FORMATS ARE NOT A CANDIDATE HOWEVER MANY SPACES THE FIRST LINE
+        // CARRIES INSIDE ITS VALUES (ISSUE #6946)
+        if (bestSeparator.getKey() == ' ' && settings.options.get("delimiter") == null) {
           // CHECK IF IS A VECTOR EMBEDDING TEXT FILE
           final StringBuilder line2 = new StringBuilder();
           while (parser.isAvailable() && parser.nextChar() != '\n')
@@ -371,7 +395,7 @@ public class SourceDiscovery {
         if (format == null) {
           LogManager.instance()
               .log(this, Level.INFO, "Best separator candidate='%s' (all candidates=%s)", bestSeparator.getKey(), list);
-          settings.options.put("delimiter", "" + bestSeparator.getKey());
+          applyDetectedDelimiter(settings, bestSeparator.getKey());
           format = new CSVImporterFormat();
         }
       }
@@ -448,7 +472,7 @@ public class SourceDiscovery {
         if (allDelimitersAreTheSame) {
           // RDF
           settings.typeIdProperty = "id";
-          settings.options.put("delimiter", "" + delimiters.getFirst());
+          applyDetectedDelimiter(settings, delimiters.getFirst());
           return new RDFImporterFormat();
         }
       }

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -219,21 +219,19 @@ public class SourceDiscovery {
   }
 
   /**
-   * Records a separator detected by sniffing the source content, unless the user already supplied a delimiter: a guess
-   * never overrides an explicit choice. The one place every detection site goes through, so a new site cannot fall
-   * back to the unconditional write that overwrote the user's {@code -delimiter} / {@code WITH delimiter = ...} whenever
-   * the file extension did not short-circuit detection (issue #6946, the sibling of #6811). A discarded guess is logged
-   * so the "best separator candidate" line just above it does not read as authoritative.
+   * The delimiter a CSV source is parsed with when content sniffing found {@code detected}: the user's own delimiter when
+   * there is one, the guess otherwise. A guess never overrides an explicit choice - that is what overwrote the user's
+   * {@code -delimiter} / {@code WITH delimiter = ...} whenever the file extension did not short-circuit detection (issue
+   * #6946, the sibling of #6811) - and a discarded guess is logged so the "best separator candidate" line just above it
+   * does not read as authoritative.
    */
-  static void applyDetectedDelimiter(final ImporterSettings settings, final char detected) {
-    final Object userDelimiter = settings.options.get("delimiter");
-    if (userDelimiter != null) {
-      if (!userDelimiter.toString().equals(String.valueOf(detected)))
-        LogManager.instance().log(SourceDiscovery.class, Level.INFO,
-            "Detected separator '%s' discarded: using the delimiter '%s' explicitly set by the user", detected, userDelimiter);
-      return;
-    }
-    settings.options.put("delimiter", String.valueOf(detected));
+  static String resolveDelimiter(final String userDelimiter, final char detected) {
+    if (userDelimiter == null)
+      return String.valueOf(detected);
+    if (!userDelimiter.equals(String.valueOf(detected)))
+      LogManager.instance().log(SourceDiscovery.class, Level.INFO,
+          "Detected separator '%s' discarded: using the delimiter '%s' explicitly set by the user", detected, userDelimiter);
+    return userDelimiter;
   }
 
   private FormatImporter analyzeSourceContent(final Parser parser, final AnalyzedEntity.EntityType entityType,
@@ -276,16 +274,16 @@ public class SourceDiscovery {
       throw new IllegalArgumentException("entityType '" + entityType + "' not supported");
     }
 
-    // THE USER'S DELIMITER IS SETTLED HERE, ONCE, BEFORE ANY DETECTION RUNS: THE PER-ENTITY DELIMITER IS AN OVERRIDE
-    // OF THE GENERIC `delimiter` OPTION, NOT A MANDATORY VALUE, SO AN ABSENT ONE LEAVES THE OPTION ALONE (CLOBBERING IT
-    // WITH NULL MADE EVERY NON-COMMA CSV UNIMPORTABLE, ISSUE #6811). FROM HERE ON `settings.options` HOLDS THE USER'S
-    // CHOICE, WHICH EVERY DETECTED SEPARATOR BELOW HAS TO YIELD TO THROUGH applyDetectedDelimiter() (ISSUE #6946)
-    if (knownDelimiter != null)
-      settings.options.put("delimiter", knownDelimiter);
+    // THE USER'S DELIMITER FOR THIS ENTITY, RESOLVED ONCE AND KEPT LOCAL: THE PER-ENTITY OVERRIDE FIRST, THEN THE GENERIC
+    // `delimiter` OPTION (-delimiter / IMPORT DATABASE ... WITH delimiter = ';'). AN ABSENT PER-ENTITY DELIMITER IS NOT A
+    // VALUE (CLOBBERING THE OPTION WITH NULL MADE EVERY NON-COMMA CSV UNIMPORTABLE, ISSUE #6811). IT IS HANDED TO THE
+    // FORMAT RATHER THAN WRITTEN INTO settings.options, WHICH ONE IMPORT SHARES ACROSS ITS DOCUMENTS, VERTICES AND EDGES
+    // FILES: A DELIMITER SETTLED OR DETECTED FOR ONE OF THEM MUST NOT STAND IN FOR THE NEXT ONE'S (ISSUE #6946)
+    final String userDelimiter = knownDelimiter != null ? knownDelimiter : settings.getValue("delimiter", null);
 
     if (knownFileType != null) {
       if ("csv".equalsIgnoreCase(knownFileType)) {
-        return new CSVImporterFormat();
+        return new CSVImporterFormat(userDelimiter);
       } else if ("json".equalsIgnoreCase(knownFileType)) {
         return new JSONImporterFormat();
       } else if ("jsonl".equalsIgnoreCase(knownFileType)) {
@@ -326,6 +324,18 @@ public class SourceDiscovery {
     if (format != null)
       return format;
 
+    return analyzeText(parser, settings, logger, userDelimiter);
+  }
+
+  /**
+   * The content sniffing that follows {@link #analyzeChar}: comments are skipped, then the first line is read for a
+   * separator to decide between the delimited-text formats.
+   *
+   * @param userDelimiter the delimiter the user supplied for this entity, or null - a detected one yields to it
+   */
+  private FormatImporter analyzeText(final Parser parser, final ImporterSettings settings, final ConsoleLogger logger,
+      final String userDelimiter) throws IOException {
+    FormatImporter format = null;
     parser.mark();
 
     // SKIP COMMENTS '#' IF ANY
@@ -377,7 +387,7 @@ public class SourceDiscovery {
         // A DELIMITER THE USER SUPPLIED SETTLES THE QUESTION THE SNIFFING IS ASKING: THE FILE IS DELIMITED TEXT WITH
         // THAT DELIMITER, SO THE SPACE-SEPARATED VECTOR FORMATS ARE NOT A CANDIDATE HOWEVER MANY SPACES THE FIRST LINE
         // CARRIES INSIDE ITS VALUES (ISSUE #6946)
-        if (bestSeparator.getKey() == ' ' && settings.options.get("delimiter") == null) {
+        if (bestSeparator.getKey() == ' ' && userDelimiter == null) {
           // CHECK IF IS A VECTOR EMBEDDING TEXT FILE
           final StringBuilder line2 = new StringBuilder();
           while (parser.isAvailable() && parser.nextChar() != '\n')
@@ -395,8 +405,7 @@ public class SourceDiscovery {
         if (format == null) {
           LogManager.instance()
               .log(this, Level.INFO, "Best separator candidate='%s' (all candidates=%s)", bestSeparator.getKey(), list);
-          applyDetectedDelimiter(settings, bestSeparator.getKey());
-          format = new CSVImporterFormat();
+          format = new CSVImporterFormat(resolveDelimiter(userDelimiter, bestSeparator.getKey()));
         }
       }
 
@@ -470,9 +479,9 @@ public class SourceDiscovery {
         }
 
         if (allDelimitersAreTheSame) {
-          // RDF
+          // RDF. THE DELIMITER FOUND HERE USED TO BE WRITTEN INTO settings.options ALTHOUGH THE RDF IMPORTER NEVER READS IT,
+          // WHERE IT LEAKED INTO THE NEXT CSV ENTITY OF THE SAME IMPORT (ISSUE #6946)
           settings.typeIdProperty = "id";
-          applyDetectedDelimiter(settings, delimiters.getFirst());
           return new RDFImporterFormat();
         }
       }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -65,6 +65,27 @@ import java.util.logging.Level;
  * transaction-ownership contract this and {@code JSONImporterFormat} both satisfy, by different means.
  */
 public class CSVImporterFormat extends AbstractImporterFormat {
+  /**
+   * The delimiter resolved for the entity this format was created for - the user's own, else the one content sniffing
+   * found - or null when the format was created without one, in which case the generic {@code delimiter} option and
+   * then a comma apply. Carried here rather than read back from {@code settings.options}: that map is shared by every
+   * entity of one import, so a delimiter written there for the documents file stood in for the vertices file's own
+   * (issue #6946).
+   */
+  private final String delimiter;
+
+  public CSVImporterFormat() {
+    this(null);
+  }
+
+  public CSVImporterFormat(final String delimiter) {
+    this.delimiter = delimiter;
+  }
+
+  private String delimiterFor(final ImporterSettings settings) {
+    return delimiter != null ? delimiter : settings.getValue("delimiter", ",");
+  }
+
   private static final Object[] NO_PARAMS = new Object[] {};
   public static final  int      _32MB     = 32 * 1024 * 1024;
 
@@ -702,7 +723,7 @@ public class CSVImporterFormat extends AbstractImporterFormat {
       final AnalyzedSchema analyzedSchema) throws IOException {
     parser.reset();
 
-    final String delimiter = settings.getValue("delimiter", ",");
+    final String delimiter = delimiterFor(settings);
 
     final CsvParserSettings csvParserSettings;
     final TsvParserSettings tsvParserSettings;
@@ -834,9 +855,7 @@ public class CSVImporterFormat extends AbstractImporterFormat {
   }
 
   protected AbstractParser createCSVParser(final ImporterSettings settings) {
-    String delimiter = ",";
-    if (settings.options.containsKey("delimiter"))
-      delimiter = settings.getValue("delimiter", ",");
+    final String delimiter = delimiterFor(settings);
 
     if ("\t".equals(delimiter) || "\\t".equals(delimiter)) {
       final TsvParserSettings tsvParserSettings = new TsvParserSettings();

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6946AutoDetectDelimiterOptionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6946AutoDetectDelimiterOptionTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.integration.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6946, the sibling of #6811: when the source file carries no known extension the format is
+ * sniffed from its content, and the sniffed separator was written over the delimiter the user had explicitly supplied.
+ * The file below is exactly the shape that makes someone choose ';': its values carry commas, so the sniffer's best
+ * candidate is ',' and the whole line came back as one column.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6946AutoDetectDelimiterOptionTest {
+
+  @Test
+  void theUserDelimiterWinsOverTheSniffedOneWithSql() throws IOException {
+    final String databasePath = "target/databases/test-import-6946-sql";
+    final File file = writeFile("importer-6946-sql.txt");
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + file.getAbsolutePath() + " WITH delimiter = ';'");
+      assertImportedColumns(db);
+    } finally {
+      db.drop();
+      file.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  @Test
+  void theUserDelimiterWinsOverTheSniffedOneOnTheCommandLine() throws Exception {
+    final String databasePath = "target/databases/test-import-6946-cli";
+    final File file = writeFile("importer-6946-cli.txt");
+
+    try {
+      new Importer(new String[] { "-url", "file://" + file.getAbsolutePath(), "-database", databasePath, "-forceDatabaseCreate",
+          "true", "-delimiter", ";" }).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertImportedColumns(db);
+      }
+    } finally {
+      final DatabaseFactory factory = new DatabaseFactory(databasePath);
+      if (factory.exists())
+        factory.open().drop();
+      file.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * Guard against over-fixing: with nothing supplied by the user the sniffed separator is still what drives the import.
+   */
+  @Test
+  void theSniffedDelimiterStillAppliesWhenTheUserSuppliedNone() throws IOException {
+    final String databasePath = "target/databases/test-import-6946-sniffed";
+    final File file = new File("target/importer-6946-sniffed.txt");
+    file.getParentFile().mkdirs();
+    try (final FileWriter writer = new FileWriter(file)) {
+      writer.write("id|name|age\n");
+      writer.write("1|Alice|30\n");
+      writer.write("2|Bob|25\n");
+    }
+
+    final DatabaseFactory databaseFactory = new DatabaseFactory(databasePath);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      db.command("sql", "IMPORT DATABASE file://" + file.getAbsolutePath());
+      assertThat(db.countType("Document", true)).isEqualTo(2);
+      final Document first = db.iterateType("Document", true).next().asDocument(true);
+      assertThat(first.getPropertyNames()).contains("id", "name", "age");
+    } finally {
+      db.drop();
+      file.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  private static void assertImportedColumns(final Database db) {
+    assertThat(db.countType("Document", true)).isEqualTo(2);
+
+    final Document first = db.iterateType("Document", true).next().asDocument(true);
+    assertThat(first.getPropertyNames()).contains("id", "last,first,middle,suffix", "age");
+    // BEFORE THE FIX THE SNIFFER PICKED ',' (4 COMMAS AGAINST 2 SEMICOLONS ON THE FIRST LINE) OVER THE USER'S ';'
+    assertThat(first.getPropertyNames()).doesNotContain("id;last");
+  }
+
+  private static File writeFile(final String fileName) throws IOException {
+    final File file = new File("target/" + fileName);
+    file.getParentFile().mkdirs();
+    try (final FileWriter writer = new FileWriter(file)) {
+      writer.write("id;last,first,middle,suffix;age\n");
+      writer.write("1;Doe, John, Q, Jr;30\n");
+      writer.write("2;Roe, Jane, R, Sr;25\n");
+    }
+    return file;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6946AutoDetectDelimiterOptionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6946AutoDetectDelimiterOptionTest.java
@@ -82,6 +82,45 @@ class Issue6946AutoDetectDelimiterOptionTest {
   }
 
   /**
+   * One import walks its documents, vertices and edges files against one shared settings instance. A delimiter settled
+   * for the documents file (explicit ';') must not stand in for the vertices file, which supplies none and has to be
+   * sniffed on its own ('|'): the delimiter is resolved per entity and handed to the format, never parked in the shared
+   * options map.
+   */
+  @Test
+  void aDelimiterSettledForOneEntityDoesNotLeakIntoTheNext() throws Exception {
+    final String databasePath = "target/databases/test-import-6946-entities";
+    final File documents = writeFile("importer-6946-documents.txt");
+    final File vertices = new File("target/importer-6946-vertices.txt");
+    try (final FileWriter writer = new FileWriter(vertices)) {
+      writer.write("id|label|weight\n");
+      writer.write("1|first|10\n");
+      writer.write("2|second|20\n");
+    }
+
+    try {
+      new Importer(new String[] { "-documents", "file://" + documents.getAbsolutePath(), "-documentsDelimiter", ";", "-vertices",
+          "file://" + vertices.getAbsolutePath(), "-database", databasePath, "-forceDatabaseCreate", "true" }).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertImportedColumns(db);
+
+        assertThat(db.countType("Node", true)).isEqualTo(2);
+        final Document node = db.iterateType("Node", true).next().asDocument(true);
+        assertThat(node.getPropertyNames()).as("the vertices file is parsed with its own, sniffed, separator")
+            .contains("id", "label", "weight").doesNotContain("id|label|weight");
+      }
+    } finally {
+      final DatabaseFactory factory = new DatabaseFactory(databasePath);
+      if (factory.exists())
+        factory.open().drop();
+      documents.delete();
+      vertices.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
    * Guard against over-fixing: with nothing supplied by the user the sniffed separator is still what drives the import.
    */
   @Test

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6946AutoDetectDelimiterOptionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6946AutoDetectDelimiterOptionTest.java
@@ -121,6 +121,50 @@ class Issue6946AutoDetectDelimiterOptionTest {
   }
 
   /**
+   * The same leak with nothing explicit at all: a separator sniffed for the documents file (',') must not be mistaken for
+   * a user choice when the vertices file ('|') is sniffed next.
+   */
+  @Test
+  void aDelimiterSniffedForOneEntityDoesNotLeakIntoTheNext() throws Exception {
+    final String databasePath = "target/databases/test-import-6946-sniffed-entities";
+    final File documents = new File("target/importer-6946-sniffed-documents.txt");
+    try (final FileWriter writer = new FileWriter(documents)) {
+      writer.write("id,name,age\n");
+      writer.write("1,Alice,30\n");
+      writer.write("2,Bob,25\n");
+    }
+    final File vertices = new File("target/importer-6946-sniffed-vertices.txt");
+    try (final FileWriter writer = new FileWriter(vertices)) {
+      writer.write("id|label|weight\n");
+      writer.write("1|first|10\n");
+      writer.write("2|second|20\n");
+    }
+
+    try {
+      new Importer(new String[] { "-documents", "file://" + documents.getAbsolutePath(), "-vertices",
+          "file://" + vertices.getAbsolutePath(), "-database", databasePath, "-forceDatabaseCreate", "true" }).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.countType("Document", true)).isEqualTo(2);
+        final Document document = db.iterateType("Document", true).next().asDocument(true);
+        assertThat(document.getPropertyNames()).contains("id", "name", "age");
+
+        assertThat(db.countType("Node", true)).isEqualTo(2);
+        final Document node = db.iterateType("Node", true).next().asDocument(true);
+        assertThat(node.getPropertyNames()).as("the vertices file is sniffed on its own, not parsed with the documents' ','")
+            .contains("id", "label", "weight").doesNotContain("id|label|weight");
+      }
+    } finally {
+      final DatabaseFactory factory = new DatabaseFactory(databasePath);
+      if (factory.exists())
+        factory.open().drop();
+      documents.delete();
+      vertices.delete();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
    * Guard against over-fixing: with nothing supplied by the user the sniffed separator is still what drives the import.
    */
   @Test


### PR DESCRIPTION
Fixes #7000, fixes #6999, fixes #6997, fixes #6946, fixes #6935.

Five small defects with one shape in common: a read path deriving a key, an order or a setting independently of the write path that produced it.

### #7000 - full-text field qualifiers and normalization
- A field-qualified **phrase** looked its terms up by bare text and matched across every indexed property. Every collector now builds its key through `buildSearchKey`/`fieldPrefix`.
- A qualifier on a multi-property index never met the modifier-qualified prefix `put()` stores for a **BY ITEM** property. `storedFieldFor` moved next to `isUnqualified` in `FullTextQueryExecutor` and is consulted by both query paths, so the executor resolves `keywords:` to `keywords by item:` the way the direct `get()` path already did.
- Wildcard/prefix/fuzzy/regexp terms were unconditionally lower-cased. They are now normalized through the analyzer itself (`Analyzer.normalize`), so a `WhitespaceAnalyzer` index answers `Fo*` and the standard analyzer keeps folding.

### #6999 - MATCH NOT patterns lost on re-render
`MatchStatement.toString()` now renders the negative patterns after the positive ones. The round-trip test exposed a second defect: the AST builder indexed the sparse list of NOT tokens by pattern position (`ctx.NOT(i - 1)`), so `MATCH {..}, NOT {..}, {..}` negated the wrong pattern. Both builder sites now walk the parse tree in order.

### #6997 - STRING order UTF-16 vs UTF-8
`compare()` and the static `compareTo()` share a new `compareStrings()`: an allocation-free comparison that sorts UTF-16 as UTF-8 by remapping the surrogate block at the first differing unit. This is preferred over the suggested `getBytes()` on both sides because the index cursor pays this comparison once per key while walking a range.

### #6946 - importer delimiter override on the sniffing path
The user's delimiter (per-entity first, then the generic option) is settled once before any detection; every detected separator goes through `applyDetectedDelimiter()`, which yields to it and logs the discarded guess. With a user delimiter, the space-separated vector formats are no longer a candidate either.

### #6935 - super type unlink
Rather than subtracting the subtree (wrong for a diamond, where a bucket is still reachable through another path), unlinking rebuilds the former super type's polymorphic caches from the surviving links, up the tree. `removeSuperType` and the rollback path of `addSuperType` share the helper.

### Tests
- `Issue7000FieldQualifiedFullTextTest` (phrase, BY ITEM, WhitespaceAnalyzer, default-analyzer guard)
- `Issue6999MatchStatementNotPatternToStringTest` (render, builder assignment, execution parity)
- `Issue6997BinaryComparatorUtf8OrderTest` (both entry points, indexed range scan)
- `Issue6935RemoveSuperTypeGrandchildTest` (grandchild, diamond, reopen)
- `Issue6946AutoDetectDelimiterOptionTest` (SQL, CLI, sniffed default still applies)

All red before the fix. Related lanes run green: full-text, serializer, schema, SQL parser, MATCH execution, LSM index, importer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved field-qualified full-text searches across term, phrase, prefix, wildcard, fuzzy, and regexp queries.
  - Preserved analyzer-specific normalization, field restrictions, and boosts.
  - Corrected `MATCH ... NOT` parsing and statement round-tripping.
  - Fixed schema inheritance cache updates, including complex inheritance graphs.
  - Corrected UTF-8 string ordering and indexed range-query behavior.
  - Preserved explicitly configured import delimiters during automatic detection and prevented settings from leaking between imports.

- **Tests**
  - Added regression coverage for full-text search, MATCH queries, inheritance, string ordering, and delimiter detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->