### PR TITLE
fix(#7122): bound the client-supplied language tag of arcadedb.query.duration

### DIFF
--- a/docs/7122-query-duration-language-tag-unbounded.md
+++ b/docs/7122-query-duration-language-tag-unbounded.md
@@ -1,0 +1,88 @@
+# #7122 — `arcadedb.query.duration` registers a Timer per client-supplied `language` string
+
+## Problem
+
+`MicrometerQueryMetricsRecorder.queryTimer()` builds one Micrometer `Timer` per
+`protocol|db|language|type` tuple and caches it in a static `ConcurrentHashMap`. The class comment
+called the tuple "bounded", which holds for `protocol` (a fixed set of constants passed to
+`ProtocolContext.set`) and `type` (`query`/`command`) but **not** for `language`: the value travels
+straight from the caller — `db.query("<language>", …)`, the `{lang}` path segment of the HTTP API,
+the Postgres portal language — and reaches the tag with no validation.
+
+Every distinct string therefore registers a permanent percentile-histogram `Timer` in the static
+`Metrics.globalRegistry` **and** a permanent entry in the recorder's own cache. Micrometer never
+evicts, so heap and `/metrics` grow without bound. This is the shape #6805 fixed for the `db` tag of
+`arcadedb.http.requests`, at a meter #6805 did not cover.
+
+## Root cause
+
+Three gaps, the same three #6805 had:
+
+1. no validation of `language` before it becomes a tag value;
+2. no `MeterFilter.maximumAllowableTags` backstop for `arcadedb.query.duration` in
+   `ArcadeDBServer.startMetrics()` (the two existing filters cover only `arcadedb.http.requests`);
+3. no ceiling on the recorder's own cache — a `MeterFilter` can deny the meter but cannot stop
+   `computeIfAbsent` from retaining the key.
+
+## Fix
+
+- `QueryEngineManager.isLanguageRegistered(String)` — a lock-free lookup against the copy-on-write
+  engine map, so "is this a real language?" is answered by the one component that owns the answer.
+- `MicrometerQueryMetricsRecorder.languageTag()` lowercases the value (so case permutations of a
+  real language cannot multiply the tag space) and collapses anything unregistered onto the constant
+  `unknown`.
+- `queryTimer()` looks the raw key up first (unchanged hot path: one concat, one `get`), and only on
+  a miss bounds the tags — so a bogus language is never retained as a cache key. Past
+  `MAX_QUERY_TIMERS` the `db` half collapses onto `other`, the remaining dimension that can grow
+  through database create/drop churn.
+- `ArcadeDBServer.startMetrics()` installs two more `MeterFilter`s, on the `language` and `db` tags
+  of `arcadedb.query.duration`, sized from the recorder's own public constants so the registry-side
+  and cache-side bounds stay one number rather than two independently chosen ones.
+- `MicrometerQueryTracer` routes its `language` low-cardinality key through the same helper, so an
+  attached observation handler that turns keys into meter tags inherits the same bound.
+
+## Also in this sweep
+
+`LoadCSVStep.openReader()` leaked the raw `InputStream` when the `.gz`/`.zip` wrapper threw: the
+outer stream was already open and nothing closed it on that path. The empty-ZIP refusal also escaped
+as `CommandExecutionException`, which the caller's `IOException` arm does not catch, so it surfaced
+without the "Error opening CSV file: <url>" context every other open failure carries. Both fixed
+with one try/catch and an `IOException`.
+
+## Why the leak is reachable
+
+`LocalDatabase.query()/command()` record in a `finally`, so the timer is registered even when
+`getQueryEngine(language)` throws `Query engine '<language>' was not found`. An unauthenticated
+`GET /api/v1/query/{db}/{lang}/{query}` that fails therefore still minted a permanent meter, which is
+what makes the repro in the issue work.
+
+## Verification
+
+Every new test was run against the unfixed code first and fails there:
+
+| Test | Unfixed result |
+|---|---|
+| `anUnregisteredLanguageCollapsesToABoundedConstant` | `expected: "unknown"` |
+| `anUnregisteredLanguageIsNeverRetainedAsACacheKey` | `expected: 1` (500 entries retained) |
+| `languageTagIsCaseNormalized` | two distinct timers |
+| `aNullLanguageCollapsesInsteadOfBeingTaggedNull` | `NullPointerException` |
+| `theDatabaseTagCollapsesOnceTheCacheCeilingIsReached` | `expected: "other"` |
+| `aCorruptGzipHeaderDoesNotStrandTheRawStream` | stream left open |
+| `anEmptyZipDoesNotStrandTheRawStream` | `CommandExecutionException`, stream left open |
+
+Suites run green after the fix:
+
+- `server`: `MicrometerQueryMetricsRecorderTest` (8), `ArcadeDBServerMetricsFiltersTest` (3),
+  `ServerMetricsLifecycleTest` (7), `AbstractServerHttpHandlerMetricsTest` (6)
+- `engine`: `LoadCSVStepOpenReaderTest` (3), `OpenCypherLoadCSVTest` (26),
+  `OpenCypherLoadCsvFunctionsComprehensiveTest` (16), `CypherLoadCSVRowContextIssue6402Test` (5),
+  `QueryEngineManagerLanguagesTest` (5), `QueryEngineManagerPoolTest` (4), `QueryMetricsRecorderTest` (3),
+  `LocalDatabaseQueryMetricsTest` (1), `LocalDatabaseQueryTracerTest` (2), `ProtocolContextTest` (3),
+  `DedicatedThreadPoolTest` (11)
+
+## Performance
+
+The hot path is unchanged for an already-seen tuple: one string concatenation and one
+`ConcurrentHashMap.get`, exactly as before. `languageTag()` — a `toLowerCase` scan (which returns
+`this` when nothing changes) plus one volatile read and one hash lookup — runs only on a cache miss,
+and a miss already pays for a `Timer.Builder`, a `Tags` list and a registry registration.

--- a/docs/7122-query-duration-language-tag-unbounded.md
+++ b/docs/7122-query-duration-language-tag-unbounded.md
@@ -86,3 +86,23 @@ The hot path is unchanged for an already-seen tuple: one string concatenation an
 `ConcurrentHashMap.get`, exactly as before. `languageTag()` — a `toLowerCase` scan (which returns
 `this` when nothing changes) plus one volatile read and one hash lookup — runs only on a cache miss,
 and a miss already pays for a `Timer.Builder`, a `Tags` list and a registry registration.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7157
+
+### Review cycles
+
+| Cycle | Head SHA | Changes | Bot review outcome |
+|---|---|---|---|
+| 1 | `2134ad3e98` | initial implementation + regression tests | `claude` responded with no actionable items; CodeRabbit: "No actionable comments were generated in the recent review"; Codacy: 0 new issues |
+
+No review comment in cycle 1 required a code change, and no item was deferred.
+
+### Deferred items
+
+None.
+
+### Final state
+
+`clean-approval` — one cycle, nothing to address. Merge remains the developer's decision.

--- a/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
+++ b/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
@@ -143,4 +143,20 @@ public class QueryEngineManager extends DedicatedThreadPool {
   public List<String> getAvailableLanguages() {
     return new ArrayList<>(implementations.keySet());
   }
+
+  /**
+   * Whether {@code language} names an engine registered on this JVM, matched the way
+   * {@link #getEngine(String, DatabaseInternal)} matches it (case-insensitively). Unlike
+   * {@link #getAvailableLanguages()} this answers the question without copying the key set, so it is usable
+   * from instrumentation that runs once per query: one volatile read of the copy-on-write map plus one hash
+   * lookup, no allocation.
+   * <p>
+   * Exists so the {@code language} tag of {@code arcadedb.query.duration} can be bounded at its source. The
+   * language travels straight from the caller - {@code db.query("<language>", ...)}, the {@code {lang}} path
+   * segment of the HTTP API - so a metric that echoed it verbatim registered one permanent meter per invented
+   * name; the engine registry is the component that knows which values are real (issue #7122).
+   */
+  public boolean isLanguageRegistered(final String language) {
+    return language != null && implementations.containsKey(language.toLowerCase(Locale.ENGLISH));
+  }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/LoadCSVStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/LoadCSVStep.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.zip.GZIPInputStream;
-import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 /**
@@ -323,19 +322,46 @@ public class LoadCSVStep extends AbstractExecutionStep {
    * Transparently decompresses .gz and .zip files.
    */
   static BufferedReader openReader(final String url, final CommandContext context) throws IOException {
-    InputStream is = openRawInputStream(url, context);
+    return decompressingReader(url, openRawInputStream(url, context));
+  }
 
-    if (url.endsWith(".gz"))
-      is = new GZIPInputStream(is);
-    else if (url.endsWith(".zip")) {
-      final ZipInputStream zis = new ZipInputStream(is);
-      final ZipEntry entry = zis.getNextEntry();
-      if (entry == null)
-        throw new CommandExecutionException("ZIP file is empty: " + url);
-      is = zis;
+  /**
+   * Wraps an already-open stream in the decompressor the URL's extension calls for and hands back a reader over
+   * it. Split from {@link #openReader} so the failure paths - a corrupt archive header, an archive with no entry
+   * - can be driven from a test with a stream whose closing is observable, without a live file or HTTP source.
+   * <p>
+   * Owns {@code raw} from here on: on every throw it closes what it has built, so a malformed archive costs no
+   * file descriptor (issue #7122).
+   */
+  static BufferedReader decompressingReader(final String url, final InputStream raw) throws IOException {
+    // The decompressing wrappers read (and can reject) the archive header in their own constructor, and the
+    // empty-ZIP check below reads the first entry, so this block throws on a malformed archive with the outer
+    // stream already open. Nothing further up closes it - the caller only closes the BufferedReader it never
+    // received - so each such LOAD CSV leaked one file descriptor / socket (issue #7122).
+    InputStream is = raw;
+    try {
+      if (url.endsWith(".gz"))
+        is = new GZIPInputStream(raw);
+      else if (url.endsWith(".zip")) {
+        final ZipInputStream zis = new ZipInputStream(raw);
+        is = zis;
+        // An archive carrying no entry is an unreadable CSV source, reported as the IOException the caller
+        // already handles: thrown as anything else it would bypass the "Error opening CSV file: <url>" arm and
+        // surface without the url every other open failure names.
+        if (zis.getNextEntry() == null)
+          throw new IOException("ZIP file is empty: " + url);
+      }
+
+      return new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+    } catch (final IOException | RuntimeException e) {
+      // Closes the outermost stream built so far, which closes the ones it wraps.
+      try {
+        is.close();
+      } catch (final IOException suppressed) {
+        e.addSuppressed(suppressed);
+      }
+      throw e;
     }
-
-    return new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/QueryEngineManagerLanguagesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/QueryEngineManagerLanguagesTest.java
@@ -57,4 +57,27 @@ class QueryEngineManagerLanguagesTest {
     // registration must not collapse them.
     assertThat(languages).contains("opencypher", "cypher");
   }
+
+  @Test
+  void isLanguageRegisteredAnswersForEveryAvailableLanguage() {
+    final QueryEngineManager manager = QueryEngineManager.getInstance();
+    // The bounded "language" tag of arcadedb.query.duration is derived from this predicate, so it has to
+    // agree with the list every registered alias is surfaced in (issue #7122).
+    for (final String language : manager.getAvailableLanguages())
+      assertThat(manager.isLanguageRegistered(language)).as(language).isTrue();
+  }
+
+  @Test
+  void isLanguageRegisteredMatchesCaseInsensitivelyAndRejectsTheRest() {
+    final QueryEngineManager manager = QueryEngineManager.getInstance();
+
+    // getEngine() lowercases before resolving, so the predicate has to agree: "SQL" runs the sql engine.
+    assertThat(manager.isLanguageRegistered("SQL")).isTrue();
+    assertThat(manager.isLanguageRegistered("SqL")).isTrue();
+
+    // Whatever a caller invents must be rejected - that is what keeps the metric tag bounded.
+    assertThat(manager.isLanguageRegistered("lang12345")).isFalse();
+    assertThat(manager.isLanguageRegistered("")).isFalse();
+    assertThat(manager.isLanguageRegistered(null)).isFalse();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/LoadCSVStepOpenReaderTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/LoadCSVStepOpenReaderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.BufferedReader;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for {@code LOAD CSV} opening a malformed archive (issue #7122): the raw stream is already
+ * open by the time the {@code .gz}/{@code .zip} wrapper rejects the header, and the caller only ever closes the
+ * {@link BufferedReader} it never received - so every failed open used to strand one file descriptor (or, for an
+ * {@code http(s)} source, one socket).
+ */
+class LoadCSVStepOpenReaderTest {
+
+  /** An InputStream that records whether it was closed, so the ownership handover is directly observable. */
+  private static final class TrackingInputStream extends FilterInputStream {
+    private boolean closed;
+
+    private TrackingInputStream(final byte[] content) {
+      super(new ByteArrayInputStream(content));
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed = true;
+      super.close();
+    }
+  }
+
+  @Test
+  void aCorruptGzipHeaderDoesNotStrandTheRawStream() {
+    // Not gzip: GZIPInputStream rejects the magic number from inside its own constructor, with the stream
+    // it was handed already open.
+    final TrackingInputStream raw = new TrackingInputStream("id,name\n1,alice\n".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> LoadCSVStep.decompressingReader("file:///data.csv.gz", raw))
+        .isInstanceOf(IOException.class);
+
+    assertThat(raw.closed).as("a rejected archive header must not cost a file descriptor").isTrue();
+  }
+
+  @Test
+  void anEmptyZipDoesNotStrandTheRawStream() throws IOException {
+    final TrackingInputStream raw = new TrackingInputStream(emptyZipArchive());
+
+    assertThatThrownBy(() -> LoadCSVStep.decompressingReader("file:///data.csv.zip", raw))
+        // An IOException, so the caller's "Error opening CSV file: <url>" arm reports it with the url the way
+        // it reports every other open failure, instead of letting it escape uncontextualised.
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("ZIP file is empty");
+
+    assertThat(raw.closed).as("an archive with no entry must not cost a file descriptor").isTrue();
+  }
+
+  @Test
+  void aPlainStreamIsHandedToTheReaderStillOpen() throws IOException {
+    final TrackingInputStream raw = new TrackingInputStream("id,name\n1,alice\n".getBytes(StandardCharsets.UTF_8));
+
+    try (final BufferedReader reader = LoadCSVStep.decompressingReader("file:///data.csv", raw)) {
+      assertThat(raw.closed).as("the success path must hand the caller a usable reader").isFalse();
+      assertThat(reader.readLine()).isEqualTo("id,name");
+    }
+
+    // Closing the reader is what closes the underlying stream, as before.
+    assertThat(raw.closed).isTrue();
+  }
+
+  private static byte[] emptyZipArchive() throws IOException {
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    // A ZipOutputStream closed without a single entry writes only the end-of-central-directory record, which is
+    // exactly what getNextEntry() answers null for.
+    new ZipOutputStream(bytes).close();
+    return bytes.toByteArray();
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -703,25 +703,47 @@ public class ArcadeDBServer {
     }
   }
 
+  /**
+   * Installs the cardinality backstops for the RED timers. Each caps the number of distinct values a
+   * client-influenced tag may take and denies the meter beyond it, so a future route, a new wire protocol or a
+   * plain regression can never grow the registry without bound. Every limit is read from the constant on the
+   * component that produces the tag, so the registry-side bound and that component's own timer-cache bound stay
+   * tied to one number rather than two independently-chosen ones.
+   * <p>
+   * Extracted so the filters can be applied to a throwaway registry and asserted directly, without starting a
+   * server and without depending on JVM-wide state a {@code MeterFilter} can never be removed from.
+   */
+  // @VisibleForTesting
+  static void installCardinalityMeterFilters(final MeterRegistry.Config config) {
+    // arcadedb.http.requests / path: the handler already collapses unmatched URIs to a constant (issue #5025).
+    config.meterFilter(MeterFilter.maximumAllowableTags("arcadedb.http.requests", "path", 100, MeterFilter.deny()));
+    // arcadedb.http.requests / db: the handler already collapses a {database} path parameter naming no existing
+    // database onto a constant, but database name churn - or a future route exposing another free segment as
+    // "db" - must not be able to grow the registry either (issue #6805).
+    config.meterFilter(MeterFilter.maximumAllowableTags("arcadedb.http.requests", "db",
+        AbstractServerHttpHandler.MAX_DB_TAG_VALUES + AbstractServerHttpHandler.RESERVED_DB_TAG_VALUES,
+        MeterFilter.deny()));
+    // arcadedb.query.duration / language: the recorder already collapses anything that does not name a
+    // registered query engine onto a constant, but the language reaches it straight from the caller, so this
+    // meter gets the same registry-side backstop its HTTP sibling has (issue #7122).
+    config.meterFilter(MeterFilter.maximumAllowableTags("arcadedb.query.duration", "language",
+        MicrometerQueryMetricsRecorder.MAX_LANGUAGE_TAG_VALUES
+            + MicrometerQueryMetricsRecorder.RESERVED_LANGUAGE_TAG_VALUES,
+        MeterFilter.deny()));
+    // arcadedb.query.duration / db: same reasoning as the HTTP timer's "db" tag - the value is a real database
+    // name, so only create/drop churn can grow it, and the recorder's own cache ceiling collapses it far later
+    // than this bound does (issue #7122).
+    config.meterFilter(MeterFilter.maximumAllowableTags("arcadedb.query.duration", "db",
+        MicrometerQueryMetricsRecorder.MAX_DB_TAG_VALUES + MicrometerQueryMetricsRecorder.RESERVED_DB_TAG_VALUES,
+        MeterFilter.deny()));
+  }
+
   private void startMetrics() {
     synchronized (METRICS_INSTALL_MUTEX) {
       if (!metricsFiltersInstalled) {
-        // Backstop against a path-tag cardinality explosion on arcadedb.http.requests. The handler already
-        // collapses unmatched URIs to a constant, but this caps the number of distinct "path" tag values and
-        // denies further ones so a future route or regression can never grow the registry without bound.
-        // A MeterFilter cannot be removed from a registry, so it is installed once per JVM, and before any
-        // meter exists as Micrometer requires MeterFilters to precede the meters they govern.
-        Metrics.globalRegistry.config().meterFilter(
-            MeterFilter.maximumAllowableTags("arcadedb.http.requests", "path", 100, MeterFilter.deny()));
-        // Same backstop for the "db" half of the tuple (issue #6805). The handler already collapses a
-        // {database} path parameter naming no existing database onto a constant, but database name churn -
-        // or a future route exposing another free segment as "db" - must not be able to grow the registry
-        // either. The limit comes from the handler that produces the tag, so the registry-side bound and the
-        // handler's own timer-cache bound stay tied to one number.
-        Metrics.globalRegistry.config().meterFilter(
-            MeterFilter.maximumAllowableTags("arcadedb.http.requests", "db",
-                AbstractServerHttpHandler.MAX_DB_TAG_VALUES + AbstractServerHttpHandler.RESERVED_DB_TAG_VALUES,
-                MeterFilter.deny()));
+        // A MeterFilter cannot be removed from a registry, so the whole set is installed once per JVM, and
+        // before any meter exists as Micrometer requires MeterFilters to precede the meters they govern.
+        installCardinalityMeterFilters(Metrics.globalRegistry.config());
         metricsFiltersInstalled = true;
       }
 

--- a/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java
@@ -19,9 +19,11 @@
 package com.arcadedb.server.monitor;
 
 import com.arcadedb.database.QueryMetricsRecorder;
+import com.arcadedb.query.QueryEngineManager;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -31,10 +33,46 @@ import java.util.concurrent.TimeUnit;
  * metrics are enabled; otherwise the engine keeps the no-op recorder and pays no timing cost.
  */
 public final class MicrometerQueryMetricsRecorder implements QueryMetricsRecorder {
+  // Constant language tag used for any value that does not name a query engine registered on this JVM. The
+  // language is whatever the caller asked to run - db.query("<language>", ...), the {lang} path segment of
+  // the HTTP API, the Postgres portal language - and the timer is recorded whether or not the query
+  // succeeded, so echoing it verbatim registered one permanent percentile-histogram Timer per invented name:
+  // the unbounded-tag leak of #5025/#6805, on this meter (issue #7122).
+  private static final String UNKNOWN_LANGUAGE_TAG = "unknown";
+  // Constant db tag substituted once the timer cache is full. With protocol, type and language all bounded
+  // above, the database name is the one part of the tuple that can still grow (create/drop churn), so it is
+  // what collapses when the ceiling is reached.
+  private static final String OVERFLOW_DB_TAG      = "other";
+  // Maximum number of distinct values allowed in the "language" tag of arcadedb.query.duration.
+  // ArcadeDBServer.startMetrics() installs the matching MeterFilter from this constant, so the registry-side
+  // bound and the collapse above stay one number. Comfortably above the number of engines ArcadeDB can
+  // register (sql, sqlscript, java, cypher, opencypher, gremlin, mongo, graphql, redis plus whichever
+  // GraalVM polyglot languages are on the classpath).
+  public static final  int    MAX_LANGUAGE_TAG_VALUES  = 50;
+  // The one value above and beyond a registered language name that the tag can carry: UNKNOWN_LANGUAGE_TAG.
+  // MeterFilter.maximumAllowableTags counts EVERY distinct value, so the filter limit has to include it, or
+  // a JVM that had used the whole budget on real languages would have its own collapse value denied -
+  // exactly the meter that exists to keep cardinality down.
+  public static final  int    RESERVED_LANGUAGE_TAG_VALUES = 1;
+  // Maximum number of distinct DATABASE NAMES allowed in the "db" tag of arcadedb.query.duration, matching
+  // the budget the HTTP RED timer gives the same tag. Far above any realistic per-server database count.
+  public static final  int    MAX_DB_TAG_VALUES        = 1_000;
+  // The one value above and beyond a database name that the tag can carry: OVERFLOW_DB_TAG.
+  public static final  int    RESERVED_DB_TAG_VALUES   = 1;
+  // Ceiling on the number of cached tuples: a MeterFilter can deny the meter but cannot stop computeIfAbsent
+  // from retaining the key, so the cache needs a bound of its own. Sized as a multiple of MAX_DB_TAG_VALUES
+  // so a deployment with the maximum admissible number of databases still gets per-database RED visibility
+  // across ten protocol/language/type combinations each before anything collapses onto OVERFLOW_DB_TAG - the
+  // collapse is a backstop against unbounded growth, not a routine operating mode. Note this is a soft
+  // ceiling: the size test and the computeIfAbsent are not one atomic step, so concurrent misses right at the
+  // boundary can overshoot it by a bounded handful of entries before the collapse engages.
+  static final         int    MAX_QUERY_TIMERS         = MAX_DB_TAG_VALUES * 10;
   // Cache of resolved arcadedb.query.duration timers keyed by protocol|db|language|type. record() runs
   // for every query/command from every wire protocol; caching removes the per-call Timer.Builder/Tags/
-  // Meter.Id allocation and registry lookup on the hot path. The key space is bounded because every tag
-  // is low-cardinality (finite protocols/languages/types and the finite set of database names).
+  // Meter.Id allocation and registry lookup on the hot path. The key space is bounded because every tag is
+  // low-cardinality: protocol and type are small enumerations of constants set by the wire listeners, the
+  // language is validated against the registered engines below, and db is a database name - backed by the
+  // MAX_QUERY_TIMERS ceiling for the churn case.
   private static final ConcurrentHashMap<String, Timer> QUERY_TIMERS = new ConcurrentHashMap<>();
 
   @Override
@@ -53,12 +91,38 @@ public final class MicrometerQueryMetricsRecorder implements QueryMetricsRecorde
     QUERY_TIMERS.clear();
   }
 
+  /** Number of tuples currently cached. Package-private for direct unit testing of the ceiling. */
+  static int cachedTimerCount() {
+    return QUERY_TIMERS.size();
+  }
+
   /**
-   * Resolves (and caches) the {@code arcadedb.query.duration} timer for the given bounded tag tuple.
+   * Resolves (and caches) the {@code arcadedb.query.duration} timer for the given tag tuple, bounding the
+   * two halves of it that are not small enumerations.
+   * <p>
+   * The already-seen tuple is answered by the first lookup, so the hot path is exactly one concatenation and
+   * one hash lookup, as before. Only a miss pays for the bounds, and it pays before anything is retained:
+   * an unregistered {@code language} collapses onto {@link #UNKNOWN_LANGUAGE_TAG} and past
+   * {@link #MAX_QUERY_TIMERS} entries the {@code db} half collapses onto {@link #OVERFLOW_DB_TAG}, so
+   * neither an invented language nor database-name churn can grow the cache (issue #7122). Recurses at most
+   * twice - once per collapse - because each collapsed value is itself in the bounded set.
+   * <p>
    * Package-private for direct unit testing.
    */
   static Timer queryTimer(final String protocol, final String database, final String language, final String type) {
-    return QUERY_TIMERS.computeIfAbsent(protocol + '|' + database + '|' + language + '|' + type,
+    final String key = protocol + '|' + database + '|' + language + '|' + type;
+    final Timer cached = QUERY_TIMERS.get(key);
+    if (cached != null)
+      return cached;
+
+    final String boundedLanguage = languageTag(language);
+    if (!boundedLanguage.equals(language))
+      return queryTimer(protocol, database, boundedLanguage, type);
+
+    if (QUERY_TIMERS.size() >= MAX_QUERY_TIMERS && !OVERFLOW_DB_TAG.equals(database))
+      return queryTimer(protocol, OVERFLOW_DB_TAG, language, type);
+
+    return QUERY_TIMERS.computeIfAbsent(key,
         k -> Timer.builder("arcadedb.query.duration")
             .description("Query/command execution duration")
             .tag("protocol", protocol)
@@ -67,5 +131,19 @@ public final class MicrometerQueryMetricsRecorder implements QueryMetricsRecorde
             .tag("type", type)
             .publishPercentileHistogram()
             .register(Metrics.globalRegistry));
+  }
+
+  /**
+   * Bounded {@code language} tag: the value is echoed only when it names a query engine registered on this
+   * JVM, and collapses to the constant {@link #UNKNOWN_LANGUAGE_TAG} otherwise. Normalised to lower case the
+   * way {@code QueryEngineManager.getEngine()} normalises it, so the case permutations of a real language
+   * name cannot multiply the tag space either (issue #7122). Package-private so
+   * {@link MicrometerQueryTracer} bounds the same key the same way, and for direct unit testing.
+   */
+  static String languageTag(final String language) {
+    if (language == null)
+      return UNKNOWN_LANGUAGE_TAG;
+    final String normalized = language.toLowerCase(Locale.ENGLISH);
+    return QueryEngineManager.getInstance().isLanguageRegistered(normalized) ? normalized : UNKNOWN_LANGUAGE_TAG;
   }
 }

--- a/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryTracer.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryTracer.java
@@ -51,7 +51,10 @@ public final class MicrometerQueryTracer implements QueryTracer {
     final Observation observation = Observation.createNotStarted("arcadedb.query", observationRegistry)
         .lowCardinalityKeyValue("protocol", protocol != null ? protocol : "internal")
         .lowCardinalityKeyValue("db", database != null ? database : "none")
-        .lowCardinalityKeyValue("language", language != null ? language : "unknown")
+        // Bounded through the same helper the RED timer uses: "low cardinality" is a promise to whatever
+        // handler is attached - one of which may turn these keys into meter tags - and the language is
+        // client-supplied, so the promise has to be enforced rather than assumed (issue #7122).
+        .lowCardinalityKeyValue("language", MicrometerQueryMetricsRecorder.languageTag(language))
         .lowCardinalityKeyValue("type", type != null ? type : "query")
         .highCardinalityKeyValue("db.statement", query != null ? query : "");
     observation.start();

--- a/server/src/test/java/com/arcadedb/server/ArcadeDBServerMetricsFiltersTest.java
+++ b/server/src/test/java/com/arcadedb/server/ArcadeDBServerMetricsFiltersTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.server.monitor.MicrometerQueryMetricsRecorder;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the registry-side cardinality backstops {@link ArcadeDBServer} installs on the RED timers.
+ * The recorder and the HTTP handler already collapse client-influenced tag values onto constants, so these
+ * filters exist for the case where that collapse is bypassed by a future route, a new wire protocol, or a
+ * regression: past the budget the meter must be denied rather than registered forever (issues #6805, #7122).
+ * <p>
+ * Applied to a throwaway registry rather than to {@code Metrics.globalRegistry}, because a
+ * {@code MeterFilter} can never be removed from a registry once installed.
+ */
+class ArcadeDBServerMetricsFiltersTest {
+
+  @Test
+  void theLanguageTagOfTheQueryTimerIsCappedInTheRegistry() {
+    final MeterRegistry registry = new SimpleMeterRegistry();
+    ArcadeDBServer.installCardinalityMeterFilters(registry.config());
+
+    final int budget = MicrometerQueryMetricsRecorder.MAX_LANGUAGE_TAG_VALUES
+        + MicrometerQueryMetricsRecorder.RESERVED_LANGUAGE_TAG_VALUES;
+    for (int i = 0; i < budget; i++)
+      queryTimer(registry, "lang" + i, "graph");
+
+    // Everything inside the budget is registered, so real languages keep their own series.
+    assertThat(registry.find("arcadedb.query.duration").timers()).hasSize(budget);
+
+    queryTimer(registry, "one-language-too-many", "graph");
+
+    assertThat(registry.find("arcadedb.query.duration").tag("language", "one-language-too-many").timer())
+        .as("past the budget the meter must be denied, never registered permanently").isNull();
+    assertThat(registry.find("arcadedb.query.duration").timers()).hasSize(budget);
+  }
+
+  @Test
+  void theDatabaseTagOfTheQueryTimerIsCappedInTheRegistry() {
+    final MeterRegistry registry = new SimpleMeterRegistry();
+    ArcadeDBServer.installCardinalityMeterFilters(registry.config());
+
+    final int budget = MicrometerQueryMetricsRecorder.MAX_DB_TAG_VALUES
+        + MicrometerQueryMetricsRecorder.RESERVED_DB_TAG_VALUES;
+    for (int i = 0; i < budget; i++)
+      queryTimer(registry, "sql", "db" + i);
+
+    queryTimer(registry, "sql", "one-database-too-many");
+
+    assertThat(registry.find("arcadedb.query.duration").tag("db", "one-database-too-many").timer())
+        .as("database-name churn must not grow the registry without bound").isNull();
+    assertThat(registry.find("arcadedb.query.duration").timers()).hasSize(budget);
+  }
+
+  @Test
+  void thePathTagOfTheHttpTimerIsStillCapped() {
+    // The #5025 filter must survive the extraction that moved all four into one method.
+    final MeterRegistry registry = new SimpleMeterRegistry();
+    ArcadeDBServer.installCardinalityMeterFilters(registry.config());
+
+    for (int i = 0; i < 100; i++)
+      Timer.builder("arcadedb.http.requests").tag("path", "/p" + i).tag("db", "none").register(registry);
+
+    Timer.builder("arcadedb.http.requests").tag("path", "/one-too-many").tag("db", "none").register(registry);
+
+    assertThat(registry.find("arcadedb.http.requests").tag("path", "/one-too-many").timer()).isNull();
+  }
+
+  private static void queryTimer(final MeterRegistry registry, final String language, final String db) {
+    Timer.builder("arcadedb.query.duration")
+        .tag("protocol", "http")
+        .tag("db", db)
+        .tag("language", language)
+        .tag("type", "query")
+        .register(registry);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorderTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorderTest.java
@@ -18,8 +18,14 @@
  */
 package com.arcadedb.server.monitor;
 
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,8 +33,23 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit test for the per-tuple timer cache in {@link MicrometerQueryMetricsRecorder} (issue #5025):
  * {@code record()} runs on the query hot path for every wire protocol, so a repeated tag tuple must
  * reuse the same cached {@link Timer} instead of rebuilding the builder/tags/id each time.
+ * <p>
+ * Also covers the bounds that keep that cache - and the meters it registers - finite (issue #7122):
+ * the {@code language} tag arrives from the caller, so an unregistered value must collapse onto a
+ * constant before it is ever used as a cache key, and the cache as a whole must have a ceiling.
  */
 class MicrometerQueryMetricsRecorderTest {
+  private static final String OVERFLOW_PROTOCOL = "overflow-test";
+
+  @AfterEach
+  void dropTimersRegisteredByThisTest() {
+    // The cache and Metrics.globalRegistry are both JVM-wide, so the overflow test below would otherwise
+    // leave its fill behind for every later test sharing the fork.
+    MicrometerQueryMetricsRecorder.invalidateTimerCache();
+    final List<Meter> mine = new ArrayList<>(
+        Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", OVERFLOW_PROTOCOL).meters());
+    mine.forEach(Metrics.globalRegistry::remove);
+  }
 
   @Test
   void queryTimerIsCachedPerTagTuple() {
@@ -51,5 +72,77 @@ class MicrometerQueryMetricsRecorderTest {
     // The tuple recorded above must resolve to an already-cached timer (same instance returned).
     final Timer cached = MicrometerQueryMetricsRecorder.queryTimer("bolt", "graph", "cypher", "query");
     assertThat(MicrometerQueryMetricsRecorder.queryTimer("bolt", "graph", "cypher", "query")).isSameAs(cached);
+  }
+
+  @Test
+  void anUnregisteredLanguageCollapsesToABoundedConstant() {
+    // Issue #7122: the language reaches the recorder straight from the caller - db.query("<language>", ...),
+    // the {lang} segment of the HTTP API - so echoing it verbatim registered one permanent
+    // percentile-histogram Timer, plus one permanent cache entry, per invented name.
+    final Timer bogus = MicrometerQueryMetricsRecorder.queryTimer("http", "graph", "not-a-language-12345", "query");
+
+    assertThat(bogus.getId().getTag("language")).isEqualTo("unknown");
+
+    // Two different invented names must land on the ONE collapsed timer, not on two.
+    assertThat(MicrometerQueryMetricsRecorder.queryTimer("http", "graph", "not-a-language-67890", "query"))
+        .isSameAs(bogus);
+  }
+
+  @Test
+  void anUnregisteredLanguageIsNeverRetainedAsACacheKey() {
+    // A MeterFilter can deny the meter but cannot stop computeIfAbsent from retaining the key, so the
+    // collapse has to happen before anything is cached - otherwise the cache leaks even when the registry
+    // does not (the third part of the #6805 fix).
+    MicrometerQueryMetricsRecorder.invalidateTimerCache();
+
+    for (int i = 0; i < 500; i++)
+      MicrometerQueryMetricsRecorder.queryTimer("http", "graph", "bogus" + i, "query");
+
+    // Exactly one entry: protocol|graph|unknown|query.
+    assertThat(MicrometerQueryMetricsRecorder.cachedTimerCount()).isEqualTo(1);
+  }
+
+  @Test
+  void aRegisteredLanguageKeepsItsOwnTagValue() {
+    // sql is always registered, so the tag must stay useful - the collapse is a backstop, not the norm.
+    assertThat(MicrometerQueryMetricsRecorder.queryTimer("http", "graph", "sql", "query").getId().getTag("language"))
+        .isEqualTo("sql");
+  }
+
+  @Test
+  void languageTagIsCaseNormalized() {
+    // getEngine() lowercases before resolving, so "SQL" runs the sql engine. Without the same normalisation
+    // here every case permutation of a real language would be its own tag value and its own cache entry.
+    final Timer lower = MicrometerQueryMetricsRecorder.queryTimer("http", "graph", "sql", "query");
+
+    assertThat(MicrometerQueryMetricsRecorder.queryTimer("http", "graph", "SQL", "query")).isSameAs(lower);
+    assertThat(MicrometerQueryMetricsRecorder.queryTimer("http", "graph", "SqL", "query")).isSameAs(lower);
+  }
+
+  @Test
+  void aNullLanguageCollapsesInsteadOfBeingTaggedNull() {
+    assertThat(MicrometerQueryMetricsRecorder.queryTimer("http", "graph", null, "query").getId().getTag("language"))
+        .isEqualTo("unknown");
+  }
+
+  @Test
+  void theDatabaseTagCollapsesOnceTheCacheCeilingIsReached() {
+    // With the language bounded, database-name churn (create/drop in a loop) is the one dimension left that
+    // can still grow the cache, so past the ceiling it collapses onto a constant.
+    MicrometerQueryMetricsRecorder.invalidateTimerCache();
+
+    for (int i = 0; i < MicrometerQueryMetricsRecorder.MAX_QUERY_TIMERS; i++)
+      MicrometerQueryMetricsRecorder.queryTimer(OVERFLOW_PROTOCOL, "db" + i, "sql", "query");
+
+    assertThat(MicrometerQueryMetricsRecorder.cachedTimerCount())
+        .isGreaterThanOrEqualTo(MicrometerQueryMetricsRecorder.MAX_QUERY_TIMERS);
+
+    final Timer overflowed = MicrometerQueryMetricsRecorder.queryTimer(OVERFLOW_PROTOCOL, "one-database-too-many",
+        "sql", "query");
+    assertThat(overflowed.getId().getTag("db")).isEqualTo("other");
+
+    // The collapsed tuple space is finite, so it is itself cacheable: a second overflowing name reuses it.
+    assertThat(MicrometerQueryMetricsRecorder.queryTimer(OVERFLOW_PROTOCOL, "another-one-too-many", "sql", "query"))
+        .isSameAs(overflowed);
   }
 }


### PR DESCRIPTION
Closes #7122

## Summary

`MicrometerQueryMetricsRecorder` built one `arcadedb.query.duration` Timer per
`protocol|db|language|type` tuple and called the tuple "bounded". That holds for `protocol` (constants
the wire listeners pass to `ProtocolContext.set`) and `type` (`query`/`command`), but not for
`language`: the value travels straight from the caller - `db.query("<language>", …)`, the `{lang}`
path segment of the HTTP API, the Postgres portal language - and reached the tag with no validation.
`LocalDatabase.query()/command()` record in a `finally`, so a request that fails with
`Query engine '<language>' was not found` **still** registered a permanent percentile-histogram Timer
in the static `Metrics.globalRegistry` and a permanent entry in the recorder's own cache. Micrometer
never evicts, so heap and `/metrics` grew without bound - the #6805 shape at a meter #6805 did not cover.

This bounds the tag the same three ways #6805 bounded `db` on `arcadedb.http.requests`:

- **Validate at the source.** New `QueryEngineManager.isLanguageRegistered()` answers "is this a real
  language?" with one volatile read of the copy-on-write engine map and one hash lookup, no allocation.
  `MicrometerQueryMetricsRecorder.languageTag()` lowercases (so case permutations of a real language
  cannot multiply the tag space either) and collapses anything unregistered onto `unknown`.
- **Backstop in the registry.** `ArcadeDBServer.startMetrics()` now installs `MeterFilter`s on the
  `language` and `db` tags of `arcadedb.query.duration` alongside the two it already had. All four moved
  into `installCardinalityMeterFilters(MeterRegistry.Config)`, so they can be applied to a throwaway
  registry and asserted directly - a `MeterFilter` can never be removed from a registry once installed.
- **Bound the cache.** A `MeterFilter` can deny the meter but cannot stop `computeIfAbsent` from
  retaining the key. `queryTimer()` looks the raw key up first (unchanged hot path: one concatenation,
  one `get`) and only on a miss bounds the tags, before anything is retained; past `MAX_QUERY_TIMERS`
  the `db` half collapses onto `other`, the one dimension left that database create/drop churn can grow.

`MicrometerQueryTracer` routes its `language` low-cardinality key through the same helper: "low
cardinality" is a promise to whatever observation handler is attached, one of which may turn those keys
into meter tags.

Also in this sweep, as the issue notes: `LoadCSVStep.openReader()` stranded the raw `InputStream` when
the `.gz`/`.zip` wrapper rejected the archive header - the caller only closes the `BufferedReader` it
never received, so each failed `LOAD CSV` of a malformed archive cost one file descriptor (or, for an
`http(s)` source, one socket). The empty-ZIP refusal also escaped as `CommandExecutionException`, which
the caller's `IOException` arm does not catch, so it surfaced without the `Error opening CSV file: <url>`
context every other open failure carries. Both fixed; the wrapper is split out as
`decompressingReader(url, raw)` so the failure paths are testable with a stream whose closing is observable.

## Test plan

Every new test was run against the unfixed code first and fails there:

| Test | Unfixed result |
|---|---|
| `anUnregisteredLanguageCollapsesToABoundedConstant` | `expected: "unknown"` |
| `anUnregisteredLanguageIsNeverRetainedAsACacheKey` | `expected: 1`, 500 entries retained |
| `languageTagIsCaseNormalized` | two distinct timers for `sql`/`SQL` |
| `aNullLanguageCollapsesInsteadOfBeingTaggedNull` | `NullPointerException` |
| `theDatabaseTagCollapsesOnceTheCacheCeilingIsReached` | `expected: "other"` |
| `aCorruptGzipHeaderDoesNotStrandTheRawStream` | stream left open |
| `anEmptyZipDoesNotStrandTheRawStream` | `CommandExecutionException`, stream left open |

- [x] `mvn -o -pl server surefire:test -Dtest='MicrometerQueryMetricsRecorderTest,ArcadeDBServerMetricsFiltersTest,ServerMetricsLifecycleTest,AbstractServerHttpHandlerMetricsTest'` — 24/24 green
- [x] `mvn -o -pl engine surefire:test -Dtest='LoadCSVStepOpenReaderTest,OpenCypherLoadCSVTest,OpenCypherLoadCsvFunctionsComprehensiveTest,CypherLoadCSVRowContextIssue6402Test,QueryMetricsRecorderTest,LocalDatabaseQueryMetricsTest,LocalDatabaseQueryTracerTest,ProtocolContextTest'` — 59/59 green
- [x] `mvn -o -pl engine surefire:test -Dtest='QueryEngine*Test,DedicatedThreadPool*Test'` — 18/18 green (plus the 2 new `QueryEngineManagerLanguagesTest` cases)
- [x] `mvn -o -pl engine,server -am -DskipTests install` — compiles clean

The issue's repro (`/api/v1/query/{db}/lang$i/select%201` in a loop) is covered at the recorder rather
than over HTTP: `anUnregisteredLanguageIsNeverRetainedAsACacheKey` drives 500 distinct invented
languages through the exact call the failing request reaches via `LocalDatabase`'s `finally`, and
asserts the cache holds one entry, not 500. No live server loop was run.

**Performance:** the hot path is unchanged for an already-seen tuple - one string concatenation and one
`ConcurrentHashMap.get`, as before. `languageTag()` runs only on a cache miss, which already pays for a
`Timer.Builder`, a `Tags` list and a registry registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrEkRtrTi2mMLiGRuSCKwe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query and HTTP metrics stability by limiting tag-value cardinality.
  * Normalized query-language metric tags and grouped unknown or excess database values safely.
  * Improved `LOAD CSV` handling for compressed, malformed, and empty archive inputs, including better stream cleanup and error reporting.

* **Tests**
  * Added coverage for metric cardinality limits, language normalization, and compressed CSV reader failure scenarios.

* **Documentation**
  * Documented query-duration metric behavior and `LOAD CSV` reliability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->