### PR TITLE
fix(#7169): MERGE binds the path it merged, not just the elements it named

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -279,6 +279,9 @@ public class MergeStep extends AbstractExecutionStep {
     if (variable != null) {
       final Object existing = baseResult.getProperty(variable);
       if (existing instanceof Vertex bound) {
+        // No query reaches this today - the semantic validator refuses a single-node MERGE naming a variable an
+        // earlier clause bound - but the row still describes a path if one ever does, so bind it here rather
+        // than leave the variable unset behind a check that only holds as long as the validator does.
         baseResult.setProperty("  wasCreated", false);
         bindSingleNodePath(baseResult, pathPattern, bound);
         return List.of(baseResult);
@@ -1051,18 +1054,31 @@ public class MergeStep extends AbstractExecutionStep {
     if (!pathPattern.hasPathVariable())
       return;
 
-    final int relationshipCount = pathPattern.getRelationshipCount();
-    if (trace == null || !(trace[0] instanceof Vertex startVertex))
-      return; // the walk did not bind a start node: nothing to describe
-
-    final TraversalPath path = new TraversalPath(startVertex);
-    for (int i = 0; i < relationshipCount; i++) {
-      if (!(trace[2 * i + 1] instanceof Edge edge) || !(trace[2 * i + 2] instanceof Vertex vertex))
-        break;
-      path.addStep(edge, vertex);
-    }
+    // A path variable means newPathTrace allocated the array, and every emit point fills every slot of it
+    // before reaching here, so a hole is a bug in the walk rather than a shape a query can produce. Reading
+    // past it would bind a truncated path - silently wrong data, which is the exact defect this method exists
+    // to fix - so say so instead.
+    final TraversalPath path = new TraversalPath(tracedVertex(trace, 0, pathPattern));
+    for (int i = 0; i < pathPattern.getRelationshipCount(); i++)
+      path.addStep(tracedEdge(trace, 2 * i + 1, pathPattern), tracedVertex(trace, 2 * i + 2, pathPattern));
 
     result.setProperty(pathPattern.getPathVariable(), path);
+  }
+
+  private static Vertex tracedVertex(final Object[] trace, final int slot, final PathPattern pathPattern) {
+    final Object element = trace == null ? null : trace[slot];
+    if (element instanceof Vertex vertex)
+      return vertex;
+    throw new IllegalStateException(
+        "MERGE left node " + (slot / 2) + " of path '" + pathPattern.getPathVariable() + "' unbound: " + element);
+  }
+
+  private static Edge tracedEdge(final Object[] trace, final int slot, final PathPattern pathPattern) {
+    final Object element = trace == null ? null : trace[slot];
+    if (element instanceof Edge edge)
+      return edge;
+    throw new IllegalStateException(
+        "MERGE left relationship " + (slot / 2) + " of path '" + pathPattern.getPathVariable() + "' unbound: " + element);
   }
 
   private ResultInternal copyResult(final Result source) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -626,7 +626,14 @@ public class MergeStep extends AbstractExecutionStep {
       walkLeft(pathPattern, anchorIdx, anchorVertex, rr.result(), rr.trace(), results);
   }
 
-  /** A partially-walked path: the row's bindings paired with the path slots {@link #newPathTrace} allocated. */
+  /**
+   * A partially-walked path: the row's bindings paired with the path slots {@link #newPathTrace} allocated.
+   * <p>
+   * Unlike the slot array itself, this wrapper is not gated on the pattern naming a path variable: the list it
+   * goes into has one element type, and splitting the walk into traced and untraced variants to save one small
+   * record per right-side completion would duplicate the walker. It is the one allocation this carries into a
+   * MERGE that binds no path, and only for a pattern whose bound anchor sits in the middle of a longer one.
+   */
   private record TracedResult(ResultInternal result, Object[] trace) {
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -758,6 +758,10 @@ public class MergeStep extends AbstractExecutionStep {
    * node).  {@code forcedVertex} is non-null when the node was reached via a
    * preceding edge traversal; otherwise the node is resolved from
    * {@code currentResult} or left as "unbound" for a full-scan.
+   *
+   * @param trace path slots this call owns outright - every caller either allocates a fresh array or hands over
+   *              a {@link #branchPathTrace(Object[])} clone of its own, so this method writes its position into
+   *              the array directly and only clones again where it forks into sibling branches
    */
   private void traverseFromNode(final PathPattern pathPattern, final int nodeIndex,
       final Vertex forcedVertex, final ResultInternal currentResult, final Object[] trace, final List<Result> results) {
@@ -799,9 +803,8 @@ public class MergeStep extends AbstractExecutionStep {
       if (nodePattern.getVariable() != null)
         r.setProperty(nodePattern.getVariable(), vertex);
       r.setProperty("  wasCreated", false);
-      final Object[] terminalTrace = branchPathTrace(trace);
-      tracePathElement(terminalTrace, 2 * nodeIndex, vertex);
-      addPathBinding(r, pathPattern, terminalTrace);
+      tracePathElement(trace, 2 * nodeIndex, vertex);
+      addPathBinding(r, pathPattern, trace);
       results.add(r);
       return;
     }
@@ -817,10 +820,9 @@ public class MergeStep extends AbstractExecutionStep {
       if (nodePattern.getVariable() != null)
         stepResult.setProperty(nodePattern.getVariable(), vertex);
 
-      final Object[] stepTrace = branchPathTrace(trace);
-      tracePathElement(stepTrace, 2 * nodeIndex, vertex);
+      tracePathElement(trace, 2 * nodeIndex, vertex);
 
-      traverseEdgesFromVertex(pathPattern, nodeIndex, vertex, relPattern, stepResult, stepTrace, results);
+      traverseEdgesFromVertex(pathPattern, nodeIndex, vertex, relPattern, stepResult, trace, results);
     } else {
       // Anchor is unbound — scan all edges of the required type; both endpoints
       // of each edge must satisfy their respective node patterns
@@ -1070,7 +1072,7 @@ public class MergeStep extends AbstractExecutionStep {
     if (element instanceof Vertex vertex)
       return vertex;
     throw new IllegalStateException(
-        "MERGE left node " + (slot / 2) + " of path '" + pathPattern.getPathVariable() + "' unbound: " + element);
+        "MERGE: node " + (slot / 2) + " of path '" + pathPattern.getPathVariable() + "' was left unbound: " + element);
   }
 
   private static Edge tracedEdge(final Object[] trace, final int slot, final PathPattern pathPattern) {
@@ -1078,7 +1080,7 @@ public class MergeStep extends AbstractExecutionStep {
     if (element instanceof Edge edge)
       return edge;
     throw new IllegalStateException(
-        "MERGE left relationship " + (slot / 2) + " of path '" + pathPattern.getPathVariable() + "' unbound: " + element);
+        "MERGE: relationship " + (slot / 2) + " of path '" + pathPattern.getPathVariable() + "' was left unbound: " + element);
   }
 
   private ResultInternal copyResult(final Result source) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -45,6 +45,7 @@ import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
 import com.arcadedb.query.opencypher.executor.LabelReplacements;
 import com.arcadedb.query.opencypher.parser.CypherASTBuilder;
 import com.arcadedb.query.opencypher.temporal.TemporalUtil;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.QueryStatistics;
@@ -242,16 +243,10 @@ public class MergeStep extends AbstractExecutionStep {
       }
 
       final List<Result> results;
-      if (pathPattern.isSingleNode()) {
-        results = mergeSingleNodeAll(pathPattern.getFirstNode(), baseResult);
-        // Add path binding for single-node MERGE (e.g., MERGE p = (a {num: 1}))
-        if (pathPattern.hasPathVariable()) {
-          for (final Result r : results)
-            addPathBinding((ResultInternal) r, pathPattern);
-        }
-      } else {
+      if (pathPattern.isSingleNode())
+        results = mergeSingleNodeAll(pathPattern, baseResult);
+      else
         results = mergePathAll(pathPattern, baseResult);
-      }
 
       // Apply ON CREATE SET or ON MATCH SET to each result
       for (final Result r : results) {
@@ -275,15 +270,17 @@ public class MergeStep extends AbstractExecutionStep {
    * Merges a single node, returning ALL matching nodes or creating one.
    * MERGE returns one row per matching node, or creates if none match.
    */
-  private List<Result> mergeSingleNodeAll(final NodePattern nodePattern, final ResultInternal baseResult) {
+  private List<Result> mergeSingleNodeAll(final PathPattern pathPattern, final ResultInternal baseResult) {
+    final NodePattern nodePattern = pathPattern.getFirstNode();
     final String variable = nodePattern.getVariable();
 
     // Only check for already-bound variable when explicitly named by the user.
     // Anonymous MERGE nodes (no variable) should always search for matches.
     if (variable != null) {
       final Object existing = baseResult.getProperty(variable);
-      if (existing instanceof Vertex) {
+      if (existing instanceof Vertex bound) {
         baseResult.setProperty("  wasCreated", false);
+        bindSingleNodePath(baseResult, pathPattern, bound);
         return List.of(baseResult);
       }
     }
@@ -292,7 +289,7 @@ public class MergeStep extends AbstractExecutionStep {
     final List<Vertex> matches = findAllNodes(nodePattern, baseResult);
 
     if (!matches.isEmpty())
-      return buildMatchResults(matches, variable, baseResult);
+      return buildMatchResults(matches, pathPattern, baseResult);
 
     // No match - create one.  If a UNIQUE-index collision is raised on create
     // (issue #4351: another row in the same batch/transaction already produced
@@ -304,22 +301,33 @@ public class MergeStep extends AbstractExecutionStep {
       if (variable != null)
         baseResult.setProperty(variable, vertex);
       baseResult.setProperty("  wasCreated", true);
+      bindSingleNodePath(baseResult, pathPattern, vertex);
       return List.of(baseResult);
     } catch (final DuplicatedKeyException e) {
       final List<Vertex> retryMatches = findAllNodes(nodePattern, baseResult);
       if (retryMatches.isEmpty())
         throw e;
-      return buildMatchResults(retryMatches, variable, baseResult);
+      return buildMatchResults(retryMatches, pathPattern, baseResult);
     }
   }
 
-  private List<Result> buildMatchResults(final List<Vertex> matches, final String variable, final ResultInternal baseResult) {
+  /** Binds {@code MERGE p = (a {num: 1})} - a zero-length path over the single node the pattern merged. */
+  private void bindSingleNodePath(final ResultInternal result, final PathPattern pathPattern, final Vertex vertex) {
+    final Object[] trace = newPathTrace(pathPattern);
+    tracePathElement(trace, 0, vertex);
+    addPathBinding(result, pathPattern, trace);
+  }
+
+  private List<Result> buildMatchResults(final List<Vertex> matches, final PathPattern pathPattern,
+      final ResultInternal baseResult) {
+    final String variable = pathPattern.getFirstNode().getVariable();
     final List<Result> results = new ArrayList<>(matches.size());
     for (final Vertex v : matches) {
       final ResultInternal r = copyResult(baseResult);
       if (variable != null)
         r.setProperty(variable, v);
       r.setProperty("  wasCreated", false);
+      bindSingleNodePath(r, pathPattern, v);
       results.add(r);
     }
     return results;
@@ -376,7 +384,7 @@ public class MergeStep extends AbstractExecutionStep {
     if (anchorIdx < 0) {
       // No bound anchor: the existing forward walker scans the relevant edge
       // type. The optimizer's MATCH-path is responsible for index-based seeds.
-      traverseFromNode(pathPattern, 0, null, copyResult(baseResult), results);
+      traverseFromNode(pathPattern, 0, null, copyResult(baseResult), newPathTrace(pathPattern), results);
       return results;
     }
 
@@ -388,7 +396,7 @@ public class MergeStep extends AbstractExecutionStep {
     if (anchorIdx == 0) {
       // Anchor is at the start: the forward walker already picks up the
       // binding from currentResult and walks the anchor's outgoing edges.
-      traverseFromNode(pathPattern, 0, null, copyResult(baseResult), results);
+      traverseFromNode(pathPattern, 0, null, copyResult(baseResult), newPathTrace(pathPattern), results);
       return results;
     }
 
@@ -484,7 +492,12 @@ public class MergeStep extends AbstractExecutionStep {
       if (relPattern.getVariable() != null)
         r.setProperty(relPattern.getVariable(), matchingEdge);
       r.setProperty("  wasCreated", false);
-      addPathBinding(r, pathPattern);
+
+      final Object[] trace = newPathTrace(pathPattern);
+      tracePathElement(trace, 2 * anchorIdx, anchorVertex);
+      tracePathElement(trace, 2 * unboundIdx, candidate);
+      tracePathElement(trace, 1, matchingEdge);
+      addPathBinding(r, pathPattern, trace);
       results.add(r);
     }
 
@@ -592,17 +605,26 @@ public class MergeStep extends AbstractExecutionStep {
     if (anchorPattern.getVariable() != null)
       anchored.setProperty(anchorPattern.getVariable(), anchorVertex);
 
+    final Object[] anchoredTrace = newPathTrace(pathPattern);
+    tracePathElement(anchoredTrace, 2 * anchorIdx, anchorVertex);
+
     final int lastIdx = pathPattern.getRelationshipCount();
 
     if (anchorIdx == lastIdx) {
-      walkLeft(pathPattern, anchorIdx, anchorVertex, anchored, results);
+      walkLeft(pathPattern, anchorIdx, anchorVertex, anchored, anchoredTrace, results);
       return;
     }
 
-    final List<Result> rightResults = new ArrayList<>();
-    walkRight(pathPattern, anchorIdx, anchorVertex, anchored, rightResults);
-    for (final Result rr : rightResults)
-      walkLeft(pathPattern, anchorIdx, anchorVertex, (ResultInternal) rr, results);
+    // Every right-side completion carries its own bindings, so it carries its own trace too: the left walk
+    // that continues it has to extend that one rather than the anchor's.
+    final List<TracedResult> rightResults = new ArrayList<>();
+    walkRight(pathPattern, anchorIdx, anchorVertex, anchored, anchoredTrace, rightResults);
+    for (final TracedResult rr : rightResults)
+      walkLeft(pathPattern, anchorIdx, anchorVertex, rr.result(), rr.trace(), results);
+  }
+
+  /** A partially-walked path: the row's bindings paired with the path slots {@link #newPathTrace} allocated. */
+  private record TracedResult(ResultInternal result, Object[] trace) {
   }
 
   /**
@@ -611,9 +633,9 @@ public class MergeStep extends AbstractExecutionStep {
    * in {@code rightResults} when {@code nodeIdx} reaches the last node.
    */
   private void walkRight(final PathPattern pathPattern, final int nodeIdx, final Vertex currentVertex,
-      final ResultInternal current, final List<Result> rightResults) {
+      final ResultInternal current, final Object[] trace, final List<TracedResult> rightResults) {
     if (nodeIdx == pathPattern.getRelationshipCount()) {
-      rightResults.add(current);
+      rightResults.add(new TracedResult(current, trace));
       return;
     }
 
@@ -629,16 +651,16 @@ public class MergeStep extends AbstractExecutionStep {
 
     if (dir == Direction.OUT || dir == Direction.BOTH)
       walkRightDir(pathPattern, nodeIdx, currentVertex, relPattern, relType, relProps, nextPattern,
-          Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN, current, rightResults);
+          Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN, current, trace, rightResults);
     if (dir == Direction.IN || dir == Direction.BOTH)
       walkRightDir(pathPattern, nodeIdx, currentVertex, relPattern, relType, relProps, nextPattern,
-          Vertex.DIRECTION.IN, Vertex.DIRECTION.OUT, current, rightResults);
+          Vertex.DIRECTION.IN, Vertex.DIRECTION.OUT, current, trace, rightResults);
   }
 
   private void walkRightDir(final PathPattern pathPattern, final int nodeIdx, final Vertex currentVertex,
       final RelationshipPattern relPattern, final String relType, final Map<String, Object> relProps,
       final NodePattern nextPattern, final Vertex.DIRECTION edgeDir, final Vertex.DIRECTION otherEnd,
-      final ResultInternal current, final List<Result> rightResults) {
+      final ResultInternal current, final Object[] trace, final List<TracedResult> rightResults) {
     for (final Edge edge : currentVertex.getEdges(edgeDir, relType)) {
       if (relProps != null && !matchesProperties(edge, relProps))
         continue;
@@ -655,7 +677,10 @@ public class MergeStep extends AbstractExecutionStep {
         next.setProperty(nextPattern.getVariable(), nextV);
       if (relPattern.getVariable() != null)
         next.setProperty(relPattern.getVariable(), edge);
-      walkRight(pathPattern, nodeIdx + 1, nextV, next, rightResults);
+      final Object[] nextTrace = branchPathTrace(trace);
+      tracePathElement(nextTrace, 2 * nodeIdx + 1, edge);
+      tracePathElement(nextTrace, 2 * nodeIdx + 2, nextV);
+      walkRight(pathPattern, nodeIdx + 1, nextV, next, nextTrace, rightResults);
     }
   }
 
@@ -665,11 +690,11 @@ public class MergeStep extends AbstractExecutionStep {
    * into {@code results} when index 0 is reached.
    */
   private void walkLeft(final PathPattern pathPattern, final int nodeIdx, final Vertex currentVertex,
-      final ResultInternal current, final List<Result> results) {
+      final ResultInternal current, final Object[] trace, final List<Result> results) {
     if (nodeIdx == 0) {
       final ResultInternal r = copyResult(current);
       r.setProperty("  wasCreated", false);
-      addPathBinding(r, pathPattern);
+      addPathBinding(r, pathPattern, trace);
       results.add(r);
       return;
     }
@@ -691,16 +716,16 @@ public class MergeStep extends AbstractExecutionStep {
     // dir == BOTH → walk both
     if (dir == Direction.OUT || dir == Direction.BOTH)
       walkLeftDir(pathPattern, nodeIdx, currentVertex, relPattern, relType, relProps, prevPattern,
-          Vertex.DIRECTION.IN, Vertex.DIRECTION.OUT, current, results);
+          Vertex.DIRECTION.IN, Vertex.DIRECTION.OUT, current, trace, results);
     if (dir == Direction.IN || dir == Direction.BOTH)
       walkLeftDir(pathPattern, nodeIdx, currentVertex, relPattern, relType, relProps, prevPattern,
-          Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN, current, results);
+          Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN, current, trace, results);
   }
 
   private void walkLeftDir(final PathPattern pathPattern, final int nodeIdx, final Vertex currentVertex,
       final RelationshipPattern relPattern, final String relType, final Map<String, Object> relProps,
       final NodePattern prevPattern, final Vertex.DIRECTION edgeDir, final Vertex.DIRECTION otherEnd,
-      final ResultInternal current, final List<Result> results) {
+      final ResultInternal current, final Object[] trace, final List<Result> results) {
     for (final Edge edge : currentVertex.getEdges(edgeDir, relType)) {
       if (relProps != null && !matchesProperties(edge, relProps))
         continue;
@@ -717,7 +742,10 @@ public class MergeStep extends AbstractExecutionStep {
         next.setProperty(prevPattern.getVariable(), prevV);
       if (relPattern.getVariable() != null)
         next.setProperty(relPattern.getVariable(), edge);
-      walkLeft(pathPattern, nodeIdx - 1, prevV, next, results);
+      final Object[] nextTrace = branchPathTrace(trace);
+      tracePathElement(nextTrace, 2 * nodeIdx - 1, edge);
+      tracePathElement(nextTrace, 2 * nodeIdx - 2, prevV);
+      walkLeft(pathPattern, nodeIdx - 1, prevV, next, nextTrace, results);
     }
   }
 
@@ -729,7 +757,7 @@ public class MergeStep extends AbstractExecutionStep {
    * {@code currentResult} or left as "unbound" for a full-scan.
    */
   private void traverseFromNode(final PathPattern pathPattern, final int nodeIndex,
-      final Vertex forcedVertex, final ResultInternal currentResult, final List<Result> results) {
+      final Vertex forcedVertex, final ResultInternal currentResult, final Object[] trace, final List<Result> results) {
 
     final NodePattern nodePattern = pathPattern.getNode(nodeIndex);
 
@@ -768,7 +796,9 @@ public class MergeStep extends AbstractExecutionStep {
       if (nodePattern.getVariable() != null)
         r.setProperty(nodePattern.getVariable(), vertex);
       r.setProperty("  wasCreated", false);
-      addPathBinding(r, pathPattern);
+      final Object[] terminalTrace = branchPathTrace(trace);
+      tracePathElement(terminalTrace, 2 * nodeIndex, vertex);
+      addPathBinding(r, pathPattern, terminalTrace);
       results.add(r);
       return;
     }
@@ -784,7 +814,10 @@ public class MergeStep extends AbstractExecutionStep {
       if (nodePattern.getVariable() != null)
         stepResult.setProperty(nodePattern.getVariable(), vertex);
 
-      traverseEdgesFromVertex(pathPattern, nodeIndex, vertex, relPattern, stepResult, results);
+      final Object[] stepTrace = branchPathTrace(trace);
+      tracePathElement(stepTrace, 2 * nodeIndex, vertex);
+
+      traverseEdgesFromVertex(pathPattern, nodeIndex, vertex, relPattern, stepResult, stepTrace, results);
     } else {
       // Anchor is unbound — scan all edges of the required type; both endpoints
       // of each edge must satisfy their respective node patterns
@@ -819,7 +852,10 @@ public class MergeStep extends AbstractExecutionStep {
                 stepResult.setProperty(nodePattern.getVariable(), sourceV);
               if (relPattern.getVariable() != null)
                 stepResult.setProperty(relPattern.getVariable(), edge);
-              traverseFromNode(pathPattern, nodeIndex + 1, targetV, stepResult, results);
+              final Object[] stepTrace = branchPathTrace(trace);
+              tracePathElement(stepTrace, 2 * nodeIndex, sourceV);
+              tracePathElement(stepTrace, 2 * nodeIndex + 1, edge);
+              traverseFromNode(pathPattern, nodeIndex + 1, targetV, stepResult, stepTrace, results);
             }
           }
           if (dir == Direction.IN || dir == Direction.BOTH) {
@@ -831,7 +867,10 @@ public class MergeStep extends AbstractExecutionStep {
                 stepResult.setProperty(nodePattern.getVariable(), sourceV);
               if (relPattern.getVariable() != null)
                 stepResult.setProperty(relPattern.getVariable(), edge);
-              traverseFromNode(pathPattern, nodeIndex + 1, targetV, stepResult, results);
+              final Object[] stepTrace = branchPathTrace(trace);
+              tracePathElement(stepTrace, 2 * nodeIndex, sourceV);
+              tracePathElement(stepTrace, 2 * nodeIndex + 1, edge);
+              traverseFromNode(pathPattern, nodeIndex + 1, targetV, stepResult, stepTrace, results);
             }
           }
         } catch (final RecordNotFoundException e) {
@@ -848,7 +887,7 @@ public class MergeStep extends AbstractExecutionStep {
    */
   private void traverseEdgesFromVertex(final PathPattern pathPattern, final int nodeIndex,
       final Vertex vertex, final RelationshipPattern relPattern,
-      final ResultInternal currentResult, final List<Result> results) {
+      final ResultInternal currentResult, final Object[] trace, final List<Result> results) {
 
     if (!relPattern.hasTypes())
       return;
@@ -871,7 +910,10 @@ public class MergeStep extends AbstractExecutionStep {
         if (relPattern.getVariable() != null)
           stepResult.setProperty(relPattern.getVariable(), edge);
 
-        traverseFromNode(pathPattern, nodeIndex + 1, nextV, stepResult, results);
+        final Object[] stepTrace = branchPathTrace(trace);
+        tracePathElement(stepTrace, 2 * nodeIndex + 1, edge);
+
+        traverseFromNode(pathPattern, nodeIndex + 1, nextV, stepResult, stepTrace, results);
       } catch (final RecordNotFoundException e) {
         // Ghost edge: segment pointer exists but record was concurrently deleted.
         // Skip and continue - the edge does not satisfy the MERGE pattern.
@@ -891,7 +933,10 @@ public class MergeStep extends AbstractExecutionStep {
           if (relPattern.getVariable() != null)
             stepResult.setProperty(relPattern.getVariable(), edge);
 
-          traverseFromNode(pathPattern, nodeIndex + 1, nextV, stepResult, results);
+          final Object[] stepTrace = branchPathTrace(trace);
+          tracePathElement(stepTrace, 2 * nodeIndex + 1, edge);
+
+          traverseFromNode(pathPattern, nodeIndex + 1, nextV, stepResult, stepTrace, results);
         } catch (final RecordNotFoundException e) {
           // Ghost edge - same case: segment pointer to a concurrently-deleted edge record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
@@ -927,6 +972,10 @@ public class MergeStep extends AbstractExecutionStep {
       vertices.add(vertex);
     }
 
+    final Object[] trace = newPathTrace(pathPattern);
+    for (int i = 0; i <= pathPattern.getRelationshipCount(); i++)
+      tracePathElement(trace, 2 * i, vertices.get(i));
+
     for (int i = 0; i < pathPattern.getRelationshipCount(); i++) {
       final RelationshipPattern relPattern = pathPattern.getRelationship(i);
       final Vertex fromVertex = relPattern.getDirection() == Direction.IN
@@ -935,11 +984,12 @@ public class MergeStep extends AbstractExecutionStep {
           ? vertices.get(i) : vertices.get(i + 1);
 
       final Edge edge = createEdge(fromVertex, toVertex, relPattern, baseResult);
+      tracePathElement(trace, 2 * i + 1, edge);
       if (relPattern.getVariable() != null)
         baseResult.setProperty(relPattern.getVariable(), edge);
     }
 
-    addPathBinding(baseResult, pathPattern);
+    addPathBinding(baseResult, pathPattern, trace);
     baseResult.setProperty("  wasCreated", true);
     return List.of(baseResult);
   }
@@ -962,28 +1012,57 @@ public class MergeStep extends AbstractExecutionStep {
     return true;
   }
 
-  private void addPathBinding(final ResultInternal result, final PathPattern pathPattern) {
+  /**
+   * Allocates the slot array a path walk fills in as it binds each element of {@code pathPattern}.
+   * <p>
+   * Slot {@code 2*i} holds the vertex bound to node {@code i}, slot {@code 2*i+1} the edge bound to
+   * relationship {@code i} - a position in the pattern, not a variable name, which is the whole point: a path
+   * is made of every node and relationship the pattern names <i>or does not</i>, so it cannot be reconstructed
+   * from the row's variable bindings alone (issue #7169).
+   */
+  private static Object[] newPathTrace(final PathPattern pathPattern) {
+    // No path variable, nothing to reconstruct: the walk carries a null trace and every step below is a no-op,
+    // so an ordinary MERGE - the overwhelmingly common one, and a bulk-load hot path - allocates nothing extra.
+    return pathPattern.hasPathVariable() ? new Object[2 * pathPattern.getRelationshipCount() + 1] : null;
+  }
+
+  /** Branches the trace so a sibling walk of the same prefix cannot see this branch's later steps. */
+  private static Object[] branchPathTrace(final Object[] trace) {
+    return trace == null ? null : trace.clone();
+  }
+
+  private static void tracePathElement(final Object[] trace, final int slot, final Object element) {
+    if (trace != null)
+      trace[slot] = element;
+  }
+
+  /**
+   * Binds the named path variable to the path the walk actually traversed.
+   * <p>
+   * The value is a {@link TraversalPath}, the same type MATCH and CREATE bind, so {@code length()},
+   * {@code nodes()} and {@code relationships()} answer for a merged path exactly as they do for a matched or
+   * created one. This used to be a flat list of just the elements the pattern happened to name, which made an
+   * anonymous hop vanish from the path: {@code MERGE p = (a)<-[r]-(b)<-[:T]-(c)} reported {@code length(p) = 1}
+   * over three nodes, and {@code MERGE p = (:A)-[:T]->(:B)} - nothing named at all - bound an empty path.
+   *
+   * @param trace the slot array {@link #newPathTrace(PathPattern)} allocated, filled by the walk
+   */
+  private void addPathBinding(final ResultInternal result, final PathPattern pathPattern, final Object[] trace) {
     if (!pathPattern.hasPathVariable())
       return;
-    final String pathVar = pathPattern.getPathVariable();
-    final List<Object> pathElements = new ArrayList<>();
-    for (int i = 0; i <= pathPattern.getRelationshipCount(); i++) {
-      final NodePattern np = pathPattern.getNode(i);
-      if (np.getVariable() != null) {
-        final Object v = result.getProperty(np.getVariable());
-        if (v != null)
-          pathElements.add(v);
-      }
-      if (i < pathPattern.getRelationshipCount()) {
-        final RelationshipPattern rp = pathPattern.getRelationship(i);
-        if (rp.getVariable() != null) {
-          final Object e = result.getProperty(rp.getVariable());
-          if (e != null)
-            pathElements.add(e);
-        }
-      }
+
+    final int relationshipCount = pathPattern.getRelationshipCount();
+    if (trace == null || !(trace[0] instanceof Vertex startVertex))
+      return; // the walk did not bind a start node: nothing to describe
+
+    final TraversalPath path = new TraversalPath(startVertex);
+    for (int i = 0; i < relationshipCount; i++) {
+      if (!(trace[2 * i + 1] instanceof Edge edge) || !(trace[2 * i + 2] instanceof Vertex vertex))
+        break;
+      path.addStep(edge, vertex);
     }
-    result.setProperty(pathVar, pathElements);
+
+    result.setProperty(pathPattern.getPathVariable(), path);
   }
 
   private ResultInternal copyResult(final Result source) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergePathBindingIssue7169Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergePathBindingIssue7169Test.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for GitHub issue #7169: inserting a no-op {@code OPTIONAL MATCH (:NoSuchLabel) WHERE false}
+ * barrier plus a scope-preserving {@code WITH} into a query changed its answer.
+ * <p>
+ * The reported divergence - an {@code OPTIONAL MATCH} written straight after a {@code MERGE} bound {@code null}
+ * where the barriered form bound the relationship the MERGE had just created - is the clause-scoped relationship
+ * uniqueness bug of issue #7165, and the first test here pins the reporter's own pair against it. Cypher scopes
+ * relationship uniqueness to a single clause, so the {@code OPTIONAL MATCH} may bind the very edge the
+ * {@code MERGE} bound: the barriered form was the correct one.
+ * <p>
+ * Reproducing that pair exposed a second, independent defect in the same query, which the rest of this class
+ * covers: {@code MERGE p = ...} did not bind {@code p} to the path it merged. It bound a flat list of only the
+ * elements the pattern happened to <i>name</i>, so an anonymous hop simply disappeared - the reporter's
+ * three-node, two-relationship pattern reported {@code length(p0) = 1}, and a pattern that names nothing at all
+ * bound an empty path. MATCH and CREATE have always bound a real path over every element of the pattern,
+ * named or not, and MERGE now does the same.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherMergePathBindingIssue7169Test extends TestHelper {
+
+  private static final String BARRIER = "OPTIONAL MATCH (__optional_probe:NoSuchLabel) WHERE false";
+
+  /**
+   * The reporter's pair, reduced to the two clauses that carried the divergence. Both forms must report the
+   * relationship the MERGE bound: the {@code OPTIONAL MATCH} is a clause of its own, so {@code r0} is not one of
+   * <i>its</i> relationships and the uniqueness rule has nothing to reject.
+   */
+  @Test
+  void anOptionalMatchAfterMergeBindsTheMergedRelationshipWithOrWithoutABarrier() {
+    final String withoutBarrier = """
+        MERGE p0 = (n0:l5:l3 {id: 128})<-[r0:rt3 {klist: ["9v6OzPkCL"]}]-(:l3:l8:l5 {id: 129})<-[:rt9 {id: 398}]-(:l3:l8 {id: 130})
+        OPTIONAL MATCH (:l3&l5&l8)-[r1:rt3|rt5 {klist: ["9v6OzPkCL"]}]->(n0)
+        RETURN r1.klist[0] AS bound, length(p0) AS len""";
+    final String withBarrier = """
+        MERGE p0 = (n0:l5:l3 {id: 128})<-[r0:rt3 {klist: ["9v6OzPkCL"]}]-(:l3:l8:l5 {id: 129})<-[:rt9 {id: 398}]-(:l3:l8 {id: 130})
+        """ + BARRIER + """
+
+        WITH n0, r0, p0
+        """ + BARRIER + """
+
+        WITH n0, r0, p0
+        OPTIONAL MATCH (:l3&l5&l8)-[r1:rt3|rt5 {klist: ["9v6OzPkCL"]}]->(n0)
+        RETURN r1.klist[0] AS bound, length(p0) AS len""";
+
+    final List<Result> plain = command(withoutBarrier);
+    wipe();
+    final List<Result> barriered = command(withBarrier);
+
+    assertThat(plain).hasSize(1);
+    assertThat(barriered).hasSize(1);
+    assertThat((Object) plain.get(0).getProperty("bound"))
+        .as("the OPTIONAL MATCH is a clause of its own, so the edge the MERGE bound is one it may bind")
+        .isEqualTo("9v6OzPkCL");
+    assertThat((Object) barriered.get(0).getProperty("bound")).isEqualTo(plain.get(0).getProperty("bound"));
+    assertThat(((Number) plain.get(0).getProperty("len")).intValue())
+        .as("the merged pattern is two relationships long, the second one being anonymous")
+        .isEqualTo(2);
+    assertThat((Object) barriered.get(0).getProperty("len")).isEqualTo(plain.get(0).getProperty("len"));
+  }
+
+  /**
+   * The reporter's path variable. Two relationships were written, so the path is two long - the second hop being
+   * anonymous does not remove it from the path any more than an anonymous node removes a node.
+   */
+  @Test
+  void aMergedPathSpansEveryHopEvenWhenTheHopIsAnonymous() {
+    final String query = """
+        MERGE p = (a:A {id: 1})<-[r:R1 {t: 'x'}]-(b:B {id: 2})<-[:R2 {t: 'y'}]-(c:C {id: 3})
+        RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""";
+
+    assertPathShape(query, 2, 3, 2);
+    // ...and identically on the second run, which takes the match branch rather than the create branch.
+    assertPathShape(query, 2, 3, 2);
+  }
+
+  /** Nothing in the pattern is named, so the old implementation had nothing to list and bound an empty path. */
+  @Test
+  void aMergedPathIsBoundEvenWhenThePatternNamesNothing() {
+    final String query = """
+        MERGE p = (:A {id: 21})-[:R1 {t: 'z'}]->(:B {id: 22})
+        RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""";
+
+    assertPathShape(query, 1, 2, 1);
+    assertPathShape(query, 1, 2, 1);
+  }
+
+  /**
+   * MERGE reaches an existing path through three different walkers - a full scan when no endpoint is bound, an
+   * index seek over the unbound endpoint of a single-relationship pattern, and an outward walk from a bound
+   * anchor - and each one has to describe the path it found the same way.
+   */
+  @Test
+  void everyMatchBranchDescribesTheFoundPathTheSameWay() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE A IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY A.id IF NOT EXISTS INTEGER");
+      database.command("sql", "CREATE INDEX IF NOT EXISTS ON A (id) UNIQUE");
+    });
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (:A {id: 31})-[:R1 {t: 'q'}]->(:B {id: 32})-[:R2 {t: 'w'}]->(:C {id: 33})"));
+
+    // full scan: no endpoint is bound and the pattern spans two relationships
+    assertPathShape("""
+        MERGE p = (:A {id: 31})-[:R1 {t: 'q'}]->(:B {id: 32})-[:R2 {t: 'w'}]->(:C {id: 33})
+        RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""", 2, 3, 2);
+
+    // index seek: a single relationship whose unbound endpoint carries an indexed property
+    assertPathShape("""
+        MATCH (b:B {id: 32})
+        MERGE p = (:A {id: 31})-[:R1 {t: 'q'}]->(b)
+        RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""", 1, 2, 1);
+
+    // anchor walk: the bound anchor sits in the middle, so the walk runs right then left
+    assertPathShape("""
+        MATCH (b:B {id: 32})
+        MERGE p = (:A {id: 31})-[:R1 {t: 'q'}]->(b)-[:R2 {t: 'w'}]->(:C {id: 33})
+        RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""", 2, 3, 2);
+  }
+
+  /** A single-node MERGE binds a zero-length path over that node, on both the create and the match branch. */
+  @Test
+  void aSingleNodeMergeBindsAZeroLengthPath() {
+    final String named = """
+        MERGE p = (a:A {id: 41})
+        RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""";
+    assertPathShape(named, 0, 1, 0);
+    assertPathShape(named, 0, 1, 0);
+
+    final String anonymous = """
+        MERGE p = (:A {id: 42})
+        RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""";
+    assertPathShape(anonymous, 0, 1, 0);
+    assertPathShape(anonymous, 0, 1, 0);
+  }
+
+  /**
+   * The real assertion behind all of the above: a path is a path whichever clause bound it. MERGE's create
+   * branch, MERGE's match branch, CREATE and MATCH must all describe the same three-node pattern identically -
+   * which is what stops MERGE from drifting into a shape of its own again.
+   */
+  @Test
+  void mergeMatchAndCreateDescribeTheSamePathIdentically() {
+    final String projection =
+        "RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount, p AS p";
+
+    final Result created = single("CREATE p = (:A {id: 51})<-[:R1 {t: 'c'}]-(:B {id: 52})<-[:R2 {t: 'd'}]-(:C {id: 53}) " + projection);
+    final Result merged = single("MERGE p = (:A {id: 51})<-[:R1 {t: 'c'}]-(:B {id: 52})<-[:R2 {t: 'd'}]-(:C {id: 53}) " + projection);
+    final Result matched = single("MATCH p = (:A {id: 51})<-[:R1 {t: 'c'}]-(:B {id: 52})<-[:R2 {t: 'd'}]-(:C {id: 53}) " + projection);
+
+    for (final String column : new String[] { "len", "nodeCount", "relCount" }) {
+      assertThat((Object) merged.getProperty(column)).as(column).isEqualTo(created.getProperty(column));
+      assertThat((Object) matched.getProperty(column)).as(column).isEqualTo(created.getProperty(column));
+    }
+    assertThat(merged.<Object>getProperty("p"))
+        .as("MERGE must bind the same kind of path value MATCH and CREATE bind, not a bare list")
+        .hasSameClassAs(matched.<Object>getProperty("p"));
+  }
+
+  private void assertPathShape(final String query, final int length, final int nodeCount, final int relCount) {
+    final Result row = single(query);
+    assertThat(((Number) row.getProperty("len")).intValue()).as("length(p) of: %s", query).isEqualTo(length);
+    assertThat(((Number) row.getProperty("nodeCount")).intValue()).as("nodes(p) of: %s", query).isEqualTo(nodeCount);
+    assertThat(((Number) row.getProperty("relCount")).intValue()).as("relationships(p) of: %s", query).isEqualTo(relCount);
+  }
+
+  private Result single(final String query) {
+    final List<Result> rows = command(query);
+    assertThat(rows).as("one row from: %s", query).hasSize(1);
+    return rows.get(0);
+  }
+
+  private List<Result> command(final String query) {
+    final List<Result> rows = new ArrayList<>();
+    database.transaction(() -> {
+      try (final ResultSet resultSet = database.command("opencypher", query)) {
+        while (resultSet.hasNext())
+          rows.add(resultSet.next());
+      }
+    });
+    return rows;
+  }
+
+  /** Empties the graph so the two halves of a left/right comparison start from the same state. */
+  private void wipe() {
+    database.transaction(() -> {
+      for (final String type : new String[] { "rt3", "rt9", "l3", "l5", "l8" })
+        if (database.getSchema().existsType(type))
+          database.command("sql", "DELETE FROM " + type);
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergePathBindingIssue7169Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergePathBindingIssue7169Test.java
@@ -148,6 +148,13 @@ class CypherMergePathBindingIssue7169Test extends TestHelper {
         MATCH (b:B {id: 32})
         MERGE p = (:A {id: 31})-[:R1 {t: 'q'}]->(b)-[:R2 {t: 'w'}]->(:C {id: 33})
         RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""", 2, 3, 2);
+
+    // anchor walk, left half only: the bound anchor is the pattern's last node, so there is no right side to
+    // walk and the whole path is discovered backwards. Two relationships keep it off the index-seek fast path.
+    assertPathShape("""
+        MATCH (c:C {id: 33})
+        MERGE p = (:A {id: 31})-[:R1 {t: 'q'}]->(:B {id: 32})-[:R2 {t: 'w'}]->(c)
+        RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""", 2, 3, 2);
   }
 
   /** A single-node MERGE binds a zero-length path over that node, on both the create and the match branch. */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergePathBindingIssue7169Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergePathBindingIssue7169Test.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression tests for GitHub issue #7169: inserting a no-op {@code OPTIONAL MATCH (:NoSuchLabel) WHERE false}
@@ -162,6 +164,20 @@ class CypherMergePathBindingIssue7169Test extends TestHelper {
         RETURN length(p) AS len, size(nodes(p)) AS nodeCount, size(relationships(p)) AS relCount""";
     assertPathShape(anonymous, 0, 1, 0);
     assertPathShape(anonymous, 0, 1, 0);
+  }
+
+  /**
+   * The semantic validator refuses a single-node MERGE over a variable an earlier clause bound, so no query can
+   * reach the short-circuit branch that check guards. Pinned here so that stays true: were the validator ever to
+   * let the shape through, the branch behind it has to bind the path rather than silently leave it unset.
+   */
+  @Test
+  void aSingleNodeMergeCannotRebindAnAlreadyBoundVariable() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:A {id: 43})"));
+
+    assertThatThrownBy(() -> command("MATCH (a:A {id: 43}) MERGE p = (a) RETURN length(p) AS len"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("already defined");
   }
 
   /**


### PR DESCRIPTION
Closes #7169.

## What the issue reported

Inserting a no-op `OPTIONAL MATCH (__optional_probe:NoSuchLabel) WHERE false` barrier plus a scope-preserving `WITH` changed the answer: the plain form bound `r1 = NULL`, the barriered form bound `r1` to the relationship the `MERGE` had just created.

That half is the clause-scoped relationship uniqueness bug of #7165, already fixed on `main` (PR #7168). Cypher scopes relationship uniqueness to a single clause, so the `OPTIONAL MATCH` may bind the very edge the `MERGE` bound - the barriered form was the correct one. Verified: the reporter's pair diverges at `6de7080ebb` (pre-#7165-fix) and agrees on `main`. It is pinned here as a regression test rather than left to rot.

## The bug this PR fixes

Reproducing that query surfaced a second, independent defect in it: `MERGE p0 = ...` did not bind `p0` to the path it merged.

`addPathBinding` built a flat `ArrayList` by reading back the row's variable bindings, and skipped any pattern element without a variable name. So:

| query | `length(p)` | `nodes(p)` | `relationships(p)` |
|---|---|---|---|
| `MERGE p = (a)<-[r]-(b)<-[:T]-(c)` | **1** | 3 | **1** |
| `MERGE p = (:A)-[:T]->(:B)` | **0** | **0** | **0** |
| `MATCH`/`CREATE` of the same patterns | 2 / 1 | 3 / 2 | 2 / 1 |

The value was also an `ArrayList` where MATCH and CREATE both bind a `TraversalPath`, so a merged path was internally inconsistent as well as wrong: three nodes joined by one relationship.

A path is made of every node and relationship of the pattern, named or not, which is exactly why it cannot be reconstructed from the row's variable bindings after the fact - the walk has to record what it bound as it goes.

## The fix

Each walker carries a slot array indexed by *position in the pattern* (`2*i` = node `i`, `2*i+1` = relationship `i`), branched alongside the row at every fork, and the emit points build a `TraversalPath` from it. All four ways MERGE reaches a path are covered: the full edge-type scan, the index seek over an unbound endpoint, the outward walk from a bound anchor (which needed the trace paired with each right-side completion, since every completion carries its own bindings), and creation.

An incomplete trace is a bug in the walk, not a shape a query can produce, so `addPathBinding` names the unbound position rather than binding a truncated path.

**Allocation:** the slot array is allocated only when the pattern names a path variable; without one the walk carries a null trace and every step is a no-op. One shape does pay a little: the anchor walk now pairs each right-side completion with its own trace via a `TracedResult` record, so a MERGE with a bound anchor in the middle of a multi-hop pattern allocates one small wrapper per right-side completion regardless of the path variable. Removing it would mean either two parallel lists or interleaving `walkLeft` into `walkRight`'s recursion - the latter nests two edge iterations over the same anchor vertex, which is not a trade worth making for one record per row.

## Alternative considered

Giving every anonymous node and relationship a synthetic internal variable at plan time would have needed no walker changes, but it leaks names into `RETURN *` and into scope resolution, and it turns a display concern into a scoping concern. Recording positions keeps the fix inside the step that owns the walk.

## Verification

- New `CypherMergePathBindingIssue7169Test`: 7 tests, 5 of which fail on the unfixed `MergeStep`. Covers the anonymous hop, the all-anonymous pattern, each of the three match branches, the single-node zero-length path, both the create and the re-match branch, MERGE/MATCH/CREATE parity on an identical pattern, and the #7165 pin.
- A differential sweep over 13 query shapes (MATCH, OPTIONAL MATCH, aggregation, UNWIND, CALL subquery, MERGE, CREATE, DISTINCT, variable-length, FOREACH) confirms no remaining barrier-insertion divergence.
- `engine` unit lane: 14496 tests, 0 failures.
- openCypher TCK suite: 3897 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cypher `MERGE` path binding for named, anonymous, and unnamed path elements.
  - Correctly binds zero-length paths in single-node merges.
  - Ensured consistent path results across scans, index-based matching, anchored matches, `CREATE`, and `MATCH`.
  - Improved relationship bindings in `OPTIONAL MATCH`.
  - Added validation for incomplete path bindings and invalid single-node variable rebinding.

- **Tests**
  - Added regression coverage for `MERGE` path shapes, matching strategies, and optional-match behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->