### PR TITLE
fix(#7146): size the HNSW build cache from the heap ceiling so served matches embedded

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1034,18 +1034,19 @@ public enum GlobalConfiguration {
       Maximum number of vectors to cache in memory during HNSW graph building. \
       Higher values speed up construction but use more RAM. \
       RAM usage = cacheSize * (dimensions * 4 + 64) bytes. \
-      0 (default) sizes it automatically: an index whose vectors live in the documents (no quantization, or \
-      PRODUCT) caches the whole set when it fits arcadedb.vectorIndex.graphBuildCacheMaxHeapPercent, because \
-      every miss costs a record read; an inline-quantized index (INT8/BINARY) reads a miss straight from an \
-      index page and keeps a small bound instead.""",
+      0 (default) sizes it automatically: the cache holds the whole corpus when it fits \
+      arcadedb.vectorIndex.graphBuildCacheMaxHeapPercent, for document-backed indexes (no quantization, or \
+      PRODUCT) and for inline-quantized indexes (INT8/BINARY). An explicit positive size still wins.""",
       Integer.class, 0),
 
   VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT("arcadedb.vectorIndex.graphBuildCacheMaxHeapPercent", SCOPE.DATABASE,
       """
-      Maximum share of the JVM heap (percentage) the auto-sized graph-build cache may use. Only applies when \
-      arcadedb.vectorIndex.graphBuildCacheSize is left at 0. A corpus larger than this budget still builds: \
-      the cache evicts instead of holding everything. Measured against the heap currently AVAILABLE rather than \
-      against the ceiling, so a rebuild that is holding the old graph resident asks for less (issue #6503). \
+      Maximum share of the JVM heap ceiling (percentage) the auto-sized graph-build cache may use. Only applies \
+      when arcadedb.vectorIndex.graphBuildCacheSize is left at 0. A corpus larger than this budget still builds: \
+      the cache evicts instead of holding everything. Taken as this percent of -Xmx, then capped at 90% of the \
+      heap currently AVAILABLE: a served ingest that already holds the corpus in this JVM must not get a third \
+      of the cache an embedded build of the same corpus would get (issue #7146), and an online rebuild that is \
+      holding the old graph must still ask for less (issue #6503). Applies to INT8/BINARY as well as fp32. \
       Values above 90 are clamped to 90: no cache is allowed to plan on the whole heap.""",
       Integer.class, 25),
 

--- a/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
@@ -129,8 +129,27 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
       final String vectorPropertyName, final VectorLocationIndex snapshot, final int[] ordinalToVectorId,
       final LSMVectorIndex lsmIndex, final int cacheSize) {
     final int effectiveCacheSize = cacheSize <= 0 ? DEFAULT_CACHE_SIZE : cacheSize;
+    return forGraphBuild(database, dimensions, vectorPropertyName, snapshot, ordinalToVectorId, lsmIndex,
+        new VectorCache(effectiveCacheSize));
+  }
+
+  /**
+   * Same reader, over a cache the caller has already warmed.
+   * <p>
+   * The validation phase reads every vector anyway, so it warms the build cache as it goes. It used to collect
+   * those vectors into a {@code HashMap<Integer, VectorFloat<?>>} first and copy them into the cache afterwards,
+   * which held both structures at once at the peak of the build: a boxed key, a map node and a table slot per
+   * cached vector, on top of the cache entry that survives them. That is around 50 bytes a vector of pure
+   * transient overhead - some 500 MB on a ten-million-vector build, at the exact moment the build is about to
+   * allocate the graph - and it is not counted by {@link VectorHeapBudget#bytesPerCachedVector(int)}, so it was
+   * spent outside the budget that is supposed to bound the build. Handing the cache in and warming it directly
+   * removes the intermediate copy entirely.
+   */
+  public static ArcadePageVectorValues forGraphBuild(final DatabaseInternal database, final int dimensions,
+      final String vectorPropertyName, final VectorLocationIndex snapshot, final int[] ordinalToVectorId,
+      final LSMVectorIndex lsmIndex, final VectorCache warmedCache) {
     return new ArcadePageVectorValues(database, dimensions, vectorPropertyName, snapshot, true, ordinalToVectorId,
-        lsmIndex, new VectorCache(effectiveCacheSize));
+        lsmIndex, warmedCache != null ? warmedCache : new VectorCache(DEFAULT_CACHE_SIZE));
   }
 
   /**
@@ -306,19 +325,6 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
           "Error reading vector from document (ordinal=%d, RID=%s): %s", ordinal, rid, e.getMessage());
       return deletedSentinelVector;
     }
-  }
-
-  /**
-   * Pre-populates the cache with a vector for a given vectorId.
-   * Must be called from a thread that has a database context (e.g., the main thread during validation).
-   * This allows JVector's parallel ForkJoinPool threads to find vectors in the cache
-   * without needing their own database context for lookupByRID.
-   */
-  public void putInCache(final int vectorId, final VectorFloat<?> vector) {
-    // The cache has a fixed capacity (issue #3144), so warming it from the validation phase cannot hold
-    // a full second copy of the vector set on heap.
-    if (vectorCache != null)
-      vectorCache.put(vectorId, vector);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1868,7 +1868,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
               metadata.dimensions, vectorProp,
               snapshotOf(vectorIndex(), ordinalToVectorId), ordinalToVectorId, this,
-              computeGraphBuildCacheCapacity(ordinalToVectorId.length, false));
+              computeGraphBuildCacheCapacity(ordinalToVectorId.length));
           buildAndPersistPQ(vectors);
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.WARNING,
@@ -1973,7 +1973,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
           metadata.dimensions, vectorProp,
           snapshotOf(vectorIndex(), gapOrdinalToVectorId), gapOrdinalToVectorId, this,
-          computeGraphBuildCacheCapacity(gapOrdinalToVectorId.length, false));
+          computeGraphBuildCacheCapacity(gapOrdinalToVectorId.length));
 
       // Collected into a local list first, exactly the way buildGraphFromScratchExclusively collects its own
       // unreachable-node re-queue before its publish step: appended into the shared deltaVectors only once this
@@ -2593,10 +2593,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // searchers, so the available-heap cap no longer counts them. Move this call above that block - or that
       // block below this call - and the close-path rebuild would shrink its own build cache to make room for
       // memory it is in the act of freeing.
-      final int graphBuildCacheSize = computeGraphBuildCacheCapacity(expectedSize, inlineQuantization);
+      final int graphBuildCacheSize = computeGraphBuildCacheCapacity(expectedSize);
       // Never preload more than the cache can hold: the surplus used to be read, boxed and then dropped.
       final int preloadBudget = Math.min(expectedSize, graphBuildCacheSize);
-      final Map<Integer, VectorFloat<?>> preloadedVectors = new HashMap<>(preloadBudget * 4 / 3 + 1);
+      // Warm the build cache in place rather than through an intermediate map. The validation loop below reads
+      // every vector anyway; collecting them into a HashMap first and copying that into the cache afterwards held
+      // both at once at the peak of the build, for a boxed key, a map node and a table slot per vector that
+      // VectorHeapBudget.bytesPerCachedVector() does not account for. Sizing the cache from the heap ceiling
+      // (issue #7146) makes that intermediate copy scale with the corpus, so it is the wrong moment to be paying
+      // ~50 extra bytes a vector immediately before the graph itself is allocated.
+      // Same fallback forGraphBuild() applied when it allocated the cache itself, so a non-positive capacity still
+      // yields the flat default rather than a one-slot cache.
+      final VectorCache buildCache = new VectorCache(
+          graphBuildCacheSize <= 0 ? ArcadePageVectorValues.DEFAULT_CACHE_SIZE : graphBuildCacheSize);
+      int preloadedVectorCount = 0;
       final List<Integer> validVectorIds = new ArrayList<>(expectedSize);
       int skippedDeletedDocs = 0;
 
@@ -2651,8 +2661,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
                   validVectorIds.add(vectorId);
                   // Only warm the cache up to the budget; the rest are re-read from index pages
                   // lazily during the build (issue #3144).
-                  if (preloadedVectors.size() < preloadBudget)
-                    preloadedVectors.put(vectorId, vts.createFloatVector(vector));
+                  if (preloadedVectorCount < preloadBudget) {
+                    buildCache.put(vectorId, vts.createFloatVector(vector));
+                    preloadedVectorCount++;
+                  }
                   validationSuccesses++;
                 } else {
                   validationAllZeros++;
@@ -2683,8 +2695,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
               if (fromDelta.length() == metadata.dimensions && !VectorUtils.isZeroVector(fromDelta)) {
                 vectorLocationSnapshot.addOrUpdate(vectorId, locationIsCompacted, locationOffset, vectorRid, false);
                 validVectorIds.add(vectorId);
-                if (preloadedVectors.size() < preloadBudget)
-                  preloadedVectors.put(vectorId, fromDelta);
+                if (preloadedVectorCount < preloadBudget) {
+                  buildCache.put(vectorId, fromDelta);
+                  preloadedVectorCount++;
+                }
               }
             } else {
               // Without quantization: validate by reading from document.
@@ -2700,8 +2714,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
                   if (vector.length == metadata.dimensions && !VectorUtils.isZeroVector(vector)) {
                     vectorLocationSnapshot.addOrUpdate(vectorId, locationIsCompacted, locationOffset, vectorRid, false);
                     validVectorIds.add(vectorId);
-                    if (preloadedVectors.size() < preloadBudget)
-                      preloadedVectors.put(vectorId, vts.createFloatVector(vector));
+                    if (preloadedVectorCount < preloadBudget) {
+                      buildCache.put(vectorId, vts.createFloatVector(vector));
+                      preloadedVectorCount++;
+                    }
                   }
                 }
 
@@ -2764,20 +2780,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
           "Building graph with %d vectors using property '%s' (cache enabled: size=%d of %d)",
           filteredVectorIds.length, vectorProp, graphBuildCacheSize, filteredVectorIds.length);
 
-      // Create lazy-loading vector values that reads vectors from documents or index pages (if quantized)
+      // Create lazy-loading vector values that reads vectors from documents or index pages (if quantized), over
+      // the cache the validation phase above already warmed in place. That is what lets JVector's parallel
+      // ForkJoinPool threads resolve a vector without a DatabaseContext of their own for lookupByRID.
       final ArcadePageVectorValues pageVectors = ArcadePageVectorValues.forGraphBuild(database, metadata.dimensions,
           vectorProp,
           vectorLocationSnapshot,  // Use immutable snapshot
           finalActiveVectorIds, this,  // Pass LSM index reference for quantization support
-          graphBuildCacheSize  // Pass configurable cache size
+          buildCache  // already holds the preloadBudget vectors read during validation
       );
-
-      // Pre-populate cache with vectors validated during the validation phase above.
-      // This ensures JVector's parallel ForkJoinPool threads can access vectors
-      // from cache without needing a DatabaseContext for lookupByRID.
-      for (final Map.Entry<Integer, VectorFloat<?>> entry : preloadedVectors.entrySet())
-        pageVectors.putInCache(entry.getKey(), entry.getValue());
-      preloadedVectors.clear(); // Free memory
 
       vectors = pageVectors;
 
@@ -3989,10 +4000,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       return true; // nothing built yet: this is a first build in all but name, and must not be declined
 
     final long nodes = Math.max(resident.getIdUpperBound(), vectorIndex().getActiveCount());
-    final boolean inlineQuantization = metadata.quantizationType == VectorQuantizationType.INT8
-        || metadata.quantizationType == VectorQuantizationType.BINARY;
-    final long buildCacheCapacity = computeGraphBuildCacheCapacity((int) Math.min(nodes, Integer.MAX_VALUE / 2),
-        inlineQuantization);
+    final long buildCacheCapacity = computeGraphBuildCacheCapacity((int) Math.min(nodes, Integer.MAX_VALUE / 2));
 
     final long estimate = VectorHeapBudget.estimateRebuildHeapBytes(nodes, metadata.dimensions, buildCacheCapacity,
         true);
@@ -8396,20 +8404,19 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * holding the old graph ask for the same amount whether that headroom existed or not (issue #6503). See
    * {@link VectorHeapBudget#buildCacheBudgetBytes(int)}.
    *
-   * @param expectedSize        number of vectors the build will walk
-   * @param inlineQuantization  whether vectors are readable from index pages without a record lookup; no longer
-   *                            changes the capacity (issue #7146), kept so callers keep declaring which kind of
-   *                            index they have
+   * @param expectedSize number of vectors the build will walk
    *
    * @return the number of vectors to hold, always positive
    */
-  int computeGraphBuildCacheCapacity(final int expectedSize, final boolean inlineQuantization) {
+  int computeGraphBuildCacheCapacity(final int expectedSize) {
     final int configured = getGraphBuildCacheSize();
     if (configured > 0)
       return configured;
 
-    // `inlineQuantization` used to return DEFAULT_CACHE_SIZE here (issue #3144). The percent knob must
-    // apply to INT8/BINARY as well (issue #7146), so both kinds of index share the heap-budgeted path below.
+    // There used to be an `if (inlineQuantization) return DEFAULT_CACHE_SIZE;` here (issue #3144), and with it a
+    // boolean parameter every caller had to compute. The percent knob must apply to INT8/BINARY as well
+    // (issue #7146), so the parameter went with the branch: how a miss is resolved is a property of the reader,
+    // not of the capacity, and keeping an argument the method ignores only invites a caller to believe otherwise.
 
     final int heapPercent = mutable.getDatabase().getConfiguration()
         .getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2581,18 +2581,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final VectorLocationIndex vectorLocationSnapshot = new VectorLocationIndex(Math.max(16, expectedSize));
 
       // Issue #3144: for inline-quantized indexes (INT8/BINARY) the graph builder reads vectors
-      // straight from index pages on any thread (getImmutablePage needs no DatabaseContext), so we
-      // only warm the bounded build cache instead of holding a full second on-heap copy of the whole
-      // vector set. Document-based indexes (NONE/PRODUCT) still need a full preload because JVector's
-      // worker threads cannot lookupByRID without a transaction context bound to the thread.
+      // straight from index pages on any thread (getImmutablePage needs no DatabaseContext). Document-based
+      // indexes (NONE/PRODUCT) still need a full preload because JVector's worker threads cannot lookupByRID
+      // without a transaction context bound to the thread. Both kinds of index now share the same heap-percent
+      // cache budget (issue #7146); this flag only changes how a miss is resolved, not how large the cache is.
       final boolean inlineQuantization = metadata.quantizationType == VectorQuantizationType.INT8
           || metadata.quantizationType == VectorQuantizationType.BINARY;
-      // ORDERING: this now budgets off AVAILABLE heap (issue #6503), so it must stay AFTER the
-      // releaseResidentGraphFirst block at the top of this method. On the close path that block has already
-      // dropped the old graph, the search cache and the pooled searchers, so this sizes against a heap that no
-      // longer counts them. Move this call above that block - or that block below this call - and the close-path
-      // rebuild would shrink its own build cache to make room for memory it is in the act of freeing, which is
-      // the slow-build failure mode this change exists to avoid rather than cause.
+      // ORDERING: the budget is a share of the heap ceiling, then capped at currently AVAILABLE heap
+      // (issues #6503 / #7146), so this must stay AFTER the releaseResidentGraphFirst block at the top of this
+      // method. On the close path that block has already dropped the old graph, the search cache and the pooled
+      // searchers, so the available-heap cap no longer counts them. Move this call above that block - or that
+      // block below this call - and the close-path rebuild would shrink its own build cache to make room for
+      // memory it is in the act of freeing.
       final int graphBuildCacheSize = computeGraphBuildCacheCapacity(expectedSize, inlineQuantization);
       // Never preload more than the cache can hold: the surplus used to be read, boxed and then dropped.
       final int preloadBudget = Math.min(expectedSize, graphBuildCacheSize);
@@ -2760,8 +2760,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
         return;
       }
 
-      LogManager.instance().log(this, Level.INFO, "Building graph with %d vectors using property '%s' (cache enabled: size=%d)",
-          filteredVectorIds.length, vectorProp, graphBuildCacheSize);
+      LogManager.instance().log(this, Level.INFO,
+          "Building graph with %d vectors using property '%s' (cache enabled: size=%d of %d)",
+          filteredVectorIds.length, vectorProp, graphBuildCacheSize, filteredVectorIds.length);
 
       // Create lazy-loading vector values that reads vectors from documents or index pages (if quantized)
       final ArcadePageVectorValues pageVectors = ArcadePageVectorValues.forGraphBuild(database, metadata.dimensions,
@@ -8383,22 +8384,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Computes how many vectors the graph-build cache should hold.
    * <p>
    * An explicit {@code arcadedb.vectorIndex.graphBuildCacheSize} (or the per-index metadata) wins. Otherwise the
-   * capacity depends on what a cache miss costs during the build:
-   * <ul>
-   *   <li>inline-quantized indexes (INT8/BINARY) read a miss straight from an index page on any thread, so a
-   *       small bound is enough and the heap is better spent elsewhere;</li>
-   *   <li>document-based indexes (NONE/PRODUCT) pay a record lookup plus a full property deserialization on
-   *       every miss, so the whole corpus is cached when the heap allows it. This is what the validation phase
-   *       materializes anyway: bounding the cache below it (issue #3144) threw the vectors away right after
-   *       reading them and made a from-scratch fp32 build re-read almost every vector, hundreds of times each.</li>
-   * </ul>
-   * The budget is a share of the heap actually AVAILABLE, not of the whole heap (issue #6503): a rebuild keeps the
-   * old graph and its search cache resident for its whole duration, and sizing off the ceiling made the cache ask
-   * for the same amount whether that headroom existed or not - which is also why raising {@code -Xmx} did not help,
-   * since it grew the cache proportionally. See {@link VectorHeapBudget} for how availability is measured.
+   * cache holds the whole corpus when it fits {@code arcadedb.vectorIndex.graphBuildCacheMaxHeapPercent}, for both
+   * document-backed indexes (NONE/PRODUCT) and inline-quantized indexes (INT8/BINARY). Document-backed misses still
+   * cost a record lookup plus a full property deserialization, which is why a bound below the corpus (issue #3144)
+   * made a from-scratch fp32 build re-read almost every vector, hundreds of times each; INT8/BINARY misses are
+   * cheaper (an index page) but the percent knob used to skip them entirely (issue #7146).
+   * <p>
+   * The budget is a share of the heap ceiling, then capped at 90% of the heap currently AVAILABLE: taking the
+   * percent of leftover heap made a served ingest of the same corpus choose a third of the cache an embedded
+   * build would get (issue #7146), while sizing off the ceiling with no available-heap cap made an online rebuild
+   * holding the old graph ask for the same amount whether that headroom existed or not (issue #6503). See
+   * {@link VectorHeapBudget#buildCacheBudgetBytes(int)}.
    *
    * @param expectedSize        number of vectors the build will walk
-   * @param inlineQuantization  whether vectors are readable from index pages without a record lookup
+   * @param inlineQuantization  whether vectors are readable from index pages without a record lookup; no longer
+   *                            changes the capacity (issue #7146), kept so callers keep declaring which kind of
+   *                            index they have
    *
    * @return the number of vectors to hold, always positive
    */
@@ -8407,15 +8408,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (configured > 0)
       return configured;
 
-    if (inlineQuantization)
-      return ArcadePageVectorValues.DEFAULT_CACHE_SIZE;
+    // `inlineQuantization` used to return DEFAULT_CACHE_SIZE here (issue #3144). The percent knob must
+    // apply to INT8/BINARY as well (issue #7146), so both kinds of index share the heap-budgeted path below.
 
     final int heapPercent = mutable.getDatabase().getConfiguration()
         .getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT);
     if (heapPercent <= 0)
       return ArcadePageVectorValues.DEFAULT_CACHE_SIZE;
 
-    final long heapBudget = VectorHeapBudget.budgetBytes(heapPercent);
+    final long heapBudget = VectorHeapBudget.buildCacheBudgetBytes(heapPercent);
     final long affordable = Math.max(ArcadePageVectorValues.DEFAULT_CACHE_SIZE,
         heapBudget / VectorHeapBudget.bytesPerCachedVector(metadata.dimensions));
     final long wanted = Math.max(1, expectedSize);

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorHeapBudget.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorHeapBudget.java
@@ -36,6 +36,11 @@ import java.util.logging.Level;
  * after them, not the whole heap. Raising {@code -Xmx} did not create headroom either, because a bigger heap grew
  * both caches proportionally and the rebuild was no more likely to fit (issue #6503).
  * <p>
+ * The graph-build cache is the exception to "percent of leftover". A served ingest that already holds the
+ * corpus in this JVM would otherwise get a third of the cache an embedded build of the same corpus would get
+ * (issue #7146). {@link #buildCacheBudgetBytes(int)} takes the percent of the ceiling and caps it at 90% of
+ * leftover, so the two deployments agree until an online rebuild is actually holding the old graph.
+ * <p>
  * <b>Why not {@code Runtime.freeMemory()}.</b> That reports free space in the <em>currently committed</em> heap,
  * and everything allocated since the last collection counts as used whether it is live or garbage. Read just
  * before a collection it says the heap is nearly full even when almost all of it is about to be reclaimed, so a
@@ -139,6 +144,34 @@ final class VectorHeapBudget {
     if (percent <= 0)
       return 0L;
     return availableHeapBytes() / 100 * Math.min(percent, 90);
+  }
+
+  /**
+   * Heap the graph-build cache may claim: the operator's share of the ceiling, never more than 90% of what is
+   * currently free.
+   * <p>
+   * {@link #budgetBytes(int)} takes the percent of AVAILABLE heap, which is the right denominator for an admission
+   * gate that must not OOM (issue #6503). It is the wrong denominator for the build cache itself. A served ingest
+   * that has just written the corpus into this JVM reports a small leftover, so 25% of that leftover is a third of
+   * the cache an embedded build of the same corpus would get - and that is the steep side of the cache curve
+   * (issue #7146). Taking the percent of {@code -Xmx} instead makes the two deployments agree; capping at 90% of
+   * currently free heap is what still shrinks the cache when an online rebuild is holding the old graph.
+   */
+  static long buildCacheBudgetBytes(final int percent) {
+    return buildCacheBudgetBytes(percent, maxHeapBytes(), availableHeapBytes());
+  }
+
+  /**
+   * Same arithmetic as {@link #buildCacheBudgetBytes(int)}, with the heap figures supplied so a test can pin the
+   * served vs embedded numbers from issue #7146 without a 24 GB fixture.
+   */
+  static long buildCacheBudgetBytes(final int percent, final long maxHeap, final long availableHeap) {
+    if (percent <= 0)
+      return 0L;
+    final int p = Math.min(percent, 90);
+    final long fromCeiling = Math.max(0L, maxHeap) / 100 * p;
+    final long fromAvailable = Math.max(0L, availableHeap) / 100 * 90;
+    return Math.min(fromCeiling, fromAvailable);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7146GraphBuildCacheBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7146GraphBuildCacheBudgetTest.java
@@ -115,11 +115,20 @@ class Issue7146GraphBuildCacheBudgetTest {
         .isEqualTo(VectorHeapBudget.buildCacheBudgetBytes(90, MAX_HEAP, EMBEDDED_AVAILABLE));
   }
 
+  /**
+   * The live overload reads {@link VectorHeapBudget#availableHeapBytes()} itself, and that reading moves whenever
+   * the JVM collects - so comparing it against a second reading taken here would be a coin flip on whether a GC
+   * landed between the two, which in a full-suite run it regularly does. What is invariant, and is the whole
+   * point of the change, is the upper bound: a share of a ceiling that cannot move for the life of the JVM.
+   */
   @Test
-  void theLiveJvmOverloadAgreesWithTheFiguresTheJvmReports() {
+  void theLiveJvmOverloadNeverExceedsTheShareOfTheCeilingItIsGiven() {
     final int percent = 25;
-    assertThat(VectorHeapBudget.buildCacheBudgetBytes(percent))
-        .isEqualTo(VectorHeapBudget.buildCacheBudgetBytes(percent, VectorHeapBudget.maxHeapBytes(),
-            VectorHeapBudget.availableHeapBytes()));
+    final long budget = VectorHeapBudget.buildCacheBudgetBytes(percent);
+
+    assertThat(budget).isNotNegative();
+    assertThat(budget)
+        .as("the share of -Xmx is the most the build cache may claim, whatever the live heap happens to say")
+        .isLessThanOrEqualTo(VectorHeapBudget.maxHeapBytes() / 100 * percent);
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7146GraphBuildCacheBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7146GraphBuildCacheBudgetTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7146: {@code graphBuildCacheMaxHeapPercent} sized the HNSW build cache from leftover heap at
+ * build start. A served ingest that already held the corpus in the same JVM therefore chose a third of
+ * the cache an embedded build of the same corpus would get. The numbers below are the DEEP-10M snapshot
+ * from the report (24 GB {@code -Xmx}, 96-d, 9,990,000 vectors, served leftover ~6.6 GB).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7146GraphBuildCacheBudgetTest {
+
+  private static final int  DIMENSIONS          = 96;
+  private static final int  CORPUS              = 9_990_000;
+  private static final int  DEFAULT_PERCENT     = 25;
+  /** 24 GiB, the {@code -Xmx} both deployments used. */
+  private static final long MAX_HEAP            = 24L * 1024 * 1024 * 1024;
+  /**
+   * Leftover heap the engine saw on the served arm: working back from the log line
+   * {@code cache enabled: size=3674697} at 448 bytes/vector and a 25% share of available heap.
+   */
+  private static final long SERVED_AVAILABLE    = 6_585_057_024L;
+  /** Embedded arm: corpus lives in numpy outside the JVM, so almost the whole ceiling is free. */
+  private static final long EMBEDDED_AVAILABLE  = MAX_HEAP - 512L * 1024 * 1024;
+
+  @Test
+  void theOldPercentOfAvailableFormulaChoseAThirdOfTheCorpusOnTheServedArm() {
+    final long bytesPer = VectorHeapBudget.bytesPerCachedVector(DIMENSIONS);
+    assertThat(bytesPer).isEqualTo(448L);
+
+    // This is budgetBytes(): percent of leftover, not of the ceiling.
+    final long oldServedBudget = SERVED_AVAILABLE / 100 * DEFAULT_PERCENT;
+    final long oldServedCapacity = oldServedBudget / bytesPer;
+
+    assertThat(oldServedCapacity)
+        .as("the size=3674697 log line the served default actually chose")
+        .isBetween(3_600_000L, 3_700_000L);
+    assertThat(oldServedCapacity).isLessThan(CORPUS);
+
+    final long oldEmbeddedBudget = EMBEDDED_AVAILABLE / 100 * DEFAULT_PERCENT;
+    final long oldEmbeddedCapacity = oldEmbeddedBudget / bytesPer;
+    assertThat(oldEmbeddedCapacity)
+        .as("embedded 25% of ~23.5 GB pays for more than the corpus, so it was capped at N")
+        .isGreaterThanOrEqualTo(CORPUS);
+  }
+
+  @Test
+  void theDefaultPercentOfTheCeilingPaysForTheWholeDeep10mCorpusOnBothArms() {
+    final long bytesPer = VectorHeapBudget.bytesPerCachedVector(DIMENSIONS);
+
+    final long servedBudget = VectorHeapBudget.buildCacheBudgetBytes(DEFAULT_PERCENT, MAX_HEAP, SERVED_AVAILABLE);
+    final long servedCapacity = servedBudget / bytesPer;
+    assertThat(servedCapacity)
+        .as("served must no longer land on the steep side of the cache curve at the default")
+        .isGreaterThanOrEqualTo(CORPUS);
+
+    final long embeddedBudget = VectorHeapBudget.buildCacheBudgetBytes(DEFAULT_PERCENT, MAX_HEAP, EMBEDDED_AVAILABLE);
+    final long embeddedCapacity = embeddedBudget / bytesPer;
+    assertThat(embeddedCapacity).isGreaterThanOrEqualTo(CORPUS);
+
+    // Served leftover is the cap (~90% of 6.6 GB), embedded leftover is not; both still clear the corpus.
+    assertThat(servedBudget).isLessThanOrEqualTo(embeddedBudget);
+  }
+
+  @Test
+  void anOnlineRebuildWithLittleLeftoverStillCapsAtAvailableHeap() {
+    // Old graph resident: ~2 GB free. The cache must not ask for 25% of 24 GB on top of that (issue #6503).
+    final long tightAvailable = 2L * 1024 * 1024 * 1024;
+    final long budget = VectorHeapBudget.buildCacheBudgetBytes(DEFAULT_PERCENT, MAX_HEAP, tightAvailable);
+
+    assertThat(budget).isEqualTo(tightAvailable / 100 * 90);
+    assertThat(budget).isLessThan(MAX_HEAP / 100 * DEFAULT_PERCENT);
+  }
+
+  @Test
+  void buildCacheBudgetIsNeverSmallerThanTheAdmissionGateShareOfTheSameLeftover() {
+    // Admission control (budgetBytes) stays on leftover heap. The build cache may claim more than that
+    // share of leftover, but never less: otherwise we would reintroduce the served under-size.
+    for (final int percent : new int[] { 10, 25, 50, 75, 90, 100 }) {
+      final long admission = SERVED_AVAILABLE / 100 * Math.min(percent, 90);
+      final long cache = VectorHeapBudget.buildCacheBudgetBytes(percent, MAX_HEAP, SERVED_AVAILABLE);
+      assertThat(cache)
+          .as("build-cache budget at %d%% must not undershoot the admission-gate share of leftover", percent)
+          .isGreaterThanOrEqualTo(admission);
+    }
+  }
+
+  @Test
+  void aZeroOrNegativePercentIsNoBudgetAndValuesAboveNinetyClamp() {
+    assertThat(VectorHeapBudget.buildCacheBudgetBytes(0, MAX_HEAP, SERVED_AVAILABLE)).isZero();
+    assertThat(VectorHeapBudget.buildCacheBudgetBytes(-5, MAX_HEAP, SERVED_AVAILABLE)).isZero();
+    assertThat(VectorHeapBudget.buildCacheBudgetBytes(100, MAX_HEAP, EMBEDDED_AVAILABLE))
+        .isEqualTo(VectorHeapBudget.buildCacheBudgetBytes(90, MAX_HEAP, EMBEDDED_AVAILABLE));
+  }
+
+  @Test
+  void theLiveJvmOverloadAgreesWithTheFiguresTheJvmReports() {
+    final int percent = 25;
+    assertThat(VectorHeapBudget.buildCacheBudgetBytes(percent))
+        .isEqualTo(VectorHeapBudget.buildCacheBudgetBytes(percent, VectorHeapBudget.maxHeapBytes(),
+            VectorHeapBudget.availableHeapBytes()));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBuildCacheSizingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBuildCacheSizingTest.java
@@ -21,11 +21,15 @@ package com.arcadedb.index.vector;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.log.WarningCapture;
+import com.arcadedb.log.WarningCapture.LogLine;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Random;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * document-backed indexes, where a miss costs a record lookup plus a full property deserialization. The
  * validation phase read every vector and then dropped everything past the bound, so a from-scratch build of a
  * corpus larger than the cache re-read almost every vector, hundreds of times each. The cache is now sized from
- * the corpus and the heap for document-backed indexes, and keeps the small bound only where misses are cheap.
+ * the corpus and a share of the heap ceiling (issue #7146) for both document-backed and inline-quantized indexes.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -77,15 +81,40 @@ class LSMVectorIndexBuildCacheSizingTest extends TestHelper {
     }
   }
 
-  // Inline-quantized indexes resolve a miss from an index page, so they keep the small bound instead of
-  // spending heap on full residency.
+  // Inline-quantized indexes resolve a miss from an index page, but the heap-percent knob must still move
+  // the cache (issue #7146). Only percent=0 (or an explicit graphBuildCacheSize) keeps the flat bound.
   @Test
-  void inlineQuantizedBuildKeepsTheSmallBound() {
+  void inlineQuantizedBuildHonoursTheHeapPercentKnob() {
     createIndex(VectorQuantizationType.INT8);
     final LSMVectorIndex index = index();
 
-    assertThat(index.computeGraphBuildCacheCapacity(50_000_000, true))
-        .isEqualTo(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
+    final int auto = index.computeGraphBuildCacheCapacity(50_000_000, true);
+    assertThat(auto)
+        .as("INT8 and fp32 share the same heap-budgeted auto size; INT8 must not stay at 100,000 while fp32 grows")
+        .isEqualTo(index.computeGraphBuildCacheCapacity(50_000_000, false));
+    assertThat(auto).isLessThan(50_000_000);
+    assertThat(auto).isGreaterThanOrEqualTo(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
+
+    final int previous = GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.getValueAsInteger();
+    GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(0);
+    try {
+      assertThat(index.computeGraphBuildCacheCapacity(50_000_000, true))
+          .isEqualTo(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
+    } finally {
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(previous);
+    }
+  }
+
+  @Test
+  void aFromScratchBuildLogsCacheCapacityNextToTheCorpusSize() {
+    createIndex(null);
+    final LSMVectorIndex index = index();
+
+    final List<LogLine> lines = WarningCapture.capture(Level.INFO, index::buildVectorGraphNow);
+
+    assertThat(lines.stream().map(LogLine::message))
+        .as("the chosen cache size next to the corpus is what makes a too-small default a one-line diagnosis")
+        .anyMatch(message -> message.contains("cache enabled: size=" + NUM_VECTORS + " of " + NUM_VECTORS));
   }
 
   // A corpus too large for the heap budget must still build: the cache is capped, not the corpus.

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBuildCacheSizingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBuildCacheSizingTest.java
@@ -69,7 +69,7 @@ class LSMVectorIndexBuildCacheSizingTest extends TestHelper {
       createIndex(null);
       final LSMVectorIndex index = index();
 
-      assertThat(index.computeGraphBuildCacheCapacity(NUM_VECTORS, false)).isEqualTo(16);
+      assertThat(index.computeGraphBuildCacheCapacity(NUM_VECTORS)).isEqualTo(16);
 
       final long before = index.getStats().getOrDefault("vectorFetchFromDocuments", 0L);
       index.buildVectorGraphNow();
@@ -88,17 +88,16 @@ class LSMVectorIndexBuildCacheSizingTest extends TestHelper {
     createIndex(VectorQuantizationType.INT8);
     final LSMVectorIndex index = index();
 
-    final int auto = index.computeGraphBuildCacheCapacity(50_000_000, true);
+    final int auto = index.computeGraphBuildCacheCapacity(50_000_000);
     assertThat(auto)
-        .as("INT8 and fp32 share the same heap-budgeted auto size; INT8 must not stay at 100,000 while fp32 grows")
-        .isEqualTo(index.computeGraphBuildCacheCapacity(50_000_000, false));
-    assertThat(auto).isLessThan(50_000_000);
-    assertThat(auto).isGreaterThanOrEqualTo(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
+        .as("INT8 must not stay at the flat 100,000 bound while the same corpus in fp32 gets the heap share")
+        .isGreaterThan(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
+    assertThat((long) auto).isLessThanOrEqualTo(ceilingShareCapacity());
 
     final int previous = GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.getValueAsInteger();
     GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(0);
     try {
-      assertThat(index.computeGraphBuildCacheCapacity(50_000_000, true))
+      assertThat(index.computeGraphBuildCacheCapacity(50_000_000))
           .isEqualTo(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
     } finally {
       GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(previous);
@@ -117,26 +116,60 @@ class LSMVectorIndexBuildCacheSizingTest extends TestHelper {
         .anyMatch(message -> message.contains("cache enabled: size=" + NUM_VECTORS + " of " + NUM_VECTORS));
   }
 
+  // The same line for an INT8 index: before issue #7146 it read "size=100000", whatever the knob said, which is
+  // the form the report had to work back from. This also pins the warm-in-place path for inline quantization,
+  // whose vectors are read from index pages during validation rather than from documents.
+  @Test
+  void anInlineQuantizedBuildLogsTheSameCapacityAsADocumentBackedOne() {
+    createIndex(VectorQuantizationType.INT8);
+    final LSMVectorIndex index = index();
+
+    final List<LogLine> lines = WarningCapture.capture(Level.INFO, index::buildVectorGraphNow);
+
+    assertThat(lines.stream().map(LogLine::message))
+        .anyMatch(message -> message.contains("cache enabled: size=" + NUM_VECTORS + " of " + NUM_VECTORS));
+  }
+
   // A corpus too large for the heap budget must still build: the cache is capped, not the corpus.
   @Test
   void autoSizingIsCappedByTheHeapBudget() {
     createIndex(null);
     final LSMVectorIndex index = index();
 
-    // 50M vectors x 32 dims is ~9.6GB of payload, well past any sane share of a test JVM heap
-    final int capacity = index.computeGraphBuildCacheCapacity(50_000_000, false);
-    assertThat(capacity).isLessThan(50_000_000);
-    assertThat(capacity).isGreaterThanOrEqualTo(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
+    // The budget is a share of -Xmx (issue #7146), so a bound derived from the live heap would be the only
+    // assertion that holds on a 16 GB CI runner AND on a 256 GB workstation. 1% of any ceiling a JVM can be
+    // given is far short of 50M x 32-dim vectors, so the cap provably binds here rather than by luck.
+    final int previous = GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.getValueAsInteger();
+    GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(1);
+    try {
+      final int capacity = index.computeGraphBuildCacheCapacity(50_000_000);
+      assertThat(capacity).isLessThan(50_000_000);
+      assertThat(capacity).isGreaterThanOrEqualTo(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
+    } finally {
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(previous);
+    }
+
+    // At the default the share of the ceiling is the ceiling of what may be chosen: the available-heap cap can
+    // only lower it. Asserting the upper bound rather than an exact figure keeps this deterministic while a
+    // concurrent test is allocating.
+    assertThat(index.computeGraphBuildCacheCapacity(50_000_000))
+        .isLessThanOrEqualTo((int) Math.min(50_000_000L, ceilingShareCapacity()));
 
     // Disabling the heap share falls back to the flat bound rather than to an unbounded cache
-    final int previous = GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.getValueAsInteger();
     GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(0);
     try {
-      assertThat(index.computeGraphBuildCacheCapacity(50_000_000, false))
+      assertThat(index.computeGraphBuildCacheCapacity(50_000_000))
           .isEqualTo(ArcadePageVectorValues.DEFAULT_CACHE_SIZE);
     } finally {
       GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(previous);
     }
+  }
+
+  /** Vectors the configured share of {@code -Xmx} pays for. Depends on no live-heap reading, so it cannot drift. */
+  private static long ceilingShareCapacity() {
+    final int percent = Math.min(90,
+        GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.getValueAsInteger());
+    return VectorHeapBudget.maxHeapBytes() / 100 * percent / VectorHeapBudget.bytesPerCachedVector(DIMENSIONS);
   }
 
   private void createIndex(final VectorQuantizationType quantization) {


### PR DESCRIPTION
Fixes #7146

## What does this PR do?

`graphBuildCacheMaxHeapPercent` now takes its share of the JVM heap ceiling (`-Xmx`), then caps that at 90% of the heap currently available. A served ingest of the same corpus as an embedded build therefore gets the same cache at the default, instead of a third of it. The percent knob also applies to INT8/BINARY, and the INFO line is `cache enabled: size=N of corpus`.

## Motivation

On DEEP-10M the same jars built in 190 to 198 min served against 38 to 42 min embedded, with identical recall. Pinning `graphBuildCacheSize` showed the two deployments are within 10% of each other at every matched cache capacity, so this is the default sizer, not the transport. The served arm had just ingested the corpus into the same heap, leftover was ~6.6 GB of 24 GB, and 25% of that leftover paid for 3.67 million of 9.99 million vectors. INT8 never read the percent knob at all: `graphBuildCacheMaxHeapPercent=75` still chose 100,000.

## Related issues

- Fixes #7146
- Preserves #6503: the available-heap cap still shrinks the cache when an online rebuild is holding the old graph. Admission control continues to use `budgetBytes()` (percent of leftover).

## Additional Notes

The search cache is unchanged: it still budgets from leftover heap. Only the graph-build cache moves to percent-of-ceiling, because that is the working set whose size should be an operator policy of `-Xmx`, not of whatever happens to be live at the instant the build starts.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

Targeted engine tests, all green: `Issue7146GraphBuildCacheBudgetTest`, `LSMVectorIndexBuildCacheSizingTest`, `Issue6503VectorHeapBudgetTest`, `Issue6503RebuildAdmissionControlTest`, `LowRamProfileTest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector index graph-build cache sizing for fp32, INT8, and BINARY indexes.
  * Caches can now accommodate the full vector corpus when within the configured heap budget.
  * Heap-based limits are consistently enforced and capped by currently available memory.
  * Reduced duplicate memory use during graph-build validation.
  * Improved logging to show cache capacity and vector count.

* **Tests**
  * Added regression coverage for cache sizing across deployment modes, heap conditions, and percentage limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->