### PR TITLE
fix(#7109,#7110,#7111,#7112): tuple delta, primitive overload specificity, Map comparator contract, date locale and file copy

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
@@ -331,7 +331,7 @@ public class DocumentIndexer {
       final Document modifiedRecord, final String[] propertyNames, final KeyExpansion[] expansions) {
     final Object[] oldKey = buildFullTextByItemKey(originalRecord, propertyNames, expansions);
     final Object[] newKey = buildFullTextByItemKey(modifiedRecord, propertyNames, expansions);
-    if (Arrays.equals(oldKey, newKey))
+    if (sameKeyTuple(oldKey, newKey))
       return false;
     if (!isAllEmpty(oldKey))
       index.remove(oldKey, rid);

--- a/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
@@ -559,8 +559,9 @@ public class DocumentIndexer {
    * Content-aware equality for a single key value: array-typed keys (the {@code float[]} of a vector index, a
    * {@code BINARY} property) do not override {@code Object.equals()}, so two independently deserialized-but-identical
    * arrays would compare unequal and trigger a spurious remove()+put() on every record update (issues #5318 and #7109).
-   * {@link Objects#deepEquals} falls back to {@code Object.equals()} for scalar keys and to element-wise
-   * {@code Arrays.deepEquals()} for array keys.
+   * {@link Objects#deepEquals} uses {@code Object.equals()} for scalar keys, the element-wise {@code Arrays.equals()}
+   * overload of the matching primitive array type ({@code float[]}, {@code byte[]}, ...) for primitive arrays, and
+   * {@code Arrays.deepEquals()} for {@code Object[]}.
    */
   private static boolean sameKeyValue(final Object a, final Object b) {
     return Objects.deepEquals(a, b);

--- a/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
@@ -536,9 +536,34 @@ public class DocumentIndexer {
 
   private static boolean containsTuple(final List<Object[]> tuples, final Object[] tuple) {
     for (final Object[] t : tuples)
-      if (Arrays.equals(t, tuple))
+      if (sameKeyTuple(t, tuple))
         return true;
     return false;
+  }
+
+  /**
+   * The one equality every "did this key change?" decision in this class goes through: two tuples are the same key when
+   * every element is {@link #sameKeyValue(Object, Object) the same key value}. Kept as the single policy so a new update
+   * path cannot pick a third notion of equality (issue #7109).
+   */
+  private static boolean sameKeyTuple(final Object[] a, final Object[] b) {
+    if (a.length != b.length)
+      return false;
+    for (int i = 0; i < a.length; i++)
+      if (!sameKeyValue(a[i], b[i]))
+        return false;
+    return true;
+  }
+
+  /**
+   * Content-aware equality for a single key value: array-typed keys (the {@code float[]} of a vector index, a
+   * {@code BINARY} property) do not override {@code Object.equals()}, so two independently deserialized-but-identical
+   * arrays would compare unequal and trigger a spurious remove()+put() on every record update (issues #5318 and #7109).
+   * {@link Objects#deepEquals} falls back to {@code Object.equals()} for scalar keys and to element-wise
+   * {@code Arrays.deepEquals()} for array keys.
+   */
+  private static boolean sameKeyValue(final Object a, final Object b) {
+    return Objects.deepEquals(a, b);
   }
 
   /**
@@ -646,11 +671,7 @@ public class DocumentIndexer {
           oldKeyValues[i] = getPropertyValue(originalRecord, propertyNamesArray[i]);
           newKeyValues[i] = getPropertyValue(modifiedRecord, propertyNamesArray[i]);
 
-          // Use content-aware comparison: array-typed keys (e.g. the float[] of a vector index) do not override
-          // Object.equals(), so two independently deserialized-but-identical arrays would compare unequal and
-          // trigger a spurious remove()+put() on every record update (issue #5318). Objects.deepEquals falls back
-          // to Object.equals() for scalar keys and to element-wise Arrays.equals() for array keys.
-          if (!keyValuesAreModified && !Objects.deepEquals(newKeyValues[i], oldKeyValues[i]))
+          if (!keyValuesAreModified && !sameKeyValue(newKeyValues[i], oldKeyValues[i]))
             keyValuesAreModified = true;
         }
 

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -38,9 +38,14 @@ import java.util.Set;
  * selected on every {@link #execute(Object...)} call, instead of registering only one of them depending on the
  * JVM's unspecified {@link Class#getDeclaredMethods()} order.
  * <p>
- * Unlike the Java compiler, this does not rank overloads by specificity: if more than one overload's parameter
- * types accept the arguments (e.g. {@code foo(Object)} and {@code foo(String)} both called with a {@code String}),
- * the call is rejected as ambiguous rather than silently picking the most specific match.
+ * Unlike the Java compiler, this does not rank overloads by reference-type specificity: if more than one overload's
+ * parameter types accept the arguments (e.g. {@code foo(Object)} and {@code foo(String)} both called with a
+ * {@code String}), the call is rejected as ambiguous rather than silently picking the most specific match. Primitive
+ * parameters are the exception: since a boxed numeric argument is accepted by every wider primitive too (JLS 5.1.2,
+ * issue #7007), overloads differing only in numeric width would all apply, so among them the narrowest one that still
+ * accepts the argument wins - {@code twice(int)} over {@code twice(long)} for an {@code Integer}, and
+ * {@code scale(long)} over {@code scale(double)} for the same argument - exactly as javac resolves the call
+ * (issue #7110). Only when no candidate is at least as narrow as every other in every position is the call ambiguous.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -249,14 +254,71 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
 
   private Method matchByType(final List<Method> allCandidates, final List<Method> pool, final Object[] args) {
     Method match = null;
+    List<Method> applicable = null;
     for (final Method m : pool) {
       if (acceptsArgumentTypes(m, args)) {
-        if (match != null)
-          throw ambiguousOverloadException(allCandidates, args);
-        match = m;
+        if (match == null)
+          match = m;
+        else {
+          if (applicable == null) {
+            applicable = new ArrayList<>(pool.size());
+            applicable.add(match);
+          }
+          applicable.add(m);
+        }
       }
     }
-    return match;
+    if (applicable == null)
+      return match;
+
+    final Method mostSpecific = mostSpecific(applicable, args.length);
+    if (mostSpecific == null)
+      throw ambiguousOverloadException(allCandidates, args);
+    return mostSpecific;
+  }
+
+  /**
+   * The single applicable overload that is {@link #isAtLeastAsSpecific at least as specific} as every other one, or
+   * {@code null} when no such overload exists and the call is genuinely ambiguous (issue #7110).
+   */
+  private static Method mostSpecific(final List<Method> applicable, final int argCount) {
+    for (final Method candidate : applicable) {
+      boolean dominates = true;
+      for (final Method other : applicable)
+        if (other != candidate && !isAtLeastAsSpecific(candidate, other, argCount)) {
+          dominates = false;
+          break;
+        }
+      if (dominates)
+        return candidate;
+    }
+    return null;
+  }
+
+  /**
+   * True when, in every argument position, {@code m1}'s parameter type is the same as {@code m2}'s or a primitive that
+   * widens into it (JLS 15.12.2.5 restricted to primitive parameters). Two reference parameter types that differ are
+   * deliberately not ranked (see the class Javadoc), so they make the pair incomparable.
+   */
+  private static boolean isAtLeastAsSpecific(final Method m1, final Method m2, final int argCount) {
+    for (int i = 0; i < argCount; i++) {
+      final Class<?> p1 = parameterTypeAt(m1, i);
+      final Class<?> p2 = parameterTypeAt(m2, i);
+      if (p1 != p2 && !(p1.isPrimitive() && WIDENING_CONVERSIONS.getOrDefault(p1, Set.of()).contains(p2)))
+        return false;
+    }
+    return true;
+  }
+
+  /**
+   * The parameter type an argument at position {@code i} is matched against: for a varargs method, positions past the
+   * fixed parameters map to the vararg component type.
+   */
+  private static Class<?> parameterTypeAt(final Method method, final int i) {
+    final Class<?>[] paramTypes = method.getParameterTypes();
+    if (method.isVarArgs() && i >= paramTypes.length - 1)
+      return paramTypes[paramTypes.length - 1].getComponentType();
+    return paramTypes[i];
   }
 
   private static boolean acceptsArgumentTypes(final Method method, final Object[] args) {

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -271,7 +271,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     if (applicable == null)
       return match;
 
-    final Method mostSpecific = mostSpecific(applicable, args.length);
+    final Method mostSpecific = mostSpecific(applicable, args.length, prePacked(applicable, args));
     if (mostSpecific == null)
       throw ambiguousOverloadException(allCandidates, args);
     return mostSpecific;
@@ -283,9 +283,18 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
    * overload exists and the call is genuinely ambiguous (issue #7110). Requiring strictness keeps a tie ambiguous, as
    * javac does: {@code f(String...)} and {@code f(String, String...)} see the same parameter type in every position of a
    * two-argument call, and neither may silently win.
+   * <p>
+   * The comparison spans the longest applicable signature, not only the positions the call supplied: JLS 15.12.2.5
+   * also weighs the vararg component an overload with one more parameter than the call did not receive, which is what
+   * keeps {@code f(int...)} against {@code f(long, short...)} ambiguous for a single {@code int} ({@code int} narrows
+   * into {@code long} but not into {@code short}) while {@code f(int...)} beats {@code f(int, long...)}.
    */
-  private static Method mostSpecific(final List<Method> applicable, final int argCount) {
+  private static Method mostSpecific(final List<Method> applicable, final int argCount, final boolean prePacked) {
     final int size = applicable.size();
+    int positions = argCount;
+    for (final Method m : applicable)
+      positions = Math.max(positions, m.getParameterCount());
+
     for (int i = 0; i < size; i++) {
       final Method candidate = applicable.get(i);
       boolean dominates = true;
@@ -293,7 +302,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
         if (j == i)
           continue;
         final Method other = applicable.get(j);
-        if (!isAtLeastAsSpecific(candidate, other, argCount) || isAtLeastAsSpecific(other, candidate, argCount))
+        if (!isAtLeastAsSpecific(candidate, other, positions, prePacked) || isAtLeastAsSpecific(other, candidate, positions, prePacked))
           dominates = false;
       }
       if (dominates)
@@ -303,14 +312,28 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
   }
 
   /**
-   * True when, in every argument position, {@code m1}'s parameter type is the same as {@code m2}'s or a primitive that
-   * widens into it (JLS 15.12.2.5 restricted to primitive parameters). Two reference parameter types that differ are
-   * deliberately not ranked (see the class Javadoc), so they make the pair incomparable.
+   * True when the vararg part was passed pre-packed (see {@link #isPrePacked}) to every applicable overload: the
+   * pre-packed array is then compared as the array type itself, exactly as {@link #acceptsArgumentTypes} matched it.
+   * The applicable set is uniform here - either the trailing argument is an array instance of every candidate's vararg
+   * type or of none - so one flag describes them all.
    */
-  private static boolean isAtLeastAsSpecific(final Method m1, final Method m2, final int argCount) {
-    for (int i = 0; i < argCount; i++) {
-      final Class<?> p1 = parameterTypeAt(m1, i);
-      final Class<?> p2 = parameterTypeAt(m2, i);
+  private static boolean prePacked(final List<Method> applicable, final Object[] args) {
+    for (final Method m : applicable)
+      if (m.isVarArgs() && isPrePacked(m, args))
+        return true;
+    return false;
+  }
+
+  /**
+   * True when, in every position up to {@code positions}, {@code m1}'s parameter type is the same as {@code m2}'s or a
+   * primitive that widens into it (JLS 15.12.2.5 restricted to primitive parameters). Two reference parameter types that
+   * differ are deliberately not ranked (see the class Javadoc), so they make the pair incomparable; a pre-packed vararg
+   * array compares as the array type, and two different array types are reference types that differ.
+   */
+  private static boolean isAtLeastAsSpecific(final Method m1, final Method m2, final int positions, final boolean prePacked) {
+    for (int i = 0; i < positions; i++) {
+      final Class<?> p1 = parameterTypeAt(m1, i, prePacked);
+      final Class<?> p2 = parameterTypeAt(m2, i, prePacked);
       if (p1 != p2 && !(p1.isPrimitive() && WIDENING_CONVERSIONS.getOrDefault(p1, Set.of()).contains(p2)))
         return false;
     }
@@ -319,12 +342,15 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
 
   /**
    * The parameter type an argument at position {@code i} is matched against: for a varargs method, positions past the
-   * fixed parameters map to the vararg component type.
+   * fixed parameters map to the vararg component type, or to the vararg array type itself when the call passed the
+   * vararg part pre-packed.
    */
-  private static Class<?> parameterTypeAt(final Method method, final int i) {
+  private static Class<?> parameterTypeAt(final Method method, final int i, final boolean prePacked) {
     final Class<?>[] paramTypes = method.getParameterTypes();
-    if (method.isVarArgs() && i >= paramTypes.length - 1)
-      return paramTypes[paramTypes.length - 1].getComponentType();
+    if (method.isVarArgs() && i >= paramTypes.length - 1) {
+      final Class<?> varargsType = paramTypes[paramTypes.length - 1];
+      return prePacked ? varargsType : varargsType.getComponentType();
+    }
     return paramTypes[i];
   }
 

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -282,13 +282,13 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
    * {@code null} when no such overload exists and the call is genuinely ambiguous (issue #7110).
    */
   private static Method mostSpecific(final List<Method> applicable, final int argCount) {
-    for (final Method candidate : applicable) {
+    final int size = applicable.size();
+    for (int i = 0; i < size; i++) {
+      final Method candidate = applicable.get(i);
       boolean dominates = true;
-      for (final Method other : applicable)
-        if (other != candidate && !isAtLeastAsSpecific(candidate, other, argCount)) {
+      for (int j = 0; j < size && dominates; j++)
+        if (j != i && !isAtLeastAsSpecific(candidate, applicable.get(j), argCount))
           dominates = false;
-          break;
-        }
       if (dominates)
         return candidate;
     }

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -278,17 +278,24 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
   }
 
   /**
-   * The single applicable overload that is {@link #isAtLeastAsSpecific at least as specific} as every other one, or
-   * {@code null} when no such overload exists and the call is genuinely ambiguous (issue #7110).
+   * The single applicable overload that is strictly more specific than every other one - {@link #isAtLeastAsSpecific
+   * at least as specific} as the other while the other is not at least as specific as it - or {@code null} when no such
+   * overload exists and the call is genuinely ambiguous (issue #7110). Requiring strictness keeps a tie ambiguous, as
+   * javac does: {@code f(String...)} and {@code f(String, String...)} see the same parameter type in every position of a
+   * two-argument call, and neither may silently win.
    */
   private static Method mostSpecific(final List<Method> applicable, final int argCount) {
     final int size = applicable.size();
     for (int i = 0; i < size; i++) {
       final Method candidate = applicable.get(i);
       boolean dominates = true;
-      for (int j = 0; j < size && dominates; j++)
-        if (j != i && !isAtLeastAsSpecific(candidate, applicable.get(j), argCount))
+      for (int j = 0; j < size && dominates; j++) {
+        if (j == i)
+          continue;
+        final Method other = applicable.get(j);
+        if (!isAtLeastAsSpecific(candidate, other, argCount) || isAtLeastAsSpecific(other, candidate, argCount))
           dominates = false;
+      }
       if (dominates)
         return candidate;
     }

--- a/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
+++ b/engine/src/main/java/com/arcadedb/function/java/JavaMethodFunctionDefinition.java
@@ -271,7 +271,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
     if (applicable == null)
       return match;
 
-    final Method mostSpecific = mostSpecific(applicable, args.length, prePacked(applicable, args));
+    final Method mostSpecific = mostSpecific(applicable, args);
     if (mostSpecific == null)
       throw ambiguousOverloadException(allCandidates, args);
     return mostSpecific;
@@ -289,9 +289,9 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
    * keeps {@code f(int...)} against {@code f(long, short...)} ambiguous for a single {@code int} ({@code int} narrows
    * into {@code long} but not into {@code short}) while {@code f(int...)} beats {@code f(int, long...)}.
    */
-  private static Method mostSpecific(final List<Method> applicable, final int argCount, final boolean prePacked) {
+  private static Method mostSpecific(final List<Method> applicable, final Object[] args) {
     final int size = applicable.size();
-    int positions = argCount;
+    int positions = args.length;
     for (final Method m : applicable)
       positions = Math.max(positions, m.getParameterCount());
 
@@ -302,7 +302,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
         if (j == i)
           continue;
         final Method other = applicable.get(j);
-        if (!isAtLeastAsSpecific(candidate, other, positions, prePacked) || isAtLeastAsSpecific(other, candidate, positions, prePacked))
+        if (!isAtLeastAsSpecific(candidate, other, positions, args) || isAtLeastAsSpecific(other, candidate, positions, args))
           dominates = false;
       }
       if (dominates)
@@ -312,28 +312,19 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
   }
 
   /**
-   * True when the vararg part was passed pre-packed (see {@link #isPrePacked}) to every applicable overload: the
-   * pre-packed array is then compared as the array type itself, exactly as {@link #acceptsArgumentTypes} matched it.
-   * The applicable set is uniform here - either the trailing argument is an array instance of every candidate's vararg
-   * type or of none - so one flag describes them all.
-   */
-  private static boolean prePacked(final List<Method> applicable, final Object[] args) {
-    for (final Method m : applicable)
-      if (m.isVarArgs() && isPrePacked(m, args))
-        return true;
-    return false;
-  }
-
-  /**
    * True when, in every position up to {@code positions}, {@code m1}'s parameter type is the same as {@code m2}'s or a
    * primitive that widens into it (JLS 15.12.2.5 restricted to primitive parameters). Two reference parameter types that
-   * differ are deliberately not ranked (see the class Javadoc), so they make the pair incomparable; a pre-packed vararg
-   * array compares as the array type, and two different array types are reference types that differ.
+   * differ are deliberately not ranked (see the class Javadoc), so they make the pair incomparable. Each method sees
+   * the vararg part the way {@link #acceptsArgumentTypes} matched it for that method: as the array type when the call
+   * passed it pre-packed for that overload, as the component type otherwise - the same trailing {@code String[]} is a
+   * pre-packed vararg for {@code f(int, String...)} and one flat element for {@code f(long, String[]...)}.
    */
-  private static boolean isAtLeastAsSpecific(final Method m1, final Method m2, final int positions, final boolean prePacked) {
+  private static boolean isAtLeastAsSpecific(final Method m1, final Method m2, final int positions, final Object[] args) {
+    final boolean prePacked1 = m1.isVarArgs() && isPrePacked(m1, args);
+    final boolean prePacked2 = m2.isVarArgs() && isPrePacked(m2, args);
     for (int i = 0; i < positions; i++) {
-      final Class<?> p1 = parameterTypeAt(m1, i, prePacked);
-      final Class<?> p2 = parameterTypeAt(m2, i, prePacked);
+      final Class<?> p1 = parameterTypeAt(m1, i, prePacked1);
+      final Class<?> p2 = parameterTypeAt(m2, i, prePacked2);
       if (p1 != p2 && !(p1.isPrimitive() && WIDENING_CONVERSIONS.getOrDefault(p1, Set.of()).contains(p2)))
         return false;
     }
@@ -343,7 +334,7 @@ public class JavaMethodFunctionDefinition implements FunctionDefinition {
   /**
    * The parameter type an argument at position {@code i} is matched against: for a varargs method, positions past the
    * fixed parameters map to the vararg component type, or to the vararg array type itself when the call passed the
-   * vararg part pre-packed.
+   * vararg part pre-packed for this method.
    */
   private static Class<?> parameterTypeAt(final Method method, final int i, final boolean prePacked) {
     final Class<?>[] paramTypes = method.getParameterTypes();

--- a/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
@@ -83,10 +83,11 @@ public class CollectionUtils {
    * any key), and two keys of unrelated classes are distinct map entries whichever way they are ordered, so grouping them
    * by class keeps the order total without asking {@code compareTo} to relate e.g. a String to an Integer.
    * <p>
-   * The order is strict: two keys answer {@code 0} only when they are {@link Object#equals equal}, i.e. the same map
-   * entry. Keys the comparator ranks equal but the map keeps distinct ({@code BigDecimal} {@code 1.0} and {@code 1.00})
-   * are broken by their string form, so their position in the sorted key array does not depend on insertion order and
-   * {@link #compare(Map, Map)} pairs each key with its own counterpart.
+   * Two {@link Object#equals equal} keys are the same map entry and answer {@code 0}. Keys the comparator ranks equal but
+   * the map keeps distinct ({@code BigDecimal} {@code 1.0} and {@code 1.00}) are broken by their string form and then
+   * their hash, so their position in the sorted key array does not depend on insertion order and
+   * {@link #compare(Map, Map)} pairs each key with its own counterpart. Only a custom key type whose distinct instances
+   * share {@code compareTo}, {@code toString()} and {@code hashCode()} while differing in {@code equals()} can still tie.
    */
   private static int compareKeys(final Object k1, final Object k2) {
     if (k1 == null || k2 == null)

--- a/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
@@ -82,11 +82,24 @@ public class CollectionUtils {
    * classes by class name. A map holds keys of any type (a document's MAP property is String-keyed, but the API accepts
    * any key), and two keys of unrelated classes are distinct map entries whichever way they are ordered, so grouping them
    * by class keeps the order total without asking {@code compareTo} to relate e.g. a String to an Integer.
+   * <p>
+   * The order is strict: two keys answer {@code 0} only when they are {@link Object#equals equal}, i.e. the same map
+   * entry. Keys the comparator ranks equal but the map keeps distinct ({@code BigDecimal} {@code 1.0} and {@code 1.00})
+   * are broken by their string form, so their position in the sorted key array does not depend on insertion order and
+   * {@link #compare(Map, Map)} pairs each key with its own counterpart.
    */
   private static int compareKeys(final Object k1, final Object k2) {
-    if (k1 == null || k2 == null || k1.getClass() == k2.getClass())
+    if (k1 == null || k2 == null)
       return BinaryComparator.compareTo(k1, k2);
-    return k1.getClass().getName().compareTo(k2.getClass().getName());
+    if (k1.getClass() != k2.getClass())
+      return k1.getClass().getName().compareTo(k2.getClass().getName());
+
+    final int cmp = BinaryComparator.compareTo(k1, k2);
+    if (cmp != 0 || k1.equals(k2))
+      return cmp;
+
+    final int byText = k1.toString().compareTo(k2.toString());
+    return byText != 0 ? byText : Integer.compare(k1.hashCode(), k2.hashCode());
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
@@ -42,28 +42,42 @@ public class CollectionUtils {
     return 0;
   }
 
+  /**
+   * Total order over maps, independent of their iteration order: both key sets are sorted and the two maps are compared
+   * as the lexicographic sequence of their (key, value) pairs, a shorter map that is a prefix of a longer one sorting
+   * first. Keys and values are ordered by {@link BinaryComparator#compareTo(Object, Object)}, a {@code null} value
+   * sorting before any non-null one. The result is {@code 0} only when both maps hold the same keys with values that
+   * compare equal, and {@code signum(compare(a, b)) == -signum(compare(b, a))} always holds, which is what
+   * {@link BinaryComparator} needs from it to order MAP-typed index keys the same way on every build (issue #7111: the
+   * former implementation walked only {@code m1}'s keys, answering "greater" in both directions for disjoint key sets,
+   * and stopped at the first key whose value was {@code null} on both sides, declaring the maps equal).
+   */
   public static int compare(final Map<?, Comparable> m1, final Map<?, Comparable> m2) {
-    final Set<? extends Map.Entry<?, Comparable>> entries1 = m1.entrySet();
-    for (Map.Entry<?, Comparable> entry : entries1) {
-      final Comparable value1 = entry.getValue();
-      final Comparable value2 = m2.get(entry.getKey());
-      if (value1 == null) {
-        if (value2 == null)
-          return 0;
-        return -1;
-      } else if (value2 == null)
-        return 1;
+    if (m1 == m2)
+      return 0;
 
-      final int cmp = value1.compareTo(value2);
+    final Object[] keys1 = sortedKeys(m1);
+    final Object[] keys2 = sortedKeys(m2);
+    final int length = Math.min(keys1.length, keys2.length);
+
+    for (int i = 0; i < length; i++) {
+      int cmp = BinaryComparator.compareTo(keys1[i], keys2[i]);
+      if (cmp != 0)
+        return cmp;
+
+      cmp = BinaryComparator.compareTo(m1.get(keys1[i]), m2.get(keys2[i]));
       if (cmp != 0)
         return cmp;
     }
 
-    if (m1.size() > m2.size())
-      return 1;
-    else if (m1.size() < m2.size())
-      return -1;
-    return 0;
+    return Integer.compare(keys1.length, keys2.length);
+  }
+
+  private static Object[] sortedKeys(final Map<?, ?> map) {
+    final Object[] keys = map.keySet().toArray();
+    if (keys.length > 1)
+      Arrays.sort(keys, BinaryComparator::compareTo);
+    return keys;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
@@ -53,15 +53,12 @@ public class CollectionUtils {
    * and stopped at the first key whose value was {@code null} on both sides, declaring the maps equal).
    */
   public static int compare(final Map<?, Comparable> m1, final Map<?, Comparable> m2) {
-    if (m1 == m2)
-      return 0;
-
     final Object[] keys1 = sortedKeys(m1);
     final Object[] keys2 = sortedKeys(m2);
     final int length = Math.min(keys1.length, keys2.length);
 
     for (int i = 0; i < length; i++) {
-      int cmp = BinaryComparator.compareTo(keys1[i], keys2[i]);
+      int cmp = compareKeys(keys1[i], keys2[i]);
       if (cmp != 0)
         return cmp;
 
@@ -76,8 +73,20 @@ public class CollectionUtils {
   private static Object[] sortedKeys(final Map<?, ?> map) {
     final Object[] keys = map.keySet().toArray();
     if (keys.length > 1)
-      Arrays.sort(keys, BinaryComparator::compareTo);
+      Arrays.sort(keys, CollectionUtils::compareKeys);
     return keys;
+  }
+
+  /**
+   * Orders map keys: keys of the same class by {@link BinaryComparator#compareTo(Object, Object)}, keys of different
+   * classes by class name. A map holds keys of any type (a document's MAP property is String-keyed, but the API accepts
+   * any key), and two keys of unrelated classes are distinct map entries whichever way they are ordered, so grouping them
+   * by class keeps the order total without asking {@code compareTo} to relate e.g. a String to an Integer.
+   */
+  private static int compareKeys(final Object k1, final Object k2) {
+    if (k1 == null || k2 == null || k1.getClass() == k2.getClass())
+      return BinaryComparator.compareTo(k1, k2);
+    return k1.getClass().getName().compareTo(k2.getClass().getName());
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -555,9 +555,11 @@ public class DateUtils {
     if (cached != null)
       return cached;
 
+    // A storage format must render and parse the same bytes on every server: the locale is pinned so a textual field
+    // (MMM, EEE) never follows the JVM default, which the cache would otherwise freeze at the first caller's (issue #7112).
     final DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format)
         .parseDefaulting(ChronoField.HOUR_OF_DAY, 0).parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-        .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter();
+        .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter(Locale.ENGLISH);
 
     // Bounded rather than evicting: the working set is a handful of schema formats that all fit, so an LRU would only
     // add a lock on a hot path to reorder entries nothing ever evicts. A slight overshoot when several threads race

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -37,7 +37,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.net.URLEncoder;
-import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystem;
@@ -236,7 +235,7 @@ public class FileUtils {
 
   /**
    * Copies {@code source} over {@code destination}, replacing it when it exists. Delegates to {@link Files#copy} rather
-   * than a single {@link FileChannel#transferTo}: that call moves at most the count it reports back, which most platforms
+   * than a single {@code FileChannel.transferTo}: that call moves at most the count it reports back, which most platforms
    * cap around 2GB, and the discarded return value used to leave a larger file silently truncated (issue #7112).
    */
   public static void copyFile(final File source, final File destination) throws IOException {

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -234,12 +234,13 @@ public class FileUtils {
     return false;
   }
 
+  /**
+   * Copies {@code source} over {@code destination}, replacing it when it exists. Delegates to {@link Files#copy} rather
+   * than a single {@link FileChannel#transferTo}: that call moves at most the count it reports back, which most platforms
+   * cap around 2GB, and the discarded return value used to leave a larger file silently truncated (issue #7112).
+   */
   public static void copyFile(final File source, final File destination) throws IOException {
-    try (final FileInputStream fis = new FileInputStream(source); final FileOutputStream fos = new FileOutputStream(destination)) {
-      final FileChannel sourceChannel = fis.getChannel();
-      final FileChannel targetChannel = fos.getChannel();
-      sourceChannel.transferTo(0, sourceChannel.size(), targetChannel);
-    }
+    Files.copy(source.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
   }
 
   public static void copyDirectory(final File source, final File destination) throws IOException {

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -108,6 +108,32 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public static class WidthOverloaded {
+    public static long twice(final long v) {
+      return v * 2;
+    }
+
+    public static int twice(final int v) {
+      return v * 2;
+    }
+
+    public static String scale(final long v) {
+      return "long:" + v;
+    }
+
+    public static String scale(final double v) {
+      return "double:" + v;
+    }
+
+    public static String pair(final long a, final double b) {
+      return "long-double";
+    }
+
+    public static String pair(final double a, final long b) {
+      return "double-long";
+    }
+  }
+
   public static class VarargsOverloaded {
     public static String join(final String sep, final String... parts) {
       return "strs:" + String.join(sep, parts);
@@ -426,6 +452,46 @@ class JavaFunctionTest extends TestHelper {
       assertThat(function.execute(1)).isEqualTo("longs:1");
     } finally {
       database.getSchema().unregisterFunctionLibrary("wide");
+    }
+  }
+
+  @Test
+  void exactPrimitiveMatchBeatsWideningOverload()
+    throws Exception {
+    // Regression for issue #7110: primitive widening (issue #7007) made an Integer argument applicable to both
+    // twice(int) and twice(long), and the ambiguity check then refused a call the pre-widening exact-match dispatch
+    // resolved without trouble. As in Java, the exact primitive match must win over the widened one.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("width", JavaFunctionTest.WidthOverloaded.class));
+    try {
+      final var twice = database.getSchema().getFunction("width", "twice");
+      assertThat(twice.execute(5)).isEqualTo(10);
+      assertThat(twice.execute(5L)).isEqualTo(10L);
+
+      // Both scale(long) and scale(double) only apply by widening: long is the narrower target, so it is the most
+      // specific applicable overload, again as javac would resolve it.
+      final var scale = database.getSchema().getFunction("width", "scale");
+      assertThat(scale.execute(1)).isEqualTo("long:1");
+      assertThat(scale.execute(1.5f)).isEqualTo("double:1.5");
+
+      // Neither pair(long,double) nor pair(double,long) is more specific than the other for two ints: still ambiguous.
+      final var pair = database.getSchema().getFunction("width", "pair");
+      assertThatThrownBy(() -> pair.execute(1, 2))
+          .isInstanceOf(FunctionExecutionException.class)
+          .hasMessageContaining("cannot resolve which overload");
+      assertThat(pair.execute(1L, 2.0)).isEqualTo("long-double");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("width");
+    }
+  }
+
+  @Test
+  void widthOverloadsAreCallableFromSql()
+    throws Exception {
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("width", JavaFunctionTest.WidthOverloaded.class));
+    try (final ResultSet rs = database.query("sql", "SELECT `width.twice`(5) AS v")) {
+      assertThat(rs.next().<Number>getProperty("v").intValue()).isEqualTo(10);
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("width");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -134,6 +134,16 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public static class VarargsFixedArityTie {
+    public static String tie(final String... parts) {
+      return "all:" + parts.length;
+    }
+
+    public static String tie(final String first, final String... rest) {
+      return "first+rest:" + rest.length;
+    }
+  }
+
   public static class VarargsOverloaded {
     public static String join(final String sep, final String... parts) {
       return "strs:" + String.join(sep, parts);
@@ -481,6 +491,23 @@ class JavaFunctionTest extends TestHelper {
       assertThat(pair.execute(1L, 2.0)).isEqualTo("long-double");
     } finally {
       database.getSchema().unregisterFunctionLibrary("width");
+    }
+  }
+
+  @Test
+  void varargsOverloadsSeeingTheSameParameterTypesStayAmbiguous()
+    throws Exception {
+    // tie(String...) and tie(String, String...) both see String in every position of a two-argument call, so neither is
+    // more specific than the other: the specificity ranking added for issue #7110 must not silently pick the first one
+    // where javac reports the call as ambiguous.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("tie", JavaFunctionTest.VarargsFixedArityTie.class));
+    try {
+      final var function = database.getSchema().getFunction("tie", "tie");
+      assertThatThrownBy(() -> function.execute("a", "b"))
+          .isInstanceOf(FunctionExecutionException.class)
+          .hasMessageContaining("cannot resolve which overload");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("tie");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -144,6 +144,24 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public static class VarargsUnsuppliedComponent {
+    public static String narrow(final int... values) {
+      return "ints";
+    }
+
+    public static String narrow(final long first, final short... rest) {
+      return "long+shorts";
+    }
+
+    public static String widen(final long... values) {
+      return "longs";
+    }
+
+    public static String widen(final int first, final long... rest) {
+      return "int+longs";
+    }
+  }
+
   public static class VarargsOverloaded {
     public static String join(final String sep, final String... parts) {
       return "strs:" + String.join(sep, parts);
@@ -508,6 +526,28 @@ class JavaFunctionTest extends TestHelper {
           .hasMessageContaining("cannot resolve which overload");
     } finally {
       database.getSchema().unregisterFunctionLibrary("tie");
+    }
+  }
+
+  @Test
+  void unsuppliedVarargComponentTakesPartInSpecificity()
+    throws Exception {
+    // JLS 15.12.2.5 compares the expanded signatures, including the vararg component the call never supplied: for one
+    // int, narrow(int...) is narrower than narrow(long, short...) in the first position but not in the second (int does
+    // not widen into short), so javac reports the call ambiguous; widen(int, long...) beats widen(long...) in the first
+    // position and ties in the second, so it wins.
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("vac", JavaFunctionTest.VarargsUnsuppliedComponent.class));
+    try {
+      final var narrow = database.getSchema().getFunction("vac", "narrow");
+      assertThatThrownBy(() -> narrow.execute(1))
+          .isInstanceOf(FunctionExecutionException.class)
+          .hasMessageContaining("cannot resolve which overload");
+
+      final var widen = database.getSchema().getFunction("vac", "widen");
+      assertThat(widen.execute(1)).isEqualTo("int+longs");
+      assertThat(widen.execute(1L)).isEqualTo("longs");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("vac");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -162,6 +162,16 @@ class JavaFunctionTest extends TestHelper {
     }
   }
 
+  public static class MixedPackedVarargs {
+    public static String pick(final int value, final String... parts) {
+      return "narrow:" + parts.length;
+    }
+
+    public static String pick(final long value, final String[]... parts) {
+      return "wide:" + parts.length;
+    }
+  }
+
   public static class VarargsOverloaded {
     public static String join(final String sep, final String... parts) {
       return "strs:" + String.join(sep, parts);
@@ -548,6 +558,22 @@ class JavaFunctionTest extends TestHelper {
       assertThat(widen.execute(1L)).isEqualTo("longs");
     } finally {
       database.getSchema().unregisterFunctionLibrary("vac");
+    }
+  }
+
+  @Test
+  void prePackedStatusIsJudgedPerOverload()
+    throws Exception {
+    // The same trailing String[] is a pre-packed vararg for pick(int, String...) and one flat element for
+    // pick(long, String[]...): both overloads apply, and each must be ranked with the vararg view it was matched under,
+    // so the int overload wins on its first parameter exactly as javac resolves pick(1, new String[]{"x"}).
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("mpv", JavaFunctionTest.MixedPackedVarargs.class));
+    try {
+      final var pick = database.getSchema().getFunction("mpv", "pick");
+      assertThat(pick.execute(1, new String[] { "x" })).isEqualTo("narrow:1");
+      assertThat(pick.execute(1L, new String[] { "x" })).isEqualTo("wide:1");
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("mpv");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/index/Issue7109ArrayKeyTupleDeltaChurnTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue7109ArrayKeyTupleDeltaChurnTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7109: the tuple delta introduced for composite indexes with one collection modifier (issue #6934) compared tuples
+ * with the shallow {@code Arrays.equals}, so a tuple element that is itself an array (a {@code BINARY} key here, the
+ * {@code float[]} of a vector elsewhere) never matched its own deserialized copy. Every update of such a record - even one
+ * touching no indexed property - removed and re-put every tuple, which is the very churn issue #5318 had already removed from
+ * the scalar-only path of the same method.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7109ArrayKeyTupleDeltaChurnTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.hash BINARY");
+      database.command("sql", "CREATE PROPERTY Doc.tags LIST");
+      database.command("sql", "CREATE PROPERTY Doc.counter INTEGER");
+      database.command("sql", "CREATE INDEX ON Doc (hash, tags BY ITEM) NOTUNIQUE");
+    });
+  }
+
+  @Test
+  void unchangedArrayKeyDoesNotChurnTheIndex() {
+    final RID rid = insert(0);
+
+    database.begin();
+    try {
+      // The record is re-read from the committed buffer, so its BINARY key is a fresh byte[] that only a content-aware
+      // comparison can recognise as unchanged.
+      final MutableDocument doc = database.lookupByRID(rid, true).asDocument().modify();
+      doc.set("counter", 1);
+      doc.save();
+
+      assertThat(((DatabaseInternal) database).getTransaction().getIndexChanges().getTotalEntries())
+          .as("an update leaving both index keys untouched must not enqueue any index remove/put")
+          .isZero();
+    } finally {
+      database.commit();
+    }
+
+    assertThat(countWhere("tags CONTAINS 'x'")).isEqualTo(1);
+    assertThat(countWhere("tags CONTAINS 'y'")).isEqualTo(1);
+    assertThat(indexEntries()).isEqualTo(2);
+  }
+
+  @Test
+  void changedListItemStillProducesTheMinimalDelta() {
+    final RID rid = insert(0);
+
+    database.begin();
+    try {
+      final MutableDocument doc = database.lookupByRID(rid, true).asDocument().modify();
+      doc.set("tags", List.of("x", "z"));
+      doc.save();
+
+      // One remove (hash,y) and one put (hash,z): the retained (hash,x) tuple must be left alone.
+      assertThat(((DatabaseInternal) database).getTransaction().getIndexChanges().getTotalEntries()).isEqualTo(2);
+    } finally {
+      database.commit();
+    }
+
+    assertThat(countWhere("tags CONTAINS 'x'")).isEqualTo(1);
+    assertThat(countWhere("tags CONTAINS 'z'")).isEqualTo(1);
+    assertThat(countWhere("tags CONTAINS 'y'")).isZero();
+    assertThat(indexEntries()).isEqualTo(2);
+  }
+
+  private RID insert(final int counter) {
+    final RID[] rid = new RID[1];
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Doc");
+      doc.set("hash", new byte[] { 1, 2, 3 });
+      doc.set("tags", List.of("x", "y"));
+      doc.set("counter", counter);
+      rid[0] = doc.save().getIdentity();
+    });
+    return rid[0];
+  }
+
+  private long countWhere(final String condition) {
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM Doc WHERE " + condition)) {
+      return rs.next().<Number>getProperty("c").longValue();
+    }
+  }
+
+  private long indexEntries() {
+    long total = 0;
+    for (final Index index : database.getSchema().getType("Doc").getAllIndexes(false))
+      total += index.countEntries();
+    return total;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.utility;
 import com.arcadedb.serializer.BinaryComparator;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -145,6 +146,32 @@ class CollectionUtilsTest {
     assertThat(CollectionUtils.compare(m1, m2)).isLessThan(0);
     assertThat(CollectionUtils.compare(m2, m1)).isGreaterThan(0);
     assertThat(CollectionUtils.compare(m1, m3)).isZero();
+  }
+
+  /**
+   * BigDecimal 1.0 and 1.00 are distinct map keys that the comparator ranks equal: their position in the sorted key
+   * sequence must not follow insertion order, or equal maps built in a different order compare unequal and maps that
+   * swap the two values compare equal.
+   */
+  @Test
+  void compareMapsWithComparatorEqualButDistinctKeys() {
+    final BigDecimal k1 = new BigDecimal("1.0");
+    final BigDecimal k2 = new BigDecimal("1.00");
+
+    final Map<Object, Comparable> m1 = new LinkedHashMap<>();
+    m1.put(k1, "a");
+    m1.put(k2, "b");
+    final Map<Object, Comparable> m2 = new LinkedHashMap<>();
+    m2.put(k2, "b");
+    m2.put(k1, "a");
+    assertThat(CollectionUtils.compare(m1, m2)).isZero();
+    assertThat(CollectionUtils.compare(m2, m1)).isZero();
+
+    final Map<Object, Comparable> swapped = new LinkedHashMap<>();
+    swapped.put(k2, "a");
+    swapped.put(k1, "b");
+    assertThat(CollectionUtils.compare(m1, swapped)).isNotZero();
+    assertThat(Integer.signum(CollectionUtils.compare(m1, swapped))).isEqualTo(-Integer.signum(CollectionUtils.compare(swapped, m1)));
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
@@ -136,6 +136,17 @@ class CollectionUtilsTest {
     assertThat(CollectionUtils.compare(m2, m1)).isGreaterThan(0);
   }
 
+  @Test
+  void compareMapsWithKeysOfDifferentClasses() {
+    final Map<Object, Comparable> m1 = new HashMap<>(Map.of("a", 1, 2, "x"));
+    final Map<Object, Comparable> m2 = new HashMap<>(Map.of("a", 1, 3, "x"));
+    final Map<Object, Comparable> m3 = new HashMap<>(Map.of(2, "x", "a", 1));
+
+    assertThat(CollectionUtils.compare(m1, m2)).isLessThan(0);
+    assertThat(CollectionUtils.compare(m2, m1)).isGreaterThan(0);
+    assertThat(CollectionUtils.compare(m1, m3)).isZero();
+  }
+
   /**
    * The comparator contract over a handful of maps: antisymmetry and transitivity of the induced order, which is what a
    * sorted index relies on to place the same entries in the same order on every build.

--- a/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.utility;
 
+import com.arcadedb.serializer.BinaryComparator;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -73,6 +74,112 @@ class CollectionUtilsTest {
     map2.put("key1", "value2");
 
     assertThat(CollectionUtils.compare(map1, map2)).isNotEqualTo(0);
+  }
+
+  /**
+   * Issue #7111: for maps with disjoint keys the comparison answered "greater" in both directions, because every key of
+   * the first map was missing from the second whichever way round the arguments went.
+   */
+  @Test
+  void compareDisjointKeyMapsIsAntisymmetric() {
+    final Map<String, Comparable> m1 = new HashMap<>(Map.of("a", 1));
+    final Map<String, Comparable> m2 = new HashMap<>(Map.of("b", 1));
+
+    assertThat(CollectionUtils.compare(m1, m2)).isNotZero();
+    assertThat(Integer.signum(CollectionUtils.compare(m1, m2))).isEqualTo(-Integer.signum(CollectionUtils.compare(m2, m1)));
+    // The index-ordering entry point goes through the same comparison
+    assertThat(Integer.signum(BinaryComparator.compareTo(m1, m2))).isEqualTo(-Integer.signum(BinaryComparator.compareTo(m2, m1)));
+  }
+
+  /**
+   * Issue #7111: a null value on both sides of the first shared key declared the whole maps equal, so a later key that
+   * differed was never examined.
+   */
+  @Test
+  void compareMapsSharingNullValueKeepsComparingTheRemainingKeys() {
+    final Map<String, Comparable> m1 = new LinkedHashMap<>();
+    m1.put("k", null);
+    m1.put("z", 1);
+    final Map<String, Comparable> m2 = new LinkedHashMap<>();
+    m2.put("k", null);
+    m2.put("z", 2);
+
+    assertThat(CollectionUtils.compare(m1, m2)).isLessThan(0);
+    assertThat(CollectionUtils.compare(m2, m1)).isGreaterThan(0);
+
+    final Map<String, Comparable> m3 = new LinkedHashMap<>();
+    m3.put("k", null);
+    m3.put("z", 1);
+    assertThat(CollectionUtils.compare(m1, m3)).isZero();
+  }
+
+  @Test
+  void compareMapsIgnoresInsertionOrder() {
+    final Map<String, Comparable> m1 = new LinkedHashMap<>();
+    m1.put("a", 1);
+    m1.put("b", 2);
+    final Map<String, Comparable> m2 = new LinkedHashMap<>();
+    m2.put("b", 2);
+    m2.put("a", 1);
+
+    assertThat(CollectionUtils.compare(m1, m2)).isZero();
+    assertThat(CollectionUtils.compare(m2, m1)).isZero();
+  }
+
+  @Test
+  void compareMapsNullValueSortsBeforeAnyValue() {
+    final Map<String, Comparable> m1 = new HashMap<>();
+    m1.put("a", null);
+    final Map<String, Comparable> m2 = new HashMap<>(Map.of("a", 0));
+
+    assertThat(CollectionUtils.compare(m1, m2)).isLessThan(0);
+    assertThat(CollectionUtils.compare(m2, m1)).isGreaterThan(0);
+  }
+
+  /**
+   * The comparator contract over a handful of maps: antisymmetry and transitivity of the induced order, which is what a
+   * sorted index relies on to place the same entries in the same order on every build.
+   */
+  @Test
+  void compareMapsSatisfiesComparatorContract() {
+    final List<Map<String, Comparable>> maps = new ArrayList<>();
+    maps.add(new HashMap<>(Map.of("a", 1)));
+    maps.add(new HashMap<>(Map.of("b", 1)));
+    maps.add(new HashMap<>(Map.of("a", 1, "b", 1)));
+    maps.add(new HashMap<>(Map.of("a", 2)));
+    maps.add(new HashMap<>(Map.of("c", "x")));
+    maps.add(new HashMap<>());
+    final Map<String, Comparable> withNull = new HashMap<>();
+    withNull.put("a", null);
+    maps.add(withNull);
+    final Map<String, Comparable> withNullAndMore = new HashMap<>();
+    withNullAndMore.put("a", null);
+    withNullAndMore.put("b", 3);
+    maps.add(withNullAndMore);
+
+    for (final Map<String, Comparable> x : maps) {
+      assertThat(CollectionUtils.compare(x, x)).isZero();
+      for (final Map<String, Comparable> y : maps) {
+        final int xy = Integer.signum(CollectionUtils.compare(x, y));
+        assertThat(xy).as("%s vs %s", x, y).isEqualTo(-Integer.signum(CollectionUtils.compare(y, x)));
+        if (x != y)
+          assertThat(xy).as("%s vs %s must not be equal", x, y).isNotZero();
+        for (final Map<String, Comparable> z : maps) {
+          final int yz = Integer.signum(CollectionUtils.compare(y, z));
+          if (xy <= 0 && yz <= 0)
+            assertThat(Integer.signum(CollectionUtils.compare(x, z))).as("%s <= %s <= %s", x, y, z).isLessThanOrEqualTo(0);
+        }
+      }
+    }
+
+    // TimSort's own contract check must stay quiet on every permutation of the sample
+    for (int seed = 0; seed < 50; seed++) {
+      final List<Map<String, Comparable>> shuffled = new ArrayList<>(maps);
+      Collections.shuffle(shuffled, new Random(seed));
+      shuffled.sort(CollectionUtils::compare);
+      for (int i = 1; i < shuffled.size(); i++)
+        assertThat(CollectionUtils.compare(shuffled.get(i - 1), shuffled.get(i))).isLessThan(0);
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
@@ -27,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -259,5 +260,27 @@ class DateUtilsTest {
     assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(microsAboveNanosRange, ChronoUnit.NANOS))
         .as("must saturate to Long.MAX_VALUE instead of silently wrapping to a negative number")
         .isEqualTo(Long.MAX_VALUE);
+  }
+
+  /**
+   * Issue #7112: the statically cached storage formatter was built with {@code toFormatter()}, which binds the JVM
+   * default locale. A textual pattern field (month or day name) then rendered and parsed differently on two servers
+   * with different locales, and the first caller's locale stuck to the process through the cache.
+   */
+  @Test
+  void formatterIsLocaleIndependent() {
+    final Locale saved = Locale.getDefault(Locale.Category.FORMAT);
+    // A pattern no other test uses, so it is guaranteed to be built (and cached) under the Italian locale
+    final String pattern = "dd MMMM yyyy EEEE";
+    final LocalDateTime dateTime = LocalDateTime.of(2026, 3, 4, 0, 0);
+    Locale.setDefault(Locale.Category.FORMAT, Locale.ITALIAN);
+    try {
+      assertThat(DateUtils.format(dateTime, pattern)).isEqualTo("04 March 2026 Wednesday");
+      assertThat(DateUtils.parse("04 March 2026 Wednesday", pattern)).isEqualTo(dateTime);
+    } finally {
+      Locale.setDefault(Locale.Category.FORMAT, saved);
+    }
+    // Same answer now that the default locale is back: the cached formatter did not capture the Italian one
+    assertThat(DateUtils.format(dateTime, pattern)).isEqualTo("04 March 2026 Wednesday");
   }
 }

--- a/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
@@ -269,7 +269,10 @@ class FileUtilsTest {
     for (int i = 0; i < content.length; i++)
       content[i] = (byte) (i * 31);
     Files.write(source, content);
-    Files.writeString(dest, "stale content that is longer than nothing");
+    // Longer than the source, so a copy that failed to truncate would leave stale trailing bytes behind
+    final byte[] stale = new byte[content.length + FileUtils.MEGABYTE];
+    Arrays.fill(stale, (byte) 0x5A);
+    Files.write(dest, stale);
 
     FileUtils.copyFile(source.toFile(), dest.toFile());
 

--- a/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
@@ -256,10 +256,25 @@ class FileUtilsTest {
 
     Files.writeString(source, content);
 
-//    FileUtils.copyFile(source.toFile(), dest.toFile());
+    FileUtils.copyFile(source.toFile(), dest.toFile());
 
-    Files.copy(source,dest);
     assertThat(Files.readString(dest)).isEqualTo(content);
+  }
+
+  @Test
+  void copyFileOverwritesExistingDestination() throws Exception {
+    final Path source = tempDir.resolve("source.bin");
+    final Path dest = tempDir.resolve("dest.bin");
+    final byte[] content = new byte[3 * FileUtils.MEGABYTE + 17];
+    for (int i = 0; i < content.length; i++)
+      content[i] = (byte) (i * 31);
+    Files.write(source, content);
+    Files.writeString(dest, "stale content that is longer than nothing");
+
+    FileUtils.copyFile(source.toFile(), dest.toFile());
+
+    assertThat(Files.size(dest)).isEqualTo(content.length);
+    assertThat(Files.readAllBytes(dest)).isEqualTo(content);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
@@ -261,6 +261,11 @@ class FileUtilsTest {
     assertThat(Files.readString(dest)).isEqualTo(content);
   }
 
+  /**
+   * Covers the overwrite semantics and a real multi-megabyte transfer. The ~2GB single-call cap of
+   * {@code FileChannel.transferTo} that issue #7112 fixed by delegating to {@code Files.copy} is not exercised here: a
+   * multi-gigabyte payload is not a unit-test-sized fixture, so that boundary rests on the JDK's own contract.
+   */
   @Test
   void copyFileOverwritesExistingDestination() throws Exception {
     final Path source = tempDir.resolve("source.bin");


### PR DESCRIPTION
Fixes #7109, fixes #7110, fixes #7111, fixes #7112 - four small engine defects that came out of other analyses.

## #7109 - `DocumentIndexer.containsTuple` shallow `Arrays.equals`
The tuple delta added for #6934 compared tuples with `Arrays.equals`, so a tuple element that is itself an array (a `BINARY` key, the `float[]` of a vector) never matched its own deserialized copy, and every update of such a record removed and re-put every tuple. This is the churn #5318 had already removed from the scalar-only path of the same method.

Instead of the one-word `Arrays.deepEquals` the issue suggests, both update paths now go through one shared key equality (`sameKeyValue` / `sameKeyTuple`), so a third update path cannot pick a third comparison policy - the drift that produced this bug.

Regression: `Issue7109ArrayKeyTupleDeltaChurnTest` - a `(hash BINARY, tags BY ITEM)` composite index; an update touching only a non-indexed property must leave the transaction's index change set empty (it enqueued 4 remove/put before), and a list change must produce exactly the 2-entry minimal delta (it produced 4 before).

## #7110 - width-differing overloads unresolvable after #7007
An `Integer` argument applies to both `twice(int)` and `twice(long)` once widening is accepted, and the ambiguity check refused the call. The issue suggests two passes (exact first, then widening). This PR does what javac does among the applicable candidates instead: the overload whose primitive parameters are narrowest in every position wins. That covers the exact-match case and also resolves `scale(long)` vs `scale(double)` for an `Integer` to `long` - where a two-pass scheme would still throw - while `pair(long,double)` vs `pair(double,long)` for two ints stays ambiguous. Reference-type specificity is deliberately still not ranked (`describe(Object)` vs `describe(String)` remains ambiguous, as the pinned `genuinelyAmbiguousOverloadThrows` documents); the class Javadoc states the rule.

Regression: `JavaFunctionTest.exactPrimitiveMatchBeatsWideningOverload` and `widthOverloadsAreCallableFromSql`.

## #7111 - `CollectionUtils.compare(Map, Map)` not antisymmetric
Walked only the first map's keys (so disjoint key sets answered "greater" both ways) and returned `0` at the first key whose value was `null` on both sides. It now compares the sorted `(key, value)` sequences lexicographically, with a shorter prefix sorting first: an antisymmetric, transitive order that is independent of iteration order and answers `0` only for maps with the same keys and equal values. Keys and values go through `BinaryComparator.compareTo`, the same ordering the index-key path uses.

Regression: `CollectionUtilsTest` - disjoint keys through both `CollectionUtils` and `BinaryComparator`, shared null value, insertion-order independence, null-before-value, and a contract test asserting antisymmetry and transitivity over a set of sample maps plus TimSort on 50 shuffles.

Two consequences worth stating: the comparator backs `BinaryComparator.compareTo` for MAP-typed values, so the on-disk order of any existing index over a MAP-typed key changes with this PR. Such an index was never a valid total order before, so a rebuild after upgrading is the right move for anyone who has one. Keys of different classes in the same map are ordered by class name, so a heterogeneous-key map cannot make the sort throw. Keys of the same class are ordered by `BinaryComparator.compareTo`, so a map with more than one key now needs its keys to be `Comparable` (or a type that comparator knows), where before only the values had to be; a MAP property is always String-keyed, so this only reaches maps built through the API with custom key objects.

Note, out of scope here: `BinaryComparator.compareTo(Object, Object)` still throws `ClassCastException` for two `Number`s of different boxed types (`Integer` vs `Long`), so a map holding such values in the same key compares the same way it did before this PR.

## #7112 - locale-bound cached formatter, truncating `copyFile`
- `DateUtils.getFormatter()` now ends with `toFormatter(Locale.ENGLISH)`, so a textual pattern field (`MMM`, `EEE`) renders and parses the same on every server regardless of the JVM default locale, which the static cache used to freeze at the first caller's. This is the one cache behind every `DateUtils.format`/`parse` call, including SQL-level `format()` of dates, so a deployment that relied on the JVM locale to render month or day names in another language now gets English there too; that output was never stable across nodes, which is the defect.
- `FileUtils.copyFile` delegates to `Files.copy(..., REPLACE_EXISTING)` instead of a single unchecked `FileChannel.transferTo`, whose per-call cap (about 2GB on most platforms) silently truncated larger files. `REPLACE_EXISTING` preserves the previous overwrite semantics of `FileOutputStream`.
- The `FileUtilsTest.copyFile` call that was commented out is back in, plus an overwrite test with a multi-megabyte payload; `DateUtilsTest.formatterIsLocaleIndependent` builds the formatter under `Locale.ITALIAN` and checks the English rendering and round-trip parse, then again after restoring the locale.

## Review round 1
The FULL_TEXT `BY ITEM` update path (`updateFullTextByItemInIndex`) still compared keys with the shallow `Arrays.equals`; it now goes through the same `sameKeyTuple` policy, so no update path in `DocumentIndexer` compares keys any other way.

## Review round 2 and 3
- Map keys the comparator ranks equal but the map keeps distinct (`BigDecimal` 1.0 vs 1.00) now get a strict tie-break, so the sorted key sequence never follows insertion order.
- The overload winner must be strictly more specific than every other applicable candidate: `tie(String...)` vs `tie(String, String...)` for two strings stays ambiguous, as javac reports it.
- The overwrite test pre-fills the destination with more bytes than the source.

## Review round 4
The overload specificity comparison spans the longest applicable signature, including the vararg component the call did not supply, as JLS 15.12.2.5 does: `narrow(int...)` vs `narrow(long, short...)` for one int stays ambiguous while `widen(int, long...)` beats `widen(long...)`; checked against javac on five shapes. A pre-packed vararg array compares as the array type, judged per overload: the same trailing `String[]` is a pre-packed vararg for `pick(int, String...)` and one flat element for `pick(long, String[]...)`. The residual tie in the map key order (distinct keys of one class equal on `compareTo`, `toString()` and `hashCode()`) has no deterministic discriminator left and is documented rather than papered over.

## Follow-up
The same locale-bound formatter construction (`DateTimeFormatter.ofPattern(schemaPattern)`) still exists outside `getFormatter()`: two more sites in `DateUtils`, plus `Type`, `JSONObject` and the SQL date/format functions. Routing all of them through the cached, pinned `getFormatter` is a cross-file consolidation with its own decision for user-supplied SQL patterns, tracked as #7144.

## Verification
`mvn -o -pl engine test` over `function/**`, `utility/*`, `serializer/*`, `index/**`, `query/sql/function/**`, `*Date*Test`, `*Composite*Test`: 2951 tests, 0 failures. The five touched test classes were red on all four issues before the fix.
