### PR TITLE
feat(native): align GraalVM to mainline CE 25.0.2 and add local build scripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,17 +41,15 @@ updates:
       # gremlin ANTLR PR is closed by hand instead.
       #
       # The GraalVM Truffle/polyglot coordinates (org.graalvm.*) are unlisted for
-      # the same reason. They appear with two different intents:
-      # native/pom.xml's native.graalvm.version MUST equal the native-image
-      # builder pinned by native-image.yml's java-version (a mismatch aborts the
-      # image build with NoSuchMethodError getLoopNodeFactory()), while
-      # engine/pom.xml's graalvm.version tracks the latest independently for the
-      # JVM-side JS engine. A coordinate-wide ignore would freeze the engine
-      # along with the native pin. A GraalVM PR is therefore reviewed by hand:
-      # merge it only together with a matching java-version bump in
-      # native-image.yml, otherwise close it. Bumps 3fecba4bf (-> 25.2.4) and
-      # b53c48c1e2 (-> 25.3.4.1) both did exactly this wrong and broke every
-      # native leg.
+      # the same reason. THREE places carry this version and all three must move
+      # in one commit: native/pom.xml's native.graalvm.version,
+      # engine/pom.xml's graalvm.version, and the builder pinned by
+      # native-image.yml's java-version. A mismatch between the artifacts and
+      # the builder aborts the image build with NoSuchMethodError
+      # getLoopNodeFactory(), naming neither side. A GraalVM PR is therefore
+      # reviewed by hand: merge it only when it moves all three, otherwise close
+      # it. Bumps 3fecba4bf (-> 25.2.4) and b53c48c1e2 (-> 25.3.4.1) both did
+      # exactly this wrong and broke every native leg.
       #
       # A bump is not impossible, just not a one-line edit. native-image.yml
       # pins the builder through setup-graalvm's `java-version` input, which

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,12 +54,20 @@ updates:
       # native leg.
       #
       # A bump is not impossible, just not a one-line edit. native-image.yml
-      # pins the builder through setup-graalvm's `version` input precisely so
-      # it can address the intermediate release graal-25.2.4; the
-      # `java-version` input reaches jdk-* releases only. Whatever the new
-      # version is, its tag must parse as three-component semver -
-      # graal-25.3.4.1 is reachable through neither input, because node-semver
-      # rejects its four numeric components.
+      # pins the builder through setup-graalvm's `java-version` input, which
+      # reaches jdk-* releases only - deliberately, because that is GraalVM's
+      # MAINLINE line and the one the OS packagers carry, so a contributor can
+      # install the matching builder and run a local native build. The other
+      # input, `version`, additionally reaches the intermediate graal-* releases;
+      # the pin used it while it tracked graal-25.2.4.
+      #
+      # Two traps for whoever raises the pin next. Its tag must parse as
+      # three-component semver - graal-25.3.4.1 is reachable through neither
+      # input, because node-semver rejects its four numeric components. And the
+      # version must exist as a CE TARBALL, which being on Maven Central does
+      # not imply: 25.0.3 and 25.0.4 publish the full org.graalvm.* set and were
+      # never released as a distribution, so a pin bumped to either resolves
+      # cleanly in Maven and then has no builder to match, on any platform.
       #
       # Two guards now back that up, because "reviewed by hand" was not one:
       # .github/scripts/check-native-graalvm-pin.py fails the always-on `lint`

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -98,24 +98,32 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # `version`, NOT `java-version`, and the difference is load-bearing. setup-graalvm resolves a
-      # Community build two ways: `java-version` fetches a `jdk-<version>` release and so can only
-      # ever reach GraalVM's MAINLINE builds, while `version` looks up `graal-<version>` first and
-      # falls back to `jdk-<version>`. 25.2.4 is an intermediate release, published as the tag
-      # graal-25.2.4 (assets graalvm-community-jdk-25i2-25.0.4_*), so it is reachable through
-      # `version` alone. Both paths still go through findLatestGraalVMCEVersion, which skips any
-      # tag node-semver's semver.valid() rejects - which is why the four-component 25.3.4.1 is
-      # reachable through NEITHER input, and must never be pinned in native/pom.xml.
+      # `java-version`, which fetches the `jdk-<version>` release and so reaches GraalVM's MAINLINE
+      # builds only. That is deliberate and is the point of the pin: mainline is the line the OS
+      # packagers carry (`brew install --cask graalvm-community-jdk25` is 25.0.2), so a contributor
+      # can install the matching builder and run a local native build instead of hand-downloading a
+      # tarball. The alternative input, `version`, looks up `graal-<version>` first and falls back
+      # to `jdk-<version>`, so it reaches the intermediate line too - this step used it while the
+      # pin tracked 25.2.4. `version: "25.0.2"` would work here as well; `java-version` is used
+      # because it states the intent that this pin stays mainline.
+      #
+      # Both paths go through findLatestGraalVMCEVersion, which skips any tag node-semver's
+      # semver.valid() rejects - which is why the four-component 25.3.4.1 is reachable through
+      # NEITHER input, and must never be pinned in native/pom.xml.
+      #
+      # Careful with the mainline patch numbers: 25.0.3 and 25.0.4 exist on Maven Central but were
+      # never published as CE tarballs, so neither is installable here even though bumping
+      # native/pom.xml to one of them resolves cleanly. See that property's comment for the table.
       #
       # This is pinned to the EXACT release that native/pom.xml's native.graalvm.version pins the
       # Truffle/polyglot artifacts to. A builder/Truffle version skew fails the native build at
       # feature registration (NoSuchMethodError: OptimizedTruffleRuntime.getLoopNodeFactory()) -
       # see docs/native-image.md "Prerequisites". Move the two together or not at all;
       # .github/scripts/check-native-graalvm-pin.py fails the `lint` job if they disagree.
-      - name: Set up GraalVM (Community 25.2.4, JDK 25.0.4)
+      - name: Set up GraalVM (Community 25.0.2)
         uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.1
         with:
-          version: "25.2.4"
+          java-version: "25.0.2"
           distribution: "graalvm-community"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: "true"
@@ -150,10 +158,11 @@ jobs:
       #     --static --libc=musl, nothing path-related).
       #
       # linux/arm64 (linkmode: mostly-static) deliberately does NOT run this step: GraalVM CE
-      # ships no static musl JDK libraries for aarch64 (the graalvm-community-jdk-25i2-25.0.4
+      # ships no static musl JDK libraries for aarch64 (the graalvm-community-jdk-25.0.2
       # linux-aarch64 release tarball has lib/static/linux-aarch64/glibc but not
       # lib/static/linux-aarch64/musl - linux-amd64 ships both - see oracle/graal#4645, closed
-      # not-planned; re-checked against this tarball when the pin moved off 25.0.2), so --static --libc=musl can never link on that architecture regardless of
+      # not-planned; both halves re-listed out of the 25.0.2 tarballs when the pin moved back to
+      # this release), so --static --libc=musl can never link on that architecture regardless of
       # toolchain setup. Rather than run a toolchain step known to be useless there, the arm64 leg
       # instead builds with -Dnative.mostlystatic=true (native/pom.xml's native-mostly-static
       # profile: -H:+StaticExecutableWithDynamicLibC - static except glibc itself), which needs no

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -260,6 +260,15 @@ cannot cross-compile, so a macOS host has no other way to produce the Linux bina
 need. Both **runtime** Dockerfiles are used unmodified, so what you get is the shipped image
 rather than a local approximation; only the builder image is local-only, and it is never published.
 
+**Give Docker at least 12 GiB of memory** (Docker Desktop: Settings -> Resources -> Memory; CI's
+Linux runners have 16 GiB). `native-image` sizes its build heap at ~80% of the memory it can see,
+and inside a container that is the Docker VM's allocation, not the host's - so a 36 GiB Mac left on
+Docker Desktop's 8 GiB default still fails, with a Java heap `OutOfMemoryError` about 21 minutes in,
+once the whole Maven reactor has already built. This image embeds GraalJS, which is why it is so
+hungry: `native-image.yml` had to move its macOS leg onto a paid larger runner for the same reason.
+The script checks this up front rather than letting you discover it 21 minutes later;
+`--builder-memory <size>` caps the builder heap explicitly, and `--allow-low-memory` skips the check.
+
 The GraalVM download URL is resolved at build time from the `graal-<version>` release matching
 `native/pom.xml`'s `native.graalvm.version`, so the builder cannot drift from the pin the way a
 hardcoded URL would - see that property's comment for why that matters. The Maven repository and

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -14,22 +14,41 @@ treat it as best-effort outside Linux.
 
 ## Prerequisites
 
-- **GraalVM CE 25.2.4 (JDK 25.0.4).** The build uses the GraalVM Native Image Community Edition
-  builder pinned by CI to `graal-25.2.4` (assets `graalvm-community-jdk-25i2-25.0.4_*`) via
-  [`graalvm/setup-graalvm`](https://github.com/graalvm/setup-graalvm). `native/pom.xml` pins the
-  GraalVM polyglot/Truffle artifacts (`graal-sdk`, `polyglot`, `js-language`, `truffle-*`, etc.) to
-  the same `25.2.4` to match the builder exactly; a Truffle version skew between the builder and
-  those artifacts fails the build at feature registration (`NoSuchMethodError:
-  OptimizedTruffleRuntime.getLoopNodeFactory()`). That error names neither file, and two Dependabot
-  bumps have shipped the skew, so `.github/scripts/check-native-graalvm-pin.py` enforces the
-  equality in the always-on `lint` job. Move both sides in the same change, or neither.
+- **GraalVM CE 25.0.2.** The build uses the GraalVM Native Image Community Edition builder pinned
+  by CI to `jdk-25.0.2` via [`graalvm/setup-graalvm`](https://github.com/graalvm/setup-graalvm).
+  Install it the easy way - it is a *mainline* release, so the OS packagers carry it:
 
-  **The workflow pins the builder through setup-graalvm's `version` input, not `java-version`, and
-  that is not interchangeable.** The action resolves a CE build two ways: `java-version` fetches a
-  `jdk-<version>` release and requires exactly three dot-components, so it reaches *mainline*
-  builds only; `version` looks up `graal-<version>` first and falls back to `jdk-<version>`.
-  25.2.4 is an *intermediate* release published under the `graal-25.2.4` tag, so only `version`
-  can select it - switching that step back to `java-version` would stop resolving this build.
+  ```bash
+  brew install --cask graalvm-community-jdk25     # macOS: 25.0.2
+  ```
+
+  `native/pom.xml` pins the GraalVM polyglot/Truffle artifacts (`graal-sdk`, `polyglot`,
+  `js-language`, `truffle-*`, etc.) to the same `25.0.2` to match the builder exactly; a Truffle
+  version skew between the builder and those artifacts fails the build at feature registration
+  (`NoSuchMethodError: OptimizedTruffleRuntime.getLoopNodeFactory()`). That error names neither
+  file, and two Dependabot bumps have shipped the skew, so
+  `.github/scripts/check-native-graalvm-pin.py` enforces the equality in the always-on `lint` job.
+  Move both sides in the same change, or neither.
+
+  **Being on Maven Central does not make a version installable.** `25.0.3` and `25.0.4` publish
+  the full set of `org.graalvm.*` artifacts but were never released as CE tarballs, so bumping
+  `native/pom.xml` to either resolves cleanly and then leaves no builder to match, on any platform
+  and through any setup-graalvm input. As of 2026-09-03 the CE distributions are:
+
+  | Version | CE tarball | Maven artifacts | |
+  |---|---|---|---|
+  | 25.0.2 | `jdk-25.0.2` | yes | **pinned** |
+  | 25.0.3 | none | yes | |
+  | 25.0.4 | none | yes | |
+  | 25.1.3 | `graal-25.1.3` | yes | intermediate |
+  | 25.2.4 | `graal-25.2.4` | yes | intermediate, the previous pin |
+
+  The workflow selects the builder with setup-graalvm's `java-version` input, which fetches a
+  `jdk-<version>` release and so reaches mainline builds only - which is the point. The other
+  input, `version`, looks up `graal-<version>` first and falls back to `jdk-<version>`, so it
+  reaches the intermediate line too; the pin used it while it tracked 25.2.4. `version: "25.0.2"`
+  would work here as well, and `java-version` is used to state the intent that the pin stays
+  mainline.
 
   Any future pin must be a version whose tag parses as three-component semver. `graal-25.3.4.1` is
   reachable through **neither** input: node-semver rejects its four numeric components, so
@@ -44,7 +63,7 @@ treat it as best-effort outside Linux.
   JAVA_HOME`. Export both explicitly before building locally, e.g. on macOS:
 
   ```bash
-  export JAVA_HOME=/path/to/graalvm-community-25.2.4/Contents/Home
+  export JAVA_HOME=/path/to/graalvm-community-25.0.2/Contents/Home
   export GRAALVM_HOME=$JAVA_HOME
   ```
 

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -58,6 +58,20 @@ treat it as best-effort outside Linux.
 ## Building locally
 
 ```bash
+./native/scripts/build-native.sh              # host binary, with preflight checks
+./native/scripts/build-native.sh --smoke      # ... and run the smoke test against it
+```
+
+`native/scripts/build-native.sh` wraps the raw Maven command below with the three checks that turn
+this build's cryptic failures into an immediate, named error: that `JAVA_HOME`/`GRAALVM_HOME`
+really point at a GraalVM home with `bin/native-image`; that the builder is the version
+`native/pom.xml` pins its Truffle artifacts to (the `getLoopNodeFactory()` skew below, which has
+shipped to main twice); and, for a musl-static build, that the musl toolchain and its static
+`libz.a` are in place before the link step rather than after several minutes of compilation. It
+also picks the link mode CI uses for the host platform, and locates the produced binary the same
+way the workflow does. Pass `--` to forward extra arguments to Maven, or use the raw command:
+
+```bash
 mvn -Pnative -pl native -am -DskipTests package
 ```
 
@@ -222,6 +236,41 @@ reaches the Docker jobs. A manual `workflow_dispatch` run still builds and smoke
 (`--load` into the runner's local Docker daemon) without logging into Docker Hub or pushing anything,
 so the Dockerfiles can be validated end to end from any branch without publishing under
 `arcadedata/arcadedb`.
+
+### Building the images locally
+
+```bash
+./native/scripts/build-native-docker.sh                    # host arch, build + smoke, no push
+./native/scripts/build-native-docker.sh --port 2481        # ... if something already holds 2480
+./native/scripts/build-native-docker.sh --skip-binary-build  # iterate on the Dockerfiles only
+```
+
+`native/scripts/build-native-docker.sh` produces the same per-arch image the workflow publishes,
+from your working tree, without a registry. It does in one pass what CI splits across the `build`
+and `docker` jobs: build a throwaway builder image
+(`native/src/main/docker/Dockerfile.native-builder`) carrying the pinned GraalVM CE builder and -
+for amd64 - the musl toolchain with its musl-built static zlib; run the ordinary Maven native
+build **inside** it with the repository bind-mounted, so the Linux binary lands in `native/target`
+on the host; stage the build context the way the workflow's "Stage build context" step does; build
+the runtime image with `buildx --load`; then run `exercise.sh` against the container and scan its
+startup log, the same two assertions the workflow's "Smoke the container" step makes.
+
+The container step is what makes this work on a machine that is not Linux at all. Native Image
+cannot cross-compile, so a macOS host has no other way to produce the Linux binary these images
+need. Both **runtime** Dockerfiles are used unmodified, so what you get is the shipped image
+rather than a local approximation; only the builder image is local-only, and it is never published.
+
+The GraalVM download URL is resolved at build time from the `graal-<version>` release matching
+`native/pom.xml`'s `native.graalvm.version`, so the builder cannot drift from the pin the way a
+hardcoded URL would - see that property's comment for why that matters. The Maven repository and
+the `./mvnw` distribution are cached in `~/.cache/arcadedb-native-m2` (override with
+`ARCADEDB_NATIVE_M2`), so only the first run pays for populating them.
+
+The default architecture is the host's. Building the other one needs `--allow-emulation` and runs
+the entire native-image build under QEMU, which takes hours and often runs out of memory - that is
+why CI's `docker` job gives each architecture its own native runner instead of one runner with
+`buildx --platform`. The image is tagged `arcadedb:<version>-native-<arch>-local` by default, which
+deliberately is not a publishable `arcadedata/arcadedb` name.
 
 ## Running the container
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -39,11 +39,26 @@
         <lz4-java.version>1.11.2</lz4-java.version>
         <lucene.version>10.5.1</lucene.version>
         <!--
-            If this version changes, native/pom.xml's native.graalvm.version AND the
-            native-image.yml setup-graalvm java-version must move in lockstep: the native-image
-            builder pins a matching GraalVM CE patch release, and a builder/Truffle version skew
-            breaks the native build at feature registration (see native/pom.xml's
-            native.graalvm.version comment for the exact failure mode).
+            This does NOT have to equal native/pom.xml's native.graalvm.version, and as of this
+            commit it does not: that property is 25.0.2 while this one is 25.2.4. The pair that
+            must move in lockstep is native.graalvm.version and native-image.yml's setup-graalvm
+            input - a skew between THOSE two breaks the image build at feature registration (see
+            native/pom.xml's native.graalvm.version comment for the failure mode). This property
+            governs the JVM-side JS engine only and tracks the latest independently, which is also
+            what .github/dependabot.yml says when it explains why the org.graalvm.* coordinates
+            are not ignored wholesale.
+
+            The independence is structural, not luck: native/pom.xml declares dependencyManagement
+            entries for every org.graalvm.* coordinate at ${native.graalvm.version}, so the native
+            image resolves those rather than the versions this module asks for. Verified by
+            building the image with the two at 25.0.2 and 25.2.4 respectively and running
+            native/src/test/scripts/smoke.sh against it - the JS round-trip, which is the polyglot
+            path this property feeds, passes.
+
+            There is one real constraint in that arrangement, and it is one-way: the image resolves
+            the OLDER of the two, so engine code must stay within the API of
+            native.graalvm.version. Reaching for something added after it compiles fine here and
+            fails in the native build.
         -->
         <graalvm.version>25.2.4</graalvm.version>
         <!--

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -39,28 +39,32 @@
         <lz4-java.version>1.11.2</lz4-java.version>
         <lucene.version>10.5.1</lucene.version>
         <!--
-            This does NOT have to equal native/pom.xml's native.graalvm.version, and as of this
-            commit it does not: that property is 25.0.2 while this one is 25.2.4. The pair that
-            must move in lockstep is native.graalvm.version and native-image.yml's setup-graalvm
-            input - a skew between THOSE two breaks the image build at feature registration (see
-            native/pom.xml's native.graalvm.version comment for the failure mode). This property
-            governs the JVM-side JS engine only and tracks the latest independently, which is also
-            what .github/dependabot.yml says when it explains why the org.graalvm.* coordinates
-            are not ignored wholesale.
+            ONE GraalVM version, everywhere. This property, native/pom.xml's
+            native.graalvm.version and native-image.yml's setup-graalvm java-version are all
+            25.0.2 and must be changed together, in one commit, or not at all.
 
-            The independence is structural, not luck: native/pom.xml declares dependencyManagement
-            entries for every org.graalvm.* coordinate at ${native.graalvm.version}, so the native
-            image resolves those rather than the versions this module asks for. Verified by
-            building the image with the two at 25.0.2 and 25.2.4 respectively and running
-            native/src/test/scripts/smoke.sh against it - the JS round-trip, which is the polyglot
-            path this property feeds, passes.
+            Why they are kept equal rather than allowed to drift apart: they were 25.2.4 here and
+            25.0.2 in the native module for a while, which technically works - native/pom.xml's
+            dependencyManagement pins the org.graalvm.* coordinates for the image - but it means
+            engine bytecode compiled against one Truffle API runs against another inside the
+            image, and the only thing standing between that and a NoSuchMethodError is nobody
+            having reached for the newer API yet. Aligning them removes the whole question.
 
-            There is one real constraint in that arrangement, and it is one-way: the image resolves
-            the OLDER of the two, so engine code must stay within the API of
-            native.graalvm.version. Reaching for something added after it compiles fine here and
-            fails in the native build.
+            Why 25.0.2 specifically: it is the newest MAINLINE GraalVM CE release that exists as a
+            distribution, so it is the one every consumer can actually install - graalvm/setup-graalvm
+            fetches jdk-25.0.2 in CI, and Homebrew's graalvm-community-jdk25 cask is 25.0.2. The
+            intermediate line (25.1.x/25.2.x) ships tarballs from the graalvm-ce-builds releases
+            page and nowhere else, so pinning it makes a local native build start with a hand
+            download. See native/pom.xml's native.graalvm.version comment for the full table,
+            including why 25.0.3 and 25.0.4 look pinnable and are not.
+
+            A builder/artifact skew fails the native build at feature registration with
+            NoSuchMethodError OptimizedTruffleRuntime.getLoopNodeFactory(), which names neither
+            side of the mismatch; it has shipped to main twice.
+            .github/scripts/check-native-graalvm-pin.py fails the always-on `lint` job whenever
+            native.graalvm.version and native-image.yml disagree.
         -->
-        <graalvm.version>25.2.4</graalvm.version>
+        <graalvm.version>25.0.2</graalvm.version>
         <!--
             Bumping this requires re-checking several things LSMVectorIndex relies on that jvector does not
             contractually guarantee across versions:

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -53,46 +53,75 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <!--
             GraalVM polyglot/Truffle version used ONLY for the native image build. It MUST match the
-            native-image builder (GraalVM CE 25.2.4, which carries JDK 25.0.4) shipped with the
-            local GRAALVM_HOME and pinned by native-image.yml's `version` input, otherwise the
-            in-image Truffle feature (TruffleBaseFeature.afterRegistration) fails at build time with
-            NoSuchMethodError OptimizedTruffleRuntime.getLoopNodeFactory(), because the SVM Truffle
-            runtime bundled in the builder is compiled against a different Truffle API than the one
-            the engine pulls transitively. Pinning here (native module only) leaves the JVM engine
-            build untouched (engine/pom.xml's own graalvm.version tracks latest independently -
-            currently also 25.2.4, which is a coincidence, not a constraint) while letting the JS
-            language embed into the image.
+            native-image builder (GraalVM CE 25.0.2) shipped with the local GRAALVM_HOME and pinned
+            by native-image.yml's `java-version` input, otherwise the in-image Truffle feature
+            (TruffleBaseFeature.afterRegistration) fails at build time with NoSuchMethodError
+            OptimizedTruffleRuntime.getLoopNodeFactory(), because the SVM Truffle runtime bundled in
+            the builder is compiled against a different Truffle API than the one the engine pulls
+            transitively. Pinning here (native module only) leaves the JVM engine build untouched
+            while letting the JS language embed into the image: engine/pom.xml's own
+            graalvm.version tracks the latest independently and is 25.2.4 as of this commit, and
+            the dependencyManagement block below is what insulates the image from it - every
+            org.graalvm.* coordinate resolves at THIS version regardless of what engine asks for.
+            Verified by building the image with the two at 25.0.2 and 25.2.4 and running
+            native/src/test/scripts/smoke.sh against it, JS round-trip included. The one constraint
+            that arrangement creates runs one way: the image resolves the older of the two, so
+            engine code must stay within the API of whatever is pinned here.
+
+            WHY A MAINLINE VERSION, AND WHY THIS ONE. The pin has to be a build a contributor can
+            actually install, because the builder is not optional: without a matching GRAALVM_HOME
+            there is no local native build at all, only CI. Mainline releases are the ones the OS
+            packagers carry - Homebrew's graalvm-community-jdk25 cask is 25.0.2 - while the
+            intermediate line this pin previously tracked (25.1.x/25.2.x) is published as tarballs
+            on the graalvm-ce-builds releases page and nowhere else, which made every local build a
+            manual download.
+
+            25.0.2 is the NEWEST mainline CE release that exists as a distribution. Checked against
+            the graalvm-ce-builds releases and Maven Central on 2026-09-03:
+
+              version   CE tarball        Maven artifacts
+              25.0.2    jdk-25.0.2        yes      <- pinned here
+              25.0.3    none              yes
+              25.0.4    none              yes
+              25.1.3    graal-25.1.3      yes      (intermediate)
+              25.2.4    graal-25.2.4      yes      (intermediate, the previous pin)
+
+            Note the trap in rows 25.0.3 and 25.0.4: the Maven artifacts exist, so bumping THIS
+            property to either one looks perfectly reasonable and resolves fine, but no CE tarball
+            was ever published for them - there is no builder to match, through any input, on any
+            platform. A version being on Maven Central is not evidence it is installable.
 
             HOW THE BUILDER IS SELECTED, because it is not the obvious input. setup-graalvm resolves
-            a Community build two ways, and only one of them can reach this version:
+            a Community build two ways:
 
               - `java-version` -> setUpGraalVMJDKCEByJavaVersion: requires exactly three
                 dot-components, then fetches the `jdk-<version>` release. Reaches MAINLINE builds
-                only.
+                only - which is what this pin now is, so native-image.yml uses it.
               - `version` -> setUpGraalVMJDKCE -> findReleaseTag: looks up `graal-<version>` FIRST
                 and `jdk-<version>` second. Reaches both.
 
-            25.2.4 is an INTERMEDIATE release - tag graal-25.2.4, assets
-            graalvm-community-jdk-25i2-25.0.4_* - so native-image.yml pins it through `version`.
-            Switching that step back to `java-version` would silently stop resolving this build.
+            `version: "25.0.2"` would therefore also work (it misses graal-25.0.2 and falls through
+            to jdk-25.0.2). `java-version` is used because it states the intent: this pin is a
+            mainline release and is meant to stay one. Any future pin must be a version whose
+            graal-* or jdk-* tag parses as three-component semver, and - if that step keeps
+            `java-version` - must have a jdk-* tag specifically.
 
             DEPENDABOT WILL TRY TO BUMP THIS AND MUST BE REFUSED unless native-image.yml moves in
             the same change. It has got through twice:
 
               1. 3fecba4bf (merged [skip ci] as d463a31d0) raised this to 25.2.4 while the workflow
                  stayed on java-version 25.0.2, and broke every native leg with exactly the
-                 getLoopNodeFactory() error above. Reverted, and this warning first written, by
-                 #5811 (1ca1bc4420). Note what that means: the VERSION was never the problem, only
-                 the skew - which is why the pin sits at 25.2.4 today, with the builder moved too.
+                 getLoopNodeFactory() error above. Reverted by #5811 (1ca1bc4420), which is where
+                 this warning was first written. Note what that means: the VERSION was never the
+                 problem, only the skew.
               2. b53c48c1e2 (merged [skip ci] as e32e663604) then raised it to 25.3.4.1 from a base
-                 that still said 25.2.4, silently undoing that revert, and broke all three legs of
-                 run 33608446679 the same way.
+                 that said 25.2.4, silently undoing that revert, and broke all three legs of run
+                 33608446679 the same way.
 
             25.3.4.1 in particular must NEVER be pinned here: it is not installable by setup-graalvm
             through either input. Its tag graal-25.3.4.1 exists, but node-semver rejects four
             numeric components, so findLatestGraalVMCEVersion skips it as an "unexpected GraalVM CE
-            release", finds no jdk-25.3.4.1 either, and throws. Any future pin must be a version
-            whose graal-* or jdk-* tag parses as three-component semver.
+            release", finds no jdk-25.3.4.1 either, and throws.
 
             A comment is not a control: it did not stop attempt 2, because .mergify.yml auto-merged
             a dependabot PR on one approval with no green-CI condition, and stamped [skip ci] on the
@@ -102,7 +131,7 @@
             `java-version` both, preferring `version` as setup-graalvm itself does), and .mergify.yml
             no longer auto-merges a PR that touches this file.
         -->
-        <native.graalvm.version>25.2.4</native.graalvm.version>
+        <native.graalvm.version>25.0.2</native.graalvm.version>
         <!--
             Flag plumbed through by the CI matrix (native-image.yml) for the linux/amd64 job.
             Activates the native-static profile below, which appends the fully-static musl

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -58,15 +58,12 @@
             (TruffleBaseFeature.afterRegistration) fails at build time with NoSuchMethodError
             OptimizedTruffleRuntime.getLoopNodeFactory(), because the SVM Truffle runtime bundled in
             the builder is compiled against a different Truffle API than the one the engine pulls
-            transitively. Pinning here (native module only) leaves the JVM engine build untouched
-            while letting the JS language embed into the image: engine/pom.xml's own
-            graalvm.version tracks the latest independently and is 25.2.4 as of this commit, and
-            the dependencyManagement block below is what insulates the image from it - every
-            org.graalvm.* coordinate resolves at THIS version regardless of what engine asks for.
-            Verified by building the image with the two at 25.0.2 and 25.2.4 and running
-            native/src/test/scripts/smoke.sh against it, JS round-trip included. The one constraint
-            that arrangement creates runs one way: the image resolves the older of the two, so
-            engine code must stay within the API of whatever is pinned here.
+            transitively. engine/pom.xml's graalvm.version is held at this SAME version rather
+            than tracking the latest independently: the dependencyManagement block below would
+            insulate the image either way, but a split means engine bytecode compiled against one
+            Truffle API runs against another inside the image, and the only thing between that and
+            a NoSuchMethodError is nobody having reached for the newer API yet. One version
+            everywhere costs nothing and removes the question.
 
             WHY A MAINLINE VERSION, AND WHY THIS ONE. The pin has to be a build a contributor can
             actually install, because the builder is not optional: without a matching GRAALVM_HOME

--- a/native/scripts/build-native-docker.sh
+++ b/native/scripts/build-native-docker.sh
@@ -312,6 +312,11 @@ if [ "$SKIP_BINARY" = "0" ]; then
   mkdir -p "$M2_DIR"
   log "building the linux/$ARCH binary in the container (this is the slow part)"
   log "  maven cache: $M2_DIR"
+  # -pl :arcadedb-native selects the module by artifactId. A path selector would work here too,
+  # since -w below makes /workspace the execution root, but it is one less thing to get wrong and
+  # it matches build-native.sh, where the path form breaks outright when the caller's cwd is not
+  # the repository root.
+  #
   # ${GIT_MOUNT[@]+...}: the array is empty for a normal checkout, and macOS still ships bash 3.2,
   # where expanding an empty array under `set -u` aborts with "unbound variable".
   docker run --rm \
@@ -324,7 +329,7 @@ if [ "$SKIP_BINARY" = "0" ]; then
     ${GIT_MOUNT[@]+"${GIT_MOUNT[@]}"} \
     -w /workspace \
     "$BUILDER_IMAGE" \
-    ./mvnw -B -ntp -Pnative -pl native -am -DskipTests "$MODE_ARG" package
+    ./mvnw -B -ntp -Pnative -pl :arcadedb-native -am -DskipTests "$MODE_ARG" package
 else
   log "--skip-binary-build: reusing whatever is already in native/target"
 fi

--- a/native/scripts/build-native-docker.sh
+++ b/native/scripts/build-native-docker.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Usage: build-native-docker.sh [options]
+#
+# Builds the native Docker image locally: the same per-arch image .github/workflows/native-image.yml
+# publishes on a release, from your working tree, on your machine, without pushing anything.
+#
+# Native Image cannot cross-compile, so the LINUX binary the image needs cannot be built on macOS
+# directly. This script therefore does what CI does across two jobs, in one pass:
+#
+#   1. builds a throwaway builder image (native/src/main/docker/Dockerfile.native-builder) holding
+#      the GraalVM CE builder pinned by native/pom.xml, plus - for amd64 - the musl toolchain and
+#      musl-built static zlib that a fully-static link needs;
+#   2. runs the ordinary `./mvnw -Pnative -pl native -am -DskipTests package` INSIDE that image
+#      with this repository bind-mounted, so the Linux binary lands in native/target on the host;
+#   3. stages the build context exactly as native-image.yml's `docker` job does (binary + config,
+#      plus a CA bundle for the scratch image) and builds the runtime image with buildx --load;
+#   4. smoke-tests the resulting container with native/src/test/scripts/exercise.sh and scans its
+#      startup log, the same two assertions CI makes.
+#
+# The runtime Dockerfiles are used unmodified, so what you get is the shipped image, not a
+# local approximation:
+#
+#   amd64 -> fully static musl binary   -> Dockerfile.native.scratch      (FROM scratch)
+#   arm64 -> mostly-static glibc binary -> Dockerfile.native.distroless   (distroless base)
+#
+# Nothing is pushed and nothing is tagged under a publishable name: the default tag ends in
+# "-local" so it cannot be confused with a released arcadedata/arcadedb tag.
+#
+# Options:
+#   --arch <amd64|arm64>   Target architecture. Defaults to the host's, because native-image under
+#                          QEMU emulation is unusably slow; building the other arch needs
+#                          --allow-emulation and a lot of patience.
+#   --tag <tag>            Image tag to build. Default: arcadedb:<version>-native-<arch>-local
+#   --skip-binary-build    Reuse the Linux binary already in native/target (steps 3-4 only).
+#                          Useful when iterating on the Dockerfiles themselves.
+#   --no-smoke             Build the image but do not run the container smoke test.
+#   --port <port>          Host port the smoke test publishes 2480 on. Default 2480. A dev machine
+#                          is not a clean CI runner: an IDE-launched server or a previous run
+#                          already holding 2480 makes `docker run -p 2480:2480` fail, or - worse,
+#                          if it started before the publish - makes exercise.sh assert against
+#                          THAT server and pass while telling you nothing about this image.
+#   --rebuild-builder      Rebuild the builder image even if it already exists locally.
+#   --allow-emulation      Permit --arch different from the host's (QEMU; expect hours, not minutes).
+#   -h, --help             Print this help.
+#
+# Env:
+#   ARCADEDB_NATIVE_M2   Host directory used as HOME for the containerised Maven build, so the
+#                        local repository and the ./mvnw distribution survive between runs.
+#                        Default: ~/.cache/arcadedb-native-m2
+#
+# First run downloads a GraalVM tarball and populates a fresh Maven repository, so budget a good
+# while; later runs reuse both.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+NATIVE_POM="$REPO_ROOT/native/pom.xml"
+DOCKER_DIR="$REPO_ROOT/native/src/main/docker"
+M2_DIR="${ARCADEDB_NATIVE_M2:-$HOME/.cache/arcadedb-native-m2}"
+
+ARCH=""
+TAG=""
+SKIP_BINARY=0
+RUN_SMOKE=1
+REBUILD_BUILDER=0
+ALLOW_EMULATION=0
+HTTP_PORT=2480
+
+log()  { echo "[native-docker] $*"; }
+fail() { echo "[native-docker] ERROR: $*" >&2; exit 1; }
+
+# Prints the header comment block above, from '# Usage:' to the first non-comment line, so the
+# help text cannot drift out of sync with hardcoded line numbers.
+usage() { awk '/^# Usage:/{f=1} f{ if ($0 !~ /^#/) exit; sub(/^# ?/,""); print }' "${BASH_SOURCE[0]}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --arch)             ARCH="${2:-}"; shift 2 ;;
+    --arch=*)           ARCH="${1#*=}"; shift ;;
+    --tag)              TAG="${2:-}"; shift 2 ;;
+    --tag=*)            TAG="${1#*=}"; shift ;;
+    --skip-binary-build) SKIP_BINARY=1; shift ;;
+    --no-smoke)         RUN_SMOKE=0; shift ;;
+    --port)             HTTP_PORT="${2:-}"; shift 2 ;;
+    --port=*)           HTTP_PORT="${1#*=}"; shift ;;
+    --rebuild-builder)  REBUILD_BUILDER=1; shift ;;
+    --allow-emulation)  ALLOW_EMULATION=1; shift ;;
+    -h|--help)          usage; exit 0 ;;
+    *)                  fail "unknown option '$1' (see --help)" ;;
+  esac
+done
+
+command -v docker >/dev/null 2>&1 || fail "docker not found on PATH"
+docker buildx version >/dev/null 2>&1 || fail "docker buildx not available (needed to build with --load)"
+
+case "$(uname -m)" in
+  x86_64|amd64)  HOST_ARCH="amd64" ;;
+  aarch64|arm64) HOST_ARCH="arm64" ;;
+  *)             fail "unsupported host architecture '$(uname -m)'" ;;
+esac
+ARCH="${ARCH:-$HOST_ARCH}"
+case "$ARCH" in
+  amd64|arm64) ;;
+  *) fail "invalid --arch '$ARCH' (amd64|arm64)" ;;
+esac
+
+if [ "$ARCH" != "$HOST_ARCH" ] && [ "$ALLOW_EMULATION" != "1" ]; then
+  fail "--arch $ARCH on a $HOST_ARCH host would run the whole native-image build under QEMU
+  emulation, which takes hours and frequently exhausts memory. Pass --allow-emulation if you
+  really want that; otherwise build $ARCH on a $ARCH machine (that is why CI's docker job runs
+  each arch on its own native runner rather than one runner with buildx --platform)."
+fi
+
+# amd64 links fully static against musl and runs on scratch; arm64 cannot (GraalVM CE ships no
+# static musl JDK libs for aarch64 - oracle/graal#4645) and builds mostly-static against glibc,
+# so it needs a base image that has glibc. Same split as native-image.yml's docker matrix.
+if [ "$ARCH" = "amd64" ]; then
+  DOCKERFILE="$DOCKER_DIR/Dockerfile.native.scratch"
+  MODE_ARG="-Dnative.static=true"
+  GRAALVM_ASSET_ARCH="linux-x64"
+else
+  DOCKERFILE="$DOCKER_DIR/Dockerfile.native.distroless"
+  MODE_ARG="-Dnative.mostlystatic=true"
+  GRAALVM_ASSET_ARCH="linux-aarch64"
+fi
+[ -f "$DOCKERFILE" ] || fail "missing $DOCKERFILE"
+
+# ---------------------------------------------------------------------------
+# Builder image.
+#
+# The GraalVM version comes out of native/pom.xml, the one place it is written down (the lint job
+# already enforces that native-image.yml agrees with it). The download URL is then asked of the
+# GitHub release API rather than constructed, because the asset name is not derivable from the
+# version: the pinned 25.2.4 publishes as graalvm-community-jdk-25i2-25.0.4_linux-<arch>_bin.tar.gz.
+# ---------------------------------------------------------------------------
+PIN="$(sed -n 's:.*<native\.graalvm\.version>\(.*\)</native\.graalvm\.version>.*:\1:p' "$NATIVE_POM" | head -1)"
+[ -n "$PIN" ] || fail "could not read <native.graalvm.version> from $NATIVE_POM"
+BUILDER_IMAGE="arcadedb-native-builder:${PIN}-${ARCH}"
+
+if [ "$REBUILD_BUILDER" = "1" ] || ! docker image inspect "$BUILDER_IMAGE" >/dev/null 2>&1; then
+  log "resolving GraalVM CE $PIN ($GRAALVM_ASSET_ARCH) from the graalvm-ce-builds releases"
+  RELEASE_API="https://api.github.com/repos/graalvm/graalvm-ce-builds/releases/tags/graal-${PIN}"
+  if command -v gh >/dev/null 2>&1; then
+    RELEASE_JSON="$(gh api "repos/graalvm/graalvm-ce-builds/releases/tags/graal-${PIN}")"
+  else
+    RELEASE_JSON="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASE_API")"
+  fi
+  # Plain grep rather than jq/python: neither is guaranteed present, and the field is unambiguous.
+  GRAALVM_URL="$(grep -o "https://[^\"]*graalvm-community[^\"]*_${GRAALVM_ASSET_ARCH}_bin\.tar\.gz" <<<"$RELEASE_JSON" | head -1)"
+  [ -n "$GRAALVM_URL" ] || fail "no ${GRAALVM_ASSET_ARCH} asset in the graal-${PIN} release.
+  Every GraalVM version reachable here must be published under a graal-<version> tag - see the
+  <native.graalvm.version> comment in native/pom.xml for which versions are and are not."
+  GRAALVM_SHA256="$(curl -fsSL "${GRAALVM_URL}.sha256" | tr -d '[:space:]')"
+  [ -n "$GRAALVM_SHA256" ] || fail "could not fetch ${GRAALVM_URL}.sha256"
+
+  log "building builder image $BUILDER_IMAGE"
+  log "  $GRAALVM_URL"
+  docker buildx build \
+    --platform "linux/$ARCH" \
+    -f "$DOCKER_DIR/Dockerfile.native-builder" \
+    --build-arg "GRAALVM_URL=$GRAALVM_URL" \
+    --build-arg "GRAALVM_SHA256=$GRAALVM_SHA256" \
+    --build-arg "TARGET_ARCH=$ARCH" \
+    -t "$BUILDER_IMAGE" \
+    --load \
+    "$DOCKER_DIR"
+else
+  log "reusing builder image $BUILDER_IMAGE (--rebuild-builder to refresh)"
+fi
+
+# ---------------------------------------------------------------------------
+# Native binary, built inside the builder image against the bind-mounted working tree.
+# ---------------------------------------------------------------------------
+
+# In a git WORKTREE, .git is a file holding "gitdir: <abs path>/.git/worktrees/<name>", which lives
+# outside the directory bind-mounted below. buildnumber-maven-plugin shells out to `git log` during
+# arcadedb-engine's build, so without the real git directory in scope the build dies 20 seconds in
+# with "fatal: not a git repository: .../.git/worktrees/<name>" - and it names a host path that
+# does exist, which makes the failure read like a git problem rather than a mount problem. Mount
+# the main repository's .git at its own absolute path so that pointer resolves inside the
+# container too. A normal (non-worktree) checkout has its .git inside the mount already and needs
+# nothing extra.
+GIT_MOUNT=()
+if [ -f "$REPO_ROOT/.git" ]; then
+  GITDIR="$(sed -n 's/^gitdir: *//p' "$REPO_ROOT/.git" | head -1)"
+  case "$GITDIR" in
+    /*) ;;
+    *)  GITDIR="$REPO_ROOT/$GITDIR" ;;
+  esac
+  # Strip the /worktrees/<name> suffix to get the common git dir, which holds the object store the
+  # worktree's own gitdir refers back to; mounting the common dir brings both into scope.
+  GIT_COMMON="${GITDIR%%/worktrees/*}"
+  if [ -d "$GIT_COMMON" ]; then
+    GIT_MOUNT=(-v "$GIT_COMMON:$GIT_COMMON")
+    log "git worktree detected; also mounting $GIT_COMMON"
+  else
+    log "WARN: $REPO_ROOT/.git points at '$GITDIR', which does not resolve to a git directory;"
+    log "WARN: git-dependent Maven plugins may fail inside the container."
+  fi
+fi
+
+if [ "$SKIP_BINARY" = "0" ]; then
+  mkdir -p "$M2_DIR"
+  log "building the linux/$ARCH binary in the container (this is the slow part)"
+  log "  maven cache: $M2_DIR"
+  # ${GIT_MOUNT[@]+...}: the array is empty for a normal checkout, and macOS still ships bash 3.2,
+  # where expanding an empty array under `set -u` aborts with "unbound variable".
+  docker run --rm \
+    --platform "linux/$ARCH" \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/m2 \
+    -v "$REPO_ROOT:/workspace" \
+    -v "$M2_DIR:/m2" \
+    ${GIT_MOUNT[@]+"${GIT_MOUNT[@]}"} \
+    -w /workspace \
+    "$BUILDER_IMAGE" \
+    ./mvnw -B -ntp -Pnative -pl native -am -DskipTests "$MODE_ARG" package
+else
+  log "--skip-binary-build: reusing whatever is already in native/target"
+fi
+
+# Locate the LINUX binary by the executable bit, the same way native-image.yml does. The name
+# carries os-maven-plugin's os.detected.arch (x86_64 / aarch64), not this script's amd64/arm64
+# label, so match on the "linux-" infix and let the glob supply the rest. A host build for macOS
+# leaves an arcadedb-*-osx-* binary in the same directory; the linux- prefix keeps them apart.
+cd "$REPO_ROOT/native/target" 2>/dev/null || fail "native/target does not exist - drop --skip-binary-build"
+CANDIDATES=()
+while IFS= read -r f; do CANDIDATES+=("$f"); done \
+  < <(find . -maxdepth 1 -type f -name 'arcadedb-*-linux-*' -perm -u+x -print | sed 's|^\./||')
+if [ "${#CANDIDATES[@]}" -ne 1 ]; then
+  echo "[native-docker] ERROR: expected exactly one linux binary in native/target, found ${#CANDIDATES[@]}" >&2
+  ls -la "$REPO_ROOT/native/target" >&2
+  exit 1
+fi
+BIN_NAME="${CANDIDATES[0]}"
+# Version is parsed back out of the filename (greedy up to the single "-linux-" separator, so a
+# version containing dashes like 26.9.1-SNAPSHOT survives) rather than by re-invoking Maven.
+VERSION="$(sed -E 's/^arcadedb-(.*)-linux-[^-]+$/\1/' <<<"$BIN_NAME")"
+[ -n "$VERSION" ] && [ "$VERSION" != "$BIN_NAME" ] || fail "could not parse a version out of '$BIN_NAME'"
+TAG="${TAG:-arcadedb:${VERSION}-native-${ARCH}-local}"
+log "binary:  native/target/$BIN_NAME"
+log "version: $VERSION"
+
+# ---------------------------------------------------------------------------
+# Stage the build context, mirroring native-image.yml's "Stage build context" step.
+# ---------------------------------------------------------------------------
+CTX="$(mktemp -d)"
+trap 'rm -rf "$CTX"' EXIT
+mkdir -p "$CTX/config"
+cp "$REPO_ROOT/native/target/$BIN_NAME" "$CTX/arcadedb"
+chmod 0755 "$CTX/arcadedb"
+cp -R "$REPO_ROOT/package/src/main/config/." "$CTX/config/"
+if [ "$ARCH" = "amd64" ]; then
+  # scratch has no trust store at all, so the scratch Dockerfile COPYs one in. CI takes the
+  # runner's /etc/ssl/certs/ca-certificates.crt; a macOS host has no such file, so take it from
+  # the builder image instead - which is a Debian-family bundle either way, and keeps this step
+  # working identically on every host.
+  log "extracting a CA bundle from the builder image for the scratch base"
+  docker run --rm --platform "linux/$ARCH" --entrypoint cat "$BUILDER_IMAGE" \
+    /etc/ssl/certs/ca-certificates.crt > "$CTX/ca-certificates.crt"
+  [ -s "$CTX/ca-certificates.crt" ] || fail "extracted CA bundle is empty"
+fi
+
+log "building image $TAG from $(basename "$DOCKERFILE")"
+docker buildx build \
+  --platform "linux/$ARCH" \
+  -f "$DOCKERFILE" \
+  -t "$TAG" \
+  --load \
+  "$CTX"
+
+log "image built: $TAG ($(docker image inspect "$TAG" --format '{{.Size}}' | awk '{printf "%.0f MB", $1/1024/1024}'))"
+
+# ---------------------------------------------------------------------------
+# Container smoke test, mirroring native-image.yml's "Smoke the container" step: exercise.sh
+# hard-asserts HTTP/Studio/SQL/Cypher/JS against the RUNNING IMAGE, and the startup log is then
+# scanned for the non-fatal failures exercise.sh can stay green through (a class the JUL config
+# loads reflectively being absent from the image degrades logging without failing anything).
+# ---------------------------------------------------------------------------
+if [ "$RUN_SMOKE" = "1" ]; then
+  CONTAINER="arcadedb-native-smoke-$$"
+  # Refuse to start if something already holds the host port. Without this the run either fails
+  # opaquely on the port bind, or - if the squatter was there first and docker picked a different
+  # binding - exercise.sh happily asserts against the OTHER server and reports a green smoke for
+  # an image it never touched.
+  if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"$HTTP_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port $HTTP_PORT is already in use, so the smoke test would either fail to bind or assert
+  against whatever is already listening. Free it, or pass --port <other> / --no-smoke.
+  Culprit: $(lsof -nP -iTCP:"$HTTP_PORT" -sTCP:LISTEN | awk 'NR==2 {print $1" (pid "$2")"}')"
+  fi
+  log "smoke-testing the container (host port $HTTP_PORT -> container 2480)"
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  docker run -d --name "$CONTAINER" --platform "linux/$ARCH" -p "$HTTP_PORT":2480 \
+    "$TAG" -Darcadedb.server.rootPassword=PlayWithData123! >/dev/null
+
+  rc=0
+  HTTP="$HTTP_PORT" "$REPO_ROOT/native/src/test/scripts/exercise.sh" || rc=$?
+  LOGS="$(docker logs "$CONTAINER" 2>&1)"
+  echo "$LOGS"
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+
+  [ "$rc" -eq 0 ] || fail "container exercise.sh failed (rc=$rc)"
+  if grep -qiE "ClassNotFoundException|Can't load log handler" <<<"$LOGS"; then
+    fail "container startup logged a ClassNotFoundException / log-handler load failure"
+  fi
+  log "smoke test passed"
+fi
+
+# The scratch image has no /etc/passwd and runs as UID 0 unless overridden, so the amd64 hint
+# carries a --user line; the distroless :nonroot base already runs non-root and needs none.
+# Built as a variable rather than inline in the heredoc: a $(...) substitution there emits its
+# output without a trailing newline, which would fold the --user line into the tag line.
+USER_HINT=""
+if [ "$ARCH" = "amd64" ]; then
+  USER_HINT='    --user $(id -u):$(id -g) \'$'\n'
+fi
+
+cat <<EOF
+
+[native-docker] done. Run it with:
+
+  docker run --rm -p 2480:2480 \\
+    -v "\$(pwd)/databases:/home/arcadedb/databases" \\
+${USER_HINT}    $TAG \\
+    -Darcadedb.server.rootPassword=PlayWithData123!
+
+Neither base image has a shell, so -D flags go as trailing arguments, not via
+-e ARCADEDB_SETTINGS. See docs/native-image.md "Running the container".
+EOF

--- a/native/scripts/build-native-docker.sh
+++ b/native/scripts/build-native-docker.sh
@@ -59,6 +59,10 @@ set -euo pipefail
 #                          already holding 2480 makes `docker run -p 2480:2480` fail, or - worse,
 #                          if it started before the publish - makes exercise.sh assert against
 #                          THAT server and pass while telling you nothing about this image.
+#   --builder-memory <sz>  Cap the native-image builder heap, e.g. 10g, via NATIVE_IMAGE_OPTIONS
+#                          (-J-Xmx). By default native-image sizes its own heap at ~80% of what it
+#                          can see, which is the Docker VM's memory, not the host's.
+#   --allow-low-memory     Proceed even though Docker has less memory than this build needs.
 #   --rebuild-builder      Rebuild the builder image even if it already exists locally.
 #   --allow-emulation      Permit --arch different from the host's (QEMU; expect hours, not minutes).
 #   -h, --help             Print this help.
@@ -83,6 +87,8 @@ SKIP_BINARY=0
 RUN_SMOKE=1
 REBUILD_BUILDER=0
 ALLOW_EMULATION=0
+ALLOW_LOW_MEMORY=0
+BUILDER_MEMORY=""
 HTTP_PORT=2480
 
 log()  { echo "[native-docker] $*"; }
@@ -102,6 +108,9 @@ while [ $# -gt 0 ]; do
     --no-smoke)         RUN_SMOKE=0; shift ;;
     --port)             HTTP_PORT="${2:-}"; shift 2 ;;
     --port=*)           HTTP_PORT="${1#*=}"; shift ;;
+    --builder-memory)   BUILDER_MEMORY="${2:-}"; shift 2 ;;
+    --builder-memory=*) BUILDER_MEMORY="${1#*=}"; shift ;;
+    --allow-low-memory) ALLOW_LOW_MEMORY=1; shift ;;
     --rebuild-builder)  REBUILD_BUILDER=1; shift ;;
     --allow-emulation)  ALLOW_EMULATION=1; shift ;;
     -h|--help)          usage; exit 0 ;;
@@ -128,6 +137,54 @@ if [ "$ARCH" != "$HOST_ARCH" ] && [ "$ALLOW_EMULATION" != "1" ]; then
   emulation, which takes hours and frequently exhausts memory. Pass --allow-emulation if you
   really want that; otherwise build $ARCH on a $ARCH machine (that is why CI's docker job runs
   each arch on its own native runner rather than one runner with buildx --platform)."
+fi
+
+# ---------------------------------------------------------------------------
+# Memory preflight.
+#
+# native-image sizes its build heap at roughly 80% of the memory it can SEE, and inside a
+# container that is the Docker VM's allocation, not the host's. A Mac with 36 GB whose Docker
+# Desktop is left on the 8 GB default therefore OOMs - and it does so ~21 minutes in, after the
+# entire Maven reactor has already built, with "Terminating due to java.lang.OutOfMemoryError:
+# Java heap space" and no hint that the VM setting is the cause. That is an expensive way to
+# learn it, so check up front. This image embeds GraalJS, which is what makes it so hungry:
+# native-image.yml had to move its macOS leg onto a paid larger runner for the same reason,
+# because the free ~7 GB one OOM-thrashed for 40+ minutes.
+#
+# 12 GiB is the floor enforced here and 16 GiB is what CI's Linux runners have; 8 GiB is known
+# to fail. Raise it in Docker Desktop under Settings -> Resources -> Memory.
+# ---------------------------------------------------------------------------
+DOCKER_MEM_BYTES="$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo 0)"
+case "$DOCKER_MEM_BYTES" in
+  ''|*[!0-9]*) DOCKER_MEM_BYTES=0 ;;
+esac
+if [ "$DOCKER_MEM_BYTES" -gt 0 ] && [ "$SKIP_BINARY" = "0" ]; then
+  # Tenths of a GiB, so a 7.6 GiB VM does not print as a flat "7" next to a "needs 12" and read
+  # like a bigger shortfall than it is.
+  DOCKER_MEM_MIB=$(( DOCKER_MEM_BYTES / 1024 / 1024 ))
+  DOCKER_MEM="$(( DOCKER_MEM_MIB / 1024 )).$(( (DOCKER_MEM_MIB % 1024) * 10 / 1024 ))"
+  HOST_MEM_BYTES="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
+  HOST_MEM_NOTE=""
+  if [ "$HOST_MEM_BYTES" -gt "$DOCKER_MEM_BYTES" ]; then
+    HOST_MEM_NOTE=" (this machine has $(( HOST_MEM_BYTES / 1024 / 1024 / 1024 )) GiB, but Docker only gets what you allot it)"
+  fi
+  if [ "$DOCKER_MEM_MIB" -lt $(( 12 * 1024 )) ]; then
+    if [ "$ALLOW_LOW_MEMORY" = "1" ]; then
+      log "WARN: Docker has only ${DOCKER_MEM} GiB; proceeding anyway (--allow-low-memory)."
+    else
+      fail "Docker has ${DOCKER_MEM} GiB of memory, which is not enough to link this image${HOST_MEM_NOTE}.
+  native-image sizes its build heap at ~80% of the memory it can see, and inside a container that
+  is the Docker VM's allocation. At ${DOCKER_MEM} GiB it dies with a Java heap OutOfMemoryError
+  about 21 minutes in, once the whole Maven reactor has already built. CI's Linux runners have
+  16 GiB; 12 is the floor checked here.
+  Raise it in Docker Desktop: Settings -> Resources -> Memory, then restart Docker.
+  Or pass --allow-low-memory to try regardless, --builder-memory <size> to cap the builder heap
+  explicitly, or --skip-binary-build if you only need to rebuild the image around an existing
+  binary (that step is cheap and needs none of this)."
+    fi
+  else
+    log "docker memory: ${DOCKER_MEM} GiB"
+  fi
 fi
 
 # amd64 links fully static against musl and runs on scratch; arm64 cannot (GraalVM CE ships no
@@ -218,6 +275,15 @@ if [ -f "$REPO_ROOT/.git" ]; then
   fi
 fi
 
+# native-image reads NATIVE_IMAGE_OPTIONS from the environment and prepends it to its own
+# arguments (it announces "Picked up NATIVE_IMAGE_OPTIONS: ..." when it does), so the builder heap
+# can be capped without touching native/pom.xml's buildArgs, which are shared with CI.
+NI_OPTS=()
+if [ -n "$BUILDER_MEMORY" ]; then
+  NI_OPTS=(-e "NATIVE_IMAGE_OPTIONS=-J-Xmx${BUILDER_MEMORY}")
+  log "capping the native-image builder heap at $BUILDER_MEMORY"
+fi
+
 if [ "$SKIP_BINARY" = "0" ]; then
   mkdir -p "$M2_DIR"
   log "building the linux/$ARCH binary in the container (this is the slow part)"
@@ -228,6 +294,7 @@ if [ "$SKIP_BINARY" = "0" ]; then
     --platform "linux/$ARCH" \
     --user "$(id -u):$(id -g)" \
     -e HOME=/m2 \
+    ${NI_OPTS[@]+"${NI_OPTS[@]}"} \
     -v "$REPO_ROOT:/workspace" \
     -v "$M2_DIR:/m2" \
     ${GIT_MOUNT[@]+"${GIT_MOUNT[@]}"} \

--- a/native/scripts/build-native-docker.sh
+++ b/native/scripts/build-native-docker.sh
@@ -207,7 +207,9 @@ fi
 # The GraalVM version comes out of native/pom.xml, the one place it is written down (the lint job
 # already enforces that native-image.yml agrees with it). The download URL is then asked of the
 # GitHub release API rather than constructed, because the asset name is not derivable from the
-# version: the pinned 25.2.4 publishes as graalvm-community-jdk-25i2-25.0.4_linux-<arch>_bin.tar.gz.
+# version, and the shape differs per release line: mainline 25.0.2 publishes as
+# graalvm-community-jdk-25.0.2_linux-<arch>_bin.tar.gz, intermediate 25.2.4 as
+# graalvm-community-jdk-25i2-25.0.4_linux-<arch>_bin.tar.gz.
 # ---------------------------------------------------------------------------
 PIN="$(sed -n 's:.*<native\.graalvm\.version>\(.*\)</native\.graalvm\.version>.*:\1:p' "$NATIVE_POM" | head -1)"
 [ -n "$PIN" ] || fail "could not read <native.graalvm.version> from $NATIVE_POM"
@@ -215,17 +217,39 @@ BUILDER_IMAGE="arcadedb-native-builder:${PIN}-${ARCH}"
 
 if [ "$REBUILD_BUILDER" = "1" ] || ! docker image inspect "$BUILDER_IMAGE" >/dev/null 2>&1; then
   log "resolving GraalVM CE $PIN ($GRAALVM_ASSET_ARCH) from the graalvm-ce-builds releases"
-  RELEASE_API="https://api.github.com/repos/graalvm/graalvm-ce-builds/releases/tags/graal-${PIN}"
-  if command -v gh >/dev/null 2>&1; then
-    RELEASE_JSON="$(gh api "repos/graalvm/graalvm-ce-builds/releases/tags/graal-${PIN}")"
-  else
-    RELEASE_JSON="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASE_API")"
-  fi
-  # Plain grep rather than jq/python: neither is guaranteed present, and the field is unambiguous.
-  GRAALVM_URL="$(grep -o "https://[^\"]*graalvm-community[^\"]*_${GRAALVM_ASSET_ARCH}_bin\.tar\.gz" <<<"$RELEASE_JSON" | head -1)"
-  [ -n "$GRAALVM_URL" ] || fail "no ${GRAALVM_ASSET_ARCH} asset in the graal-${PIN} release.
-  Every GraalVM version reachable here must be published under a graal-<version> tag - see the
-  <native.graalvm.version> comment in native/pom.xml for which versions are and are not."
+
+  # Fetches one release by tag; empty output (and success) when that tag does not exist, so the
+  # caller can fall through to the next candidate rather than aborting under `set -e`.
+  fetch_release() {
+    if command -v gh >/dev/null 2>&1; then
+      gh api "repos/graalvm/graalvm-ce-builds/releases/tags/$1" 2>/dev/null || true
+    else
+      curl -fsSL -H 'Accept: application/vnd.github+json' \
+        "https://api.github.com/repos/graalvm/graalvm-ce-builds/releases/tags/$1" 2>/dev/null || true
+    fi
+  }
+
+  # graal-<version> FIRST, jdk-<version> second - the same order setup-graalvm's own findReleaseTag
+  # uses, so this resolves whichever release the workflow would install. The two tags are not
+  # interchangeable and which one exists depends on the line the pin tracks: intermediate releases
+  # publish graal-* (graal-25.2.4), mainline ones publish jdk-* (jdk-25.0.2). Trying only one
+  # breaks the moment native/pom.xml's pin moves between the two lines.
+  RELEASE_JSON=""
+  RESOLVED_TAG=""
+  for candidate in "graal-${PIN}" "jdk-${PIN}"; do
+    RELEASE_JSON="$(fetch_release "$candidate")"
+    # Plain grep rather than jq/python: neither is guaranteed present, and the field is unambiguous.
+    GRAALVM_URL="$(grep -o "https://[^\"]*graalvm-community[^\"]*_${GRAALVM_ASSET_ARCH}_bin\.tar\.gz" <<<"$RELEASE_JSON" | head -1 || true)"
+    if [ -n "$GRAALVM_URL" ]; then
+      RESOLVED_TAG="$candidate"
+      break
+    fi
+  done
+  [ -n "$GRAALVM_URL" ] || fail "no ${GRAALVM_ASSET_ARCH} asset under either graal-${PIN} or jdk-${PIN}.
+  A version has to be published as a CE tarball to be usable here, and being on Maven Central is
+  not the same thing: 25.0.3 and 25.0.4 have full org.graalvm.* artifacts and no tarball at all.
+  See the <native.graalvm.version> comment in native/pom.xml for which versions do exist."
+  log "  release tag: $RESOLVED_TAG"
   GRAALVM_SHA256="$(curl -fsSL "${GRAALVM_URL}.sha256" | tr -d '[:space:]')"
   [ -n "$GRAALVM_SHA256" ] || fail "could not fetch ${GRAALVM_URL}.sha256"
 

--- a/native/scripts/build-native.sh
+++ b/native/scripts/build-native.sh
@@ -142,15 +142,15 @@ log "GraalVM home: $GVM"
 # exact release the builder must be. Read the pin from the pom (single source of truth - the lint
 # job already enforces that it matches native-image.yml) and look for it in the builder's own
 # --version banner, which prints e.g.
-#   GraalVM Runtime Environment GraalVM CE 25.2.4+9.1 (build ...)
+#   GraalVM Runtime Environment GraalVM CE 25.0.2+10.1 (build ...)
 # ---------------------------------------------------------------------------
 PIN="$(sed -n 's:.*<native\.graalvm\.version>\(.*\)</native\.graalvm\.version>.*:\1:p' "$NATIVE_POM" | head -1)"
 [ -n "$PIN" ] || fail "could not read <native.graalvm.version> from $NATIVE_POM"
 
 NI_VERSION="$("$GVM/bin/native-image" --version 2>&1 || true)"
-# The banner carries a build suffix - the pinned 25.2.4 reports "GraalVM CE 25.2.4+7.1" - so match
-# the pin followed by a non-digit rather than the bare string, which would also accept a future
-# "25.2.40". Dots in the pin are escaped so they cannot match an arbitrary character.
+# The banner carries a build suffix - 25.0.2 reports "GraalVM CE 25.0.2+10.1", 25.2.4 reports
+# "GraalVM CE 25.2.4+7.1" - so match the pin followed by a non-digit rather than the bare string,
+# which would also accept a "25.0.20". Dots are escaped so they cannot match an arbitrary character.
 if grep -qE "GraalVM CE ${PIN//./\\.}([^0-9]|\$)" <<<"$NI_VERSION"; then
   log "builder matches native/pom.xml pin (GraalVM CE $PIN)"
 else

--- a/native/scripts/build-native.sh
+++ b/native/scripts/build-native.sh
@@ -234,12 +234,23 @@ esac
 #    compile-no-fork goal to it, so `compile` resolves the reactor but produces no binary.
 # ---------------------------------------------------------------------------
 log "building (link mode: $LINK_MODE)"
+# Run from the repository root, and select the module by artifactId rather than by path.
+#
+# `-pl <path>` is resolved relative to Maven's execution root, i.e. the directory Maven was
+# launched from - NOT the directory holding the root pom. So `-pl native` from anywhere other
+# than the repository root looks for <cwd>/native and dies with "Could not find the selected
+# project in the reactor: native", which points at the reactor rather than at the caller's cwd.
+# Running the script from native/ (./scripts/build-native.sh) hits this immediately.
+#
+# `-pl :arcadedb-native` selects by artifactId and is position-independent, so the two together
+# make this work from any working directory.
+cd "$REPO_ROOT"
 set -x
 # ${ARR[@]+"${ARR[@]}"} rather than a plain "${ARR[@]}": both arrays are empty in the common case
 # (dynamic link mode, no forwarded Maven args) and macOS still ships bash 3.2, where expanding an
 # empty array under `set -u` aborts with "unbound variable". native-image.yml carries the same
 # caveat for its macOS leg.
-"$REPO_ROOT/mvnw" -B -ntp -Pnative -pl native -am -DskipTests \
+"$REPO_ROOT/mvnw" -B -ntp -Pnative -pl :arcadedb-native -am -DskipTests \
   ${MODE_ARGS[@]+"${MODE_ARGS[@]}"} ${MVN_EXTRA[@]+"${MVN_EXTRA[@]}"} package
 set +x
 

--- a/native/scripts/build-native.sh
+++ b/native/scripts/build-native.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Usage: build-native.sh [options] [-- <extra maven args>]
+#
+# Builds the ArcadeDB GraalVM native image FOR THE MACHINE YOU ARE ON, wrapping the raw
+#   ./mvnw -Pnative -pl native -am -DskipTests package
+# from docs/native-image.md with the three preflight checks that turn this build's cryptic
+# failure modes into an immediate, named error:
+#
+#   1. JAVA_HOME/GRAALVM_HOME actually point at a GraalVM home that contains bin/native-image.
+#      native-maven-plugin resolves the builder from those variables, NOT by searching PATH, so a
+#      version-manager shim that only puts `native-image` on PATH fails with "native-image is not
+#      installed in your JAVA_HOME" after Maven has already resolved the whole reactor.
+#   2. That builder is the version native/pom.xml pins its Truffle/polyglot artifacts to. A skew
+#      there fails minutes into the build with `NoSuchMethodError:
+#      OptimizedTruffleRuntime.getLoopNodeFactory()`, which names neither side of the mismatch.
+#      This has shipped to main twice - see the long comment on native.graalvm.version in
+#      native/pom.xml. Override with --allow-version-skew if you are deliberately testing another
+#      builder.
+#   3. For --link-mode musl-static, the musl toolchain AND a musl-built static libz are present
+#      before the build starts, rather than failing at the final link step.
+#
+# Native Image cannot cross-compile: this produces a binary for the host OS/arch only. To build
+# the LINUX binaries and the Docker images from a non-Linux machine, use build-native-docker.sh,
+# which runs this same Maven build inside a Linux container.
+#
+# Options:
+#   --link-mode <mode>     auto (default) | dynamic | musl-static | mostly-static
+#                          auto picks the mode CI uses for this platform:
+#                            linux/x86_64  -> musl-static   (fully static musl; runs on scratch)
+#                            linux/aarch64 -> mostly-static (static except glibc; needs a glibc base)
+#                            macOS/Windows -> dynamic       (the only mode those platforms have)
+#                          On linux/x86_64 without a musl toolchain, auto degrades to dynamic with
+#                          a warning rather than failing - a dynamic binary is still a usable local
+#                          build, it just cannot go into the scratch Docker image.
+#   --smoke                After building, run native/src/test/scripts/smoke.sh against the binary
+#                          (boots the server, asserts HTTP/Studio/SQL/Cypher/JS round-trips).
+#   --wire                 With --smoke, additionally enable every wire-protocol plugin and set
+#                          WIRE_STRICT=1, matching what native-image.yml's two Linux legs assert.
+#                          Needs psql/grpcurl/python3/xxd installed locally or the strict checks
+#                          fail; without this flag those checks WARN-skip.
+#   --allow-version-skew   Downgrade preflight check 2 from an error to a warning.
+#   -h, --help             Print this help.
+#
+# Anything after a literal `--` is forwarded verbatim to Maven, e.g.
+#   build-native.sh -- -o -Dnative.compile.threads=4
+#
+# Env:
+#   GRAALVM_HOME / JAVA_HOME   GraalVM home. Either may be set; the script exports both to
+#                              whichever one contains bin/native-image.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+NATIVE_POM="$REPO_ROOT/native/pom.xml"
+
+LINK_MODE="auto"
+RUN_SMOKE=0
+WIRE=0
+ALLOW_SKEW=0
+MVN_EXTRA=()
+
+log()  { echo "[build-native] $*"; }
+fail() { echo "[build-native] ERROR: $*" >&2; exit 1; }
+
+# Prints the header comment block above, from '# Usage:' to the first non-comment line, so the
+# help text cannot drift out of sync with hardcoded line numbers.
+usage() { awk '/^# Usage:/{f=1} f{ if ($0 !~ /^#/) exit; sub(/^# ?/,""); print }' "${BASH_SOURCE[0]}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --link-mode)         LINK_MODE="${2:-}"; shift 2 ;;
+    --link-mode=*)       LINK_MODE="${1#*=}"; shift ;;
+    --smoke)             RUN_SMOKE=1; shift ;;
+    --wire)              WIRE=1; shift ;;
+    --allow-version-skew) ALLOW_SKEW=1; shift ;;
+    -h|--help)           usage; exit 0 ;;
+    --)                  shift; MVN_EXTRA=("$@"); break ;;
+    *)                   fail "unknown option '$1' (see --help)" ;;
+  esac
+done
+
+case "$LINK_MODE" in
+  auto|dynamic|musl-static|mostly-static) ;;
+  *) fail "invalid --link-mode '$LINK_MODE' (auto|dynamic|musl-static|mostly-static)" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 1. Locate the GraalVM home.
+#
+# native-maven-plugin reads GRAALVM_HOME first, then JAVA_HOME. Accept either as the input and
+# export BOTH pointing at the one that actually has bin/native-image, so the plugin cannot pick
+# up a different JDK than the one this script validated.
+# ---------------------------------------------------------------------------
+has_native_image() { [ -n "${1:-}" ] && [ -x "$1/bin/native-image" ]; }
+
+GVM=""
+for candidate in "${GRAALVM_HOME:-}" "${JAVA_HOME:-}"; do
+  if has_native_image "$candidate"; then GVM="$candidate"; break; fi
+done
+
+if [ -z "$GVM" ]; then
+  echo "[build-native] ERROR: no GraalVM home with bin/native-image found." >&2
+  echo "  GRAALVM_HOME=${GRAALVM_HOME:-<unset>}" >&2
+  echo "  JAVA_HOME=${JAVA_HOME:-<unset>}" >&2
+  echo "" >&2
+  echo "  native-maven-plugin resolves the builder from GRAALVM_HOME/JAVA_HOME, not from PATH:" >&2
+  echo "  a jenv/sdkman shim that only exposes \`native-image\` on PATH is NOT enough. Point both" >&2
+  echo "  at a real GraalVM home, e.g." >&2
+  echo "    export JAVA_HOME=/path/to/graalvm-community-<version>/Contents/Home   # macOS" >&2
+  echo "    export GRAALVM_HOME=\$JAVA_HOME" >&2
+  echo "  See docs/native-image.md \"Prerequisites\"." >&2
+  exit 1
+fi
+
+export GRAALVM_HOME="$GVM"
+export JAVA_HOME="$GVM"
+log "GraalVM home: $GVM"
+
+# ---------------------------------------------------------------------------
+# 2. Builder/Truffle pin check.
+#
+# native/pom.xml's native.graalvm.version pins graal-sdk/polyglot/js-language/truffle-* to the
+# exact release the builder must be. Read the pin from the pom (single source of truth - the lint
+# job already enforces that it matches native-image.yml) and look for it in the builder's own
+# --version banner, which prints e.g.
+#   GraalVM Runtime Environment GraalVM CE 25.2.4+9.1 (build ...)
+# ---------------------------------------------------------------------------
+PIN="$(sed -n 's:.*<native\.graalvm\.version>\(.*\)</native\.graalvm\.version>.*:\1:p' "$NATIVE_POM" | head -1)"
+[ -n "$PIN" ] || fail "could not read <native.graalvm.version> from $NATIVE_POM"
+
+NI_VERSION="$("$GVM/bin/native-image" --version 2>&1 || true)"
+# The banner carries a build suffix - the pinned 25.2.4 reports "GraalVM CE 25.2.4+7.1" - so match
+# the pin followed by a non-digit rather than the bare string, which would also accept a future
+# "25.2.40". Dots in the pin are escaped so they cannot match an arbitrary character.
+if grep -qE "GraalVM CE ${PIN//./\\.}([^0-9]|\$)" <<<"$NI_VERSION"; then
+  log "builder matches native/pom.xml pin (GraalVM CE $PIN)"
+else
+  {
+    echo "[build-native] builder does NOT match native/pom.xml's <native.graalvm.version> ($PIN)."
+    echo "  builder reports:"
+    sed 's/^/    /' <<<"$NI_VERSION"
+    echo ""
+    echo "  A builder/Truffle skew fails this build minutes in, at feature registration, with"
+    echo "    NoSuchMethodError: OptimizedTruffleRuntime.getLoopNodeFactory()"
+    echo "  which names neither side of the mismatch. Install GraalVM CE $PIN, or pass"
+    echo "  --allow-version-skew to proceed anyway. See docs/native-image.md \"Prerequisites\"."
+  } >&2
+  [ "$ALLOW_SKEW" = "1" ] || exit 1
+  log "continuing despite the skew (--allow-version-skew)"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Resolve the link mode, and preflight the musl toolchain if one is needed.
+# ---------------------------------------------------------------------------
+UNAME_S="$(uname -s)"
+UNAME_M="$(uname -m)"
+
+# Returns 0 when a musl toolchain with a musl-built static libz is usable for this host.
+musl_ready() {
+  local triplet="${UNAME_M}-linux-musl"
+  command -v "${triplet}-gcc" >/dev/null 2>&1 || return 1
+  "${triplet}-gcc" -print-file-name=libz.a 2>/dev/null | grep -q '/' || return 1
+  return 0
+}
+
+if [ "$LINK_MODE" = "auto" ]; then
+  case "$UNAME_S/$UNAME_M" in
+    Linux/x86_64)
+      if musl_ready; then
+        LINK_MODE="musl-static"
+      else
+        LINK_MODE="dynamic"
+        log "WARN: no musl toolchain with a musl-built static libz found; falling back to"
+        log "WARN: --link-mode dynamic. CI's linux/amd64 leg builds musl-static, and only a"
+        log "WARN: musl-static binary can go into the scratch Docker image. See"
+        log "WARN: docs/native-image.md, or use build-native-docker.sh which sets the toolchain up."
+      fi
+      ;;
+    Linux/aarch64|Linux/arm64) LINK_MODE="mostly-static" ;;
+    *)                         LINK_MODE="dynamic" ;;
+  esac
+  log "auto-selected --link-mode $LINK_MODE for $UNAME_S/$UNAME_M"
+fi
+
+MODE_ARGS=()
+case "$LINK_MODE" in
+  musl-static)
+    [ "$UNAME_S" = "Linux" ] || fail "--link-mode musl-static is Linux-only (host is $UNAME_S)"
+    case "$UNAME_M" in
+      aarch64|arm64)
+        fail "--link-mode musl-static cannot link on aarch64: GraalVM CE ships no static musl JDK
+  libraries for that architecture (oracle/graal#4645, closed not-planned). Use
+  --link-mode mostly-static, which is what CI's linux/arm64 leg builds."
+        ;;
+    esac
+    musl_ready || fail "--link-mode musl-static needs ${UNAME_M}-linux-musl-gcc and a musl-built
+  static libz.a on its library path. Install musl-tools + musl-dev, then build zlib with
+    CC=${UNAME_M}-linux-musl-gcc ./configure --static --prefix=/usr \\
+      --includedir=/usr/include/${UNAME_M}-linux-musl --libdir=/usr/lib/${UNAME_M}-linux-musl
+  musl-gcc's specs file restricts header/library search to that triplet directory and does NOT
+  fall back to /usr/include or /usr/lib, so a plain --prefix=/usr install stays invisible to it.
+  See docs/native-image.md, or use build-native-docker.sh which does all of this in a container."
+    MODE_ARGS=(-Dnative.static=true)
+    export CC="${UNAME_M}-linux-musl-gcc"
+    ;;
+  mostly-static)
+    [ "$UNAME_S" = "Linux" ] || fail "--link-mode mostly-static is Linux-only (host is $UNAME_S)"
+    MODE_ARGS=(-Dnative.mostlystatic=true)
+    ;;
+  dynamic) ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 4. Build. `package` is the phase that matters: native/pom.xml binds the plugin's
+#    compile-no-fork goal to it, so `compile` resolves the reactor but produces no binary.
+# ---------------------------------------------------------------------------
+log "building (link mode: $LINK_MODE)"
+set -x
+# ${ARR[@]+"${ARR[@]}"} rather than a plain "${ARR[@]}": both arrays are empty in the common case
+# (dynamic link mode, no forwarded Maven args) and macOS still ships bash 3.2, where expanding an
+# empty array under `set -u` aborts with "unbound variable". native-image.yml carries the same
+# caveat for its macOS leg.
+"$REPO_ROOT/mvnw" -B -ntp -Pnative -pl native -am -DskipTests \
+  ${MODE_ARGS[@]+"${MODE_ARGS[@]}"} ${MVN_EXTRA[@]+"${MVN_EXTRA[@]}"} package
+set +x
+
+# ---------------------------------------------------------------------------
+# 5. Locate the binary the same way native-image.yml does: by the executable bit, not by
+#    reconstructing os-maven-plugin's os.detected.name/arch naming, and not by excluding known
+#    non-binary extensions (native-image writes build-report files such as svm_err_*.md into the
+#    same directory, and those match arcadedb-* too).
+# ---------------------------------------------------------------------------
+cd "$REPO_ROOT/native/target"
+CANDIDATES=()
+if [ "$UNAME_S" != "Linux" ] && [ "$UNAME_S" != "Darwin" ]; then
+  while IFS= read -r f; do CANDIDATES+=("$f"); done \
+    < <(find . -maxdepth 1 -type f -name 'arcadedb-*.exe' -print | sed 's|^\./||')
+else
+  while IFS= read -r f; do CANDIDATES+=("$f"); done \
+    < <(find . -maxdepth 1 -type f -name 'arcadedb-*' -perm -u+x -print | sed 's|^\./||')
+fi
+[ "${#CANDIDATES[@]}" -eq 1 ] || fail "expected exactly one native binary in native/target, found ${#CANDIDATES[@]}"
+BIN="$REPO_ROOT/native/target/${CANDIDATES[0]}"
+
+log "binary: $BIN"
+log "size:   $(du -h "$BIN" | cut -f1)"
+if [ "$LINK_MODE" = "musl-static" ] && command -v ldd >/dev/null 2>&1; then
+  log "ldd:    $(ldd "$BIN" 2>&1 | head -1)   # expected: 'not a dynamic executable'"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Optional smoke test, reusing the exact script CI runs.
+# ---------------------------------------------------------------------------
+if [ "$RUN_SMOKE" = "1" ]; then
+  SMOKE=("$REPO_ROOT/native/src/test/scripts/smoke.sh" "$BIN" -Dorg.jline.terminal.dumb=true)
+  if [ "$WIRE" = "1" ]; then
+    PLUGINS="Postgres:com.arcadedb.postgres.PostgresProtocolPlugin"
+    PLUGINS="$PLUGINS,Redis:com.arcadedb.redis.RedisProtocolPlugin"
+    PLUGINS="$PLUGINS,MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin"
+    PLUGINS="$PLUGINS,Bolt:com.arcadedb.bolt.BoltProtocolPlugin"
+    PLUGINS="$PLUGINS,Grpc:com.arcadedb.server.grpc.GrpcServerPlugin"
+    SMOKE+=("-Darcadedb.server.plugins=$PLUGINS")
+    log "running smoke test with every wire plugin and WIRE_STRICT=1"
+    WIRE_STRICT=1 "${SMOKE[@]}"
+  else
+    log "running smoke test"
+    "${SMOKE[@]}"
+  fi
+fi
+
+log "done"

--- a/native/src/main/docker/Dockerfile.native-builder
+++ b/native/src/main/docker/Dockerfile.native-builder
@@ -1,0 +1,123 @@
+# syntax=docker/dockerfile:1
+#
+# Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# BUILD-TIME TOOLCHAIN ONLY - this image is never published and never runs ArcadeDB. It exists so
+# `native/scripts/build-native-docker.sh` can produce the LINUX native binary on a machine that is
+# not Linux: GraalVM Native Image cannot cross-compile, so a macOS host has no other way to build
+# the binary that goes into Dockerfile.native.scratch / Dockerfile.native.distroless. The script
+# builds this image, then runs the ordinary Maven native build inside it with the repository
+# bind-mounted, so the binary lands in native/target on the host exactly as a Linux host build
+# would leave it. The two runtime Dockerfiles are untouched by this and stay the artifacts CI
+# publishes.
+#
+# It reproduces what .github/workflows/native-image.yml's build job sets up on its runners:
+# the pinned GraalVM CE builder, and - for the amd64 leg only - the musl toolchain plus a
+# musl-built static zlib.
+#
+# Pinned by manifest-list digest (resolves per-architecture, so one digest serves both the amd64
+# and arm64 builds) to match this repo's other base-image pins. Refresh with:
+#   docker buildx imagetools inspect ubuntu:24.04 --format '{{.Manifest.Digest}}'
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+# GRAALVM_URL / GRAALVM_SHA256 are resolved by build-native-docker.sh from the GitHub release for
+# tag graal-<native.graalvm.version>, reading that version out of native/pom.xml. They are NOT
+# defaulted here on purpose: a default would be a second place the GraalVM version is written
+# down, and a stale one would reintroduce exactly the builder/Truffle skew that
+# native/pom.xml's native.graalvm.version comment documents (it has shipped to main twice). The
+# asset name cannot be derived from the version either - the pinned 25.2.4 publishes as
+# graalvm-community-jdk-25i2-25.0.4_linux-<arch>_bin.tar.gz - so the script asks the release API
+# rather than constructing it.
+ARG GRAALVM_URL
+ARG GRAALVM_SHA256
+# amd64 | arm64. Selects whether the musl toolchain below is installed; see that step.
+ARG TARGET_ARCH
+ARG ZLIB_VERSION=1.3.2
+
+# build-essential/zlib1g-dev are what native-image's link step needs for the default (glibc) and
+# mostly-static builds. curl+unzip are for the GraalVM download and for ./mvnw, which is
+# configured as distributionType=only-script and fetches Maven itself on first use. git is here
+# because a Maven build in a git checkout can invoke plugins that shell out to it.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        unzip \
+        git \
+        build-essential \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    test -n "$GRAALVM_URL"; \
+    test -n "$GRAALVM_SHA256"; \
+    curl -fsSL "$GRAALVM_URL" -o /tmp/graalvm.tar.gz; \
+    echo "${GRAALVM_SHA256}  /tmp/graalvm.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/graalvm; \
+    tar xzf /tmp/graalvm.tar.gz -C /opt/graalvm --strip-components=1; \
+    rm -f /tmp/graalvm.tar.gz; \
+    /opt/graalvm/bin/native-image --version
+
+# musl toolchain, amd64 ONLY, mirroring native-image.yml's "Set up musl toolchain" step - both
+# what it installs and why:
+#   - musl-dev provides the arch-prefixed wrapper native-image's musl probe looks for
+#     (x86_64-linux-musl-gcc, oracle/graal#7103) plus musl's static libc.a and headers under
+#     /usr/{include,lib}/x86_64-linux-musl/; musl-tools adds the unprefixed musl-gcc wrapper.
+#   - zlib is rebuilt from source against musl because native-image links libz for the JDK's
+#     zip/net code. It MUST be installed into that same triplet directory: musl-gcc's generated
+#     specs file passes -nostdinc/-nostdlib and restricts search to it, with no fallback to
+#     /usr/include or /usr/lib, so a plain --prefix=/usr install stays invisible and the -lz link
+#     step fails.
+# arm64 deliberately skips all of this: GraalVM CE ships no static musl JDK libraries for
+# aarch64 (oracle/graal#4645, closed not-planned), so --static --libc=musl can never link there
+# regardless of toolchain. That leg builds -Dnative.mostlystatic=true instead, which needs no
+# musl at all. Same split as the CI matrix.
+RUN set -eux; \
+    if [ "$TARGET_ARCH" = "amd64" ]; then \
+        apt-get update; \
+        apt-get install -y --no-install-recommends musl-tools musl-dev; \
+        rm -rf /var/lib/apt/lists/*; \
+        TRIPLET="$(uname -m)-linux-musl"; \
+        MUSL_GCC="${TRIPLET}-gcc"; \
+        command -v "$MUSL_GCC" >/dev/null; \
+        curl -fsSL "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz" -o /tmp/zlib.tar.gz; \
+        tar xzf /tmp/zlib.tar.gz -C /tmp; \
+        cd "/tmp/zlib-${ZLIB_VERSION}"; \
+        CC="$MUSL_GCC" ./configure --static --prefix=/usr \
+            --includedir="/usr/include/${TRIPLET}" --libdir="/usr/lib/${TRIPLET}"; \
+        make -j"$(nproc)"; \
+        make install; \
+        cd /; \
+        rm -rf "/tmp/zlib-${ZLIB_VERSION}" /tmp/zlib.tar.gz; \
+        "$MUSL_GCC" -print-file-name=libz.a; \
+    else \
+        echo "TARGET_ARCH=${TARGET_ARCH}: skipping musl toolchain (mostly-static build needs none)"; \
+    fi
+
+# native-maven-plugin resolves the builder from GRAALVM_HOME/JAVA_HOME, never from PATH, so both
+# are set - see docs/native-image.md "Prerequisites".
+ENV JAVA_HOME=/opt/graalvm \
+    GRAALVM_HOME=/opt/graalvm \
+    PATH=/opt/graalvm/bin:$PATH
+
+# The script bind-mounts the repository here and runs as the HOST's uid:gid, so everything the
+# build writes (target/ trees, the binary) is owned by the invoking user rather than by root.
+# That means no HOME and no /etc/passwd entry for that uid inside the container: the script
+# passes HOME explicitly, pointing at a cache directory it creates on the host, so ./mvnw and the
+# local Maven repository have somewhere writable to live and stay warm between runs.
+WORKDIR /workspace

--- a/native/src/main/docker/Dockerfile.native-builder
+++ b/native/src/main/docker/Dockerfile.native-builder
@@ -40,8 +40,9 @@ FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a
 # defaulted here on purpose: a default would be a second place the GraalVM version is written
 # down, and a stale one would reintroduce exactly the builder/Truffle skew that
 # native/pom.xml's native.graalvm.version comment documents (it has shipped to main twice). The
-# asset name cannot be derived from the version either - the pinned 25.2.4 publishes as
-# graalvm-community-jdk-25i2-25.0.4_linux-<arch>_bin.tar.gz - so the script asks the release API
+# asset name cannot be derived from the version either, and its shape differs per release line
+# (mainline 25.0.2 -> graalvm-community-jdk-25.0.2_linux-<arch>_bin.tar.gz; intermediate 25.2.4 ->
+# graalvm-community-jdk-25i2-25.0.4_linux-<arch>_bin.tar.gz), so the script asks the release API
 # rather than constructing it.
 ARG GRAALVM_URL
 ARG GRAALVM_SHA256


### PR DESCRIPTION
Single PR for all the native-image work. **Supersedes #7095**, whose commits are already in this branch.

## 1. One GraalVM version, everywhere: 25.0.2

The pin tracked the **intermediate** release line (`graal-25.2.4`), published as tarballs on the graalvm-ce-builds releases page and nowhere else. The builder is not optional - `native-maven-plugin` resolves it from `GRAALVM_HOME`/`JAVA_HOME` - so that made every local native build start with a hand download, leaving CI as the only place the image could be built.

Three places carry this version and all three are now `25.0.2`:

| File | Property | Was | Now |
|---|---|---|---|
| `engine/pom.xml` | `graalvm.version` | 25.2.4 | **25.0.2** |
| `native/pom.xml` | `native.graalvm.version` | 25.2.4 | **25.0.2** |
| `native-image.yml` | builder | `version: "25.2.4"` | `java-version: "25.0.2"` |

`engine/pom.xml` was initially left at 25.2.4, on the grounds that `native/pom.xml`'s `dependencyManagement` insulates the image and a build with the two apart demonstrably worked. It did work - but a split means engine bytecode compiled against one Truffle API runs against another inside the image, and the only thing between that and a `NoSuchMethodError` is nobody having reached for the newer API yet. One version everywhere costs nothing and deletes the question.

### Why 25.0.2 and not 25.0.3

Mainline is the line the OS packagers carry, so `brew install --cask graalvm-community-jdk25` gets you the matching builder. But the patch number matters:

| Version | CE tarball | Maven artifacts | |
|---|---|---|---|
| **25.0.2** | `jdk-25.0.2` | yes | **pinned** |
| 25.0.3 | **none in graalvm-ce-builds** | yes | Canonical ships it as an Ubuntu snap |
| 25.0.4 | **none** | yes | |
| 25.1.3 | `graal-25.1.3` | yes | intermediate |
| 25.2.4 | `graal-25.2.4` | yes | intermediate, previous pin |

**Being on Maven Central does not make a version installable.** 25.0.3 and 25.0.4 publish the full `org.graalvm.*` set, so bumping the property to either resolves cleanly and then leaves no builder to match. `graalvm/setup-graalvm` resolves only from `graalvm-ce-builds`, which has neither `jdk-25.0.3` nor `graal-25.0.3`. That trap is now recorded in the property comment, `docs/native-image.md` and `dependabot.yml`, because it is invisible from Maven alone.

`java-version` replaces `version` as the setup-graalvm input: both resolve 25.0.2, but `java-version` reaches `jdk-*` releases **only**, which states the intent that the pin stays mainline. `.mergify.yml` already said `java-version` - written when the pin was 25.0.2 and never updated - so this restores that consistency.

## 2. Scripts to build the native image and its Docker image locally

### `native/scripts/build-native.sh` - host binary

Wraps `./mvnw -Pnative -pl :arcadedb-native -am -DskipTests package` with preflight for the three failures that otherwise surface minutes in, naming neither cause:

| Check | Failure it replaces |
|---|---|
| `JAVA_HOME`/`GRAALVM_HOME` really is a GraalVM home | `native-image is not installed in your JAVA_HOME`, *after* the whole reactor resolves. The plugin reads those variables, never `PATH`, so a jenv/sdkman shim is not enough |
| Builder matches the pin | `NoSuchMethodError: OptimizedTruffleRuntime.getLoopNodeFactory()` - the skew that has shipped to main twice |
| musl toolchain + musl-built static `libz.a` | a failed `-lz` at the final link step |

It also picks the link mode CI uses for the host platform and locates the binary by the executable bit, as `native-image.yml` does.

### `native/scripts/build-native-docker.sh` - the shipped image, locally

Does in one pass what CI splits across the `build` and `docker` jobs: build a local-only builder image (`Dockerfile.native-builder`) carrying the pinned GraalVM plus, for amd64, the musl toolchain and musl-built zlib; run the ordinary Maven native build **inside** it with the repository bind-mounted, so the Linux binary lands in `native/target` on the host; stage the context as the workflow does; `buildx --load` the runtime image; then run `exercise.sh` against the container and scan its startup log.

Native Image cannot cross-compile, so this is the only way to produce the Linux binary these images need from a macOS host. Both **runtime** Dockerfiles are used unmodified, so the result is the shipped image. Nothing is pushed; the default tag `arcadedb:<version>-native-<arch>-local` is deliberately not publishable.

The GraalVM URL is resolved from the release matching `native/pom.xml`, trying `graal-<version>` then `jdk-<version>` - the same order setup-graalvm's own `findReleaseTag` uses - so it follows the pin across either release line rather than drifting from it.

## Bugs found by running these, not by reading them

- **A git worktree breaks the containerised build.** `.git` is a *file* pointing at a gitdir outside the bind mount, so `buildnumber-maven-plugin`'s `git log` died with `fatal: not a git repository: .../.git/worktrees/<name>` - naming a host path that *does* exist, which reads as a git problem rather than a mount problem. The main repository's git dir is now mounted at its own absolute path.
- **`native-image` OOMs on Docker Desktop's 8 GB default**, even on a 36 GB host: it sizes its heap at ~80% of what it can *see*, which is the VM's allocation. It dies ~21 minutes in, *after* the whole reactor has built, naming nothing; its own output asks for >10.20 GB. There is now a 12 GiB preflight, plus `--builder-memory` (via `NATIVE_IMAGE_OPTIONS`, verified honoured) and `--allow-low-memory`.
- **`-pl native` is resolved relative to the working directory**, not the repo root, so `./scripts/build-native.sh` from inside `native/` died with `Could not find the selected project in the reactor: native`. Both scripts now `cd` to the root and select by artifactId.
- **Empty-array expansion under `set -u` aborts on macOS's stock bash 3.2**, confirmed by running it there. Both scripts use the guarded idiom.
- The smoke test takes `--port` and refuses to start if the port is taken, because a dev machine is not a clean CI runner - a server already on 2480 either breaks the bind or gets asserted against *instead of* the image under test. This bit twice during verification: once as a `403 Studio index` from a stray JVM server.

## Verification

**CI, on the pin (dispatch run [33743647738](https://github.com/ArcadeData/arcadedb/actions/runs/33743647738), all six jobs green):** linux-amd64 musl-static, linux-arm64 mostly-static, windows-amd64, and both Docker images built and container-smoked. The run used the workflow file from the branch, so `java-version: "25.0.2"` was exercised for real, and the only GraalVM string in the 1.1 MB log is `GraalVM CE 25.0.2+10.1`. Both Linux legs run `smoke.sh` with `WIRE_STRICT=1` and produced **zero `WARN` lines**, so Postgres, Redis, MongoDB, Bolt and gRPC were hard assertions. One `docker-amd64` attempt failed on a Docker Hub `502` resolving `docker/dockerfile:1` at step #3, before touching anything here; rerunning that job alone passed.

**Locally on macOS arm64, against Homebrew's CE 25.0.2:** engine compiles clean; 192 JS/script/polyglot tests pass (the surface the engine downgrade could break); full native image `BUILD SUCCESS` in 3m43s with all three versions aligned; `smoke.sh` against that binary `PASS`, JS round-trip included; `check-native-graalvm-pin.py` passes; both POMs and both YAMLs parse; both scripts syntax-check under bash 5 **and** 3.2.

**Also re-listed both 25.0.2 Linux tarballs** to confirm the static-libc split the two Docker images depend on still holds at this version: `linux-amd64` ships `lib/static/linux-amd64/{glibc,musl}`, `linux-aarch64` ships `glibc` only ([oracle/graal#4645](https://github.com/oracle/graal/issues/4645)). The musl-static amd64 / mostly-static arm64 split is unaffected.

## Not verified

- **The containerised Docker path end to end.** The link step has never completed on this machine - Docker Desktop is at 7.6 GiB, below the 12 GiB floor - so `--skip-binary-build`, context staging, the runtime image build and the container smoke are untested locally. CI's `docker-amd64`/`docker-arm64` jobs do cover the Dockerfiles and container smoke, just not this script's orchestration of them.
- **Patch-level builder skew.** Ubuntu's snap ships CE **25.0.3**, which will not match this 25.0.2 pin, and CI cannot pin 25.0.3. On such a host the script needs `--allow-version-skew`. Whether patch-level skew is actually harmful is untested - if it is harmless, the right follow-up is a graded check: fail on differing major/minor, warn on differing patch.
- `main`'s own CI is red independently of this branch (six consecutive runs), including `Issue6797DeltaScanScalingTest`, which also fails here. This diff touches no `.java` and no surefire config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCf7qa3nj6xaBWESFUy4LV
