### PR TITLE
fix(#7171): plant an eager read/write barrier so a Cypher query never reads back what it just created

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/SimpleCypherStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/SimpleCypherStatement.java
@@ -281,18 +281,24 @@ public class SimpleCypherStatement implements CypherStatement {
   private static boolean anyWriteProcedureCall(final List<CallClause> calls) {
     if (calls.isEmpty())
       return false;
-    for (final CallClause call : calls) {
-      final CypherProcedure procedure = CypherProcedureRegistry.get(call.getProcedureName());
-      if (procedure != null) {
-        // A per-call refinement may only narrow, so a procedure that never writes needs no second look.
-        if (procedure.isWriteProcedure() && procedure.isWriteProcedure(literalArguments(call)))
-          return true;
-        continue;
-      }
-      if (!isConfirmedPureFunctionName(call.getProcedureName()))
+    for (final CallClause call : calls)
+      if (isWriteProcedureCall(call))
         return true;
-    }
     return false;
+  }
+
+  /**
+   * Whether one {@code CALL} can modify the database, resolved the same way {@link #anyWriteProcedureCall} needs it
+   * and the query planner does: the planner plants an eager read/write barrier ahead of a write procedure whose
+   * writes an upstream pattern could otherwise re-read (issue #7171), and it must classify a call exactly as the
+   * read-only flag above does or the two disagree about the same statement.
+   */
+  public static boolean isWriteProcedureCall(final CallClause call) {
+    final CypherProcedure procedure = CypherProcedureRegistry.get(call.getProcedureName());
+    if (procedure != null)
+      // A per-call refinement may only narrow, so a procedure that never writes needs no second look.
+      return procedure.isWriteProcedure() && procedure.isWriteProcedure(literalArguments(call));
+    return !isConfirmedPureFunctionName(call.getProcedureName());
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -80,6 +80,7 @@ import com.arcadedb.query.opencypher.ast.RelationshipPattern;
 import com.arcadedb.query.opencypher.ast.RemoveClause;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
 import com.arcadedb.query.opencypher.ast.SetClause;
+import com.arcadedb.query.opencypher.ast.SimpleCypherStatement;
 import com.arcadedb.query.opencypher.ast.ShortestPathExpression;
 import com.arcadedb.query.opencypher.ast.ShortestPathPattern;
 import com.arcadedb.query.opencypher.ast.StarExpression;
@@ -105,6 +106,7 @@ import com.arcadedb.query.opencypher.executor.steps.CountOp;
 import com.arcadedb.query.opencypher.executor.steps.CreateStep;
 import com.arcadedb.query.opencypher.executor.steps.DegreeProductOp;
 import com.arcadedb.query.opencypher.executor.steps.DeleteStep;
+import com.arcadedb.query.opencypher.executor.steps.EagerStep;
 import com.arcadedb.query.opencypher.executor.steps.ExpandPathStep;
 import com.arcadedb.query.opencypher.executor.steps.FilterPropertiesStep;
 import com.arcadedb.query.opencypher.executor.steps.FinalProjectionStep;
@@ -135,6 +137,7 @@ import com.arcadedb.query.opencypher.executor.steps.UnwindStep;
 import com.arcadedb.query.opencypher.executor.steps.VariableProjectionStep;
 import com.arcadedb.query.opencypher.executor.steps.WithStep;
 import com.arcadedb.query.opencypher.executor.steps.ZeroLengthPathStep;
+import com.arcadedb.query.opencypher.planner.CypherEagernessAnalyzer;
 import com.arcadedb.query.opencypher.optimizer.plan.PhysicalPlan;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
@@ -1125,6 +1128,10 @@ public class CypherExecutionPlan {
     // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
     // whichever DELETE segment is reached next - see matchClausesNeedEagerDelete().
     final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
+    // See buildExecutionStepsWithOrder(): the same read/write barrier analysis, over the same clause list
+    // (issue #7171). This path never sees a CALL or a FOREACH, so only CREATE and MERGE are weighed here.
+    final CypherEagernessAnalyzer eagerness = new CypherEagernessAnalyzer();
+    final Set<String> optimizerBoundVariables = new HashSet<>();
     if (clausesInOrder != null) {
       for (final ClauseEntry entry : clausesInOrder) {
         switch (entry.getType()) {
@@ -1133,6 +1140,8 @@ public class CypherExecutionPlan {
           // attached to MATCH clauses still need to be applied as filters.
           final MatchClause matchClause = entry.getTypedClause();
           currentSegmentMatchClauses.add(matchClause);
+          eagerness.observeRead(matchClause);
+          collectPatternVariables(matchClause, optimizerBoundVariables);
           if (matchClause.hasWhereClause()) {
             final FilterPropertiesStep filterStep =
                 new FilterPropertiesStep(matchClause.getWhereClause(), context);
@@ -1145,6 +1154,8 @@ public class CypherExecutionPlan {
         case CREATE: {
           final CreateClause createClause = entry.getTypedClause();
           if (!createClause.isEmpty()) {
+            if (eagerness.needsBarrier(createClause, optimizerBoundVariables))
+              currentStep = withEagerBarrier(currentStep, context);
             final CreateStep createStep = new CreateStep(createClause, context, functionFactory);
             createStep.setPrevious(currentStep);
             currentStep = createStep;
@@ -1185,6 +1196,8 @@ public class CypherExecutionPlan {
 
         case MERGE: {
           final MergeClause mergeClause = entry.getTypedClause();
+          if (eagerness.needsBarrier(mergeClause, optimizerBoundVariables))
+            currentStep = withEagerBarrier(currentStep, context);
           final MergeStep mergeStep = new MergeStep(mergeClause, context, functionFactory);
           mergeStep.setPrevious(currentStep);
           currentStep = mergeStep;
@@ -1196,12 +1209,16 @@ public class CypherExecutionPlan {
           final UnwindStep unwindStep = new UnwindStep(unwindClause, context, functionFactory);
           unwindStep.setPrevious(currentStep);
           currentStep = unwindStep;
+          optimizerBoundVariables.add(unwindClause.getVariable());
           break;
         }
 
         case WITH: {
           final WithClause withClause = entry.getTypedClause();
           currentStep = buildWithStepForOptimizer(withClause, currentStep, context, functionFactory);
+          if (withClause.hasAggregations())
+            eagerness.observeAggregationBoundary();
+          applyProjectionToScope(withClause.getItems(), optimizerBoundVariables);
           // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE
           // that comes after it (issue #6631). Unlike buildExecutionStepsWithOrder()'s WITH case, a
           // plain clear() here (no taint tracking for a DELETE that plainly forwards a disconnected
@@ -1398,6 +1415,10 @@ public class CypherExecutionPlan {
     // them unchanged) - see closeMatchSegment() and deleteMayTargetTaintedVariable().
     final Set<String> disconnectedTaintedVariables = new HashSet<>();
 
+    // Shape of everything read so far, weighed against each write clause's own shape to decide where an
+    // eager read/write barrier has to go so the query never reads back what it just created (issue #7171).
+    final CypherEagernessAnalyzer eagerness = new CypherEagernessAnalyzer();
+
     // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
     // never look at the incoming rows. That makes the enumerating form of them wrong the moment the seed row binds
     // one of those pattern variables - a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound to one
@@ -1482,12 +1503,17 @@ public class CypherExecutionPlan {
       case MATCH:
         final MatchClause matchClause = entry.getTypedClause();
         currentSegmentMatchClauses.add(matchClause);
+        eagerness.observeRead(matchClause);
         if (matchClause.isOptional()) {
           // Try chained count optimization first (handles 2 consecutive OPTIONAL MATCH + count)
           final AbstractExecutionStep chainedOptimized = tryOptimizeChainedOptionalMatchCount(
               matchClause, clausesInOrder, entryIndex, currentStep, context, boundVariables);
           if (chainedOptimized != null) {
             currentStep = chainedOptimized;
+            // The optimization swallows the next OPTIONAL MATCH whole, so its patterns are read without ever
+            // reaching this switch: fold them into the read footprint before skipping past them.
+            if (clausesInOrder.get(entryIndex + 1).getType() == ClauseEntry.ClauseType.MATCH)
+              eagerness.observeRead(clausesInOrder.get(entryIndex + 1).getTypedClause());
             entryIndex += 2; // skip both the next OPTIONAL MATCH and the WITH clause
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
@@ -1529,10 +1555,16 @@ public class CypherExecutionPlan {
         // A rename (WITH n AS m) doesn't change how rows flow either - propagate the taint onto the
         // new name too, or a later DELETE of m would find nothing tainted under that name.
         propagateTaintThroughRenames(withClause, disconnectedTaintedVariables);
+        // Only an aggregating WITH provably drains the enumerations feeding it, closing the #7171 hazard for
+        // everything read before it; a plain forwarding WITH leaves them just as open as they were.
+        if (withClause.hasAggregations())
+          eagerness.observeAggregationBoundary();
         break;
 
       case MERGE:
         final MergeClause mergeClause = entry.getTypedClause();
+        if (currentStep != null && eagerness.needsBarrier(mergeClause, boundVariables))
+          currentStep = withEagerBarrier(currentStep, context);
         final MergeStep mergeStep =
             new MergeStep(mergeClause, context, functionFactory);
         if (currentStep != null) {
@@ -1544,6 +1576,8 @@ public class CypherExecutionPlan {
       case CREATE:
         final CreateClause createClause = entry.getTypedClause();
         if (!createClause.isEmpty()) {
+          if (currentStep != null && eagerness.needsBarrier(createClause, boundVariables))
+            currentStep = withEagerBarrier(currentStep, context);
           final CreateStep createStep = new CreateStep(createClause, context, functionFactory);
           if (currentStep != null) {
             createStep.setPrevious(currentStep);
@@ -1589,6 +1623,11 @@ public class CypherExecutionPlan {
 
       case CALL:
         final CallClause callClause = entry.getTypedClause();
+        // A write procedure is opaque to the planner - merge.relationship takes its type as a runtime
+        // argument - so it conflicts with every read still in flight ahead of it (issue #7171).
+        if (currentStep != null && eagerness.needsBarrierForWriteProcedure()
+            && SimpleCypherStatement.isWriteProcedureCall(callClause))
+          currentStep = withEagerBarrier(currentStep, context);
         final CallStep callStep =
             new CallStep(callClause, context, functionFactory);
         if (currentStep != null) {
@@ -1615,6 +1654,8 @@ public class CypherExecutionPlan {
         final boolean foreachEagerExecution =
             database.getConfiguration().getValueAsBoolean(GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ)
                 && graphReadFollows(clausesInOrder, entryIndex);
+        if (currentStep != null && eagerness.needsBarrier(foreachClause, boundVariables))
+          currentStep = withEagerBarrier(currentStep, context);
         final ForeachStep foreachStep =
             new ForeachStep(foreachClause, context, functionFactory, foreachEagerMaterialize, foreachEagerExecution);
         if (currentStep != null) {
@@ -2974,6 +3015,37 @@ public class CypherExecutionPlan {
   }
 
   /**
+   * Inserts the eager read/write barrier of issue #7171 ahead of a write clause: everything the pipeline has
+   * read is drained into memory before the first row reaches the write, so no enumeration is still open while
+   * the write adds entities it could match. Where the barrier is needed is decided by
+   * {@link CypherEagernessAnalyzer}, which keeps it off every shape whose writes cannot feed a read.
+   */
+  private static AbstractExecutionStep withEagerBarrier(final AbstractExecutionStep currentStep,
+      final CommandContext context) {
+    if (currentStep == null)
+      return null;
+    final EagerStep eagerStep = new EagerStep(context);
+    eagerStep.setPrevious(currentStep);
+    return eagerStep;
+  }
+
+  /**
+   * Adds every node and relationship variable a MATCH binds to {@code target}. Used to tell a CREATE/MERGE node
+   * that names an already-matched entity (a reference) from one that creates a new entity, which is what stops
+   * {@code MATCH (a:A), (b:B) MERGE (a)-[:R]->(b)} from being read as creating unlabelled vertices.
+   */
+  private static void collectPatternVariables(final MatchClause matchClause, final Set<String> target) {
+    for (final PathPattern pathPattern : matchClause.getPathPatterns()) {
+      for (final NodePattern node : pathPattern.getNodes())
+        if (node.getVariable() != null)
+          target.add(node.getVariable());
+      for (final RelationshipPattern relationship : pathPattern.getRelationships())
+        if (relationship.getVariable() != null)
+          target.add(relationship.getVariable());
+    }
+  }
+
+  /**
    * Closes the MATCH segment tracked in {@code currentSegmentMatchClauses} at a WITH boundary: if the
    * segment being closed needs the eager guard at all ({@link #matchClausesNeedEagerDelete}), every node
    * AND relationship variable it bound is added to {@code disconnectedTaintedVariables} before the
@@ -3564,8 +3636,19 @@ public class CypherExecutionPlan {
       }
     }
 
+    // The read/write barrier analysis of buildExecutionStepsWithOrder(), over the flat clause lists this
+    // method works from (issue #7171). It only runs for a statement with no tracked clause order, which is
+    // single-segment by construction, so the whole MATCH list is the read footprint for both writes below.
+    // legacyBoundVariables already holds every variable the MATCH clauses above bound, which is what tells a
+    // CREATE/MERGE node that names an existing entity from one that creates a new one.
+    final CypherEagernessAnalyzer eagerness = new CypherEagernessAnalyzer();
+    for (final MatchClause matchClause : statement.getMatchClauses())
+      eagerness.observeRead(matchClause);
+
     // Step 3: MERGE clause - find or create pattern
     if (statement.getMergeClause() != null) {
+      if (currentStep != null && eagerness.needsBarrier(statement.getMergeClause(), legacyBoundVariables))
+        currentStep = withEagerBarrier(currentStep, context);
       final MergeStep mergeStep = new MergeStep(
           statement.getMergeClause(), context, functionFactory);
       // MERGE is typically standalone, but can be chained
@@ -3577,6 +3660,8 @@ public class CypherExecutionPlan {
 
     // Step 4: CREATE clause - create vertices/edges
     if (statement.getCreateClause() != null && !statement.getCreateClause().isEmpty()) {
+      if (currentStep != null && eagerness.needsBarrier(statement.getCreateClause(), legacyBoundVariables))
+        currentStep = withEagerBarrier(currentStep, context);
       final CreateStep createStep = new CreateStep(statement.getCreateClause(), context, functionFactory);
       if (currentStep != null) {
         // Chained CREATE (after MATCH/WHERE)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1155,7 +1155,7 @@ public class CypherExecutionPlan {
           final CreateClause createClause = entry.getTypedClause();
           if (!createClause.isEmpty()) {
             if (eagerness.needsBarrier(createClause, optimizerBoundVariables))
-              currentStep = withEagerBarrier(currentStep, context);
+              currentStep = withEagerBarrier(currentStep, context, eagerness);
             final CreateStep createStep = new CreateStep(createClause, context, functionFactory);
             createStep.setPrevious(currentStep);
             currentStep = createStep;
@@ -1197,7 +1197,7 @@ public class CypherExecutionPlan {
         case MERGE: {
           final MergeClause mergeClause = entry.getTypedClause();
           if (eagerness.needsBarrier(mergeClause, optimizerBoundVariables))
-            currentStep = withEagerBarrier(currentStep, context);
+            currentStep = withEagerBarrier(currentStep, context, eagerness);
           final MergeStep mergeStep = new MergeStep(mergeClause, context, functionFactory);
           mergeStep.setPrevious(currentStep);
           currentStep = mergeStep;
@@ -1564,7 +1564,7 @@ public class CypherExecutionPlan {
       case MERGE:
         final MergeClause mergeClause = entry.getTypedClause();
         if (currentStep != null && eagerness.needsBarrier(mergeClause, boundVariables))
-          currentStep = withEagerBarrier(currentStep, context);
+          currentStep = withEagerBarrier(currentStep, context, eagerness);
         final MergeStep mergeStep =
             new MergeStep(mergeClause, context, functionFactory);
         if (currentStep != null) {
@@ -1577,7 +1577,7 @@ public class CypherExecutionPlan {
         final CreateClause createClause = entry.getTypedClause();
         if (!createClause.isEmpty()) {
           if (currentStep != null && eagerness.needsBarrier(createClause, boundVariables))
-            currentStep = withEagerBarrier(currentStep, context);
+            currentStep = withEagerBarrier(currentStep, context, eagerness);
           final CreateStep createStep = new CreateStep(createClause, context, functionFactory);
           if (currentStep != null) {
             createStep.setPrevious(currentStep);
@@ -1627,7 +1627,7 @@ public class CypherExecutionPlan {
         // argument - so it conflicts with every read still in flight ahead of it (issue #7171).
         if (currentStep != null && eagerness.needsBarrierForWriteProcedure()
             && SimpleCypherStatement.isWriteProcedureCall(callClause))
-          currentStep = withEagerBarrier(currentStep, context);
+          currentStep = withEagerBarrier(currentStep, context, eagerness);
         final CallStep callStep =
             new CallStep(callClause, context, functionFactory);
         if (currentStep != null) {
@@ -1655,7 +1655,7 @@ public class CypherExecutionPlan {
             database.getConfiguration().getValueAsBoolean(GlobalConfiguration.OPENCYPHER_FOREACH_EAGER_READ)
                 && graphReadFollows(clausesInOrder, entryIndex);
         if (currentStep != null && eagerness.needsBarrier(foreachClause, boundVariables))
-          currentStep = withEagerBarrier(currentStep, context);
+          currentStep = withEagerBarrier(currentStep, context, eagerness);
         final ForeachStep foreachStep =
             new ForeachStep(foreachClause, context, functionFactory, foreachEagerMaterialize, foreachEagerExecution);
         if (currentStep != null) {
@@ -3021,11 +3021,13 @@ public class CypherExecutionPlan {
    * {@link CypherEagernessAnalyzer}, which keeps it off every shape whose writes cannot feed a read.
    */
   private static AbstractExecutionStep withEagerBarrier(final AbstractExecutionStep currentStep,
-      final CommandContext context) {
+      final CommandContext context, final CypherEagernessAnalyzer eagerness) {
     if (currentStep == null)
       return null;
     final EagerStep eagerStep = new EagerStep(context);
     eagerStep.setPrevious(currentStep);
+    // The barrier closes every enumeration behind it, so the writes that follow it need no second one.
+    eagerness.observeBarrier();
     return eagerStep;
   }
 
@@ -3648,7 +3650,7 @@ public class CypherExecutionPlan {
     // Step 3: MERGE clause - find or create pattern
     if (statement.getMergeClause() != null) {
       if (currentStep != null && eagerness.needsBarrier(statement.getMergeClause(), legacyBoundVariables))
-        currentStep = withEagerBarrier(currentStep, context);
+        currentStep = withEagerBarrier(currentStep, context, eagerness);
       final MergeStep mergeStep = new MergeStep(
           statement.getMergeClause(), context, functionFactory);
       // MERGE is typically standalone, but can be chained
@@ -3661,7 +3663,7 @@ public class CypherExecutionPlan {
     // Step 4: CREATE clause - create vertices/edges
     if (statement.getCreateClause() != null && !statement.getCreateClause().isEmpty()) {
       if (currentStep != null && eagerness.needsBarrier(statement.getCreateClause(), legacyBoundVariables))
-        currentStep = withEagerBarrier(currentStep, context);
+        currentStep = withEagerBarrier(currentStep, context, eagerness);
       final CreateStep createStep = new CreateStep(statement.getCreateClause(), context, functionFactory);
       if (currentStep != null) {
         // Chained CREATE (after MATCH/WHERE)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVertexReload.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVertexReload.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.Vertex;
+
+/**
+ * Re-resolves a bound vertex to its latest state before its edges are enumerated.
+ * <p>
+ * Every MERGE-shaped write has to ask "does this edge already exist?" and answer it by walking the start
+ * vertex's outgoing edges. The vertex instance a row carries was loaded when the row was produced, which is
+ * before any of the writes the rows behind it have applied - and appending the first edge in a direction is
+ * the one write that rewrites the vertex record's edge-list head pointer. Walking the row's own instance
+ * therefore misses an edge a previous row already created, and the "merge" creates a second one.
+ * <p>
+ * {@code database.lookupByRID} re-reads the RID - the current transaction's cache first, the page store
+ * otherwise - so it observes the latest state regardless of which transaction wrote it. Extracted from
+ * {@code MergeStep}, where it was written for issue #6461, once {@code merge.relationship} turned out to
+ * have the identical hole (issue #7174).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class CypherVertexReload {
+  private CypherVertexReload() {
+  }
+
+  /**
+   * @return the vertex re-read from {@code database}, or {@code vertex} unchanged when it has no identity yet
+   * (not persisted) or was concurrently deleted - both left for the ordinary handling downstream to react to
+   */
+  public static Vertex latest(final Database database, final Vertex vertex) {
+    if (vertex == null)
+      return null;
+    final RID rid = vertex.getIdentity();
+    if (rid == null)
+      return vertex;
+    try {
+      final Record fresh = database.lookupByRID(rid, true);
+      return fresh instanceof Vertex reloaded ? reloaded : vertex;
+    } catch (final RecordNotFoundException e) {
+      return vertex;
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/EagerStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/EagerStep.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.query.sql.executor.AbstractExecutionStep;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Barrier step that reads its whole input before letting the first row through, so that a clause which
+ * creates vertices or edges never runs while a clause that reads the graph is still enumerating.
+ * <p>
+ * openCypher requires a query's reads to be unaffected by that same query's writes; Neo4j gets there by
+ * planting an {@code Eager} operator wherever a write conflicts with a read, and this is that operator.
+ * The pipeline here is a pull model: a MATCH re-enumerates its pattern once per input row and hands the
+ * rows downstream as it goes, so a downstream CREATE/MERGE/write-procedure that adds an edge of a type the
+ * MATCH can match adds a row to an enumeration that has not run yet. Issue #7171 is the visible form of
+ * that - {@code FOR alias0 IN [a,b,c] MATCH (:l3|l8)<-[r0]-(:l6), ... CALL merge.relationship(...)}
+ * returned 480 rows where the graph only ever held 79 matching edges (79 x 6 = 474), the six extra rows
+ * being the procedure's own new edges seen by the third {@code alias0} iteration's enumeration.
+ * <p>
+ * Placed as the write step's immediate input, it turns "read some, write some, read some more" into
+ * "read everything, then write", which is the only ordering under which every row of the read sees the
+ * same graph. Cost is memory: the input rows are held until the last of them has been handed downstream.
+ * The planner therefore inserts it only where the write's shape can actually feed an upstream pattern -
+ * see {@code CypherEagernessAnalyzer} - so the common bulk shapes ({@code UNWIND ... CREATE},
+ * {@code MATCH (a)-[:KNOWS]->(b) CREATE (a)-[:SCORED]->(b)}) keep streaming untouched.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class EagerStep extends AbstractExecutionStep {
+  public EagerStep(final CommandContext context) {
+    super(context);
+  }
+
+  @Override
+  public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
+    checkForPrevious("EagerStep requires a previous step");
+
+    return new ResultSet() {
+      private List<Result> materialized = null;
+      private int          currentIndex = 0;
+
+      @Override
+      public boolean hasNext() {
+        if (materialized == null)
+          materialize();
+        return currentIndex < materialized.size();
+      }
+
+      @Override
+      public Result next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        return materialized.get(currentIndex++);
+      }
+
+      private void materialize() {
+        final long begin = context.isProfiling() ? System.nanoTime() : 0;
+        try {
+          materialized = new ArrayList<>();
+          // Integer.MAX_VALUE rather than nRecords: a partial drain would leave the upstream cursor open
+          // across the writes, which is the very interleaving this step exists to prevent.
+          final ResultSet prevResults = prev.syncPull(context, Integer.MAX_VALUE);
+          while (prevResults.hasNext())
+            materialized.add(prevResults.next());
+          if (context.isProfiling())
+            rowCount += materialized.size();
+        } finally {
+          if (context.isProfiling())
+            cost += System.nanoTime() - begin;
+        }
+      }
+
+      @Override
+      public void close() {
+        EagerStep.this.close();
+      }
+    };
+  }
+
+  @Override
+  public String prettyPrint(final int depth, final int indent) {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("  ".repeat(Math.max(0, depth * indent)));
+    builder.append("+ EAGER (read/write barrier)");
+    if (context.isProfiling())
+      builder.append(" (").append(getCostFormatted()).append(")");
+    return builder.toString();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/EagerStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/EagerStep.java
@@ -23,6 +23,7 @@ import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,22 +48,39 @@ import java.util.NoSuchElementException;
  * The planner therefore inserts it only where the write's shape can actually feed an upstream pattern -
  * see {@code CypherEagernessAnalyzer} - so the common bulk shapes ({@code UNWIND ... CREATE},
  * {@code MATCH (a)-[:KNOWS]->(b) CREATE (a)-[:SCORED]->(b)}) keep streaming untouched.
+ * <p>
+ * The other thing draining everything costs is a downstream {@code LIMIT}'s short-circuit: a barriered
+ * query runs its write for every matched row rather than stopping at the first N. That is inherent to the
+ * ordering the barrier exists to impose - stopping early would mean some rows never saw the writes the
+ * earlier ones did - and Neo4j's {@code Eager} has the same effect, but it is worth knowing when a write
+ * query with a LIMIT suddenly touches more rows than it used to.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class EagerStep extends AbstractExecutionStep {
+  /**
+   * The drained input, and how far the result sets handed out so far have read into it. Both live on the
+   * step rather than on the {@link ResultSet} it returns, so a second {@code syncPull} continues where the
+   * first left off instead of re-reading {@code prev} and handing back rows a caller already consumed.
+   */
+  private List<Result> materialized = null;
+  private int          currentIndex = 0;
+
   public EagerStep(final CommandContext context) {
     super(context);
   }
 
+  /**
+   * {@code nRecords} is a batching hint here, not a per-pull cap: every step in this pipeline returns a
+   * result set that iterates the whole of its input (see {@code OrderByStep}, and {@code ForeachStep}'s
+   * refilling buffer), and its consumer pulls once and drains until {@code hasNext()} is false. Capping the
+   * returned set at {@code nRecords} would silently truncate the query at one batch.
+   */
   @Override
   public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
     checkForPrevious("EagerStep requires a previous step");
 
     return new ResultSet() {
-      private List<Result> materialized = null;
-      private int          currentIndex = 0;
-
       @Override
       public boolean hasNext() {
         if (materialized == null)
@@ -81,11 +99,17 @@ public class EagerStep extends AbstractExecutionStep {
         final long begin = context.isProfiling() ? System.nanoTime() : 0;
         try {
           materialized = new ArrayList<>();
+          // The drain is one uninterrupted region, and the statement-level drain that tests the command
+          // deadline per row only starts once this one has finished - so a TIMEOUT clause could not end a
+          // long barrier before this guard. Same reason CypherExecutionPlan.execute() carries one (#6266).
+          final WorkGuard guard = WorkGuard.forCommandDeadline(context);
           // Integer.MAX_VALUE rather than nRecords: a partial drain would leave the upstream cursor open
           // across the writes, which is the very interleaving this step exists to prevent.
           final ResultSet prevResults = prev.syncPull(context, Integer.MAX_VALUE);
-          while (prevResults.hasNext())
+          while (prevResults.hasNext()) {
+            guard.check();
             materialized.add(prevResults.next());
+          }
           if (context.isProfiling())
             rowCount += materialized.size();
         } finally {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -23,7 +23,6 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.Record;
-import com.arcadedb.database.RID;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
@@ -41,6 +40,7 @@ import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.CypherValues;
+import com.arcadedb.query.opencypher.executor.CypherVertexReload;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
 import com.arcadedb.query.opencypher.executor.LabelReplacements;
 import com.arcadedb.query.opencypher.parser.CypherASTBuilder;
@@ -1239,25 +1239,11 @@ public class MergeStep extends AbstractExecutionStep {
    * rewrites the vertex record's edge-list head pointer) the row's own instance still reflects the
    * pre-append state and a direct {@code vertex.getEdges(...)} on it would miss that edge.
    * <p>
-   * {@code database.lookupByRID} re-reads that RID - the current transaction's cache first, the page
-   * store otherwise - so it observes the latest COMMITTED state regardless of which transaction wrote it,
-   * unlike the row's own possibly-stale instance. Mirrors {@code SetStep.reloadLatestDoc} (issue #5227).
-   *
-   * @return the reloaded vertex, or {@code anchor} unchanged if it has no identity yet (not persisted) or
-   * was concurrently deleted (left for the ordinary not-found handling downstream to react to)
+   * The re-read itself lives in {@link CypherVertexReload}, shared with {@code merge.relationship}, which
+   * asks the same question of the same rows and had the same hole (issue #7174).
    */
   private Vertex reloadAnchorVertex(final Vertex anchor) {
-    if (anchor == null)
-      return null;
-    final RID rid = anchor.getIdentity();
-    if (rid == null)
-      return anchor;
-    try {
-      final Record fresh = context.getDatabase().lookupByRID(rid, true);
-      return fresh instanceof Vertex v ? v : anchor;
-    } catch (final RecordNotFoundException e) {
-      return anchor;
-    }
+    return CypherVertexReload.latest(context.getDatabase(), anchor);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherEagernessAnalyzer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherEagernessAnalyzer.java
@@ -106,6 +106,21 @@ public final class CypherEagernessAnalyzer {
    * runs - the one place in the pipeline where that is provably true.
    */
   public void observeAggregationBoundary() {
+    clearReadFootprint();
+  }
+
+  /**
+   * Clears the read footprint once a barrier has actually been planted. The barrier drains everything
+   * upstream of it, so the enumerations that made the following write conflict are closed before that write
+   * runs, and a second write behind it needs no barrier of its own: {@code MATCH (n:A) CREATE (:A) CREATE
+   * (:A)} plants one, not two. A later MATCH re-opens an enumeration and {@link #observeRead} records it
+   * again, so nothing that does need a barrier loses one.
+   */
+  public void observeBarrier() {
+    clearReadFootprint();
+  }
+
+  private void clearReadFootprint() {
     readNodeLabels.clear();
     readRelationshipTypes.clear();
     anyRead = false;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherEagernessAnalyzer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherEagernessAnalyzer.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.planner;
+
+import com.arcadedb.query.opencypher.ast.ClauseEntry;
+import com.arcadedb.query.opencypher.ast.CreateClause;
+import com.arcadedb.query.opencypher.ast.ForeachClause;
+import com.arcadedb.query.opencypher.ast.MatchClause;
+import com.arcadedb.query.opencypher.ast.MergeClause;
+import com.arcadedb.query.opencypher.ast.NodePattern;
+import com.arcadedb.query.opencypher.ast.PathPattern;
+import com.arcadedb.query.opencypher.ast.RelationshipPattern;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Decides where a query needs an eager read/write barrier: the openCypher rule that a query's reads must
+ * not be affected by that same query's writes, which Neo4j implements by planting an {@code Eager}
+ * operator between a write and a read it conflicts with.
+ * <p>
+ * The execution pipeline is a pull model, so a MATCH hands rows downstream while it is still enumerating -
+ * and re-enumerates its pattern once per input row. A CREATE, MERGE or write procedure further down the
+ * pipeline that adds a vertex or an edge the MATCH's pattern can match therefore adds rows to the
+ * enumerations that have not run yet, and the query reports entities it created itself. Issue #7171 is
+ * that bug seen from the outside: inserting empty {@code FOREACH} clauses into a query changed its row
+ * count from 480 to 474, because an empty FOREACH happens to be eager with respect to a following read
+ * (issue #6922) and so accidentally supplied the barrier the query was missing. 474 - the number of rows
+ * the pattern matched before the query wrote anything - is the correct answer.
+ * <p>
+ * <b>What it tracks.</b> The analyzer accumulates the <i>shape</i> of everything read so far - the node
+ * labels and relationship types the MATCH patterns can match, plus the two "matches anything" flags an
+ * unlabelled node pattern and an untyped relationship pattern raise - and compares each write clause's
+ * own shape against it. That comparison is what keeps the barrier off the shapes that do not need it:
+ * {@code UNWIND range(1, 1000000) AS i CREATE (:Log {i: i})} reads nothing, and
+ * {@code MATCH (a)-[:KNOWS]->(b) CREATE (a)-[:SCORED]->(b)} writes a type no pattern reads, so both keep
+ * their streaming, bounded-memory profile. A write procedure is opaque - it can create anything - so it
+ * conflicts with any read at all.
+ * <p>
+ * <b>Read state is never narrowed by a WITH.</b> Rows out of a MATCH still flow one at a time through a
+ * plain {@code WITH n, m}, so the enumeration behind it is just as open as before; only a WITH that
+ * aggregates genuinely drains its input, and that is the one boundary {@link #observeAggregationBoundary()}
+ * resets on.
+ * <p>
+ * <b>Deletions are out of scope on purpose.</b> This barrier is about entities appearing under a running
+ * enumeration, not disappearing from one: a DELETE can only take away rows a forward scan has usually
+ * already passed, it carries its own dangling-reference guard for the shapes where that is not true
+ * (issues #6491 and #7023, see {@code DeleteStep}), and making {@code MATCH (n:Big) DETACH DELETE n}
+ * eager would hold every matched vertex in memory to buy nothing this issue can demonstrate.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class CypherEagernessAnalyzer {
+  private final Set<String> readNodeLabels         = new HashSet<>();
+  private final Set<String> readRelationshipTypes  = new HashSet<>();
+  private       boolean     anyRead                = false;
+  private       boolean     readsAnyNodeLabel      = false;
+  private       boolean     readsAnyRelationshipType = false;
+
+  /**
+   * Folds one MATCH (or OPTIONAL MATCH) clause into the read footprint. A node pattern with no static and
+   * no dynamic label matches every vertex, and a relationship pattern with no type matches every edge, so
+   * either raises the corresponding "matches anything" flag rather than contributing a name; a dynamic
+   * label ({@code (n:$(expr))}) is not known until the row is evaluated and counts the same way.
+   */
+  public void observeRead(final MatchClause matchClause) {
+    if (matchClause == null)
+      return;
+    anyRead = true;
+    for (final PathPattern pathPattern : matchClause.getPathPatterns()) {
+      for (final NodePattern node : pathPattern.getNodes()) {
+        if (node.hasDynamicLabels() || !node.hasLabels())
+          readsAnyNodeLabel = true;
+        else
+          readNodeLabels.addAll(node.getLabels());
+      }
+      for (final RelationshipPattern relationship : pathPattern.getRelationships()) {
+        if (!relationship.hasTypes())
+          readsAnyRelationshipType = true;
+        else
+          readRelationshipTypes.addAll(relationship.getTypes());
+      }
+    }
+  }
+
+  /**
+   * Clears the read footprint at a WITH that aggregates. An aggregation cannot emit its first row before it
+   * has consumed its last input one, so every enumeration feeding it is closed by the time a clause after it
+   * runs - the one place in the pipeline where that is provably true.
+   */
+  public void observeAggregationBoundary() {
+    readNodeLabels.clear();
+    readRelationshipTypes.clear();
+    anyRead = false;
+    readsAnyNodeLabel = false;
+    readsAnyRelationshipType = false;
+  }
+
+  /** True when at least one graph read is still potentially in flight ahead of the current clause. */
+  public boolean hasPendingRead() {
+    return anyRead;
+  }
+
+  /**
+   * True when a CREATE needs the barrier: one of the vertices or edges it adds could be matched by a pattern
+   * that has already been read from.
+   *
+   * @param boundVariables the names already bound when this clause runs - a CREATE node pattern that names one
+   *                       of them refers to that entity instead of creating a new one
+   */
+  public boolean needsBarrier(final CreateClause createClause, final Set<String> boundVariables) {
+    if (!anyRead || createClause == null || createClause.isEmpty())
+      return false;
+    return pathPatternsConflict(createClause.getPathPatterns(), boundVariables);
+  }
+
+  /**
+   * True when a MERGE needs the barrier. MERGE creates only when its pattern finds no match, but the planner
+   * cannot know which rows will find one, so its pattern is weighed exactly as a CREATE's is.
+   */
+  public boolean needsBarrier(final MergeClause mergeClause, final Set<String> boundVariables) {
+    if (!anyRead || mergeClause == null || mergeClause.getPathPattern() == null)
+      return false;
+    return pathPatternsConflict(List.of(mergeClause.getPathPattern()), boundVariables);
+  }
+
+  /**
+   * True when a FOREACH needs the barrier, i.e. when any CREATE or MERGE in its body at any nesting depth
+   * does. The loop variable is deliberately not added to {@code boundVariables}: treating a body node pattern
+   * that names it as a creation only ever keeps a barrier that is not strictly needed, never drops one.
+   */
+  public boolean needsBarrier(final ForeachClause foreachClause, final Set<String> boundVariables) {
+    if (!anyRead || foreachClause == null)
+      return false;
+    for (final ClauseEntry innerClause : foreachClause.getInnerClauses()) {
+      switch (innerClause.getType()) {
+      case CREATE:
+        if (needsBarrier((CreateClause) innerClause.getClause(), boundVariables))
+          return true;
+        break;
+      case MERGE:
+        if (needsBarrier((MergeClause) innerClause.getClause(), boundVariables))
+          return true;
+        break;
+      case FOREACH:
+        if (needsBarrier((ForeachClause) innerClause.getClause(), boundVariables))
+          return true;
+        break;
+      default:
+        break;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * True when a call to a write procedure needs the barrier. What such a procedure creates is not visible to
+   * the planner - {@code merge.relationship} takes its type as a runtime argument - so any read at all counts
+   * as a conflict.
+   */
+  public boolean needsBarrierForWriteProcedure() {
+    return anyRead;
+  }
+
+  private boolean pathPatternsConflict(final List<PathPattern> pathPatterns, final Set<String> boundVariables) {
+    for (final PathPattern pathPattern : pathPatterns) {
+      for (final NodePattern node : pathPattern.getNodes()) {
+        if (node.getVariable() != null && boundVariables != null && boundVariables.contains(node.getVariable()))
+          continue; // a reference to an entity that already exists, not a creation
+        if (readsAnyNodeLabel)
+          return true;
+        if (node.hasDynamicLabels())
+          return true; // the label is only known per row: it could be any of the ones read
+        if (!node.hasLabels())
+          return true; // an unlabelled creation could land in any type a read pattern scans
+        for (final String label : node.getLabels())
+          if (readNodeLabels.contains(label))
+            return true;
+      }
+      for (final RelationshipPattern relationship : pathPattern.getRelationships()) {
+        if (relationship.getVariable() != null && boundVariables != null
+            && boundVariables.contains(relationship.getVariable()))
+          continue;
+        if (readsAnyRelationshipType)
+          return true;
+        if (!relationship.hasTypes())
+          return true;
+        for (final String type : relationship.getTypes())
+          if (readRelationshipTypes.contains(type))
+            return true;
+      }
+    }
+    return false;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/merge/MergeRelationship.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/merge/MergeRelationship.java
@@ -24,6 +24,7 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.executor.CypherVertexReload;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -104,8 +105,17 @@ public class MergeRelationship implements CypherProcedure {
     if (!database.getSchema().existsType(relType))
       database.getSchema().createEdgeType(relType);
 
+    // The vertex instances the row carries were loaded before the rows ahead of it applied their merges, and
+    // appending an edge rewrites the edge-list head pointer of BOTH endpoints - out on the start, in on the
+    // end. Everything below reads those pointers: the existence check missed an edge a previous row had
+    // already created and merged a duplicate, and appending against a stale head fails outright with
+    // "Edge list IN head of vertex ... changed by a concurrent transaction" (issue #7174). Re-read both,
+    // exactly as MergeStep does for the anchor of a MERGE clause (issue #6461).
+    final Vertex latestStartNode = CypherVertexReload.latest(database, startNode);
+    final Vertex latestEndNode = CypherVertexReload.latest(database, endNode);
+
     // Try to find existing relationship matching the criteria
-    Edge existingEdge = findMatchingEdge(startNode, endNode, relType, matchProps);
+    final Edge existingEdge = findMatchingEdge(latestStartNode, latestEndNode, relType, matchProps);
 
     if (existingEdge != null)
       // Return existing relationship
@@ -113,7 +123,7 @@ public class MergeRelationship implements CypherProcedure {
 
     // Create new relationship with both matchProps and createProps
     // Note: using bidirectional=true so the edge can be traversed from both ends
-    final MutableEdge newEdge = startNode.newEdge(relType, endNode);
+    final MutableEdge newEdge = latestStartNode.newEdge(relType, latestEndNode);
 
     // Apply matchProps
     if (matchProps != null) {
@@ -140,8 +150,7 @@ public class MergeRelationship implements CypherProcedure {
    */
   private Edge findMatchingEdge(final Vertex startNode, final Vertex endNode,
                                 final String relType, final Map<String, Object> matchProps) {
-    // Get outgoing edges of the specified type
-
+    // startNode must be the re-read instance, not the one the row carries - see execute() (issue #7174).
     for (final Edge edge : startNode.getEdges(Vertex.DIRECTION.OUT, relType)) {
       try {
         // Check if edge connects to the endNode

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherEagerWriteBarrierIssue7171Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherEagerWriteBarrierIssue7171Test.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for GitHub issue #7171: inserting empty {@code FOREACH} clauses into a query changed its
+ * row count, from 480 rows to 474.
+ * <p>
+ * An empty FOREACH runs no body at all, so it cannot change anything - and it did not. What it changed was
+ * the plan around it: a FOREACH followed by a clause that reads the graph is eager (issue #6922), so it
+ * drained the MATCH before the write procedure behind it ran, and accidentally supplied a read/write barrier
+ * the query was missing. 474 is the correct answer - the pattern matched 79 edges before the query wrote
+ * anything, and 79 x 3 {@code alias0} values x 2 {@code n1} bindings is 474. The six extra rows the query
+ * without the FOREACH clauses returned were the {@code rt2} edges {@code merge.relationship} had itself just
+ * created, re-read by an enumeration that had not yet run when they appeared.
+ * <p>
+ * openCypher requires a query's reads to be unaffected by that query's own writes, so the fix is the barrier
+ * itself rather than the FOREACH: see {@code CypherEagernessAnalyzer} for where it goes and, just as
+ * importantly, where it must not.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherEagerWriteBarrierIssue7171Test {
+  /** The reporter's graph: 45 vertices carrying up to twelve labels each, and 78 {@code R} edges. */
+  private static final String CREATE_NODES = "CREATE (:l6:l7:l0:l1:l2:l4:l8:l5:l11:l9:l3:l10 {id: 1}), (:l1:l3:l4:l8:l10:l0:l2:l7:l11:l6:l9 {id: 3}), (:l7:l5:l8:l1:l10:l6:l9:l11:l4:l3 {id: 5}), (:l4:l2:l8:l9:l0:l7:l3:l6:l11:l5:l10 {id: 7}), (:l3:l6:l7 {id: 8}), (:l3:l8:l2:l9:l10:l5:l6:l7 {id: 17}), (:l1:l0:l5:l10:l3:l2:l11:l6:l4 {id: 22}), (:l3:l8:l4:l10:l2:l7:l5:l11:l6:l9 {id: 23}), (:l10:l8:l4:l7:l6:l5 {id: 24}), (:l0:l7:l5:l6:l11:l10 {id: 26}), (:l0:l6:l7:l11:l10:l8 {id: 29}), (:l7:l8:l2:l0:l10:l11:l1 {id: 32}), (:l9:l6:l3:l8:l5:l2:l10:l0:l4:l7:l1:l11 {id: 34}), (:l11:l9:l8:l4 {id: 39}), (:l1:l10:l11:l0:l4:l6:l3:l9:l5:l7 {id: 41}), (:l1:l6:l5:l10:l8:l11:l9:l3:l0 {id: 46}), (:l5:l9:l6:l1:l2:l11:l0 {id: 47}), (:l11:l10:l2:l5:l0:l7:l6:l8:l3:l9 {id: 48, k0: ['EccO', 'Ng1RgDR', 'KLaHa4c']}), (:l11:l10:l2:l5:l0:l7:l6:l8:l3:l9 {id: 49, k0: ['EccO', 'Ng1RgDR', 'KLaHa4c']}), (:l3:l1 {id: 52}), (:l10:l11:l3:l7:l9 {id: 53}), (:l1:l6:l10 {id: 55}), (:l1:l8:l4:l3 {id: 58}), (:l5:l0:l2:l3:l6:l9:l1:l10:l11:l7 {id: 61}), (:l4:l8:l6:l7:l9:l2:l5:l11 {id: 63}), (:l8:l1:l5:l7:l10:l2:l6:l0:l11 {id: 65}), (:l10:l5:l8 {id: 68}), (:l2:l3 {id: 70}), (:l3:l8:l2:l1:l11:l7:l10 {id: 72}), (:l10:l6:l0:l3:l2:l7:l9:l11 {id: 75}), (:l7:l8:l5:l10:l6:l11:l0 {id: 76}), (:l11:l3:l4:l8:l6:l7 {id: 77}), (:l11:l6:l2:l5:l10:l1:l9:l3:l4 {id: 78}), (:l7:l6:l11:l5:l2:l8 {id: 80}), (:l10:l6:l2:l4:l5:l1:l3:l8:l9:l7:l0:l11 {id: 87}), (:l5:l7:l10:l9:l3 {id: 92}), (:l11:l9:l0:l6:l4:l3:l2:l1:l10:l8:l5 {id: 94}), (:l0:l1:l10:l3:l11:l5:l9:l8:l7:l2:l4:l6 {id: 96}), (:l0:l6:l3 {id: 97}), (:l2:l4:l9:l7:l3:l10:l6:l11:l5 {id: 105, k1: false, k3: 'vfn', k7: 1727121251}), (:l7:l0:l10:l11:l8:l6:l9:l3:l1:l5 {id: 106}), (:l8:l2:l7:l1:l3:l10:l11:l9:l0:l4:l6:l5 {id: 110}), (:l6:l8 {id: 114}), (:l11:l9:l8:l6:l10:l3:l7:l4:l2 {id: 117}), (:l3:l11:l7:l10:l8:l0:l1:l6:l2:l9 {id: 127})";
+  private static final String CREATE_EDGES = "UNWIND [[22, 61], [96, 114], [127, 114], [46, 34], [17, 17], [46, 105], [29, 29], [96, 77], [55, 117], [114, 39], [127, 46], [117, 63], [22, 87], [8, 22], [5, 78], [34, 17], [22, 80], [80, 49], [97, 32], [117, 58], [75, 5], [7, 17], [26, 76], [63, 53], [29, 61], [47, 41], [24, 87], [127, 94], [80, 127], [105, 46], [65, 76], [96, 32], [94, 114], [87, 114], [77, 17], [17, 17], [24, 24], [75, 23], [114, 58], [114, 114], [80, 127], [17, 72], [78, 72], [1, 68], [5, 1], [5, 94], [78, 58], [5, 5], [17, 114], [105, 32], [24, 29], [117, 110], [41, 92], [106, 76], [77, 5], [17, 49], [3, 94], [7, 61], [17, 70], [78, 78], [46, 87], [80, 46], [49, 49], [46, 29], [63, 63], [26, 46], [75, 75], [26, 49], [97, 49], [117, 58], [8, 32], [46, 3], [17, 17], [17, 17], [127, 94], [46, 97], [17, 52], [61, 24], [114, 68]] AS edge MATCH (s {id: edge[0]}), (t {id: edge[1]}) CREATE (s)-[:R]->(t)";
+
+  /** The reporter's query, verbatim. */
+  private static final String WITHOUT_FOREACH = """
+      FOR alias0 IN [-598838671,-1233757578,-1797380024]
+      MATCH p0 = (:l3|l8) <-[r0]- (:l6),
+        (n0 {k7: 1727121251, k1: false}),
+        (n1:l9&l3&l8&l10&l5&l0&l6&l2&l11&l7
+            {k0: ["EccO", "Ng1RgDR", "KLaHa4c"]})
+      WHERE (toStringOrNull(n0.k3) > 'S')
+      WITH * WHERE n1 IS NOT NULL AND n0 IS NOT NULL
+      CALL merge.relationship(n1, 'rt2', {}, {generated: true}, n0) YIELD rel AS alias45
+      RETURN {alias0: alias0, n0: n0, n1: n1, r0: r0, p0: p0, alias45: alias45} AS __layer_row""";
+
+  /** The same query with an empty FOREACH before FOR, MATCH, WITH and CALL. */
+  private static final String WITH_FOREACH = """
+      FOREACH (elem37 IN [] | CREATE (:NoOp))
+      FOR alias0 IN [-598838671,-1233757578,-1797380024]
+      FOREACH (elem38 IN [] | CREATE (:NoOp))
+      MATCH p0 = (:l3|l8) <-[r0]- (:l6),
+        (n0 {k7: 1727121251, k1: false}),
+        (n1:l9&l3&l8&l10&l5&l0&l6&l2&l11&l7
+            {k0: ["EccO", "Ng1RgDR", "KLaHa4c"]})
+      WHERE (toStringOrNull(n0.k3) > 'S')
+      FOREACH (elem39 IN [] | CREATE (:NoOp))
+      WITH * WHERE n1 IS NOT NULL AND n0 IS NOT NULL
+      FOREACH (elem40 IN [] | CREATE (:NoOp))
+      CALL merge.relationship(n1, 'rt2', {}, {generated: true}, n0) YIELD rel AS alias45
+      RETURN {alias0: alias0, n0: n0, n1: n1, r0: r0, p0: p0, alias45: alias45} AS __layer_row""";
+
+  /**
+   * 79 edges match {@code (:l3|l8)<-[r0]-(:l6)} in the graph as loaded, and the MATCH cross-joins that with
+   * three {@code alias0} values, one {@code n0} and two {@code n1} bindings.
+   */
+  private static final long ROWS_BEFORE_ANY_WRITE = 79 * 3 * 2;
+
+  private Database database;
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void emptyForeachClausesDoNotChangeTheRowCount() {
+    final long withoutForeach = rowCountOf("without-foreach", WITHOUT_FOREACH);
+    final long withForeach = rowCountOf("with-foreach", WITH_FOREACH);
+
+    assertThat(withForeach)
+        .as("an empty FOREACH runs no body: it cannot change what the query returns")
+        .isEqualTo(withoutForeach);
+    assertThat(withoutForeach)
+        .as("the rows are the ones the pattern matched before the query created anything")
+        .isEqualTo(ROWS_BEFORE_ANY_WRITE);
+  }
+
+  /** No row may report an edge the query's own {@code merge.relationship} created. */
+  @Test
+  void theQueryNeverReadsBackTheEdgesItCreates() {
+    open("no-readback");
+
+    final List<String> types = new ArrayList<>();
+    try (final ResultSet resultSet = database.command("opencypher", """
+        FOR alias0 IN [-598838671,-1233757578,-1797380024]
+        MATCH p0 = (:l3|l8) <-[r0]- (:l6),
+          (n0 {k7: 1727121251, k1: false}),
+          (n1:l9&l3&l8&l10&l5&l0&l6&l2&l11&l7 {k0: ["EccO", "Ng1RgDR", "KLaHa4c"]})
+        CALL merge.relationship(n1, 'rt2', {}, {generated: true}, n0) YIELD rel AS alias45
+        RETURN type(r0) AS relationshipType""")) {
+      while (resultSet.hasNext())
+        types.add(resultSet.next().getProperty("relationshipType"));
+    }
+
+    assertThat(types).hasSize((int) ROWS_BEFORE_ANY_WRITE).containsOnly("R");
+    assertThat(count("MATCH ()-[r:rt2]->() RETURN count(*) AS c"))
+        .as("one rt2 edge per (n1, n0) pair, and both n1 bindings resolve to the same n0")
+        .isEqualTo(2);
+  }
+
+  /**
+   * The same hazard reached through a plain MERGE rather than a procedure: {@code [r0]} is untyped, so it
+   * matches the {@code rt2} edges the MERGE adds.
+   */
+  @Test
+  void mergeAfterAnUntypedRelationshipPatternIsEager() {
+    open("merge-eager");
+
+    assertThat(rowCount("""
+        FOR alias0 IN [-598838671,-1233757578,-1797380024]
+        MATCH p0 = (:l3|l8) <-[r0]- (:l6),
+          (n0 {k7: 1727121251, k1: false}),
+          (n1:l9&l3&l8&l10&l5&l0&l6&l2&l11&l7 {k0: ["EccO", "Ng1RgDR", "KLaHa4c"]})
+        MERGE (n1)-[:rt2]->(n0)
+        RETURN r0"""))
+        .isEqualTo(ROWS_BEFORE_ANY_WRITE);
+  }
+
+  /** A write whose type no pattern reads keeps streaming: the barrier is not a blanket eager mode. */
+  @Test
+  void aWriteThatNoPatternCanReadKeepsStreaming() {
+    open("no-barrier");
+    database.getSchema().createVertexType("Person");
+    database.transaction(() -> database.command("opencypher", "UNWIND range(1, 5) AS i CREATE (:Person {id: i})"));
+
+    assertThat(explain("MATCH (a:Person)-[r:KNOWS]->(b:Person) CREATE (a)-[:SCORED]->(b) RETURN a"))
+        .as("KNOWS is read, SCORED is written: nothing the CREATE adds can feed the MATCH")
+        .doesNotContain("EAGER");
+    assertThat(explain("UNWIND range(1, 10) AS i CREATE (:Person {id: i}) RETURN i"))
+        .as("a bulk insert reads nothing at all")
+        .doesNotContain("EAGER");
+    assertThat(explain("MATCH (a:Person) CREATE (:Person {name: a.name}) RETURN a"))
+        .as("the CREATE adds vertices of the very type the MATCH is scanning")
+        .contains("EAGER");
+  }
+
+  private long rowCountOf(final String name, final String query) {
+    open(name);
+    return rowCount(query);
+  }
+
+  private long rowCount(final String query) {
+    long rows = 0;
+    try (final ResultSet resultSet = database.command("opencypher", query)) {
+      while (resultSet.hasNext()) {
+        final Result ignored = resultSet.next();
+        ++rows;
+      }
+    }
+    return rows;
+  }
+
+  private long count(final String query) {
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      return ((Number) resultSet.next().getProperty("c")).longValue();
+    }
+  }
+
+  private String explain(final String query) {
+    try (final ResultSet resultSet = database.command("opencypher", "EXPLAIN " + query)) {
+      return resultSet.getExecutionPlan().orElseThrow().prettyPrint(0, 2);
+    }
+  }
+
+  private void open(final String name) {
+    if (database != null)
+      database.drop();
+    database = new DatabaseFactory("./target/databases/cypher-eager-write-barrier-7171-" + name).create();
+    database.transaction(() -> {
+      database.command("opencypher", CREATE_NODES);
+      database.command("opencypher", CREATE_EDGES);
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherEagerWriteBarrierIssue7171Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherEagerWriteBarrierIssue7171Test.java
@@ -169,6 +169,43 @@ class CypherEagerWriteBarrierIssue7171Test {
         .contains("EAGER");
   }
 
+  /**
+   * A FOREACH whose body actually writes goes through the analyzer's recursive body walk, not the
+   * empty-body path the reported query exercises: {@code CREATE (:l6)} inside the body adds vertices the
+   * MATCH's own {@code (:l6)} anchor scans, so the FOREACH gets a barrier of its own.
+   */
+  @Test
+  void aForeachWhoseBodyWritesAConflictingPatternIsBarriered() {
+    open("foreach-body");
+
+    assertThat(explain("""
+        MATCH (:l3|l8) <-[r0]- (:l6)
+        FOREACH (x IN [1] | CREATE (:l6))
+        RETURN r0"""))
+        .as("the body creates vertices of a label the MATCH anchor scans")
+        .contains("EAGER");
+    assertThat(explain("""
+        MATCH (:l3|l8) <-[r0]- (:l6)
+        FOREACH (x IN [1] | CREATE (:Untouched))
+        RETURN r0"""))
+        .as("Untouched is a label no pattern reads")
+        .doesNotContain("EAGER");
+  }
+
+  /** One barrier is enough for the writes behind it: it already drained every enumeration they could see. */
+  @Test
+  void consecutiveConflictingWritesShareOneBarrier() {
+    open("one-barrier");
+
+    final String plan = explain("""
+        MATCH (n:l6)
+        CREATE (:l6)
+        CREATE (:l6)
+        RETURN n""");
+    assertThat(plan).contains("EAGER");
+    assertThat(plan.split("EAGER", -1).length - 1).as("exactly one barrier, not one per write").isEqualTo(1);
+  }
+
   private long rowCountOf(final String name, final String query) {
     open(name);
     return rowCount(query);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeRelationshipStaleAnchorIssue7174Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMergeRelationshipStaleAnchorIssue7174Test.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #7174: {@code CALL merge.relationship(a, 'U', {}, {}, b)} created a second
+ * edge for a pair it had already merged.
+ * <p>
+ * The existence check walked {@code startNode.getEdges(OUT, type)} on the vertex instance the row carried.
+ * That instance was loaded before the rows ahead of it applied their merges, and appending the first edge of
+ * a direction rewrites the vertex record's edge-list head pointer, so the check looked at a pre-append
+ * snapshot and concluded the edge was missing. The MERGE clause on the identical rows was already correct -
+ * {@code MergeStep} re-reads the anchor by RID (issue #6461) - and the procedure now shares that re-read.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherMergeRelationshipStaleAnchorIssue7174Test {
+  /**
+   * 120 {@code C} vertices cross-joined with two {@code A} vertices: 240 rows, spanning several of the
+   * pipeline's 100-row pull batches, over only two distinct {@code (a, b)} pairs.
+   */
+  private static final String MANY_ROWS_TWO_PAIRS = "MATCH (c:C), (a:A), (b:B)\n";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/cypher-merge-relationship-stale-anchor-7174").create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:A {id: 1}), (:A {id: 2}), (:B {id: 3})");
+      database.command("opencypher", "UNWIND range(1, 120) AS i CREATE (:C {id: i})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void mergeRelationshipCreatesOneEdgePerPairHoweverManyRowsReachIt() {
+    assertThat(rowsOf(MANY_ROWS_TWO_PAIRS + "CALL merge.relationship(a, 'U', {}, {}, b) YIELD rel RETURN rel"))
+        .isEqualTo(240);
+    assertThat(edgeCount("U")).as("two distinct (a, b) pairs, so two edges").isEqualTo(2);
+  }
+
+  /** The MERGE clause was already right on these rows; the procedure must not disagree with it. */
+  @Test
+  void theMergeClauseAgreesWithTheProcedure() {
+    database.command("opencypher", MANY_ROWS_TWO_PAIRS + "MERGE (a)-[:V]->(b)").close();
+    assertThat(edgeCount("V")).isEqualTo(2);
+  }
+
+  /** A second run must find what the first one created rather than merging a fresh pair of edges. */
+  @Test
+  void aSecondRunMergesNothingNew() {
+    database.command("opencypher", MANY_ROWS_TWO_PAIRS + "CALL merge.relationship(a, 'U', {}, {}, b) YIELD rel RETURN rel")
+        .close();
+    database.command("opencypher", MANY_ROWS_TWO_PAIRS + "CALL merge.relationship(a, 'U', {}, {}, b) YIELD rel RETURN rel")
+        .close();
+    assertThat(edgeCount("U")).isEqualTo(2);
+  }
+
+  /**
+   * Distinct match properties still merge into distinct edges. This is the other half of the re-read: the
+   * append writes the vertex record's edge-list head pointer back, so doing it on the row's stale instance
+   * would drop the edges the rows before it appended, and 240 distinct merges would not end up as 240 edges.
+   */
+  @Test
+  void matchPropertiesStillSeparateTheEdges() {
+    database.command("opencypher", MANY_ROWS_TWO_PAIRS
+        + "CALL merge.relationship(a, 'W', {kind: c.id}, {}, b) YIELD rel RETURN rel").close();
+    assertThat(edgeCount("W")).as("two pairs x 120 distinct match-property values").isEqualTo(240);
+
+    database.command("opencypher", MANY_ROWS_TWO_PAIRS
+        + "CALL merge.relationship(a, 'W', {kind: c.id}, {}, b) YIELD rel RETURN rel").close();
+    assertThat(edgeCount("W")).as("a second run finds every one of them").isEqualTo(240);
+  }
+
+  private long rowsOf(final String query) {
+    long rows = 0;
+    try (final ResultSet resultSet = database.command("opencypher", query)) {
+      while (resultSet.hasNext()) {
+        resultSet.next();
+        ++rows;
+      }
+    }
+    return rows;
+  }
+
+  private long edgeCount(final String type) {
+    try (final ResultSet resultSet = database.query("opencypher",
+        "MATCH ()-[r:" + type + "]->() RETURN count(*) AS c")) {
+      return ((Number) resultSet.next().getProperty("c")).longValue();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/planner/CypherEagernessAnalyzerTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/planner/CypherEagernessAnalyzerTest.java
@@ -27,7 +27,9 @@ import com.arcadedb.query.opencypher.ast.MatchClause;
 import com.arcadedb.query.opencypher.ast.MergeClause;
 import com.arcadedb.query.opencypher.ast.NodePattern;
 import com.arcadedb.query.opencypher.ast.PathPattern;
+import com.arcadedb.query.opencypher.ast.RemoveClause;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
+import com.arcadedb.query.opencypher.ast.SetClause;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -126,6 +128,20 @@ class CypherEagernessAnalyzerTest {
     assertThat(analyzer.needsBarrier(emptyForeach(), NOTHING_BOUND)).as("an empty body writes nothing").isFalse();
   }
 
+  /**
+   * A body that only updates existing entities creates nothing, so it can add no row to an enumeration.
+   * Property and label writes are a different hazard class and deliberately out of this barrier's scope -
+   * see the note on {@link CypherEagernessAnalyzer}.
+   */
+  @Test
+  void aForeachBodyThatOnlyUpdatesNeedsNoBarrier() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node("Person", "n")));
+
+    assertThat(analyzer.needsBarrier(foreachSetting(), NOTHING_BOUND)).isFalse();
+    assertThat(analyzer.needsBarrier(foreachRemoving(), NOTHING_BOUND)).isFalse();
+  }
+
   @Test
   void aNestedForeachBodyIsWeighedToo() {
     final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
@@ -203,6 +219,19 @@ class CypherEagernessAnalyzerTest {
   private static ForeachClause foreachNesting(final ForeachClause nested) {
     return new ForeachClause("x", new LiteralExpression(List.of(1), "[1]"),
         List.of(new ClauseEntry(ClauseEntry.ClauseType.FOREACH, nested, 0)));
+  }
+
+  private static ForeachClause foreachSetting() {
+    final SetClause set = new SetClause(
+        List.of(new SetClause.SetItem("n", "touched", new LiteralExpression(true, "true"))));
+    return new ForeachClause("x", new LiteralExpression(List.of(1), "[1]"),
+        List.of(new ClauseEntry(ClauseEntry.ClauseType.SET, set, 0)));
+  }
+
+  private static ForeachClause foreachRemoving() {
+    final RemoveClause remove = new RemoveClause(List.of(new RemoveClause.RemoveItem("n", "touched")));
+    return new ForeachClause("x", new LiteralExpression(List.of(1), "[1]"),
+        List.of(new ClauseEntry(ClauseEntry.ClauseType.REMOVE, remove, 0)));
   }
 
   private static ForeachClause emptyForeach() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/planner/CypherEagernessAnalyzerTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/planner/CypherEagernessAnalyzerTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.planner;
+
+import com.arcadedb.query.opencypher.ast.ClauseEntry;
+import com.arcadedb.query.opencypher.ast.CreateClause;
+import com.arcadedb.query.opencypher.ast.Direction;
+import com.arcadedb.query.opencypher.ast.ForeachClause;
+import com.arcadedb.query.opencypher.ast.LiteralExpression;
+import com.arcadedb.query.opencypher.ast.MatchClause;
+import com.arcadedb.query.opencypher.ast.MergeClause;
+import com.arcadedb.query.opencypher.ast.NodePattern;
+import com.arcadedb.query.opencypher.ast.PathPattern;
+import com.arcadedb.query.opencypher.ast.RelationshipPattern;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit coverage for the shape comparison behind the eager read/write barrier of issue #7171.
+ * <p>
+ * {@code CypherEagerWriteBarrierIssue7171Test} pins the observable behaviour through whole queries; this
+ * pins the decision itself, so a change to one rule (label matching, an untyped relationship pattern,
+ * skipping an already-bound variable, the aggregation and barrier resets) says which rule it broke.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherEagernessAnalyzerTest {
+  private static final Set<String> NOTHING_BOUND = Set.of();
+
+  @Test
+  void aWriteWithNoReadAheadOfItNeedsNoBarrier() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+
+    assertThat(analyzer.hasPendingRead()).isFalse();
+    assertThat(analyzer.needsBarrier(createOf(node("Log", "x")), NOTHING_BOUND)).isFalse();
+    assertThat(analyzer.needsBarrierForWriteProcedure()).isFalse();
+  }
+
+  @Test
+  void creatingALabelThatIsBeingScannedConflicts() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node("Person", "n")));
+
+    assertThat(analyzer.needsBarrier(createOf(node("Person", null)), NOTHING_BOUND)).isTrue();
+    assertThat(analyzer.needsBarrier(createOf(node("Company", null)), NOTHING_BOUND)).isFalse();
+  }
+
+  @Test
+  void anUnlabelledReadPatternIsFedByAnyCreatedVertex() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node(null, "n")));
+
+    assertThat(analyzer.needsBarrier(createOf(node("Anything", null)), NOTHING_BOUND)).isTrue();
+  }
+
+  @Test
+  void anUntypedRelationshipPatternIsFedByAnyCreatedEdge() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(path(node("A", "a"), relationship(null, "r"), node("B", "b"))));
+
+    // Both endpoints are already bound, so only the edge counts - and an untyped [r] matches it.
+    assertThat(analyzer.needsBarrier(mergeOf(path(node(null, "a"), relationship("rt2", null), node(null, "b"))),
+        Set.of("a", "b"))).isTrue();
+  }
+
+  @Test
+  void aRelationshipTypeNoPatternReadsDoesNotConflict() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(path(node("A", "a"), relationship("KNOWS", "r"), node("B", "b"))));
+
+    assertThat(analyzer.needsBarrier(createOf(path(node(null, "a"), relationship("SCORED", null), node(null, "b"))),
+        Set.of("a", "b"))).isFalse();
+  }
+
+  @Test
+  void anAlreadyBoundNodeIsAReferenceNotACreation() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node("A", "a")));
+    analyzer.observeRead(matchOf(node("B", "b")));
+
+    final CreateClause create = createOf(path(node(null, "a"), relationship("R", null), node(null, "b")));
+    assertThat(analyzer.needsBarrier(create, Set.of("a", "b")))
+        .as("no vertex is created and R is read by no pattern")
+        .isFalse();
+    assertThat(analyzer.needsBarrier(create, NOTHING_BOUND))
+        .as("unbound, the same unlabelled nodes would be fresh vertices")
+        .isTrue();
+  }
+
+  @Test
+  void aWriteProcedureConflictsWithAnyReadAtAll() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node("Person", "n")));
+
+    assertThat(analyzer.needsBarrierForWriteProcedure()).isTrue();
+  }
+
+  @Test
+  void aForeachIsWeighedByWhatItsBodyWrites() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node("Person", "n")));
+
+    assertThat(analyzer.needsBarrier(foreachCreating(node("Person", null)), NOTHING_BOUND)).isTrue();
+    assertThat(analyzer.needsBarrier(foreachCreating(node("Untouched", null)), NOTHING_BOUND)).isFalse();
+    assertThat(analyzer.needsBarrier(emptyForeach(), NOTHING_BOUND)).as("an empty body writes nothing").isFalse();
+  }
+
+  @Test
+  void aNestedForeachBodyIsWeighedToo() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node("Person", "n")));
+
+    assertThat(analyzer.needsBarrier(foreachNesting(foreachCreating(node("Person", null))), NOTHING_BOUND)).isTrue();
+  }
+
+  @Test
+  void anAggregatingWithClosesTheEnumerationsBehindIt() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node("Person", "n")));
+    analyzer.observeAggregationBoundary();
+
+    assertThat(analyzer.hasPendingRead()).isFalse();
+    assertThat(analyzer.needsBarrier(createOf(node("Person", null)), NOTHING_BOUND)).isFalse();
+  }
+
+  @Test
+  void aPlantedBarrierSpendsTheReadFootprint() {
+    final CypherEagernessAnalyzer analyzer = new CypherEagernessAnalyzer();
+    analyzer.observeRead(matchOf(node("Person", "n")));
+
+    assertThat(analyzer.needsBarrier(createOf(node("Person", null)), NOTHING_BOUND)).isTrue();
+    analyzer.observeBarrier();
+    assertThat(analyzer.needsBarrier(createOf(node("Person", null)), NOTHING_BOUND))
+        .as("the barrier already drained what the second write could have fed")
+        .isFalse();
+
+    analyzer.observeRead(matchOf(node("Person", "m")));
+    assertThat(analyzer.needsBarrier(createOf(node("Person", null)), NOTHING_BOUND))
+        .as("a later MATCH re-opens an enumeration")
+        .isTrue();
+  }
+
+  private static NodePattern node(final String label, final String variable) {
+    return new NodePattern(variable, label == null ? List.of() : List.of(label), Map.<String, Object>of());
+  }
+
+  private static RelationshipPattern relationship(final String type, final String variable) {
+    return new RelationshipPattern(variable, type == null ? List.of() : List.of(type), Direction.OUT,
+        Map.<String, Object>of(), null, null);
+  }
+
+  private static PathPattern path(final NodePattern from, final RelationshipPattern relationship,
+      final NodePattern to) {
+    return new PathPattern(from, relationship, to);
+  }
+
+  private static MatchClause matchOf(final NodePattern node) {
+    return matchOf(new PathPattern(node));
+  }
+
+  private static MatchClause matchOf(final PathPattern pathPattern) {
+    return new MatchClause(List.of(pathPattern), false);
+  }
+
+  private static CreateClause createOf(final NodePattern node) {
+    return createOf(new PathPattern(node));
+  }
+
+  private static CreateClause createOf(final PathPattern pathPattern) {
+    return new CreateClause(List.of(pathPattern));
+  }
+
+  private static MergeClause mergeOf(final PathPattern pathPattern) {
+    return new MergeClause(pathPattern);
+  }
+
+  private static ForeachClause foreachCreating(final NodePattern node) {
+    return new ForeachClause("x", new LiteralExpression(List.of(1), "[1]"),
+        List.of(new ClauseEntry(ClauseEntry.ClauseType.CREATE, createOf(node), 0)));
+  }
+
+  private static ForeachClause foreachNesting(final ForeachClause nested) {
+    return new ForeachClause("x", new LiteralExpression(List.of(1), "[1]"),
+        List.of(new ClauseEntry(ClauseEntry.ClauseType.FOREACH, nested, 0)));
+  }
+
+  private static ForeachClause emptyForeach() {
+    return new ForeachClause("x", new LiteralExpression(List.of(), "[]"), List.of());
+  }
+}


### PR DESCRIPTION
Fixes #7171
Fixes #7174

## #7171 - empty `FOREACH` clauses changed the row count

The reported symptom is the inverse of what it looks like: **474 is the correct answer, 480 was the bug.**

The graph holds **79** edges matching `(:l3|l8)<-[r0]-(:l6)`, and `79 x 3 alias0 x 2 n1 = 474`. An empty `FOREACH` runs no body, so it cannot change anything - what it changed was the plan around it. A `FOREACH` followed by a clause that reads the graph is eager (#6922), so it drained the `MATCH` before the write procedure behind it ran, and accidentally supplied a read/write barrier the query was missing.

Without it, the pipeline streams: a `MATCH` hands rows downstream while it is still enumerating, and re-enumerates its pattern once per input row. `CALL merge.relationship(n1, 'rt2', ...)` creates `rt2` edges behind it, and `rt2` matches the query's untyped `[r0]` between an `l6` source and an `l3` target - so the third `alias0` iteration read back three edges the query had itself just created. Six extra rows.

openCypher requires a query's reads to be unaffected by that query's own writes; Neo4j implements it by planting an `Eager` operator between a write and a read it conflicts with, and would return 474 here too.

### The fix

- **`EagerStep`** - the barrier. Reads its whole input before letting the first row through, so no enumeration is still open while a write adds entities it could match.
- **`CypherEagernessAnalyzer`** - decides where it goes. It accumulates the *shape* of everything read so far (the node labels and relationship types the MATCH patterns can match, plus the "matches anything" flags an unlabelled node pattern and an untyped relationship pattern raise) and weighs each `CREATE`, `MERGE`, write-procedure `CALL` and `FOREACH` body against it. A write procedure is opaque - `merge.relationship` takes its type as a runtime argument - so it conflicts with any read at all.

That comparison is the point, because what the barrier costs is memory. The common shapes keep streaming untouched:

| query | barrier? | why |
|---|---|---|
| `UNWIND range(1, 1000000) AS i CREATE (:Log {i: i})` | no | reads nothing |
| `MATCH (a)-[:KNOWS]->(b) CREATE (a)-[:SCORED]->(b)` | no | writes a type no pattern reads |
| `MATCH (a:A), (b:B) MERGE (a)-[:R]->(b)` | no | both endpoints are bound; no node is created |
| `MATCH (n:Person) CREATE (:Person {...})` | **yes** | the CREATE adds vertices of the very type being scanned |
| `MATCH ... CALL merge.relationship(...)` | **yes** | opaque write procedure |

Only a `WITH` that aggregates resets the read footprint - it is the one boundary that provably drains its input. A plain forwarding `WITH` leaves the enumerations behind it just as open as they were.

**Deletions are out of scope on purpose.** This is about entities appearing under a running enumeration, not disappearing from one. A DELETE can only take away rows a forward scan has usually already passed, it carries its own dangling-reference guard for the shapes where that is not true (#6491, #7023), and making `MATCH (n:Big) DETACH DELETE n` eager would hold every matched vertex in memory to buy nothing this issue can demonstrate.

`SimpleCypherStatement.anyWriteProcedureCall` is refactored to expose its per-call classification, so the planner and the read-only/HA-routing flag cannot disagree about the same statement.

## #7174 - `merge.relationship` merged the same pair twice

Found while working on the above: the reporter's graph ends with **three** `rt2` edges where two are correct, and the two defects are independent (this one reproduces with or without the barrier).

The vertex instances the row carries were loaded before the rows ahead of it applied their merges, and appending an edge rewrites the edge-list head pointer of *both* endpoints - out on the start, in on the end. Everything the procedure does reads those pointers: the existence check walked the start node's pre-append snapshot and concluded the edge was missing, and the append itself wrote a stale head back, which fails outright with `Edge list IN head of vertex ... changed by a concurrent transaction` once the match properties vary per row.

The `MERGE` clause on the identical rows was already correct - `MergeStep` re-reads its anchor by RID (#6461) - so that re-read moves into a shared `CypherVertexReload`, and `merge.relationship` applies it to the start node and the end node alike.

## Testing

- `CypherEagerWriteBarrierIssue7171Test` - the reporter's two queries verbatim (equal row counts, and equal to the pre-write pattern count), no row reporting an edge the query created, the same hazard through a plain `MERGE`, and `EXPLAIN` assertions that the barrier stays **off** the non-conflicting shapes. All 4 fail on `main`.
- `CypherMergeRelationshipStaleAnchorIssue7174Test` - one edge per pair however many rows reach it, a second run merging nothing new, distinct match properties still separating edges, and the `MERGE` clause as the control. 3 of 4 fail on `main` (the 4th is the control, already correct).
- Full engine unit suite: **14509 tests, 0 failures, 0 errors**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cypher query consistency when reads and writes are combined, preventing later reads from observing incomplete intermediate changes.
  - Fixed relationship merging to reliably use current vertex data, including repeated executions and concurrent updates.
  - Corrected behavior for empty `FOREACH` clauses, relationship patterns, and write operations so result counts and query outcomes remain accurate.
- **Reliability**
  - Added safeguards for refreshed, transient, missing, or concurrently deleted vertices.
  - Prevented redundant execution barriers while preserving correct query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->