### PR TITLE
fix(#7149): a write to a record this transaction already deleted is dropped, not reported as a deadlock

### DIFF
--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt7149VarLengthDetachDeleteIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt7149VarLengthDetachDeleteIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end wire test for issue #7149: a 2-hop variable-length traversal whose rows repeat the same node, followed
+ * by {@code SET} and {@code DETACH DELETE} on that node, answered a single Bolt client with
+ * {@code Neo.TransientError.Transaction.DeadlockDetected} - telling the driver to retry a statement that could
+ * never succeed, since there was no second transaction to conflict with.
+ * <p>
+ * The wire is the point of this test: the engine-level exception that produced the report is a
+ * {@code ConcurrentModificationException}, and only the Bolt classifier turns that into a transient status. The
+ * defects behind it are pinned in the engine module -
+ * {@link com.arcadedb.query.opencypher.CypherVarLengthDetachDeleteIssue7149Test} and
+ * {@link com.arcadedb.database.Issue7149UpdateAfterDeleteInSameTxTest}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Bolt7149VarLengthDetachDeleteIT extends BaseGraphServerTest {
+  private static final String EDGES = "[[14,126],[72,112],[13,11],[57,54],[2,105],[64,13],[123,26],[60,75],[101,2],[70,51],"
+      + "[59,2],[33,113],[73,52],[94,46],[73,93],[93,104],[64,41],[33,38],[27,72],[118,118],[85,24],[85,67],[51,89],[19,38],"
+      + "[113,22],[59,78],[0,33],[76,76],[78,64],[15,16],[95,95],[9,38],[2,2],[67,2],[126,87],[42,86],[54,54],[48,101],"
+      + "[107,50],[85,39],[116,13],[101,47],[5,84],[123,81],[93,26],[107,127],[57,116],[10,57],[65,65],[101,81],[22,22],"
+      + "[65,65],[117,116],[27,42],[116,116],[26,93],[41,5],[35,38],[57,71],[86,47],[67,84],[107,124],[98,110],[67,28],"
+      + "[48,48],[72,17],[52,95],[123,2],[93,127],[52,65],[98,105],[13,5]]";
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+    // The reporter ran a stock container: one bucket per type, so every node of a type shares the same page.
+    GlobalConfiguration.TYPE_DEFAULT_BUCKETS.setValue(1);
+  }
+
+  @Override
+  protected void populateDatabase() {
+    // The issue reproduces on a clean database: the Cypher setup below creates every type it needs.
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+  }
+
+  private void setUpGraph(final Session s) {
+    s.run("UNWIND range(0, 127) AS id CREATE (:N {id: id})").consume();
+    s.run("UNWIND " + EDGES + " AS e MATCH (a {id: e[0]}), (b {id: e[1]}) CREATE (a)-[:R]->(b)").consume();
+  }
+
+  private long countSurvivingNodes(final Session s) {
+    return s.run("MATCH (n:N) RETURN count(n) AS c").single().get("c").asLong();
+  }
+
+  @Test
+  void controlWithoutDetachDeleteReturnsEveryTwoHopPath() {
+    try (final Driver driver = getDriver()) {
+      try (final Session s = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        setUpGraph(s);
+
+        final List<Record> rows = s.run("""
+            MERGE (:DeadlockProbe {id: 999995})
+            MATCH p0 = (n2) -[*2]-()
+            SET n2.marker = 'probe'
+            RETURN null AS alias0""").list();
+
+        assertThat(rows).as("the issue's control case returns the 2-hop paths").hasSize(256);
+      }
+    }
+  }
+
+  @Test
+  void varLengthTraversalThenDetachDeleteDoesNotReportADeadlock() {
+    try (final Driver driver = getDriver()) {
+      try (final Session s = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        setUpGraph(s);
+
+        // Pre-fix: org.neo4j.driver.exceptions.TransientException, code
+        // Neo.TransientError.Transaction.DeadlockDetected. The records are consumed here (.list()), as the issue
+        // notes a lazy unconsumed result can report success before the server would have reported the failure.
+        final List<Record> rows = s.run("""
+            MERGE (:DeadlockProbe {id: 999995})
+            MATCH p0 = (n2) -[*2]-()
+            SET n2.marker = 'probe'
+            DETACH DELETE n2
+            CALL merge.node(['ProbePerson'], {name: 'ArcadeGenerated'}, {name: 'ArcadeGenerated'}) YIELD node AS alias3
+            RETURN null AS alias0""").list();
+
+        assertThat(rows).as("one projected row per traversal row").hasSize(256);
+        assertThat(countSurvivingNodes(s)).as("only the nodes no 2-hop path reaches survive").isEqualTo(71);
+      }
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1370,7 +1370,11 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         // RECORD
         try {
           final TransactionContext tx = getTransaction();
-          tx.addUpdatedRecord(record);
+          // #7149: false means this transaction has already deleted the record, so there is nothing to write and
+          // nothing to index - the delete wins, and the index entries went with it. Returning here also keeps the
+          // after-update events from firing for a write that never happened.
+          if (!tx.addUpdatedRecord(record))
+            return null;
 
           if (record instanceof Document document) {
             // UPDATE THE INDEX IN MEMORY BEFORE UPDATING THE PAGE

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1358,8 +1358,6 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       if (!((RecordEventsRegistry) document.getType().getEvents()).onBeforeUpdate(record))
         return;
 
-    stats.updateRecord.incrementAndGet();
-
     executeInReadLock(() -> {
       if (isTransactionActive()) {
         // MARK THE RECORD FOR UPDATE IN TX AND DEFER THE SERIALIZATION AT COMMIT TIME. THIS SPEEDS UP CASES WHEN THE
@@ -1405,6 +1403,12 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         }
       } else
         updateRecordNoLock(record, false);
+
+      // Counted HERE rather than before the branch (#7149): the statistic reports records this database actually
+      // updated, and the two ways out above that are not an update - a listener vetoing the write, and a write to a
+      // record this transaction already deleted - both leave without reaching it. Both also skip the after-update
+      // events right below, so the two stay in step.
+      stats.updateRecord.incrementAndGet();
 
       // INVOKE EVENT CALLBACKS
       events.onAfterUpdate(record);

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -554,6 +554,13 @@ public class TransactionContext implements Transaction {
 
   /**
    * Queues a record for the deferred write performed by {@link #commit1stPhase()}.
+   * <p>
+   * A dropped write (see {@code false} below) leaves two traces, both deliberate. {@code onBeforeUpdate} has already
+   * fired by the time {@code LocalDatabase.updateRecord} reaches here, so a listener sees a "before" with no matching
+   * "after" - the write genuinely did not happen, and the caller is told so by the return value rather than by an
+   * exception. And the record keeps its dirty flag, because only the commit clears it, over {@code
+   * modifiedRecordsCache}, which the delete already emptied of this RID. Neither matters for a record that no longer
+   * exists, and clearing the flag would claim a write that was never persisted.
    *
    * @return {@code false} when this same transaction has already deleted the record, so nothing was queued and the
    * caller must skip the rest of the update (index maintenance, after-update events) too; {@code true} otherwise.

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -552,8 +552,25 @@ public class TransactionContext implements Transaction {
           + "its read and its update. Please retry the operation");
   }
 
-  public void addUpdatedRecord(final Record record) throws IOException {
+  /**
+   * Queues a record for the deferred write performed by {@link #commit1stPhase()}.
+   *
+   * @return {@code false} when this same transaction has already deleted the record, so nothing was queued and the
+   * caller must skip the rest of the update (index maintenance, after-update events) too; {@code true} otherwise.
+   */
+  public boolean addUpdatedRecord(final Record record) throws IOException {
     final RID rid = record.getIdentity();
+
+    // #7149: the delete wins. A record this transaction already deleted cannot exist at commit, so a write to it
+    // can never be observed - exactly as the symmetric order already behaves, where removeRecordFromCache() drops
+    // an update queued BEFORE the delete. Queueing it instead makes commit1stPhase find the record missing and
+    // raise a ConcurrentModificationException blaming a concurrent transaction that never existed. That lie is
+    // expensive as well as wrong: it is a NeedRetryException, so the caller re-runs the whole command
+    // 'arcadedb.txRetries' times against a state that can never change, and a Bolt client is finally told
+    // Neo.TransientError.Transaction.DeadlockDetected for a single-client statement. The commit-time arm stays for
+    // what it was written for (#4959): a delete by a genuinely CONCURRENT transaction, which no local state shows.
+    if (deletedRecordsInTx.contains(rid))
+      return false;
 
     if (updatedRecords == null)
       updatedRecords = new HashMap<>();
@@ -583,6 +600,7 @@ public class TransactionContext implements Transaction {
     }
     updateRecordInCache(record);
     removeImmutableRecordsOfSamePage(record.getIdentity());
+    return true;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/database/Issue7149UpdateAfterDeleteInSameTxTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue7149UpdateAfterDeleteInSameTxTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for GitHub issue #7149.
+ * <p>
+ * Writing to a record that the SAME transaction has already deleted used to be queued for the deferred
+ * commit-time write like any other update. {@code commit1stPhase()} then found the record missing and reported a
+ * {@link ConcurrentModificationException} saying it "was deleted by a concurrent transaction" - naming a
+ * concurrent transaction that never existed. Because that is a {@code NeedRetryException}, the caller re-ran the
+ * whole command {@code arcadedb.txRetries} times against a state that could never change, and a single Bolt
+ * client was finally told {@code Neo.TransientError.Transaction.DeadlockDetected}.
+ * <p>
+ * The delete wins instead: the record cannot exist at commit, so the write is dropped, exactly as the symmetric
+ * order (an update queued BEFORE the delete, which {@code removeRecordFromCache} drops) already behaved. The
+ * commit-time arm stays for what it was written for (#4959): a delete by a genuinely concurrent transaction.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7149UpdateAfterDeleteInSameTxTest {
+  private static final String DB_PATH = "./target/databases/testissue7149-update-after-delete";
+
+  private DatabaseInternal database;
+
+  @BeforeEach
+  void setUp() {
+    database = (DatabaseInternal) new DatabaseFactory(DB_PATH).create();
+    final VertexType type = database.getSchema().createVertexType("Doc");
+    type.createProperty("id", Integer.class);
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Doc", "id");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  private RID createRecord(final int id) {
+    final RID[] rid = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex v = database.newVertex("Doc");
+      v.set("id", id);
+      v.set("value", "initial");
+      v.save();
+      rid[0] = v.getIdentity();
+    });
+    return rid[0];
+  }
+
+  private long countRecords() {
+    try (final ResultSet rs = database.query("sql", "SELECT count(@rid) AS c FROM Doc")) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private List<RID> indexEntriesFor(final int id) {
+    final IndexCursor cursor = database.getSchema().getIndexByName("Doc[id]").get(new Object[] { id });
+    final java.util.ArrayList<RID> found = new java.util.ArrayList<>();
+    while (cursor.hasNext())
+      found.add(cursor.next().getIdentity());
+    return found;
+  }
+
+  @Test
+  void savingAStaleInstanceAfterAnInTransactionDeleteDoesNotReportAPhantomConflict() {
+    final RID rid = createRecord(1);
+
+    assertThatCode(() -> database.transaction(() -> {
+      final MutableVertex stale = database.lookupByRID(rid, true).asVertex().modify();
+      stale.set("value", "updated");
+      stale.save();
+
+      database.deleteRecord(database.lookupByRID(rid, true));
+      assertThat(database.getTransaction().isDeletedInTransaction(rid)).isTrue();
+
+      // The stale instance is still live in the caller's hands - this is what an OpenCypher row fanout, or any
+      // application holding the record across the delete, does. Pre-fix this queued the write and the COMMIT blew
+      // up with "deleted by a concurrent transaction".
+      stale.set("value", "after-delete");
+      stale.save();
+    })).doesNotThrowAnyException();
+
+    assertThat(countRecords()).as("the delete wins: the record must be gone").isZero();
+  }
+
+  @Test
+  void theDroppedWriteLeavesNoPhantomIndexEntry() {
+    final RID rid = createRecord(7);
+
+    database.transaction(() -> {
+      final MutableVertex stale = database.lookupByRID(rid, true).asVertex().modify();
+      database.deleteRecord(database.lookupByRID(rid, true));
+      // A write that changes the INDEXED property: the index maintenance must be skipped along with the write,
+      // otherwise the delete's own index cleanup is undone and the key resurrects pointing at a dead RID.
+      stale.set("id", 8);
+      stale.save();
+    });
+
+    assertThat(countRecords()).isZero();
+    assertThat(indexEntriesFor(7)).as("the delete removed the original key").isEmpty();
+    assertThat(indexEntriesFor(8)).as("the dropped write must not have added a key").isEmpty();
+  }
+
+  @Test
+  void aRecordDeletedInThisTransactionDoesNotBlockUpdatesToOtherRecords() {
+    final RID deleted = createRecord(2);
+    final RID survivor = createRecord(3);
+
+    database.transaction(() -> {
+      database.deleteRecord(database.lookupByRID(deleted, true));
+
+      final MutableVertex v = database.lookupByRID(survivor, true).asVertex().modify();
+      v.set("value", "still-written");
+      v.save();
+    });
+
+    assertThat(countRecords()).isEqualTo(1);
+    assertThat(database.lookupByRID(survivor, true).asVertex().getString("value")).isEqualTo("still-written");
+  }
+
+  @Test
+  void anUpdateQueuedBeforeTheDeleteIsStillDropped() {
+    // The symmetric order, which removeRecordFromCache() has always handled: pinned here so the two halves of the
+    // invariant the commit-time arm relies on stay together.
+    final RID rid = createRecord(4);
+
+    database.transaction(() -> {
+      final MutableVertex v = database.lookupByRID(rid, true).asVertex().modify();
+      v.set("value", "updated");
+      v.save();
+      database.deleteRecord(database.lookupByRID(rid, true));
+    });
+
+    assertThat(countRecords()).isZero();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue7149UpdateAfterDeleteInSameTxTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue7149UpdateAfterDeleteInSameTxTest.java
@@ -155,6 +155,36 @@ class Issue7149UpdateAfterDeleteInSameTxTest {
   }
 
   @Test
+  void aDroppedWriteIsNotCountedAsAnUpdate() {
+    final RID rid = createRecord(5);
+
+    final long before = ((Number) database.getStats().get("updateRecord")).longValue();
+    database.transaction(() -> {
+      final MutableVertex stale = database.lookupByRID(rid, true).asVertex().modify();
+      database.deleteRecord(database.lookupByRID(rid, true));
+      stale.set("value", "dropped");
+      stale.save();
+    });
+
+    assertThat(((Number) database.getStats().get("updateRecord")).longValue())
+        .as("a write that was never applied is not an update").isEqualTo(before);
+  }
+
+  @Test
+  void anOrdinaryUpdateIsStillCounted() {
+    final RID rid = createRecord(6);
+
+    final long before = ((Number) database.getStats().get("updateRecord")).longValue();
+    database.transaction(() -> {
+      final MutableVertex v = database.lookupByRID(rid, true).asVertex().modify();
+      v.set("value", "counted");
+      v.save();
+    });
+
+    assertThat(((Number) database.getStats().get("updateRecord")).longValue()).isEqualTo(before + 1);
+  }
+
+  @Test
   void anUpdateQueuedBeforeTheDeleteIsStillDropped() {
     // The symmetric order, which removeRecordFromCache() has always handled: pinned here so the two halves of the
     // invariant the commit-time arm relies on stay together.

--- a/engine/src/test/java/com/arcadedb/database/Issue7149UpdateAfterDeleteInSameTxTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue7149UpdateAfterDeleteInSameTxTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,7 +91,7 @@ class Issue7149UpdateAfterDeleteInSameTxTest {
 
   private List<RID> indexEntriesFor(final int id) {
     final IndexCursor cursor = database.getSchema().getIndexByName("Doc[id]").get(new Object[] { id });
-    final java.util.ArrayList<RID> found = new java.util.ArrayList<>();
+    final List<RID> found = new ArrayList<>();
     while (cursor.hasNext())
       found.add(cursor.next().getIdentity());
     return found;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVarLengthDetachDeleteIssue7149Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVarLengthDetachDeleteIssue7149Test.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #7149: a 2-hop variable-length traversal whose rows repeat the same node,
+ * followed by {@code SET} and {@code DETACH DELETE} on that node, reported a transaction deadlock to a single
+ * client ({@code Neo.TransientError.Transaction.DeadlockDetected} over Bolt).
+ * <p>
+ * Two independent defects met on that query. The traversal is now read to completion before the first deletion is
+ * applied (the eager gate widened for issue #7023), so every {@code SET} lands while its node is still there -
+ * which is what Neo4j's own Eager operator does for the same shape. And underneath, a write to a record the same
+ * transaction had already deleted is now dropped rather than queued for a commit that reported it as a conflict
+ * with a concurrent transaction that never existed - see
+ * {@link com.arcadedb.database.Issue7149UpdateAfterDeleteInSameTxTest}.
+ * <p>
+ * The graph is the reporter's: 128 nodes and 72 relationships, chosen so the 2-hop pattern yields 256 rows over
+ * 128 nodes and therefore binds most nodes from several rows.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherVarLengthDetachDeleteIssue7149Test {
+  private static final String EDGES = "[[14,126],[72,112],[13,11],[57,54],[2,105],[64,13],[123,26],[60,75],[101,2],[70,51],"
+      + "[59,2],[33,113],[73,52],[94,46],[73,93],[93,104],[64,41],[33,38],[27,72],[118,118],[85,24],[85,67],[51,89],[19,38],"
+      + "[113,22],[59,78],[0,33],[76,76],[78,64],[15,16],[95,95],[9,38],[2,2],[67,2],[126,87],[42,86],[54,54],[48,101],"
+      + "[107,50],[85,39],[116,13],[101,47],[5,84],[123,81],[93,26],[107,127],[57,116],[10,57],[65,65],[101,81],[22,22],"
+      + "[65,65],[117,116],[27,42],[116,116],[26,93],[41,5],[35,38],[57,71],[86,47],[67,84],[107,124],[98,110],[67,28],"
+      + "[48,48],[72,17],[52,95],[123,2],[93,127],[52,65],[98,105],[13,5]]";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    // No pre-created schema, exactly as the reporter's clean database: the Cypher setup creates every type.
+    database = new DatabaseFactory("./target/databases/testopencypher-7149-detach-delete").create();
+    database.command("opencypher", "UNWIND range(0, 127) AS id CREATE (:N {id: id})").close();
+    database.command("opencypher",
+        "UNWIND " + EDGES + " AS e MATCH (a {id: e[0]}), (b {id: e[1]}) CREATE (a)-[:R]->(b)").close();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  private int countRows(final String query) {
+    int rows = 0;
+    try (final ResultSet rs = database.command("opencypher", query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        ++rows;
+      }
+    }
+    return rows;
+  }
+
+  private long countNodes(final String label) {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:" + label + ") RETURN count(n) AS c")) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  /**
+   * The state every successful run of the reproduction must leave behind: the 57 nodes the 2-hop pattern binds are
+   * gone with their relationships, the 71 that no 2-hop path reaches are untouched, and no surviving node carries
+   * the marker - a marked survivor would mean a node was written and then NOT deleted.
+   */
+  private void assertEveryTraversedNodeWasDeleted() {
+    assertThat(countNodes("N")).as("only the nodes no 2-hop path reaches survive").isEqualTo(71);
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:N) WHERE n.marker IS NOT NULL RETURN count(n) AS c")) {
+      assertThat(((Number) rs.next().getProperty("c")).longValue()).as("no marked node survived the delete").isZero();
+    }
+    try (final ResultSet rs = database.query("opencypher", "MATCH (a)-[*2]-() RETURN count(a) AS c")) {
+      assertThat(((Number) rs.next().getProperty("c")).longValue()).as("no 2-hop path is left").isZero();
+    }
+  }
+
+  @Test
+  void controlWithoutDetachDeleteReturnsEveryTwoHopPath() {
+    // The issue's control case: it must keep returning the 256 rows the reporter measured, so the reproduction
+    // below is known to be exercising a traversal that really does bind the same node from several rows.
+    assertThat(countRows("""
+        MERGE (:DeadlockProbe {id: 999995})
+        MATCH p0 = (n2) -[*2]-()
+        SET n2.marker = 'probe'
+        RETURN null AS alias0""")).isEqualTo(256);
+  }
+
+  @Test
+  void varLengthTraversalFollowedByDetachDeleteCompletes() {
+    // The issue's reproduction, verbatim. Pre-fix: ConcurrentModificationException ("... was deleted by a
+    // concurrent transaction"), retried arcadedb.txRetries times and reported as DeadlockDetected over Bolt.
+    assertThat(countRows("""
+        MERGE (:DeadlockProbe {id: 999995})
+        MATCH p0 = (n2) -[*2]-()
+        SET n2.marker = 'probe'
+        DETACH DELETE n2
+        CALL merge.node(['Person'], {name: 'ArcadeGenerated'}, {name: 'ArcadeGenerated'}) YIELD node AS alias3
+        RETURN null AS alias0""")).isEqualTo(256);
+
+    assertEveryTraversedNodeWasDeleted();
+    assertThat(countNodes("Person")).as("the procedure merged one node, not one per row").isEqualTo(1);
+  }
+
+  @Test
+  void varLengthTraversalFollowedByDetachDeleteCompletesInsideAnExplicitTransaction() {
+    // The same statement inside a caller-owned transaction: the deferred write reaches a commit the statement does
+    // not own, so nothing about the drop of a write to an already-deleted record may depend on who commits.
+    database.transaction(() -> assertThat(countRows("""
+        MERGE (:DeadlockProbe {id: 999995})
+        MATCH p0 = (n2) -[*2]-()
+        SET n2.marker = 'probe'
+        DETACH DELETE n2
+        CALL merge.node(['Person'], {name: 'ArcadeGenerated'}, {name: 'ArcadeGenerated'}) YIELD node AS alias3
+        RETURN null AS alias0""")).isEqualTo(256));
+
+    assertEveryTraversedNodeWasDeleted();
+  }
+
+  @Test
+  void aSetOnANodeThatSurvivesIsStillWritten() {
+    // Regression guard for the drop: only a write to a node this statement has already deleted may vanish.
+    assertThat(countRows("MATCH (n:N {id: 5}) SET n.marker = 'kept' RETURN n")).isEqualTo(1);
+
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:N {id: 5}) RETURN n.marker AS marker")) {
+      assertThat(rs.next().<String>getProperty("marker")).isEqualTo("kept");
+    }
+  }
+}


### PR DESCRIPTION
Closes #7149.

## What was reported

A 2-hop variable-length traversal whose 256 rows repeat 128 nodes, with `SET` and `DETACH DELETE` on the traversed node, answered a **single** Bolt client with `Neo.TransientError.Transaction.DeadlockDetected`.

Reproduced verbatim against the reporter's image (`arcadedata/arcadedb@sha256:f5f66ea9...`, build `e823ffbe2`, 2026-08-31). Over HTTP the same setup gives the real error:

```
com.arcadedb.exception.ConcurrentModificationException:
Record #1:101 updated in transaction was deleted by a concurrent transaction
```

There was no concurrent transaction.

## Two layers

**The query itself already completes on `main`.** The eager gate widened for #7023 (PR #7051, 2026-09-02, after the reporter's image was built) now reads the traversal to completion before applying the first deletion, so every `SET` lands while its node is still there - which is what Neo4j's own Eager operator does for this shape. Bisected: fails at `e6e2f0422`, passes at `9f79c9627`.

**The engine defect behind the misleading error is still live**, and is reachable from any caller that keeps a record across an in-transaction delete (proved by a plain engine-API test on `main`, pre-fix):

- a write to a record the SAME transaction already deleted was queued for the deferred commit-time flush like any other update;
- `commit1stPhase()` then found the record gone and raised `ConcurrentModificationException` blaming a concurrent transaction that never existed;
- that is a `NeedRetryException`, so the caller re-ran the whole command `arcadedb.txRetries` times against a state that could never change;
- and Bolt finally classified it as a transient deadlock, telling the driver to retry a statement that can never succeed.

## The fix

The delete wins. `TransactionContext.addUpdatedRecord()` drops a write to a record `deletedRecordsInTx` already holds and answers `false`, so `LocalDatabase.updateRecord()` skips the index maintenance and the after-update events with it.

This restores the symmetry the commit-time arm's own comment already assumes - *"an in-tx delete removes the entry from updatedRecords and never gets here"* - which only held for the other order, where `removeRecordFromCache()` drops an update queued **before** the delete. The commit-time arm stays for what it was written for (#4959): a delete by a genuinely **concurrent** transaction, which no local state can show.

Dropping the write is unobservable rather than lossy: the record cannot exist at commit either way, which is also the outcome Neo4j's Eager produces for the same query.

## Tests

- `Issue7149UpdateAfterDeleteInSameTxTest` (engine) - the phantom conflict is gone; the dropped write leaves **no phantom index entry** resurrecting the key the delete removed; other records in the same transaction still commit; the symmetric order stays dropped. Verified to fail without the fix (2 of 4 red, on the exact `ConcurrentModificationException`).
- `CypherVarLengthDetachDeleteIssue7149Test` (engine) - the issue's query and its control, on the reporter's 128-node/72-relationship graph, in autocommit and inside a caller-owned transaction, asserting the control's 256 rows and that no marked node survives the delete.
- `Bolt7149VarLengthDetachDeleteIT` (bolt) - the wire, where the transient classification happens.

Full engine suite: 14387 tests, 0 failures attributable to this change (one unrelated full-suite timing flake in `ParallelScanSafetyTest`, green in isolation).

## Note on the milestone

The `26.9.1` milestone is closed (released 2026-09-03), so this is filed under `26.10.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction handling when records are updated and deleted within the same transaction.
  * Prevented deleted records from generating false conflicts, stale index entries, or unintended updates.
  * Improved reliability of variable-length traversals combined with `SET` and `DETACH DELETE`.
  * Ensured procedure calls and updates to surviving records continue to work correctly after deletions.

* **Tests**
  * Added regression and end-to-end coverage for these transaction and graph deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->