### PR TITLE
fix: CREATE INDEX on a populated type no longer truncates datetimes to milliseconds (#7164)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -922,6 +922,14 @@ public class OpenCypherQueryEngine implements QueryEngine {
    * nanoseconds (nothing can widen it further), and the caller is about to walk every record anyway
    * to build the index, so it costs one extra sequential scan on a DDL statement that is already
    * linear in the type's size.
+   * <p>
+   * That scan is unconditional once the property is seen to be temporal, including the common case
+   * where every value is plain millisecond-precision and the answer is the {@code DATETIME} the
+   * capped scan would have given. So indexing a temporal column on a very large type costs a
+   * measurable amount of extra wall clock on top of the index build - deliberately, because the
+   * alternative is silently truncating precision that is already persisted. If a slow
+   * {@code CREATE INDEX} on a huge temporal column ever needs to be cut down, this is the place, and
+   * anything that reintroduces a bound reintroduces the truncation of issue #7164 with it.
    */
   private Type inferPropertyTypeFromExistingData(final String typeName, final String propertyName) {
     try {
@@ -935,8 +943,8 @@ public class OpenCypherQueryEngine implements QueryEngine {
         scanned++;
         if (!(record instanceof Document doc))
           continue;
-        if (!doc.has(propertyName))
-          continue;
+        // NO has() GUARD: get() ALREADY ANSWERS null FOR AN ABSENT PROPERTY, AND EACH OF THE TWO MAKES ITS OWN PASS
+        // OVER THE RECORD BUFFER - ASKING TWICE DOUBLED THE COST OF EVERY RECORD IN THE UNCAPPED SWEEP ABOVE
         final Object value = doc.get(propertyName);
         if (value == null)
           continue;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -48,6 +48,7 @@ import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.CollectionUtils;
+import com.arcadedb.utility.DateUtils;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
@@ -58,6 +59,7 @@ import com.arcadedb.security.SecurityManager;
 import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
 import com.arcadedb.index.Index;
 
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -902,14 +904,33 @@ public class OpenCypherQueryEngine implements QueryEngine {
    * {@code propertyName} and returns the {@link Type} that matches its Java class. Returns
    * {@code null} if no record sets the property. Used by Cypher DDL to preserve numeric
    * properties across {@code CREATE INDEX} on an already-populated type (issue #4222).
+   * <p>
+   * Temporal values are the one case where the Java class alone is not enough:
+   * {@link Type#getTypeByClass} maps every temporal class onto the millisecond {@link Type#DATETIME},
+   * while an <em>undeclared</em> temporal property is serialized at the precision of each value
+   * (see {@code BinaryTypes.getTypeFromValue}). Declaring {@code DATETIME} would therefore silently
+   * truncate to milliseconds every write made after the index was created, on a property whose
+   * existing rows carry microseconds or nanoseconds (issue #7164). So the first non-null value still
+   * decides the property's <em>kind</em>, but when that kind is temporal the scan keeps going and
+   * declares the widest precision the data actually holds. Milliseconds stay the floor - a value that
+   * happens to land on a whole second must not declare the property {@code DATETIME_SECOND} and
+   * truncate the millisecond writes ArcadeDB has always accepted by default.
+   * <p>
+   * The 256-record cap that bounds the kind lookup is deliberately not applied to that precision
+   * sweep: a capped sweep would silently truncate a type whose first 256 rows happen to sit on a
+   * millisecond boundary, which is the very failure being fixed. The sweep stops as soon as it sees
+   * nanoseconds (nothing can widen it further), and the caller is about to walk every record anyway
+   * to build the index, so it costs one extra sequential scan on a DDL statement that is already
+   * linear in the type's size.
    */
   private Type inferPropertyTypeFromExistingData(final String typeName, final String propertyName) {
     try {
       final Iterator<Record> it = database.iterateType(typeName, true);
       int scanned = 0;
+      ChronoUnit temporalPrecision = null;
       // 256 is enough to spot the dominant value type without doing a full table scan; users
       // hitting heterogeneous-typed properties can declare the property explicitly via SQL.
-      while (it.hasNext() && scanned < 256) {
+      while (it.hasNext() && (temporalPrecision != null || scanned < 256)) {
         final Record record = it.next();
         scanned++;
         if (!(record instanceof Document doc))
@@ -919,6 +940,26 @@ public class OpenCypherQueryEngine implements QueryEngine {
         final Object value = doc.get(propertyName);
         if (value == null)
           continue;
+
+        final ChronoUnit precision = DateUtils.getPrecisionFromValue(value);
+
+        if (temporalPrecision != null) {
+          // THE KIND IS ALREADY SETTLED AS TEMPORAL: LATER VALUES ONLY WIDEN THE PRECISION
+          if (precision != null && precision.compareTo(temporalPrecision) < 0)
+            temporalPrecision = precision;
+          if (temporalPrecision == ChronoUnit.NANOS)
+            break;
+          continue;
+        }
+
+        if (precision != null) {
+          // MILLIS IS THE FLOOR: NEVER NARROW BELOW THE DEFAULT DATETIME PRECISION
+          temporalPrecision = precision.compareTo(ChronoUnit.MILLIS) < 0 ? precision : ChronoUnit.MILLIS;
+          if (temporalPrecision == ChronoUnit.NANOS)
+            break;
+          continue;
+        }
+
         try {
           return Type.getTypeByClass(value.getClass());
         } catch (final IllegalArgumentException ignored) {
@@ -927,6 +968,9 @@ public class OpenCypherQueryEngine implements QueryEngine {
           return null;
         }
       }
+
+      if (temporalPrecision != null)
+        return Type.getByBinaryType(DateUtils.getBestBinaryTypeForPrecision(temporalPrecision));
     } catch (final Exception ignored) {
       // If iteration fails for any reason (e.g. schema in transient state) just skip inference.
     }

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -476,9 +476,29 @@ public class DateUtils {
       case null -> throw new IllegalArgumentException("Object is null");
       case LocalDateTime time -> time.getNano();
       case ZonedDateTime time -> time.getNano();
+      case OffsetDateTime time -> time.getNano();
       case Instant instant -> instant.getNano();
       default -> throw new IllegalArgumentException("Object of class '" + obj.getClass() + "' is not supported");
     };
+  }
+
+  /**
+   * Returns the sub-second precision actually carried by a temporal value, or {@code null} when the object is not a
+   * temporal ArcadeDB stores with a sub-second precision (a {@code LocalDate}, a number, a string, anything else).
+   * {@code Date} and {@code Calendar} cannot hold anything finer than a millisecond, so they always report
+   * {@link ChronoUnit#MILLIS}.
+   *
+   * @param obj value to inspect
+   *
+   * @return the value's precision, or {@code null} if it is not a sub-second-capable temporal
+   */
+  public static ChronoUnit getPrecisionFromValue(final Object obj) {
+    if (obj instanceof Date || obj instanceof Calendar)
+      return ChronoUnit.MILLIS;
+    if (obj instanceof LocalDateTime || obj instanceof ZonedDateTime || obj instanceof OffsetDateTime
+        || obj instanceof Instant)
+      return getPrecision(getNanos(obj));
+    return null;
   }
 
   public static boolean isDate(final Object obj) {
@@ -494,13 +514,8 @@ public class DateUtils {
 
     ChronoUnit highestPrecision = ChronoUnit.MILLIS;
     for (int i = 0; i < objs.length; i++) {
-      final Object obj = objs[i];
-      final ChronoUnit precision;
-      if (obj instanceof Date || obj instanceof Calendar)
-        precision = ChronoUnit.MILLIS;
-      else if (obj instanceof LocalDateTime || obj instanceof ZonedDateTime || obj instanceof Instant)
-        precision = getPrecision(getNanos(obj));
-      else
+      final ChronoUnit precision = getPrecisionFromValue(objs[i]);
+      if (precision == null)
         continue;
 
       if (precision.compareTo(highestPrecision) < 0)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherIndexDatetimePrecisionIssue7164Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherIndexDatetimePrecisionIssue7164Test.java
@@ -132,6 +132,20 @@ class CypherIndexDatetimePrecisionIssue7164Test {
   }
 
   @Test
+  void aLaterNonTemporalValueDoesNotResetTheInferredPrecision() {
+    // Heterogeneous properties are already an unsupported shape, but the sweep must degrade gracefully: a row whose
+    // value is not a temporal reports no precision and is simply skipped, it must not reset the kind settled by the
+    // first value nor drag the precision back down to milliseconds.
+    insert("Het", "micro", MICROS);
+    database.command("cypher", "CREATE (n:Het {uuid:'text', created_at:'not a date'})");
+    insert("Het", "micro2", MICROS);
+    database.command("cypher", "CREATE INDEX het_created IF NOT EXISTS FOR (n:Het) ON (n.created_at)");
+
+    assertThat(database.getSchema().getType("Het").getProperty("created_at").getType()).isEqualTo(Type.DATETIME_MICROS);
+    assertThat(readBack("Het", "micro")).isEqualTo(MICROS);
+  }
+
+  @Test
   void nonTemporalPropertyStillInfersFromTheFirstValue() {
     // Non-temporal inference (issue #4222) is unchanged: the first non-null value decides the type.
     database.command("cypher", "CREATE (n:Num {uuid:'a', val:1})");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherIndexDatetimePrecisionIssue7164Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherIndexDatetimePrecisionIssue7164Test.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.temporal.CypherLocalDateTime;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7164. {@code CREATE INDEX} on an already-populated type declares the indexed
+ * property so that the index key has a stable type (issue #4222). The declared type used to come from
+ * {@code Type.getTypeByClass(value.getClass())}, which maps every temporal class to {@code DATETIME}, i.e.
+ * millisecond precision, no matter what precision the stored values actually carry. Records written before
+ * the index kept their microseconds - an undeclared temporal is serialized at the precision of its own value -
+ * while every write after it was silently truncated to milliseconds.
+ * <p>
+ * Creating an index must never narrow the precision already present in the data, so once the inference sees a
+ * temporal value it sweeps the type for the widest precision the rows actually hold, with milliseconds as the
+ * floor (a value that happens to land on a whole second must not declare the property {@code DATETIME_SECOND}).
+ * {@code CREATE CONSTRAINT} shares the same inference and is covered here too.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherIndexDatetimePrecisionIssue7164Test {
+  private static final LocalDateTime MICROS  = LocalDateTime.of(2026, 1, 2, 3, 4, 5, 123_456_000);
+  private static final LocalDateTime NANOS   = LocalDateTime.of(2026, 1, 2, 3, 4, 5, 123_456_789);
+  private static final LocalDateTime MILLIS  = LocalDateTime.of(2026, 1, 2, 3, 4, 5, 123_000_000);
+  private static final LocalDateTime SECONDS = LocalDateTime.of(2026, 1, 2, 3, 4, 5, 0);
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/issue7164").create();
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  private void insert(final String label, final String uuid, final LocalDateTime ts) {
+    database.command("cypher", "CREATE (n:" + label + " {uuid:$uuid, created_at:$ts})", Map.of("uuid", uuid, "ts", ts));
+  }
+
+  private LocalDateTime readBack(final String label, final String uuid) {
+    final ResultSet rs = database.command("cypher",
+        "MATCH (n:" + label + ") WHERE n.uuid = $uuid RETURN n.created_at AS ts", Map.of("uuid", uuid));
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    // Cypher hands temporal values back wrapped in its own value type.
+    final Object ts = row.getProperty("ts");
+    return ts instanceof CypherLocalDateTime cypherValue ? cypherValue.getValue() : (LocalDateTime) ts;
+  }
+
+  @Test
+  void indexOnPopulatedTypePreservesMicrosecondPrecision() {
+    insert("Ev", "before", MICROS);
+    database.command("cypher", "CREATE INDEX ev_created IF NOT EXISTS FOR (n:Ev) ON (n.created_at)");
+    insert("Ev", "after", MICROS);
+
+    assertThat(database.getSchema().getType("Ev").getProperty("created_at").getType()).isEqualTo(Type.DATETIME_MICROS);
+    assertThat(readBack("Ev", "before")).isEqualTo(MICROS);
+    assertThat(readBack("Ev", "after")).isEqualTo(MICROS);
+  }
+
+  @Test
+  void indexOnPopulatedTypePreservesNanosecondPrecision() {
+    insert("Nano", "before", NANOS);
+    database.command("cypher", "CREATE INDEX nano_created IF NOT EXISTS FOR (n:Nano) ON (n.created_at)");
+    insert("Nano", "after", NANOS);
+
+    assertThat(database.getSchema().getType("Nano").getProperty("created_at").getType()).isEqualTo(Type.DATETIME_NANOS);
+    assertThat(readBack("Nano", "before")).isEqualTo(NANOS);
+    assertThat(readBack("Nano", "after")).isEqualTo(NANOS);
+  }
+
+  @Test
+  void widestPrecisionAmongSampledRecordsWins() {
+    // The first record carries only milliseconds: sampling must not stop there and declare DATETIME, or the
+    // microseconds already stored on the second record would be truncated on every subsequent write.
+    insert("Mixed", "milli", MILLIS);
+    insert("Mixed", "micro", MICROS);
+    database.command("cypher", "CREATE INDEX mixed_created IF NOT EXISTS FOR (n:Mixed) ON (n.created_at)");
+    insert("Mixed", "after", MICROS);
+
+    assertThat(database.getSchema().getType("Mixed").getProperty("created_at").getType()).isEqualTo(Type.DATETIME_MICROS);
+    assertThat(readBack("Mixed", "micro")).isEqualTo(MICROS);
+    assertThat(readBack("Mixed", "after")).isEqualTo(MICROS);
+  }
+
+  @Test
+  void microsecondsBeyondTheSampleCapStillWiden() {
+    // The kind lookup samples at most 256 records. The precision sweep must not stop there, or a type whose
+    // first 256 rows happen to land on a millisecond boundary would still be truncated.
+    for (int i = 0; i < 300; i++)
+      insert("Deep", "milli" + i, MILLIS);
+    insert("Deep", "micro", MICROS);
+    database.command("cypher", "CREATE INDEX deep_created IF NOT EXISTS FOR (n:Deep) ON (n.created_at)");
+    insert("Deep", "after", MICROS);
+
+    assertThat(database.getSchema().getType("Deep").getProperty("created_at").getType()).isEqualTo(Type.DATETIME_MICROS);
+    assertThat(readBack("Deep", "after")).isEqualTo(MICROS);
+  }
+
+  @Test
+  void nonTemporalPropertyStillInfersFromTheFirstValue() {
+    // Non-temporal inference (issue #4222) is unchanged: the first non-null value decides the type.
+    database.command("cypher", "CREATE (n:Num {uuid:'a', val:1})");
+    database.command("cypher", "CREATE INDEX num_val IF NOT EXISTS FOR (n:Num) ON (n.val)");
+
+    assertThat(database.getSchema().getType("Num").getProperty("val").getType()).isEqualTo(Type.INTEGER);
+  }
+
+  @Test
+  void wholeSecondValuesDoNotNarrowBelowMilliseconds() {
+    // A value that lands on a whole second must keep DATETIME as the floor: declaring DATETIME_SECOND would
+    // narrow the type below what the engine has always used by default.
+    insert("Sec", "before", SECONDS);
+    database.command("cypher", "CREATE INDEX sec_created IF NOT EXISTS FOR (n:Sec) ON (n.created_at)");
+    insert("Sec", "after", MILLIS);
+
+    assertThat(database.getSchema().getType("Sec").getProperty("created_at").getType()).isEqualTo(Type.DATETIME);
+    assertThat(readBack("Sec", "after")).isEqualTo(MILLIS);
+  }
+
+  @Test
+  void constraintOnPopulatedTypePreservesMicrosecondPrecision() {
+    // CREATE CONSTRAINT goes through the same inference as CREATE INDEX.
+    insert("Uniq", "before", MICROS);
+    database.command("cypher", "CREATE CONSTRAINT uniq_created IF NOT EXISTS FOR (n:Uniq) REQUIRE n.created_at IS UNIQUE");
+
+    assertThat(database.getSchema().getType("Uniq").getProperty("created_at").getType()).isEqualTo(Type.DATETIME_MICROS);
+    assertThat(readBack("Uniq", "before")).isEqualTo(MICROS);
+  }
+
+  @Test
+  void indexCreatedBeforeAnyDataStillWorks() {
+    database.command("cypher", "CREATE INDEX empty_created IF NOT EXISTS FOR (n:Empty) ON (n.created_at)");
+    insert("Empty", "after", MICROS);
+
+    assertThat(readBack("Empty", "after")).isEqualTo(MICROS);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
@@ -283,4 +283,39 @@ class DateUtilsTest {
     // Same answer now that the default locale is back: the cached formatter did not capture the Italian one
     assertThat(DateUtils.format(dateTime, pattern)).isEqualTo("04 March 2026 Wednesday");
   }
+
+  /**
+   * Issue #7164: the Cypher {@code CREATE INDEX} type inference needs to know the precision a value actually
+   * carries, because {@code Type.getTypeByClass} collapses every temporal class onto the millisecond
+   * {@code DATETIME}. A non-temporal must report {@code null} so the caller falls back to the class-based
+   * inference.
+   */
+  @Test
+  void precisionFromValueReportsWhatTheValueCarries() {
+    assertThat(DateUtils.getPrecisionFromValue(LocalDateTime.of(2026, 1, 2, 3, 4, 5, 0))).isEqualTo(ChronoUnit.SECONDS);
+    assertThat(DateUtils.getPrecisionFromValue(LocalDateTime.of(2026, 1, 2, 3, 4, 5, 123_000_000))).isEqualTo(ChronoUnit.MILLIS);
+    assertThat(DateUtils.getPrecisionFromValue(LocalDateTime.of(2026, 1, 2, 3, 4, 5, 123_456_000))).isEqualTo(ChronoUnit.MICROS);
+    assertThat(DateUtils.getPrecisionFromValue(LocalDateTime.of(2026, 1, 2, 3, 4, 5, 123_456_789))).isEqualTo(ChronoUnit.NANOS);
+    assertThat(DateUtils.getPrecisionFromValue(Instant.ofEpochSecond(1, 123_456_000))).isEqualTo(ChronoUnit.MICROS);
+    assertThat(DateUtils.getPrecisionFromValue(ZonedDateTime.of(2026, 1, 2, 3, 4, 5, 123_456_789, ZoneOffset.UTC)))
+        .isEqualTo(ChronoUnit.NANOS);
+    // A Date cannot hold more than milliseconds
+    assertThat(DateUtils.getPrecisionFromValue(new java.util.Date())).isEqualTo(ChronoUnit.MILLIS);
+    // Not a sub-second-capable temporal
+    assertThat(DateUtils.getPrecisionFromValue(LocalDate.of(2026, 1, 2))).isNull();
+    assertThat(DateUtils.getPrecisionFromValue("2026-01-02")).isNull();
+    assertThat(DateUtils.getPrecisionFromValue(null)).isNull();
+  }
+
+  /**
+   * {@link DateUtils#getHigherPrecision} used to skip {@code OffsetDateTime} entirely, so two offset datetimes
+   * differing only below the millisecond compared as if they were both millisecond-precision.
+   */
+  @Test
+  void higherPrecisionCoversOffsetDateTime() {
+    final OffsetDateTime micros = OffsetDateTime.of(2026, 1, 2, 3, 4, 5, 123_456_000, ZoneOffset.UTC);
+    final OffsetDateTime millis = OffsetDateTime.of(2026, 1, 2, 3, 4, 5, 123_000_000, ZoneOffset.UTC);
+    assertThat(DateUtils.getPrecisionFromValue(micros)).isEqualTo(ChronoUnit.MICROS);
+    assertThat(DateUtils.getHigherPrecision(millis, micros)).isEqualTo(ChronoUnit.MICROS);
+  }
 }


### PR DESCRIPTION
Closes #7164

## Problem

Cypher DDL declares an undeclared indexed property so the index key has a stable type (#4222), inferring that type with `Type.getTypeByClass(value.getClass())`. Every temporal Java class maps onto the millisecond `DATETIME` there, regardless of the precision the values carry.

So indexing a `created_at` whose rows hold microseconds declared it `DATETIME`. Rows written *before* the index kept their microseconds - an undeclared temporal is serialized at the precision of its own value (`BinaryTypes.getTypeFromValue`) - while every write *after* it was silently truncated to milliseconds. No warning; visible only on read-back:

```
written before index -> nanosecond=123456000   OK
written after  index -> nanosecond=123000000   TRUNCATED
```

The reporter hit this with [graphiti](https://github.com/getzep/graphiti), a bi-temporal knowledge graph that calls `build_indices_and_constraints()` on startup: on a fresh database the indexes precede the data and precision survives, on any existing database the same call truncates every subsequent timestamp, and two events in the same millisecond then compare equal - exactly the ordering the model depends on.

Neo4j never changes a stored value's precision when an index is created, so this is an ArcadeDB defect and not a Cypher usage mistake.

## Fix

The first non-null value still decides the property's *kind*. When that kind is temporal, the inference now sweeps the type for the widest precision the rows actually hold and declares `DATETIME_MICROS` / `DATETIME_NANOS` accordingly.

- **Milliseconds stay the floor.** A value that happens to land on a whole second must not declare the property `DATETIME_SECOND` and narrow the millisecond writes ArcadeDB has always accepted by default.
- **The sweep is not subject to the 256-record cap** that bounds the kind lookup. A capped sweep would still truncate a type whose first 256 rows sit on a millisecond boundary, which is the failure being fixed. It stops early as soon as it sees nanoseconds, and `CREATE INDEX` is about to walk every record to build the index anyway, so the cost is one extra sequential scan on a DDL statement that is already linear in the type's size.
- `CREATE CONSTRAINT` shares the same inference and is fixed with it.

The issue asked for "infer `DATETIME_MICROS` when sub-millisecond values are present". Declaring the *widest precision found across the whole type* is strictly better: it also covers nanoseconds, it does not depend on which record happens to be sampled first, and it cannot be defeated by a large prefix of millisecond-precision rows. The alternative of leaving the property undeclared (the existing `withDefaultKeyTypesForUndeclaredProperties` fallback) would preserve per-value precision too, but at the cost of `STRING`-serialised index keys, which is worse for the range queries these temporal properties exist for.

`DateUtils` gains `getPrecisionFromValue()`, which `getHigherPrecision()` now delegates to, and `getNanos()` learns `OffsetDateTime`. `getHigherPrecision()` used to skip `OffsetDateTime` entirely, so `BinaryComparator` compared two offset datetimes differing only below the millisecond as if both were millisecond-precision.

## Tests

New `CypherIndexDatetimePrecisionIssue7164Test` (8 cases): micros and nanos preserved across `CREATE INDEX`; widest precision wins when the first row is coarser; micros beyond the 256-record cap still widen; whole-second values do not narrow below `DATETIME`; non-temporal inference (#4222) unchanged; `CREATE CONSTRAINT` covered; index-before-data still works. Two cases added to `DateUtilsTest` for `getPrecisionFromValue` and the `OffsetDateTime` gap.

Regression: engine `opencypher` / `schema` / `serializer` / `utility` (6503 tests), `sql` / `database` / `index` (4509 tests), and the `bolt` module (349 tests) all green.

## Files changed

- `engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java`
- `engine/src/main/java/com/arcadedb/utility/DateUtils.java`
- `engine/src/test/java/com/arcadedb/query/opencypher/CypherIndexDatetimePrecisionIssue7164Test.java` (new)
- `engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbn7hrmTeyEWpkK2AmLjAp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cypher index and constraint handling for temporal values with millisecond, microsecond, and nanosecond precision.
  * Preserved temporal precision when indexes or constraints are created on populated data, including values beyond the initial sampling range.
  * Improved support for offset-based date-time values and consistent precision detection across temporal types.
  * Ensured whole-second temporal values retain appropriate millisecond precision handling.
  * Maintained existing inference behavior for non-temporal properties and mixed-value data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->