### PR TITLE
fix(#7178): answer the pg_type type-resolver bootstrap the Arrow ADBC driver connects with

### DIFF
--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -718,15 +718,23 @@ public class PostgresCatalog {
     final List<PostgresType> types = PostgresTypeCatalog.types();
     final List<Row> rows = new ArrayList<>(types.size());
 
-    for (final PostgresType type : types) {
-      final Row row = new Row();
-      final Map<String, Object> columns = row.of("pg_type");
-      for (final String column : PostgresTypeCatalog.COLUMNS)
-        columns.put(column, PostgresTypeCatalog.columnValue(type, column));
-      rows.add(row.complete());
-    }
+    for (final PostgresType type : types)
+      rows.add(describeType(new Row(), type).complete());
 
     return rows;
+  }
+
+  /**
+   * Fills a row's {@code pg_type} columns with the given type's, which is the one place that decides what
+   * this catalog says a type is. Both callers need it to be the same answer: a client that enumerates
+   * pg_type and one that reads a column's type off a {@code pg_attribute} join must not be told two
+   * different things about the same OID.
+   */
+  private static Row describeType(final Row row, final PostgresType type) {
+    final Map<String, Object> columns = row.of("pg_type");
+    for (final String column : PostgresTypeCatalog.COLUMNS)
+      columns.put(column, PostgresTypeCatalog.columnValue(type, column));
+    return row;
   }
 
   private static Row schemaRow(final Context context) {
@@ -796,12 +804,7 @@ public class PostgresCatalog {
 
         // The type row a client joins pg_attribute to in order to name the column's type. It describes the
         // column's own type, which is the only reading of that join that makes sense.
-        final Map<String, Object> typeColumns = row.of("pg_type");
-        for (final String column : PostgresTypeCatalog.COLUMNS)
-          typeColumns.put(column, PostgresTypeCatalog.columnValue(pgType, column));
-        typeColumns.put("typnamespace", 11);
-
-        rows.add(row.complete());
+        rows.add(describeType(row, pgType).complete());
       }
     }
 

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -90,7 +90,7 @@ public class PostgresCatalog {
   static final int OWNER_OID = 10;
 
   /** A catalog query whose shape this class will not answer. The caller sends an empty result set. */
-  public static final Answer DECLINED = new Answer(new LinkedHashMap<>(), null);
+  public static final Answer DECLINED = new Answer(new LinkedHashMap<>(), null, false);
 
   /**
    * The emulated relations and the columns each one has. A column outside its relation's set makes the query
@@ -109,10 +109,20 @@ public class PostgresCatalog {
   public static class Answer {
     public final LinkedHashMap<String, PostgresType> columns;
     public final List<Map<String, Object>>           rows;
+    /**
+     * Whether these rows are a closed set a filter selects a real subset of, rather than everything the
+     * connection can see anyway. It travels with the answer so that a query reading it through a derived
+     * table applies the same strictness to its outer WHERE as the inner one did - without it, wrapping
+     * pg_type in a sub-select would reach the permissive default and reopen the "answers every type" hole
+     * the strictness exists to close.
+     */
+    final boolean filtersExactly;
 
-    private Answer(final LinkedHashMap<String, PostgresType> columns, final List<Map<String, Object>> rows) {
+    private Answer(final LinkedHashMap<String, PostgresType> columns, final List<Map<String, Object>> rows,
+        final boolean filtersExactly) {
       this.columns = columns;
       this.rows = rows;
+      this.filtersExactly = filtersExactly;
     }
   }
 
@@ -293,6 +303,10 @@ public class PostgresCatalog {
       if (inner == null || inner.rows == null)
         return inner == null ? null : DECLINED;
 
+      // The inner query decides how its own rows may be filtered, and the outer WHERE reads those same
+      // rows: a sub-select over pg_type must not become the way to get the permissive filter back.
+      toleratesUnreadableFilter = !inner.filtersExactly;
+
       final String name = from.get(0).alias == null ? "" : from.get(0).alias;
       rows = new ArrayList<>(inner.rows.size());
       for (final Map<String, Object> innerRow : inner.rows)
@@ -409,7 +423,12 @@ public class PostgresCatalog {
    * How specific a family is, when a query names relations belonging to more than one. TYPES stays at the
    * bottom on purpose: pg_type joined to pg_class or pg_attribute is a question about tables or columns that
    * happens to name the type of each, and answering it with one row per type instead of one row per column
-   * would change what every such query means. It wins only when nothing else in the FROM has a family.
+   * would change what every such query means.
+   * <p>
+   * So TYPES loses to every ranked family. Against the other rank-0 ones - ROLES, DATABASES, PRIVILEGES,
+   * CHARACTER_SETS, COLLATIONS - it does not lose, it ties, and the FROM order settles it. That is what this
+   * scheme happens to give rather than a considered answer; no client joins pg_type to pg_roles, and if one
+   * ever does it is the tie that needs deciding, not the ranking above it.
    */
   private static int rank(final Family family) {
     return switch (family) {
@@ -1029,7 +1048,7 @@ public class PostgresCatalog {
     if (statement.limit != null && result.size() > statement.limit)
       result = new ArrayList<>(result.subList(0, statement.limit));
 
-    return new Answer(columnsOf(projection, result), result);
+    return new Answer(columnsOf(projection, result), result, !toleratesUnreadableFilter);
   }
 
   /** An all-null row carrying every column the query's relations have, used to validate a projection. */

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -23,6 +23,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -283,6 +284,7 @@ public class PostgresCatalog {
 
     final Map<String, Collection<String>> columnsByRelation = new LinkedHashMap<>();
     final List<Row> rows;
+    boolean toleratesUnreadableFilter = true;
 
     if (from.size() == 1 && from.get(0).derived != null) {
       // A derived table: the inner SELECT is the catalog query and this one is a filter over its output. The
@@ -327,10 +329,68 @@ public class PostgresCatalog {
       if (family == null)
         return DECLINED;
 
+      if (readsOneRelationThroughTwoAliases(statement, from))
+        return DECLINED;
+
+      // The permissive-WHERE rule rests on every row being one of the user's own types in the one database
+      // this connection is bound to, so a predicate that cannot be read can only be excluding rows this
+      // catalog never produced. pg_type breaks that premise: its rows are a fixed set of built-in types, and
+      // a filter over them selects a real subset. Answering "every type" to "the type named hstore" is the
+      // fabricated system-catalog row this class exists to avoid - psycopg asks exactly that and fails with
+      // "found 23 different types named hstore" - so here an unreadable predicate declines instead.
+      toleratesUnreadableFilter = family != Family.TYPES;
+
       rows = buildRows(family, context);
     }
 
-    return project(statement, from, rows, context, columnsByRelation);
+    return project(statement, from, rows, context, columnsByRelation, toleratesUnreadableFilter);
+  }
+
+  /**
+   * Whether the query reads columns through two different aliases of the same relation, which is a shape this
+   * row model cannot represent: a {@link Row} carries one map per relation, so both aliases read the same map.
+   * The second alias would answer with the first one's values, and a projection naming a column through both
+   * would announce one column where the client asked for two - which is precisely the kind of miscount that
+   * makes a strict client (the Arrow ADBC driver among them) abort. So the query is declined instead, and the
+   * caller sends the empty result set that any unreadable catalog shape gets.
+   * <p>
+   * The self-join that matters in practice - {@code FROM pg_type t, pg_type e WHERE t.oid = N AND t.typelem =
+   * e.oid}, where the projected columns describe a different row from the one the filter selects - is
+   * answered by {@link PostgresTypeCatalog}, which runs first and recognises it as its own shape.
+   * <p>
+   * Only aliases the query actually <b>reads through</b> count. An alias that appears solely in a join
+   * condition does not, because those conditions are skipped rather than evaluated: the JDBC driver's
+   * {@code getColumns()} joins {@code pg_class} and {@code pg_namespace} a second time purely to look up a
+   * comment it then never projects, and declining that would take out the column list of every JDBC client.
+   */
+  private static boolean readsOneRelationThroughTwoAliases(final Statement statement, final List<FromEntry> from) {
+    final Map<String, String> aliasesByRelation = new HashMap<>();
+
+    for (final List<PostgresCatalogToken> clause : Arrays.asList(statement.projection, statement.where,
+        statement.orderBy)) {
+      if (clause == null)
+        continue;
+
+      for (int i = 0; i + 1 < clause.size(); i++) {
+        final PostgresCatalogToken token = clause.get(i);
+        if (token.type != PostgresCatalogToken.Type.IDENTIFIER
+            && token.type != PostgresCatalogToken.Type.QUOTED_IDENTIFIER)
+          continue;
+        if (!clause.get(i + 1).isSymbol("."))
+          continue;
+
+        final String qualifier = token.text.toLowerCase(Locale.ENGLISH);
+        final FromEntry entry = entryFor(from, qualifier);
+        if (entry == null || entry.derived != null)
+          continue;
+
+        final String previous = aliasesByRelation.putIfAbsent(entry.relation, qualifier);
+        if (previous != null && !previous.equals(qualifier))
+          return true;
+      }
+    }
+
+    return false;
   }
 
   private static Family mostSpecific(final Family current, final Family candidate) {
@@ -893,7 +953,8 @@ public class PostgresCatalog {
   // ---------------------------------------------------------------- projection
 
   private static Answer project(final Statement statement, final List<FromEntry> from, final List<Row> rows,
-      final Context context, final Map<String, Collection<String>> columnsByRelation) {
+      final Context context, final Map<String, Collection<String>> columnsByRelation,
+      final boolean toleratesUnreadableFilter) {
     final List<ProjectionItem> projection = parseProjection(statement.projection, from, columnsByRelation);
     if (projection == null)
       return DECLINED;
@@ -904,9 +965,18 @@ public class PostgresCatalog {
         PostgresCatalogExpression.parse(statement.where);
 
     final List<Row> surviving = new ArrayList<>(rows.size());
-    for (final Row row : rows)
-      if (where == null || PostgresCatalogExpression.isTrue(where.evaluate(new RowResolver(row, from, context, null, 0))))
+    for (final Row row : rows) {
+      if (where == null) {
         surviving.add(row);
+        continue;
+      }
+
+      final Object matches = where.evaluate(new RowResolver(row, from, context, null, 0));
+      if (matches == PostgresCatalogExpression.UNKNOWN && !toleratesUnreadableFilter)
+        return DECLINED;
+      if (PostgresCatalogExpression.isTrue(matches))
+        surviving.add(row);
+    }
 
     // Window functions are the one thing that cannot be computed a row at a time: row_number() is defined by
     // the other rows of its partition. They are computed here, over the rows that survived the filter.

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -114,7 +114,7 @@ public class PostgresCatalog {
 
   /** The families of rows a catalog query can be about. */
   private enum Family {
-    SCHEMAS, TABLES, COLUMNS, DATABASES, ROLES, PRIVILEGES, CHARACTER_SETS, COLLATIONS, VIEWS
+    SCHEMAS, TABLES, COLUMNS, DATABASES, ROLES, PRIVILEGES, CHARACTER_SETS, COLLATIONS, VIEWS, TYPES
   }
 
   private static void relation(final String name, final Family family, final String... columns) {
@@ -168,14 +168,20 @@ public class PostgresCatalog {
     relation("information_schema.views", Family.VIEWS, "table_catalog", "table_schema", "table_name", "view_definition",
         "check_option", "is_updatable", "is_insertable_into");
 
+    // pg_type is both: on its own it is a query about the types this protocol can produce (issue #7178), and
+    // joined to pg_attribute it decorates a column row with that column's type. Which of the two a query is
+    // about is decided by rank(): TYPES never outranks anything, so it only wins when nothing else is named.
+    relation("pg_type", Family.TYPES, "oid", "typname", "typnamespace", "typowner", "typlen", "typbyval", "typtype",
+        "typcategory", "typispreferred", "typisdefined", "typdelim", "typrelid", "typelem", "typarray", "typinput",
+        "typoutput", "typreceive", "typsend", "typmodin", "typmodout", "typanalyze", "typsubscript", "typalign",
+        "typstorage", "typbasetype", "typtypmod", "typnotnull", "typndims", "typcollation", "typdefaultbin",
+        "typdefault", "typacl");
+
     // Decorating relations: they never decide the family, they only contribute columns to a row. Every one of
     // them is something ArcadeDB has no equivalent of, so their columns are all NULL - which is exactly what a
     // LEFT JOIN against them yields in PostgreSQL when there is no comment, no default and no inheritance.
     relation("pg_description", null, "objoid", "classoid", "objsubid", "description");
     relation("pg_attrdef", null, "oid", "adrelid", "adnum", "adbin", "adsrc");
-    relation("pg_type", null, "oid", "typname", "typnamespace", "typowner", "typlen", "typbyval", "typtype",
-        "typcategory", "typispreferred", "typisdefined", "typdelim", "typrelid", "typelem", "typarray", "typinput",
-        "typoutput", "typbasetype", "typtypmod", "typnotnull", "typndims", "typcollation", "typdefault");
     relation("pg_collation", null, "oid", "collname", "collnamespace", "collowner", "collprovider", "collcollate",
         "collctype");
   }
@@ -336,6 +342,12 @@ public class PostgresCatalog {
     return current;
   }
 
+  /**
+   * How specific a family is, when a query names relations belonging to more than one. TYPES stays at the
+   * bottom on purpose: pg_type joined to pg_class or pg_attribute is a question about tables or columns that
+   * happens to name the type of each, and answering it with one row per type instead of one row per column
+   * would change what every such query means. It wins only when nothing else in the FROM has a family.
+   */
   private static int rank(final Family family) {
     return switch (family) {
       case SCHEMAS -> 1;
@@ -682,9 +694,36 @@ public class PostgresCatalog {
       case PRIVILEGES -> List.of(privilegeRow(context).complete());
       case CHARACTER_SETS -> List.of(characterSetRow(context).complete());
       case COLLATIONS -> List.of(collationRow(context).complete());
+      case TYPES -> typeRows();
       // ArcadeDB has no relation that a PostgreSQL client would render as a view.
       case VIEWS -> List.of();
     };
+  }
+
+  /**
+   * One row per type this protocol can produce, which is the only set of types it can honestly describe. The
+   * values come from {@link PostgresTypeCatalog}, so a client reading pg_type through the generic catalog is
+   * told exactly what {@code SELECT ... FROM pg_type} tells it through the recogniser that runs first.
+   * <p>
+   * This is what makes the Apache Arrow ADBC driver able to connect (issue #7178). Its type-resolver
+   * bootstrap - {@code SELECT oid, typname, typreceive, typbasetype, typrelid, typarray FROM pg_catalog.pg_type
+   * WHERE (typreceive != 0 OR typsend != 0) AND typtype != 'r' AND typreceive::TEXT != 'array_recv'} - is a
+   * shape no regular expression should be asked to read, and the driver rejects the connection outright when
+   * the answer has no columns rather than falling back to anything.
+   */
+  private static List<Row> typeRows() {
+    final PostgresType[] types = PostgresTypeCatalog.types();
+    final List<Row> rows = new ArrayList<>(types.length);
+
+    for (final PostgresType type : types) {
+      final Row row = new Row();
+      final Map<String, Object> columns = row.of("pg_type");
+      for (final String column : PostgresTypeCatalog.COLUMNS)
+        columns.put(column, PostgresTypeCatalog.columnValue(type, column));
+      rows.add(row.complete());
+    }
+
+    return rows;
   }
 
   private static Row schemaRow(final Context context) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -82,8 +82,11 @@ public class PostgresCatalog {
   /** PostgreSQL's own first user OID: everything below it is a system object. */
   private static final int FIRST_USER_OID = 16384;
   private static final int OID_SPACE      = 1_000_000;
-  /** The OID of the bootstrap superuser in a stock PostgreSQL, used for every "owner" column. */
-  private static final int OWNER_OID      = 10;
+  /**
+   * The OID of the bootstrap superuser in a stock PostgreSQL, used for every "owner" column - here and in
+   * {@link PostgresTypeCatalog}'s {@code typowner}, so the two surfaces cannot drift apart on who owns what.
+   */
+  static final int OWNER_OID = 10;
 
   /** A catalog query whose shape this class will not answer. The caller sends an empty result set. */
   public static final Answer DECLINED = new Answer(new LinkedHashMap<>(), null);
@@ -712,8 +715,8 @@ public class PostgresCatalog {
    * the answer has no columns rather than falling back to anything.
    */
   private static List<Row> typeRows() {
-    final PostgresType[] types = PostgresTypeCatalog.types();
-    final List<Row> rows = new ArrayList<>(types.length);
+    final List<PostgresType> types = PostgresTypeCatalog.types();
+    final List<Row> rows = new ArrayList<>(types.size());
 
     for (final PostgresType type : types) {
       final Row row = new Row();

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
@@ -401,6 +401,14 @@ abstract class PostgresCatalogExpression {
       return operator.startsWith("NOT") != matches;
     }
 
+    /**
+     * Compares two values the way a catalog predicate needs them compared. Mixed types fall back to comparing
+     * their text, which is what lets a client that writes {@code typreceive != 0} against a column this
+     * catalog answers with a function <i>name</i> still get the answer it expects: PostgreSQL's own column is
+     * a {@code regproc}, an OID that formats as that name, and no name ever reads as {@code 0}. That is a
+     * property of the text comparison rather than a modelled regproc - an ordering test on such a column
+     * ({@code typreceive > 0}) would compare names against "0" and answer something the client did not mean.
+     */
     private static Object compare(final String operator, final Object l, final Object r) {
       if (l == null || r == null)
         return null;

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
@@ -68,6 +68,12 @@ public class PostgresTypeCatalog {
       "typbyval", "typispreferred", "typisdefined", "typalign", "typstorage", "typtypmod", "typndims",//
       "typcollation", "typdefault");
 
+  /**
+   * pg_collation's {@code default} entry, whose OID PostgreSQL fixes at 100. It is what pg_type.typcollation
+   * holds for every collation-sensitive built-in type.
+   */
+  static final int DEFAULT_COLLATION_OID = 100;
+
   /** {@code SELECT <projection> FROM [pg_catalog.]pg_type [alias] [WHERE <filter>]} and nothing more. */
   private static final Pattern QUERY = Pattern.compile(
       "^SELECT\\s+(.+?)\\s+FROM\\s+(?:PG_CATALOG\\s*\\.\\s*)?PG_TYPE(?:\\s+(?:AS\\s+)?[A-Za-z_][A-Za-z0-9_$]*)?"
@@ -392,7 +398,7 @@ public class PostgresTypeCatalog {
   }
 
   /**
-   * pg_type.typcollation: 100, the OID of the default collation, for the types whose comparison is
+   * pg_type.typcollation: {@link #DEFAULT_COLLATION_OID} for the types whose comparison is
    * collation-sensitive; 0 for every other, which is what PostgreSQL stores.
    * <p>
    * An array of a collatable element is itself collatable. PostgreSQL declares no {@code BKI_ARRAY_DEFAULT}
@@ -405,7 +411,7 @@ public class PostgresTypeCatalog {
       return element == null ? 0 : collation(element);
     }
     return switch (type) {
-      case VARCHAR, TEXT, BPCHAR -> 100;
+      case VARCHAR, TEXT, BPCHAR -> DEFAULT_COLLATION_OID;
       default -> 0;
     };
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
@@ -63,7 +63,9 @@ public class PostgresTypeCatalog {
    */
   static final List<String> COLUMNS = List.of(//
       "oid", "typname", "typelem", "typarray", "typdelim", "typtype", "typcategory", "typlen", "typinput",//
-      "typnotnull", "typbasetype", "typnamespace", "typrelid");
+      "typoutput", "typreceive", "typsend", "typnotnull", "typbasetype", "typnamespace", "typrelid", "typowner",//
+      "typbyval", "typispreferred", "typisdefined", "typalign", "typstorage", "typtypmod", "typndims",//
+      "typcollation", "typdefault");
 
   /** {@code SELECT <projection> FROM [pg_catalog.]pg_type [alias] [WHERE <filter>]} and nothing more. */
   private static final Pattern QUERY = Pattern.compile(
@@ -108,6 +110,14 @@ public class PostgresTypeCatalog {
       .toArray(PostgresType[]::new);
 
   private PostgresTypeCatalog() {
+  }
+
+  /**
+   * Every type this protocol can produce, in OID order. {@link PostgresCatalog} enumerates pg_type from here
+   * rather than sorting {@code PostgresType.values()} again, so that both surfaces answer in the same order.
+   */
+  static PostgresType[] types() {
+    return TYPES_BY_OID;
   }
 
   /**
@@ -284,29 +294,89 @@ public class PostgresTypeCatalog {
       case "typtype" -> "b";           // base type: none of these is a composite, a domain or an enum
       case "typcategory" -> category(type);
       case "typlen" -> type.size;
-      case "typinput" -> inputFunction(type);
+      case "typinput" -> ioFunction(type, "in");
+      case "typoutput" -> ioFunction(type, "out");
+      case "typreceive" -> ioFunction(type, "recv");
+      case "typsend" -> ioFunction(type, "send");
       case "typnotnull" -> Boolean.FALSE;
       case "typbasetype" -> 0;         // not a domain, so no base type
       case "typnamespace" -> 11;       // pg_catalog, whose OID is fixed at 11 in PostgreSQL
       case "typrelid" -> 0;            // not a composite, so no backing relation
+      case "typowner" -> 10;           // the bootstrap superuser, which owns every built-in type
+      case "typbyval" -> type.size > 0 && type.size <= 8;
+      case "typispreferred" -> preferred(type);
+      case "typisdefined" -> Boolean.TRUE;
+      case "typalign" -> align(type);
+      case "typstorage" -> storage(type);
+      case "typtypmod" -> -1;          // not a domain, so no modifier of its own
+      case "typndims" -> 0;            // not a domain over an array
+      case "typcollation" -> collation(type);
+      case "typdefault" -> null;       // no built-in type has one
       default -> null;
     };
   }
 
   /**
-   * pg_type.typinput, the name of the C function PostgreSQL parses the type's text representation with.
-   * Spelled out rather than synthesised from the type name, because PostgreSQL is not consistent about it:
-   * most are {@code <name>in}, but the temporal types, json and numeric take an underscore.
+   * The name of the C function PostgreSQL converts the type with: {@code typinput}/{@code typoutput} for its
+   * text representation, {@code typreceive}/{@code typsend} for its binary one. Spelled out rather than
+   * synthesised from the type name alone, because PostgreSQL is not consistent about it: most are
+   * {@code <name><suffix>}, but the temporal types, json and numeric take an underscore.
+   * <p>
+   * The receive function is what the Apache Arrow ADBC driver reads to decide how to decode a column, so it
+   * has to be PostgreSQL's own name and not something plausible: a name the driver does not know leaves the
+   * type out of its resolver, and every column of that type then fails to bind.
    */
-  private static String inputFunction(final PostgresType type) {
+  private static String ioFunction(final PostgresType type, final String suffix) {
     if (type.isArrayType())
-      return "array_in";
+      return "array_" + suffix;
     return switch (type) {
-      case DATE -> "date_in";
-      case TIMESTAMP -> "timestamp_in";
-      case JSON -> "json_in";
-      case NUMERIC -> "numeric_in";
-      default -> type.typeName + "in";
+      case DATE, TIMESTAMP, JSON, NUMERIC -> type.typeName + "_" + suffix;
+      default -> type.typeName + suffix;
+    };
+  }
+
+  /**
+   * pg_type.typispreferred: within a category, the type PostgreSQL casts towards when it has a choice. Only
+   * one member of each category carries it.
+   */
+  private static Boolean preferred(final PostgresType type) {
+    return switch (type) {
+      case DOUBLE, TEXT, BOOLEAN, TIMESTAMP -> Boolean.TRUE;
+      default -> Boolean.FALSE;
+    };
+  }
+
+  /**
+   * pg_type.typstorage: {@code p} for a fixed-width type, which is stored plain; {@code x} for a varlena one,
+   * which TOAST may compress and move out of line; {@code m} for numeric, the one variable-width type
+   * PostgreSQL keeps in the main table and only compresses.
+   */
+  private static String storage(final PostgresType type) {
+    if (type == PostgresType.NUMERIC)
+      return "m";
+    return type.size > 0 ? "p" : "x";
+  }
+
+  /** pg_type.typalign: the storage alignment PostgreSQL gives the type, from its width. */
+  private static String align(final PostgresType type) {
+    if (type.isArrayType())
+      return "i";
+    return switch (type.size) {
+      case 1 -> "c";
+      case 2 -> "s";
+      case 8 -> "d";
+      default -> "i";
+    };
+  }
+
+  /**
+   * pg_type.typcollation: 100, the OID of the default collation, for the types whose comparison is
+   * collation-sensitive; 0 for every other, which is what PostgreSQL stores.
+   */
+  private static int collation(final PostgresType type) {
+    return switch (type) {
+      case VARCHAR, TEXT, BPCHAR, ARRAY_TEXT -> 100;
+      default -> 0;
     };
   }
 

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Answers the {@code pg_type} queries a PostgreSQL client makes to find out what the OIDs it was handed in
@@ -103,11 +104,13 @@ public class PostgresTypeCatalog {
 
   /**
    * The types in OID order, so that an enumeration is stable across runs and across JVMs - a client that
-   * caches the answer must not see it reshuffle.
+   * caches the answer must not see it reshuffle. Immutable, because {@link #types()} hands it out: every
+   * enumeration and every by-name lookup here reads this order, so one in-place sort by a caller would
+   * quietly reshuffle all of them.
    */
-  private static final PostgresType[] TYPES_BY_OID = Arrays.stream(PostgresType.values())
+  private static final List<PostgresType> TYPES_BY_OID = Arrays.stream(PostgresType.values())
       .sorted(Comparator.comparingInt(t -> t.code))
-      .toArray(PostgresType[]::new);
+      .collect(Collectors.toUnmodifiableList());
 
   private PostgresTypeCatalog() {
   }
@@ -116,7 +119,7 @@ public class PostgresTypeCatalog {
    * Every type this protocol can produce, in OID order. {@link PostgresCatalog} enumerates pg_type from here
    * rather than sorting {@code PostgresType.values()} again, so that both surfaces answer in the same order.
    */
-  static PostgresType[] types() {
+  static List<PostgresType> types() {
     return TYPES_BY_OID;
   }
 
@@ -261,7 +264,7 @@ public class PostgresTypeCatalog {
    */
   private static List<PostgresType> select(final String filter) {
     if (filter == null)
-      return List.of(TYPES_BY_OID);
+      return TYPES_BY_OID;
 
     final String trimmed = filter.trim();
 
@@ -302,7 +305,7 @@ public class PostgresTypeCatalog {
       case "typbasetype" -> 0;         // not a domain, so no base type
       case "typnamespace" -> 11;       // pg_catalog, whose OID is fixed at 11 in PostgreSQL
       case "typrelid" -> 0;            // not a composite, so no backing relation
-      case "typowner" -> 10;           // the bootstrap superuser, which owns every built-in type
+      case "typowner" -> PostgresCatalog.OWNER_OID; // the bootstrap superuser owns every built-in type
       case "typbyval" -> type.size > 0 && type.size <= 8;
       case "typispreferred" -> preferred(type);
       case "typisdefined" -> Boolean.TRUE;
@@ -357,10 +360,17 @@ public class PostgresTypeCatalog {
     return type.size > 0 ? "p" : "x";
   }
 
-  /** pg_type.typalign: the storage alignment PostgreSQL gives the type, from its width. */
+  /**
+   * pg_type.typalign: the storage alignment PostgreSQL gives the type, from its width. An array takes INT
+   * alignment unless its element needs DOUBLE, which is the rule PostgreSQL's own catalog generator applies
+   * ({@code Catalog.pm}, {@code GenerateArrayTypes}) - so {@code _int8} and {@code _float8} are {@code d}
+   * while every other array is {@code i}.
+   */
   private static String align(final PostgresType type) {
-    if (type.isArrayType())
-      return "i";
+    if (type.isArrayType()) {
+      final PostgresType element = PostgresType.byCode(type.elementCode);
+      return element != null && "d".equals(align(element)) ? "d" : "i";
+    }
     return switch (type.size) {
       case 1 -> "c";
       case 2 -> "s";
@@ -372,10 +382,18 @@ public class PostgresTypeCatalog {
   /**
    * pg_type.typcollation: 100, the OID of the default collation, for the types whose comparison is
    * collation-sensitive; 0 for every other, which is what PostgreSQL stores.
+   * <p>
+   * An array of a collatable element is itself collatable. PostgreSQL declares no {@code BKI_ARRAY_DEFAULT}
+   * for this column, so an auto-generated array type copies its element's value verbatim - which is why
+   * {@code _text} carries 100 and not 0, exactly as {@code text} does.
    */
   private static int collation(final PostgresType type) {
+    if (type.isArrayType()) {
+      final PostgresType element = PostgresType.byCode(type.elementCode);
+      return element == null ? 0 : collation(element);
+    }
     return switch (type) {
-      case VARCHAR, TEXT, BPCHAR, ARRAY_TEXT -> 100;
+      case VARCHAR, TEXT, BPCHAR -> 100;
       default -> 0;
     };
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
@@ -328,6 +328,13 @@ public class PostgresTypeCatalog {
    * The receive function is what the Apache Arrow ADBC driver reads to decide how to decode a column, so it
    * has to be PostgreSQL's own name and not something plausible: a name the driver does not know leaves the
    * type out of its resolver, and every column of that type then fails to bind.
+   * <p>
+   * These four columns are {@code regproc} in PostgreSQL, which is an OID that formats as the function's
+   * name. Clients exploit both readings at once - the ADBC bootstrap filters on {@code typreceive != 0}
+   * (the OID) and projects the same column to read the name - and this catalog can only answer with the
+   * name. That still gives the right answer for the filter, because a name never compares equal to
+   * {@code 0}, but it is an accident of the comparison rather than a modelled regproc: a client that
+   * expected an actual OID here, or wrote {@code typreceive > 0}, would not be served correctly.
    */
   private static String ioFunction(final PostgresType type, final String suffix) {
     if (type.isArrayType())
@@ -341,6 +348,11 @@ public class PostgresTypeCatalog {
   /**
    * pg_type.typispreferred: within a category, the type PostgreSQL casts towards when it has a choice. Only
    * one member of each category carries it.
+   * <p>
+   * Category D is an approximation: PostgreSQL's preferred date/time type is {@code timestamptz}, which this
+   * protocol does not produce, so {@code timestamp} is the closest of the two it does have. It is the right
+   * answer for choosing between {@code date} and {@code timestamp}, which is the only choice a client can
+   * face here, but it is not what a stock server would report.
    */
   private static Boolean preferred(final PostgresType type) {
     return switch (type) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7178ArrowAdbcBootstrapIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7178ArrowAdbcBootstrapIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7178, reported in discussion #6888: the Apache Arrow native PostgreSQL ADBC
+ * driver cannot connect to ArcadeDB, failing with
+ * {@code Expected 5 or 6 columns from type resolver pg_type query but got 0}.
+ * <p>
+ * The driver's {@code PostgresDatabase::RebuildTypeResolver} runs three queries before it hands the caller
+ * a connection, and it validates the <i>shape</i> of each answer rather than its content - zero rows are
+ * fine, zero columns are fatal:
+ * <ol>
+ * <li>{@code SELECT version();} - exactly one row and one column;</li>
+ * <li>{@code SELECT attrelid, attname, atttypid FROM pg_catalog.pg_attribute ORDER BY attrelid, attnum} -
+ * exactly three columns;</li>
+ * <li>{@code SELECT oid, typname, typreceive, typbasetype, typrelid, typarray FROM pg_catalog.pg_type WHERE
+ * (typreceive != 0 OR typsend != 0) AND typtype != 'r' AND typreceive::TEXT != 'array_recv'} - five or six
+ * columns.</li>
+ * </ol>
+ * The third one is the one that was declined: {@link PostgresTypeCatalog} knew neither {@code typreceive}
+ * nor {@code typsend}, and its WHERE clause parser accepted only a single {@code oid = N} or
+ * {@code typname = '...'} equality; {@link PostgresCatalog} then declined it too, because {@code pg_type}
+ * was registered there only as a relation that decorates a {@code pg_attribute} join and never as one a
+ * query could be about. The query fell through to the empty-result fallback, which announces a
+ * RowDescription with no fields at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7178ArrowAdbcBootstrapIT extends PostgresWireProtocolTestBase {
+
+  /** Verbatim from arrow-adbc {@code c/driver/postgresql/database.cc}, {@code RebuildTypeResolver}. */
+  private static final String ADBC_PG_TYPE_QUERY = //
+      "SELECT oid, typname, typreceive, typbasetype, typrelid, typarray FROM "
+          + "pg_catalog.pg_type WHERE (typreceive != 0 OR typsend != 0) AND typtype != 'r' AND "
+          + "typreceive::TEXT != 'array_recv'";
+
+  /** Verbatim from the same function, {@code kColumnsQuery}. */
+  private static final String ADBC_PG_ATTRIBUTE_QUERY = //
+      "SELECT attrelid, attname, atttypid FROM pg_catalog.pg_attribute ORDER BY attrelid, attnum";
+
+  @Test
+  void theArrowAdbcTypeResolverQueryAnswersWithSixColumns() throws Exception {
+    try (final Connection connection = openJdbcConnection();
+        final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement.executeQuery(ADBC_PG_TYPE_QUERY)) {
+
+      final ResultSetMetaData metaData = resultSet.getMetaData();
+      assertThat(metaData.getColumnCount())
+          .as("the ADBC driver rejects anything but 5 or 6 columns from its pg_type bootstrap")
+          .isEqualTo(6);
+      assertThat(metaData.getColumnName(1)).isEqualTo("oid");
+      assertThat(metaData.getColumnName(2)).isEqualTo("typname");
+      assertThat(metaData.getColumnName(3)).isEqualTo("typreceive");
+      assertThat(metaData.getColumnName(4)).isEqualTo("typbasetype");
+      assertThat(metaData.getColumnName(5)).isEqualTo("typrelid");
+      assertThat(metaData.getColumnName(6)).isEqualTo("typarray");
+
+      final Map<Integer, String[]> byOid = new HashMap<>();
+      while (resultSet.next())
+        byOid.put(resultSet.getInt("oid"), new String[] { resultSet.getString("typname"),
+            resultSet.getString("typreceive"), resultSet.getString("typarray") });
+
+      assertThat(byOid).as("an empty catalog leaves the resolver unable to name any column's type").isNotEmpty();
+
+      // int4: the driver reads typreceive to pick a decoder, so it has to be the real receive function.
+      assertThat(byOid.get(23)).as("int4").isNotNull();
+      assertThat(byOid.get(23)[0]).isEqualTo("int4");
+      assertThat(byOid.get(23)[1]).isEqualTo("int4recv");
+      assertThat(byOid.get(23)[2]).as("int4's typarray, from which the driver synthesises _int4").isEqualTo("1007");
+
+      assertThat(byOid.get(25)[1]).as("text").isEqualTo("textrecv");
+      assertThat(byOid.get(16)[1]).as("bool").isEqualTo("boolrecv");
+      assertThat(byOid.get(1114)[1]).as("timestamp").isEqualTo("timestamp_recv");
+
+      assertThat(byOid)
+          .as("typreceive::TEXT != 'array_recv' excludes the array types: the driver derives them from typarray")
+          .doesNotContainKey(1007);
+    }
+  }
+
+  @Test
+  void theArrowAdbcPgAttributeQueryAnswersWithThreeColumns() throws Exception {
+    try (final Connection connection = openJdbcConnection();
+        final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement.executeQuery(ADBC_PG_ATTRIBUTE_QUERY)) {
+
+      assertThat(resultSet.getMetaData().getColumnCount())
+          .as("the ADBC driver rejects anything but 3 columns from its pg_attribute bootstrap")
+          .isEqualTo(3);
+    }
+  }
+
+  @Test
+  void theArrowAdbcVersionQueryAnswersWithOneRowAndOneColumn() throws Exception {
+    try (final Connection connection = openJdbcConnection();
+        final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement.executeQuery("SELECT version();")) {
+
+      assertThat(resultSet.getMetaData().getColumnCount()).isEqualTo(1);
+      assertThat(resultSet.next()).isTrue();
+      assertThat(resultSet.getString(1)).startsWith("PostgreSQL ");
+      assertThat(resultSet.next()).as("exactly one row").isFalse();
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    properties.setProperty("preferQueryMode", "simple");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7178ArrowAdbcBootstrapIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7178ArrowAdbcBootstrapIT.java
@@ -133,6 +133,32 @@ class Issue7178ArrowAdbcBootstrapIT extends PostgresWireProtocolTestBase {
     }
   }
 
+  @Test
+  void aPgTypeColumnThisCatalogDoesNotModelAnswersNullRatherThanNothing() throws Exception {
+    // The two recognisers disagree about this shape on purpose, and only the end-to-end answer settles it.
+    // PostgresTypeCatalog declines a projection naming a column it cannot value, which used to end the
+    // query with an empty result set because pg_type had no family in PostgresCatalog either. Now it falls
+    // through to the generic catalog, where an unmodelled column of a modelled relation answers NULL - the
+    // same treatment pg_class and pg_attribute have always given one. A client that asks for typacl gets
+    // the rest of its row instead of being told the whole query matched nothing.
+    try (final Connection connection = openJdbcConnection();
+        final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement.executeQuery("SELECT oid, typname, typacl FROM pg_catalog.pg_type")) {
+
+      assertThat(resultSet.getMetaData().getColumnCount()).isEqualTo(3);
+
+      int rows = 0;
+      while (resultSet.next()) {
+        ++rows;
+        assertThat(resultSet.getInt("oid")).isPositive();
+        assertThat(resultSet.getString("typname")).isNotBlank();
+        assertThat(resultSet.getString("typacl")).as("no built-in type carries an ACL").isNull();
+      }
+
+      assertThat(rows).as("an unmodelled column must not empty the result set").isPositive();
+    }
+  }
+
   private Connection openJdbcConnection() throws Exception {
     Class.forName("org.postgresql.Driver");
     final Properties properties = new Properties();

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -518,6 +518,73 @@ class PostgresCatalogTest {
     assertThat(names(answer.rows, "typtype")).containsOnly("b");
   }
 
+  @Test
+  void aPgTypeFilterThisCatalogCannotReadDeclinesRatherThanAnsweringEveryType() {
+    // psycopg looks a type up by name to decide whether the server has it, and casts to ::regtype to do so.
+    // The permissive-WHERE rule - an unreadable predicate does not get to remove rows - is right for every
+    // other relation here, because their rows are the user's own types and such a predicate can only be
+    // excluding rows this catalog never produced. pg_type is a fixed set of built-in types where a filter
+    // selects a real subset, so keeping every row answers "all 23 types" to "the one named hstore", and
+    // psycopg fails outright with "found 23 different types named hstore" rather than concluding it is
+    // absent. An unanswerable filter over pg_type has to decline.
+    assertThat(resolveRaw(PSYCOPG_TYPE_LOOKUP)).isSameAs(PostgresCatalog.DECLINED);
+  }
+
+  /**
+   * psycopg's {@code TypeInfo.fetch}, verbatim from {@code psycopg/_typeinfo.py}, with its {@code %(name)s}
+   * parameter bound. {@code to_regtype()} is a function this catalog does not implement, so the whole
+   * predicate evaluates to UNKNOWN - which is exactly the case the permissive-WHERE rule used to wave
+   * through, and pg_type is the one relation where waving it through fabricates an answer.
+   */
+  private static final String PSYCOPG_TYPE_LOOKUP =
+      "SELECT typname AS name, oid, typarray AS array_oid, oid::regtype::text AS regtype, typdelim AS delimiter "
+          + "FROM pg_type t WHERE t.oid = to_regtype('hstore'::text) ORDER BY t.oid";
+
+  @Test
+  void aPgTypeFilterThisCatalogCanReadStillSelectsASubset() {
+    // Declining an unreadable filter must not become declining every filter: the readable ones still work,
+    // and a name this protocol does not produce correctly answers no rows rather than being declined.
+    assertThat(names(resolve("SELECT oid, typname FROM pg_type WHERE typname = 'hstore'").rows, "typname"))
+        .as("a type this protocol cannot produce is absent, not unanswerable").isEmpty();
+    assertThat(names(resolve("SELECT oid, typname FROM pg_type WHERE typname = 'int4'").rows, "typname"))
+        .containsExactly("int4");
+  }
+
+  @Test
+  void readingOneRelationThroughTwoAliasesIsDeclined() {
+    // Every Row carries one map per relation, so two aliases of the same relation read the same map. The
+    // second would answer with the first's values, and a projection naming a column through both announces
+    // one column where the client asked for two - a miscount that makes a strict client abort. There is no
+    // honest answer, so the query is declined rather than guessed at.
+    assertThat(resolveRaw("SELECT t.typname, e.typname FROM pg_type t, pg_type e WHERE t.typelem = e.oid"))
+        .isSameAs(PostgresCatalog.DECLINED);
+    assertThat(resolveRaw("SELECT a.relname, b.relname FROM pg_class a, pg_class b WHERE a.oid = b.oid"))
+        .isSameAs(PostgresCatalog.DECLINED);
+  }
+
+  @Test
+  void theDriverSelfJoinIsStillAnsweredByTheTypeCatalog() {
+    // The one self-join that matters is recognised by PostgresTypeCatalog, which runs before this class, so
+    // declining the shape here does not take it away: the projected columns describe the element type of the
+    // array the filter names, which is what the client's join asks for.
+    final List<Map<String, Object>> rows = PostgresTypeCatalog
+        .resolve("SELECT e.typdelim, e.typname FROM pg_type t, pg_type e WHERE t.oid = 1009 AND t.typelem = e.oid");
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0)).containsEntry("typname", "text").containsEntry("typdelim", ",");
+  }
+
+  @Test
+  void aSecondAliasUsedOnlyInAJoinConditionDoesNotDeclineTheQuery() {
+    // The driver's getColumns() joins pg_class and pg_namespace a second time purely to look up a comment it
+    // never projects. Those aliases live only in ON conditions, which are skipped rather than evaluated, so
+    // they must not count as reading the relation twice - declining here would take out the column list of
+    // every JDBC client.
+    final PostgresCatalog.Answer answer = resolve(JDBC_GET_COLUMNS, "Article", "%");
+
+    assertThat(names(answer.rows, "attname")).containsExactly("id", "title");
+  }
+
   // ---------------------------------------------------------------- helpers
 
   private PostgresCatalog.Answer resolve(final String query, final Object... parameters) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -459,6 +459,65 @@ class PostgresCatalogTest {
     assertThat(answer.columns.keySet()).containsExactly("relname", "current_database", "?column?");
   }
 
+  // ---------------------------------------------------------------- pg_type as a relation of its own
+
+  /**
+   * The Apache Arrow ADBC driver's type-resolver bootstrap, verbatim from arrow-adbc
+   * {@code c/driver/postgresql/database.cc}. Its WHERE clause is a conjunction of three inequalities, one of
+   * them behind a cast and one of them parenthesised - which is why answering it belongs to the expression
+   * evaluator rather than to {@link PostgresTypeCatalog}'s single-equality patterns (issue #7178).
+   */
+  private static final String ADBC_TYPE_RESOLVER_QUERY =
+      "SELECT oid, typname, typreceive, typbasetype, typrelid, typarray FROM "
+          + "pg_catalog.pg_type WHERE (typreceive != 0 OR typsend != 0) AND typtype != 'r' AND "
+          + "typreceive::TEXT != 'array_recv'";
+
+  @Test
+  void theArrowAdbcTypeResolverQueryIsAnswered() {
+    final PostgresCatalog.Answer answer = resolve(ADBC_TYPE_RESOLVER_QUERY);
+
+    assertThat(answer.columns.keySet())
+        .as("the driver validates the column count before it looks at a single row")
+        .containsExactly("oid", "typname", "typreceive", "typbasetype", "typrelid", "typarray");
+    assertThat(answer.rows).isNotEmpty();
+
+    assertThat(names(answer.rows, "typname")).contains("int4", "text", "bool", "timestamp", "numeric")
+        .as("typreceive::TEXT != 'array_recv' filters the array types out").doesNotContain("_int4", "_text");
+
+    final Map<String, Object> int4 = answer.rows.stream().filter(row -> "int4".equals(row.get("typname")))
+        .findFirst().orElseThrow();
+    assertThat(int4.get("oid")).isEqualTo(PostgresType.INTEGER.code);
+    assertThat(int4.get("typreceive")).isEqualTo("int4recv");
+    assertThat(int4.get("typarray")).isEqualTo(PostgresType.ARRAY_INT.code);
+    assertThat(int4.get("typbasetype")).isEqualTo(0);
+    assertThat(int4.get("typrelid")).isEqualTo(0);
+  }
+
+  @Test
+  void aPlainEnumerationOfPgTypeListsEveryTypeInOidOrder() {
+    final PostgresCatalog.Answer answer = resolve("SELECT oid, typname FROM pg_catalog.pg_type ORDER BY oid");
+
+    assertThat(answer.rows).hasSize(PostgresType.values().length);
+    assertThat(names(answer.rows, "oid")).isSorted();
+  }
+
+  @Test
+  void aFilteredLookupInPgTypeSelectsOneRow() {
+    final PostgresCatalog.Answer answer = resolve("SELECT typname, typlen FROM pg_type WHERE typcategory = 'N' AND typlen = 8");
+
+    assertThat(names(answer.rows, "typname")).containsExactlyInAnyOrder("int8", "float8");
+  }
+
+  @Test
+  void aColumnListJoiningPgTypeStillAnswersOneRowPerColumn() {
+    // pg_type carrying a family of its own must not turn the driver's column list - which joins pg_attribute
+    // to pg_type to name each column's type - into an enumeration of the type catalog.
+    final PostgresCatalog.Answer answer = resolve(JDBC_GET_COLUMNS, "Article", "%");
+
+    assertThat(names(answer.rows, "attname")).containsExactly("id", "title");
+    assertThat(names(answer.rows, "typtype")).containsOnly("b");
+  }
+
   // ---------------------------------------------------------------- helpers
 
   private PostgresCatalog.Answer resolve(final String query, final Object... parameters) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -541,6 +541,20 @@ class PostgresCatalogTest {
           + "FROM pg_type t WHERE t.oid = to_regtype('hstore'::text) ORDER BY t.oid";
 
   @Test
+  void wrappingPgTypeInASubSelectDoesNotGetThePermissiveFilterBack() {
+    // The strictness has to travel with the rows, not with the statement that built them: the outer WHERE
+    // reads the same closed set of types, so a sub-select must not become the way back to "an unreadable
+    // predicate keeps every row" - which is the hole that answered psycopg with all 23 types.
+    assertThat(resolveRaw("SELECT * FROM (SELECT oid, typname FROM pg_type) t "
+        + "WHERE t.oid = to_regtype('hstore'::text)")).isSameAs(PostgresCatalog.DECLINED);
+
+    // A readable outer filter over the same sub-select still answers, so the strictness has not become a
+    // blanket refusal of derived tables over pg_type.
+    assertThat(names(resolve("SELECT * FROM (SELECT oid, typname FROM pg_type) t WHERE t.typname = 'int4'").rows,
+        "typname")).containsExactly("int4");
+  }
+
+  @Test
   void aPgTypeFilterThisCatalogCanReadStillSelectsASubset() {
     // Declining an unreadable filter must not become declining every filter: the readable ones still work,
     // and a name this protocol does not produce correctly answers no rows rather than being declined.

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
@@ -109,7 +109,7 @@ class PostgresTypeCatalogTest {
       "SELECT oid FROM pg_type WHERE typtype = 'b' AND typlen > 4",
       "SELECT oid FROM pg_type ORDER BY oid",
       // A column this catalog cannot produce is declined whole rather than answered with a hole in it.
-      "SELECT oid, typcollation FROM pg_type",
+      "SELECT oid, typacl FROM pg_type",
       // Not pg_type at all.
       "SELECT oid FROM pg_class" })
   void shapesThisCatalogCannotAnswerAreDeclined(final String query) {
@@ -195,6 +195,46 @@ class PostgresTypeCatalogTest {
     assertThat(byOid).containsEntry(PostgresType.JSON.code, "json_in");
     assertThat(byOid).containsEntry(PostgresType.NUMERIC.code, "numeric_in");
     assertThat(byOid).containsEntry(PostgresType.ARRAY_TEXT.code, "array_in");
+  }
+
+  @Test
+  void binaryIoFunctionsAreSpelledTheWayPostgresSpellsThem() {
+    // issue #7178: the Apache Arrow ADBC driver picks a column's decoder by typreceive's name, so a plausible
+    // name is no better than none - the type is simply left out of its resolver.
+    final Map<Integer, Map<String, Object>> byOid = new HashMap<>();
+    for (final Map<String, Object> row : PostgresTypeCatalog.resolve("SELECT oid, typreceive, typsend, typoutput FROM pg_type"))
+      byOid.put((Integer) row.get("oid"), row);
+
+    assertThat(byOid.get(PostgresType.INTEGER.code)).containsEntry("typreceive", "int4recv")
+        .containsEntry("typsend", "int4send").containsEntry("typoutput", "int4out");
+    assertThat(byOid.get(PostgresType.BOOLEAN.code)).containsEntry("typreceive", "boolrecv");
+    assertThat(byOid.get(PostgresType.BYTEA.code)).containsEntry("typreceive", "bytearecv");
+    assertThat(byOid.get(PostgresType.VARCHAR.code)).containsEntry("typreceive", "varcharrecv");
+    assertThat(byOid.get(PostgresType.TIMESTAMP.code)).containsEntry("typreceive", "timestamp_recv")
+        .containsEntry("typsend", "timestamp_send");
+    assertThat(byOid.get(PostgresType.NUMERIC.code)).containsEntry("typreceive", "numeric_recv");
+    assertThat(byOid.get(PostgresType.JSON.code)).containsEntry("typreceive", "json_recv");
+    assertThat(byOid.get(PostgresType.ARRAY_TEXT.code))
+        .as("the driver excludes arrays with typreceive != 'array_recv' and rebuilds them from typarray")
+        .containsEntry("typreceive", "array_recv").containsEntry("typsend", "array_send");
+  }
+
+  @Test
+  void storageAttributesFollowEachTypesWidth() {
+    final Map<Integer, Map<String, Object>> byOid = new HashMap<>();
+    for (final Map<String, Object> row : PostgresTypeCatalog
+        .resolve("SELECT oid, typbyval, typalign, typstorage, typcollation FROM pg_type"))
+      byOid.put((Integer) row.get("oid"), row);
+
+    assertThat(byOid.get(PostgresType.SMALLINT.code)).containsEntry("typbyval", Boolean.TRUE)
+        .containsEntry("typalign", "s").containsEntry("typstorage", "p").containsEntry("typcollation", 0);
+    assertThat(byOid.get(PostgresType.LONG.code)).containsEntry("typalign", "d");
+    assertThat(byOid.get(PostgresType.BOOLEAN.code)).containsEntry("typalign", "c");
+    assertThat(byOid.get(PostgresType.TEXT.code)).containsEntry("typbyval", Boolean.FALSE)
+        .containsEntry("typstorage", "x")
+        .as("a collation-sensitive type carries the default collation's OID").containsEntry("typcollation", 100);
+    assertThat(byOid.get(PostgresType.NUMERIC.code))
+        .as("numeric is the one varlena type PostgreSQL keeps in the main table").containsEntry("typstorage", "m");
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
@@ -266,6 +266,22 @@ class PostgresTypeCatalogTest {
   }
 
   @Test
+  void noArrayTypeHasAnArrayForAnElement() {
+    // typalign and typcollation are derived by reading the element's, which is a single step only because
+    // this protocol has no array of arrays. The assumption is invisible in that code and would misbehave
+    // quietly rather than fail if one were ever added, so it is asserted here instead.
+    for (final PostgresType type : PostgresType.values()) {
+      if (!type.isArrayType())
+        continue;
+      final PostgresType element = PostgresType.byCode(type.elementCode);
+      assertThat(element).as("%s declares element OID %d, which is not a type this protocol produces",
+          type.typeName, type.elementCode).isNotNull();
+      assertThat(element.isArrayType()).as("%s's element %s must not itself be an array",
+          type.typeName, element.typeName).isFalse();
+    }
+  }
+
+  @Test
   void numericIsCategorisedAsNumberLikeEveryOtherNumericType() {
     // issue #6447: NUMERIC used to fall through category()'s default "U" (user-defined) arm, the same bucket
     // real PostgreSQL uses for json - wrong for a type PostgreSQL itself files under "N" alongside int4/float8.

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
@@ -238,6 +238,34 @@ class PostgresTypeCatalogTest {
   }
 
   @Test
+  void anArrayTakesItsStorageAttributesFromItsElement() {
+    // PostgreSQL auto-generates each array type from its element (Catalog.pm, GenerateArrayTypes). Only the
+    // columns with a BKI_ARRAY_DEFAULT get a fixed array value; the rest are copied from the element, and
+    // typalign has a rule of its own: INT unless the element needs DOUBLE.
+    final Map<Integer, Map<String, Object>> byOid = new HashMap<>();
+    for (final Map<String, Object> row : PostgresTypeCatalog
+        .resolve("SELECT oid, typalign, typcollation, typstorage, typbyval, typcategory FROM pg_type"))
+      byOid.put((Integer) row.get("oid"), row);
+
+    assertThat(byOid.get(PostgresType.ARRAY_LONG.code))
+        .as("_int8's element is DOUBLE-aligned, so the array is too").containsEntry("typalign", "d");
+    assertThat(byOid.get(PostgresType.ARRAY_DOUBLE.code)).containsEntry("typalign", "d");
+    assertThat(byOid.get(PostgresType.ARRAY_INT.code))
+        .as("_int4's element is INT-aligned").containsEntry("typalign", "i");
+    assertThat(byOid.get(PostgresType.ARRAY_CHAR.code))
+        .as("an array never narrows to its element's CHAR alignment").containsEntry("typalign", "i");
+
+    assertThat(byOid.get(PostgresType.ARRAY_TEXT.code))
+        .as("typcollation has no BKI_ARRAY_DEFAULT, so _text copies text's collation rather than dropping it")
+        .containsEntry("typcollation", 100);
+    assertThat(byOid.get(PostgresType.ARRAY_INT.code))
+        .as("an array of a non-collatable element stays non-collatable").containsEntry("typcollation", 0);
+
+    assertThat(byOid.get(PostgresType.ARRAY_TEXT.code)).containsEntry("typstorage", "x")
+        .containsEntry("typbyval", Boolean.FALSE).containsEntry("typcategory", "A");
+  }
+
+  @Test
   void numericIsCategorisedAsNumberLikeEveryOtherNumericType() {
     // issue #6447: NUMERIC used to fall through category()'s default "U" (user-defined) arm, the same bucket
     // real PostgreSQL uses for json - wrong for a type PostgreSQL itself files under "N" alongside int4/float8.


### PR DESCRIPTION
Fixes #7178. Reported in discussion #6888 by @singhpratech.

## The problem

The Apache Arrow **native PostgreSQL ADBC driver** (1.12.0) could not open a connection to ArcadeDB's PostgreSQL-protocol plugin. It aborted at connect with:

```
Expected 5 or 6 columns from type resolver pg_type query but got 0
```

`PostgresDatabase::RebuildTypeResolver` (arrow-adbc `c/driver/postgresql/database.cc`) runs three queries before it hands the caller a connection, and validates the **shape** of each answer rather than its content - zero rows are fine, zero columns are fatal:

| # | query | required |
|---|-------|----------|
| 1 | `SELECT version();` | 1 row, 1 column |
| 2 | `SELECT attrelid, attname, atttypid FROM pg_catalog.pg_attribute ORDER BY attrelid, attnum` | 3 columns |
| 3 | `SELECT oid, typname, typreceive, typbasetype, typrelid, typarray FROM pg_catalog.pg_type WHERE (typreceive != 0 OR typsend != 0) AND typtype != 'r' AND typreceive::TEXT != 'array_recv'` | 5 or 6 columns |

(1) and (2) were already answered correctly. (3) was declined twice over:

- `PostgresTypeCatalog` knew neither `typreceive` nor `typsend`, so it declined the projection whole; and its WHERE parser reads only a single `oid = N` or `typname = '...'` equality, not a conjunction of inequalities with a parenthesised disjunction and a `::TEXT` cast.
- `PostgresCatalog` then declined it too, because `pg_type` was registered there **only** as a relation that decorates a `pg_attribute` join - it had no family of its own, so a query naming it alone resolved to no family at all.

The query fell through to the empty-result fallback, which announces a RowDescription with **no fields**, and the driver has no fallback for that.

## The fix

The obvious repair is another regular expression in `PostgresTypeCatalog`. That would fix this one query and nothing else - the next client that reads `pg_type` with two predicates gets the same empty answer.

So instead `pg_type` becomes a relation the **generic catalog** can answer on its own: a `TYPES` family whose rows are the types this protocol can produce, projected and filtered by the same tokenizer and expression evaluator every other `pg_catalog` relation already goes through. Parenthesised boolean expressions, `!=`, `::` casts, aliases, `ORDER BY`, `LIMIT` and `DISTINCT` all come for free, because they are already implemented once.

`TYPES` sits at the **bottom** of the specificity ranking on purpose. A query that joins `pg_type` to `pg_class` or `pg_attribute` - which is how every JDBC driver's `getColumns()` names each column's type - keeps meaning exactly what it meant: one row per table or per column, with `pg_type` decorating it. `TYPES` wins only when nothing else in the `FROM` carries a family.

`PostgresTypeCatalog` gains the columns that made the projection undescribable, and stays the recogniser for the element-type self-join (`FROM pg_type t, pg_type e WHERE t.oid = ? AND t.typelem = e.oid`), which is a correlated self-join no plain projection can express:

- `typreceive`, `typsend`, `typoutput`, spelled the way PostgreSQL spells them. This matters: the ADBC driver picks a column's decoder **by `typreceive`'s name**, so a plausible name is no better than none - the type is silently left out of its resolver and every column of that type then fails to bind. `int4recv`, `bytearecv`, `timestamp_recv`, `numeric_recv`, `array_recv`, and so on, all checked against arrow-adbc's own `PostgresTyprecv` table.
- the storage attributes other clients read off the same row: `typbyval`, `typalign`, `typstorage`, `typcollation`, `typispreferred`, `typisdefined`, `typowner`, `typtypmod`, `typndims`, `typdefault`.

`array_recv` on the array types is what makes the driver's own `typreceive::TEXT != 'array_recv'` filter work: it excludes them from the result and rebuilds each one from its element's `typarray`, which is what PostgreSQL's own catalog leads it to do.

## Alternative considered

`pg_type` could have been given a rank above `SCHEMAS`, so that `pg_type JOIN pg_namespace` (which some clients write to filter on `nspname = 'pg_catalog'`) enumerated types rather than answering the one schema row. That was deliberately **not** done here: the two relations mean different namespaces in that query - the emulated `public` schema for a table, `pg_catalog` for a built-in type - and reconciling them is a separate question from this bug. The current behaviour for that shape is unchanged.

## One deliberate behaviour change beyond the bug

Giving `pg_type` a family changes the answer to one shape that is not the ADBC query: **a projection naming a pg_type column this catalog does not value**, such as `SELECT oid, typacl FROM pg_type`.

`PostgresTypeCatalog` declines such a projection rather than answering it with a hole, and before this PR that ended the query with an empty result set, because `pg_type` had no family in `PostgresCatalog` either. Now it falls through to the generic catalog, where an unmodelled column of a modelled relation answers `NULL` - the same treatment `pg_class` and `pg_attribute` have always had. So the client gets the rest of its row instead of being told the whole query matched nothing.

This is intentional and consistent with the rest of the emulation. `Issue7178ArrowAdbcBootstrapIT.aPgTypeColumnThisCatalogDoesNotModelAnswersNullRatherThanNothing` pins it end to end, since the two recognisers only disagree about this shape when you look at what actually reaches the wire.

## Verification

- `Issue7178ArrowAdbcBootstrapIT` - all three of the driver's bootstrap queries over the wire, asserting the column count each one is validated against, the `typreceive` names, `typarray`, and that the array types are filtered out. The pg_type test **fails on `main`** with `expected: 6 but was: 0`, which is the reported error exactly.
- `PostgresCatalogTest` - the ADBC query at unit level, a plain enumeration in OID order, a multi-predicate filtered lookup, and a regression guard that the JDBC `getColumns()` join still answers one row per column rather than one per type.
- `PostgresTypeCatalogTest` - the binary I/O function names against PostgreSQL's own spellings, the storage attributes against each type's width, the array-inherits-from-element rules for `typalign`/`typcollation`, and a guard that no array type's element is itself an array (the single-step recursion those two derivations rely on).

Full `postgresw` suite green: 434 unit tests, 221 integration tests, plus the 737 in `server` that the reactor pulls in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded PostgreSQL `pg_type` compatibility with comprehensive type metadata, including I/O functions, ownership, storage, alignment, collation, dimensions, and default values.
  - Improved Apache Arrow ADBC bootstrap queries and type resolution.
  - Added metadata support for array types and derived attributes.
  - Preserved correct behavior when combining type information with table and column catalog queries.

- **Bug Fixes**
  - Ensured type results use stable OID ordering.
  - Improved filtering of numeric type lookups.
  - Declined ambiguous or unreadable catalog queries instead of returning misleading results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->