### PR TITLE
fix(#7096, #7093): vertex UPDATE in autocommit on the Postgres wire; pin dynamic label REMOVE

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.ImmutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.SerializationException;
@@ -83,18 +84,21 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
   }
 
   public MutableVertex modify() {
-    final Record recordInCache = database.getTransaction().getRecordFromCache(rid);
+    final TransactionContext transaction = database.getTransaction();
+    final Record recordInCache = transaction.getRecordFromCache(rid);
     if (recordInCache != null) {
       if (recordInCache instanceof MutableVertex fromCache)
         return fromCache;
-    } else if (!database.getTransaction().hasPageForRecord(rid.getPageId(database))) {
+    } else if (transaction.isActive() && !transaction.hasPageForRecord(rid.getPageId(database))) {
       // THE RECORD IS NOT IN TX, SO IT MUST HAVE BEEN LOADED WITHOUT A TX OR PASSED FROM ANOTHER TX
-      // IT MUST BE RELOADED TO GET THE LATEST CHANGES. FORCE RELOAD
+      // IT MUST BE RELOADED TO GET THE LATEST CHANGES. FORCE RELOAD.
+      // With no transaction open there is no page image to pin the record to: the write that follows opens its own
+      // implicit transaction (auto-transaction mode) and verifies there that the record is still the one read (#6950),
+      // so modifying outside a transaction is legitimate for a vertex exactly as it is for a document (issue #7096).
       try {
         // RELOAD THE PAGE FIRST TO AVOID LOOP WITH TRIGGERS (ENCRYPTION)
-        database.getTransaction()
-            .getPageToModify(rid.getPageId(database), ((LocalBucket) database.getSchema().getBucketById(rid.getBucketId())).getPageSize(),
-                false);
+        transaction.getPageToModify(rid.getPageId(database),
+            ((LocalBucket) database.getSchema().getBucketById(rid.getBucketId())).getPageSize(), false);
         reload();
       } catch (final IOException e) {
         throw new DatabaseOperationException("Error on reloading vertex " + rid, e);

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
@@ -94,7 +94,7 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
       // IT MUST BE RELOADED TO GET THE LATEST CHANGES. FORCE RELOAD.
       // With no transaction open there is no page image to pin the record to: the write that follows opens its own
       // implicit transaction (auto-transaction mode) and verifies there that the record is still the one read (#6950),
-      // so modifying outside a transaction is legitimate for a vertex exactly as it is for a document (issue #7096).
+      // so modifying outside a transaction is legitimate for a vertex, as it already was for a document (issue #7096).
       try {
         // RELOAD THE PAGE FIRST TO AVOID LOOP WITH TRIGGERS (ENCRYPTION)
         transaction.getPageToModify(rid.getPageId(database),

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateEdgeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateEdgeStatement.java
@@ -21,7 +21,6 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.CreateEdgeExecutionPlanner;
@@ -56,14 +55,15 @@ public class CreateEdgeStatement extends Statement {
     context.setDatabase(database);
     context.setInputParameters(args);
 
-    final boolean implicitTransaction = ((DatabaseInternal) database).checkTransactionIsActive(database.isAutoTransaction());
+    final boolean implicitTransaction = beginImplicitTransaction(database);
+    boolean success = false;
     try {
       final InsertExecutionPlan executionPlan = createExecutionPlan(context);
       executionPlan.executeInternal();
+      success = true;
       return new LocalResultSet(executionPlan);
     } finally {
-      if (implicitTransaction)
-        database.commit();
+      endImplicitTransaction(database, implicitTransaction, success);
     }
   }
 
@@ -77,14 +77,15 @@ public class CreateEdgeStatement extends Statement {
     context.setDatabase(database);
     context.setInputParameters(params);
 
-    final boolean implicitTransaction = ((DatabaseInternal) database).checkTransactionIsActive(database.isAutoTransaction());
+    final boolean implicitTransaction = beginImplicitTransaction(database);
+    boolean success = false;
     try {
       final InsertExecutionPlan executionPlan = createExecutionPlan(context);
       executionPlan.executeInternal();
+      success = true;
       return new LocalResultSet(executionPlan);
     } finally {
-      if (implicitTransaction)
-        database.commit();
+      endImplicitTransaction(database, implicitTransaction, success);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatement.java
@@ -21,7 +21,6 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -57,14 +56,15 @@ public class CreateVertexStatement extends Statement {
     context.setDatabase(database);
     context.setInputParameters(params);
 
-    final boolean implicitTransaction = ((DatabaseInternal) database).checkTransactionIsActive(database.isAutoTransaction());
+    final boolean implicitTransaction = beginImplicitTransaction(database);
+    boolean success = false;
     try {
       final InsertExecutionPlan executionPlan = (InsertExecutionPlan) createExecutionPlan(context);
       executionPlan.executeInternal();
+      success = true;
       return new LocalResultSet(executionPlan);
     } finally {
-      if (implicitTransaction)
-        database.commit();
+      endImplicitTransaction(database, implicitTransaction, success);
     }
   }
 
@@ -78,15 +78,15 @@ public class CreateVertexStatement extends Statement {
     context.setDatabase(database);
     context.setInputParameters(args);
 
-    final boolean implicitTransaction = ((DatabaseInternal) database).checkTransactionIsActive(database.isAutoTransaction());
+    final boolean implicitTransaction = beginImplicitTransaction(database);
+    boolean success = false;
     try {
-
       final InsertExecutionPlan executionPlan = (InsertExecutionPlan) createExecutionPlan(context);
       executionPlan.executeInternal();
+      success = true;
       return new LocalResultSet(executionPlan);
     } finally {
-      if (implicitTransaction)
-        database.commit();
+      endImplicitTransaction(database, implicitTransaction, success);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DeleteStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DeleteStatement.java
@@ -90,9 +90,16 @@ public class DeleteStatement extends Statement {
     }
     context.setDatabase(db);
     context.setInputParameters(params);
-    final DeleteExecutionPlan executionPlan = createExecutionPlan(context);
-    executionPlan.executeInternal();
-    return new LocalResultSet(executionPlan);
+    final boolean implicitTransaction = beginImplicitTransaction(db);
+    boolean success = false;
+    try {
+      final DeleteExecutionPlan executionPlan = createExecutionPlan(context);
+      executionPlan.executeInternal();
+      success = true;
+      return new LocalResultSet(executionPlan);
+    } finally {
+      endImplicitTransaction(db, implicitTransaction, success);
+    }
   }
 
   @Override
@@ -103,9 +110,16 @@ public class DeleteStatement extends Statement {
     }
     context.setDatabase(db);
     context.setInputParameters(args);
-    final DeleteExecutionPlan executionPlan = createExecutionPlan(context);
-    executionPlan.executeInternal();
-    return new LocalResultSet(executionPlan);
+    final boolean implicitTransaction = beginImplicitTransaction(db);
+    boolean success = false;
+    try {
+      final DeleteExecutionPlan executionPlan = createExecutionPlan(context);
+      executionPlan.executeInternal();
+      success = true;
+      return new LocalResultSet(executionPlan);
+    } finally {
+      endImplicitTransaction(db, implicitTransaction, success);
+    }
   }
 
   public DeleteExecutionPlan createExecutionPlan(final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InsertStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InsertStatement.java
@@ -120,9 +120,16 @@ public class InsertStatement extends Statement {
 
     context.setDatabase(db);
     context.setInputParameters(args);
-    final InsertExecutionPlan executionPlan = createExecutionPlan(context);
-    executionPlan.executeInternal();
-    return new LocalResultSet(executionPlan);
+    final boolean implicitTransaction = beginImplicitTransaction(db);
+    boolean success = false;
+    try {
+      final InsertExecutionPlan executionPlan = createExecutionPlan(context);
+      executionPlan.executeInternal();
+      success = true;
+      return new LocalResultSet(executionPlan);
+    } finally {
+      endImplicitTransaction(db, implicitTransaction, success);
+    }
   }
 
   @Override
@@ -133,9 +140,16 @@ public class InsertStatement extends Statement {
 
     context.setDatabase(db);
     context.setInputParameters(params);
-    final InsertExecutionPlan executionPlan = createExecutionPlan(context);
-    executionPlan.executeInternal();
-    return new LocalResultSet(executionPlan);
+    final boolean implicitTransaction = beginImplicitTransaction(db);
+    boolean success = false;
+    try {
+      final InsertExecutionPlan executionPlan = createExecutionPlan(context);
+      executionPlan.executeInternal();
+      success = true;
+      return new LocalResultSet(executionPlan);
+    } finally {
+      endImplicitTransaction(db, implicitTransaction, success);
+    }
   }
 
   public InsertExecutionPlan createExecutionPlan(final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MoveVertexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MoveVertexStatement.java
@@ -3,7 +3,6 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.InternalExecutionPlan;
@@ -33,12 +32,14 @@ public class MoveVertexStatement extends Statement {
       for (int i = 0; i < args.length; i++)
         params.put(String.valueOf(i), args[i]);
 
-    final boolean implicitTransaction = ((DatabaseInternal) database).checkTransactionIsActive(database.isAutoTransaction());
+    final boolean implicitTransaction = beginImplicitTransaction(database);
+    boolean success = false;
     try {
-      return execute(database, params, parentCtx, usePlanCache);
+      final ResultSet result = execute(database, params, parentCtx, usePlanCache);
+      success = true;
+      return result;
     } finally {
-      if (implicitTransaction)
-        database.commit();
+      endImplicitTransaction(database, implicitTransaction, success);
     }
   }
 
@@ -52,16 +53,15 @@ public class MoveVertexStatement extends Statement {
     ctx.setDatabase(database);
     ctx.setInputParameters(params);
 
-    final boolean implicitTransaction = ((DatabaseInternal) database).checkTransactionIsActive(database.isAutoTransaction());
+    final boolean implicitTransaction = beginImplicitTransaction(database);
+    boolean success = false;
     try {
       final UpdateExecutionPlan executionPlan = createExecutionPlan(ctx, limit != null ? limit.getValue(ctx) : 0);
-
       executionPlan.executeInternal();
+      success = true;
       return new LocalResultSet(executionPlan);
-
     } finally {
-      if (implicitTransaction)
-        database.commit();
+      endImplicitTransaction(database, implicitTransaction, success);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MoveVertexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MoveVertexStatement.java
@@ -32,6 +32,8 @@ public class MoveVertexStatement extends Statement {
       for (int i = 0; i < args.length; i++)
         params.put(String.valueOf(i), args[i]);
 
+    // The Map overload below begins its own implicit transaction too, but finds this one active and joins it, so only
+    // this outer call commits or rolls back.
     final boolean implicitTransaction = beginImplicitTransaction(database);
     boolean success = false;
     try {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
@@ -82,7 +82,10 @@ public class Statement extends SimpleNode {
    * matches no record, a validation failure ahead of the first write - keeps behaving as it always did.
    * <p>
    * One transaction per statement is what makes autocommit atomic: a multi-record {@code UPDATE} either lands whole
-   * or not at all, instead of committing once per record and stopping halfway on the first failure. Before every write
+   * or not at all, instead of committing once per record and stopping halfway on the first failure. The one exception
+   * is the one the statement asks for: {@code BATCH n} commits the running transaction every {@code n} records
+   * ({@code BatchStep}), so a statement carrying it lands in chunks of {@code n} and a failure keeps every chunk already
+   * committed - with a per-record implicit transaction that clause had no transaction to chunk and was a no-op. Before every write
    * statement did this (issue #7096) an auto-committed {@code UPDATE} relied on the per-record implicit transaction of
    * {@code save()}, which a vertex never reached: {@code ImmutableVertex.modify()} pinned the record to the
    * transaction's page image first and failed with "Transaction not active" when there was none.

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
@@ -79,7 +79,9 @@ public class Statement extends SimpleNode {
    * owns it and must close it with {@link #endImplicitTransaction}; {@code false} when the statement joins the
    * caller's transaction. Outside auto-transaction mode this opens nothing and refuses nothing: a statement that ends
    * up writing a record is refused there ("Transaction not begun"), while one that writes nothing - a filter that
-   * matches no record, a validation failure ahead of the first write - keeps behaving as it always did.
+   * matches no record, a validation failure ahead of the first write - completes. That is what UPDATE, DELETE and
+   * INSERT always did; CREATE VERTEX, CREATE EDGE and MOVE VERTEX used to check on entry, so a CREATE EDGE or MOVE
+   * VERTEX whose source selection was empty was refused although it had nothing to write. They now behave alike.
    * <p>
    * One transaction per statement is what makes autocommit atomic: a multi-record {@code UPDATE} either lands whole
    * or not at all, instead of committing once per record and stopping halfway on the first failure. The one exception

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
@@ -21,6 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.InternalExecutionPlan;
@@ -70,6 +71,38 @@ public class Statement extends SimpleNode {
 
   public void validate() throws CommandSQLParsingException {
     // NO VALIDATION BY DEFAULT
+  }
+
+  /**
+   * Opens the statement-level implicit transaction a write statement runs in when the database is in auto-transaction
+   * mode and the caller did not begin one. Returns {@code true} when a transaction was opened here, so the caller
+   * owns it and must close it with {@link #endImplicitTransaction}; {@code false} when the statement joins the
+   * caller's transaction. Outside auto-transaction mode this opens nothing and refuses nothing: a statement that ends
+   * up writing a record is refused there ("Transaction not begun"), while one that writes nothing - a filter that
+   * matches no record, a validation failure ahead of the first write - keeps behaving as it always did.
+   * <p>
+   * One transaction per statement is what makes autocommit atomic: a multi-record {@code UPDATE} either lands whole
+   * or not at all, instead of committing once per record and stopping halfway on the first failure. Before every write
+   * statement did this (issue #7096) an auto-committed {@code UPDATE} relied on the per-record implicit transaction of
+   * {@code save()}, which a vertex never reached: {@code ImmutableVertex.modify()} pinned the record to the
+   * transaction's page image first and failed with "Transaction not active" when there was none.
+   */
+  protected static boolean beginImplicitTransaction(final Database database) {
+    return database.isAutoTransaction() && ((DatabaseInternal) database).checkTransactionIsActive(true);
+  }
+
+  /**
+   * Closes the implicit transaction {@link #beginImplicitTransaction} opened: committed when the statement completed,
+   * rolled back when it threw. Call from a {@code finally}. A no-op when {@code implicitTransaction} is false.
+   */
+  protected static void endImplicitTransaction(final Database database, final boolean implicitTransaction,
+      final boolean success) {
+    if (!implicitTransaction)
+      return;
+    if (success)
+      database.commit();
+    else
+      database.rollback();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
@@ -85,10 +85,12 @@ public class Statement extends SimpleNode {
    * or not at all, instead of committing once per record and stopping halfway on the first failure. The one exception
    * is the one the statement asks for: {@code BATCH n} commits the running transaction every {@code n} records
    * ({@code BatchStep}), so a statement carrying it lands in chunks of {@code n} and a failure keeps every chunk already
-   * committed - with a per-record implicit transaction that clause had no transaction to chunk and was a no-op. Before every write
-   * statement did this (issue #7096) an auto-committed {@code UPDATE} relied on the per-record implicit transaction of
-   * {@code save()}, which a vertex never reached: {@code ImmutableVertex.modify()} pinned the record to the
-   * transaction's page image first and failed with "Transaction not active" when there was none.
+   * committed - with a per-record implicit transaction that clause had no transaction to chunk and was a no-op.
+   * <p>
+   * Until issue #7096 only CREATE VERTEX, CREATE EDGE and MOVE VERTEX did this. An auto-committed {@code UPDATE} relied
+   * on the per-record implicit transaction that {@code save()} opens, and a vertex never got that far:
+   * {@code ImmutableVertex.modify()} pinned the record to the transaction's page image first, and with no transaction
+   * open that failed with "Transaction not active".
    */
   protected static boolean beginImplicitTransaction(final Database database) {
     return database.isAutoTransaction() && ((DatabaseInternal) database).checkTransactionIsActive(true);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateStatement.java
@@ -121,9 +121,16 @@ public class UpdateStatement extends Statement {
 
     context.setDatabase(db);
     context.setInputParameters(args);
-    final UpdateExecutionPlan executionPlan = createExecutionPlan(context);
-    executionPlan.executeInternal();
-    return new LocalResultSet(executionPlan);
+    final boolean implicitTransaction = beginImplicitTransaction(db);
+    boolean success = false;
+    try {
+      final UpdateExecutionPlan executionPlan = createExecutionPlan(context);
+      executionPlan.executeInternal();
+      success = true;
+      return new LocalResultSet(executionPlan);
+    } finally {
+      endImplicitTransaction(db, implicitTransaction, success);
+    }
   }
 
   @Override
@@ -134,9 +141,16 @@ public class UpdateStatement extends Statement {
 
     context.setDatabase(db);
     context.setInputParameters(params);
-    final UpdateExecutionPlan executionPlan = createExecutionPlan(context);
-    executionPlan.executeInternal();
-    return new LocalResultSet(executionPlan);
+    final boolean implicitTransaction = beginImplicitTransaction(db);
+    boolean success = false;
+    try {
+      final UpdateExecutionPlan executionPlan = createExecutionPlan(context);
+      executionPlan.executeInternal();
+      success = true;
+      return new LocalResultSet(executionPlan);
+    } finally {
+      endImplicitTransaction(db, implicitTransaction, success);
+    }
   }
 
   public UpdateExecutionPlan createExecutionPlan(final CommandContext context) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherDynamicLabelRemoveIssue7093Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherDynamicLabelRemoveIssue7093Test.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7093: {@code REMOVE n:$('V')} succeeded without an error but left label {@code V} on the node, while the
+ * static {@code REMOVE n:V} removed it. The reporter's exact script: an unlabelled {@code MATCH} on a property, a
+ * literal-string dynamic label, and a node created with two labels in one pattern. The dynamic-label interpolation
+ * landed with issue #7059; this pins the reporter's scenario, which differs from the #7059 coverage in every one of
+ * those three respects, so a regression in any of them is caught here.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherDynamicLabelRemoveIssue7093Test extends TestHelper {
+
+  private List<String> labelsOfNode1() {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n {id: 1}) RETURN labels(n) AS l")) {
+      final List<String> labels = rs.next().getProperty("l");
+      assertThat(rs.hasNext()).isFalse();
+      return labels;
+    }
+  }
+
+  @Test
+  void aLiteralStringDynamicLabelIsRemovedLikeTheStaticForm() {
+    database.transaction(() -> database.command("opencypher", "CREATE (n:U:V {id: 1})").close());
+    assertThat(labelsOfNode1()).containsExactlyInAnyOrder("U", "V");
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n {id: 1}) REMOVE n:$('V')").close());
+
+    assertThat(labelsOfNode1()).containsExactly("U");
+  }
+
+  @Test
+  void theStaticFormStaysTheControl() {
+    database.transaction(() -> database.command("opencypher", "CREATE (n:U:V {id: 1})").close());
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n {id: 1}) REMOVE n:V").close());
+
+    assertThat(labelsOfNode1()).containsExactly("U");
+  }
+
+  /** Both spellings in one statement, each removing one of the two labels, leave the node with neither. */
+  @Test
+  void staticAndDynamicRemovalsCombineInOneClause() {
+    database.transaction(() -> database.command("opencypher", "CREATE (n:U:V:W {id: 1})").close());
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n {id: 1}) REMOVE n:U:$('V')").close());
+
+    assertThat(labelsOfNode1()).containsExactly("W");
+  }
+
+  /** The {@code IS} spelling of the same removal. */
+  @Test
+  void theIsSpellingRemovesTheDynamicLabelToo() {
+    database.transaction(() -> database.command("opencypher", "CREATE (n:U:V {id: 1})").close());
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n {id: 1}) REMOVE n IS $('V')").close());
+
+    assertThat(labelsOfNode1()).containsExactly("U");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MoveVertexStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MoveVertexStatementExecutionTest.java
@@ -19,11 +19,16 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * original @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdatabase.com)
@@ -350,6 +355,34 @@ class MoveVertexStatementExecutionTest extends TestHelper {
       assertThat(moved.<Integer>getProperty("newfield")).isEqualTo(7);
       assertThat(moved.hasProperty("somefield")).isFalse();
     }
+  }
+
+  /**
+   * Issue #7096: the auto-transaction a MOVE VERTEX opens for itself is rolled back when the statement fails, instead of
+   * being committed from the {@code finally} with whatever the statement had moved before failing. The second vertex
+   * collides with the first on the target type's unique index, so without the rollback the first would have been
+   * moved and the source left with one vertex.
+   */
+  @Test
+  void aFailedMoveVertexRollsBackItsAutoTransaction() {
+    final String typeA = "testMoveRollbackA";
+    final String typeB = "testMoveRollbackB";
+    database.transaction(() -> {
+      database.getSchema().createVertexType(typeA);
+      final VertexType target = database.getSchema().createVertexType(typeB);
+      target.createProperty("name", Type.STRING);
+      target.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+      database.command("sql", "create vertex " + typeA + " set name = 'same'").close();
+      database.command("sql", "create vertex " + typeA + " set name = 'same'").close();
+    });
+    database.setAutoTransaction(true);
+
+    assertThatThrownBy(() -> database.command("sql", "MOVE VERTEX (SELECT FROM " + typeA + ") TO TYPE:" + typeB).close())
+        .isInstanceOf(DuplicatedKeyException.class);
+    assertThat(database.isTransactionActive()).isFalse();
+
+    assertThat(database.countType(typeA, true)).as("nothing moved out of the source").isEqualTo(2);
+    assertThat(database.countType(typeB, true)).as("nothing landed in the target").isEqualTo(0);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7096, engine side: with {@code setAutoTransaction(true)} and no transaction open, {@code UPDATE} on a
+ * vertex type failed with "Transaction not active" while the same statement on a document type ran. The Postgres
+ * wire plugin runs every connection in that mode, which is how the asymmetry surfaced to JDBC and Spark clients.
+ * <p>
+ * Two things changed. {@code ImmutableVertex.modify()} pinned the vertex to the transaction's page image even when
+ * no transaction was open, which is where the error came from; it now only does so inside a transaction, as
+ * {@code ImmutableDocument.modify()} always did. And every SQL write statement now runs in one statement-level
+ * implicit transaction instead of one per record, so an auto-committed multi-record statement is atomic.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class UpdateAutoTransactionIssue7096Test extends TestHelper {
+
+  @BeforeEach
+  void createTypes() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Character");
+      database.getSchema().createDocumentType("Note");
+      database.command("sql", "CREATE VERTEX Character SET name = 'Napoleon'").close();
+      database.command("sql", "INSERT INTO Note SET text = 'a'").close();
+    });
+    database.setAutoTransaction(true);
+    assertThat(database.isTransactionActive()).isFalse();
+  }
+
+  @AfterEach
+  void resetAutoTransaction() {
+    database.setAutoTransaction(false);
+  }
+
+  @Test
+  void vertexUpdateRunsUnderAutoTransaction() {
+    database.command("sql", "UPDATE Character SET name = 'Bonaparte', aliases = ['Emperor'], attrs = {'nation':'France'} "
+        + "WHERE name = 'Napoleon'").close();
+    assertThat(database.isTransactionActive()).as("the implicit transaction is committed by the statement").isFalse();
+
+    try (final ResultSet rs = database.query("sql", "SELECT name, aliases, attrs FROM Character")) {
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("name")).isEqualTo("Bonaparte");
+      assertThat(row.<Iterable<String>>getProperty("aliases")).containsExactly("Emperor");
+      assertThat(row.<java.util.Map<String, Object>>getProperty("attrs")).containsEntry("nation", "France");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void documentUpdateRunsUnderAutoTransactionAsBefore() {
+    database.command("sql", "UPDATE Note SET text = 'b'").close();
+    assertThat(database.isTransactionActive()).isFalse();
+
+    try (final ResultSet rs = database.query("sql", "SELECT text FROM Note")) {
+      assertThat(rs.next().<String>getProperty("text")).isEqualTo("b");
+    }
+  }
+
+  /** Cypher SET goes through the same {@code modify()}, with no statement-level transaction of its own. */
+  @Test
+  void cypherSetOnAVertexRunsUnderAutoTransaction() {
+    database.command("opencypher", "MATCH (n:Character {name: 'Napoleon'}) SET n.name = 'Bonaparte'").close();
+    assertThat(database.isTransactionActive()).isFalse();
+
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM Character")) {
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Bonaparte");
+    }
+  }
+
+  /** The Java API shape of the same defect: {@code modify()} on a vertex read outside any transaction. */
+  @Test
+  void vertexModifyAndSaveOutsideATransactionRunsUnderAutoTransaction() {
+    final Vertex napoleon;
+    try (final ResultSet rs = database.query("sql", "SELECT FROM Character")) {
+      napoleon = rs.next().getVertex().get();
+    }
+
+    final MutableVertex mutable = napoleon.modify();
+    mutable.set("name", "Bonaparte").save();
+    assertThat(database.isTransactionActive()).isFalse();
+
+    assertThat(database.lookupByRID(napoleon.getIdentity(), true).asVertex().getString("name")).isEqualTo("Bonaparte");
+  }
+
+  /** The read-then-write race that pinning guarded against (#6950) is still refused without the pin. */
+  @Test
+  void aVertexModifiedFromAReplacedImageIsStillRefused() throws Exception {
+    final Vertex stale;
+    try (final ResultSet rs = database.query("sql", "SELECT FROM Character")) {
+      stale = rs.next().getVertex().get();
+    }
+    final MutableVertex mutable = stale.modify();
+
+    final RID rid = stale.getIdentity();
+    final ExecutorService other = Executors.newSingleThreadExecutor();
+    try {
+      other.submit(() -> database.transaction(
+          () -> database.lookupByRID(rid, true).asVertex().modify().set("name", "Emperor").save())).get(60, TimeUnit.SECONDS);
+    } finally {
+      other.shutdownNow();
+    }
+
+    assertThatThrownBy(() -> mutable.set("name", "Bonaparte").save()).isInstanceOf(ConcurrentModificationException.class);
+    assertThat(database.lookupByRID(rid, true).asVertex().getString("name")).isEqualTo("Emperor");
+  }
+
+  /** Autocommit is one transaction per statement, so a failure on the second record undoes the first. */
+  @Test
+  void anAutoCommittedMultiRecordUpdateIsAtomic() {
+    database.transaction(() -> {
+      final VertexType type = (VertexType) database.getSchema().getType("Character");
+      type.createProperty("name", Type.STRING);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+      database.command("sql", "CREATE VERTEX Character SET name = 'Myriel'").close();
+    });
+
+    // The first record takes the name, the second one collides with it on the unique index.
+    assertThatThrownBy(() -> database.command("sql", "UPDATE Character SET name = 'Anonymous'").close())
+        .isInstanceOf(DuplicatedKeyException.class);
+    assertThat(database.isTransactionActive()).as("the failed statement's implicit transaction is rolled back").isFalse();
+
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM Character ORDER BY name")) {
+      assertThat(rs.next().<String>getProperty("name")).as("no record of the failed statement survives").isEqualTo("Myriel");
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Napoleon");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void deleteAndInsertRunUnderAutoTransactionToo() {
+    database.command("sql", "INSERT INTO Character SET name = 'Myriel'").close();
+    database.command("sql", "DELETE FROM Character WHERE name = 'Napoleon'").close();
+    assertThat(database.isTransactionActive()).isFalse();
+
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM Character")) {
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Myriel");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /** A statement issued inside a caller's transaction joins it rather than committing on its own. */
+  @Test
+  void aStatementInsideACallerTransactionDoesNotCommitIt() {
+    database.begin();
+    try {
+      database.command("sql", "UPDATE Character SET name = 'Bonaparte'").close();
+      assertThat(database.isTransactionActive()).isTrue();
+      database.rollback();
+    } finally {
+      if (database.isTransactionActive())
+        database.rollback();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM Character")) {
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Napoleon");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.exception.TransactionException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.EdgeType;
@@ -241,6 +242,27 @@ class UpdateAutoTransactionIssue7096Test extends TestHelper {
     try (final ResultSet rs = database.query("sql", "SELECT name FROM Character")) {
       assertThat(rs.next().<String>getProperty("name")).isEqualTo("Myriel");
       assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /**
+   * Outside auto-transaction mode nothing changed: a write statement issued with no transaction open is still refused,
+   * for the statements that used to check eagerly on entry (CREATE VERTEX) and for the ones that never did (UPDATE)
+   * alike. The refusal now comes from the record write in both cases.
+   */
+  @Test
+  void withoutAutoTransactionAWriteStatementOutsideATransactionIsStillRefused() {
+    database.setAutoTransaction(false);
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE VERTEX Character SET name = 'Myriel'").close())
+        .isInstanceOf(TransactionException.class).hasMessageContaining("Transaction not begun");
+    assertThatThrownBy(() -> database.command("sql", "UPDATE Character SET name = 'Bonaparte'").close())
+        .isInstanceOf(TransactionException.class).hasMessageContaining("Transaction not begun");
+    assertThat(database.isTransactionActive()).isFalse();
+
+    assertThat(database.countType("Character", true)).isEqualTo(1);
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM Character")) {
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Napoleon");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +80,7 @@ class UpdateAutoTransactionIssue7096Test extends TestHelper {
       final Result row = rs.next();
       assertThat(row.<String>getProperty("name")).isEqualTo("Bonaparte");
       assertThat(row.<Iterable<String>>getProperty("aliases")).containsExactly("Emperor");
-      assertThat(row.<java.util.Map<String, Object>>getProperty("attrs")).containsEntry("nation", "France");
+      assertThat(row.<Map<String, Object>>getProperty("attrs")).containsEntry("nation", "France");
       assertThat(rs.hasNext()).isFalse();
     }
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
@@ -24,6 +24,7 @@ import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
@@ -190,6 +191,45 @@ class UpdateAutoTransactionIssue7096Test extends TestHelper {
     try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM Character")) {
       assertThat(rs.next().<Long>getProperty("c")).isEqualTo(2L);
     }
+  }
+
+  /**
+   * CREATE VERTEX used to commit its implicit transaction from the {@code finally} even when the statement had thrown,
+   * so the records created before the failure survived it. The second entry collides with the first on the unique
+   * index; nothing of the statement may remain.
+   */
+  @Test
+  void aFailedCreateVertexRollsBackItsAutoTransaction() {
+    database.transaction(() -> {
+      final VertexType type = (VertexType) database.getSchema().getType("Character");
+      type.createProperty("name", Type.STRING);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+    });
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE VERTEX Character CONTENT [{'name':'Myriel'},{'name':'Myriel'}]").close())
+        .isInstanceOf(DuplicatedKeyException.class);
+    assertThat(database.isTransactionActive()).isFalse();
+
+    assertThat(database.countType("Character", true)).as("only the vertex created by the fixture survives").isEqualTo(1);
+  }
+
+  /** The same for CREATE EDGE: the first edge is created, the second one fails, neither survives. */
+  @Test
+  void aFailedCreateEdgeRollsBackItsAutoTransaction() {
+    database.transaction(() -> {
+      final EdgeType type = database.getSchema().createEdgeType("Knows");
+      type.createProperty("since", Type.INTEGER);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "since");
+      database.command("sql", "CREATE VERTEX Character SET name = 'Myriel'").close();
+    });
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE EDGE Knows FROM (SELECT FROM Character) TO (SELECT FROM Character WHERE name = 'Myriel') SET since = 1815").close())
+        .isInstanceOf(DuplicatedKeyException.class);
+    assertThat(database.isTransactionActive()).isFalse();
+
+    assertThat(database.countType("Knows", true)).as("no edge of the failed statement survives").isEqualTo(0);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
@@ -233,6 +233,23 @@ class UpdateAutoTransactionIssue7096Test extends TestHelper {
     assertThat(database.countType("Knows", true)).as("no edge of the failed statement survives").isEqualTo(0);
   }
 
+  /** INSERT had no transaction wrapping at all before; a multi-record one is atomic under autocommit too. */
+  @Test
+  void aFailedMultiRecordInsertRollsBackItsAutoTransaction() {
+    database.transaction(() -> {
+      final VertexType type = (VertexType) database.getSchema().getType("Character");
+      type.createProperty("name", Type.STRING);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+    });
+
+    assertThatThrownBy(() -> database.command("sql",
+        "INSERT INTO Character CONTENT [{'name':'Myriel'},{'name':'Valjean'},{'name':'Myriel'}]").close())
+        .isInstanceOf(DuplicatedKeyException.class);
+    assertThat(database.isTransactionActive()).isFalse();
+
+    assertThat(database.countType("Character", true)).as("neither record inserted before the collision survives").isEqualTo(1);
+  }
+
   @Test
   void deleteAndInsertRunUnderAutoTransactionToo() {
     database.command("sql", "INSERT INTO Character SET name = 'Myriel'").close();
@@ -264,6 +281,29 @@ class UpdateAutoTransactionIssue7096Test extends TestHelper {
     try (final ResultSet rs = database.query("sql", "SELECT name FROM Character")) {
       assertThat(rs.next().<String>getProperty("name")).isEqualTo("Napoleon");
     }
+  }
+
+  /**
+   * CREATE EDGE and MOVE VERTEX used to refuse an empty source selection outside a transaction (without
+   * auto-transaction) before finding out they had nothing to write; they now complete, as UPDATE and DELETE with a
+   * filter matching nothing always did.
+   */
+  @Test
+  void withoutAutoTransactionAStatementThatWritesNothingCompletes() {
+    database.transaction(() -> database.getSchema().createEdgeType("Knows"));
+    database.setAutoTransaction(false);
+
+    try (final ResultSet rs = database.command("sql",
+        "CREATE EDGE Knows FROM (SELECT FROM Character WHERE name = 'Nobody') TO (SELECT FROM Character)")) {
+      assertThat(rs.hasNext()).isFalse();
+    }
+    try (final ResultSet rs = database.command("sql", "MOVE VERTEX (SELECT FROM Character WHERE name = 'Nobody') TO TYPE:Character")) {
+      assertThat(rs.hasNext()).isFalse();
+    }
+    try (final ResultSet rs = database.command("sql", "UPDATE Character SET name = 'x' WHERE name = 'Nobody'")) {
+      assertThat(rs.next().<Long>getProperty("count")).isEqualTo(0L);
+    }
+    assertThat(database.isTransactionActive()).isFalse();
   }
 
   /** A statement issued inside a caller's transaction joins it rather than committing on its own. */

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
@@ -186,10 +186,10 @@ class UpdateAutoTransactionIssue7096Test extends TestHelper {
         .isInstanceOf(DuplicatedKeyException.class);
     assertThat(database.isTransactionActive()).as("the failed chunk's transaction is rolled back").isFalse();
 
-    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM Character WHERE name = 'Anonymous'")) {
+    try (final ResultSet rs = database.query("sql", "SELECT count() AS c FROM Character WHERE name = 'Anonymous'")) {
       assertThat(rs.next().<Long>getProperty("c")).as("the chunk committed before the failure survives").isEqualTo(1L);
     }
-    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM Character")) {
+    try (final ResultSet rs = database.query("sql", "SELECT count() AS c FROM Character")) {
       assertThat(rs.next().<Long>getProperty("c")).isEqualTo(2L);
     }
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateAutoTransactionIssue7096Test.java
@@ -164,6 +164,33 @@ class UpdateAutoTransactionIssue7096Test extends TestHelper {
     }
   }
 
+  /**
+   * {@code BATCH n} is the statement asking for chunked commits, so it is the one shape autocommit does not make atomic:
+   * every chunk committed before the failure stays. With a per-record implicit transaction the clause had nothing to
+   * chunk; now it commits the statement's transaction every {@code n} records, as it always did inside a caller's.
+   */
+  @Test
+  void anAutoCommittedUpdateWithBatchCommitsEveryChunk() {
+    database.transaction(() -> {
+      final VertexType type = (VertexType) database.getSchema().getType("Character");
+      type.createProperty("name", Type.STRING);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+      database.command("sql", "CREATE VERTEX Character SET name = 'Myriel'").close();
+    });
+
+    // Chunk 1 (the first record) is committed before chunk 2 collides with it on the unique index.
+    assertThatThrownBy(() -> database.command("sql", "UPDATE Character SET name = 'Anonymous' BATCH 1").close())
+        .isInstanceOf(DuplicatedKeyException.class);
+    assertThat(database.isTransactionActive()).as("the failed chunk's transaction is rolled back").isFalse();
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM Character WHERE name = 'Anonymous'")) {
+      assertThat(rs.next().<Long>getProperty("c")).as("the chunk committed before the failure survives").isEqualTo(1L);
+    }
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM Character")) {
+      assertThat(rs.next().<Long>getProperty("c")).isEqualTo(2L);
+    }
+  }
+
   @Test
   void deleteAndInsertRunUnderAutoTransactionToo() {
     database.command("sql", "INSERT INTO Character SET name = 'Myriel'").close();

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7096VertexUpdateAutocommitIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7096VertexUpdateAutocommitIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7096: on the Postgres wire port an {@code UPDATE} against a vertex type failed with
+ * "Transaction not active" unless the client had opened an explicit transaction, while the same statement against a
+ * document or an edge type, and every {@code INSERT}/{@code CREATE VERTEX}/{@code DELETE}, ran fine in autocommit.
+ * Autocommit is the JDBC default and what Spark's Postgres connector uses for one-shot DML, so the asymmetry made
+ * vertex updates unusable from those clients.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7096VertexUpdateAutocommitIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Postgres:com.arcadedb.postgres.PostgresProtocolPlugin");
+    GlobalConfiguration.POSTGRES_DEBUG.setValue("false");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    GlobalConfiguration.POSTGRES_DEBUG.setValue("false");
+    super.endTest();
+  }
+
+  @Override
+  protected String getDatabaseName() {
+    return "postgresdb";
+  }
+
+  private Connection getConnection() throws SQLException, ClassNotFoundException {
+    Class.forName("org.postgresql.Driver");
+    final Properties props = new Properties();
+    props.setProperty("user", "root");
+    props.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    props.setProperty("ssl", "false");
+    return DriverManager.getConnection("jdbc:postgresql://localhost/" + getDatabaseName(), props);
+  }
+
+  @Test
+  @DisplayName("[#7096] a scalar vertex UPDATE runs in autocommit, exactly like a document UPDATE")
+  void scalarVertexUpdateInAutocommit() throws Exception {
+    try (final Connection conn = getConnection(); final Statement st = conn.createStatement()) {
+      assertThat(conn.getAutoCommit()).isTrue();
+      st.execute("CREATE VERTEX TYPE Character7096 IF NOT EXISTS");
+      st.execute("CREATE VERTEX Character7096 SET name = 'Napoleon'");
+
+      st.execute("UPDATE Character7096 SET name = 'Bonaparte' WHERE name = 'Napoleon'");
+
+      try (final ResultSet rs = st.executeQuery("SELECT name FROM Character7096")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("name")).isEqualTo("Bonaparte");
+        assertThat(rs.next()).isFalse();
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("[#7096] a vertex UPDATE assigning LIST and MAP literals runs in autocommit")
+  void containerVertexUpdateInAutocommit() throws Exception {
+    try (final Connection conn = getConnection(); final Statement st = conn.createStatement()) {
+      st.execute("CREATE VERTEX TYPE Character7096 IF NOT EXISTS");
+      st.execute("CREATE VERTEX Character7096 SET name = 'Napoleon'");
+
+      st.execute("UPDATE Character7096 SET aliases = ['Emperor','Bonaparte'], attrs = {'title':'Emperor','nation':'France'} "
+          + "WHERE name = 'Napoleon'");
+
+      try (final ResultSet rs = st.executeQuery("SELECT aliases, attrs FROM Character7096 WHERE name = 'Napoleon'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("aliases")).contains("Emperor").contains("Bonaparte");
+        assertThat(rs.getString("attrs")).contains("France");
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("[#7096] the same vertex UPDATE through the extended protocol (prepared statement) in autocommit")
+  void preparedVertexUpdateInAutocommit() throws Exception {
+    try (final Connection conn = getConnection(); final Statement st = conn.createStatement()) {
+      st.execute("CREATE VERTEX TYPE Character7096 IF NOT EXISTS");
+      st.execute("CREATE VERTEX Character7096 SET name = 'Napoleon'");
+
+      try (final PreparedStatement ps = conn.prepareStatement("UPDATE Character7096 SET name = ? WHERE name = ?")) {
+        ps.setString(1, "Bonaparte");
+        ps.setString(2, "Napoleon");
+        // execute(), not executeUpdate(): ArcadeDB answers a DML statement with its count row, which pgJDBC's
+        // executeUpdate() refuses as "a result was returned when none was expected" on every wire path, not just this one.
+        ps.execute();
+      }
+
+      try (final ResultSet rs = st.executeQuery("SELECT name FROM Character7096")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("name")).isEqualTo("Bonaparte");
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("[#7096] a vertex UPDATE followed by an edge UPDATE and a DELETE, all in autocommit on one connection")
+  void mixedDmlInAutocommit() throws Exception {
+    try (final Connection conn = getConnection(); final Statement st = conn.createStatement()) {
+      st.execute("CREATE VERTEX TYPE Character7096 IF NOT EXISTS");
+      st.execute("CREATE EDGE TYPE Appearance7096 IF NOT EXISTS");
+      st.execute("CREATE VERTEX Character7096 SET name = 'Napoleon'");
+      st.execute("CREATE VERTEX Character7096 SET name = 'Myriel'");
+      st.execute("CREATE EDGE Appearance7096 FROM (SELECT FROM Character7096 WHERE name = 'Napoleon') "
+          + "TO (SELECT FROM Character7096 WHERE name = 'Myriel') SET weight = 1");
+
+      st.execute("UPDATE Character7096 SET rank = 1 WHERE name = 'Napoleon'");
+      st.execute("UPDATE Appearance7096 SET weight = 2");
+      st.execute("UPDATE Character7096 SET rank = 2");
+      st.execute("DELETE FROM Character7096 WHERE name = 'Myriel'");
+
+      try (final ResultSet rs = st.executeQuery("SELECT name, rank FROM Character7096")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("name")).isEqualTo("Napoleon");
+        assertThat(rs.getInt("rank")).isEqualTo(2);
+        assertThat(rs.next()).isFalse();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #7096, closes #7093.

### #7096 - Postgres wire: vertex `UPDATE` fails in autocommit (`Transaction not active`)

Reproduced with a JDBC IT (`Issue7096VertexUpdateAutocommitIT`) and in the engine (`UpdateAutoTransactionIssue7096Test`). Root cause: `ImmutableVertex.modify()` pins the vertex to the transaction's page image (`getPageToModify` + reload) whenever the record is not in the transaction cache, and `getPageToModify` throws when no transaction is active. `ImmutableDocument.modify()` never does that outside a transaction, hence the vertex/document asymmetry. The Postgres executor relies on auto-transaction mode with no explicit `begin`, so a vertex `UPDATE` hit it on every autocommit connection (JDBC default, Spark).

Two changes:

1. **`ImmutableVertex.modify()`** pins the page only when a transaction is active. With none open there is no page image to pin to; the write that follows opens its own implicit transaction and re-checks there that the record is still the one read (#6950). A new test proves a stale image is still refused with `ConcurrentModificationException` without the pin.
2. **One implicit transaction per SQL write statement.** `UPDATE`, `DELETE` and `INSERT` now open a statement-level implicit transaction in auto-transaction mode, exactly as `CREATE VERTEX`, `CREATE EDGE` and `MOVE VERTEX` already did (moved into a shared `Statement.beginImplicitTransaction`/`endImplicitTransaction`). This is what autocommit means in Postgres: a multi-record statement lands whole or not at all, instead of committing once per record and stopping halfway on the first failure (test: a unique-index collision on the second record leaves the first untouched). The helper also **rolls back on failure**; the three existing statements committed from their `finally` even when `executeInternal()` threw. Outside auto-transaction mode nothing changes: no eager check, a statement that writes a record is still refused at the write, one that writes nothing keeps working.

Cypher `SET` on a vertex goes through the same `modify()` and is covered too.

### #7093 - Dynamic label `REMOVE n:$('V')` is a silent no-op

Not reproducible on `main`: it was fixed by #7059 (PR #7081), merged after the reporter's snapshot `b7c6c800`. Added `CypherDynamicLabelRemoveIssue7093Test` pinning the reporter's exact script (unlabelled `MATCH`, literal-string dynamic label, node created with two labels), plus the `IS` spelling and a static+dynamic mix in one clause, which the #7059 coverage did not exercise.

## Verification

- `engine`: new tests + `com.arcadedb.query.sql.executor.*`, `sql.parser.*`, `database.*`, `graph.*`, `opencypher.*`, `com.arcadedb.*` (6,062 tests, green)
- `server`: full unit lane (909 tests, green)
- `postgresw`: `Issue7096VertexUpdateAutocommitIT`, `PostgresProtocolIT`, `PostgresWJdbcIT`, the aborted-transaction ITs (134 tests, green)

## Docs

Worth a line in the SQL/Postgres docs: in auto-transaction mode each write statement is one transaction (atomic), so `setAutoCommit(true)` now behaves as documented for vertex `UPDATE` too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic transaction handling for SQL, Cypher, Java API, and PostgreSQL write operations.
  - Writes now commit only after successful execution and roll back correctly after failures, including constraint violations.
  - Improved atomicity for updates, deletes, inserts, and batch processing.
  - Existing caller-managed transactions remain unaffected.
  - Failed vertex moves now roll back cleanly without partial results.
  - Improved record modification when transaction page data is unavailable.
  - Fixed dynamic label removal in Cypher, including combined static and dynamic syntax.
  - No-op vertex and edge operations now complete reliably.
  - Improved PostgreSQL autocommit support for vertex and edge updates and deletes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->