### PR TITLE
fix(#7097): bundle the BOM-managed Jackson in the gremlin uber-jar instead of TinkerPop's 2.15.2 copy

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -186,8 +186,9 @@ The following table lists runtime dependencies bundled with ArcadeDB distributio
 | org.apache.tinkerpop | gremlin-groovy | 3.8.x | Apache 2.0 | https://tinkerpop.apache.org/ |
 | org.apache.groovy | groovy | ~4.0.x | Apache 2.0 | https://groovy-lang.org/ |
 | org.antlr | antlr4-runtime (shaded, relocated to `com.arcadedb.gremlin.shaded.org.antlr`) | 4.9.1 | BSD 3-Clause | https://www.antlr.org/ |
+| com.fasterxml.jackson.core | jackson-core, jackson-databind, jackson-annotations (shaded, relocated to `org.apache.tinkerpop.shaded.jackson`) | 2.22.x | Apache 2.0 | https://github.com/FasterXML/jackson |
 
-**Note:** Gremlin support is an optional module. These dependencies are only included when the Gremlin module is enabled. The Gremlin module's shaded jar bundles its own relocated copy of `antlr4-runtime` 4.9.1 (required by the TinkerPop/OpenCypher-Gremlin translation layer), independent of the engine's `antlr4-runtime` 4.13.2 listed under Core Dependencies.
+**Note:** Gremlin support is an optional module. These dependencies are only included when the Gremlin module is enabled. The Gremlin module's shaded jar bundles its own relocated copy of `antlr4-runtime` 4.9.1 (required by the TinkerPop/OpenCypher-Gremlin translation layer), independent of the engine's `antlr4-runtime` 4.13.2 listed under Core Dependencies. It also bundles Jackson under TinkerPop's own relocation prefix, in place of the copy that `org.apache.tinkerpop:gremlin-shaded` ships (2.15.2 for TinkerPop 3.8.1), rebuilt from the Jackson version the root BOM manages so that the bundled bytecode and its `META-INF/maven` metadata match the plain Jackson jars in `lib/` (issue #7097).
 
 ### gRPC (Optional Module)
 

--- a/gremlin-it/pom.xml
+++ b/gremlin-it/pom.xml
@@ -194,6 +194,12 @@
                          not attached, classifier/coordinate mismatch) instead of silently passing with
                          zero tests. -->
                     <failIfNoTests>true</failIfNoTests>
+                    <!-- ShadedJarLayoutTest checks the Jackson bundled in the uber-jar against the BOM
+                         version the parent pom manages (issue #7097). Appended, so the parent's own
+                         variables survive the merge. -->
+                    <systemPropertyVariables combine.children="append">
+                        <jackson.version>${jackson.version}</jackson.version>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/gremlin-it/src/test/java/com/arcadedb/gremlin/shading/ShadedJarLayoutTest.java
+++ b/gremlin-it/src/test/java/com/arcadedb/gremlin/shading/ShadedJarLayoutTest.java
@@ -24,9 +24,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -152,5 +156,60 @@ class ShadedJarLayoutTest {
         swing.add(name);
     }
     assertThat(swing).isEmpty();
+  }
+
+  /**
+   * Regression test for <a href="https://github.com/ArcadeData/arcadedb/issues/7097">#7097</a>.
+   * TinkerPop's {@code gremlin-shaded} bundles a relocated copy of whatever Jackson TinkerPop was
+   * released with (2.15.2 for 3.8.1) together with Jackson's ORIGINAL {@code META-INF/maven}
+   * metadata, so an SBOM/CVE scanner pointed at the distribution reported jackson-core 2.15.2 while
+   * every plain Jackson jar in {@code lib/} was the BOM-managed version. gremlin/pom.xml now drops
+   * TinkerPop's copy from the shade and rebuilds the same relocation from the BOM version, so this
+   * pins that the bytecode that actually runs, the metadata a scanner reads and the version the
+   * parent pom manages are one and the same.
+   */
+  @Test
+  void bundledJacksonIsTheBomVersionAndItsMetadataSaysSo() throws Exception {
+    final String managed = System.getProperty("jackson.version");
+    assertThat(managed)
+        .as("gremlin-it's surefire configuration passes ${jackson.version} as a system property")
+        .isNotBlank();
+
+    // The bytecode that runs. TinkerPop's own relocation prefix is the target, because gremlin-core
+    // and gremlin-util were compiled against it and are not rewritten by our shade.
+    assertThat(versionOf("org.apache.tinkerpop.shaded.jackson.core.json.PackageVersion"))
+        .as("relocated jackson-core is TinkerPop's 2.15.2 copy, not the BOM version")
+        .isEqualTo(managed);
+    assertThat(versionOf("org.apache.tinkerpop.shaded.jackson.databind.cfg.PackageVersion"))
+        .as("relocated jackson-databind is TinkerPop's 2.15.2 copy, not the BOM version")
+        .isEqualTo(managed);
+
+    // The metadata a scanner reads: one pom.properties per bundled Jackson artifact, each at the
+    // version of the bytecode next to it. A stale copy left behind by gremlin-shaded would show up
+    // here as a second, older jackson-core.
+    final Map<String, String> declared = new TreeMap<>();
+    for (final JarEntry entry : (Iterable<JarEntry>) shadedJar.stream()::iterator) {
+      final String name = entry.getName();
+      if (!name.startsWith("META-INF/maven/com.fasterxml.jackson") || !name.endsWith("/pom.properties"))
+        continue;
+      final Properties properties = new Properties();
+      try (final InputStream in = shadedJar.getInputStream(entry)) {
+        properties.load(in);
+      }
+      final String previous = declared.put(properties.getProperty("artifactId"), properties.getProperty("version"));
+      assertThat(previous).as("two copies of %s in the uber-jar", name).isNull();
+    }
+    assertThat(declared)
+        .containsOnlyKeys("jackson-annotations", "jackson-core", "jackson-databind")
+        .containsEntry("jackson-core", managed)
+        .containsEntry("jackson-databind", managed);
+    // The BOM versions jackson-annotations per minor release (2.22, not 2.22.2).
+    final String[] parts = managed.split("\\.");
+    assertThat(declared.get("jackson-annotations")).startsWith(parts[0] + "." + parts[1]);
+  }
+
+  /** {@code PackageVersion.VERSION} of a relocated Jackson module, loaded by name because the package is a shade target. */
+  private static String versionOf(final String packageVersionClass) throws Exception {
+    return Class.forName(packageVersionClass).getField("VERSION").get(null).toString();
   }
 }

--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -400,15 +400,12 @@
                              2.15.2 copy used to be. That copy is dropped by the gremlin-shaded filter below.
                              The multi-release overlays need their own patterns because shade rewrites the class
                              bodies under META-INF/versions but not their paths; the levels listed are the ones
-                             jackson-core ships today, and everyBundledThirdPartyPackageIsRelocated fails on a
+                             jackson-core ships classes at today (its versions/9 holds only the module-info that
+                             the filter below drops), and everyBundledThirdPartyPackageIsRelocated fails on a
                              new one, since com/fasterxml is not on its allow-list. -->
                         <relocation>
                             <pattern>com.fasterxml.jackson</pattern>
                             <shadedPattern>org.apache.tinkerpop.shaded.jackson</shadedPattern>
-                        </relocation>
-                        <relocation>
-                            <pattern>META-INF/versions/9/com.fasterxml.jackson</pattern>
-                            <shadedPattern>META-INF/versions/9/org.apache.tinkerpop.shaded.jackson</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>META-INF/versions/11/com.fasterxml.jackson</pattern>

--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -117,6 +117,22 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Jackson, bundled+relocated in the shaded jar in place of TinkerPop's own copy (issue #7097).
+             org.apache.tinkerpop:gremlin-shaded carries a relocated Jackson at whatever version TinkerPop
+             was released with (2.15.2 for 3.8.1) TOGETHER WITH Jackson's original META-INF/maven metadata,
+             so every SBOM/CVE scanner pointed at the distribution reports jackson-core 2.15.2 against
+             arcadedb-gremlin-*-shaded.jar while lib/ ships the BOM-managed version. The shade below drops
+             TinkerPop's copy and rebuilds the very same relocation from this dependency, so the bytecode
+             that runs, the metadata a scanner reads and the plain Jackson next to it are one version.
+             Optional for the same reason as antlr4-runtime above: bundled+relocated only, never leaked to
+             Maven consumers, for whom gremlin-shaded still provides org.apache.tinkerpop.shaded.jackson.
+             ShadedJarLayoutTest.bundledJacksonIsTheBomVersionAndItsMetadataSaysSo is the guard. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
@@ -378,7 +394,34 @@
                             <pattern>com.squareup.javapoet</pattern>
                             <shadedPattern>com.arcadedb.gremlin.shaded.com.squareup.javapoet</shadedPattern>
                         </relocation>
-
+                        <!-- Jackson at the BOM version, rebuilt onto TinkerPop's OWN relocation prefix (issue #7097):
+                             gremlin-core and gremlin-util were compiled against org.apache.tinkerpop.shaded.jackson
+                             and are not rewritten here, so the replacement must land exactly where TinkerPop's
+                             2.15.2 copy used to be. That copy is dropped by the gremlin-shaded filter below.
+                             The multi-release overlays need their own patterns because shade rewrites the class
+                             bodies under META-INF/versions but not their paths; the levels listed are the ones
+                             jackson-core ships today, and everyBundledThirdPartyPackageIsRelocated fails on a
+                             new one, since com/fasterxml is not on its allow-list. -->
+                        <relocation>
+                            <pattern>com.fasterxml.jackson</pattern>
+                            <shadedPattern>org.apache.tinkerpop.shaded.jackson</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>META-INF/versions/9/com.fasterxml.jackson</pattern>
+                            <shadedPattern>META-INF/versions/9/org.apache.tinkerpop.shaded.jackson</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>META-INF/versions/11/com.fasterxml.jackson</pattern>
+                            <shadedPattern>META-INF/versions/11/org.apache.tinkerpop.shaded.jackson</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>META-INF/versions/17/com.fasterxml.jackson</pattern>
+                            <shadedPattern>META-INF/versions/17/org.apache.tinkerpop.shaded.jackson</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>META-INF/versions/21/com.fasterxml.jackson</pattern>
+                            <shadedPattern>META-INF/versions/21/org.apache.tinkerpop.shaded.jackson</shadedPattern>
+                        </relocation>
                     </relocations>
                     <!-- Groovy's extension-module descriptor is a SINGLE-module properties file at a
                          fixed path, so it cannot be merged: of the modules bundled here only one
@@ -407,6 +450,20 @@
                                 <exclude>META-INF/versions/*/org/yaml/**</exclude>
                                 <exclude>META-INF/versions/*/module-info.class</exclude>
                                 <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                        <!-- TinkerPop's bundled Jackson (2.15.2 for 3.8.1) and the Maven metadata that made every
+                             scanner report it (issue #7097): both are rebuilt from the BOM-managed jackson-databind
+                             dependency by the relocation above, so nothing of TinkerPop's copy may survive, or
+                             shade keeps whichever class it met first and the uber-jar runs a mix of two Jacksons.
+                             Kryo, minlog and objenesis stay: TinkerPop relocates those into the same jar and no
+                             scanner has anything to say about them. -->
+                        <filter>
+                            <artifact>org.apache.tinkerpop:gremlin-shaded</artifact>
+                            <excludes>
+                                <exclude>org/apache/tinkerpop/shaded/jackson/**</exclude>
+                                <exclude>META-INF/versions/*/org/apache/tinkerpop/shaded/jackson/**</exclude>
+                                <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
                             </excludes>
                         </filter>
                     </filters>


### PR DESCRIPTION
Fixes #7097.

## Root cause

`org.apache.tinkerpop:gremlin-shaded` 3.8.1 carries a relocated Jackson (`org.apache.tinkerpop.shaded.jackson`) at the version TinkerPop was released with, 2.15.2, together with Jackson's original `META-INF/maven/com.fasterxml.jackson.core/*/pom.properties`. The gremlin shade merged both into `arcadedb-gremlin-*-shaded.jar`, the only jar in the image carrying that metadata:

```
$ unzip -p lib/arcadedb-gremlin-26.8.1-shaded.jar META-INF/maven/com.fasterxml.jackson.core/jackson-core/pom.properties
version=2.15.2
$ unzip -l lib/arcadedb-gremlin-26.8.1-shaded.jar | grep -c org/apache/tinkerpop/shaded/jackson
1094
```

So Docker Scout / grype were right, not just confused by metadata: the GraphSON code path in the distribution really ran Jackson 2.15.2, while `lib/` shipped the BOM-managed 2.22.x for everything else.

## Fix

The gremlin shade now:
- filters TinkerPop's Jackson classes, multi-release overlays and Maven metadata out of `gremlin-shaded`;
- bundles an **optional** `jackson-databind` (version from the root `jackson-bom`) and relocates it onto TinkerPop's own prefix `org.apache.tinkerpop.shaded.jackson`, including the `META-INF/versions/{11,17,21}` overlays, so `gremlin-core`/`gremlin-util` keep linking against the prefix they were compiled for.

Optional means Maven consumers of the plain `arcadedb-gremlin` jar get no new transitive dependency (same pattern as `antlr4-runtime`). Kryo/minlog/objenesis stay as TinkerPop ships them.

Result on the rebuilt jar: metadata says 2.22.2, no unrelocated `com/fasterxml` entry, overlays at 11/17/21 relocated, `META-INF/services` entries rewritten.

## Alternative considered

Only stripping `META-INF/maven/com.fasterxml.jackson.core/**` from the uber-jar would silence the scanner while leaving the 2.15.2 bytecode in place. Rejected: the report was about code that actually runs.

## Tests

- `ShadedJarLayoutTest.bundledJacksonIsTheBomVersionAndItsMetadataSaysSo` (gremlin-it): pins the relocated `PackageVersion` of jackson-core and jackson-databind and every bundled Jackson `pom.properties` to `${jackson.version}`, which gremlin-it's surefire now passes through. Red on the previous jar (`expected: "2.22.2" but was: "2.15.2"`), green now.
- `mvn -o verify -pl gremlin,gremlin-it`: 387 tests, 0 failures.
- `mvn -o verify -pl gremlin-it -Pintegration`: 1870 tests, 0 failures (TinkerPop structure/process suites and the remote GraphSON server ITs).
- `mvn -o verify -pl graphql`: 104 tests, 0 failures.

`ATTRIBUTIONS.md` lists the shaded Jackson under the TinkerPop section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the optional Gremlin shaded artifact to include Jackson dependencies managed by the project BOM.
  - Relocated Jackson packages under the TinkerPop namespace and included required multi-release Java overlays.

- **Bug Fixes**
  - Replaced the previously bundled Jackson copy with the BOM-managed version in the shaded artifact.

- **Tests**
  - Added regression coverage verifying shaded Jackson classes, metadata, and version consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->