### PR TITLE
fix(#6934,#7084,#7036,#7034,#7033): composite BY ITEM index update, CONTAINSANY array rhs, GraphQL introspection aliases, Postgres portal row cap, volatile bucket lists

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2161,14 +2161,15 @@ public enum GlobalConfiguration {
       "Maximum size in bytes accepted for a single bind-message parameter value on the Postgres wire protocol. Values declaring a larger size are rejected before allocation. Default is 16MB",
       Integer.class, 16 * 1024 * 1024),
 
-  POSTGRES_SIMPLE_QUERY_MAX_ROWS("arcadedb.postgres.simpleQueryMaxRows", SCOPE.SERVER, """
-      Maximum number of rows a simple-query protocol ('Q' message) SELECT is allowed to buffer server-side before \
-      the first row is sent. Unlike the extended query protocol, the simple-query protocol has no client-driven \
-      cursor/max-rows mechanism and always expects the complete result set in one response, so the server has to \
-      hold it in memory to determine the row description (column set and types) before streaming it. A SELECT whose \
-      result exceeds this limit is refused with an error instead of risking an OutOfMemoryError; the client should \
-      use the extended query protocol with a bounded portal fetch size for very large result sets. Default is \
-      1000000""", Integer.class, 1_000_000),
+  POSTGRES_QUERY_MAX_ROWS("arcadedb.postgres.queryMaxRows", SCOPE.SERVER, """
+      Maximum number of rows the result of one statement is allowed to occupy server-side before the first row is \
+      sent to a Postgres wire protocol client, on the simple-query ('Q') and the extended-query (Parse/Bind/\
+      Describe/Execute) protocol alike. Postgres fixes the column set in the RowDescription that precedes every \
+      DataRow, and a schemaless document can carry a property no earlier row had, so the server has to see the \
+      whole result before it can announce it: on the extended protocol the portal's row limit bounds what each \
+      Execute sends, not what the server holds. A statement whose result exceeds this limit is refused with an \
+      error instead of risking an OutOfMemoryError; narrow it with a WHERE or LIMIT clause or raise the limit. \
+      0 means unlimited. Default is 1000000""", Integer.class, 1_000_000),
 
   // BOLT (Neo4j)
   BOLT_PORT("arcadedb.bolt.port", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 public class DocumentIndexer {
   private final LocalDatabase database;
@@ -482,7 +481,43 @@ public class DocumentIndexer {
       final Document modifiedRecord, final String[] propertyNames, final KeyExpansion[] expansions) {
     final List<Object[]> oldTuples = buildMultiListItemTuples(originalRecord, propertyNames, expansions);
     final List<Object[]> newTuples = buildMultiListItemTuples(modifiedRecord, propertyNames, expansions);
+    return applyTupleDelta(index, rid, oldTuples, newTuples);
+  }
 
+  /**
+   * Updates an index with a single collection modifier ({@code BY ITEM}, {@code BY KEY} or {@code BY VALUE}) by diffing the
+   * complete key tuples the write path would produce for the original and the modified record. Diffing whole tuples rather than
+   * the collection's element membership is what keeps the non-expanded sibling properties of the same composite key honest: a
+   * change to a scalar sibling alone changes every tuple, so every stale entry is removed and re-added under the new key
+   * (issue #6934). The tuples are produced by the same builders used at insert time, so update and insert cannot disagree on
+   * the key shape.
+   *
+   * @return {@code true} if at least one index entry was removed or added.
+   */
+  private boolean updateExpandedKeysInIndex(final Index index, final RID rid, final Document originalRecord,
+      final Document modifiedRecord, final String[] propertyNames, final int expansionIndex, final KeyExpansion expansion) {
+    final List<Object[]> oldTuples = collectExpandedKeys(originalRecord, propertyNames, expansionIndex, expansion);
+    final List<Object[]> newTuples = collectExpandedKeys(modifiedRecord, propertyNames, expansionIndex, expansion);
+    return applyTupleDelta(index, rid, oldTuples, newTuples);
+  }
+
+  private List<Object[]> collectExpandedKeys(final Document record, final String[] propertyNames, final int expansionIndex,
+      final KeyExpansion expansion) {
+    final List<Object[]> tuples = new ArrayList<>();
+    if (expansion == KeyExpansion.LIST_ITEM)
+      forEachListItemKey(record, propertyNames, expansionIndex, tuples::add);
+    else
+      forEachMapEntryKey(record, propertyNames, expansionIndex, expansion, tuples::add);
+    return tuples;
+  }
+
+  /**
+   * Removes the tuples no longer produced by the record and adds the ones that are new, leaving unchanged tuples untouched.
+   *
+   * @return {@code true} if at least one index entry was removed or added.
+   */
+  private static boolean applyTupleDelta(final Index index, final RID rid, final List<Object[]> oldTuples,
+      final List<Object[]> newTuples) {
     boolean changed = false;
     for (final Object[] oldTuple : oldTuples) {
       if (!containsTuple(newTuples, oldTuple)) {
@@ -636,12 +671,10 @@ public class DocumentIndexer {
         index.remove(oldKeyValues, rid);
         index.put(newKeyValues, new RID[] { rid });
         anyIndexModified = true;
-      } else if (expansion == KeyExpansion.LIST_ITEM) {
-        // List update logic - compute delta
-        anyIndexModified |= updateListItemsInIndex(index, rid, originalRecord, modifiedRecord, propertyNamesArray, expansionIndex);
       } else {
-        // Map update logic - compute delta on keys or values
-        anyIndexModified |= updateMapEntriesInIndex(index, rid, originalRecord, modifiedRecord, propertyNamesArray,
+        // Single BY ITEM / BY KEY / BY VALUE modifier: diff the complete key tuples, so a change to a scalar sibling of the
+        // collection property is reflected too (issue #6934)
+        anyIndexModified |= updateExpandedKeysInIndex(index, rid, originalRecord, modifiedRecord, propertyNamesArray,
             expansionIndex, expansion);
       }
     }
@@ -675,161 +708,6 @@ public class DocumentIndexer {
       }
     }
     return new DetachedDocument(modifiedRecord, values);
-  }
-
-  /** @return {@code true} if at least one index entry was removed or added. */
-  private boolean updateMapEntriesInIndex(final Index index, final RID rid, final Document originalRecord,
-      final Document modifiedRecord, final String[] propertyNames, final int mapPropertyIndex, final KeyExpansion expansion) {
-    final Collection<Object> oldElements = mapElements(originalRecord, propertyNames[mapPropertyIndex], expansion);
-    final Collection<Object> newElements = mapElements(modifiedRecord, propertyNames[mapPropertyIndex], expansion);
-
-    boolean changed = false;
-
-    // Remove entries for elements no longer present
-    for (final Object oldElement : oldElements) {
-      if (!newElements.contains(oldElement)) {
-        final Object[] keyValues = new Object[propertyNames.length];
-        for (int i = 0; i < keyValues.length; ++i)
-          keyValues[i] = i == mapPropertyIndex ? oldElement : getPropertyValue(originalRecord, propertyNames[i]);
-        index.remove(keyValues, rid);
-        changed = true;
-      }
-    }
-
-    // Add entries for new elements
-    for (final Object newElement : newElements) {
-      if (!oldElements.contains(newElement)) {
-        final Object[] keyValues = new Object[propertyNames.length];
-        for (int i = 0; i < keyValues.length; ++i)
-          keyValues[i] = i == mapPropertyIndex ? newElement : getPropertyValue(modifiedRecord, propertyNames[i]);
-        index.put(keyValues, new RID[] { rid });
-        changed = true;
-      }
-    }
-
-    return changed;
-  }
-
-  /** @return {@code true} if at least one index entry was removed or added. */
-  private boolean updateListItemsInIndex(final Index index, final RID rid,
-      final Document originalRecord, final Document modifiedRecord,
-      final String[] propertyNames, final int listPropertyIndex) {
-    boolean changed = false;
-    final String propertyName = propertyNames[listPropertyIndex];
-    final String[] pathParts = propertyName.split("\\.");
-    final String listPropertyName = pathParts[0];
-
-    // Get the list values from both records
-    final Object oldListValue = originalRecord.get(listPropertyName);
-    final Object newListValue = modifiedRecord.get(listPropertyName);
-
-    final List<?> oldList = oldListValue instanceof List<?> list ? list : List.of();
-    final List<?> newList = newListValue instanceof List<?> list ? list : List.of();
-
-    // For nested paths, we need to compare the extracted values, not the objects themselves
-    final boolean isNested = pathParts.length > 1;
-
-    if (isNested) {
-      // Build a helper to extract nested values
-      Function<Object, Object> extractValue = item -> {
-        Object value = item;
-        for (int j = 1; j < pathParts.length; j++) {
-          if (value == null)
-            break;
-          if (value instanceof Document doc) {
-            value = doc.get(pathParts[j]);
-          } else if (value instanceof Map<?, ?> map) {
-            value = map.get(pathParts[j]);
-          } else {
-            value = null;
-            break;
-          }
-        }
-        return value;
-      };
-
-      // Collect old and new values
-      final List<Object> oldValues = new ArrayList<>();
-      for (Object item : oldList) {
-        final Object val = extractValue.apply(item);
-        if (val != null)
-          oldValues.add(val);
-      }
-
-      final List<Object> newValues = new ArrayList<>();
-      for (Object item : newList) {
-        final Object val = extractValue.apply(item);
-        if (val != null)
-          newValues.add(val);
-      }
-
-      // Remove entries for values that are no longer in the list
-      for (final Object oldValue : oldValues) {
-        if (!newValues.contains(oldValue)) {
-          final Object[] keyValues = new Object[propertyNames.length];
-          for (int i = 0; i < keyValues.length; ++i) {
-            if (i == listPropertyIndex) {
-              keyValues[i] = oldValue;
-            } else {
-              keyValues[i] = getPropertyValue(originalRecord, propertyNames[i]);
-            }
-          }
-          index.remove(keyValues, rid);
-          changed = true;
-        }
-      }
-
-      // Add entries for new values
-      for (final Object newValue : newValues) {
-        if (!oldValues.contains(newValue)) {
-          final Object[] keyValues = new Object[propertyNames.length];
-          for (int i = 0; i < keyValues.length; ++i) {
-            if (i == listPropertyIndex) {
-              keyValues[i] = newValue;
-            } else {
-              keyValues[i] = getPropertyValue(modifiedRecord, propertyNames[i]);
-            }
-          }
-          index.put(keyValues, new RID[] { rid });
-          changed = true;
-        }
-      }
-    } else {
-      // Simple list items - use direct comparison
-      // Remove entries for items that are no longer in the list
-      for (final Object oldItem : oldList) {
-        if (!newList.contains(oldItem)) {
-          final Object[] keyValues = new Object[propertyNames.length];
-          for (int i = 0; i < keyValues.length; ++i) {
-            if (i == listPropertyIndex) {
-              keyValues[i] = oldItem;
-            } else {
-              keyValues[i] = getPropertyValue(originalRecord, propertyNames[i]);
-            }
-          }
-          index.remove(keyValues, rid);
-          changed = true;
-        }
-      }
-
-      // Add entries for new items
-      for (final Object newItem : newList) {
-        if (!oldList.contains(newItem)) {
-          final Object[] keyValues = new Object[propertyNames.length];
-          for (int i = 0; i < keyValues.length; ++i) {
-            if (i == listPropertyIndex) {
-              keyValues[i] = newItem;
-            } else {
-              keyValues[i] = getPropertyValue(modifiedRecord, propertyNames[i]);
-            }
-          }
-          index.put(keyValues, new RID[] { rid });
-          changed = true;
-        }
-      }
-    }
-
-    return changed;
   }
 
   public void deleteDocument(final Document record) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -2442,10 +2442,12 @@ public class SelectExecutionPlanner {
     for (int i = 0; i < partitionProps.size(); i++)
       partitionPropPositions.put(partitionProps.get(i), i);
 
-    // Cache the bucket list once for the whole derivation. The list is invariant during
-    // planning (schema mutations take the same lock the planner doesn't hold), and the per
-    // AndBlock loop below would otherwise call getBuckets(false) once per block on the planner
-    // hot path.
+    // Cache the bucket list once for the whole derivation, so the per AndBlock loop below does
+    // not call getBuckets(false) once per block on the planner hot path. The planner holds no
+    // schema lock: the list is a copy-on-write snapshot published through a volatile field
+    // (issue #7033), so this read sees a complete list - the one current at this instant - and
+    // the whole derivation works on that same snapshot rather than on whatever a concurrent
+    // ALTER TYPE ... BUCKET publishes halfway through.
     // FQN is intentional: the file's top-level {@code Bucket} import refers to the SQL parser
     // AST node, not the engine type returned here. Using {@code var} would silently rebind to
     // the wrong type if a future edit added an {@code import com.arcadedb.engine.Bucket}.

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAnyCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAnyCondition.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.IndexSearchInfo;
 import com.arcadedb.query.sql.executor.MultiValue;
+import com.arcadedb.query.sql.executor.QueryOperatorEquals;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
@@ -37,20 +38,9 @@ public class ContainsAnyCondition extends BooleanExpression {
   public ContainsAnyCondition() {
   }
 
-  public boolean execute(Object left, Object right) {
-    if (left instanceof Collection<?> collection) {
-      if (right instanceof Iterable<?> iterable)
-        right = iterable.iterator();
-
-      if (right instanceof Iterator<?> iterator) {
-        while (iterator.hasNext()) {
-          final Object next = iterator.next();
-          if (collection.contains(next))
-            return true;
-        }
-      }
-      return collection.contains(right);
-    }
+  public boolean execute(Object left, final Object right) {
+    if (left instanceof Collection<?> leftCollection)
+      return containsAny(leftCollection, right);
 
     if (left instanceof Iterable<?> iterable)
       left = iterable.iterator();
@@ -58,20 +48,48 @@ public class ContainsAnyCondition extends BooleanExpression {
       left = MultiValue.getMultiValueIterator(left);
 
     if (left instanceof Iterator<?> leftIterator) {
-      if (!(right instanceof Iterable))
-        right = Set.of(right);
+      // Collect into a list so it can be re-scanned for every right-hand item: iterating the left operand only once
+      // used to make any right-hand item after the first one invisible once the left iterator was exhausted
+      final List<Object> leftItems = new ArrayList<>();
+      while (leftIterator.hasNext())
+        leftItems.add(leftIterator.next());
+      return containsAny(leftItems, right);
+    }
+    return false;
+  }
 
-      right = ((Iterable<?>) right).iterator();
+  /**
+   * @return {@code true} when at least one item of the right-hand operand is an element of {@code leftCollection}. A
+   *     right-hand array is expanded into its items exactly as a List is (issue #7084): an array satisfies neither
+   *     {@code instanceof Iterable} nor {@code instanceof Iterator}, so it used to be compared as one opaque object
+   *     against the collection and the condition was always false, e.g. {@code tags CONTAINSANY 'a b'.split(' ')}.
+   *     A {@code byte[]} is ArcadeDB's BINARY scalar and stays a single value being searched for, the same carve-out
+   *     {@link ContainsCondition} applies. Items are compared with {@link QueryOperatorEquals} so
+   *     {@code [1,2,3] CONTAINSANY [2L]} answers the same whatever the concrete type of the left operand, as
+   *     {@link ContainsAllCondition} already does.
+   */
+  private static boolean containsAny(final Collection<?> leftCollection, Object right) {
+    if (right instanceof Iterable<?> iterable)
+      right = iterable.iterator();
+    else if (right != null && right.getClass().isArray() && !(right instanceof byte[]))
+      right = MultiValue.getMultiValueIterator(right);
 
-      final Iterator<?> rightIterator = (Iterator<?>) right;
-      while (rightIterator.hasNext()) {
-        final Object leftItem = rightIterator.next();
-        while (leftIterator.hasNext()) {
-          final Object rightItem = leftIterator.next();
-          if (leftItem != null && leftItem.equals(rightItem))
-            return true;
-        }
-      }
+    if (right instanceof Iterator<?> iterator) {
+      while (iterator.hasNext())
+        if (containsItem(leftCollection, iterator.next()))
+          return true;
+      return false;
+    }
+    return containsItem(leftCollection, right);
+  }
+
+  private static boolean containsItem(final Collection<?> collection, final Object item) {
+    for (final Object o : collection) {
+      if (o == null) {
+        if (item == null)
+          return true;
+      } else if (QueryOperatorEquals.equals(o, item))
+        return true;
     }
     return false;
   }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -71,12 +71,14 @@ public class LocalDocumentType implements DocumentType {
   protected final Map<List<String>, TypeIndex>      indexesByProperties          = new HashMap<>();
   protected final RecordEventsRegistry              events                       = new RecordEventsRegistry();
   protected final Map<String, Object>               custom                       = new HashMap<>();
-  protected       List<Bucket>                      buckets                      = new ArrayList<>();
-  // Copy-on-write reassigned under schema mutation and read lock-free by query planning (getBuckets(true)/
-  // getBucketIds(true)): volatile so a planning thread has a happens-before edge against a concurrent
-  // ALTER TYPE ... BUCKET, matching the LocalSchema.bucketId2TypeMap publication pattern (issue #6678).
+  // The four bucket lists are copy-on-write: reassigned under the schema mutation lock and read lock-free by query
+  // planning through getBuckets(polymorphic)/getBucketIds(polymorphic), both branches of the ternary - the
+  // non-polymorphic pair feeds SelectExecutionPlanner's partition pruning and FetchFromSchemaTypesStep exactly as the
+  // polymorphic pair does. All four are volatile so a planning thread has a happens-before edge against a concurrent
+  // ALTER TYPE ... BUCKET, matching the LocalSchema.bucketId2TypeMap publication pattern (issues #6678 and #7033).
+  protected volatile List<Bucket>                   buckets                      = new ArrayList<>();
   protected volatile List<Bucket>                   cachedPolymorphicBuckets     = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
-  protected       List<Integer>                     bucketIds                    = new ArrayList<>();
+  protected volatile List<Integer>                  bucketIds                    = new ArrayList<>();
   protected volatile List<Integer>                  cachedPolymorphicBucketIds   = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
   protected       BucketSelectionStrategy           bucketSelectionStrategy      = new RoundRobinBucketSelectionStrategy();
   // Names of the OWN properties that declare a DEFAULT. A cache: the authority is the per-property default value, but

--- a/engine/src/test/java/com/arcadedb/index/Issue6934CompositeExpandedKeyScalarUpdateTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6934CompositeExpandedKeyScalarUpdateTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6934: a composite index mixing a scalar property with exactly one {@code BY ITEM}/{@code BY KEY}/{@code BY VALUE}
+ * property was never updated when only the scalar changed, because the single-expansion update path diffed the collection's
+ * element membership instead of the complete key tuples. The record stayed visible under the stale key and invisible under the
+ * real one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6934CompositeExpandedKeyScalarUpdateTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.status STRING");
+      database.command("sql", "CREATE PROPERTY Doc.tags LIST");
+      database.command("sql", "CREATE PROPERTY Doc.attrs MAP");
+      database.command("sql", "CREATE PROPERTY Doc.items LIST");
+    });
+  }
+
+  @Test
+  void scalarChangeIsReflectedInListByItemCompositeIndex() {
+    database.transaction(() -> database.command("sql", "CREATE INDEX ON Doc (status, tags BY ITEM) NOTUNIQUE"));
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET status = 'A', tags = ['x','y']"));
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET status = 'B'"));
+
+    assertThat(countWhere("B", "tags CONTAINS 'x'")).isEqualTo(1);
+    assertThat(countWhere("B", "tags CONTAINS 'y'")).isEqualTo(1);
+    assertThat(countWhere("A", "tags CONTAINS 'x'")).isZero();
+    assertThat(countWhere("A", "tags CONTAINS 'y'")).isZero();
+    assertThat(indexEntries()).isEqualTo(2);
+  }
+
+  @Test
+  void scalarAndListChangedTogetherKeepsNoStaleEntry() {
+    database.transaction(() -> database.command("sql", "CREATE INDEX ON Doc (status, tags BY ITEM) NOTUNIQUE"));
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET status = 'A', tags = ['x','y']"));
+    // Partial list change together with the scalar: before the fix the retained element 'x' kept its (A,x) entry while the new
+    // element 'z' was keyed with (B,z), so the index held a mix of old and new scalar values for the same record
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET status = 'B', tags = ['x','z']"));
+
+    assertThat(countWhere("B", "tags CONTAINS 'x'")).isEqualTo(1);
+    assertThat(countWhere("B", "tags CONTAINS 'z'")).isEqualTo(1);
+    assertThat(countWhere("A", "tags CONTAINS 'x'")).isZero();
+    assertThat(countWhere("A", "tags CONTAINS 'y'")).isZero();
+    assertThat(countWhere("B", "tags CONTAINS 'y'")).isZero();
+    assertThat(indexEntries()).isEqualTo(2);
+  }
+
+  @Test
+  void uniqueIndexReleasesTheStaleKey() {
+    database.transaction(() -> database.command("sql", "CREATE INDEX ON Doc (status, tags BY ITEM) UNIQUE"));
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET status = 'A', tags = ['x']"));
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET status = 'B'"));
+
+    // The key (A,x) is no longer held by any record: a new record can take it
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET status = 'A', tags = ['x']"));
+    assertThat(countWhere("A", "tags CONTAINS 'x'")).isEqualTo(1);
+    assertThat(countWhere("B", "tags CONTAINS 'x'")).isEqualTo(1);
+
+    // And the key (B,x) is now really taken
+    assertThatThrownBy(() -> database.transaction(() -> database.command("sql", "INSERT INTO Doc SET status = 'B', tags = ['x']")))
+        .isInstanceOf(DuplicatedKeyException.class);
+  }
+
+  @Test
+  void scalarChangeIsReflectedInMapByKeyCompositeIndex() {
+    database.transaction(() -> database.command("sql", "CREATE INDEX ON Doc (status, attrs BY KEY) NOTUNIQUE"));
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET status = 'A', attrs = {'k1': 'v1', 'k2': 'v2'}"));
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET status = 'B'"));
+
+    assertThat(countWhere("B", "attrs CONTAINSKEY 'k1'")).isEqualTo(1);
+    assertThat(countWhere("A", "attrs CONTAINSKEY 'k1'")).isZero();
+    assertThat(indexEntries()).isEqualTo(2);
+  }
+
+  @Test
+  void scalarChangeIsReflectedInMapByValueCompositeIndex() {
+    database.transaction(() -> database.command("sql", "CREATE INDEX ON Doc (status, attrs BY VALUE) NOTUNIQUE"));
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET status = 'A', attrs = {'k1': 'v1', 'k2': 'v2'}"));
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET status = 'B'"));
+
+    assertThat(countWhere("B", "attrs CONTAINSVALUE 'v1'")).isEqualTo(1);
+    assertThat(countWhere("A", "attrs CONTAINSVALUE 'v1'")).isZero();
+    assertThat(indexEntries()).isEqualTo(2);
+  }
+
+  @Test
+  void scalarChangeIsReflectedInNestedListByItemCompositeIndex() {
+    database.transaction(() -> database.command("sql", "CREATE INDEX ON Doc (status, `items.id` BY ITEM) NOTUNIQUE"));
+    database.transaction(() -> database.command("sql",
+        "INSERT INTO Doc SET status = 'A', items = [{'id': 1}, {'id': 2}]"));
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET status = 'B'"));
+
+    assertThat(lookup("B", 1)).isEqualTo(1);
+    assertThat(lookup("B", 2)).isEqualTo(1);
+    assertThat(lookup("A", 1)).isZero();
+    assertThat(lookup("A", 2)).isZero();
+  }
+
+  @Test
+  void unchangedRecordTouchesNothing() {
+    database.transaction(() -> database.command("sql", "CREATE INDEX ON Doc (status, tags BY ITEM) NOTUNIQUE"));
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET status = 'A', tags = ['x','y']"));
+    // An update that changes neither the scalar nor the list must leave the index as it is
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET other = 1"));
+
+    assertThat(countWhere("A", "tags CONTAINS 'x'")).isEqualTo(1);
+    assertThat(indexEntries()).isEqualTo(2);
+  }
+
+  /**
+   * Counts the rows matching {@code status = '<status>' AND <predicate>}, checking every returned row really carries that
+   * status: before the fix the index answered a record under a key it no longer held, returning a row with status 'B' for a
+   * query asking for 'A'.
+   */
+  private int countWhere(final String status, final String predicate) {
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE status = '" + status + "' AND " + predicate);
+    int count = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("status")).isEqualTo(status);
+      ++count;
+    }
+    return count;
+  }
+
+  /** The only index defined on Doc by the test. */
+  private TypeIndex docIndex() {
+    final TypeIndex[] indexes = database.getSchema().getType("Doc").getAllIndexes(false).toArray(new TypeIndex[0]);
+    assertThat(indexes).hasSize(1);
+    return indexes[0];
+  }
+
+  private long indexEntries() {
+    return docIndex().countEntries();
+  }
+
+  private int lookup(final Object... keys) {
+    final IndexCursor cursor = docIndex().get(keys);
+    int count = 0;
+    while (cursor.hasNext()) {
+      cursor.next();
+      ++count;
+    }
+    return count;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/QueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/QueryTest.java
@@ -1501,6 +1501,37 @@ class QueryTest extends TestHelper {
     });
   }
 
+  // Issue #7084: CONTAINSANY with an array (not a List) on the RHS - a split() or a bound Java array - never matched anything
+  @Test
+  void containsAnyWithArrayOnRhs() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc7084 IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc7084 SET tags = ['red','green']");
+      database.command("sql", "INSERT INTO doc7084 SET tags = ['black']");
+
+      final ResultSet split = database.query("sql", "SELECT FROM doc7084 WHERE tags CONTAINSANY 'red blue'.split(' ')");
+      assertThat(split.hasNext()).isTrue();
+      assertThat(split.next().<List<String>>getProperty("tags")).containsExactly("red", "green");
+      assertThat(split.hasNext()).isFalse();
+
+      final ResultSet parameter = database.query("sql", "SELECT FROM doc7084 WHERE tags CONTAINSANY :wanted",
+          Map.of("wanted", new String[] { "blue", "green" }));
+      assertThat(parameter.hasNext()).isTrue();
+      assertThat(parameter.next().<List<String>>getProperty("tags")).containsExactly("red", "green");
+      assertThat(parameter.hasNext()).isFalse();
+
+      // No row holds any of the terms, so the operator is not answering "true" blindly
+      final ResultSet none = database.query("sql", "SELECT FROM doc7084 WHERE tags CONTAINSANY 'blue white'.split(' ')");
+      assertThat(none.hasNext()).isFalse();
+
+      // CONTAINSANY and CONTAINSALL must agree on the same inputs
+      final ResultSet all = database.query("sql", "SELECT FROM doc7084 WHERE tags CONTAINSALL 'red green'.split(' ')");
+      assertThat(all.hasNext()).isTrue();
+      assertThat(all.next().<List<String>>getProperty("tags")).containsExactly("red", "green");
+      assertThat(all.hasNext()).isFalse();
+    });
+  }
+
   // Issue #3583: chained replace().ilike() inside a LET subquery combined with UNIONALL evaluates without $current null
   @Test
   void replaceWithIlikeInLetSubquery() {

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAnyConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAnyConditionTest.java
@@ -78,6 +78,73 @@ class ContainsAnyConditionTest {
     assertThat(op.execute(left, right)).isTrue();
   }
 
+  /**
+   * Issue #7084: an array right-hand side (the result of split(), a parameter bound to a Java array) must be expanded into
+   * its items exactly as a List is, instead of being compared as one opaque object against the collection.
+   */
+  @Test
+  void arrayRightHandSide() {
+    final ContainsAnyCondition op = new ContainsAnyCondition();
+    final List<Object> left = Arrays.asList("a", "b", "c");
+
+    assertThat(op.execute(left, new String[] { "a", "x" })).isTrue();
+    assertThat(op.execute(left, new String[] { "x", "c" })).isTrue();
+    assertThat(op.execute(left, new String[] { "x", "y" })).isFalse();
+    assertThat(op.execute(left, new String[0])).isFalse();
+
+    final List<Object> numbers = Arrays.asList(1, 2, 3);
+    assertThat(op.execute(numbers, new int[] { 9, 2 })).isTrue();
+    assertThat(op.execute(numbers, new int[] { 9, 8 })).isFalse();
+    // A Java array on the left is expanded too
+    assertThat(op.execute(new String[] { "a", "b" }, new String[] { "b" })).isTrue();
+    assertThat(op.execute(new String[] { "a", "b" }, Arrays.asList("x", "a"))).isTrue();
+  }
+
+  /**
+   * A byte[] is the BINARY scalar: it is the value being searched for, not a list of numbers to expand.
+   */
+  @Test
+  void byteArrayRightHandSideStaysScalar() {
+    final ContainsAnyCondition op = new ContainsAnyCondition();
+    final byte[] binary = new byte[] { 1, 2 };
+
+    assertThat(op.execute(Arrays.asList(1, 2, 3), binary)).isFalse();
+    assertThat(op.execute(Arrays.asList("x", binary), binary)).isTrue();
+  }
+
+  /**
+   * Both left-hand shapes must answer alike: the Collection branch used to compare with strict equals() while the
+   * Iterable branch applied its own comparison, so [1,2,3] CONTAINSANY [2L] depended on the left operand's concrete type.
+   */
+  @Test
+  void numericWideningIsIndependentOfLeftShape() {
+    final ContainsAnyCondition op = new ContainsAnyCondition();
+    final List<Object> collection = Arrays.asList(1, 2, 3);
+    final Iterable<Object> iterable = collection::iterator;
+
+    assertThat(op.execute(collection, Arrays.asList(2L))).isTrue();
+    assertThat(op.execute(iterable, Arrays.asList(2L))).isTrue();
+    assertThat(op.execute(collection, 2L)).isTrue();
+    assertThat(op.execute(iterable, 2L)).isTrue();
+    assertThat(op.execute(collection, 4L)).isFalse();
+    assertThat(op.execute(iterable, 4L)).isFalse();
+  }
+
+  /**
+   * The Iterable branch iterated the left operand only once, so a right-hand item after the first one could never be
+   * found once the left iterator was exhausted.
+   */
+  @Test
+  void iterableLeftIsRescannedForEveryRightItem() {
+    final ContainsAnyCondition op = new ContainsAnyCondition();
+    final Iterable<Object> left = Arrays.<Object>asList(1, 2)::iterator;
+
+    assertThat(op.execute(left, Arrays.asList(9, 1))).isTrue();
+    assertThat(op.execute(left, Arrays.asList(9, 8, 2))).isTrue();
+    assertThat(op.execute(left, Arrays.asList(9, 8))).isFalse();
+    assertThat(op.execute(Arrays.<Object>asList(1, 2).iterator(), Arrays.asList(9, 2))).isTrue();
+  }
+
   @Test
   void issue1785() {
     final ContainsAnyCondition op = new ContainsAnyCondition();

--- a/engine/src/test/java/com/arcadedb/schema/Issue6678PolymorphicBucketCacheVisibilityTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6678PolymorphicBucketCacheVisibilityTest.java
@@ -37,29 +37,27 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@code ALTER TYPE ... BUCKET} - the same publication gap the sibling {@code LocalSchema.bucketId2TypeMap} pattern
  * exists to avoid.
  * <p>
- * The fix makes both fields {@code volatile}. The first test pins the fix itself, so a future edit cannot silently
- * drop the modifier. The second is a functional regression for the concrete scenario: adding/removing a bucket
- * must be reflected by {@code getBuckets(true)}/{@code getBucketIds(true)} immediately afterward.
+ * The fix makes both fields {@code volatile}. Issue #7033 extends it to the non-polymorphic siblings {@code buckets}/
+ * {@code bucketIds}: same copy-on-write reassignment on the adjacent lines, same lock-free accessor (the other branch
+ * of the same ternary), read by {@code SelectExecutionPlanner}'s partition pruning and {@code FetchFromSchemaTypesStep}
+ * through {@code getBuckets(false)}/{@code getBucketIds(false)}. The first test pins the fix itself, so a future edit
+ * cannot silently drop the modifier from any of the four. The second is a functional regression for the concrete
+ * scenario: adding/removing a bucket must be reflected by both branches of {@code getBuckets}/{@code getBucketIds}
+ * immediately afterward.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class Issue6678PolymorphicBucketCacheVisibilityTest extends TestHelper {
 
   @Test
-  void cachedPolymorphicFieldsMustBeVolatileForCrossThreadPlanningReads() throws Exception {
-    final Field buckets = LocalDocumentType.class.getDeclaredField("cachedPolymorphicBuckets");
-    final Field bucketIds = LocalDocumentType.class.getDeclaredField("cachedPolymorphicBucketIds");
-
-    assertThat(Modifier.isVolatile(buckets.getModifiers()))
-        .as("cachedPolymorphicBuckets is copy-on-write reassigned under schema mutation and read lock-free by "
-            + "query planning - it must be volatile so planning threads have a happens-before edge against the "
-            + "writer (issue #6678)")
-        .isTrue();
-    assertThat(Modifier.isVolatile(bucketIds.getModifiers()))
-        .as("cachedPolymorphicBucketIds is copy-on-write reassigned under schema mutation and read lock-free by "
-            + "query planning - it must be volatile so planning threads have a happens-before edge against the "
-            + "writer (issue #6678)")
-        .isTrue();
+  void bucketListFieldsMustBeVolatileForCrossThreadPlanningReads() throws Exception {
+    for (final String fieldName : new String[] { "buckets", "cachedPolymorphicBuckets", "bucketIds", "cachedPolymorphicBucketIds" }) {
+      final Field field = LocalDocumentType.class.getDeclaredField(fieldName);
+      assertThat(Modifier.isVolatile(field.getModifiers()))
+          .as(fieldName + " is copy-on-write reassigned under schema mutation and read lock-free by query planning - it "
+              + "must be volatile so planning threads have a happens-before edge against the writer (issues #6678, #7033)")
+          .isTrue();
+    }
   }
 
   @Test
@@ -75,11 +73,15 @@ class Issue6678PolymorphicBucketCacheVisibilityTest extends TestHelper {
 
       assertThat(type.getBuckets(true)).hasSize(before + 1).contains(newBucket);
       assertThat(type.getBucketIds(true)).contains(newBucket.getFileId());
+      assertThat(type.getBuckets(false)).hasSize(before + 1).contains(newBucket);
+      assertThat(type.getBucketIds(false)).contains(newBucket.getFileId());
 
       type.removeBucket(newBucket);
 
       assertThat(type.getBuckets(true)).hasSize(before).doesNotContain(newBucket);
       assertThat(type.getBucketIds(true)).doesNotContain(newBucket.getFileId());
+      assertThat(type.getBuckets(false)).hasSize(before).doesNotContain(newBucket);
+      assertThat(type.getBucketIds(false)).doesNotContain(newBucket.getFileId());
     });
   }
 }

--- a/graphql/src/main/java/com/arcadedb/graphql/parser/Selection.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/parser/Selection.java
@@ -43,5 +43,35 @@ public class Selection extends SimpleNode {
   public FieldWithAlias getFieldWithAlias() {
     return fieldWithAlias;
   }
+
+  /**
+   * The field node of this selection whichever way it was written: {@code field} for a plain {@code name}, {@code fieldWithAlias}
+   * for {@code alias: name}. Null for an ellipsis selection (fragment spread / inline fragment). Every consumer that resolves a
+   * selection against the schema must go through this (or the accessors below) rather than through {@link #getField()} alone,
+   * or an aliased selection silently resolves to nothing (issues #6384, #6453, #7036).
+   */
+  public AbstractField getAnyField() {
+    return field != null ? field : fieldWithAlias;
+  }
+
+  /**
+   * The real field name to resolve against the schema: the aliased-away name for {@code alias: name}, otherwise
+   * {@link #getName()}, which for an aliased selection carries the alias instead.
+   */
+  public String getFieldName() {
+    return fieldWithAlias != null ? fieldWithAlias.getName() : getName();
+  }
+
+  public Arguments getArguments() {
+    if (field != null)
+      return field.getArguments();
+    return fieldWithAlias != null ? fieldWithAlias.getArguments() : null;
+  }
+
+  public SelectionSet getSelectionSet() {
+    if (field != null)
+      return field.getSelectionSet();
+    return fieldWithAlias != null ? fieldWithAlias.getSelectionSet() : null;
+  }
 }
 /* ParserGeneratorCC - OriginalChecksum=aac9a2d576730b830f5ef7c02bdf7951 (do not edit this line) */

--- a/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLResultSet.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLResultSet.java
@@ -27,9 +27,7 @@ import com.arcadedb.graphql.parser.AbstractField;
 import com.arcadedb.graphql.parser.Argument;
 import com.arcadedb.graphql.parser.Directive;
 import com.arcadedb.graphql.parser.Directives;
-import com.arcadedb.graphql.parser.Field;
 import com.arcadedb.graphql.parser.FieldDefinition;
-import com.arcadedb.graphql.parser.FieldWithAlias;
 import com.arcadedb.graphql.parser.ObjectTypeDefinition;
 import com.arcadedb.graphql.parser.Selection;
 import com.arcadedb.graphql.parser.SelectionSet;
@@ -138,15 +136,9 @@ public class GraphQLResultSet implements ResultSet {
       // A selection written as `alias: field` parses into fieldWithAlias (name = the real field,
       // alias carried by Selection.getName()); an unaliased selection parses into field instead.
       // Neither is set for an ellipsis selection (fragment spread / inline fragment).
-      final FieldWithAlias aliasedField = selection.getFieldWithAlias();
-      final Field          plainField = selection.getField();
-      final AbstractField  field = aliasedField != null ? aliasedField : plainField;
-      final String         fieldName = aliasedField != null ? aliasedField.getName() : selection.getName();
-      final SelectionSet   set;
-      if (aliasedField != null)
-        set = aliasedField.getSelectionSet();
-      else
-        set = plainField != null ? plainField.getSelectionSet() : null;
+      final AbstractField field = selection.getAnyField();
+      final String        fieldName = selection.getFieldName();
+      final SelectionSet  set = selection.getSelectionSet();
 
       final FieldDefinition schemaField = parentType != null ? parentType.getFieldDefinitionByName(fieldName) : null;
       final ObjectTypeDefinition subType = schemaField != null ? schema.getTypeFromField(schemaField) : null;

--- a/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLSchema.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLSchema.java
@@ -28,9 +28,7 @@ import com.arcadedb.graphql.parser.Definition;
 import com.arcadedb.graphql.parser.Directive;
 import com.arcadedb.graphql.parser.Directives;
 import com.arcadedb.graphql.parser.Document;
-import com.arcadedb.graphql.parser.Field;
 import com.arcadedb.graphql.parser.FieldDefinition;
-import com.arcadedb.graphql.parser.FieldWithAlias;
 import com.arcadedb.graphql.parser.GraphQLParser;
 import com.arcadedb.graphql.parser.InputValueDefinition;
 import com.arcadedb.graphql.parser.ObjectTypeDefinition;
@@ -126,8 +124,7 @@ public class GraphQLSchema {
       final Map<String, Object> variables = resolveVariables(op, parameters);
 
       final Selection selection = op.getSelectionSet().getSelections().getFirst();
-      final FieldWithAlias aliasField = selection.getFieldWithAlias();
-      queryName = aliasField != null ? aliasField.getName() : selection.getName();
+      queryName = selection.getFieldName();
 
       // HANDLE INTROSPECTION QUERIES
       if ("__schema".equals(queryName))
@@ -170,9 +167,8 @@ public class GraphQLSchema {
         }
       }
 
-      final Field field = selection.getField();
-      final Arguments queryArguments = field != null ? field.getArguments() : aliasField != null ? aliasField.getArguments() : null;
-      projection = field != null ? field.getSelectionSet() : aliasField != null ? aliasField.getSelectionSet() : null;
+      final Arguments queryArguments = selection.getArguments();
+      projection = selection.getSelectionSet();
 
       final Map<String, Object> boundParameters = new HashMap<>();
       final String where = buildWhereClause(queryArguments, typeArgumentNames, variables, boundParameters);
@@ -404,22 +400,14 @@ public class GraphQLSchema {
     Map<String, Object> arguments = null;
     SelectionSet projection = null;
 
-    final Field field = selection.getField();
-    final FieldWithAlias aliasField = selection.getFieldWithAlias();
-
     for (final Argument argument : directive.getArguments().getList()) {
       if ("statement".equals(argument.getName())) {
         // THE DIRECTIVE IS PART OF THE SCHEMA, NOT OF THE OPERATION: NO VARIABLE CAN BE BOUND IN IT
         final Object statementValue = resolveValue(argument.getValueWithVariable(), null);
         statement = statementValue != null ? statementValue.toString() : null;
 
-        if (field != null) {
-          arguments = getArguments(field.getArguments(), variables);
-          projection = field.getSelectionSet();
-        } else if (aliasField != null) {
-          arguments = getArguments(aliasField.getArguments(), variables);
-          projection = aliasField.getSelectionSet();
-        }
+        arguments = getArguments(selection.getArguments(), variables);
+        projection = selection.getSelectionSet();
       }
     }
 
@@ -453,22 +441,25 @@ public class GraphQLSchema {
     final InternalResultSet resultSet = new InternalResultSet();
     final ResultInternal schemaResult = new ResultInternal();
 
-    final Field field = selection.getField();
-    final SelectionSet selectionSet = field != null ? field.getSelectionSet() : null;
+    // Resolved through Selection.getSelectionSet()/getFieldName() so an aliased selection (`s: __schema { ... }`,
+    // `t: types { ... }`) is served exactly as the plain one, and the result is keyed by the alias the client wrote,
+    // as the GraphQL spec requires for response keys (issue #7036)
+    final SelectionSet selectionSet = selection.getSelectionSet();
 
     if (selectionSet != null) {
       for (final Selection sub : selectionSet.getSelections()) {
-        final String fieldName = sub.getName();
+        final String fieldName = sub.getFieldName();
+        final String responseKey = sub.getName();
         if ("types".equals(fieldName))
-          schemaResult.setProperty("types", buildTypeList(sub));
+          schemaResult.setProperty(responseKey, buildTypeList(sub));
         else if ("queryType".equals(fieldName))
-          schemaResult.setProperty("queryType", buildNameResult("Query"));
+          schemaResult.setProperty(responseKey, buildNameResult("Query"));
         else if ("mutationType".equals(fieldName))
-          schemaResult.setProperty("mutationType", null);
+          schemaResult.setProperty(responseKey, null);
         else if ("subscriptionType".equals(fieldName))
-          schemaResult.setProperty("subscriptionType", null);
+          schemaResult.setProperty(responseKey, null);
         else if ("directives".equals(fieldName))
-          schemaResult.setProperty("directives", Collections.emptyList());
+          schemaResult.setProperty(responseKey, Collections.emptyList());
       }
     }
 
@@ -477,11 +468,11 @@ public class GraphQLSchema {
   }
 
   private ResultSet executeIntrospectionType(final Selection selection, final Map<String, Object> variables) {
-    final Field field = selection.getField();
+    final Arguments arguments = selection.getArguments();
     String typeName = null;
 
-    if (field != null && field.getArguments() != null)
-      for (final Argument arg : field.getArguments().getList())
+    if (arguments != null)
+      for (final Argument arg : arguments.getList())
         if ("name".equals(arg.getName())) {
           final Object nameValue = resolveValue(arg.getValueWithVariable(), variables);
           typeName = nameValue != null ? nameValue.toString() : null;
@@ -490,8 +481,7 @@ public class GraphQLSchema {
     if (typeName == null)
       throw new CommandParsingException("__type query requires a 'name' argument");
 
-    final SelectionSet selectionSet = field != null ? field.getSelectionSet() : null;
-    final ResultInternal typeResult = buildTypeResult(typeName, selectionSet);
+    final ResultInternal typeResult = buildTypeResult(typeName, selection.getSelectionSet());
 
     if (typeResult == null)
       throw new CommandParsingException("Type '" + typeName + "' not found");
@@ -513,8 +503,7 @@ public class GraphQLSchema {
     final List<ResultInternal> types = new ArrayList<>();
     final Set<String> addedTypes = new HashSet<>();
 
-    final Field field = selection.getField();
-    final SelectionSet selectionSet = field != null ? field.getSelectionSet() : null;
+    final SelectionSet selectionSet = selection.getSelectionSet();
 
     // Add GraphQL-defined types
     for (final Map.Entry<String, ObjectTypeDefinition> entry : objectTypeDefinitionMap.entrySet()) {
@@ -570,24 +559,23 @@ public class GraphQLSchema {
 
     if (selectionSet != null) {
       for (final Selection sub : selectionSet.getSelections()) {
-        if ("fields".equals(sub.getName())) {
+        if ("fields".equals(sub.getFieldName())) {
           final List<ResultInternal> fields = new ArrayList<>();
           for (final FieldDefinition fd : objType.getFieldDefinitions()) {
             final ResultInternal fieldResult = new ResultInternal();
             fieldResult.setProperty("name", fd.getName());
 
-            final Field subField = sub.getField();
-            final SelectionSet fieldSelectionSet = subField != null ? subField.getSelectionSet() : null;
+            final SelectionSet fieldSelectionSet = sub.getSelectionSet();
             if (fieldSelectionSet != null) {
               for (final Selection fieldSub : fieldSelectionSet.getSelections()) {
-                if ("type".equals(fieldSub.getName()))
-                  fieldResult.setProperty("type", buildFieldTypeInfo(fd));
+                if ("type".equals(fieldSub.getFieldName()))
+                  fieldResult.setProperty(fieldSub.getName(), buildFieldTypeInfo(fd));
               }
             }
 
             fields.add(fieldResult);
           }
-          result.setProperty("fields", fields);
+          result.setProperty(sub.getName(), fields);
         }
       }
     }
@@ -602,28 +590,27 @@ public class GraphQLSchema {
 
     if (selectionSet != null) {
       for (final Selection sub : selectionSet.getSelections()) {
-        if ("fields".equals(sub.getName())) {
+        if ("fields".equals(sub.getFieldName())) {
           final List<ResultInternal> fields = new ArrayList<>();
           for (final Property prop : dbType.getProperties()) {
             final ResultInternal fieldResult = new ResultInternal();
             fieldResult.setProperty("name", prop.getName());
 
-            final Field subField = sub.getField();
-            final SelectionSet fieldSelectionSet = subField != null ? subField.getSelectionSet() : null;
+            final SelectionSet fieldSelectionSet = sub.getSelectionSet();
             if (fieldSelectionSet != null) {
               for (final Selection fieldSub : fieldSelectionSet.getSelections()) {
-                if ("type".equals(fieldSub.getName())) {
+                if ("type".equals(fieldSub.getFieldName())) {
                   final ResultInternal typeInfo = new ResultInternal();
                   typeInfo.setProperty("name", mapDatabaseTypeToGraphQL(prop.getType()));
                   typeInfo.setProperty("kind", "SCALAR");
-                  fieldResult.setProperty("type", typeInfo);
+                  fieldResult.setProperty(fieldSub.getName(), typeInfo);
                 }
               }
             }
 
             fields.add(fieldResult);
           }
-          result.setProperty("fields", fields);
+          result.setProperty(sub.getName(), fields);
         }
       }
     }

--- a/graphql/src/test/java/com/arcadedb/graphql/Issue7036IntrospectionAliasTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/Issue7036IntrospectionAliasTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graphql;
+
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7036 (follow-up to #6384/#6453): the introspection dispatch read {@code selection.getField()} only,
+ * never falling back to the aliased field, so {@code t: __type(name: "Book")} failed with "requires a 'name' argument",
+ * {@code s: __schema { ... }} answered an empty object and {@code f: fields { name }} was silently omitted. An aliased
+ * sub-selection is now served under the alias, which is the response key the GraphQL spec prescribes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7036IntrospectionAliasTest extends AbstractGraphQLTest {
+
+  @Test
+  void aliasedTypeIntrospectionResolvesNameArgumentAndSelection() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      try (final ResultSet resultSet = database.query("graphql", "{ t: __type(name: \"Book\") { name fields { name } } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        assertThat(record.<String>getProperty("name")).isEqualTo("Book");
+        final List<Result> fields = record.getProperty("fields");
+        assertThat(fields).isNotNull();
+        assertThat(fieldNames(fields)).contains("id", "name", "pageCount", "authors");
+        assertThat(resultSet.hasNext()).isFalse();
+      }
+
+      return null;
+    });
+  }
+
+  @Test
+  void aliasedSchemaIntrospectionReturnsTheSchema() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      try (final ResultSet resultSet = database.query("graphql", "{ s: __schema { queryType { name } types { name } } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        final Result queryType = record.getProperty("queryType");
+        assertThat(queryType).isNotNull();
+        assertThat(queryType.<String>getProperty("name")).isEqualTo("Query");
+
+        final List<Result> types = record.getProperty("types");
+        assertThat(types).isNotNull();
+        assertThat(fieldNames(types)).contains("Query", "Book", "Author");
+        assertThat(resultSet.hasNext()).isFalse();
+      }
+
+      return null;
+    });
+  }
+
+  @Test
+  void aliasedSubSelectionsAreServedUnderTheAlias() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      // GraphQL-defined type
+      try (final ResultSet resultSet = database.query("graphql",
+          "{ __type(name: \"Author\") { name f: fields { name t: type { name kind } } } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        assertThat(record.<String>getProperty("name")).isEqualTo("Author");
+        assertThat(record.getPropertyNames()).contains("f").doesNotContain("fields");
+        final List<Result> fields = record.getProperty("f");
+        assertThat(fields).isNotEmpty();
+        for (final Result field : fields) {
+          assertThat(field.getPropertyNames()).contains("t").doesNotContain("type");
+          final Result type = field.getProperty("t");
+          assertThat(type.<String>getProperty("name")).isNotNull();
+          assertThat(type.<String>getProperty("kind")).isNotNull();
+        }
+        assertThat(resultSet.hasNext()).isFalse();
+      }
+
+      // Database-only type, served by the other builder
+      database.transaction(() -> {
+        database.getSchema().createDocumentType("Shelf").createProperty("position", Type.INTEGER);
+      });
+      try (final ResultSet resultSet = database.query("graphql",
+          "{ __type(name: \"Shelf\") { name f: fields { name t: type { name kind } } } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        assertThat(record.<String>getProperty("name")).isEqualTo("Shelf");
+        final List<Result> fields = record.getProperty("f");
+        assertThat(fields).hasSize(1);
+        assertThat(fields.getFirst().<String>getProperty("name")).isEqualTo("position");
+        final Result type = fields.getFirst().getProperty("t");
+        assertThat(type.<String>getProperty("name")).isEqualTo("Int");
+        assertThat(type.<String>getProperty("kind")).isEqualTo("SCALAR");
+        assertThat(resultSet.hasNext()).isFalse();
+      }
+
+      // __schema sub-selections
+      try (final ResultSet resultSet = database.query("graphql", "{ __schema { q: queryType { name } all: types { name } } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        assertThat(record.getPropertyNames()).contains("q", "all").doesNotContain("queryType", "types");
+        assertThat(record.<Result>getProperty("q").<String>getProperty("name")).isEqualTo("Query");
+        assertThat(fieldNames(record.getProperty("all"))).contains("Query", "Book", "Author");
+        assertThat(resultSet.hasNext()).isFalse();
+      }
+
+      return null;
+    });
+  }
+
+  private static Set<String> fieldNames(final List<Result> results) {
+    return results.stream().map(r -> r.<String>getProperty("name")).collect(Collectors.toSet());
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -405,15 +405,31 @@ public class PostgresNetworkExecutor extends Thread {
         // Guarded on !executed so a second Describe('P') on the same portal (or one arriving after an Execute
         // already ran it) reuses the materialized result instead of running it again: issue #6458's follow-up
         // Execute(s) depend on this same fullResultSet being run exactly once.
-        final ResultSet resultSet = runPortalQuery(portal);
-        portal.executed = true;
-        // Materializes the whole result now (issue #6458): Describe needs every row's columns, not just the
-        // first, to catch a property that only shows up on a later row (documents can be sparse) - and the
-        // portal keeps this list so the Execute(s) that follow slice it by their own row-limit instead of
-        // re-running the statement or losing what Describe already had to read.
-        portal.fullResultSet = browseAndCacheResultSet(resultSet, 0);
-        resolvePortalColumns(portal);
-        answerWithColumns(portal);
+        try {
+          final ResultSet resultSet = runPortalQuery(portal);
+          // Materializes the whole result now (issue #6458): Describe needs every row's columns, not just the
+          // first, to catch a property that only shows up on a later row (documents can be sparse) - and the
+          // portal keeps this list so the Execute(s) that follow slice it by their own row-limit instead of
+          // re-running the statement or losing what Describe already had to read. Bounded by the same cap as
+          // the simple-query path (issue #7034): the portal's row limit bounds what each Execute SENDS, not
+          // what is held here. Marked executed only once the rows are held, so a refused portal is not left
+          // looking like a drained one.
+          portal.fullResultSet = browseAndCacheBoundedResultSet(resultSet);
+          portal.executed = true;
+          resolvePortalColumns(portal);
+          answerWithColumns(portal);
+        } catch (final CommandParsingException e) {
+          // The one reply Describe is owed is an ErrorResponse here; the client discards everything up to its
+          // Sync, exactly as after a failed Execute. Without it the refusal (or any other failure of the query)
+          // reached the server log only and the client waited for a RowDescription that never came.
+          setErrorInTx();
+          writeError(ERROR_SEVERITY.ERROR, "Syntax error on executing query: " + (e.getCause() != null ? e.getCause().getMessage() : e.getMessage()), sqlStateFor(e));
+        } catch (final PostgresProtocolException e) {
+          throw e;
+        } catch (final Exception e) {
+          setErrorInTx();
+          writeError(ERROR_SEVERITY.ERROR, "Error on executing query: " + e.getMessage(), sqlStateFor(e));
+        }
       } else if (portal.isExpectingResult && portal.columns != null) {
         // Already materialized: a synthetic answer fixed at PARSE (SHOW/system/catalog), or a portal a
         // previous Describe/Execute already ran. Its columns are answered as they stand rather than
@@ -567,13 +583,15 @@ public class PostgresNetworkExecutor extends Thread {
         if (!portal.executed) {
           final long engineStart = System.nanoTime();
           final ResultSet resultSet = runPortalQuery(portal);
-          portal.executed = true;
           if (portal.isExpectingResult) {
             // Materializes the whole result now (issue #6458), the same way Describe('P') does: a client that
             // never Described this portal first (it already knows the row shape) reaches this branch instead,
             // and every Execute on this portal from here on - including this one - slices fullResultSet by its
-            // own row-limit below rather than re-running the statement.
-            portal.fullResultSet = browseAndCacheResultSet(resultSet, 0);
+            // own row-limit below rather than re-running the statement. Bounded by the same cap as the
+            // simple-query path (issue #7034): the Execute's own row limit bounds what is SENT, not what is
+            // held here.
+            portal.fullResultSet = browseAndCacheBoundedResultSet(resultSet);
+            portal.executed = true;
             profile.addEngineNanos(System.nanoTime() - engineStart);
             // Only send RowDescription if not already sent during DESCRIBE
             if (!portal.rowDescriptionSent) {
@@ -593,6 +611,7 @@ public class PostgresNetworkExecutor extends Thread {
               profile.addSerializationNanos(System.nanoTime() - serStart);
             }
           } else {
+            portal.executed = true;
             profile.addEngineNanos(System.nanoTime() - engineStart);
           }
         }
@@ -795,8 +814,7 @@ public class PostgresNetworkExecutor extends Thread {
           resultSet = database.command(query.language, query.query, server.getConfiguration());
         }
       }
-      final List<Result> cachedResultSet = browseAndCacheBoundedResultSet(resultSet,
-          GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.getValueAsInteger());
+      final List<Result> cachedResultSet = browseAndCacheBoundedResultSet(resultSet);
       profile.addEngineNanos(System.nanoTime() - engineStart);
 
       final long serStart = System.nanoTime();
@@ -854,63 +872,39 @@ public class PostgresNetworkExecutor extends Thread {
     writeMessage("ready for query", () -> channel.writeByte(transactionStatus), 'Z', 5);
   }
 
-  private List<Result> browseAndCacheResultSet(final ResultSet resultSet, final int limit) {
-    return browseAndCacheResultSet(resultSet, limit, true);
-  }
-
   /**
-   * Browse a result set and cache results up to the limit, then close the source ResultSet.
-   * <p>
-   * <b>Ownership:</b> this method takes ownership of the supplied ResultSet and closes it before returning, in
-   * both the natural-exhaustion and the limit-hit paths. Both callers that matter for issue #6458 - Describe
-   * ('P') and the first Execute of a portal that was never Described - call this with {@code limit=0} to
-   * materialize the whole result into {@link PostgresPortal#fullResultSet}: Describe needs every row to
-   * discover every column (documents can be sparse), and Execute needs the complete list to slice by whatever
-   * row-limit each Execute call declares, including a follow-up one continuing a previously suspended fetch
-   * (see the pagination step in {@code executeCommand()}, which slices {@code fullResultSet} rather than
-   * calling this method again). The {@code limit>0} form remains for the unrelated internal callers that want
-   * a bounded sample and are happy to see the rest of the result set discarded - {@code sendSuspendedOnLimit}
-   * is {@code false} for all of them, so the always-{@code limit=0} callers are the only ones that can still
-   * reach that branch.
+   * Browses a bounded sample of a result set and closes it, discarding whatever is left: for the internal schema
+   * probes that only need to look at a row or so and must not emit any protocol message.
    *
-   * @param resultSet           The result set to browse (this method closes it)
-   * @param limit               Maximum number of results to cache (0 = unlimited)
-   * @param sendSuspendedOnLimit If true and limit is reached, sends PortalSuspended message.
-   *                            Set to false for internal queries (like schema discovery) that
-   *                            should not send protocol messages.
+   * @param resultSet The result set to browse (this method closes it)
+   * @param limit     Maximum number of results to cache
    */
-  private List<Result> browseAndCacheResultSet(final ResultSet resultSet, final int limit, final boolean sendSuspendedOnLimit) {
+  private List<Result> browseSample(final ResultSet resultSet, final int limit) {
     try (resultSet) {
-      final List<Result> cachedResultSet = new ArrayList<>();
-      while (resultSet.hasNext()) {
+      final List<Result> sample = new ArrayList<>(limit);
+      while (sample.size() < limit && resultSet.hasNext()) {
         final Result row = resultSet.next();
-        if (row == null)
-          continue;
-
-        cachedResultSet.add(row);
-
-        if (limit > 0 && cachedResultSet.size() >= limit) {
-          if (sendSuspendedOnLimit)
-            portalSuspendedResponse();
-          break;
-        }
+        if (row != null)
+          sample.add(row);
       }
-      return cachedResultSet;
+      return sample;
     }
   }
 
   /**
-   * Browses and caches a result set for the simple-query ('Q' message) protocol path, refusing (rather than
-   * silently truncating) a result larger than {@code maxRows} - and stopping the scan as soon as that is known,
+   * Materializes a statement's result and closes it, refusing (rather than silently truncating) a result larger
+   * than {@link GlobalConfiguration#POSTGRES_QUERY_MAX_ROWS} - and stopping the scan as soon as that is known,
    * rather than paying to read the rest of an oversized source just to reject it.
    * <p>
-   * Unlike the extended query protocol - where a portal's {@code Execute} message carries its own client-chosen
-   * max-rows and a limit hit is a normal, expected {@code PortalSuspended} the client explicitly asked for by
-   * fetching in batches - the simple-query protocol has no such mechanism: a 'Q' message always means "give me
-   * the complete result". This path is also why the whole result had to be held in memory in the first place:
-   * determining the row description (the union of columns and their types across heterogeneous/schemaless rows)
-   * genuinely requires having seen every row before the first one can be sent, since Postgres's wire protocol
-   * fixes the column set in {@code RowDescription}, sent before any {@code DataRow}.
+   * Every wire path that answers a statement goes through here: the simple-query ('Q') path, and the two
+   * extended-protocol sites that materialize a portal (Describe('P') and the first Execute of a portal that was
+   * never Described - issue #6458). The whole result has to be held in memory before the first row is sent on
+   * either protocol: determining the row description (the union of columns and their types across
+   * heterogeneous/schemaless rows) genuinely requires having seen every row, since Postgres's wire protocol fixes
+   * the column set in {@code RowDescription}, sent before any {@code DataRow}. The portal's client-chosen
+   * max-rows on {@code Execute} bounds how many of the held rows each Execute SENDS (a limit hit there is a
+   * normal {@code PortalSuspended}), not how many the server holds, which is why the extended path is capped by
+   * the same knob rather than left to the client (issue #7034).
    * <p>
    * Aborting the scan early is safe for a write statement too: {@code UpdateExecutionPlan.executeInternal()} (and
    * {@code DeleteExecutionPlan}, which extends it) fully executes every matched row's write and buffers the whole
@@ -921,9 +915,10 @@ public class PostgresNetworkExecutor extends Thread {
    * much of that already-complete result gets copied into {@code cachedResultSet}; it can never leave a write
    * half-done.
    *
-   * @param maxRows the maximum number of rows to buffer, 0 = unlimited (matches {@link GlobalConfiguration#POSTGRES_SIMPLE_QUERY_MAX_ROWS})
+   * @param resultSet The result set to browse (this method closes it)
    */
-  private List<Result> browseAndCacheBoundedResultSet(final ResultSet resultSet, final int maxRows) {
+  private List<Result> browseAndCacheBoundedResultSet(final ResultSet resultSet) {
+    final int maxRows = GlobalConfiguration.POSTGRES_QUERY_MAX_ROWS.getValueAsInteger();
     try (resultSet) {
       final List<Result> cachedResultSet = new ArrayList<>();
       while (resultSet.hasNext()) {
@@ -935,9 +930,9 @@ public class PostgresNetworkExecutor extends Thread {
 
         if (maxRows > 0 && cachedResultSet.size() > maxRows)
           throw new CommandExecutionException(
-              "Result set exceeds the configured limit of " + maxRows + " rows for the Postgres simple-query protocol ("
-                  + GlobalConfiguration.POSTGRES_SIMPLE_QUERY_MAX_ROWS.getKey()
-                  + "); use the extended query protocol with a bounded portal fetch size for large result sets");
+              "Result set exceeds the configured limit of " + maxRows + " rows buffered server-side for the Postgres wire protocol ("
+                  + GlobalConfiguration.POSTGRES_QUERY_MAX_ROWS.getKey()
+                  + "); narrow the statement with a WHERE or LIMIT clause, or raise the limit");
       }
 
       return cachedResultSet;
@@ -1419,7 +1414,7 @@ public class PostgresNetworkExecutor extends Thread {
       // not a client-initiated query that should send protocol messages
       final String sampleQuery = "SELECT FROM `" + typeName + "` LIMIT 1";
       final ResultSet resultSet = database.query("sql", sampleQuery, server.getConfiguration());
-      final List<Result> sampleRows = browseAndCacheResultSet(resultSet, 1, false);
+      final List<Result> sampleRows = browseSample(resultSet, 1);
 
       if (!sampleRows.isEmpty()) {
         // Use the sample row to discover columns
@@ -1646,7 +1641,7 @@ public class PostgresNetworkExecutor extends Thread {
       stripProbe(sample, context);
 
       final ResultSet resultSet = sample.execute(database, parameters != null ? parameters : NO_PARAMETERS, context);
-      final List<Result> sampleRows = browseAndCacheResultSet(resultSet, 1, false);
+      final List<Result> sampleRows = browseSample(resultSet, 1);
       return sampleRows.isEmpty() ? null : getColumns(sampleRows, resolveQueryTargetType(select), resolveAliasToSourceProperty(select));
     } catch (final Exception e) {
       if (DEBUG)

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7034PortalMaxRowsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7034PortalMaxRowsIT.java
@@ -20,12 +20,12 @@ package com.arcadedb.postgres;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
-import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.net.InetSocketAddress;
@@ -41,25 +41,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 /**
- * Regression test for issue #6679: the Postgres simple-query ('Q' message) protocol path materialized the
- * entire result set into an unbounded {@code List<Result>} before sending the first row, so a large {@code
- * SELECT} risked an {@code OutOfMemoryError}. The simple-query protocol has no client-driven cursor/max-rows
- * mechanism (unlike the extended protocol's portal {@code Execute}), so buffering could not simply be turned
- * into a silent {@code PortalSuspended} truncation without misreporting a partial result as the whole answer.
- * The fix instead bounds the buffer with {@link GlobalConfiguration#POSTGRES_QUERY_MAX_ROWS} and refuses
- * a SELECT whose result exceeds it with a clear {@code ErrorResponse}, protecting server memory without
- * silently returning wrong (truncated) data. The same knob caps the extended-protocol portal since issue #7034
- * ({@link Issue7034PortalMaxRowsIT}).
+ * Regression test for issue #7034 (follow-up to #6679): the extended-protocol portal materialized the entire
+ * result set with no cap at all, at both sites that run a portal - {@code Describe('P')} and the first
+ * {@code Execute} of a portal that was never Described - so the "whole result in memory before the first byte"
+ * defect #6679 fixed on the simple-query path was still reachable, and the {@code Execute} row limit the client
+ * chose bounded only what was sent, not what the server held. The same knob,
+ * {@link GlobalConfiguration#POSTGRES_QUERY_MAX_ROWS}, now caps every wire path.
  * <p>
- * This test speaks the wire protocol directly over a raw socket (rather than through the JDBC driver) so the
- * exact byte-level response - an {@code ErrorResponse} versus a normal {@code RowDescription}/{@code DataRow}
- * stream - can be asserted on.
+ * A refusal at {@code Describe('P')} also has to reach the client as an {@code ErrorResponse}: a failure of the
+ * query at Describe time used to go to the server log only, leaving the client waiting for a RowDescription that
+ * never came.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
-  private static final int    ROW_CAP  = 5;
-  private static final String TYPE     = "Issue6679Row";
+class Issue7034PortalMaxRowsIT extends PostgresWireProtocolTestBase {
+  private static final int    ROW_CAP = 5;
+  private static final String TYPE    = "Issue7034Row";
 
   @Override
   public void setTestConfiguration() {
@@ -85,8 +82,8 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
   }
 
   @Test
-  @DisplayName("[#6679] a simple-query SELECT whose result exceeds the configured cap is refused, not silently truncated")
-  void resultOverTheCapIsRefusedWithAnErrorResponse() throws Exception {
+  @DisplayName("[#7034] Describe('P') on a portal whose result exceeds the cap is refused with an ErrorResponse, even with a small Execute fetch size")
+  void describedPortalOverTheCapIsRefused() throws Exception {
     createRows(ROW_CAP + 10);
 
     try (final Socket socket = new Socket()) {
@@ -96,34 +93,38 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
       authenticate(out, in);
 
       assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
-        sendSimpleQuery(out, "SELECT FROM " + TYPE);
+        // The pgjdbc/psycopg shape: Parse/Bind/Describe('P')/Execute(max_rows=2)/Sync. The client asked for 2 rows;
+        // the server would have held all 15.
+        sendParse(out, "SELECT FROM " + TYPE);
+        sendBind(out, "P1");
+        sendDescribe(out, "P1");
+        sendExecute(out, "P1", 2);
+        sendSync(out);
         final List<WireMessage> response = readUntilReadyForQuery(in);
 
-        assertThat(messageTypesOf(response)).as("an ErrorResponse instead of a truncated result").contains('E');
-        assertThat(messageTypesOf(response)).as("no CommandComplete for a refused query").doesNotContain('C');
-        assertThat(messageTypesOf(response)).as("no DataRow for a refused query").doesNotContain('D');
+        assertThat(messageTypesOf(response)).as("ParseComplete, BindComplete, then the refusal").startsWith('1', '2', 'E');
+        assertThat(messageTypesOf(response)).as("no RowDescription for a refused portal").doesNotContain('T');
+        assertThat(messageTypesOf(response)).as("no DataRow for a refused portal").doesNotContain('D');
+        assertThat(messageTypesOf(response)).as("the pipelined Execute is discarded up to Sync, not answered")
+            .doesNotContain('C', 's');
         final WireMessage error = response.stream().filter(m -> m.type() == 'E').findFirst()
             .orElseThrow(() -> new AssertionError("expected an ErrorResponse"));
-        assertThat(errorFields(error).get('M')).contains("exceeds the configured limit").contains(String.valueOf(ROW_CAP));
-
-        // The session must stay usable afterwards: not left aborted/wedged by the refusal.
+        assertThat(errorFields(error).get('M')).contains("exceeds the configured limit").contains(String.valueOf(ROW_CAP))
+            .contains(GlobalConfiguration.POSTGRES_QUERY_MAX_ROWS.getKey());
         assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
 
-        // Prove it, rather than just trusting the status byte: the same socket must still accept and answer a
-        // normal query, not merely report idle while actually closed/wedged.
+        // The session must stay usable afterwards
         sendSimpleQuery(out, "SELECT 1 AS one");
         final List<WireMessage> followUp = readUntilReadyForQuery(in);
-        assertThat(messageTypesOf(followUp)).as("a normal query after the refusal must succeed").doesNotContain('E');
-        assertThat(messageTypesOf(followUp)).as("a normal query after the refusal must return its row").contains('D');
-        assertThat(readyForQueryStatusOf(followUp)).isEqualTo('I');
+        assertThat(messageTypesOf(followUp)).doesNotContain('E').contains('D');
       });
     }
   }
 
   @Test
-  @DisplayName("[#6679] a simple-query SELECT within the configured cap still returns every row normally")
-  void resultWithinTheCapIsReturnedInFull() throws Exception {
-    createRows(ROW_CAP - 2);
+  @DisplayName("[#7034] the first Execute of a never-Described portal whose result exceeds the cap is refused")
+  void unDescribedPortalOverTheCapIsRefused() throws Exception {
+    createRows(ROW_CAP + 10);
 
     try (final Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
@@ -132,20 +133,29 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
       authenticate(out, in);
 
       assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
-        sendSimpleQuery(out, "SELECT FROM " + TYPE);
+        sendParse(out, "SELECT FROM " + TYPE);
+        sendBind(out, "P1");
+        sendExecute(out, "P1", 2);
+        sendSync(out);
         final List<WireMessage> response = readUntilReadyForQuery(in);
 
-        assertThat(messageTypesOf(response)).as("no ErrorResponse for a result within the cap").doesNotContain('E');
-        final long dataRows = response.stream().filter(m -> m.type() == 'D').count();
-        assertThat(dataRows).isEqualTo(ROW_CAP - 2);
+        assertThat(messageTypesOf(response)).startsWith('1', '2', 'E');
+        assertThat(messageTypesOf(response)).doesNotContain('T', 'D', 'C', 's');
         assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+
+        // A refused portal is not left looking like a drained one: executing it again refuses again rather than
+        // answering an empty CommandComplete
+        sendExecute(out, "P1", 2);
+        sendSync(out);
+        final List<WireMessage> again = readUntilReadyForQuery(in);
+        assertThat(messageTypesOf(again)).startsWith('E').doesNotContain('D', 'C');
       });
     }
   }
 
   @Test
-  @DisplayName("[#6679] a simple-query SELECT of exactly the configured cap is returned in full")
-  void resultAtTheCapIsReturnedInFull() throws Exception {
+  @DisplayName("[#7034] a portal within the cap is still paginated by the Execute row limit exactly as before")
+  void portalWithinTheCapIsPaginatedNormally() throws Exception {
     createRows(ROW_CAP);
 
     try (final Socket socket = new Socket()) {
@@ -155,27 +165,28 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
       authenticate(out, in);
 
       assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
-        sendSimpleQuery(out, "SELECT FROM " + TYPE);
-        final List<WireMessage> response = readUntilReadyForQuery(in);
+        sendParse(out, "SELECT FROM " + TYPE);
+        sendBind(out, "P1");
+        sendDescribe(out, "P1");
+        sendExecute(out, "P1", 3);
+        sendSync(out);
+        final List<WireMessage> first = readUntilReadyForQuery(in);
+        assertThat(messageTypesOf(first)).as("exactly the cap is not refused").doesNotContain('E');
+        assertThat(first.stream().filter(m -> m.type() == 'D').count()).isEqualTo(3);
+        assertThat(messageTypesOf(first)).as("suspended with rows left").contains('s').doesNotContain('C');
 
-        assertThat(messageTypesOf(response)).as("a result of exactly the cap must not be refused").doesNotContain('E');
-        final long dataRows = response.stream().filter(m -> m.type() == 'D').count();
-        assertThat(dataRows).isEqualTo(ROW_CAP);
-        assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
+        sendExecute(out, "P1", 3);
+        sendSync(out);
+        final List<WireMessage> second = readUntilReadyForQuery(in);
+        assertThat(second.stream().filter(m -> m.type() == 'D').count()).isEqualTo(ROW_CAP - 3);
+        assertThat(messageTypesOf(second)).as("drained").contains('C').doesNotContain('s', 'E');
       });
     }
   }
 
-  /**
-   * The row cap must never leave a write statement partially executed: {@code UPDATE ... RETURN} still updates
-   * every matching row even when its RETURN result exceeds the cap, and only the (now fully-applied) result is
-   * refused.
-   */
   @Test
-  @DisplayName("[#6679] an UPDATE ... RETURN over the cap still updates every row; only the RETURN result is refused")
-  void updateReturnOverTheCapStillAppliesEveryWrite() throws Exception {
-    createRows(ROW_CAP + 10);
-
+  @DisplayName("[#7034] a query that fails at Describe('P') is reported to the client as an ErrorResponse, not only logged")
+  void queryFailingAtDescribeIsReportedToTheClient() throws Exception {
     try (final Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
       final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
@@ -183,19 +194,18 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
       authenticate(out, in);
 
       assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
-        sendSimpleQuery(out, "UPDATE " + TYPE + " SET touched = true RETURN AFTER");
+        // Parses fine (the SQL parser does not check the schema), fails when run at Describe time
+        sendParse(out, "SELECT FROM TypeThatDoesNotExist7034");
+        sendBind(out, "P1");
+        sendDescribe(out, "P1");
+        sendExecute(out, "P1", 0);
+        sendSync(out);
         final List<WireMessage> response = readUntilReadyForQuery(in);
 
-        assertThat(messageTypesOf(response)).as("the oversized RETURN result is refused").contains('E');
+        assertThat(messageTypesOf(response)).startsWith('1', '2', 'E');
+        assertThat(messageTypesOf(response)).doesNotContain('T', 'D', 'C');
         assertThat(readyForQueryStatusOf(response)).isEqualTo('I');
       });
-    }
-
-    final Database database = getServerDatabase(0, getDatabaseName());
-    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM " + TYPE + " WHERE touched = true")) {
-      assertThat(rs.hasNext()).isTrue();
-      assertThat(((Number) rs.next().getProperty("c")).longValue())
-          .as("every matching row must be updated even though the RETURN result was refused").isEqualTo(ROW_CAP + 10);
     }
   }
 
@@ -212,6 +222,59 @@ class Issue6679SimpleQueryMaxRowsIT extends PostgresWireProtocolTestBase {
     out.writeInt(4 + queryBytes.length + 1);
     out.write(queryBytes);
     out.writeByte(0);
+    out.flush();
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // unnamed statement
+    writeCString(body, query);
+    body.write(0);
+    body.write(0); // int16 numParamDataTypes = 0
+    writeFramed(out, 'P', body);
+  }
+
+  private static void sendBind(final DataOutputStream out, final String portalName) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, portalName);
+    writeCString(body, ""); // unnamed statement
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0
+    body.write(0);
+    body.write(0); // int16 numParamValues = 0
+    body.write(0);
+    body.write(0); // int16 numResultFormatCodes = 0 (all text)
+    writeFramed(out, 'B', body);
+  }
+
+  private static void sendDescribe(final DataOutputStream out, final String portalName) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    body.write('P');
+    writeCString(body, portalName);
+    writeFramed(out, 'D', body);
+  }
+
+  private static void sendExecute(final DataOutputStream out, final String portalName, final int maxRows) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, portalName);
+    body.write((maxRows >>> 24) & 0xFF);
+    body.write((maxRows >>> 16) & 0xFF);
+    body.write((maxRows >>> 8) & 0xFF);
+    body.write(maxRows & 0xFF);
+    writeFramed(out, 'E', body);
+  }
+
+  private static void sendSync(final DataOutputStream out) throws Exception {
+    out.writeByte('S');
+    out.writeInt(4);
+    out.flush();
+  }
+
+  private static void writeFramed(final DataOutputStream out, final char type, final ByteArrayOutputStream body) throws Exception {
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte(type);
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
     out.flush();
   }
 


### PR DESCRIPTION
Fixes #6934, fixes #7084, fixes #7036, fixes #7034, fixes #7033.

## #6934 - composite index with one BY ITEM/BY KEY/BY VALUE property never updated when only the scalar changes
`updateListItemsInIndex`/`updateMapEntriesInIndex` diffed the collection's element membership only, so `UPDATE Doc SET status='B'` on `(status, tags BY ITEM)` left every entry keyed by `A`: invisible under the real key, visible under the stale one, and a spurious `DuplicatedKeyException` on UNIQUE. Both updaters are replaced by one `updateExpandedKeysInIndex` that collects the complete key tuples through the same `forEachListItemKey`/`forEachMapEntryKey` builders the insert path uses and applies the delta with `applyTupleDelta`, now shared with the multi-`BY ITEM` sibling that was already correct. Insert and update can no longer disagree on the key shape.

## #7084 - CONTAINSANY with an array right-hand side never matches
An array satisfied neither `Iterable` nor `Iterator`, so it was compared as one opaque object. Beyond the array normalization the issue asks for, the operator's two left-hand branches are unified: both compare with `QueryOperatorEquals` (so `[1,2,3] CONTAINSANY [2L]` answers the same whatever the left operand's concrete type, as `CONTAINSALL` already does), a `byte[]` on the right stays the BINARY scalar (the #7079 carve-out), and an `Iterable` left is collected once and re-scanned for every right-hand item: the old loop exhausted the left iterator on the first right item, so `[1,2] CONTAINSANY [9,1]` was false through that branch.

## #7036 - GraphQL introspection ignores field aliases at five sites
Rather than patching the five sites with the same ternary, `Selection` now owns the resolution: `getAnyField()`, `getFieldName()`, `getArguments()`, `getSelectionSet()` answer for a plain or an aliased selection alike. `GraphQLSchema` (query dispatch, native directives, all introspection builders) and `GraphQLResultSet` go through them, which also removes the duplicated `field != null ? ... : aliasField != null ? ...` chains. An aliased introspection sub-selection (`f: fields`, `t: type`, `q: queryType`) is served under the alias, the response key the spec prescribes and what the query path already does.

## #7034 - Postgres extended-protocol portal buffers the whole result unbounded
The two portal sites (`Describe('P')` and the first `Execute` of an un-Described portal) now go through the same bounded materialization as the simple-query path. The knob is renamed to `arcadedb.postgres.queryMaxRows` (`POSTGRES_QUERY_MAX_ROWS`) since it caps every wire path; the old `simpleQueryMaxRows` was added by #6679 after 26.8.1 and is in no release, so nothing deployed breaks. The config text no longer recommends the extended protocol as the remedy and says why the portal's row limit cannot bound what the server holds. `portal.executed` is set only once the rows are held, so a refused portal errors again on re-Execute rather than answering an empty `CommandComplete`.

Found while testing: a query failing during `Describe('P')` (the refusal, or any runtime error) propagated to the session loop and was only logged, leaving the client without the one reply Describe is owed. It is now answered with an `ErrorResponse` like a failed Execute; `PostgresProtocolException` still closes the connection.

Streaming the portal instead of buffering it (keeping the `ResultSet` open across `Execute` messages, the real Postgres cursor model) would remove the need for the cap on the extended path, but it conflicts with the sparse-column discovery #6458 depends on and is a protocol-wide change; left as follow-up material.

## #7033 - non-polymorphic `buckets`/`bucketIds` not volatile
The whole quartet is volatile, the field comment names `getBuckets(false)` readers explicitly, and the `SelectExecutionPlanner` comment that claimed invariance "because schema mutations take the lock the planner doesn't hold" now states the actual guarantee (a complete copy-on-write snapshot published through a volatile field). `Issue6678PolymorphicBucketCacheVisibilityTest` pins all four modifiers and checks both accessor branches.

## Tests
- `Issue6934CompositeExpandedKeyScalarUpdateTest` (7 cases: LIST BY ITEM, nested `items.id BY ITEM`, MAP BY KEY/BY VALUE, UNIQUE key release, scalar+list changed together, no-op update) - fails 6/7 on main
- `ContainsAnyConditionTest` (+4), `QueryTest.containsAnyWithArrayOnRhs`
- `Issue7036IntrospectionAliasTest` (3 cases covering aliased `__type`, `__schema`, and sub-selections on both type builders)
- `Issue7034PortalMaxRowsIT` (4 cases: Describe path, un-Described Execute path, pagination within the cap, error at Describe reaches the client); `Issue6679SimpleQueryMaxRowsIT` on the renamed key
- Run: engine `index.*`, `parser.operators.*`, `schema.*`, `database.*`, `QueryTest` (1259 green); graphql module (104 green); postgresw IT lane (214 green)

## Docs
`arcadedb.postgres.simpleQueryMaxRows` becomes `arcadedb.postgres.queryMaxRows`; if the settings page already lists the former, it should be updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PostgreSQL query row limits now apply consistently to both simple and extended query protocols. A limit of `0` remains unlimited.
  - GraphQL introspection and nested selections now correctly support aliases, including aliased response fields.

- **Bug Fixes**
  - Improved `CONTAINSANY` handling for arrays, collections, iterators, nulls, and numeric comparisons.
  - Fixed composite indexes involving scalar fields and expanded collection values so updates remove stale entries and preserve valid keys.
  - Improved PostgreSQL portal limit enforcement and error handling while preserving pagination for permitted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->