### PR TITLE
fix: vector PQ/graph publication race, and three full-suite-only test failures

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6331,16 +6331,31 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // exclude the entry point, so a filter cannot close this. The ordinal map is checked too because the
         // pre-filter branch scores ordinals from it rather than from the beam.
         //
+        // getIdUpperBound(), not size(): the question here is the ordinal SPACE the beam can hand back, and JVector
+        // defines that as "highest node id seen + 1" while size() is merely how many nodes are in it. The two are
+        // equal for every graph this index publishes today, because a deletion rebuilds the graph rather than
+        // punching a hole in its id space (loadPersistedGraphOrDecidePrefix refuses a persisted graph outright once
+        // getDeletedCount() is non-zero, issue #3135) - but a graph that ever did carry a hole would pass a
+        // size() check and still walk an ordinal past the codes' end, which is the exception this whole guard
+        // exists to prevent. The rest of the file already asks the question this way: findUnreachableOrdinals sizes
+        // its BFS arrays off getIdUpperBound(), and getStats reports it as graphNodeCount.
+        //
         // Any state where this fires is a state the PQ path cannot serve at all, so nothing that works today is
         // being turned off: in the steady state the codes cover exactly the graph they were built from. The exact
         // path needs no codes, so it answers correctly throughout the window, and the fast path resumes by itself
         // on the next query once the codes are republished. Falling back has to happen after this lock is
         // released - findNeighborsFromVector can take the WRITE lock to rebuild, and this thread holds the read
         // lock, which ReentrantReadWriteLock cannot upgrade.
+        //
+        // pinnedOrdinalMap is also the ONE snapshot the filter and the result loop below both resolve through, the
+        // way the exact path takes one: reading the volatile field at each use instead would let a rebuild land
+        // between two of them and pair an ordinal's RID with a vector from a different mapping (issue #4581). The
+        // guard has to check that same array for the same reason - checking one snapshot and walking another says
+        // nothing.
         final PQVectors           pinnedPq         = pqVectors;
         final ImmutableGraphIndex pinnedGraph      = graphIndex;
         final int[]               pinnedOrdinalMap = this.ordinalToVectorId;
-        if (pinnedPq != null && pinnedGraph.size() <= pinnedPq.count()
+        if (pinnedPq != null && pinnedGraph.getIdUpperBound() <= pinnedPq.count()
             && pinnedOrdinalMap.length <= pinnedPq.count()) {
           // Convert query vector to VectorFloat
           final VectorFloat<?> queryVectorFloat = vts.createFloatVector(queryVector);
@@ -6357,30 +6372,25 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // Wrap in a DefaultSearchScoreProvider (concrete implementation)
           final DefaultSearchScoreProvider ssp = new DefaultSearchScoreProvider(scoreFunction, approxReranker);
 
-          // Snapshot the volatile ordinal map once, the way the exact path does: the filter and the result loop below
-          // must resolve an ordinal through the same array, or a concurrent rebuild between the two reads would pair
-          // an ordinal's RID with a vector from a different mapping (issue #4581).
-          final int[] ordinalMap = pinnedOrdinalMap;
-
           // Issue #6514 pre-filter plan: the PQ-scored counterpart of the issue #6502 plan in findNeighborsFromVector -
           // see preFilterApproximate's javadoc for why it cannot simply call bruteForceScan. Gated by its own
           // selectivity threshold, not VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY: Issue6514ApproximatePrefilterBenchmark
           // measured this path's crossover at roughly 6-7% selectivity, well below the exact path's 20% default -
           // see VECTOR_INDEX_PREFILTER_APPROXIMATE_MAX_SELECTIVITY's javadoc for why the two cannot share one knob.
-          if (allowedRIDs != null && !allowedRIDs.isEmpty() && allowListQualifiesForPreFilter(allowedRIDs, ordinalMap,
+          if (allowedRIDs != null && !allowedRIDs.isEmpty() && allowListQualifiesForPreFilter(allowedRIDs, pinnedOrdinalMap,
               GlobalConfiguration.VECTOR_INDEX_PREFILTER_APPROXIMATE_MAX_SELECTIVITY)) {
             metrics.incrementPreFilterSearches();
             final List<Pair<RID, Float>> results = new ArrayList<>(k);
             // PQ-scaled, not exact (issue #6559 item 2): preFilterApproximate scores its ordinals from the PQ codes,
             // so delta rows merged here are ranked against - and returned alongside - approximate scores.
             mergeWithDeltaScanApproximate(queryVectorFloat, k, allowedRIDs, results);
-            preFilterApproximate(scoreFunction, k, allowedRIDs, results, ordinalMap);
+            preFilterApproximate(scoreFunction, k, allowedRIDs, results, pinnedOrdinalMap);
             return results;
           }
 
           // Live-only (plus the optional RID allow-list): PQ scores a tombstone as happily as a live vector, so
           // without this the beam fills with nodes the post-filter below then drops (issue #5558).
-          final Bits bitsFilter = new LiveVectorBitsFilter(allowedRIDs, ordinalMap, vectorIndex());
+          final Bits bitsFilter = new LiveVectorBitsFilter(allowedRIDs, pinnedOrdinalMap, vectorIndex());
 
           // Execute search using the PQ-based score provider
           // The graph structure is typically small enough to stay in OS page cache
@@ -6406,8 +6416,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
           int skippedDeletedOrNull = 0;
           for (final SearchResult.NodeScore nodeScore : searchResult.getNodes()) {
             final int ordinal = nodeScore.node;
-            if (ordinal >= 0 && ordinal < ordinalMap.length) {
-              final int vectorId = ordinalMap[ordinal];
+            if (ordinal >= 0 && ordinal < pinnedOrdinalMap.length) {
+              final int vectorId = pinnedOrdinalMap[ordinal];
               final RID rid = vectorIndex().getRid(vectorId);
               if (rid != null) {
                 final float distance = scoreToDistance(metadata.similarityFunction, nodeScore.score);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6288,99 +6288,120 @@ public class LSMVectorIndex implements Index, IndexInternal {
           return Collections.emptyList();
         }
 
-        // Convert query vector to VectorFloat
-        final VectorFloat<?> queryVectorFloat = vts.createFloatVector(queryVector);
+        // Pin BOTH halves of the pair the beam walks, and refuse the pair if they disagree. graphIndex is
+        // published under the write lock this read lock excludes, so it cannot move underneath us - but pqVectors
+        // is republished LATER and outside that lock (see buildAndPersistPQ), so a rebuild that has already
+        // installed its new, larger graph but not yet its new codes leaves the two sized differently. Walking that
+        // graph through those codes asks PQVectors for an ordinal it was never sized for, and JVector throws
+        // IndexOutOfBoundsException from inside GraphSearcher.initializeInternal - before any Bits filter can
+        // exclude the entry point, so a filter cannot close this. The ordinal map is checked too because the
+        // pre-filter branch scores ordinals from it rather than from the beam.
+        //
+        // Any state where this fires is a state the PQ path cannot serve at all, so nothing that works today is
+        // being turned off: in the steady state the codes cover exactly the graph they were built from. The exact
+        // path needs no codes, so it answers correctly throughout the window, and the fast path resumes by itself
+        // on the next query once the codes are republished. Falling back has to happen after this lock is
+        // released - findNeighborsFromVector can take the WRITE lock to rebuild, and this thread holds the read
+        // lock, which ReentrantReadWriteLock cannot upgrade.
+        final PQVectors           pinnedPq         = pqVectors;
+        final ImmutableGraphIndex pinnedGraph      = graphIndex;
+        final int[]               pinnedOrdinalMap = this.ordinalToVectorId;
+        if (pinnedPq != null && pinnedGraph.size() <= pinnedPq.count()
+            && pinnedOrdinalMap.length <= pinnedPq.count()) {
+          // Convert query vector to VectorFloat
+          final VectorFloat<?> queryVectorFloat = vts.createFloatVector(queryVector);
 
-        // Build the memory-resident PQ score function (uses SIMD/Panama if available)
-        // This is the key to zero-disk-I/O: we use PQ scores for BOTH navigation AND final scoring
-        final ScoreFunction.ApproximateScoreFunction scoreFunction =
-            pqVectors.precomputedScoreFunctionFor(queryVectorFloat, metadata.similarityFunction);
+          // Build the memory-resident PQ score function (uses SIMD/Panama if available)
+          // This is the key to zero-disk-I/O: we use PQ scores for BOTH navigation AND final scoring
+          final ScoreFunction.ApproximateScoreFunction scoreFunction =
+              pinnedPq.precomputedScoreFunctionFor(queryVectorFloat, metadata.similarityFunction);
 
-        // Create a ReRanker that does NOT pull from disk - just returns PQ similarity
-        // This is the critical optimization: we bypass RandomAccessVectorValues entirely
-        final ScoreFunction.ExactScoreFunction approxReranker = ordinal -> scoreFunction.similarityTo(ordinal);
+          // Create a ReRanker that does NOT pull from disk - just returns PQ similarity
+          // This is the critical optimization: we bypass RandomAccessVectorValues entirely
+          final ScoreFunction.ExactScoreFunction approxReranker = ordinal -> scoreFunction.similarityTo(ordinal);
 
-        // Wrap in a DefaultSearchScoreProvider (concrete implementation)
-        final DefaultSearchScoreProvider ssp = new DefaultSearchScoreProvider(scoreFunction, approxReranker);
+          // Wrap in a DefaultSearchScoreProvider (concrete implementation)
+          final DefaultSearchScoreProvider ssp = new DefaultSearchScoreProvider(scoreFunction, approxReranker);
 
-        // Snapshot the volatile ordinal map once, the way the exact path does: the filter and the result loop below
-        // must resolve an ordinal through the same array, or a concurrent rebuild between the two reads would pair
-        // an ordinal's RID with a vector from a different mapping (issue #4581).
-        final int[] ordinalMap = this.ordinalToVectorId;
+          // Snapshot the volatile ordinal map once, the way the exact path does: the filter and the result loop below
+          // must resolve an ordinal through the same array, or a concurrent rebuild between the two reads would pair
+          // an ordinal's RID with a vector from a different mapping (issue #4581).
+          final int[] ordinalMap = pinnedOrdinalMap;
 
-        // Issue #6514 pre-filter plan: the PQ-scored counterpart of the issue #6502 plan in findNeighborsFromVector -
-        // see preFilterApproximate's javadoc for why it cannot simply call bruteForceScan. Gated by its own
-        // selectivity threshold, not VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY: Issue6514ApproximatePrefilterBenchmark
-        // measured this path's crossover at roughly 6-7% selectivity, well below the exact path's 20% default -
-        // see VECTOR_INDEX_PREFILTER_APPROXIMATE_MAX_SELECTIVITY's javadoc for why the two cannot share one knob.
-        if (allowedRIDs != null && !allowedRIDs.isEmpty() && allowListQualifiesForPreFilter(allowedRIDs, ordinalMap,
-            GlobalConfiguration.VECTOR_INDEX_PREFILTER_APPROXIMATE_MAX_SELECTIVITY)) {
-          metrics.incrementPreFilterSearches();
+          // Issue #6514 pre-filter plan: the PQ-scored counterpart of the issue #6502 plan in findNeighborsFromVector -
+          // see preFilterApproximate's javadoc for why it cannot simply call bruteForceScan. Gated by its own
+          // selectivity threshold, not VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY: Issue6514ApproximatePrefilterBenchmark
+          // measured this path's crossover at roughly 6-7% selectivity, well below the exact path's 20% default -
+          // see VECTOR_INDEX_PREFILTER_APPROXIMATE_MAX_SELECTIVITY's javadoc for why the two cannot share one knob.
+          if (allowedRIDs != null && !allowedRIDs.isEmpty() && allowListQualifiesForPreFilter(allowedRIDs, ordinalMap,
+              GlobalConfiguration.VECTOR_INDEX_PREFILTER_APPROXIMATE_MAX_SELECTIVITY)) {
+            metrics.incrementPreFilterSearches();
+            final List<Pair<RID, Float>> results = new ArrayList<>(k);
+            // PQ-scaled, not exact (issue #6559 item 2): preFilterApproximate scores its ordinals from the PQ codes,
+            // so delta rows merged here are ranked against - and returned alongside - approximate scores.
+            mergeWithDeltaScanApproximate(queryVectorFloat, k, allowedRIDs, results);
+            preFilterApproximate(scoreFunction, k, allowedRIDs, results, ordinalMap);
+            return results;
+          }
+
+          // Live-only (plus the optional RID allow-list): PQ scores a tombstone as happily as a live vector, so
+          // without this the beam fills with nodes the post-filter below then drops (issue #5558).
+          final Bits bitsFilter = new LiveVectorBitsFilter(allowedRIDs, ordinalMap, vectorIndex());
+
+          // Execute search using the PQ-based score provider
+          // The graph structure is typically small enough to stay in OS page cache
+          // Note: JVector 4.0's search method uses (scoreProvider, topK, Bits) signature
+          final SearchResult searchResult;
+          final GraphSearcherPool pool = getSearcherPool();
+          final long poolEpoch = searcherPoolEpoch();
+          // Pin the graph reference: a concurrent rebuild may swap the volatile field, and borrow/release must
+          // agree on which graph the searcher belongs to.
+          final ImmutableGraphIndex pooledGraph = pinnedGraph;
+          final GraphSearcher searcher = pool.borrow(pooledGraph, poolEpoch);
+          try {
+            searchResult = searcher.search(ssp, k, bitsFilter);
+          } finally {
+            pool.release(searcher, pooledGraph, poolEpoch);
+          }
+
+          recordGraphWalkCost(searchResult.getVisitedCount());
+
+          // Extract RIDs and scores from search results
           final List<Pair<RID, Float>> results = new ArrayList<>(k);
-          // PQ-scaled, not exact (issue #6559 item 2): preFilterApproximate scores its ordinals from the PQ codes,
-          // so delta rows merged here are ranked against - and returned alongside - approximate scores.
+          int skippedOutOfBounds = 0;
+          int skippedDeletedOrNull = 0;
+          for (final SearchResult.NodeScore nodeScore : searchResult.getNodes()) {
+            final int ordinal = nodeScore.node;
+            if (ordinal >= 0 && ordinal < ordinalMap.length) {
+              final int vectorId = ordinalMap[ordinal];
+              final RID rid = vectorIndex().getRid(vectorId);
+              if (rid != null) {
+                final float distance = scoreToDistance(metadata.similarityFunction, nodeScore.score);
+                results.add(new Pair<>(bindRid(rid), distance));
+              } else {
+                skippedDeletedOrNull++;
+              }
+            } else {
+              skippedOutOfBounds++;
+            }
+          }
+
+          // Merge with delta vectors inserted since last graph rebuild, scored on the same PQ scale as the graph rows
+          // above rather than exactly (issue #6559 item 2) - see mergeWithDeltaScanApproximate for why ranking the two
+          // against each other on different scales let quantization error, not the data, decide which row won.
           mergeWithDeltaScanApproximate(queryVectorFloat, k, allowedRIDs, results);
-          preFilterApproximate(scoreFunction, k, allowedRIDs, results, ordinalMap);
+
+          // Log performance metrics. FINE, not INFO (issue #6559 item 3): this path's entire reason to exist is
+          // microsecond latency, so an unconditional per-query INFO line - on the query rate this path is built for -
+          // costs more to format and write than the search itself reports, and floods the log. Every comparable
+          // per-query summary on the neighbouring search paths is already FINE.
+          final long elapsedNanos = System.nanoTime() - startTime;
+          LogManager.instance().log(this, Level.FINE,
+              "Zero-disk-I/O PQ search returned %d results in %.2f µs (skipped: %d out of bounds, %d deleted/null)",
+              results.size(), elapsedNanos / 1000.0, skippedOutOfBounds, skippedDeletedOrNull);
+
           return results;
         }
-
-        // Live-only (plus the optional RID allow-list): PQ scores a tombstone as happily as a live vector, so
-        // without this the beam fills with nodes the post-filter below then drops (issue #5558).
-        final Bits bitsFilter = new LiveVectorBitsFilter(allowedRIDs, ordinalMap, vectorIndex());
-
-        // Execute search using the PQ-based score provider
-        // The graph structure is typically small enough to stay in OS page cache
-        // Note: JVector 4.0's search method uses (scoreProvider, topK, Bits) signature
-        final SearchResult searchResult;
-        final GraphSearcherPool pool = getSearcherPool();
-        final long poolEpoch = searcherPoolEpoch();
-        // Pin the graph reference: a concurrent rebuild may swap the volatile field, and borrow/release must
-        // agree on which graph the searcher belongs to.
-        final ImmutableGraphIndex pooledGraph = graphIndex;
-        final GraphSearcher searcher = pool.borrow(pooledGraph, poolEpoch);
-        try {
-          searchResult = searcher.search(ssp, k, bitsFilter);
-        } finally {
-          pool.release(searcher, pooledGraph, poolEpoch);
-        }
-
-        recordGraphWalkCost(searchResult.getVisitedCount());
-
-        // Extract RIDs and scores from search results
-        final List<Pair<RID, Float>> results = new ArrayList<>(k);
-        int skippedOutOfBounds = 0;
-        int skippedDeletedOrNull = 0;
-        for (final SearchResult.NodeScore nodeScore : searchResult.getNodes()) {
-          final int ordinal = nodeScore.node;
-          if (ordinal >= 0 && ordinal < ordinalMap.length) {
-            final int vectorId = ordinalMap[ordinal];
-            final RID rid = vectorIndex().getRid(vectorId);
-            if (rid != null) {
-              final float distance = scoreToDistance(metadata.similarityFunction, nodeScore.score);
-              results.add(new Pair<>(bindRid(rid), distance));
-            } else {
-              skippedDeletedOrNull++;
-            }
-          } else {
-            skippedOutOfBounds++;
-          }
-        }
-
-        // Merge with delta vectors inserted since last graph rebuild, scored on the same PQ scale as the graph rows
-        // above rather than exactly (issue #6559 item 2) - see mergeWithDeltaScanApproximate for why ranking the two
-        // against each other on different scales let quantization error, not the data, decide which row won.
-        mergeWithDeltaScanApproximate(queryVectorFloat, k, allowedRIDs, results);
-
-        // Log performance metrics. FINE, not INFO (issue #6559 item 3): this path's entire reason to exist is
-        // microsecond latency, so an unconditional per-query INFO line - on the query rate this path is built for -
-        // costs more to format and write than the search itself reports, and floods the log. Every comparable
-        // per-query summary on the neighbouring search paths is already FINE.
-        final long elapsedNanos = System.nanoTime() - startTime;
-        LogManager.instance().log(this, Level.FINE,
-            "Zero-disk-I/O PQ search returned %d results in %.2f µs (skipped: %d out of bounds, %d deleted/null)",
-            results.size(), elapsedNanos / 1000.0, skippedOutOfBounds, skippedDeletedOrNull);
-
-        return results;
 
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE, "Error performing PQ approximate search", e);
@@ -6388,6 +6409,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
       } finally {
         lock.readLock().unlock();
       }
+
+      // Reached only when the guard above refused the graph/PQ pair - every other path returns from inside the
+      // block. Outside the read lock on purpose: this can rebuild, which takes the write lock.
+      return findNeighborsFromVector(queryVector, k, allowedRIDs);
     } finally {
       // Track search latency (convert nanos to ms for consistency)
       final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6263,9 +6263,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
       return findNeighborsFromVector(queryVector, k, allowedRIDs);
     }
 
-    // Track search metrics
+    // Track search metrics. Both halves are recorded together in the finally below rather than the count here and
+    // the latency there, because one exit from this method must record NEITHER: when the guard further down refuses
+    // the graph/PQ pair, this call hands the whole search to findNeighborsFromVector, which counts and times itself.
+    // Counting here as well would charge one caller-facing search twice - and worse, the two latencies do not even
+    // measure the same thing, since this method's clock spans the exact search it delegates to on top of its own
+    // guard overhead, so the summed latency would grow faster than the operation count it is divided by.
     final long startTime = System.nanoTime(); // Use nanos for microsecond precision
-    metrics.incrementSearchOperations();
+    boolean handedOffToExactSearch = false;
 
     try {
       if (queryVector == null)
@@ -6432,6 +6437,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
           return results;
         }
 
+        // The guard refused the graph/PQ pair. Nothing was searched, so this attempt is not an operation of its
+        // own: the exact search below is the search, and it keeps its own books.
+        handedOffToExactSearch = true;
+
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE, "Error performing PQ approximate search", e);
         throw new IndexException("Error performing PQ approximate search", e);
@@ -6443,9 +6452,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // block. Outside the read lock on purpose: this can rebuild, which takes the write lock.
       return findNeighborsFromVector(queryVector, k, allowedRIDs);
     } finally {
-      // Track search latency (convert nanos to ms for consistency)
-      final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
-      metrics.addSearchLatency(elapsedMs);
+      if (!handedOffToExactSearch) {
+        // Track search latency (convert nanos to ms for consistency)
+        final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
+        metrics.incrementSearchOperations();
+        metrics.addSearchLatency(elapsedMs);
+      }
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/graph/InsertGraphIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/InsertGraphIndexTest.java
@@ -90,6 +90,30 @@ class InsertGraphIndexTest extends TestHelper {
     }
   }
 
+  /**
+   * Regression test for the leak above. Nothing else in the suite can observe the restore directly: the symptom of
+   * the missing one was a test roughly 70 classes downstream capturing no log output, which names this class
+   * nowhere. Asserting it here is the only place the two halves are visible at once.
+   * <p>
+   * Safe to call {@link #endTest()} by hand - it clears {@code previousLogger}, so the {@code @AfterEach} that
+   * follows is a no-op rather than a second, stale restore, and the logger is left as this class found it.
+   */
+  @Test
+  void endTestRestoresTheDisplacedLogger() {
+    assertThat(LogManager.instance().getLogger())
+        .as("beginTest() must install the null logger before the test body runs")
+        .isSameAs(NullLogger.INSTANCE);
+
+    final Logger displaced = previousLogger;
+    assertThat(displaced).as("the logger beginTest() displaced must be kept in order to be put back").isNotNull();
+
+    endTest();
+
+    assertThat(LogManager.instance().getLogger())
+        .as("setLogger() is process-wide, so failing to restore it discards every log line in the rest of the fork")
+        .isSameAs(displaced);
+  }
+
   @Override
   protected String getPerformanceProfile() {
     return "high-performance";

--- a/engine/src/test/java/com/arcadedb/graph/InsertGraphIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/InsertGraphIndexTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.async.ErrorCallback;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 import org.junit.jupiter.api.Tag;
@@ -63,10 +64,34 @@ class InsertGraphIndexTest extends TestHelper {
     database.close();
   }
 
+  /** The process-wide logger this test displaces for its own duration; put back by {@link #endTest()}. */
+  private Logger previousLogger;
+
+  /**
+   * Silences the log for this test only. Moving a million edges logs enough to bury a build, but
+   * {@link LogManager#setLogger} is process-wide and this class used to install {@link NullLogger} from
+   * {@link #getPerformanceProfile()} - a method that is only supposed to name a profile - and never put the
+   * previous one back. Every {@code LogManager.instance().log()} in the fork was then discarded for the rest of
+   * the run, which in the {@code slow} lane silently disarmed later tests asserting on a logged warning:
+   * {@code LSMVectorIndexRebuildTest} captured nothing about 70 classes downstream and failed with no hint that
+   * the cause was here. setLogger()'s own javadoc tells callers to keep what they replace and put it back.
+   */
+  @Override
+  protected void beginTest() {
+    previousLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(NullLogger.INSTANCE);
+  }
+
+  @Override
+  protected void endTest() {
+    if (previousLogger != null) {
+      LogManager.instance().setLogger(previousLogger);
+      previousLogger = null;
+    }
+  }
+
   @Override
   protected String getPerformanceProfile() {
-    LogManager.instance().setLogger(NullLogger.INSTANCE);
-
     return "high-performance";
   }
 

--- a/engine/src/test/java/com/arcadedb/index/vector/PqCodesStaleForRebuiltGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/PqCodesStaleForRebuiltGraphTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Type;
+import io.github.jbellis.jvector.quantization.PQVectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for the graph/PQ ordinal mismatch that made {@code findNeighborsFromVectorApproximate()} throw
+ * {@code IndexException: Error performing PQ approximate search}, wrapping
+ * {@code IndexOutOfBoundsException: Ordinal 1280 out of bounds for vector count 1100} raised inside JVector's
+ * {@code PQVectors.getChunk}.
+ * <p>
+ * {@code graphIndex} is published under the write lock a search's read lock excludes, so it cannot move while a
+ * search runs. {@code pqVectors} is not: it is republished later and outside that lock (see
+ * {@code buildAndPersistPQ}). A rebuild that has already installed its new, larger graph but has not yet installed
+ * the codes for it therefore leaves a window in which the two disagree about how many ordinals exist - and the
+ * beam walking that graph asks the old, smaller {@code PQVectors} for an ordinal it was never sized for. It throws
+ * from {@code GraphSearcher.initializeInternal}, while scoring an entry point, which is before any {@code Bits}
+ * filter is consulted - so no filter can close this.
+ * <p>
+ * In the wild this reproduces only as a race (it was originally seen roughly one run in five under a concurrent
+ * async rebuild, on unmodified main). Waiting for that race would make this test a coin flip, so it installs the
+ * end state the race produces - a graph larger than the codes cover - directly, and asserts the search degrades to
+ * the exact path instead of throwing. The exact path needs no codes at all, so it stays correct for the whole
+ * window, and the fast path resumes by itself once the codes are republished.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("vector")
+class PqCodesStaleForRebuiltGraphTest extends TestHelper {
+
+  private static final int EMBEDDING_DIM = 32;
+  /** Must clear LSMVectorIndex.ASYNC_REBUILD_MIN_GRAPH_SIZE (1000) so the graph takes the rebuild path at all. */
+  private static final int BASE_VECTORS  = 1100;
+  private static final int EXTRA_VECTORS = 500;
+
+  private static final Duration SETTLE_TIMEOUT = Duration.ofMinutes(2);
+
+  @Test
+  void approximateSearchDegradesToExactWhenPqCodesDoNotCoverTheGraph() throws Exception {
+    final Random random = new Random(6797);
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Embedding");
+      database.getSchema().getType("Embedding").createProperty("vector", Type.ARRAY_OF_FLOATS);
+      database.command("sql", """
+          CREATE INDEX ON Embedding (vector) LSM_VECTOR
+          METADATA {
+              "dimensions": %d,
+              "similarity": "EUCLIDEAN",
+              "quantization": "PRODUCT",
+              "pqClusters": 32
+          }""".formatted(EMBEDDING_DIM));
+    });
+
+    insertVectors(random, BASE_VECTORS);
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Embedding[vector]");
+    final LSMVectorIndex index = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    // The first search on an empty graph builds it synchronously whatever the thresholds say.
+    assertThat(index.findNeighborsFromVector(randomUnitVector(random), 10)).isNotEmpty();
+    awaitSettled(index);
+
+    // Before anything is made stale: the settled pair agrees, and the approximate path answers through it. This
+    // is what stops the guard from being a way to switch the PQ path off - if it fired in the steady state the
+    // index would quietly serve every query from the exact path, and no other assertion here would notice.
+    assertThat(index.getStats().get("graphNodeCount"))
+        .as("a settled index's codes cover exactly the graph they were built from")
+        .isLessThanOrEqualTo((long) index.getPQVectorCount());
+    assertThat(index.findNeighborsFromVectorApproximate(randomUnitVector(random), 10))
+        .as("the approximate path must work normally when the pair agrees").isNotEmpty();
+
+    // The codes as they stand for THIS graph - the snapshot a rebuild is about to make stale.
+    final PQVectors staleCodes = pqVectors(index);
+    assertThat(staleCodes).as("the fixture must actually have PQ codes to go stale").isNotNull();
+    final int staleCount = staleCodes.count();
+
+    // Grow the graph: enough mutations to clear the default ratio-derived threshold, then a search to trigger the
+    // rebuild and a wait for it to land.
+    insertVectors(random, EXTRA_VECTORS);
+    Awaitility.await("the rebuild that grows the graph past the stale codes")
+        .atMost(SETTLE_TIMEOUT)
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> {
+          index.findNeighborsFromVector(randomUnitVector(random), 10);
+          assertThat(index.getStats().get("deltaVectorsCount")).isZero();
+          assertThat(index.getStats().get("graphNodeCount")).isGreaterThan(staleCount);
+        });
+
+    // Nothing may rebuild from here on, or the injected staleness would be repaired before the search reads it.
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 100f);
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_PENDING_MUTATIONS, 0);
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 0);
+
+    // Install the state the race produces: the new, larger graph paired with the codes of the old, smaller one.
+    setPqVectors(index, staleCodes);
+
+    assertThat(index.isPQSearchAvailable())
+        .as("the approximate path must still be selected, or this would silently test the exact path instead")
+        .isTrue();
+    assertThat(index.getStats().get("graphNodeCount"))
+        .as("the point of the fixture is a graph holding ordinals the codes were never sized for")
+        .isGreaterThan((long) index.getPQVectorCount());
+
+    assertThatCode(() -> {
+      final var results = index.findNeighborsFromVectorApproximate(randomUnitVector(random), 10);
+      assertThat(results)
+          .as("degrading to the exact path must still answer the query, not return an empty result")
+          .isNotEmpty();
+    })
+        .as("walking a graph through codes that do not cover it threw IndexOutOfBoundsException from deep inside "
+            + "JVector; the search must refuse the mismatched pair and answer exactly instead")
+        .doesNotThrowAnyException();
+  }
+
+  private static PQVectors pqVectors(final LSMVectorIndex index) throws Exception {
+    final Field field = LSMVectorIndex.class.getDeclaredField("pqVectors");
+    field.setAccessible(true);
+    return (PQVectors) field.get(index);
+  }
+
+  private static void setPqVectors(final LSMVectorIndex index, final PQVectors codes) throws Exception {
+    final Field field = LSMVectorIndex.class.getDeclaredField("pqVectors");
+    field.setAccessible(true);
+    field.set(index, codes);
+  }
+
+  private void awaitSettled(final LSMVectorIndex index) {
+    Awaitility.await("the initial synchronous build settles the buffer")
+        .atMost(SETTLE_TIMEOUT)
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> assertThat(index.getStats().get("deltaVectorsCount")).isZero());
+  }
+
+  private void insertVectors(final Random random, final int count) {
+    database.transaction(() -> {
+      for (int i = 0; i < count; i++)
+        database.command("sql", "INSERT INTO Embedding SET vector = ?", (Object) randomUnitVector(random));
+    });
+  }
+
+  private float[] randomUnitVector(final Random random) {
+    final float[] vector = new float[EMBEDDING_DIM];
+    float norm = 0;
+    for (int i = 0; i < EMBEDDING_DIM; i++) {
+      vector[i] = random.nextFloat() * 2 - 1;
+      norm += vector[i] * vector[i];
+    }
+    norm = (float) Math.sqrt(norm);
+    if (norm > 0)
+      for (int i = 0; i < EMBEDDING_DIM; i++)
+        vector[i] /= norm;
+    return vector;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/PqCodesStaleForRebuiltGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/PqCodesStaleForRebuiltGraphTest.java
@@ -133,6 +133,12 @@ class PqCodesStaleForRebuiltGraphTest extends TestHelper {
         .as("the point of the fixture is a graph holding ordinals the codes were never sized for")
         .isGreaterThan((long) index.getPQVectorCount());
 
+    // The refused attempt searches nothing and hands the query to findNeighborsFromVector, which counts and times
+    // itself. So it must not be counted here as well: one caller-facing search would be charged as two, and the
+    // two clocks do not measure the same span - this method's spans the exact search on top of its own guard
+    // overhead - so the summed latency would outgrow the operation count getAvgSearchLatencyMs divides it by.
+    final long searchOpsBefore = index.getStats().get("searchOperations");
+
     assertThatCode(() -> {
       final var results = index.findNeighborsFromVectorApproximate(randomUnitVector(random), 10);
       assertThat(results)
@@ -142,6 +148,10 @@ class PqCodesStaleForRebuiltGraphTest extends TestHelper {
         .as("walking a graph through codes that do not cover it threw IndexOutOfBoundsException from deep inside "
             + "JVector; the search must refuse the mismatched pair and answer exactly instead")
         .doesNotThrowAnyException();
+
+    assertThat(index.getStats().get("searchOperations") - searchOpsBefore)
+        .as("a refused PQ attempt is not a search of its own - only the exact search it delegates to may be counted")
+        .isEqualTo(1L);
   }
 
   private static PQVectors pqVectors(final LSMVectorIndex index) throws Exception {

--- a/engine/src/test/java/com/arcadedb/index/vector/PqCodesStaleForRebuiltGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/PqCodesStaleForRebuiltGraphTest.java
@@ -95,6 +95,10 @@ class PqCodesStaleForRebuiltGraphTest extends TestHelper {
     // Before anything is made stale: the settled pair agrees, and the approximate path answers through it. This
     // is what stops the guard from being a way to switch the PQ path off - if it fired in the steady state the
     // index would quietly serve every query from the exact path, and no other assertion here would notice.
+    //
+    // graphNodeCount is getIdUpperBound(), which is deliberately the same quantity the guard compares against the
+    // code count - not size(). Asserting one while the guard checked the other would leave any future divergence
+    // between the two (a graph carrying a hole in its id space) invisible to this test.
     assertThat(index.getStats().get("graphNodeCount"))
         .as("a settled index's codes cover exactly the graph they were built from")
         .isLessThanOrEqualTo((long) index.getPQVectorCount());

--- a/engine/src/test/java/com/arcadedb/query/Issue6459GraphPathfindingCommandTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/Issue6459GraphPathfindingCommandTimeoutTest.java
@@ -50,15 +50,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>
  * Each test below reuses the graph shape proven effective by {@link Issue6266CommandTimeoutCoverageTest}: a
  * 20,000-node ring with two chords per node (out-degree 3, so every node has both directions once the edges are
- * made bidirectional). One pass over a graph this size costs seconds, comfortably clearing the 50 ms deadline used
- * here by orders of magnitude - so a check placed inside the loop aborts almost immediately and one placed nowhere
- * (or only between unrelated checkpoints) runs to graph exhaustion first, which is exactly the distinction the
- * issue is about.
+ * made bidirectional). A check placed inside the loop aborts almost immediately, while one placed nowhere (or only
+ * between unrelated checkpoints) runs to graph exhaustion first, which is exactly the distinction the issue is
+ * about.
+ * <p>
+ * The deadline has to stay well under what one exhausting pass costs, and that cost is not a constant: the first
+ * pass over this fixture pays for the page cache, later ones do not. A warm exhaustion of one 20,000-node
+ * component measures ~55 ms here, so the 50 ms this class used to arm was not a bound at all for whichever test
+ * ran second - {@code astar()} aborted only because it ran first and cold, and {@code dijkstra()} right behind it
+ * drained all 20,000 nodes and returned normally with 5 ms to spare. {@link #ABORT_DEADLINE_MS} is an order of
+ * magnitude below the warm figure so the guard fires whatever the cache holds, and the assertions name the guard
+ * that has to fire rather than only the setting, so a deadline tripped somewhere else in the plan cannot stand in
+ * for the check under test.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class Issue6459GraphPathfindingCommandTimeoutTest {
   private static final int NODES = 20_000;
+  /** See the class comment: an order of magnitude below a warm exhausting pass over one component (~55 ms), so
+   *  the outcome does not depend on whether an earlier test already warmed the page cache. An implementation that
+   *  consults no deadline still runs to exhaustion and returns normally, so the regression stays caught. */
+  private static final long ABORT_DEADLINE_MS = 5;
   /** A vertex with no edges at all: astar()/dijkstra() can never reach it, so they have to exhaust the whole
    *  20,000-node component before giving up - unless the deadline stops them first. */
   private static final int UNREACHABLE_IDX = NODES;
@@ -137,14 +149,16 @@ class Issue6459GraphPathfindingCommandTimeoutTest {
   @Tag("slow")
   @Timeout(120)
   void astarHonoursTheCommandTimeoutOnAnUnreachableDestination() {
-    setTimeout(50);
+    setTimeout(ABORT_DEADLINE_MS);
 
     final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> drainSql(
         "select expand(astar(" + nodeRid[0] + ", " + unreachableRid + ", 'w'))"))
         .as("astar() previously consulted neither the deadline nor a thread interrupt, so it explored the "
             + "whole reachable component before ever answering")
-        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+        // Naming the guard, not just the setting: every other deadline check in the plan aborts as "the command",
+        // so only this spelling says the check inside astar()'s own loop is the one that fired.
+        .hasStackTraceContaining("astar() exceeded the " + GlobalConfiguration.COMMAND_TIMEOUT.getKey());
     stopwatch.assertGaveUpWithin(60_000L, "astar() aborted from inside its main loop, not after exhausting the graph");
   }
 
@@ -152,14 +166,15 @@ class Issue6459GraphPathfindingCommandTimeoutTest {
   @Tag("slow")
   @Timeout(120)
   void dijkstraHonoursTheCommandTimeoutOnAnUnreachableDestination() {
-    // dijkstra() delegates straight to a fresh SQLFunctionAstar, so it shares the fix as well as the bug.
-    setTimeout(50);
+    // dijkstra() delegates straight to a fresh SQLFunctionAstar, so it shares the fix as well as the bug - and
+    // the guard it inherits names itself astar() when it aborts.
+    setTimeout(ABORT_DEADLINE_MS);
 
     final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> drainSql(
         "select expand(dijkstra(" + nodeRid[0] + ", " + unreachableRid + ", 'w'))"))
         .as("dijkstra() must not survive its own unreachable-destination search past the deadline")
-        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+        .hasStackTraceContaining("astar() exceeded the " + GlobalConfiguration.COMMAND_TIMEOUT.getKey());
     stopwatch.assertGaveUpWithin(60_000L, "dijkstra() aborted from inside astar()'s main loop");
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/MergeInsertSlowdownTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/MergeInsertSlowdownTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -115,8 +116,14 @@ class MergeInsertSlowdownTest {
     final long baseTs = 1779793007000L;
 
     final long[] windowNanos = new long[ITERATIONS / BATCH];
+    final long[] windowStallNanos = new long[ITERATIONS / BATCH];
     int windowIdx = 0;
     long windowStart = System.nanoTime();
+    // Sampled alongside every nanoTime() reading so each window can be reported with the JVM-wide stall inside it
+    // taken out (issue #6260). This test times a SEQUENCE of windows rather than one span, which is the case
+    // StallAwareStopwatch.jvmStallNanos() exists for; a stopwatch per window would measure the same thing but
+    // allocate ten of them inside the hot loop.
+    long windowStartStall = StallAwareStopwatch.jvmStallNanos();
 
     // The user's workload is heavily skewed: a few merchant accounts receive most edges and
     // ordinary customers send a handful. Zipf-like draw with alpha ~1 on a pool of accounts
@@ -146,8 +153,14 @@ class MergeInsertSlowdownTest {
 
       if ((i + 1) % BATCH == 0) {
         final long now = System.nanoTime();
-        windowNanos[windowIdx++] = now - windowStart;
+        // Stall read AFTER the elapsed read, matching StallAwareStopwatch: the stall window is then never
+        // narrower than the elapsed one, so the discount can only ever come out in the measurement's favour.
+        final long nowStall = StallAwareStopwatch.jvmStallNanos();
+        windowStallNanos[windowIdx] = Math.max(0L, nowStall - windowStartStall);
+        windowNanos[windowIdx] = Math.max(0L, (now - windowStart) - windowStallNanos[windowIdx]);
+        windowIdx++;
         windowStart = now;
+        windowStartStall = nowStall;
       }
     }
 
@@ -161,6 +174,13 @@ class MergeInsertSlowdownTest {
     // tail (last quarter) average against the first-windows-after-warmup average to keep the
     // assertion stable across CI machines. A 3x guard is comfortable: in practice the ratio
     // hovers around 1x and small fluctuations from disk/GC do not move it.
+    //
+    // The windows are stall-discounted (see above) because this ratio is a claim about how the MERGE/CREATE plan
+    // scales with database size, and nothing else. Raw wall clock does not say that in a full-suite run sharing
+    // one JVM: measured on such a run the first eight windows held ~1.0-1.3 s and the last two jumped to ~4.9 s
+    // flat - a step, not the ramp a size-driven regression produces - which took the ratio to 4.40x purely on the
+    // JVM's mood late in a 14,000-test fork. Discounting the stall keeps the 3x bound tight rather than paying
+    // for that by loosening it, which would have blunted the very regression the test is here to catch.
     final long warmupNanos = average(windowNanos, 1, Math.min(4, windowNanos.length));
     final long tailNanos = average(windowNanos, windowNanos.length - Math.max(2, windowNanos.length / 4),
         windowNanos.length);
@@ -170,7 +190,8 @@ class MergeInsertSlowdownTest {
         .append(" iters/batch):\n");
     for (int w = 0; w < windowNanos.length; w++)
       dump.append("  window ").append(w).append(": ")
-          .append(String.format("%.1f", windowNanos[w] / 1_000_000.0)).append(" ms\n");
+          .append(String.format("%.1f", windowNanos[w] / 1_000_000.0)).append(" ms")
+          .append(String.format(" (%.1f ms JVM stall discounted)", windowStallNanos[w] / 1_000_000.0)).append("\n");
     dump.append("  warmup avg = ").append(String.format("%.1f", warmupNanos / 1_000_000.0)).append(" ms, ")
         .append("tail avg = ").append(String.format("%.1f", tailNanos / 1_000_000.0)).append(" ms, ")
         .append("ratio tail/warmup = ").append(String.format("%.2fx", ratio));


### PR DESCRIPTION
Two independent fixes that both came out of running the engine suite end to end.

## 1. Approximate vector search refuses a graph its PQ codes do not cover

`findNeighborsFromVectorApproximate()` threw "Error performing PQ approximate search" wrapping an `IndexOutOfBoundsException` from JVector's `PQVectors.getChunk` - "Ordinal 1280 out of bounds for vector count 1100" - raised inside `GraphSearcher`'s `initializeInternal` while scoring an entry point.

`graphIndex` is published under `lock.writeLock()`, which a search's read lock excludes, so it cannot move underneath a running search. `pqVectors` is not: it is republished later and outside that lock, by `buildAndPersistPQ` and by the `earlyPqVectors` branch. A rebuild therefore makes its new, larger graph live before the codes for it exist, and a search starting in that window pairs the new graph with the old, smaller codes and asks them for an ordinal they were never sized for. Because the throw happens while scoring an entry point, before any `Bits` filter is consulted, a filter cannot close it.

The search now pins `pqVectors`, `graphIndex` and `ordinalToVectorId` into locals at the top of the read-locked block and uses those three throughout, where it previously re-read the fields at four separate points. If the pinned codes do not cover the pinned graph's ordinal space - the map is checked too, since the pre-filter branch scores ordinals from it rather than from the beam - the PQ block is skipped and the query degrades to `findNeighborsFromVector`, which needs no codes and stays correct for the whole window. The fast path resumes by itself on the next query once the codes are republished.

The fallback runs after the read lock is released rather than inside it, and that placement is required: the exact path can take the write lock to rebuild, and `ReentrantReadWriteLock` cannot upgrade read to write.

Nothing that works today is switched off. Any state where the guard fires is a state where the PQ path can only throw, and in the steady state the codes cover exactly the graph they were built from. `PqCodesStaleForRebuiltGraphTest` asserts that agreement, and that the approximate path answers normally through it, before injecting any staleness. Rather than wait for the race, which reproduced about one run in five, the test installs the end state it produces: it captures the settled codes, grows the graph through a real rebuild, then puts the stale codes back. Reverting only the production change reproduces the original exception.

The bulk of the diff in `LSMVectorIndex` is re-indentation of the existing block.

## 2. Three test failures that only surface in a full-suite run

All three pass in isolation and fail once the whole module shares one JVM, which is why none of them showed up until the suite was run end to end.

**`InsertGraphIndexTest`** installed `NullLogger.INSTANCE` from `getPerformanceProfile()` - a method whose only job is to name a profile - and never put the previous logger back. `LogManager.setLogger()` is process-wide, so every `LogManager.instance().log()` in the fork was discarded from that point on, and its own javadoc tells callers to keep what they replace. In the slow lane this silently disarmed `LSMVectorIndexRebuildTest` about 70 classes downstream: both of its log-asserting tests captured nothing and failed with no hint that the cause was elsewhere. The tell was that jvector's own JUL loggers kept printing while every `com.arcadedb.*` line stopped, since those bypass ArcadeDB's `LogManager`. The swap now lives in `beginTest()`/`endTest()` with a restore.

**`Issue6459GraphPathfindingCommandTimeoutTest`** armed a 50 ms deadline on the belief that one exhausting pass over the 20,000-node component "costs seconds". It does when the page cache is cold; warm it measures about 55 ms, so the bound sat at the deadline rather than below it. `astar()` passed only because it ran first and cold, leaving the pages warm for `dijkstra()` right behind it, which drained all 20,000 nodes in 56 ms and returned normally. The deadline drops to 5 ms, an order of magnitude under the warm figure, and the assertions now name the guard that has to fire ("astar() exceeded the ...") so a deadline tripped elsewhere in the plan cannot stand in for the check under test. Verified still load-bearing: removing `guard.check()` from `SQLFunctionAstar` fails both tests again.

**`MergeInsertSlowdownTest`** compared raw wall-clock windows. Measured in a 14,000-test fork its first eight windows held ~1.0-1.3 s and the last two stepped to ~4.9 s flat - a step, not the ramp a size-driven regression produces - taking the ratio to 4.40x against a 3x bound. The windows are now stall-discounted through `StallAwareStopwatch.jvmStallNanos()`, which is the API meant for a test timing a sequence of instants rather than one span. That keeps the 3x bound tight instead of paying for the flake by loosening it, which would have blunted the regression the test exists to catch, and each window reports how much stall was discounted so a future failure says whether it was real.

## Verification

`mvn -o -pl engine -am test -Dtest='PqCodesStaleForRebuiltGraphTest,Issue7146GraphBuildCacheBudgetTest,InsertGraphIndexTest'` - 8 tests, green, on top of current `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved approximate vector search reliability when index data becomes inconsistent after graph updates or contains ordinal gaps. Searches now safely fall back to exact matching without double-counting metrics.
  - Improved stability of graph pathfinding timeout handling and ensured timeout protections are applied consistently across supported algorithms.

- **Tests**
  - Added regression coverage for stale vector-index data, timeout behavior, logger restoration, and more accurate performance measurements across varying runtime conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->