### PR TITLE
fix(#7153): resolve the FROM target alias, and keep the index when a LET-dependent condition follows

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -420,6 +420,19 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    * whose alias is in scope for the duration of this call.
    */
   private void buildSelectClauses(final SelectStatement stmt, final SQLParser.SelectStatementContext ctx) {
+    // A statement resolves names against ITS OWN output columns, never an enclosing statement's, and the enclosing
+    // scope has to come back afterwards: a nested SELECT can sit inside the very ORDER BY whose scope it would
+    // otherwise clear, leaving the items after it - "ORDER BY (SELECT ...), m" - to read m as the target again.
+    final Set<String> enclosingOutputColumnNames = outputColumnNames;
+    outputColumnNames = null;
+    try {
+      buildSelectClausesInScope(stmt, ctx);
+    } finally {
+      outputColumnNames = enclosingOutputColumnNames;
+    }
+  }
+
+  private void buildSelectClausesInScope(final SelectStatement stmt, final SQLParser.SelectStatementContext ctx) {
     // Projection
     if (ctx.projection() != null) {
       stmt.projection = (Projection) visit(ctx.projection());
@@ -446,7 +459,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         stmt.orderBy = (OrderBy) visit(ctx.orderBy());
       }
     } finally {
-      outputColumnNames = null;
+      outputColumnNames = null; // no other clause resolves against the output columns
     }
 
     // UNWIND clause
@@ -5038,6 +5051,17 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Left modifier (optional)
     if (ctx.modifier() != null) {
       item.leftModifier = (Modifier) visit(ctx.modifier());
+    }
+
+    // The assignment target is built from a propertyName rather than an expression, so it does not pass through
+    // visitIdentifierChain() and needs the target alias resolved here. Without it, UPDATE Main m SET m.touched = 1
+    // reads a property named m off the record and writes touched INSIDE that (absent) nested value, silently
+    // setting nothing the statement asked for (issue #7153).
+    if (item.leftModifier != null && item.leftModifier.suffix != null && item.leftModifier.suffix.identifier != null
+        && !item.leftModifier.suffix.star && !item.leftModifier.squareBrackets && item.leftModifier.methodCall == null
+        && item.left.getStringValue().equals(targetAliases.peek())) {
+      item.left = item.leftModifier.suffix.identifier;
+      item.leftModifier = item.leftModifier.next;
     }
 
     // Operator

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -257,6 +257,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   private final Deque<String> targetAliases = new ArrayDeque<>();
 
   /**
+   * The output column names of the SELECT whose ORDER BY or GROUP BY is being built, or {@code null} everywhere
+   * else. A name that appears in this set outranks the target alias for the duration - see
+   * {@link #resolveTargetAlias}.
+   */
+  private Set<String> outputColumnNames;
+
+  /**
    * Opens the alias scope of a statement whose target has just been built. Every {@link #pushTargetAlias} must be
    * paired with a {@link #popTargetAlias} in a finally block, so that a parse error inside one statement cannot
    * leave a stale alias in scope for the next.
@@ -268,6 +275,25 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
   private void popTargetAlias() {
     targetAliases.pop();
+  }
+
+  /**
+   * The names the projection gives its columns - the explicit {@code AS} aliases, and the expression's own text
+   * where it has none. {@code null} when there is nothing to shadow the target alias with, so the common case costs
+   * no set at all.
+   */
+  private static Set<String> outputColumnNames(final Projection projection) {
+    if (projection == null || projection.getItems() == null || projection.getItems().isEmpty())
+      return null;
+
+    final Set<String> names = new HashSet<>(projection.getItems().size());
+    for (final ProjectionItem item : projection.getItems()) {
+      final String name = item.getProjectionAliasAsString();
+      if (name != null)
+        names.add(name);
+    }
+
+    return names.isEmpty() ? null : names;
   }
 
   /**
@@ -301,6 +327,15 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       return expr;
 
     final Modifier first = expr.modifier;
+
+    // ORDER BY and GROUP BY name output columns before they name anything else, which is what SQL says and what
+    // the ORDER BY step does: it resolves a bare name against the projected row. So in
+    // "SELECT code AS m FROM Main m ORDER BY m" the trailing m is the column, not the target - rewriting it to
+    // @this would have sorted by the whole record, silently and in no useful order. Only a bare name is claimed
+    // this way: "ORDER BY m.code" still reads m as the target alias, since a column reference does not need one.
+    if (first == null && outputColumnNames != null && outputColumnNames.contains(alias))
+      return expr;
+
     if (first != null && first.suffix != null && !first.suffix.star && !first.squareBrackets && first.methodCall == null) {
       // "m.code": the qualifier adds nothing, so drop it and let the property address the record directly. This is
       // the shape the index matcher has to see.
@@ -400,14 +435,18 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       stmt.whereClause = (WhereClause) visit(ctx.whereClause());
     }
 
-    // GROUP BY clause
-    if (ctx.groupBy() != null) {
-      stmt.groupBy = (GroupBy) visit(ctx.groupBy());
-    }
+    // GROUP BY and ORDER BY, built with the output column names in scope so that they outrank the target alias
+    outputColumnNames = outputColumnNames(stmt.projection);
+    try {
+      if (ctx.groupBy() != null) {
+        stmt.groupBy = (GroupBy) visit(ctx.groupBy());
+      }
 
-    // ORDER BY clause
-    if (ctx.orderBy() != null) {
-      stmt.orderBy = (OrderBy) visit(ctx.orderBy());
+      if (ctx.orderBy() != null) {
+        stmt.orderBy = (OrderBy) visit(ctx.orderBy());
+      }
+    } finally {
+      outputColumnNames = null;
     }
 
     // UNWIND clause

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -279,6 +279,14 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    * planner matches index conditions syntactically, so an alias left in place does not merely cost the index - the
    * plan reads {@code m.code} as a property named {@code m} and answers the query with no rows at all (issue #7153).
    *
+   * <p>
+   * One shape is deliberately out of reach: the {@link #FUNCTION_NAMESPACES} fast path earlier in
+   * {@link #visitIdentifierChain} matches on the literal base identifier before this runs, so aliasing a target with
+   * a namespace name and then calling a method of that namespace on it ({@code SELECT FROM Foo map WHERE
+   * map.get('x') = 1}) still parses as the namespaced function {@code map.get}. That ambiguity predates aliases -
+   * it applies to any property named {@code map}, {@code ts}, {@code geo}, ... - and is left as is; backtick-quote
+   * the alias, or pick another one, to address the record instead.
+   *
    * @return {@code expr}, rewritten in place when it was alias-qualified
    */
   private BaseExpression resolveTargetAlias(final BaseExpression expr) {
@@ -480,6 +488,17 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchStatement visitMatchStatement(final SQLParser.MatchStatementContext ctx) {
+    // MATCH has no FROM target: its patterns declare their own aliases ({as: a}) and RETURN addresses them as
+    // "a.property". Shadow any enclosing SELECT's target alias so it cannot rewrite those (issue #7153).
+    pushTargetAlias(null);
+    try {
+      return buildMatchStatement(ctx);
+    } finally {
+      popTargetAlias();
+    }
+  }
+
+  private MatchStatement buildMatchStatement(final SQLParser.MatchStatementContext ctx) {
     final MatchStatement stmt = new MatchStatement();
 
     // Parse match expressions (both positive and negative patterns)
@@ -563,6 +582,18 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchStatement visitMatchStmt(final SQLParser.MatchStmtContext ctx) {
+    // see visitMatchStatement. Not delegated to buildMatchStatement(): that one applies LIMIT through
+    // Statement.setLimit(), which drops a negative bound, while this one assigns it - a difference this change is
+    // not the place to settle.
+    pushTargetAlias(null);
+    try {
+      return buildTopLevelMatchStatement(ctx);
+    } finally {
+      popTargetAlias();
+    }
+  }
+
+  private MatchStatement buildTopLevelMatchStatement(final SQLParser.MatchStmtContext ctx) {
     final MatchStatement stmt = new MatchStatement();
 
     // Get the matchStatement context from the labeled alternative
@@ -1455,6 +1486,27 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Get the traverseStatement context from the labeled alternative
     final SQLParser.TraverseStatementContext traverseCtx = ctx.traverseStatement();
 
+    // FROM clause (required), built first so that its alias - and only its alias - is in scope for the projections
+    // and the WHILE clause below. A TRAVERSE nested in an aliased SELECT must not inherit that SELECT's alias: the
+    // name would still refer to the outer record (issue #7153).
+    if (traverseCtx.fromClause() != null) {
+      stmt.setTarget((FromClause) visit(traverseCtx.fromClause()));
+    }
+
+    pushTargetAlias(stmt.getTarget());
+    try {
+      buildTraverseClauses(stmt, traverseCtx);
+    } finally {
+      popTargetAlias();
+    }
+
+    return stmt;
+  }
+
+  /**
+   * Builds every TRAVERSE clause but the target, whose alias is in scope for the duration of this call.
+   */
+  private void buildTraverseClauses(final TraverseStatement stmt, final SQLParser.TraverseStatementContext traverseCtx) {
     // Parse projection items (optional)
     final List<TraverseProjectionItem> projections = new ArrayList<>();
     if (CollectionUtils.isNotEmpty(traverseCtx.traverseProjectionItem())) {
@@ -1464,11 +1516,6 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       }
     }
     stmt.setProjections(projections);
-
-    // FROM clause (required)
-    if (traverseCtx.fromClause() != null) {
-      stmt.setTarget((FromClause) visit(traverseCtx.fromClause()));
-    }
 
     // MAXDEPTH clause (optional)
     if (traverseCtx.pInteger() != null) {
@@ -1496,8 +1543,6 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     if (traverseCtx.timeout() != null) {
       stmt.timeout = (Timeout) visit(traverseCtx.timeout());
     }
-
-    return stmt;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -207,8 +207,10 @@ import com.arcadedb.utility.CollectionUtils;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -242,6 +244,69 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       "map", "agg", "node", "rel", "path", "create");
 
   private int positionalParamCounter = 0;
+
+  /**
+   * Pushed for a statement whose target carries no alias. {@link ArrayDeque} rejects nulls, and a marker is needed
+   * rather than simply pushing nothing: a nested statement must NOT inherit the enclosing statement's alias, because
+   * inside it that name still refers to the OUTER record and stripping it would silently re-point the reference at
+   * the inner one.
+   */
+  private static final String NO_TARGET_ALIAS = "";
+
+  /** Target aliases of the statements currently being built, innermost first. See {@link #resolveTargetAlias}. */
+  private final Deque<String> targetAliases = new ArrayDeque<>();
+
+  /**
+   * Opens the alias scope of a statement whose target has just been built. Every {@link #pushTargetAlias} must be
+   * paired with a {@link #popTargetAlias} in a finally block, so that a parse error inside one statement cannot
+   * leave a stale alias in scope for the next.
+   */
+  private void pushTargetAlias(final FromClause target) {
+    final Identifier alias = target != null && target.getItem() != null ? target.getItem().getAlias() : null;
+    targetAliases.push(alias == null ? NO_TARGET_ALIAS : alias.getStringValue());
+  }
+
+  private void popTargetAlias() {
+    targetAliases.pop();
+  }
+
+  /**
+   * Resolves a reference qualified by the target alias of the statement being built: given {@code SELECT FROM Main m},
+   * rewrites {@code m.code} into {@code code} and a bare {@code m} into {@code @this}.
+   * <p>
+   * The rewrite happens here, at parse time, rather than in the planner, for two reasons. It is done once per
+   * statement text and then cached with the statement, so no execution pays for it; and, more importantly, the
+   * planner matches index conditions syntactically, so an alias left in place does not merely cost the index - the
+   * plan reads {@code m.code} as a property named {@code m} and answers the query with no rows at all (issue #7153).
+   *
+   * @return {@code expr}, rewritten in place when it was alias-qualified
+   */
+  private BaseExpression resolveTargetAlias(final BaseExpression expr) {
+    final String alias = targetAliases.peek();
+    if (alias == null || alias.isEmpty())
+      return expr;
+
+    final BaseIdentifier baseId = expr.identifier;
+    if (baseId == null || baseId.suffix == null || baseId.suffix.identifier == null)
+      return expr;
+    if (!alias.equals(baseId.suffix.identifier.getStringValue()))
+      return expr;
+
+    final Modifier first = expr.modifier;
+    if (first != null && first.suffix != null && !first.suffix.star && !first.squareBrackets && first.methodCall == null) {
+      // "m.code": the qualifier adds nothing, so drop it and let the property address the record directly. This is
+      // the shape the index matcher has to see.
+      baseId.suffix = first.suffix;
+      expr.modifier = first.next;
+    } else {
+      // A bare "m", or one followed by a method call, an array selector or ".*": the alias IS the record, and
+      // whatever follows applies to the record itself.
+      final RecordAttribute self = new RecordAttribute();
+      self.setName(Property.THIS_PROPERTY);
+      baseId.suffix = new SuffixIdentifier(self);
+    }
+    return expr;
+  }
 
   // ENTRY POINTS
 
@@ -291,14 +356,30 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   public SelectStatement visitSelectStatement(final SQLParser.SelectStatementContext ctx) {
     final SelectStatement stmt = new SelectStatement();
 
+    // FROM clause. Visited before every other clause even though it is not written first: the target may declare an
+    // alias, and the clauses below are the ones that reference it (issue #7153).
+    if (ctx.fromClause() != null) {
+      stmt.target = (FromClause) visit(ctx.fromClause());
+    }
+
+    pushTargetAlias(stmt.target);
+    try {
+      buildSelectClauses(stmt, ctx);
+    } finally {
+      popTargetAlias();
+    }
+
+    return stmt;
+  }
+
+  /**
+   * Builds every SELECT clause but the target, which the two {@code selectStatement} visitors have already built and
+   * whose alias is in scope for the duration of this call.
+   */
+  private void buildSelectClauses(final SelectStatement stmt, final SQLParser.SelectStatementContext ctx) {
     // Projection
     if (ctx.projection() != null) {
       stmt.projection = (Projection) visit(ctx.projection());
-    }
-
-    // FROM clause
-    if (ctx.fromClause() != null) {
-      stmt.target = (FromClause) visit(ctx.fromClause());
     }
 
     // LET clause
@@ -338,8 +419,6 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     if (ctx.timeout() != null) {
       stmt.timeout = (Timeout) visit(ctx.timeout());
     }
-
-    return stmt;
   }
 
   /**
@@ -353,54 +432,16 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Get the selectStatement context from the labeled alternative
     final SQLParser.SelectStatementContext selectCtx = ctx.selectStatement();
 
-    // Projection
-    if (selectCtx.projection() != null) {
-      stmt.projection = (Projection) visit(selectCtx.projection());
-    }
-
-    // FROM clause
+    // FROM clause, built first so that a target alias is in scope for every clause that can reference it (#7153)
     if (selectCtx.fromClause() != null) {
       stmt.target = (FromClause) visit(selectCtx.fromClause());
     }
 
-    // LET clause
-    if (selectCtx.letClause() != null) {
-      stmt.letClause = (LetClause) visit(selectCtx.letClause());
-    }
-
-    // WHERE clause
-    if (selectCtx.whereClause() != null) {
-      stmt.whereClause = (WhereClause) visit(selectCtx.whereClause());
-    }
-
-    // GROUP BY clause
-    if (selectCtx.groupBy() != null) {
-      stmt.groupBy = (GroupBy) visit(selectCtx.groupBy());
-    }
-
-    // ORDER BY clause
-    if (selectCtx.orderBy() != null) {
-      stmt.orderBy = (OrderBy) visit(selectCtx.orderBy());
-    }
-
-    // UNWIND clause
-    if (selectCtx.unwind() != null) {
-      stmt.unwind = (Unwind) visit(selectCtx.unwind());
-    }
-
-    // SKIP clause
-    if (selectCtx.skip() != null) {
-      stmt.skip = (Skip) visit(selectCtx.skip());
-    }
-
-    // LIMIT clause
-    if (selectCtx.limit() != null) {
-      stmt.limit = (Limit) visit(selectCtx.limit());
-    }
-
-    // TIMEOUT clause
-    if (selectCtx.timeout() != null) {
-      stmt.timeout = (Timeout) visit(selectCtx.timeout());
+    pushTargetAlias(stmt.target);
+    try {
+      buildSelectClauses(stmt, selectCtx);
+    } finally {
+      popTargetAlias();
     }
 
     return stmt;
@@ -1743,9 +1784,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   public FromItem visitFromIdentifier(final SQLParser.FromIdentifierContext ctx) {
     final FromItem fromItem = new FromItem();
 
-    // Identifier is the main FROM target (alias, if present, is the second identifier and ignored in execution)
+    // The first identifier is the FROM target; a second one is the target alias (FROM User u / FROM User AS u).
+    // The alias is consumed by resolveTargetAlias(), which rewrites every "u.property" reference in the rest of
+    // the statement into a plain "property" so that it addresses the record the target yields (issue #7153).
     if (ctx.identifier() != null && !ctx.identifier().isEmpty()) {
       fromItem.identifier = (Identifier) visit(ctx.identifier(0));
+      if (ctx.identifier().size() > 1)
+        fromItem.alias = (Identifier) visit(ctx.identifier(1));
     }
 
     // Handle modifiers if present - chain them using modifier.next
@@ -3584,7 +3629,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       }
     }
 
-    return baseExpr;
+    return resolveTargetAlias(baseExpr);
   }
 
   /**
@@ -4761,6 +4806,20 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Target
     stmt.target = (FromClause) visit(updateCtx.fromClause());
 
+    pushTargetAlias(stmt.target);
+    try {
+      buildUpdateClauses(stmt, updateCtx);
+    } finally {
+      popTargetAlias();
+    }
+
+    return stmt;
+  }
+
+  /**
+   * Builds every UPDATE clause but the target, whose alias is in scope for the duration of this call (issue #7153).
+   */
+  private void buildUpdateClauses(final UpdateStatement stmt, final SQLParser.UpdateStatementContext updateCtx) {
     // Update operations (SET, ADD, PUT, REMOVE, INCREMENT, MERGE, CONTENT)
     for (final SQLParser.UpdateOperationContext opCtx : updateCtx.updateOperation()) {
       final UpdateOperations ops = (UpdateOperations) visit(opCtx);
@@ -4814,8 +4873,6 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     if (updateCtx.timeout() != null) {
       stmt.timeout = (Timeout) visit(updateCtx.timeout());
     }
-
-    return stmt;
   }
 
   /**
@@ -4968,6 +5025,20 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // FROM clause
     stmt.fromClause = (FromClause) visit(deleteCtx.fromClause());
 
+    pushTargetAlias(stmt.fromClause);
+    try {
+      buildDeleteClauses(stmt, deleteCtx);
+    } finally {
+      popTargetAlias();
+    }
+
+    return stmt;
+  }
+
+  /**
+   * Builds every DELETE clause but the target, whose alias is in scope for the duration of this call (issue #7153).
+   */
+  private void buildDeleteClauses(final DeleteStatement stmt, final SQLParser.DeleteStatementContext deleteCtx) {
     // RETURN BEFORE flag
     stmt.returnBefore = deleteCtx.RETURN() != null && deleteCtx.BEFORE() != null;
 
@@ -5000,8 +5071,6 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // UNSAFE flag
     stmt.unsafe = deleteCtx.UNSAFE() != null;
-
-    return stmt;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryPlanningInfo.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryPlanningInfo.java
@@ -65,6 +65,14 @@ public class QueryPlanningInfo {
 
   FromClause     target;
   WhereClause    whereClause;
+
+  /**
+   * The part of the WHERE clause an index search left behind that has to be evaluated AFTER the per-record LET,
+   * because it reads a variable the LET computes. {@code SelectExecutionPlanner.handleTypeAsTargetWithIndex()} moves
+   * it back into {@link #whereClause} so that {@code handleWhere()} chains it downstream of {@code handleLet()};
+   * every other residual is filtered inside the fetch plan instead. Issue #7153.
+   */
+  WhereClause    deferredLetWhereClause;
   List<AndBlock> flattenedWhereClause;
   GroupBy        groupBy;
   OrderBy        orderBy;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -450,7 +450,9 @@ public class SelectExecutionPlanner {
     if (!isMinimalQuery(info))
       return false;
 
-    result.chain(new CountFromTypeStep(info.target.toString(), info.projection.getAllAliases().getFirst(), context));
+    // The type name, not the rendered target: FromItem.toString() appends " AS <alias>" when the statement declared
+    // one, and CountFromTypeStep looks its argument up in the schema (issue #7153).
+    result.chain(new CountFromTypeStep(targetClass.getStringValue(), info.projection.getAllAliases().getFirst(), context));
     handleSkipAndLimitAfterHardwired(result, info, context);
     return true;
   }
@@ -1191,8 +1193,8 @@ public class SelectExecutionPlanner {
           return;
         }
       } else {
-        final String targetStr = target.toString();
-        variableValue = context.getVariablePath(targetStr);
+        // without the alias: this is resolved as a variable path, and " AS <alias>" is not part of one
+        variableValue = context.getVariablePath(target.toStringWithoutAlias());
       }
       if (variableValue != null) {
         // Handle single Result object (e.g., from $parent.$current)
@@ -3226,7 +3228,7 @@ public class SelectExecutionPlanner {
           // a different evaluation than the full-text index semantics.
           final BooleanExpression remaining = bestIndex.getRemainingCondition();
           if (remaining != null && !remaining.isEmpty()) {
-            if (info.perRecordLetClause != null && refersToLet(Collections.singletonList(remaining))) {
+            if (refersToLet(Collections.singletonList(remaining), info.perRecordLetClause)) {
               handleLet(subPlan, info, context);
             }
             subPlan.chain(new FilterStep(createWhereFrom(remaining), context));
@@ -3238,7 +3240,7 @@ public class SelectExecutionPlanner {
               statement.getLimit() != null ? statement.getLimit().getValue(context) : 0);
           subPlan.chain(step);
           if (!block.getSubBlocks().isEmpty()) {
-            if (info.perRecordLetClause != null && refersToLet(block.getSubBlocks())) {
+            if (refersToLet(block.getSubBlocks(), info.perRecordLetClause)) {
               handleLet(subPlan, info, context);
             }
             subPlan.chain(new FilterStep(createWhereFrom(block), context));
@@ -3286,7 +3288,7 @@ public class SelectExecutionPlanner {
           plan.chain(step);
           plan.chain(new FilterByClustersStep(filterClusters, context));
           if (!block.getSubBlocks().isEmpty()) {
-            if (info.perRecordLetClause != null && refersToLet(block.getSubBlocks())) {
+            if (refersToLet(block.getSubBlocks(), info.perRecordLetClause)) {
               handleLet(plan, info, context);
             }
             plan.chain(new FilterStep(createWhereFrom(block), context));
@@ -3321,15 +3323,27 @@ public class SelectExecutionPlanner {
     }
   }
 
-  private static boolean refersToLet(final List<BooleanExpression> subBlocks) {
-    if (subBlocks == null)
+  /**
+   * Whether any of {@code subBlocks} reads one of the variables {@code letClause} declares.
+   * <p>
+   * Matched by name, on the rendered condition: a variable reference is not always the whole expression
+   * ({@code #X:Y IN $brain} reads one), and there is no generic walker over the expression AST to ask instead.
+   * Matching the declared names rather than a bare {@code "$"} keeps a string literal that merely contains the
+   * character ({@code WHERE currency = 'US$'}) from counting as a reference, which would cost the statement an
+   * index it could have used (issue #7153).
+   */
+  private static boolean refersToLet(final List<BooleanExpression> subBlocks, final LetClause letClause) {
+    if (subBlocks == null || letClause == null || letClause.getItems() == null)
       return false;
 
-    for (BooleanExpression exp : subBlocks) {
-      // Check if expression contains a variable reference (starts with or contains "$")
-      // An expression like "#X:Y IN $brain" doesn't start with "$" but contains a variable reference
-      if (exp.toString().contains("$"))
-        return true;
+    for (final BooleanExpression exp : subBlocks) {
+      final String rendered = exp.toString();
+      if (rendered.indexOf('$') < 0)
+        continue;
+
+      for (final LetItem item : letClause.getItems())
+        if (rendered.contains(item.getVarName().getStringValue()))
+          return true;
     }
     return false;
   }
@@ -3558,8 +3572,8 @@ public class SelectExecutionPlanner {
   /**
    * @param allowDeferredLetFilter whether a residual condition that reads a per-record LET variable may be deferred to
    *                               the statement's WHERE clause. Only the single, top-level target can do that: there
-   *                               is one WHERE clause to defer into, so a per-sub-type or per-OR-branch residual has
-   *                               to give the index up instead (issue #7153).
+   *                               is one WHERE clause to defer into, so a per-sub-type residual has to give the
+   *                               index up instead (issue #7153).
    */
   private List<ExecutionStepInternal> handleTypeAsTargetWithIndex(final String targetType, final Set<String> filterBuckets,
       final QueryPlanningInfo info, final CommandContext context, final boolean allowDeferredLetFilter) {
@@ -3624,9 +3638,8 @@ public class SelectExecutionPlanner {
       if (needsFilterStep(desc.getRemainingCondition(), context)) {
         if (refersToPerRecordLet(info, desc.getRemainingCondition())) {
           if (!allowDeferredLetFilter)
-            // A sub-type or OR branch: the residual would have to be deferred per branch, and there is only one
-            // WHERE clause to defer it into. Give the whole statement up to the plain scan, which evaluates the
-            // filter after the LET by construction.
+            // One sub-plan per sub-type, each with its own residual, and a single WHERE clause to defer into. Give
+            // the whole statement up to the plain scan, which evaluates the filter after the LET by construction.
             return null;
 
           // The residual reads a variable the per-record LET computes, and the LET steps run downstream of this
@@ -3639,10 +3652,14 @@ public class SelectExecutionPlanner {
           result.add(new FilterStep(createWhereFrom(desc.getRemainingCondition()), context));
       }
     } else {
+      // Defensive, and not reachable through a SELECT today: handleTypeAsTargetWithIndexedFunction() runs first at
+      // both call sites and claims every multi-block WHERE, so an OR reaches its own per-branch planning - which
+      // chains the LET into each sub-plan correctly, because that sub-plan is not empty by then. Kept because this
+      // branch chains residual filters of its own, and one reading a per-record LET would be evaluated with the
+      // variable unset, which is a wrong answer rather than a lost optimisation.
       for (final IndexSearchDescriptor desc : optimumIndexSearchDescriptors)
         if (needsFilterStep(desc.getRemainingCondition(), context) && refersToPerRecordLet(info,
             desc.getRemainingCondition()))
-          // One OR branch per sub-plan, each with its own residual: see above.
           return null;
 
       result = new ArrayList<>();
@@ -3660,7 +3677,7 @@ public class SelectExecutionPlanner {
    * is not set yet) or has to wait for the LET steps downstream of it.
    */
   private static boolean refersToPerRecordLet(final QueryPlanningInfo info, final BooleanExpression condition) {
-    return info.perRecordLetClause != null && refersToLet(Collections.singletonList(condition));
+    return refersToLet(Collections.singletonList(condition), info.perRecordLetClause);
   }
 
   private boolean fullySorted(final OrderBy orderBy, final AndBlock conditions, final Index idx) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3368,11 +3368,28 @@ public class SelectExecutionPlanner {
    * Callers that only need to know whether ANY variable is mentioned test the result for emptiness. That is the
    * right question for a filter the planner wants to evaluate inside the fetch: {@code $current} and {@code $parent}
    * are no more available there than a per-record LET is.
+   * <p>
+   * Quoted runs - string literals and backtick-quoted identifiers - are skipped whole, so nothing inside one is
+   * read as a reference. Erring here is one-directional by construction: a real {@code $name} always survives the
+   * scan, so the answer can only ever be too generous, and too generous costs an optimisation rather than a row.
    */
   private static List<String> variableNamesIn(final String rendered) {
     List<String> names = null;
 
-    for (int i = rendered.indexOf('$'); i >= 0; i = rendered.indexOf('$', i + 1)) {
+    for (int i = 0; i < rendered.length(); ++i) {
+      final char c = rendered.charAt(i);
+
+      // A quoted run is data, not SQL: skip it whole rather than reading the names it may spell. WHERE note =
+      // 'see $relation' names no variable, and a backtick-quoted `$relation` is a property whose name starts with
+      // the character. Both used to read as a LET reference.
+      if (c == '\'' || c == '"' || c == '`') {
+        i = endOfQuotedRun(rendered, i);
+        continue;
+      }
+
+      if (c != '$')
+        continue;
+
       int end = i + 1;
       while (end < rendered.length() && Character.isJavaIdentifierPart(rendered.charAt(end)))
         ++end;
@@ -3383,9 +3400,29 @@ public class SelectExecutionPlanner {
       if (names == null)
         names = new ArrayList<>(2);
       names.add(rendered.substring(i + 1, end));
+      i = end - 1;
     }
 
     return names == null ? Collections.emptyList() : names;
+  }
+
+  /**
+   * The index of the closing quote of the run {@code rendered.charAt(start)} opens, honouring backslash escapes, or
+   * the last index of the string when the run is unterminated - which a rendered statement should never contain, and
+   * which is answered this way so the caller's loop ends rather than reading the rest as SQL.
+   */
+  private static int endOfQuotedRun(final String rendered, final int start) {
+    final char quote = rendered.charAt(start);
+
+    for (int i = start + 1; i < rendered.length(); ++i) {
+      final char c = rendered.charAt(i);
+      if (c == '\\')
+        ++i;
+      else if (c == quote)
+        return i;
+    }
+
+    return rendered.length() - 1;
   }
 
   private List<Integer> classClustersFiltered(final Database db, final DocumentType clazz, final Set<String> filterClusters) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -1947,7 +1947,7 @@ public class SelectExecutionPlanner {
     // so there is no "materialize everything then discard it" cost here to reclaim.
     // Skip pushdown when WHERE references LET variables ($), since LET is evaluated after fetch.
     final boolean whereRefersToLet = info.perRecordLetClause != null && info.whereClause != null
-        && info.whereClause.toString().contains("$");
+        && !variableNamesIn(info.whereClause.toString()).isEmpty();
     if (info.whereClause != null && info.whereClause.baseExpression != null && !whereRefersToLet) {
       final FetchFromTypeWithFilterStep fetcher = new FetchFromTypeWithFilterStep(identifier.getStringValue(), effectiveClusters,
           info.whereClause, context, orderByRidAsc);
@@ -1988,7 +1988,7 @@ public class SelectExecutionPlanner {
     // method (called from handleFetchFromTarget). Chaining it into a FilterStep on the fetch-side
     // plan would evaluate it before LET populates the variable, silently dropping every row. Defer
     // to the normal scan path, which applies WHERE only after LET. See issue #5856.
-    if (info.perRecordLetClause != null && info.whereClause != null && info.whereClause.toString().contains("$"))
+    if (info.perRecordLetClause != null && info.whereClause != null && !variableNamesIn(info.whereClause.toString()).isEmpty())
       return false;
 
     final AndBlock andBlock = info.flattenedWhereClause.getFirst();
@@ -2158,7 +2158,7 @@ public class SelectExecutionPlanner {
   /** Whether any sub-block of {@code andBlock} other than the one at {@code skipIndex} mentions a variable. */
   private static boolean referencesAVariableOutside(final AndBlock andBlock, final int skipIndex) {
     for (int i = 0; i < andBlock.getSubBlocks().size(); i++)
-      if (i != skipIndex && andBlock.getSubBlocks().get(i).toString().contains("$"))
+      if (i != skipIndex && !variableNamesIn(andBlock.getSubBlocks().get(i).toString()).isEmpty())
         return true;
 
     return false;
@@ -3298,6 +3298,12 @@ public class SelectExecutionPlanner {
               statement.getLimit() != null ? statement.getLimit().getValue(context) : 0);
           subPlan.chain(step);
           if (!block.getSubBlocks().isEmpty()) {
+            // Same guard as every sibling branch: a residual that reads a per-record LET variable has to be filtered
+            // downstream of the LET steps, or it is evaluated with the variable unset and drops every row of this
+            // branch. This one was missing it (issue #7153).
+            if (refersToLet(block.getSubBlocks(), info.perRecordLetClause)) {
+              handleLet(subPlan, info, context);
+            }
             subPlan.chain(new FilterStep(createWhereFrom(block), context));
           }
           resultSubPlans.add(subPlan);
@@ -3326,26 +3332,60 @@ public class SelectExecutionPlanner {
   /**
    * Whether any of {@code subBlocks} reads one of the variables {@code letClause} declares.
    * <p>
-   * Matched by name, on the rendered condition: a variable reference is not always the whole expression
-   * ({@code #X:Y IN $brain} reads one), and there is no generic walker over the expression AST to ask instead.
-   * Matching the declared names rather than a bare {@code "$"} keeps a string literal that merely contains the
-   * character ({@code WHERE currency = 'US$'}) from counting as a reference, which would cost the statement an
-   * index it could have used (issue #7153).
+   * Read off the rendered condition rather than walked on the AST: a variable reference is not always the whole
+   * expression ({@code #X:Y IN $brain} reads one), and there is no generic walker over the expression nodes to ask
+   * instead. The names are compared whole, so a LET named {@code rel} is not found in {@code 'no relation'}
+   * (issue #7153).
+   * <p>
+   * Compared with the leading {@code $} stripped from both sides: the grammar takes a LET name as a plain
+   * identifier, so {@code LET brain = out(...)} and {@code LET $brain = out(...)} both declare the variable that
+   * {@code $brain} reads, and only one of the two spellings carries the sigil.
    */
   private static boolean refersToLet(final List<BooleanExpression> subBlocks, final LetClause letClause) {
-    if (subBlocks == null || letClause == null || letClause.getItems() == null)
+    if (subBlocks == null || letClause == null || letClause.getItems() == null || letClause.getItems().isEmpty())
       return false;
 
-    for (final BooleanExpression exp : subBlocks) {
-      final String rendered = exp.toString();
-      if (rendered.indexOf('$') < 0)
+    for (final BooleanExpression exp : subBlocks)
+      for (final String name : variableNamesIn(exp.toString()))
+        for (final LetItem item : letClause.getItems())
+          if (name.equals(withoutSigil(item.getVarName().getStringValue())))
+            return true;
+
+    return false;
+  }
+
+  private static String withoutSigil(final String variableName) {
+    return variableName.startsWith("$") ? variableName.substring(1) : variableName;
+  }
+
+  /**
+   * The context-variable names the rendered SQL mentions, each without its leading {@code $}: every sigil that
+   * actually starts a name, and the name it starts - {@code $parent.$current.x} yields {@code parent} and
+   * {@code current}. A {@code $} that starts nothing is a character inside a string literal, not a reference, which
+   * is the whole point: {@code WHERE currency = 'US$'} used to read as "this condition depends on a LET" and cost
+   * the statement a predicate pushdown, an edge-RID lookup, or an index (issue #7153).
+   * <p>
+   * Callers that only need to know whether ANY variable is mentioned test the result for emptiness. That is the
+   * right question for a filter the planner wants to evaluate inside the fetch: {@code $current} and {@code $parent}
+   * are no more available there than a per-record LET is.
+   */
+  private static List<String> variableNamesIn(final String rendered) {
+    List<String> names = null;
+
+    for (int i = rendered.indexOf('$'); i >= 0; i = rendered.indexOf('$', i + 1)) {
+      int end = i + 1;
+      while (end < rendered.length() && Character.isJavaIdentifierPart(rendered.charAt(end)))
+        ++end;
+
+      if (end == i + 1)
         continue;
 
-      for (final LetItem item : letClause.getItems())
-        if (rendered.contains(item.getVarName().getStringValue()))
-          return true;
+      if (names == null)
+        names = new ArrayList<>(2);
+      names.add(rendered.substring(i + 1, end));
     }
-    return false;
+
+    return names == null ? Collections.emptyList() : names;
   }
 
   private List<Integer> classClustersFiltered(final Database db, final DocumentType clazz, final Set<String> filterClusters) {
@@ -4452,10 +4492,10 @@ public class SelectExecutionPlanner {
       return subQuery;
     if (info.whereClause == null || info.whereClause.getBaseExpression() == null)
       return subQuery;
-    // Conservative: skip if WHERE references parent scope, LET variables, or $current/$parent (anything starting with '$').
+    // Conservative: skip if WHERE references parent scope, LET variables, or $current/$parent - any variable at all.
     if (info.whereClause.refersToParent())
       return subQuery;
-    if (info.whereClause.toString().contains("$"))
+    if (!variableNamesIn(info.whereClause.toString()).isEmpty())
       return subQuery;
 
     final TraverseStatement copy = (TraverseStatement) traverse.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3321,7 +3321,7 @@ public class SelectExecutionPlanner {
     }
   }
 
-  private boolean refersToLet(final List<BooleanExpression> subBlocks) {
+  private static boolean refersToLet(final List<BooleanExpression> subBlocks) {
     if (subBlocks == null)
       return false;
 
@@ -3459,11 +3459,15 @@ public class SelectExecutionPlanner {
       final Set<String> filterBuckets, final QueryPlanningInfo info, final CommandContext context) {
 
     final List<ExecutionStepInternal> result = handleTypeAsTargetWithIndex(targetType.getStringValue(), filterBuckets, info,
-        context);
+        context, true);
 
     if (result != null) {
       result.forEach(plan::chain);
-      info.whereClause = null;
+      // Normally null: the index search consumed the whole WHERE clause, or filtered what it left behind inside the
+      // fetch plan. What survives here is the residual that reads a per-record LET variable, kept as the statement's
+      // WHERE clause so that handleWhere() chains it after handleLet() (issue #7153).
+      info.whereClause = info.deferredLetWhereClause;
+      info.deferredLetWhereClause = null;
       info.flattenedWhereClause = null;
       return true;
     }
@@ -3519,7 +3523,7 @@ public class SelectExecutionPlanner {
 
   private List<ExecutionStepInternal> handleTypeAsTargetWithIndexRecursive(final String targetType, final Set<String> filterBuckets,
       final QueryPlanningInfo info, final CommandContext context) {
-    List<ExecutionStepInternal> result = handleTypeAsTargetWithIndex(targetType, filterBuckets, info, context);
+    List<ExecutionStepInternal> result = handleTypeAsTargetWithIndex(targetType, filterBuckets, info, context, false);
     if (result == null) {
       result = new ArrayList<>();
       final DocumentType typez = context.getDatabase().getSchema().getType(targetType);
@@ -3551,8 +3555,14 @@ public class SelectExecutionPlanner {
     return result.isEmpty() ? null : result;
   }
 
+  /**
+   * @param allowDeferredLetFilter whether a residual condition that reads a per-record LET variable may be deferred to
+   *                               the statement's WHERE clause. Only the single, top-level target can do that: there
+   *                               is one WHERE clause to defer into, so a per-sub-type or per-OR-branch residual has
+   *                               to give the index up instead (issue #7153).
+   */
   private List<ExecutionStepInternal> handleTypeAsTargetWithIndex(final String targetType, final Set<String> filterBuckets,
-      final QueryPlanningInfo info, final CommandContext context) {
+      final QueryPlanningInfo info, final CommandContext context, final boolean allowDeferredLetFilter) {
     if (info.flattenedWhereClause == null || info.flattenedWhereClause.isEmpty())
       return null;
 
@@ -3579,11 +3589,13 @@ public class SelectExecutionPlanner {
     List<IndexSearchDescriptor> optimumIndexSearchDescriptors =
         commonFactor(indexSearchDescriptors);
 
-    return executionStepFromIndexes(filterBuckets, typez, info, context, optimumIndexSearchDescriptors);
+    return executionStepFromIndexes(filterBuckets, typez, info, context, optimumIndexSearchDescriptors,
+        allowDeferredLetFilter);
   }
 
   private List<ExecutionStepInternal> executionStepFromIndexes(final Set<String> filterClusters, final DocumentType clazz,
-      final QueryPlanningInfo info, final CommandContext context, List<IndexSearchDescriptor> optimumIndexSearchDescriptors) {
+      final QueryPlanningInfo info, final CommandContext context, final List<IndexSearchDescriptor> optimumIndexSearchDescriptors,
+      final boolean allowDeferredLetFilter) {
     List<ExecutionStepInternal> result;
     if (optimumIndexSearchDescriptors.size() == 1) {
       final IndexSearchDescriptor desc = optimumIndexSearchDescriptors.getFirst();
@@ -3609,20 +3621,30 @@ public class SelectExecutionPlanner {
       if (orderAsc != null && info.orderBy != null && fullySorted(info.orderBy, (AndBlock) desc.keyCondition, desc.getIndex()))
         info.orderApplied = true;
 
-        if (needsFilterStep(desc.getRemainingCondition(), context)) {
-        if (info.perRecordLetClause != null
-            && refersToLet(Collections.singletonList(desc.getRemainingCondition()))) {
-          SelectExecutionPlan stubPlan = new SelectExecutionPlan(context,
-              statement.getLimit() != null ? statement.getLimit().getValue(context) : 0);
-          handleLet(stubPlan, info, context);
-          for (ExecutionStep step : stubPlan.getSteps()) {
-            result.add((ExecutionStepInternal) step);
-          }
-        }
-        result.add(
-            new FilterStep(createWhereFrom(desc.getRemainingCondition()), context));
+      if (needsFilterStep(desc.getRemainingCondition(), context)) {
+        if (refersToPerRecordLet(info, desc.getRemainingCondition())) {
+          if (!allowDeferredLetFilter)
+            // A sub-type or OR branch: the residual would have to be deferred per branch, and there is only one
+            // WHERE clause to defer it into. Give the whole statement up to the plain scan, which evaluates the
+            // filter after the LET by construction.
+            return null;
+
+          // The residual reads a variable the per-record LET computes, and the LET steps run downstream of this
+          // fetch. Hand it back to the planner rather than filtering here: handleWhere() chains it after
+          // handleLet(), where the variable is finally set. Filtering here would read it unset, and the LET steps
+          // used to be spliced in ahead of the fetch to compensate - which produced a plan whose first step had
+          // nothing to pull from and raised "Cannot execute a local LET on a query without a target" (issue #7153).
+          info.deferredLetWhereClause = createWhereFrom(desc.getRemainingCondition());
+        } else
+          result.add(new FilterStep(createWhereFrom(desc.getRemainingCondition()), context));
       }
     } else {
+      for (final IndexSearchDescriptor desc : optimumIndexSearchDescriptors)
+        if (needsFilterStep(desc.getRemainingCondition(), context) && refersToPerRecordLet(info,
+            desc.getRemainingCondition()))
+          // One OR branch per sub-plan, each with its own residual: see above.
+          return null;
+
       result = new ArrayList<>();
       result.add(createParallelIndexFetch(optimumIndexSearchDescriptors, filterClusters, context));
       if (optimumIndexSearchDescriptors.size() > 1) {
@@ -3630,6 +3652,15 @@ public class SelectExecutionPlanner {
       }
     }
     return result;
+  }
+
+  /**
+   * Whether {@code condition} reads a variable this statement's per-record LET computes. Asked of what an index
+   * search leaves behind, to decide whether that residual can be filtered inside the fetch plan (where the variable
+   * is not set yet) or has to wait for the LET steps downstream of it.
+   */
+  private static boolean refersToPerRecordLet(final QueryPlanningInfo info, final BooleanExpression condition) {
+    return info.perRecordLetClause != null && refersToLet(Collections.singletonList(condition));
   }
 
   private boolean fullySorted(final OrderBy orderBy, final AndBlock conditions, final Index idx) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
@@ -56,6 +56,9 @@ public class FromItem extends SimpleNode {
    * the rendered text as a name - a schema type for {@code CountFromTypeStep}, a context variable path - must use
    * this: an alias names the rows the target yields, and is never part of the target's own name. Looking up
    * {@code "Main AS m"} as a type finds nothing (issue #7153).
+   * <p>
+   * Rendered with no parameter map, exactly as the no-argument {@link #toString()} is: a name resolved out of this
+   * text is a schema or context name, never a bound value.
    */
   public String toStringWithoutAlias() {
     final StringBuilder builder = new StringBuilder();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
@@ -48,6 +48,22 @@ public class FromItem extends SimpleNode {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
+    toString(params, builder, true);
+  }
+
+  /**
+   * The target as it was written, WITHOUT the alias that {@link #toString()} renders after it. Callers that resolve
+   * the rendered text as a name - a schema type for {@code CountFromTypeStep}, a context variable path - must use
+   * this: an alias names the rows the target yields, and is never part of the target's own name. Looking up
+   * {@code "Main AS m"} as a type finds nothing (issue #7153).
+   */
+  public String toStringWithoutAlias() {
+    final StringBuilder builder = new StringBuilder();
+    toString(null, builder, false);
+    return builder.toString();
+  }
+
+  private void toString(final Map<String, Object> params, final StringBuilder builder, final boolean withAlias) {
     if (rids != null && rids.size() > 0) {
       if (rids.size() == 1) {
         rids.getFirst().toString(params, builder);
@@ -113,7 +129,7 @@ public class FromItem extends SimpleNode {
     if (modifier != null)
       modifier.toString(params, builder);
 
-    if (alias != null) {
+    if (withAlias && alias != null) {
       builder.append(" AS ");
       alias.toString(params, builder);
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/FromAliasTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/FromAliasTest.java
@@ -45,11 +45,16 @@ class FromAliasTest {
 
   @Test
   void simpleFromAlias() {
-    // Test basic FROM alias with AS keyword
-    // Note: ArcadeDB currently doesn't use alias in execution, but it should parse correctly
+    // Test basic FROM alias with AS keyword, both unqualified and qualified by the alias (issue #7153)
     ResultSet result = database.query("sql", "SELECT name, age FROM V AS v1 WHERE age > 25");
     assertThat(result.hasNext()).isTrue();
     Result row = result.next();
+    assertThat(row.<String>getProperty("name")).isEqualTo("John");
+    assertThat(row.<Integer>getProperty("age")).isEqualTo(30);
+    assertThat(result.hasNext()).isFalse();
+
+    result = database.query("sql", "SELECT v1.name AS name, v1.age AS age FROM V AS v1 WHERE v1.age > 25");
+    row = result.next();
     assertThat(row.<String>getProperty("name")).isEqualTo("John");
     assertThat(row.<Integer>getProperty("age")).isEqualTo(30);
     assertThat(result.hasNext()).isFalse();
@@ -58,7 +63,6 @@ class FromAliasTest {
   @Test
   void fromAliasWithoutAS() {
     // Test FROM alias without AS keyword (AS is optional in SQL)
-    // Note: Alias parsing works, but execution engine doesn't use it yet
     ResultSet result = database.query("sql", "SELECT name, age FROM V v2 WHERE name = 'Jane'");
     assertThat(result.hasNext()).isTrue();
     Result row = result.next();
@@ -70,7 +74,6 @@ class FromAliasTest {
   @Test
   void subqueryAlias() {
     // Test subquery with alias
-    // Note: Alias parsing works, but execution engine doesn't use it yet
     ResultSet result = database.query("sql", "SELECT name, age FROM (SELECT name, age FROM V WHERE age > 20) AS sub WHERE name = 'John'");
     assertThat(result.hasNext()).isTrue();
     Result row = result.next();

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
@@ -19,6 +19,8 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.sql.SQLQueryEngine;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,10 +87,25 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
     }
   }
 
+  /**
+   * {@code m} inside a sub-query is NOT the outer alias: the sub-query has its own target, and the outer record is
+   * reachable only through {@code $parent}. Stripping the outer alias there would silently re-point the reference at
+   * the inner record.
+   */
   @Test
   void aliasIsNotInheritedByASubQuery() {
-    // 'm' inside the sub-query is NOT the outer alias: the sub-query has its own target, and the outer record is
-    // reachable only through $parent. Stripping the outer alias there would silently re-point the reference.
+    // Data carries a property literally named like the outer alias, so the two readings are distinguishable: inside
+    // the sub-query 'm' must stay that property and not become the sub-query's own record.
+    database.transaction(() -> database.command("sql", "UPDATE Data SET m = 'a-property-not-an-alias'"));
+
+    assertThat(rendered("SELECT code FROM Main m WHERE m.code IN (SELECT m FROM Data)"))//
+        .contains("SELECT m FROM Data").doesNotContain("SELECT @this FROM Data");
+
+    try (final ResultSet rs = database.query("sql",
+        "SELECT m AS inner FROM Data WHERE code IN (SELECT code FROM Main m WHERE m.code = 'C1')")) {
+      assertThat(rs.hasNext()).isFalse(); // Data has no 'code' equal to a Main code - the point is that it parses and runs
+    }
+
     try (final ResultSet rs = database.query("sql",
         "SELECT code FROM Main m WHERE m.code IN (SELECT code FROM Data WHERE code = 'D1') OR m.code = 'C3'")) {
       assertThat(rs.next().<String>getProperty("code")).isEqualTo("C3");
@@ -124,7 +141,9 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
       final String plan = plan(rs);
       assertThat(plan).contains("FETCH FROM INDEX Main[code]");
       assertThat(plan).doesNotContain("FETCH FROM BUCKET");
-      // the LET must be chained BEFORE the filter that reads the variable it defines
+      // the LET must be chained BEFORE the filter that reads the variable it defines. Both markers are asserted
+      // present first: indexOf() answers -1 for a missing step, and -1 is less than anything.
+      assertThat(plan).contains("LET (for each record)").contains("FILTER ITEMS WHERE");
       assertThat(plan.indexOf("LET (for each record)")).isLessThan(plan.indexOf("FILTER ITEMS WHERE"));
 
       assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
@@ -139,9 +158,11 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
   }
 
   /**
-   * OR branches are planned as one indexed sub-plan each, and each one chains the LET ahead of its own residual
-   * filter. Pinned here because the deferral above must not disturb it: there is a single WHERE clause to defer
-   * into and one residual per branch, so this path keeps filtering inside the sub-plans.
+   * OR branches never reach the deferral above: {@code handleTypeAsTargetWithIndexedFunction} claims a multi-block
+   * WHERE first and plans one indexed sub-plan per branch, each chaining the LET ahead of its own residual filter -
+   * correctly, because that sub-plan is not empty when {@code handleLet()} is handed it. Pinned here because the
+   * deferral must not disturb it: there is one residual per branch and a single WHERE clause to defer into, so this
+   * path has to keep filtering inside the sub-plans.
    */
   @Test
   void everyOrBranchKeepsItsIndexAndItsOwnLet() {
@@ -179,6 +200,61 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
         "SELECT tag FROM Base b LET $relation = out('relation') WHERE b.tag = 'A1' AND $relation.size() >= 0")) {
       assertThat(plan(rs)).contains("FETCH FROM TYPE Base");
       assertThat(rs.next().<String>getProperty("tag")).isEqualTo("A1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /**
+   * {@code FromItem.toString()} renders the alias back ({@code Main AS m}), and the hardwired {@code count(*)} plan
+   * used to hand that rendering to {@code CountFromTypeStep}, which looks its argument up in the schema.
+   */
+  @Test
+  void countStarOnAnAliasedTargetCountsTheType() {
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM Main m")) {
+      assertThat(rs.next().<Long>getProperty("c")).isEqualTo(50L);
+    }
+  }
+
+  /**
+   * A nested TRAVERSE or MATCH gets its own alias scope: the enclosing SELECT's alias must not rewrite an identifier
+   * that means something else inside them - a property of the TRAVERSE target's own rows, or a MATCH pattern alias.
+   * <p>
+   * Asserted on the statement the parser built, because that is where the rewrite happens and what it did is visible
+   * there without depending on what the nested statement then computes: an inherited alias would have turned the
+   * nested {@code m} into {@code @this}.
+   */
+  @Test
+  void aNestedStatementDoesNotInheritTheAlias() {
+    assertThat(rendered("SELECT FROM Main m LET $t = (TRAVERSE m FROM Data) WHERE m.code = 'C1'"))//
+        .contains("TRAVERSE m FROM Data").doesNotContain("TRAVERSE @this");
+
+    assertThat(rendered("SELECT FROM Main m LET $x = (MATCH {type: Data, as: m} RETURN m.code AS mc) WHERE m.code = 'C1'"))//
+        .contains("m.code AS mc").doesNotContain("@this");
+
+    // and the enclosing statement's own references are still resolved
+    assertThat(rendered("SELECT FROM Main m LET $t = (TRAVERSE m FROM Data) WHERE m.code = 'C1'"))//
+        .contains("WHERE code = 'C1'");
+  }
+
+  private String rendered(final String query) {
+    return ((SQLQueryEngine) database.getQueryEngine("sql")).parse(query, (DatabaseInternal) database).toString();
+  }
+
+  /**
+   * A dollar sign inside a string literal is not a LET reference. Matching a bare {@code "$"} would defer the
+   * residual - or, on the sub-type path, give the index up altogether - for a condition no LET can influence.
+   */
+  @Test
+  void aDollarInAStringLiteralIsNotALetReference() {
+    database.transaction(() -> database.command("sql", "UPDATE Main SET currency = 'US$' WHERE code = 'C1'"));
+
+    final String query = "SELECT code FROM Main m LET $relation = out('relation') WHERE m.code = 'C1' AND currency = 'US$'";
+    try (final ResultSet rs = database.query("sql", query)) {
+      final String plan = plan(rs);
+      assertThat(plan).contains("FETCH FROM INDEX Main[code]");
+      // the residual mentions no LET variable, so it is filtered inside the fetch plan, ahead of the LET step
+      assertThat(plan.indexOf("FILTER ITEMS WHERE")).isLessThan(plan.indexOf("LET (for each record)"));
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
       assertThat(rs.hasNext()).isFalse();
     }
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
@@ -353,6 +353,20 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
         "SELECT code FROM Main m LET $relation = out('relation') WHERE m.code = 'C1' AND note = '$relation'")) {
       final String plan = plan(rs);
       assertThat(plan).contains("FETCH FROM INDEX Main[code]");
+      assertThat(plan).contains("FILTER ITEMS WHERE").contains("LET (for each record)");
+      assertThat(plan.indexOf("FILTER ITEMS WHERE")).isLessThan(plan.indexOf("LET (for each record)"));
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    // a backtick-quoted identifier is a property name, even when it opens with the sigil
+    database.transaction(() -> database.command("sql", "UPDATE Main SET `$relation` = 'a property' WHERE code = 'C1'"));
+
+    try (final ResultSet rs = database.query("sql",
+        "SELECT code FROM Main m LET $relation = out('relation') WHERE m.code = 'C1' AND `$relation` = 'a property'")) {
+      final String plan = plan(rs);
+      assertThat(plan).contains("FETCH FROM INDEX Main[code]");
+      assertThat(plan).contains("FILTER ITEMS WHERE").contains("LET (for each record)");
       assertThat(plan.indexOf("FILTER ITEMS WHERE")).isLessThan(plan.indexOf("LET (for each record)"));
       assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
       assertThat(rs.hasNext()).isFalse();
@@ -377,6 +391,33 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
         "LET $chosen = (SELECT FROM Main WHERE code = 'C1'); SELECT code FROM $chosen[0] AS c")) {
       assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
       assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /**
+   * When a column is given the same name as the target, ORDER BY and GROUP BY mean the column - that is what SQL
+   * says, and what the sort step does anyway, since it resolves a bare name against the projected row. Rewriting
+   * the name as the target would sort by the whole record instead, silently and in no useful order.
+   */
+  @Test
+  void anOutputColumnOutranksTheTargetAliasInOrderBy() {
+    // DESC over the whole type, so that the answer differs from the order the rows are stored and read in: sorting
+    // by the record instead of by the column leaves them exactly as the scan produced them, C0 first
+    try (final ResultSet rs = database.query("sql", "SELECT code AS m FROM Main m ORDER BY m DESC")) {
+      assertThat(rs.next().<String>getProperty("m")).isEqualTo("C9");
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT code AS m, count(*) AS c FROM Main m "//
+        + "WHERE m.code = 'C1' GROUP BY m")) {
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("m")).isEqualTo("C1");
+      assertThat(row.<Long>getProperty("c")).isEqualTo(1L);
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    // a qualified reference still reads the alias as the target: a column needs no qualifier
+    try (final ResultSet rs = database.query("sql", "SELECT code AS m FROM Main m WHERE m.code < 'C11' ORDER BY m.code DESC")) {
+      assertThat(rs.stream().map(r -> r.<String>getProperty("m"))).containsExactly("C10", "C1", "C0");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7153, two faults that the reporter's query hit together.
+ * <p>
+ * A FROM target alias was parsed and thrown away, so {@code SELECT FROM Main m WHERE m.code = 'C1'} was planned as a
+ * filter on a property literally named {@code m}: no index, a full scan, and no rows at all.
+ * <p>
+ * And an index search whose leftover condition read a per-record LET variable spliced the LET steps in AHEAD of the
+ * index fetch, producing a plan whose first step had nothing to pull from ("Cannot execute a local LET on a query
+ * without a target"). Those leftovers now stay in the WHERE clause, which is chained after the LET.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7153TargetAliasIndexTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("sql", "CREATE VERTEX TYPE Main");
+    database.command("sql", "CREATE PROPERTY Main.code STRING");
+    database.command("sql", "CREATE INDEX ON Main (code) UNIQUE");
+    database.command("sql", "CREATE VERTEX TYPE Data");
+    database.command("sql", "CREATE PROPERTY Data.code STRING");
+    database.command("sql", "CREATE EDGE TYPE relation");
+
+    database.transaction(() -> {
+      for (int i = 0; i < 50; i++)
+        database.command("sql", "CREATE VERTEX Main SET code = 'C" + i + "'");
+
+      database.command("sql", "CREATE VERTEX Data SET code = 'D1'");
+      database.command("sql",
+          "CREATE EDGE relation FROM (SELECT FROM Main WHERE code = 'C1') TO (SELECT FROM Data WHERE code = 'D1')");
+    });
+  }
+
+  @Test
+  void aliasQualifiedFilterUsesTheIndex() {
+    for (final String query : new String[] { //
+        "SELECT FROM Main m WHERE m.code = 'C1'", //
+        "SELECT FROM Main AS m WHERE m.code = 'C1'" }) {
+      try (final ResultSet rs = database.query("sql", query)) {
+        assertThat(plan(rs)).as(query).contains("FETCH FROM INDEX Main[code]");
+        assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
+        assertThat(rs.hasNext()).as(query).isFalse();
+      }
+    }
+  }
+
+  @Test
+  void aliasResolvesInEveryClause() {
+    try (final ResultSet rs = database.query("sql",
+        "SELECT m.code AS c FROM Main m LET $upper = m.code.toUpperCase() WHERE m.code = 'C1' ORDER BY m.code")) {
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("c")).isEqualTo("C1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    // A bare alias stands for the record itself, whether it is projected or a record attribute is read off it
+    try (final ResultSet rs = database.query("sql", "SELECT m FROM Main m WHERE m.@rid IS NOT NULL AND m.code = 'C2'")) {
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C2");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void aliasIsNotInheritedByASubQuery() {
+    // 'm' inside the sub-query is NOT the outer alias: the sub-query has its own target, and the outer record is
+    // reachable only through $parent. Stripping the outer alias there would silently re-point the reference.
+    try (final ResultSet rs = database.query("sql",
+        "SELECT code FROM Main m WHERE m.code IN (SELECT code FROM Data WHERE code = 'D1') OR m.code = 'C3'")) {
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C3");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void aliasWorksOnUpdateAndDelete() {
+    database.transaction(() -> {
+      database.command("sql", "UPDATE Main m SET touched = true WHERE m.code = 'C4'");
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Main WHERE code = 'C4'")) {
+        assertThat(rs.next().<Boolean>getProperty("touched")).isTrue();
+      }
+
+      database.command("sql", "DELETE FROM Main m WHERE m.code = 'C4'");
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Main WHERE code = 'C4'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * The reported query: the index on {@code Main.code} must survive the second AND term, which can only be decided
+   * once the per-record LET has run.
+   */
+  @Test
+  void indexSurvivesAConditionOnAPerRecordLetVariable() {
+    final String query = "SELECT FROM Main m LET $relation = out('relation') "//
+        + "WHERE m.code = 'C1' AND $relation CONTAINS (code = 'D1')";
+
+    try (final ResultSet rs = database.query("sql", query)) {
+      final String plan = plan(rs);
+      assertThat(plan).contains("FETCH FROM INDEX Main[code]");
+      assertThat(plan).doesNotContain("FETCH FROM BUCKET");
+      // the LET must be chained BEFORE the filter that reads the variable it defines
+      assertThat(plan.indexOf("LET (for each record)")).isLessThan(plan.indexOf("FILTER ITEMS WHERE"));
+
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    // and the deferred filter really filters: C2 has no relation, so the same shape must answer nothing
+    try (final ResultSet rs = database.query("sql", "SELECT FROM Main LET $relation = out('relation') "//
+        + "WHERE code = 'C2' AND $relation CONTAINS (code = 'D1')")) {
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /**
+   * OR branches are planned as one indexed sub-plan each, and each one chains the LET ahead of its own residual
+   * filter. Pinned here because the deferral above must not disturb it: there is a single WHERE clause to defer
+   * into and one residual per branch, so this path keeps filtering inside the sub-plans.
+   */
+  @Test
+  void everyOrBranchKeepsItsIndexAndItsOwnLet() {
+    final String query = "SELECT code FROM Main LET $relation = out('relation') "//
+        + "WHERE (code = 'C1' AND $relation.size() = 1) OR (code = 'C2' AND $relation.size() = 0)";
+
+    try (final ResultSet rs = database.query("sql", query)) {
+      assertThat(plan(rs)).contains("FETCH FROM INDEX Main[code]").doesNotContain("FETCH FROM BUCKET");
+      assertThat(rs.stream().map(r -> r.<String>getProperty("code"))).containsExactlyInAnyOrder("C1", "C2");
+    }
+  }
+
+  /**
+   * A type with no records of its own is answered by one indexed sub-plan per sub-type. Each sub-plan would need its
+   * own deferred residual and there is a single WHERE clause to hold one, so the statement gives the index up for a
+   * plain scan, which evaluates the filter after the LET by construction. Before issue #7153 this shape built a plan
+   * whose index fetch pulled from a LET step that had no source, and raised at the first row.
+   */
+  @Test
+  void perRecordLetResidualOnASubTypeFallsBackToTheScan() {
+    database.command("sql", "CREATE VERTEX TYPE Base");
+    database.command("sql", "CREATE PROPERTY Base.tag STRING");
+    database.command("sql", "CREATE VERTEX TYPE Sub1 EXTENDS Base");
+    database.command("sql", "CREATE VERTEX TYPE Sub2 EXTENDS Base");
+    database.command("sql", "CREATE INDEX ON Sub1 (tag) UNIQUE");
+    database.command("sql", "CREATE INDEX ON Sub2 (tag) UNIQUE");
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++) {
+        database.newVertex("Sub1").set("tag", "A" + i).save();
+        database.newVertex("Sub2").set("tag", "B" + i).save();
+      }
+    });
+
+    try (final ResultSet rs = database.query("sql",
+        "SELECT tag FROM Base b LET $relation = out('relation') WHERE b.tag = 'A1' AND $relation.size() >= 0")) {
+      assertThat(plan(rs)).contains("FETCH FROM TYPE Base");
+      assertThat(rs.next().<String>getProperty("tag")).isEqualTo("A1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  private static String plan(final ResultSet rs) {
+    return rs.getExecutionPlan().orElseThrow().prettyPrint(0, 2);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
@@ -259,6 +259,76 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
     }
   }
 
+  /**
+   * The same {@code '$'}-in-a-literal false positive gated two other optimisations, both of which skip when the
+   * WHERE clause "references a LET": the predicate pushed into the type scan, and the vertex-centric lookup that
+   * answers {@code WHERE @out = <RID>} off the vertex's edge list instead of scanning the edge type. Neither was
+   * ever a wrong answer - the condition just fell through to the post-LET filter - but both are lost for a reason
+   * that has nothing to do with the LET.
+   */
+  @Test
+  void aDollarInAStringLiteralKeepsThePushdownAndTheEdgeLookup() {
+    database.transaction(() -> database.command("sql", "UPDATE Main SET currency = 'US$' WHERE code = 'C1'"));
+
+    // predicate pushdown: an unindexed condition is filtered inside the scan, not by a step chained after it
+    try (final ResultSet rs = database.query("sql",
+        "SELECT code FROM Main LET $relation = out('relation') WHERE currency = 'US$'")) {
+      assertThat(plan(rs)).contains("FETCH FROM TYPE Main WITH FILTER");
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    // vertex-centric edge lookup
+    final String mainRid = database.query("sql", "SELECT @rid AS r FROM Main WHERE code = 'C1'").next()
+        .<Object>getProperty("r").toString();
+    try (final ResultSet rs = database.query("sql", "SELECT @rid FROM relation LET $x = in() "//
+        + "WHERE @out = " + mainRid + " AND label = 'US$'")) {
+      assertThat(plan(rs)).doesNotContain("FETCH FROM TYPE relation");
+      assertThat(rs.hasNext()).isFalse(); // no edge carries that label - the point is which plan answered
+    }
+  }
+
+  /**
+   * The grammar takes a LET name as a plain identifier, so {@code LET brain = out(...)} declares the variable that
+   * {@code $brain} reads and only the reference carries the sigil. Matching the two spellings against each other is
+   * what tells the planner this residual has to wait for the LET.
+   */
+  @Test
+  void aLetDeclaredWithoutTheSigilIsStillRecognised() {
+    final String query = "SELECT code FROM Main m LET relation = out('relation') "//
+        + "WHERE m.code = 'C1' AND $relation CONTAINS (code = 'D1')";
+
+    try (final ResultSet rs = database.query("sql", query)) {
+      final String plan = plan(rs);
+      assertThat(plan).contains("FETCH FROM INDEX Main[code]");
+      assertThat(plan).contains("LET (for each record)").contains("FILTER ITEMS WHERE");
+      assertThat(plan.indexOf("LET (for each record)")).isLessThan(plan.indexOf("FILTER ITEMS WHERE"));
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /**
+   * An OR whose branches are answered by an indexed function - {@code search_index()} here - is planned as one
+   * sub-plan per branch. That branch chained its residual filter without the LET guard every sibling branch
+   * applies, so a residual reading a per-record LET was evaluated with the variable unset and answered nothing.
+   */
+  @Test
+  void anIndexedFunctionOrBranchWaitsForThePerRecordLet() {
+    database.command("sql", "CREATE PROPERTY Main.notes STRING");
+    database.command("sql", "CREATE INDEX ON Main (notes) FULL_TEXT");
+    database.transaction(() -> {
+      database.command("sql", "UPDATE Main SET notes = 'linked to data' WHERE code = 'C1'");
+      database.command("sql", "UPDATE Main SET notes = 'nothing here' WHERE code = 'C2'");
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT code FROM Main LET $relation = out('relation') "//
+        + "WHERE (search_index('Main[notes]', 'linked') = true AND $relation.size() = 1) "//
+        + "OR (search_index('Main[notes]', 'nothing') = true AND $relation.size() = 0)")) {
+      assertThat(rs.stream().map(r -> r.<String>getProperty("code"))).containsExactlyInAnyOrder("C1", "C2");
+    }
+  }
+
   private static String plan(final ResultSet rs) {
     return rs.getExecutionPlan().orElseThrow().prettyPrint(0, 2);
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
@@ -123,11 +123,38 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
         assertThat(rs.next().<Boolean>getProperty("touched")).isTrue();
       }
 
+      // the assignment target too: SET m.touched must set the record's own property, not one nested inside a
+      // property named after the alias
+      database.command("sql", "UPDATE Main m SET m.stamped = 'yes' WHERE m.code = 'C4'");
+      try (final ResultSet rs = database.query("sql", "SELECT stamped FROM Main WHERE code = 'C4'")) {
+        assertThat(rs.next().<String>getProperty("stamped")).isEqualTo("yes");
+      }
+
       database.command("sql", "DELETE FROM Main m WHERE m.code = 'C4'");
       try (final ResultSet rs = database.query("sql", "SELECT FROM Main WHERE code = 'C4'")) {
         assertThat(rs.hasNext()).isFalse();
       }
     });
+  }
+
+  /**
+   * The rewrite rebuilds the modifier chain by hand, so every shape that is not {@code alias.property} - a method
+   * call, an array selector, {@code .*} - has to keep applying to the record the alias stands for.
+   */
+  @Test
+  void aBareAliasCarriesItsModifierChainOntoTheRecord() {
+    // a method call applies to the record the alias stands for
+    try (final ResultSet rs = database.query("sql", "SELECT m.asJSON() AS j FROM Main m WHERE m.code = 'C1'")) {
+      assertThat(rs.next().<Object>getProperty("j").toString()).contains("\"code\":\"C1\"");
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    // and an array selector or ".*" keeps its place in the chain, now applied to the record. A string-keyed
+    // selector reads null off a record whatever it is applied to - @this, a $variable - so the shape is pinned on
+    // the statement rather than on a result that would say nothing about the rewrite.
+    assertThat(rendered("SELECT m.* FROM Main m")).contains("@this.*").doesNotContain("m.*");
+    assertThat(rendered("SELECT m[0] FROM Main m")).contains("@this[0]");
+    assertThat(rendered("SELECT m.asJSON() FROM Main m")).contains("@this.asJSON()");
   }
 
   /**
@@ -414,6 +441,10 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
       assertThat(row.<Long>getProperty("c")).isEqualTo(1L);
       assertThat(rs.hasNext()).isFalse();
     }
+
+    // a nested SELECT inside the ORDER BY must not take the output-column scope away from the items after it
+    assertThat(rendered("SELECT code AS m FROM Main m ORDER BY (SELECT 1), m DESC"))//
+        .contains(", m DESC").doesNotContain("@this");
 
     // a qualified reference still reads the alias as the target: a column needs no qualifier
     try (final ResultSet rs = database.query("sql", "SELECT code AS m FROM Main m WHERE m.code < 'C11' ORDER BY m.code DESC")) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7153TargetAliasIndexTest.java
@@ -21,6 +21,8 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.SQLQueryEngine;
+import com.arcadedb.query.sql.parser.FromItem;
+import com.arcadedb.query.sql.parser.SelectStatement;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -326,6 +328,55 @@ class Issue7153TargetAliasIndexTest extends TestHelper {
         + "WHERE (search_index('Main[notes]', 'linked') = true AND $relation.size() = 1) "//
         + "OR (search_index('Main[notes]', 'nothing') = true AND $relation.size() = 0)")) {
       assertThat(rs.stream().map(r -> r.<String>getProperty("code"))).containsExactlyInAnyOrder("C1", "C2");
+    }
+  }
+
+  /**
+   * A quoted run is data. {@code WHERE note = '$relation'} spells a LET variable's name inside a string literal and
+   * names no variable at all, and a backtick-quoted {@code `$relation`} is a property whose name merely starts with
+   * the character.
+   */
+  @Test
+  void aVariableNameInsideAQuotedRunIsNotAReference() {
+    database.transaction(() -> database.command("sql", "UPDATE Main SET note = '$relation' WHERE code = 'C1'"));
+
+    try (final ResultSet rs = database.query("sql",
+        "SELECT code FROM Main LET $relation = out('relation') WHERE note = '$relation'")) {
+      // the residual reads no variable, so it is pushed into the scan rather than deferred past the LET
+      assertThat(plan(rs)).contains("FETCH FROM TYPE Main WITH FILTER");
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    // and the index survives the same literal next to an indexed condition
+    try (final ResultSet rs = database.query("sql",
+        "SELECT code FROM Main m LET $relation = out('relation') WHERE m.code = 'C1' AND note = '$relation'")) {
+      final String plan = plan(rs);
+      assertThat(plan).contains("FETCH FROM INDEX Main[code]");
+      assertThat(plan.indexOf("FILTER ITEMS WHERE")).isLessThan(plan.indexOf("LET (for each record)"));
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /**
+   * A target that is not a type name is resolved out of its rendered text, and an alias is not part of that text.
+   * The contract is asserted on {@code FromItem} directly because the one planner branch that resolves a dotted
+   * variable path this way cannot be reached from SQL today - a bare identifier carrying a modifier is read as a
+   * type name first - while an aliased {@code $var} target, which can, has to keep working.
+   */
+  @Test
+  void anAliasIsNotPartOfTheTargetsName() {
+    final FromItem target = ((SelectStatement) ((SQLQueryEngine) database.getQueryEngine("sql"))//
+        .parse("SELECT FROM Main m", (DatabaseInternal) database)).getTarget().getItem();
+
+    assertThat(target.toString()).isEqualTo("Main AS m");
+    assertThat(target.toStringWithoutAlias()).isEqualTo("Main");
+
+    try (final ResultSet rs = database.command("sqlscript",
+        "LET $chosen = (SELECT FROM Main WHERE code = 'C1'); SELECT code FROM $chosen[0] AS c")) {
+      assertThat(rs.next().<String>getProperty("code")).isEqualTo("C1");
+      assertThat(rs.hasNext()).isFalse();
     }
   }
 


### PR DESCRIPTION
Fixes #7153.

Two faults met in the reported query, and only the second one is the one the title names.

## The FROM target alias was parsed and thrown away

`SELECT FROM Main m WHERE m.code = 'C1'` was planned as a filter on a property literally named `m`. That is why the index on `Main.code` was not used - the index matcher is syntactic, and it saw no condition on `code` - but the same query also answered **no rows at all**, silently, because no record has an `m`. The AST builder said so out loud: *"alias, if present, is the second identifier and ignored in execution"*. `UPDATE` and `DELETE` take the same FROM clause and were wrong the same way.

The alias is now consumed at parse time, once per statement text and then cached with the statement:

- the target is visited before every clause that can reference it;
- an alias-qualified reference is rewritten in place: `m.code` -> `code`, and a bare `m` (or `m` followed by a method call, an array selector or `.*`) -> `@this`;
- a nested statement pushes its own scope, so an inner query does not inherit the outer alias - there that name still refers to the OUTER record, and stripping it would silently re-point the reference at the inner one.

## An index search whose residual reads a per-record LET built a broken plan

With the index restored, the second half surfaces. When an index search left behind a condition reading a per-record LET variable, the planner spliced the LET steps into the fetch plan to compensate - but `handleLet()` chains into `info.fetchExecutionPlan` when the plan handed to it is empty, and it was, so the LET landed **ahead of** the index fetch. The plan's first step then had nothing to pull from:

```
java.lang.IllegalStateException: Cannot execute a local LET on a query without a target
	at LetExpressionStep.syncPull(LetExpressionStep.java:40)
	at FetchFromIndexStep.syncPull(FetchFromIndexStep.java:107)
```

Reproduces on `main` today with `SELECT FROM Main LET $relation = out('relation') WHERE code = 'C1' AND $relation.size() >= 0` - no alias needed.

Such a residual is now handed back as the statement's WHERE clause, so `handleWhere()` chains it after `handleLet()`, where the variable is finally set. The paths that plan one sub-plan per sub-type or per OR branch have one residual each and a single WHERE clause to defer into, so they give the index up for the plain scan, which filters after the LET by construction.

## Result

```
SELECT FROM Main m LET $relation = out('relation') WHERE m.code = 'C1' AND $relation CONTAINS (code = 'D1')

+ FETCH FROM INDEX Main[code]
  code = 'C1'
+ EXTRACT VALUE FROM INDEX ENTRY
+ FILTER ITEMS BY TYPE Main
+ LET (for each record)
  $relation = (out('relation'))
+ FILTER ITEMS WHERE
  $relation CONTAINS (code = 'D1')
```

On the reporter's shape - 100k records, unique index on `Main.code` - this answers in 0.3ms warm (15ms on the first, plan-building call), against the 403ms of the full scan it used to do.

## Tests

`Issue7153TargetAliasIndexTest` - 7 tests, 6 of which fail on `main` (3 assertion failures, 3 `IllegalStateException`); the seventh pins the OR-branch path that was already correct and must stay so. `FromAliasTest` gains an alias-qualified projection and loses three stale "the execution engine doesn't use the alias yet" comments.

Full reactor green: `mvn -o verify -DexcludedGroups=benchmark,vector,slow` - 27 modules, engine alone 14395 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ2iKq3CQFjTAUCp1a756c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SQL alias handling across SELECT, UPDATE, DELETE, FROM, MATCH, and TRAVERSE queries.
  * Alias-qualified and unqualified references now resolve more consistently in nested queries.
  * Projected column names are preserved when referenced in `GROUP BY` and `ORDER BY`.
  * Improved query planning for target aliases, count queries, and variable-path targets.

* **Bug Fixes**
  * Improved filtering for per-record `LET` variables during indexed queries.
  * Improved handling of complex indexed queries, OR conditions, subtype filters, and predicate pushdown.
  * Prevented nested queries from incorrectly inheriting aliases from outer queries.
  * Improved recognition of variable references in quoted strings and identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->