### PR TITLE
fix: Raft counter double-fold, frozen gRPC peer allowlist, replay/idempotency and diagnostics defects

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2065,9 +2065,13 @@ public enum GlobalConfiguration {
 
   HA_PEER_ALLOWLIST_ENABLED("arcadedb.ha.peerAllowlist.enabled", SCOPE.SERVER,
       """
-      Reject inbound Raft gRPC connections whose remote address does not resolve to a host in \
-      arcadedb.ha.serverList. Loopback is always allowed. Does not provide peer identity or encryption: \
-      use mTLS on untrusted networks.""",
+      Reject inbound Raft gRPC connections whose remote address does not resolve to a cluster peer host. \
+      The hosts are those of arcadedb.ha.serverList (expanded with arcadedb.ha.k8sSuffix when \
+      arcadedb.ha.k8s is set), plus the members of the live Raft configuration, which are picked up on \
+      every health monitor tick so a peer that joined at runtime is admitted; on Kubernetes the headless \
+      service behind arcadedb.ha.k8sSuffix is resolved too, so a StatefulSet scale-up pod can complete its \
+      auto-join. Loopback is always allowed. Does not provide peer identity or encryption: use mTLS on \
+      untrusted networks.""",
       Boolean.class, true),
 
   HA_GRPC_ALLOWLIST_REFRESH_MS("arcadedb.ha.grpcAllowlistRefreshMs", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -436,7 +436,11 @@ public class TransactionContext implements Transaction {
             try {
               database.getSchema().getDictionary().reload();
             } catch (final IOException e) {
-              throw new SchemaException("Error on reloading schema dictionary");
+              // Chain the cause: the reason the dictionary could not be re-read is the only thing that tells a
+              // truncated file apart from a permission problem or a closed channel (issue #7141).
+              throw new SchemaException(
+                  "Error on reloading the schema dictionary of database '" + database.getName() + "' while rolling back: "
+                      + e.getMessage(), e);
             }
             break;
           }

--- a/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
@@ -97,7 +97,7 @@ public class ComponentFile {
 
   public void drop() throws IOException {
     close();
-    LogManager.instance().log(this, Level.FINE, "Deleting file %s (id=%d) to %s...", null, filePath, fileId);
+    LogManager.instance().log(this, Level.FINE, "Deleting file %s (id=%d)...", null, filePath, fileId);
     Files.delete(Path.of(getFilePath()));
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -537,6 +537,15 @@ public class TransactionManager {
   private boolean applyChangesInternal(final WALFile.WALTransaction tx, final Map<Integer, Integer> bucketRecordDelta,
       final boolean ignoreErrors) {
     boolean changed = false;
+    // Whether at least one page was written at a version STRICTLY GREATER than the one on disk, i.e. this
+    // transaction carried content the database did not have yet. `changed` cannot answer that question: since
+    // #4926 an EQUAL-version page is deliberately re-applied (torn-write repair), which sets `changed` on a
+    // transaction that was already fully applied. The bucket record-count fold at the end of this method is a
+    // RELATIVE increment, so folding it on such a replay double-counts it, and on a cleanly-restarted node the
+    // counter is live (statistics.json) and never invalidated, so the over-count is permanent (issue #7126).
+    // A version advance is the precise idempotency signal: if a previous apply of this entry had reached the
+    // fold, every page of the entry would already be at or beyond its target version, so nothing could advance.
+    boolean versionAdvanced = false;
     boolean involveDictionary = false;
 
     final int dictionaryId =
@@ -723,6 +732,10 @@ public class TransactionManager {
           involveDictionary = true;
 
         changed = true;
+        if (txPage.currentPageVersion > page.getVersion())
+          // New content for this page: the database did not have this version yet, so the record-count delta
+          // this entry carries has not been folded into the cached counters (issue #7126).
+          versionAdvanced = true;
         LogManager.instance().log(this, Level.FINE, "  - updating page %s v%d", null, pageId, modifiedPage.version);
 
       } catch (final ClosedByInterruptException e) {
@@ -740,10 +753,13 @@ public class TransactionManager {
       }
     }
 
-    if (changed) {
+    if (versionAdvanced) {
       for (final Map.Entry<Integer, Integer> entry : bucketRecordDelta.entrySet()) {
-        final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(entry.getKey());
-        if (bucket.getCachedRecordCount() > -1)
+        // getFileByIdIfExists, not getBucketById: a DROP TYPE replayed after this entry removed the bucket, and
+        // the counter of a bucket that no longer exists is nobody's business - mirrors the same fold in
+        // TransactionContext.commit2ndPhase.
+        if (database.getSchema().getFileByIdIfExists(entry.getKey()) instanceof LocalBucket bucket
+            && bucket.getCachedRecordCount() > -1)
           // UPDATE THE CACHE COUNTER ONLY IF ALREADY COMPUTED
           bucket.setCachedRecordCount(bucket.getCachedRecordCount() + entry.getValue());
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterDatabaseStatement.java
@@ -107,7 +107,11 @@ public class AlterDatabaseStatement extends DDLStatement {
       try {
         db.saveConfiguration();
       } catch (final IOException e) {
-        throw new CommandExecutionException("Error on saving database configuration");
+        // Chain the cause and name what was being written: without them a read-only filesystem, a permission
+        // problem and a full volume are indistinguishable to the caller (issue #7141).
+        throw new CommandExecutionException(
+            "Error on saving the configuration of database '" + db.getName() + "' after setting '" + settingNameAsString
+                + "' to '" + finalValue + "': " + e.getMessage(), e);
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateBucketStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateBucketStatement.java
@@ -44,19 +44,28 @@ public class CreateBucketStatement extends DDLStatement {
     final String bucketName = name.getStringValue();
     if (db.getSchema().existsBucket(bucketName)) {
       if (ifNotExists)
-        return new InternalResultSet();
+        // One row, exactly as the creating branch below, with created=false telling the two apart: a retry of
+        // an IF NOT EXISTS statement must not answer a shape that reads as failure (issue #7143).
+        return new InternalResultSet(describe(context, bucketName, db.getSchema().getBucketByName(bucketName), false));
       throw new CommandExecutionException("Bucket '" + bucketName + "' already exists");
     }
     final Bucket bucket = db.getSchema().createBucket(bucketName);
 
-    final ResultInternal result = new ResultInternal(context.getDatabase());
-    result.setProperty("operation", "create bucket");
-    result.setProperty("bucketName", bucketName);
-    result.setProperty("bucketId", bucket.getFileId());
+    final ResultInternal result = describe(context, bucketName, bucket, true);
 
     final InternalResultSet rs = new InternalResultSet();
     rs.add(result);
     return rs;
+  }
+
+  private static ResultInternal describe(final CommandContext context, final String bucketName, final Bucket bucket,
+      final boolean created) {
+    final ResultInternal result = new ResultInternal(context.getDatabase());
+    result.setProperty("operation", "create bucket");
+    result.setProperty("bucketName", bucketName);
+    result.setProperty("bucketId", bucket.getFileId());
+    result.setProperty("created", created);
+    return result;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyStatement.java
@@ -78,8 +78,12 @@ public class CreatePropertyStatement extends DDLStatement {
       throw new CommandExecutionException("Type '" + typeName.getStringValue() + "' not found");
 
     if (ifNotExists) {
-      if (typez.existsPolymorphicProperty(propertyName.getStringValue()))
+      if (typez.existsPolymorphicProperty(propertyName.getStringValue())) {
+        // Same row as the creating path, with created=false telling the two apart (issue #7143).
+        result.setProperty("created", false);
+        typeName = prevType;
         return;
+      }
     } else if (typez.existsProperty(propertyName.getStringValue()))
       throw new CommandExecutionException("Property '" + typeName.getStringValue() + "." + propertyName.getStringValue() + "' already exists");
 
@@ -88,6 +92,7 @@ public class CreatePropertyStatement extends DDLStatement {
     // CREATE IT LOCALLY
     final String ofTypeAsString = ofType != null ? ofType.getStringValue() : null;
     final Property internalProp = typez.createProperty(propertyName.getStringValue(), type, ofTypeAsString);
+    result.setProperty("created", true);
     for (final CreatePropertyAttributeStatement attr : attributes) {
       final Object val = attr.setOnProperty(internalProp, context);
       result.setProperty(attr.settingName.getStringValue(), val);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTimeSeriesTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTimeSeriesTypeStatement.java
@@ -59,7 +59,10 @@ public class CreateTimeSeriesTypeStatement extends DDLStatement {
 
     if (schema.existsType(name.getStringValue())) {
       if (ifNotExists)
-        return new InternalResultSet();
+        // One row, exactly as the creating branch below, with created=false telling the two apart. Returning
+        // an empty result set on a retry made a caller that checks the row count read success as failure,
+        // which is precisely what IF NOT EXISTS exists to prevent (issue #7143).
+        return new InternalResultSet(describe(context, false));
       else
         throw new CommandExecutionException("Type '" + name.getStringValue() + "' already exists");
     }
@@ -89,10 +92,15 @@ public class CreateTimeSeriesTypeStatement extends DDLStatement {
 
     builder.create();
 
+    return new InternalResultSet(describe(context, true));
+  }
+
+  private ResultInternal describe(final CommandContext context, final boolean created) {
     final ResultInternal result = new ResultInternal(context.getDatabase());
     result.setProperty("operation", "create timeseries type");
     result.setProperty("typeName", name.getStringValue());
-    return new InternalResultSet(result);
+    result.setProperty("created", created);
+    return result;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTypeAbstractStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTypeAbstractStatement.java
@@ -93,7 +93,15 @@ public abstract class CreateTypeAbstractStatement extends DDLStatement {
     final Schema schema = context.getDatabase().getSchema();
     if (schema.existsType(name.getStringValue())) {
       if (ifNotExists) {
-        return new InternalResultSet();
+        // One row, exactly as the creating branch below, with created=false telling the two apart. IF NOT
+        // EXISTS is there to make a retry safe, so answering an empty result set the second time - which a
+        // client checking the row count reads as failure - defeated its purpose (issue #7143).
+        final ResultInternal existing = new ResultInternal(context.getDatabase());
+        existing.setProperty("operation", commandType());
+        existing.setProperty("typeName", name.getStringValue());
+        existing.setProperty("created", false);
+        name = prevName;
+        return new InternalResultSet(existing);
       } else {
         throw new CommandExecutionException("Type " + name + " already exists");
       }
@@ -103,6 +111,7 @@ public abstract class CreateTypeAbstractStatement extends DDLStatement {
     final ResultInternal result = new ResultInternal(context.getDatabase());
     result.setProperty("operation", commandType());
     result.setProperty("typeName", name.getStringValue());
+    result.setProperty("created", true);
 
     final DocumentType[] superclasses = getSuperTypes(schema);
 

--- a/engine/src/test/java/com/arcadedb/engine/Issue7126BucketCountReplayTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue7126BucketCountReplayTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7126: the bucket record-count delta was folded as a relative increment guarded
+ * only by the "something changed" flag of {@link TransactionManager#applyChanges}. Since #4926 a page whose
+ * WAL version EQUALS the on-disk one is deliberately re-applied (torn-write repair), so a Raft entry replayed
+ * after a clean restart set that flag on a transaction that had already been applied, and the delta was added
+ * a second time. On a cleanly-stopped node the cached counter is restored from {@code statistics.json} and
+ * never invalidated, so {@code SELECT count(*)} over-reported permanently and disagreed with a full scan.
+ * <p>
+ * The fold now runs only when at least one page was written at a version STRICTLY GREATER than the one on
+ * disk, which is exactly the case in which the entry carried content this node did not already have.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7126BucketCountReplayTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Counted");
+  }
+
+  @Test
+  void replayAtEqualVersionDoesNotDoubleFoldTheRecordCountDelta() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    db.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        db.newDocument("Counted").set("name", "record-" + i).save();
+    });
+
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getType("Counted").getBuckets(false).getFirst();
+    // Materialize the cached counter: the fold is a no-op while it is still -1, which is what makes an
+    // UNCLEAN restart safe and a CLEAN one not (issue #7126).
+    final long baseline = bucket.count();
+    assertThat(bucket.getCachedRecordCount()).isEqualTo(baseline);
+
+    final int fileId = bucket.getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final PageId pageId = new PageId(db, fileId, 0);
+
+    // A Raft replay of an entry whose pages are already at their final version: same bytes, same version.
+    final long versionBeforeReplay = db.getPageManager().getImmutablePage(pageId, file.getPageSize(), false, true)
+        .getVersion();
+    final boolean replayChanged = db.getTransactionManager()
+        .applyChanges(buildWalTransaction(db, fileId, (int) versionBeforeReplay, 7001), Map.of(fileId, 5), false);
+
+    // The page IS re-written (torn-write repair, #4926) ...
+    assertThat(replayChanged).isTrue();
+    // ... but the delta must NOT be folded again: this entry brought no content the node did not have.
+    assertThat(bucket.getCachedRecordCount()).isEqualTo(baseline);
+
+    // A genuinely new entry (version advances) still folds its delta exactly once.
+    db.getPageManager().removePageFromCache(pageId);
+    final long versionAfterReplay = db.getPageManager().getImmutablePage(pageId, file.getPageSize(), false, true)
+        .getVersion();
+    final boolean freshChanged = db.getTransactionManager()
+        .applyChanges(buildWalTransaction(db, fileId, (int) versionAfterReplay + 1, 7002), Map.of(fileId, 5), false);
+
+    assertThat(freshChanged).isTrue();
+    assertThat(bucket.getCachedRecordCount()).isEqualTo(baseline + 5);
+
+    // And replaying THAT entry once more leaves the counter where it is.
+    db.getPageManager().removePageFromCache(pageId);
+    final long versionAfterFresh = db.getPageManager().getImmutablePage(pageId, file.getPageSize(), false, true)
+        .getVersion();
+    db.getTransactionManager()
+        .applyChanges(buildWalTransaction(db, fileId, (int) versionAfterFresh, 7003), Map.of(fileId, 5), false);
+    assertThat(bucket.getCachedRecordCount()).isEqualTo(baseline + 5);
+  }
+
+  /**
+   * Builds a single-page WAL transaction that rewrites the first bytes of page 0 with the content they
+   * already hold, at {@code targetVersion}. The bytes are irrelevant here: what the test drives is the
+   * version comparison that decides whether the record-count delta is folded.
+   */
+  private static WALFile.WALTransaction buildWalTransaction(final DatabaseInternal db, final int fileId,
+      final int targetVersion, final long txId) throws Exception {
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final PageId pageId = new PageId(db, fileId, 0);
+    final ImmutablePage page = db.getPageManager().getImmutablePage(pageId, file.getPageSize(), false, true);
+
+    final WALFile.WALPage walPage = new WALFile.WALPage();
+    walPage.fileId = fileId;
+    walPage.pageNumber = 0;
+    walPage.currentPageVersion = targetVersion;
+    walPage.changesFrom = BasePage.PAGE_HEADER_SIZE;
+    walPage.changesTo = BasePage.PAGE_HEADER_SIZE + 10;
+    walPage.currentPageSize = page.getContentSize();
+
+    final byte[] content = new byte[walPage.changesTo - walPage.changesFrom + 1];
+    System.arraycopy(page.getContent().array(), walPage.changesFrom, content, 0, content.length);
+    walPage.currentContent = new Binary(content);
+
+    final WALFile.WALTransaction walTx = new WALFile.WALTransaction();
+    walTx.txId = txId;
+    walTx.timestamp = System.currentTimeMillis();
+    walTx.pages = new WALFile.WALPage[] { walPage };
+    return walTx;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/log/LogMessageArityTest.java
+++ b/engine/src/test/java/com/arcadedb/log/LogMessageArityTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.log;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression guard for issue #7141: a {@code LogManager.instance().log(...)} call whose format string carries
+ * more conversions than the call supplies arguments does not fail - {@link LogManager} pads the missing slots
+ * with {@code null}, so the message prints {@code null} exactly where the offending value belonged. Two such
+ * calls had been sitting in the tree unnoticed ({@code ArcadeDBServer.loadDefaultDatabases} lost the malformed
+ * startup command, {@code ComponentFile.drop} a phantom third placeholder), each costing an operator a
+ * debugging round trip.
+ * <p>
+ * Compilers cannot catch this: the format string is a plain {@code String} and the arguments are varargs. So
+ * the check is done here, over the sources of the modules that ship the server. Deliberately conservative -
+ * only calls whose message is a single string literal (or a concatenation of literals) are inspected, and the
+ * more permissive of the two possible argument counts is used (the fourth parameter of the overload may be a
+ * {@code Throwable} slot rather than a format argument). A report from this test is therefore a genuine
+ * missing argument, never a parsing artifact.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LogMessageArityTest {
+
+  private static final Pattern CALL_START =
+      Pattern.compile("LogManager\\s*\\.\\s*instance\\s*\\(\\s*\\)\\s*\\.\\s*log\\s*\\(");
+  /** A message made only of string literals (text blocks included), possibly concatenated. */
+  private static final Pattern LITERAL_MESSAGE =
+      Pattern.compile("^(?:\"\"\"[\\s\\S]*?\"\"\"|\"(?:[^\"\\\\]|\\\\.)*\")"
+          + "(?:\\s*\\+\\s*(?:\"\"\"[\\s\\S]*?\"\"\"|\"(?:[^\"\\\\]|\\\\.)*\"))*$");
+  /** A java.util.Formatter conversion. {@code %%} and {@code %n} are stripped before this is applied. */
+  private static final Pattern CONVERSION =
+      Pattern.compile("%(?:\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?[a-zA-Z]");
+
+  @Test
+  void everyLogCallSuppliesAnArgumentForEveryFormatConversion() throws IOException {
+    final List<String> offenders = new ArrayList<>();
+
+    for (final Path module : moduleSourceRoots()) {
+      try (final Stream<Path> files = Files.walk(module)) {
+        files.filter(p -> p.toString().endsWith(".java")).forEach(p -> {
+          try {
+            inspect(p, Files.readString(p, StandardCharsets.UTF_8), offenders);
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+      }
+    }
+
+    assertThat(offenders)
+        .as("log calls whose format string has more conversions than the call supplies arguments (issue #7141)")
+        .isEmpty();
+  }
+
+  private static List<Path> moduleSourceRoots() throws IOException {
+    // The test runs with its own module directory as working directory; every sibling module lives next to
+    // it. Modules are discovered rather than listed so a new one is covered without touching this test.
+    final Path repoRoot = Path.of("").toAbsolutePath().getParent();
+    final List<Path> roots = new ArrayList<>();
+    if (repoRoot == null)
+      return roots;
+    try (final Stream<Path> modules = Files.list(repoRoot)) {
+      modules.map(m -> m.resolve("src").resolve("main").resolve("java")).filter(Files::isDirectory).sorted()
+          .forEach(roots::add);
+    }
+    assertThat(roots).as("no module source root found under " + repoRoot).isNotEmpty();
+    return roots;
+  }
+
+  private static void inspect(final Path file, final String source, final List<String> offenders) {
+    final Matcher m = CALL_START.matcher(source);
+    while (m.find()) {
+      final int argsStart = m.end();
+      final int argsEnd = findClosingParenthesis(source, argsStart);
+      if (argsEnd < 0)
+        continue;
+
+      final List<String> args = splitTopLevel(source.substring(argsStart, argsEnd));
+      if (args.size() < 3)
+        continue;
+
+      final String message = args.get(2);
+      if (!LITERAL_MESSAGE.matcher(message).matches())
+        continue;
+
+      final int conversions = countConversions(message);
+      if (conversions == 0)
+        continue;
+
+      // Everything after the message. A literal `null` in the first of those slots is unambiguously the
+      // Throwable of the log(Object, Level, String, Throwable, Object...) overload - javac picks it because
+      // Throwable is more specific than Object - so it is not a format argument. For anything else the slot
+      // is ambiguous from source alone, and the permissive reading is taken so only a genuine shortfall is
+      // reported.
+      final int supplied = args.size() - 3 - ("null".equals(args.get(3)) ? 1 : 0);
+      if (supplied >= conversions)
+        continue;
+
+      final int line = (int) source.substring(0, m.start()).chars().filter(c -> c == '\n').count() + 1;
+      offenders.add(file + ":" + line + " expects " + conversions + " argument(s), supplies at most " + supplied
+          + ": " + message.lines().findFirst().orElse(message));
+    }
+  }
+
+  private static int countConversions(final String literal) {
+    final String stripped = literal.replace("%%", "").replace("%n", "");
+    final Matcher m = CONVERSION.matcher(stripped);
+    int count = 0;
+    while (m.find())
+      count++;
+    return count;
+  }
+
+  /** Index of the parenthesis closing the argument list that starts at {@code from}, or -1. */
+  private static int findClosingParenthesis(final String source, final int from) {
+    int depth = 1;
+    for (int i = from; i < source.length(); ) {
+      final int skipped = skipLiteral(source, i);
+      if (skipped > i) {
+        i = skipped;
+        continue;
+      }
+      final char c = source.charAt(i);
+      if (c == '(')
+        depth++;
+      else if (c == ')' && --depth == 0)
+        return i;
+      i++;
+    }
+    return -1;
+  }
+
+  /** Splits an argument list on commas that are not nested inside brackets or string/char literals. */
+  private static List<String> splitTopLevel(final String args) {
+    final List<String> parts = new ArrayList<>();
+    final StringBuilder current = new StringBuilder();
+    int depth = 0;
+    for (int i = 0; i < args.length(); ) {
+      final int skipped = skipLiteral(args, i);
+      if (skipped > i) {
+        current.append(args, i, skipped);
+        i = skipped;
+        continue;
+      }
+      final char c = args.charAt(i);
+      if (c == '(' || c == '[' || c == '{')
+        depth++;
+      else if (c == ')' || c == ']' || c == '}')
+        depth--;
+      if (c == ',' && depth == 0) {
+        parts.add(current.toString().trim());
+        current.setLength(0);
+      } else
+        current.append(c);
+      i++;
+    }
+    parts.add(current.toString().trim());
+    return parts;
+  }
+
+  /**
+   * When {@code i} opens a text block, a string literal or a char literal, returns the index just past its
+   * closing delimiter; otherwise returns {@code i}.
+   */
+  private static int skipLiteral(final String s, final int i) {
+    if (s.startsWith("\"\"\"", i)) {
+      int j = i + 3;
+      while (j < s.length()) {
+        if (s.charAt(j) == '\\')
+          j += 2;
+        else if (s.startsWith("\"\"\"", j))
+          return j + 3;
+        else
+          j++;
+      }
+      return s.length();
+    }
+    final char open = s.charAt(i);
+    if (open != '"' && open != '\'')
+      return i;
+    int j = i + 1;
+    while (j < s.length()) {
+      final char c = s.charAt(j);
+      if (c == '\\')
+        j += 2;
+      else if (c == open)
+        return j + 1;
+      else
+        j++;
+    }
+    return s.length();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue7141DiagnosticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue7141DiagnosticsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.CommandExecutionException;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #7141.
+ * <p>
+ * Two of the three defects the ticket reports are behavioural and are covered here: {@code ALTER DATABASE}
+ * used to throw {@code "Error on saving database configuration"} with the {@link IOException} neither chained
+ * nor logged, so a read-only filesystem, a permission problem and a full volume were indistinguishable; and
+ * the HA single-bucket warning advised {@code CREATE VERTEX TYPE <name> BUCKETS 16} on types that by
+ * definition already exist, which cannot work. The third (two log messages printing {@code null} where the
+ * offending value belonged) is guarded by {@code LogMessageArityTest}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7141DiagnosticsTest extends TestHelper {
+
+  /**
+   * The reason the configuration could not be written must survive as the cause and the message must name
+   * both the setting and the database, so the operator can tell the failure modes apart.
+   */
+  @Test
+  void alterDatabaseReportsWhySavingTheConfigurationFailed() {
+    final File configuration = new File(((DatabaseInternal) database).getDatabasePath() + File.separator
+        + "configuration.json");
+
+    // Turning the configuration file into a directory makes the FileOutputStream behind saveConfiguration()
+    // fail with an IOException on every platform and for every user, root included.
+    assertThat(configuration.delete() || !configuration.exists()).isTrue();
+    assertThat(configuration.mkdir()).isTrue();
+    try {
+      assertThatThrownBy(() -> database.command("sql", "alter database `arcadedb.asyncWorkerThreads` 3"))
+          .isInstanceOf(CommandExecutionException.class)
+          .hasMessageContaining("arcadedb.asyncWorkerThreads")
+          .hasMessageContaining(database.getName())
+          .hasCauseInstanceOf(IOException.class);
+    } finally {
+      assertThat(configuration.delete()).isTrue();
+    }
+  }
+
+  /**
+   * The advice the HA plugin now gives has to work on a type that already exists - which every type it warns
+   * about does, since it warns while wrapping an existing database for HA.
+   */
+  @Test
+  void theBucketAdviceGivenForSingleBucketTypesActuallyRuns() {
+    database.command("sql", "create vertex type Contended buckets 1");
+    assertThat(database.getSchema().getType("Contended").getBuckets(false)).hasSize(1);
+
+    // What the warning used to advise: impossible, the type already exists.
+    assertThatThrownBy(() -> database.command("sql", "create vertex type Contended buckets 16"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("already exists");
+
+    // What it advises now.
+    database.command("sql", "alter type Contended bucket +Contended_1");
+    database.command("sql", "alter type Contended bucket +Contended_2");
+    database.command("sql", "alter type Contended bucketselectionstrategy `thread`");
+
+    assertThat(database.getSchema().getType("Contended").getBuckets(false)).hasSize(3);
+    assertThat(database.getSchema().getType("Contended").getBucketSelectionStrategy().getName()).isEqualTo("thread");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue7143CreateIfNotExistsRowShapeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue7143CreateIfNotExistsRowShapeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7143 (second item): {@code CREATE ... IF NOT EXISTS} answered one row the first
+ * time and ZERO rows on a retry, so a client that checks the row count to confirm success read the retry as a
+ * failure - which is exactly what the guard exists to prevent. {@code CREATE INDEX}, {@code CREATE TRIGGER}
+ * and {@code CREATE GRAPH ANALYTICAL VIEW} already answered one row carrying a {@code created} flag; every
+ * guarded CREATE now follows that convention.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7143CreateIfNotExistsRowShapeTest extends TestHelper {
+
+  @Test
+  void everyGuardedCreateAnswersOneRowWithACreatedFlagOnBothCalls() {
+    assertCreatedThenIdempotent("create document type Doc1 if not exists", "typeName", "Doc1");
+    assertCreatedThenIdempotent("create vertex type Vert1 if not exists", "typeName", "Vert1");
+    assertCreatedThenIdempotent("create edge type Edge1 if not exists", "typeName", "Edge1");
+    assertCreatedThenIdempotent("create bucket Bucket1 if not exists", "bucketName", "Bucket1");
+    assertCreatedThenIdempotent("create property Doc1.name if not exists string", "propertyName", "name");
+    assertCreatedThenIdempotent(
+        "create timeseries type Series1 if not exists timestamp ts tags (sensor string) fields (value double)",
+        "typeName", "Series1");
+    assertCreatedThenIdempotent("create index if not exists on Doc1 (name) unique", "name", "Doc1[name]");
+  }
+
+  /**
+   * Runs {@code statement} twice and asserts both calls answer exactly one row naming the same object, the
+   * first with {@code created=true} and the second with {@code created=false}.
+   */
+  private void assertCreatedThenIdempotent(final String statement, final String nameProperty,
+      final String expectedName) {
+    final Result first = single(statement);
+    assertThat(first.<Boolean>getProperty("created")).as("%s (first call)", statement).isTrue();
+    assertThat(first.<Object>getProperty(nameProperty)).as("%s (first call)", statement).isEqualTo(expectedName);
+
+    final Result second = single(statement);
+    assertThat(second.<Boolean>getProperty("created")).as("%s (retry)", statement).isFalse();
+    assertThat(second.<Object>getProperty(nameProperty)).as("%s (retry)", statement).isEqualTo(expectedName);
+    assertThat(second.<Object>getProperty("operation")).as("%s (retry)", statement)
+        .isEqualTo(first.getProperty("operation"));
+  }
+
+  private Result single(final String statement) {
+    try (final ResultSet rs = database.command("sql", statement)) {
+      final List<Result> rows = rs.stream().toList();
+      assertThat(rows).as("row count of: %s", statement).hasSize(1);
+      return rows.getFirst();
+    }
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -903,7 +903,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
         switch (decoded.type()) {
         case TX_ENTRY -> applyTxEntry(decoded, index, originatedLocally);
         case SCHEMA_ENTRY -> applySchemaEntry(decoded, index, originatedLocally);
-        case INSTALL_DATABASE_ENTRY -> applyInstallDatabaseEntry(decoded);
+        case INSTALL_DATABASE_ENTRY -> applyInstallDatabaseEntry(decoded, index);
         case DROP_DATABASE_ENTRY -> applyDropDatabaseEntry(decoded);
         case SECURITY_USERS_ENTRY -> applySecurityUsersEntry(decoded);
         case BOOTSTRAP_FINGERPRINT_ENTRY -> applyBootstrapFingerprintEntry(decoded, index, originatedLocally);
@@ -2561,11 +2561,35 @@ public class ArcadeStateMachine extends BaseStateMachine {
     return list != null && !list.isEmpty();
   }
 
-  private void applyInstallDatabaseEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
+  // @VisibleForTesting
+  void applyInstallDatabaseEntry(final RaftLogEntryCodec.DecodedEntry decoded, final long entryIndex) {
     final String databaseName = decoded.databaseName();
     final boolean forceSnapshot = decoded.forceSnapshot();
 
     if (forceSnapshot) {
+      // Replay guard (issue #7143). Ratis re-feeds every entry between the last snapshot marker and
+      // shutdown, and unlike the normal-create branch below the force branch has no existence check to
+      // stop it - existence is precisely what it ignores. So without this a restart re-downloaded and
+      // re-installed the whole database on every replay: correct in outcome, but a node restarting
+      // repeatedly re-pulls a multi-GB database on each attempt, lengthening every start and competing
+      // for the bandwidth the cluster needs to recover. The in-place Ratis restart (restartRatisIfNeeded,
+      // one per health-monitor tick) can repeat that without the process ever exiting.
+      //
+      // The same per-database evidence applyBootstrapFingerprintEntry uses: a persisted applied index at
+      // or beyond this entry proves a previous session ran this install to completion and that Raft has
+      // since replicated this database forward from there. It is deliberately PER-DATABASE - one state
+      // machine multiplexes every database, so a co-located database that advanced the global index must
+      // not suppress this one's reinstall (issue #4824) - and a legacy plain-number applied-index file
+      // yields -1, which re-installs exactly as before.
+      final long persistedApplied = readPersistedAppliedIndex(databaseName);
+      if (persistedApplied >= entryIndex) {
+        LogManager.instance().log(this, Level.INFO,
+            "Database '%s' already reinstalled by this entry in a previous session (persistedAppliedIndex=%d >= "
+                + "entryIndex=%d); skipping the snapshot re-download",
+            databaseName, persistedApplied, entryIndex);
+        return;
+      }
+
       // Restore flow: replace files from the leader's snapshot even if the DB exists.
       // The leader's own files are already authoritative, so the leader skips the reinstall;
       // replicas close their local copy and pull the fresh snapshot from the leader.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -29,6 +29,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -70,6 +71,16 @@ import java.util.logging.Level;
  *       picked up by the reactive miss path and the background {@link #proactiveRefresh()}.</li>
  * </ul>
  * <p>
+ * The set of hosts is NOT frozen at boot (issue #7132). The hosts declared in {@code serverList} are the
+ * <i>configured</i> ones and are the only ones the quorum and completeness latches above count, but a
+ * caller may {@link #learnPeerHosts add} more at runtime, and {@code RaftHAServer} does so on every health
+ * monitor tick from the live Raft configuration. Without that, a peer that joined after this node started -
+ * through {@code addPeer}, or through the Kubernetes StatefulSet scale-up auto-join of issue #4836 - was
+ * rejected forever by every node that had already latched {@code everQuorumResolved}: the two features are
+ * individually correct and were jointly broken, because nothing reconciled them. Learned hosts resolve
+ * exactly like configured ones but are best-effort: a name that does not resolve contributes nothing,
+ * is logged at FINE rather than WARNING, and never holds the latches back.
+ * <p>
  * This is NOT a substitute for mTLS: it does not authenticate peer identity and does not
  * encrypt the traffic. See GitHub issue #3890. The bounded startup fail-open is an acceptable
  * trade-off for that reason; set {@code startupGraceMs=0} to disable it.
@@ -86,7 +97,13 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   // (at startup or from a non-peer) while letting the allowlist converge within ~1s.
   private static final long        MISS_RESOLVE_FLOOR_MS = 1_000L;
 
+  // Hosts declared in arcadedb.ha.serverList. Immutable, and the ONLY ones the quorum/completeness
+  // latches below count: they describe the configured cluster, which is what #4828 reasoned about.
   private final List<String>                 peerHosts;
+  // Hosts learned after construction (issue #7132): the members of the live Raft configuration, plus - on
+  // Kubernetes - the headless service domain behind arcadedb.ha.k8sSuffix, which resolves to every pod of
+  // the StatefulSet. Copy-on-write so isAllowed()'s hot path never synchronises against a learner.
+  private volatile Set<String>               learnedHosts = Collections.emptySet();
   // Number of declared peer hosts that must resolve before the startup fail-open ends: a Raft
   // majority (floor(n/2)+1). Enough peers to form the cluster, so a single permanently-down peer
   // no longer holds the fail-open window open for its full duration (issue #4828).
@@ -191,8 +208,14 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
       return true;
     }
 
+    // Named settings and the full host list, because this is logged on the RECEIVING node: an operator
+    // looking at a peer that will not join sees nothing at all in ITS log (issue #7132).
     LogManager.instance().log(this, Level.WARNING,
-        "Rejecting Raft gRPC connection from non-peer address: %s (allowed=%s)", ip, allowedIps.get());
+        "Rejecting Raft gRPC connection from %s: the address is not in the cluster peer allowlist "
+            + "(allowed=%s, configured hosts=%s, learned from the live Raft configuration=%s). If this is a "
+            + "legitimate peer, add it to 'arcadedb.ha.serverList' or check that its hostname resolves from "
+            + "this node; 'arcadedb.ha.peerAllowlist.enabled=false' disables the check entirely.",
+        ip, allowedIps.get(), peerHosts, learnedHosts);
     return false;
   }
 
@@ -209,6 +232,54 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   /** True once a quorum (majority) of peer hosts has been covered at least once. Exposed for testing. */
   boolean isQuorumResolved() {
     return everQuorumResolved;
+  }
+
+  /**
+   * Adds hosts discovered after construction to the allowlist and re-resolves immediately when any of them
+   * is new (issue #7132). The caller is {@code RaftHAServer.refreshPeerAllowlist}, which passes the hosts of
+   * the live Raft configuration on every health monitor tick, and {@code installPeerAllowlist}, which seeds
+   * the Kubernetes headless service domain. Idempotent: a tick that discovers nothing new costs one set
+   * comparison and does not touch DNS.
+   * <p>
+   * Learned hosts do not count towards {@link #isQuorumResolved()} or {@link #isEverCompletelyResolved()}:
+   * those gates describe the CONFIGURED cluster (issue #4828), and a name that does not resolve yet must not
+   * hold the fail-open window open, nor - once it does resolve - retroactively widen the quorum a returning
+   * peer has to clear.
+   *
+   * @return true when at least one host was not already known, i.e. when a re-resolution was performed
+   */
+  boolean learnPeerHosts(final Collection<String> hosts) {
+    if (hosts == null || hosts.isEmpty())
+      return false;
+
+    final Set<String> added = new HashSet<>();
+    synchronized (this) {
+      for (final String host : hosts) {
+        if (host == null || host.isBlank())
+          continue;
+        final String trimmed = host.trim();
+        if (peerHosts.contains(trimmed) || learnedHosts.contains(trimmed))
+          continue;
+        added.add(trimmed);
+      }
+      if (added.isEmpty())
+        return false;
+
+      final Set<String> merged = new HashSet<>(learnedHosts);
+      merged.addAll(added);
+      learnedHosts = Collections.unmodifiableSet(merged);
+      // Unconditional, NOT resolveIfStale: a newly learned host is exactly the case the refresh floors were
+      // written to throttle away, and the connection it is meant to admit is usually already being retried.
+      doResolve();
+    }
+    LogManager.instance().log(this, Level.FINE,
+        "Raft gRPC peer allowlist learned %d new host(s): %s", added.size(), added);
+    return true;
+  }
+
+  /** The hosts learned after construction. Exposed for testing. */
+  Set<String> getLearnedHosts() {
+    return learnedHosts;
   }
 
   /** Triggers an immediate DNS re-resolution. Exposed for testing. */
@@ -253,45 +324,62 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
     final long now = clock.getAsLong();
     final Set<String> effective = new HashSet<>(LoopbackHosts.IPS);
     int covered = 0;
-    for (final String host : peerHosts) {
-      Set<String> fresh = null;
-      try {
-        final InetAddress[] addrs = resolver.resolve(host);
-        if (addrs != null && addrs.length > 0) {
-          fresh = new HashSet<>();
-          for (final InetAddress a : addrs)
-            fresh.add(a.getHostAddress());
-        }
-      } catch (final UnknownHostException e) {
-        LogManager.instance().log(this, Level.WARNING,
-            "Cannot resolve cluster peer host '%s' for Raft gRPC allowlist: %s", host, e.getMessage());
-      }
-
-      if (fresh != null && !fresh.isEmpty()) {
-        lastKnownIps.put(host, fresh);
-        lastKnownMs.put(host, now);
-        effective.addAll(fresh);
+    for (final String host : peerHosts)
+      if (resolveHostInto(host, now, effective, true))
         covered++;
-      } else {
-        // Resolution failed: keep the last-known-good IPs for a bounded time (sticky) so a transient
-        // DNS outage or pod-IP churn does not evict a peer that resolved moments ago.
-        final Set<String> prev = lastKnownIps.get(host);
-        final Long prevMs = lastKnownMs.get(host);
-        if (prev != null && prevMs != null && stickyTtlMs > 0 && now - prevMs <= stickyTtlMs) {
-          effective.addAll(prev);
-          covered++;
-        } else {
-          lastKnownIps.remove(host);
-          lastKnownMs.remove(host);
-        }
-      }
-    }
+    // Learned hosts widen the allowlist but never the gates: see learnPeerHosts.
+    for (final String host : learnedHosts)
+      resolveHostInto(host, now, effective, false);
+
     allowedIps.set(Collections.unmodifiableSet(effective));
     lastResolveMs = now;
     if (covered >= resolveQuorum)
       everQuorumResolved = true;
     if (covered == peerHosts.size())
       everCompletelyResolved = true;
+  }
+
+  /**
+   * Resolves one host into {@code effective}, applying the sticky last-known-good retention. Returns whether
+   * the host ended up covered (freshly resolved, or served from its sticky entry).
+   *
+   * @param declared true for a host from {@code serverList}, whose failure to resolve is worth a WARNING;
+   *                 false for a learned host, where a name that does not (yet) resolve is expected - a
+   *                 headless service domain outside Kubernetes is the normal case.
+   */
+  private boolean resolveHostInto(final String host, final long now, final Set<String> effective,
+      final boolean declared) {
+    Set<String> fresh = null;
+    try {
+      final InetAddress[] addrs = resolver.resolve(host);
+      if (addrs != null && addrs.length > 0) {
+        fresh = new HashSet<>();
+        for (final InetAddress a : addrs)
+          fresh.add(a.getHostAddress());
+      }
+    } catch (final UnknownHostException e) {
+      LogManager.instance().log(this, declared ? Level.WARNING : Level.FINE,
+          "Cannot resolve cluster peer host '%s' for Raft gRPC allowlist: %s", host, e.getMessage());
+    }
+
+    if (fresh != null && !fresh.isEmpty()) {
+      lastKnownIps.put(host, fresh);
+      lastKnownMs.put(host, now);
+      effective.addAll(fresh);
+      return true;
+    }
+
+    // Resolution failed: keep the last-known-good IPs for a bounded time (sticky) so a transient
+    // DNS outage or pod-IP churn does not evict a peer that resolved moments ago.
+    final Set<String> prev = lastKnownIps.get(host);
+    final Long prevMs = lastKnownMs.get(host);
+    if (prev != null && prevMs != null && stickyTtlMs > 0 && now - prevMs <= stickyTtlMs) {
+      effective.addAll(prev);
+      return true;
+    }
+    lastKnownIps.remove(host);
+    lastKnownMs.remove(host);
+    return false;
   }
 
   /**
@@ -360,6 +448,7 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
 
   @Override
   public String toString() {
-    return "PeerAddressAllowlistFilter{peerHosts=" + peerHosts + ", allowed=" + allowedIps.get() + "}";
+    return "PeerAddressAllowlistFilter{peerHosts=" + peerHosts + ", learnedHosts=" + learnedHosts + ", allowed="
+        + allowedIps.get() + "}";
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -185,7 +185,8 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
       LogManager.instance().log(this, Level.WARNING,
           "HA database '%s' has %d type(s) backed by a single bucket: %s. In a cluster all writes "
               + "execute on the leader, so these types serialize concurrent writers on the same page and cause "
-              + "MVCC retries. Increase buckets (e.g. CREATE VERTEX TYPE <name> BUCKETS 16) and set "
+              + "MVCC retries. Add buckets to an EXISTING type with 'ALTER TYPE <name> BUCKET +<name>_1' (repeat "
+              + "once per extra bucket; the bucket is created if it does not exist) and then set "
               + "'ALTER TYPE <name> BucketSelectionStrategy `thread`' to remove the contention.",
           db.getName(), singleBucketTypes.size(), singleBucketTypes);
     } catch (final RuntimeException e) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -3816,7 +3816,16 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final long refreshMs = configuration.getValueAsLong(GlobalConfiguration.HA_GRPC_ALLOWLIST_REFRESH_MS);
     final long startupGraceMs = configuration.getValueAsLong(GlobalConfiguration.HA_PEER_ALLOWLIST_STARTUP_GRACE_MS);
     final long stickyTtlMs = configuration.getValueAsLong(GlobalConfiguration.HA_PEER_ALLOWLIST_STICKY_TTL_MS);
-    final List<String> peerHosts = PeerAddressAllowlistFilter.extractPeerHosts(serverList);
+    // The same Kubernetes DNS suffix parsePeerList applies to the peer addresses (issue #7132). Without it the
+    // allowlist tried to resolve the bare pod names written in the server list ("arcadedb-0"), which only
+    // happen to resolve when the pod's DNS search list covers them - i.e. when the namespace and the headless
+    // service share a name. Everywhere else no configured host resolved, the quorum latch never tripped, and
+    // the filter fell open for the whole grace window and then rejected every peer.
+    final String k8sDnsSuffix = configuration.getValueAsBoolean(GlobalConfiguration.HA_K8S)
+        ? configuration.getValueAsString(GlobalConfiguration.HA_K8S_DNS_SUFFIX)
+        : "";
+    final List<String> peerHosts = PeerAddressAllowlistFilter.extractPeerHosts(serverList).stream()
+        .map(h -> RaftPeerAddressResolver.applyDnsSuffix(h, k8sDnsSuffix)).toList();
     if (peerHosts.isEmpty()) {
       LogManager.instance().log(this, Level.WARNING,
           "arcadedb.ha.peerAllowlist.enabled=true but arcadedb.ha.serverList is empty; allowlist not installed");
@@ -3824,13 +3833,43 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     }
     final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(peerHosts, refreshMs, startupGraceMs,
         stickyTtlMs);
+
+    // Kubernetes scale-up (issue #7132 x #4836). The joiner synthesizes itself into the group and dials the
+    // existing pods, but its host is in nobody's server list, and by then every existing pod has latched
+    // everQuorumResolved - so the join was rejected on the RECEIVING side and the new pod stayed NOT_READY
+    // forever. The headless service domain is the StatefulSet's own membership record: it resolves to the A
+    // records of every pod backing it, at any replica count and without an ordinal to guess, and it covers a
+    // pod that is not Ready yet because the service that publishes it sets publishNotReadyAddresses (which
+    // the shipped manifest documents as required, since a pod is Ready only once it has joined).
+    final String serviceDomain = headlessServiceDomain(k8sDnsSuffix);
+    if (serviceDomain != null)
+      filter.learnPeerHosts(List.of(serviceDomain));
+
     this.allowlistFilter = filter;
     GrpcConfigKeys.Server.setServicesCustomizer(parameters, new RaftGrpcServicesCustomizer(filter));
+  }
+
+  /**
+   * The headless-service FQDN behind {@code arcadedb.ha.k8sSuffix}, i.e. the suffix without its leading dot,
+   * or {@code null} when not running under Kubernetes or when no suffix is configured. Package-private for
+   * testing.
+   */
+  static String headlessServiceDomain(final String k8sDnsSuffix) {
+    if (k8sDnsSuffix == null || k8sDnsSuffix.isBlank())
+      return null;
+    final String trimmed = k8sDnsSuffix.trim();
+    final String domain = trimmed.startsWith(".") ? trimmed.substring(1) : trimmed;
+    return domain.isBlank() ? null : domain;
   }
 
   /** Package-private test hook: the transport configuration the Raft client builders read. */
   Parameters raftParametersForTest() {
     return raftParameters;
+  }
+
+  /** Package-private test hook: the inbound Raft gRPC peer allowlist, or null when disabled. */
+  PeerAddressAllowlistFilter allowlistFilterForTest() {
+    return allowlistFilter;
   }
 
   /**
@@ -3843,8 +3882,37 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   @Override
   public void refreshPeerAllowlist() {
     final PeerAddressAllowlistFilter filter = allowlistFilter;
-    if (filter != null)
-      filter.proactiveRefresh();
+    if (filter == null)
+      return;
+
+    // Reconcile the allowlist with cluster MEMBERSHIP, not with the boot-time configuration (issue #7132).
+    // getLivePeers() reads the committed Raft configuration - the same authority the cluster status endpoint
+    // uses - so a peer added at runtime (addPeer, the Kubernetes auto-join) is admitted from here on instead
+    // of being rejected forever by every node that had already latched everQuorumResolved. A tick that finds
+    // nothing new is a set comparison and does not touch DNS.
+    final List<String> memberHosts = new ArrayList<>();
+    for (final RaftPeer peer : getLivePeers()) {
+      final String host = allowlistHostOf(peer.getAddress());
+      if (host != null)
+        memberHosts.add(host);
+    }
+    filter.learnPeerHosts(memberHosts);
+
+    filter.proactiveRefresh();
+  }
+
+  /**
+   * The host of a Raft peer address in the form the allowlist resolver wants: no port, and no brackets around
+   * an IPv6 literal ({@link InetAddress#getAllByName} rejects those). Returns {@code null} when the address
+   * carries no usable host. Package-private for testing.
+   */
+  static String allowlistHostOf(final String raftAddress) {
+    final String host = extractHost(raftAddress);
+    if (host == null || host.isBlank())
+      return null;
+    if (host.startsWith("[") && host.endsWith("]"))
+      return host.length() > 2 ? host.substring(1, host.length() - 1) : null;
+    return host;
   }
 
   private static void deleteRecursive(final File file) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7132AllowlistLearnsRuntimePeersTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7132AllowlistLearnsRuntimePeersTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #7132: {@link PeerAddressAllowlistFilter} was built once from the STATIC
+ * {@code arcadedb.ha.serverList} and its host list was immutable for the life of the filter, so it never
+ * learned a peer that joined at runtime. Since the allowlist defaults to enabled and stops failing open as
+ * soon as a quorum of the static peers resolves, the Kubernetes scale-up auto-join of #4836 could not
+ * complete: the new pod's inbound Raft gRPC connections were rejected by every existing pod, so it never
+ * joined and stayed NOT_READY - and the rejection was logged on the RECEIVING pods, not on the new one.
+ * <p>
+ * Two things were wrong and both are covered here: the frozen host list, and the fact that on Kubernetes the
+ * configured hosts were resolved WITHOUT the DNS suffix {@code parsePeerList} applies to the peer addresses.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7132AllowlistLearnsRuntimePeersTest {
+
+  @Test
+  void aPeerThatJoinedAfterStartupIsAdmittedOnceItsHostIsLearned() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("arcadedb-0", List.of("10.1.13.1"));
+    dns.table.put("arcadedb-1", List.of("10.1.13.2"));
+    dns.table.put("arcadedb-2", List.of("10.1.13.3"));
+
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(
+        List.of("arcadedb-0", "arcadedb-1", "arcadedb-2"), 30_000L, 60_000L, 300_000L, clock::get, dns);
+
+    // The static peers all resolve, so the fail-open grace has already ended: this is the steady state a
+    // healthy cluster reaches about a second after startup.
+    assertThat(f.isQuorumResolved()).isTrue();
+    assertThat(f.isEverCompletelyResolved()).isTrue();
+
+    // The StatefulSet is scaled to 4. Pod 3 dials this node to join; its host is in nobody's server list.
+    dns.table.put("arcadedb-3", List.of("10.1.13.4"));
+    clock.set(120_000); // well past the grace window
+    assertThat(f.isAllowed("10.1.13.4")).as("the frozen allowlist could never admit an unknown host").isFalse();
+
+    // The health monitor tick feeds the live Raft configuration in; the joiner is admitted from here on.
+    assertThat(f.learnPeerHosts(List.of("arcadedb-0", "arcadedb-1", "arcadedb-2", "arcadedb-3"))).isTrue();
+    assertThat(f.getLearnedHosts()).containsExactly("arcadedb-3");
+    assertThat(f.isAllowed("10.1.13.4")).isTrue();
+  }
+
+  @Test
+  void learningIsIdempotentAndNeverRelearnsAConfiguredHost() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 300_000L,
+        clock::get, dns);
+
+    assertThat(f.learnPeerHosts(List.of("peerA"))).as("a configured host is not a new host").isFalse();
+    assertThat(f.learnPeerHosts(List.of())).isFalse();
+    assertThat(f.learnPeerHosts(null)).isFalse();
+
+    dns.table.put("peerB", List.of("10.0.0.2"));
+    assertThat(f.learnPeerHosts(List.of("peerB"))).isTrue();
+    assertThat(f.learnPeerHosts(List.of("peerB"))).as("a second tick with the same membership is a no-op").isFalse();
+    assertThat(f.isAllowed("10.0.0.2")).isTrue();
+  }
+
+  /**
+   * The quorum and completeness latches describe the CONFIGURED cluster (issue #4828). A learned host that
+   * does not resolve - a scale-up pod that has not been created yet - must not hold the fail-open window
+   * open, and one that does resolve must not widen the quorum a returning peer has to clear.
+   */
+  @Test
+  void learnedHostsDoNotCountTowardsTheQuorumAndCompletenessLatches() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 60_000L,
+        300_000L, clock::get, dns);
+    assertThat(f.isEverCompletelyResolved()).isTrue();
+
+    // A host that does not resolve at all: no warning, no effect on the latches, no effect on the allowlist.
+    assertThat(f.learnPeerHosts(List.of("does-not-exist"))).isTrue();
+    assertThat(f.isEverCompletelyResolved()).isTrue();
+    assertThat(f.isQuorumResolved()).isTrue();
+    assertThat(f.getAllowedIps()).contains("10.0.0.1");
+  }
+
+  /** A freshly started node whose configured peers do not resolve yet must still not latch on a learned host. */
+  @Test
+  void aLearnedHostDoesNotTripTheQuorumLatchOfAnIncompleteAllowlist() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("learned", List.of("10.0.9.9"));
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("peerA", "peerB", "peerC"),
+        30_000L, 60_000L, 300_000L, clock::get, dns);
+    assertThat(f.isQuorumResolved()).isFalse();
+
+    f.learnPeerHosts(List.of("learned"));
+
+    assertThat(f.isQuorumResolved()).as("a learned host is not a configured peer").isFalse();
+    assertThat(f.isEverCompletelyResolved()).isFalse();
+    assertThat(f.getAllowedIps()).contains("10.0.9.9");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Wiring in RaftHAServer
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void theAllowlistResolvesKubernetesPeerHostsWithTheConfiguredDnsSuffix() {
+    final ContextConfiguration config = kubernetesConfiguration();
+    final RaftHAServer server = detachedServer(config);
+
+    server.buildParameters(config);
+
+    final PeerAddressAllowlistFilter filter = server.allowlistFilterForTest();
+    assertThat(filter).isNotNull();
+    assertThat(filter.toString())
+        .as("the bare pod name from the server list only resolves when the namespace happens to match the "
+            + "headless service name; the suffix is what makes it resolve everywhere")
+        .contains("arcadedb-0.arcadedb.myns.svc.cluster.local");
+  }
+
+  /**
+   * The headless service domain is the StatefulSet's own membership record: it resolves to every pod backing
+   * it, at any replica count, which is what lets a scale-up pod's very first inbound connection through.
+   */
+  @Test
+  void theAllowlistSeedsTheHeadlessServiceDomainOnKubernetes() {
+    final ContextConfiguration config = kubernetesConfiguration();
+    final RaftHAServer server = detachedServer(config);
+
+    server.buildParameters(config);
+
+    assertThat(server.allowlistFilterForTest().getLearnedHosts())
+        .containsExactly("arcadedb.myns.svc.cluster.local");
+  }
+
+  @Test
+  void nothingIsSeededWhenNotRunningUnderKubernetes() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "localhost:2434:2480,localhost:2435:2481");
+    final RaftHAServer server = detachedServer(config);
+
+    server.buildParameters(config);
+
+    assertThat(server.allowlistFilterForTest().getLearnedHosts()).isEmpty();
+  }
+
+  @Test
+  void headlessServiceDomainStripsTheLeadingDotAndRejectsBlanks() {
+    assertThat(RaftHAServer.headlessServiceDomain(".arcadedb.myns.svc.cluster.local"))
+        .isEqualTo("arcadedb.myns.svc.cluster.local");
+    assertThat(RaftHAServer.headlessServiceDomain("arcadedb.myns.svc.cluster.local"))
+        .isEqualTo("arcadedb.myns.svc.cluster.local");
+    assertThat(RaftHAServer.headlessServiceDomain("")).isNull();
+    assertThat(RaftHAServer.headlessServiceDomain("   ")).isNull();
+    assertThat(RaftHAServer.headlessServiceDomain(".")).isNull();
+    assertThat(RaftHAServer.headlessServiceDomain(null)).isNull();
+  }
+
+  /** The resolver takes a host, not an address, and rejects the brackets of an IPv6 literal. */
+  @Test
+  void memberAddressesAreReducedToResolvableHosts() {
+    assertThat(RaftHAServer.allowlistHostOf("arcadedb-3.arcadedb.myns.svc.cluster.local:2434"))
+        .isEqualTo("arcadedb-3.arcadedb.myns.svc.cluster.local");
+    assertThat(RaftHAServer.allowlistHostOf("10.1.13.4:2434")).isEqualTo("10.1.13.4");
+    assertThat(RaftHAServer.allowlistHostOf("[fd00::4]:2434")).isEqualTo("fd00::4");
+    assertThat(RaftHAServer.allowlistHostOf("")).isNull();
+    assertThat(RaftHAServer.allowlistHostOf(null)).isNull();
+  }
+
+  private static ContextConfiguration kubernetesConfiguration() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "arcadedb-0:2434:2480");
+    config.setValue(GlobalConfiguration.HA_K8S, true);
+    config.setValue(GlobalConfiguration.HA_K8S_DNS_SUFFIX, ".arcadedb.myns.svc.cluster.local");
+    return config;
+  }
+
+  /** A {@link RaftHAServer} whose constructor has run but whose Ratis server was never started. */
+  private static RaftHAServer detachedServer(final ContextConfiguration config) {
+    final ArcadeDBServer arcadeServer = mock(ArcadeDBServer.class);
+    when(arcadeServer.getServerName()).thenReturn("arcadedb-0");
+    return new RaftHAServer(arcadeServer, config);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7143ForceSnapshotReplayGuardTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7143ForceSnapshotReplayGuardTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #7143 (first item): a {@code forceSnapshot} {@code INSTALL_DATABASE_ENTRY} had no
+ * replay guard. The normal-create branch skips by existence, but existence is exactly what the force branch
+ * ignores, so every Ratis replay of that entry - which happens on any restart, and on each in-place
+ * {@code restartRatisIfNeeded} the health monitor performs - re-downloaded and re-installed the whole
+ * database from the leader. The outcome was correct, the cost was not: a node restarting repeatedly re-pulls
+ * a multi-GB database on each attempt and competes for the bandwidth the cluster needs to recover.
+ * <p>
+ * The guard uses the same per-database applied index {@code applyBootstrapFingerprintEntry} consults.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7143ForceSnapshotReplayGuardTest {
+
+  private static final String DB   = "db-force";
+  private static final long   ENTRY_INDEX = 42L;
+
+  @TempDir
+  private Path          serverDir;
+  private ArcadeDBServer server;
+  private LocalDatabase  localDb;
+  private String         dbPath;
+
+  @BeforeEach
+  void setUp() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+    server = new ArcadeDBServer(config);
+
+    dbPath = serverDir.resolve(DB).toString();
+    localDb = (LocalDatabase) new DatabaseFactory(dbPath).create();
+    server.registerDatabase(DB, localDb);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (localDb != null && localDb.isOpen())
+      localDb.close();
+    if (dbPath != null)
+      FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void aReplayedForceSnapshotEntryDoesNotPullTheDatabaseAgain() {
+    final ArcadeStateMachine sm = newStateMachine();
+    // A previous session applied this entry and Raft has replicated this database forward since.
+    sm.writePersistedAppliedIndex(ENTRY_INDEX + 8, DB);
+
+    assertThatCode(() -> sm.applyInstallDatabaseEntry(forceSnapshotEntry(), ENTRY_INDEX))
+        .as("a replayed forceSnapshot entry must return without touching the snapshot download path")
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void aForceSnapshotEntryThisNodeHasNotAppliedStillPullsTheDatabase() {
+    final ArcadeStateMachine sm = newStateMachine();
+    // Applied index BELOW the entry: this node has not run this install, so it must not be skipped.
+    sm.writePersistedAppliedIndex(ENTRY_INDEX - 1, DB);
+
+    // Reaching the download path is what the test asserts; it cannot complete here because this unit
+    // test has no Raft server to resolve the leader from, and that failure is the proof it was reached.
+    assertThatThrownBy(() -> sm.applyInstallDatabaseEntry(forceSnapshotEntry(), ENTRY_INDEX));
+  }
+
+  @Test
+  void theGuardIsPerDatabaseSoAnotherDatabasesProgressDoesNotSuppressTheReinstall() {
+    final ArcadeStateMachine sm = newStateMachine();
+    // A co-located database advanced the GLOBAL index well past this entry. That must not suppress the
+    // reinstall of a database with no per-database evidence of its own (issue #4824).
+    sm.writePersistedAppliedIndex(ENTRY_INDEX + 100, "some-other-db");
+
+    // Same reasoning as above: reaching the download path is what is asserted.
+    assertThatThrownBy(() -> sm.applyInstallDatabaseEntry(forceSnapshotEntry(), ENTRY_INDEX));
+  }
+
+  private ArcadeStateMachine newStateMachine() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(server);
+    return sm;
+  }
+
+  private static RaftLogEntryCodec.DecodedEntry forceSnapshotEntry() {
+    return RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeInstallDatabaseEntry(DB, true));
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -1368,8 +1368,8 @@ public class ArcadeDBServer {
               break;
 
             default:
-              LogManager.instance().log(this, Level.SEVERE, "Unsupported command %s in startup command: '%s'", null
-                  , commandType);
+              LogManager.instance().log(this, Level.SEVERE,
+                  "Unsupported command '%s' in startup command: '%s'", null, commandType, command);
             }
           }
         } else {


### PR DESCRIPTION
Closes #7126, closes #7132, closes #7143, closes #7141.

## #7126 - Raft replay double-added the bucket record-count delta

`TransactionManager.applyChangesInternal` folded the bucket record-count delta as a **relative increment** guarded only by its `changed` flag. Since #4926 a page whose WAL version *equals* the on-disk one is deliberately re-applied (torn-write repair), so a replayed entry set `changed` on a transaction that had already been applied in full, and the delta was added a second time. On a **cleanly** stopped node the cached counter is restored from `statistics.json` and never invalidated, so `SELECT count(*)` over-reported permanently and disagreed with a full scan. The asymmetry is what made it survive normal operation: an *unclean* stop resets the counter to `-1` and is safe; a clean one is not.

The fold now runs only when at least one page was written at a version **strictly greater** than the one on disk. That is the precise idempotency signal rather than a heuristic: had a previous apply of the entry reached the fold, every page of that entry would already be at or beyond its target version, so nothing could advance. It covers the `SCHEMA_ENTRY` arm as well - both go through `applyChangesInternal`, which is why a fix scoped to the transaction arm would have been incomplete (thanks @ruispereira for that note, and for the two re-feed paths that reach this without any process restart: `restartRatisIfNeeded` and the post-snapshot-install reload).

The fold also stopped using `getBucketById`, which throws for a bucket a later `DROP TYPE` removed; it now mirrors the same fold in `TransactionContext.commit2ndPhase`.

## #7132 - the Raft gRPC allowlist never learned a runtime-joined peer

`PeerAddressAllowlistFilter` was built once from the static `arcadedb.ha.serverList` and its host list was immutable for the life of the filter, so the #4836 Kubernetes scale-up auto-join could not complete: the new pod's inbound Raft gRPC connections were rejected by every existing node that had already latched `everQuorumResolved`, and the rejection was logged on the *receiving* pods rather than on the new one.

Three changes, of which the issue proposed the first:

1. **Membership, not boot-time configuration.** The filter takes hosts learned after construction, fed from `getLivePeers()` (the committed Raft configuration) on every health monitor tick. A peer added at runtime - `addPeer`, the Kubernetes auto-join, or one that joined while this node was down - is admitted from then on.
2. **The Kubernetes DNS suffix is applied to the configured hosts**, exactly as `parsePeerList` applies it to the peer addresses. Without it the allowlist tried to resolve the bare pod names written in the server list (`arcadedb-0`), which only resolve when the pod's DNS search list happens to cover them, i.e. when the namespace and the headless service share a name. Anywhere else no configured host resolved, the quorum latch never tripped, and the filter fell open for the whole grace window and then rejected every peer.
3. **The headless service domain is seeded as a learned host on Kubernetes.** This is what actually unblocks the initial join, and membership tracking alone cannot: the joiner is not in the Raft configuration until its `setConfiguration` ADD lands, and that ADD cannot be delivered while the allowlist rejects it. The headless service behind `arcadedb.ha.k8sSuffix` is the StatefulSet's own membership record - it resolves to the A records of every pod backing it, at any replica count and with no ordinal to guess, and it covers a pod that is not Ready yet because the shipped manifest sets `publishNotReadyAddresses: true` (documented there as required, since a pod is Ready only once it has joined). This is offered in preference to the issue's two smaller mitigations: it needs no rollout of `serverList` to every existing pod, and it does not trade the protection away by disabling the allowlist.

Learned hosts never count towards the quorum / completeness latches, so the #4471 and #4828 semantics are untouched, and a name that does not resolve logs at FINE rather than WARNING. The rejection message now names the settings and both host lists, so the receiving pod's log says what to do about it.

## #7143 - two idempotency items

- A `forceSnapshot` `INSTALL_DATABASE_ENTRY` had no replay guard. The normal-create branch skips by existence, but existence is precisely what the force branch ignores, so every Ratis replay re-downloaded and re-installed the whole database from the leader. It now consults the same per-database applied index `applyBootstrapFingerprintEntry` uses, which is the "at or beyond the snapshot's index" the issue suggested and keeps the per-database reasoning of #4824.
- `CREATE TIMESERIES TYPE ... IF NOT EXISTS` answered one row the first time and **zero** on a retry, which a client checking the row count reads as failure. Rather than fix it in isolation, every guarded CREATE now follows the convention `CREATE INDEX`, `CREATE TRIGGER` and `CREATE GRAPH ANALYTICAL VIEW` already had: one row carrying a `created` flag. `CREATE DOCUMENT/VERTEX/EDGE TYPE`, `CREATE BUCKET` and `CREATE PROPERTY` are aligned with it.

## #7141 - three diagnostics defects

- The two format-argument mismatches printed `null` exactly where the offending value belonged. Both are fixed, and `LogMessageArityTest` is a source-level guard that keeps the whole tree free of the class: it walks every module's `src/main/java`, and reports any `LogManager...log(...)` call whose literal format string has more conversions than the call supplies arguments. It is deliberately conservative - literal messages only, and the ambiguous `Throwable` slot is read the permissive way except for a bare `null`, which javac resolves unambiguously. The tree is clean under it today.
- The HA single-bucket warning advised `CREATE VERTEX TYPE <name> BUCKETS 16` on types that by definition already exist. Rather than drop the advice, it now points at `ALTER TYPE <name> BUCKET +<name>_1`, which does work on an existing type and creates the bucket if needed; the accompanying test runs both the old advice (fails) and the new one (works).
- `ALTER DATABASE` and the rollback dictionary reload now chain the `IOException` and name the setting, the database and the reason, so a read-only filesystem, a permission problem and a full volume are no longer indistinguishable.

## Verification

New regression tests, each checked to fail without its fix:

- `Issue7126BucketCountReplayTest` - an equal-version replay must not move the counter; a version-advancing entry must fold exactly once; replaying that one leaves it alone.
- `Issue7132AllowlistLearnsRuntimePeersTest` (9 tests) - a scale-up host is rejected while frozen and admitted once learned; learning is idempotent; learned hosts do not trip the quorum/completeness latches; the suffix and headless-service seeding wiring in `RaftHAServer`.
- `Issue7143ForceSnapshotReplayGuardTest` - replayed entry skips, unapplied entry does not, and the guard is per-database.
- `Issue7143CreateIfNotExistsRowShapeTest` - all seven guarded CREATE statements answer one row with `created` on both calls.
- `Issue7141DiagnosticsTest` - `ALTER DATABASE` chains the cause; the advised bucket commands run.
- `LogMessageArityTest` - the format-arity guard.

Full reactor `mvn verify -DskipITs -DexcludedGroups=benchmark,slow,vector`: **BUILD SUCCESS**, all modules (engine alone: 14427 tests, 0 failures; ha-raft: 1101, 0 failures).

## Note on the milestone

The requested `26.9.1` milestone is closed and already released, and all four issues were already on `26.10.1`, which matches the current `26.10.1-SNAPSHOT` development version. They have been left there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xy2dEwenfM4cuwHB7sfQQ7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DDL commands using `IF NOT EXISTS` now return consistent result rows showing whether an object was created.
  * High-availability deployments can discover runtime peers and scaled Kubernetes pods more reliably.
  * Startup diagnostics now include the complete unsupported command text.

* **Bug Fixes**
  * Improved WAL replay accuracy to prevent duplicate record-count updates.
  * Prevented repeated snapshot downloads after restart.
  * Enhanced configuration error messages with database, setting, value, and underlying cause details.
  * Corrected HA guidance for adding buckets to existing types.

* **Tests**
  * Added regression coverage for replay, diagnostics, HA discovery, snapshots, and DDL result consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->