### PR TITLE
fix(#7182): an ORDER BY on a WITH no longer turns file() and linenumber() off

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java
@@ -88,16 +88,13 @@ public final class LoadCSVRowContext {
    * {@code CypherLoadCSVRowContextIssue6402Test.theRowContextSurvivesAProjectionThatDropsRowEntirely}
    * (issue #6402 code review).
    * <p>
-   * <b>Aggregation is where that stops, deliberately.</b> An aggregating clause does not project a row from a row,
-   * it folds many rows into one, and there is no row for the folded one to inherit from: three CSV lines have three
-   * line numbers and {@code linenumber()} cannot answer with one of them. Neo4j draws the boundary in exactly that
-   * place - its aggregation tables build the output row with {@code QueryState.newRow}, which starts from the
-   * query's initial row and therefore carries no {@code ResourceLinenumber} - so {@code file()} is {@code null}
-   * after {@code WITH collect(row) AS rows}, and stays {@code null} through the {@code UNWIND} that expands the
-   * list back out, because the row the {@code UNWIND} copies from never had the context to begin with. Reported as
-   * a bug in issue #7182 and pinned as the correct answer by
-   * {@code CypherLoadCSVRowContextIssue7182Test}: nothing is added here for it, and nothing may be added later
-   * without first changing what {@code linenumber()} is supposed to mean.
+   * <b>Aggregation is the boundary, deliberately.</b> An aggregating clause folds many rows into one rather than
+   * projecting a row from a row, so there is nothing for the folded row to inherit: three CSV lines have three line
+   * numbers and {@code linenumber()} cannot answer with one of them. Neo4j draws the line in the same place, so
+   * {@code file()} is {@code null} after {@code WITH collect(row) AS rows} and stays {@code null} through the
+   * {@code UNWIND} that expands the list back out. Reported as a bug in issue #7182 and pinned as the correct
+   * answer by {@code CypherLoadCSVRowContextIssue7182Test} - do not add a carry-over here without first deciding
+   * what {@code linenumber()} means on a folded row.
    */
   public static void carryOver(final Result source, final ResultInternal target) {
     if (source == null || target == null || !source.hasProperty(FILE))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java
@@ -87,6 +87,17 @@ public final class LoadCSVRowContext {
    * the row variable itself survived the projection. Pinned by
    * {@code CypherLoadCSVRowContextIssue6402Test.theRowContextSurvivesAProjectionThatDropsRowEntirely}
    * (issue #6402 code review).
+   * <p>
+   * <b>Aggregation is where that stops, deliberately.</b> An aggregating clause does not project a row from a row,
+   * it folds many rows into one, and there is no row for the folded one to inherit from: three CSV lines have three
+   * line numbers and {@code linenumber()} cannot answer with one of them. Neo4j draws the boundary in exactly that
+   * place - its aggregation tables build the output row with {@code QueryState.newRow}, which starts from the
+   * query's initial row and therefore carries no {@code ResourceLinenumber} - so {@code file()} is {@code null}
+   * after {@code WITH collect(row) AS rows}, and stays {@code null} through the {@code UNWIND} that expands the
+   * list back out, because the row the {@code UNWIND} copies from never had the context to begin with. Reported as
+   * a bug in issue #7182 and pinned as the correct answer by
+   * {@code CypherLoadCSVRowContextIssue7182Test}: nothing is added here for it, and nothing may be added later
+   * without first changing what {@code linenumber()} is supposed to mean.
    */
   public static void carryOver(final Result source, final ResultInternal target) {
     if (source == null || target == null || !source.hasProperty(FILE))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/VariableProjectionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/VariableProjectionStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -33,6 +34,14 @@ import java.util.Set;
  * Simple projection step that keeps only specified variable names in the result.
  * Used after ORDER BY + LIMIT to strip non-projected variables that were kept
  * for ORDER BY evaluation.
+ * <p>
+ * "Non-projected variables" means the query's own variables. The LOAD CSV row context is not one of them: it
+ * describes the row rather than naming a value the query bound, so it survives the strip the same way it survives
+ * the projection {@code WithStep} does (issue #6402). Without that, a {@code WITH} carrying an {@code ORDER BY}
+ * was the one projection form that turned {@code file()} and {@code linenumber()} off for the rest of the query -
+ * {@code WITH row ORDER BY row RETURN file()} answered {@code null} while the very same {@code WITH} without the
+ * {@code ORDER BY} answered the file (issue #7182). Neo4j sorts the rows it was handed rather than building new
+ * ones, so the context rides through its sort untouched.
  */
 public class VariableProjectionStep extends AbstractExecutionStep {
   private final Set<String> keepVariables;
@@ -64,6 +73,7 @@ public class VariableProjectionStep extends AbstractExecutionStep {
           if (input.getPropertyNames().contains(var))
             projected.setProperty(var, input.getProperty(var));
         }
+        LoadCSVRowContext.carryOver(input, projected);
         return projected;
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/VariableProjectionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/VariableProjectionStep.java
@@ -26,8 +26,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 
-import java.util.NoSuchElementException
-;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue7182Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue7182Test.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7182: a query that rebuilt each LOAD CSV row through a map, {@code collect} and {@code UNWIND} got
+ * {@code null} from {@code file()}, where the same query without the round trip got the CSV URL.
+ * <p>
+ * <b>That much is not a bug, and this test pins it as the answer.</b> {@code file()} and {@code linenumber()} are
+ * functions of the row, and an aggregating clause does not carry a row through - it folds many into one. Neo4j,
+ * the openCypher reference implementation, reads both functions off a {@code ResourceLinenumber} stamped on the
+ * row by {@code LoadCSVPipe}, and its aggregation tables build their output row with {@code QueryState.newRow},
+ * which starts from the query's initial row and so carries no stamp. {@code file()} is therefore {@code null}
+ * after {@code WITH collect(...)} in Neo4j too, and {@code null} for the rest of the query, because the
+ * {@code UNWIND} that expands the list back out copies a row that never had the context. Preserving it would also
+ * have to answer what {@code linenumber()} means for one row folded out of three, and there is no answer.
+ * <p>
+ * <b>What the report did surface is one clause where the context was lost and Neo4j keeps it:</b> {@code WITH}
+ * with an {@code ORDER BY}. That form defers SKIP/LIMIT and emits a merged scope for the sort to read, which a
+ * {@code VariableProjectionStep} then strips back to the projected variables - and the strip took the row context
+ * with it. So {@code WITH row ORDER BY row RETURN file()} answered {@code null} while {@code WITH row RETURN
+ * file()} answered the file, and {@code RETURN file() ORDER BY ...} answered the file as well: three spellings of
+ * the same thing, one of them disagreeing. Neo4j sorts the rows it was handed rather than building new ones, so
+ * nothing is lost across its sort.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherLoadCSVRowContextIssue7182Test {
+  private Database database;
+  private String   url;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    final File csv = new File("./target/databases/cypher-loadcsv-7182/arcade-load.csv");
+    csv.getParentFile().mkdirs();
+    try (final PrintWriter writer = new PrintWriter(csv, "UTF-8")) {
+      writer.println("id,name");
+      writer.println("load_1,Loaded Alice");
+      writer.println("load_2,Loaded Bob");
+    }
+    url = csv.getAbsolutePath();
+
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-loadcsv-7182/db");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The bug the report uncovered: ORDER BY on a WITH was the one projection form that lost the context
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theRowContextSurvivesAWithThatCarriesAnOrderBy() {
+    // The control: the same projection without the ORDER BY has answered correctly since issue #6402.
+    assertThat(rows("WITH row RETURN file() AS r")).hasSize(3).allMatch(url::equals);
+
+    assertThat(rows("WITH row ORDER BY linenumber() RETURN file() AS r")).hasSize(3).allMatch(url::equals);
+    assertThat(rows("WITH row ORDER BY row RETURN file() AS r")).hasSize(3).allMatch(url::equals);
+    // A second WITH after the sorted one must still see it: the context has to be on the row, not merely
+    // left behind on the command context by whatever was evaluated last.
+    assertThat(rows("WITH row ORDER BY row WITH row RETURN file() AS r")).hasSize(3).allMatch(url::equals);
+  }
+
+  @Test
+  void theLineNumberFollowsTheRowAcrossTheSort() {
+    // Not just "non-null": the value has to travel with its own row, so a descending sort has to hand back the
+    // line numbers in descending order rather than three copies of whichever row was evaluated last.
+    assertThat(rows("WITH row ORDER BY linenumber() DESC RETURN linenumber() AS r")).containsExactly(3, 2, 1);
+    assertThat(rows("WITH row ORDER BY linenumber() RETURN linenumber() AS r")).containsExactly(1, 2, 3);
+    assertThat(rows("WITH row ORDER BY linenumber() DESC LIMIT 2 RETURN linenumber() AS r")).containsExactly(3, 2);
+    assertThat(rows("WITH row ORDER BY linenumber() DESC SKIP 1 RETURN linenumber() AS r")).containsExactly(2, 1);
+  }
+
+  @Test
+  void theRowContextIsStillNotProjectedByReturnStarAfterASort() {
+    // It rides through the strip as execution state, so it must not surface as a column of its own (issue #5444).
+    try (final ResultSet resultSet = database.query("opencypher", load("WITH row ORDER BY row RETURN *"))) {
+      while (resultSet.hasNext()) {
+        final Result result = resultSet.next();
+        assertThat(result.getPropertyNames()).containsExactly("row");
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The report's own two queries: the difference between them is Neo4j's, and stays
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theReportedLeftQueryAnswersTheFile() {
+    final List<Object> values = rows("RETURN file() AS r, row, carrier",
+        "CALL () { RETURN ['x'] AS carrier } WITH carrier LIMIT 1 ");
+    assertThat(values).hasSize(3).allMatch(url::equals);
+  }
+
+  @Test
+  void theReportedRightQueryAnswersNullBecauseAggregationEndsTheRowContext() {
+    // Neo4j answers null here too: its aggregation table builds the output row with QueryState.newRow, which
+    // carries no ResourceLinenumber, and the UNWIND downstream copies that contextless row. Asserted rather
+    // than fixed, so that a later change to the carry-over has to come past this test on purpose.
+    final List<Object> values = rows("RETURN file() AS r, row, carrier",
+        "CALL () { RETURN ['x'] AS carrier } WITH carrier LIMIT 1 ",
+        "WITH {carrier: carrier, row: row} AS row1 WITH collect(row1) AS rows1 UNWIND rows1 AS row1 "
+            + "WITH row1.carrier AS carrier, row1.row AS row ");
+    assertThat(values).hasSize(3).containsOnlyNulls();
+  }
+
+  @Test
+  void everyAggregatingClauseEndsTheRowContextTheSameWay() {
+    assertThat(rows("WITH collect(row) AS rows UNWIND rows AS row RETURN file() AS r")).containsOnlyNulls();
+    assertThat(rows("WITH collect(row) AS rows UNWIND rows AS row RETURN linenumber() AS r")).containsOnlyNulls();
+    assertThat(rows("WITH count(*) AS c RETURN file() AS r")).containsOnlyNulls();
+    assertThat(rows("WITH row, count(*) AS c RETURN file() AS r")).containsOnlyNulls();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+
+  private String load(final String tail) {
+    return "LOAD CSV FROM '" + url + "' AS row " + tail;
+  }
+
+  private List<Object> rows(final String tail) {
+    return rows(tail, "", "");
+  }
+
+  private List<Object> rows(final String tail, final String head) {
+    return rows(tail, head, "");
+  }
+
+  private List<Object> rows(final String tail, final String head, final String middle) {
+    final List<Object> values = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", head + load(middle + tail))) {
+      while (resultSet.hasNext())
+        values.add(resultSet.next().getProperty("r"));
+    }
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue7182Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue7182Test.java
@@ -129,21 +129,31 @@ class CypherLoadCSVRowContextIssue7182Test {
 
   @Test
   void theReportedLeftQueryAnswersTheFile() {
-    final List<Object> values = rows("RETURN file() AS r, row, carrier",
-        "CALL () { RETURN ['x'] AS carrier } WITH carrier LIMIT 1 ");
-    assertThat(values).hasSize(3).allMatch(url::equals);
+    // The report's own query, quoted as it was filed.
+    assertThat(query("""
+        CALL () { RETURN ['x'] AS carrier }
+        WITH carrier LIMIT 1
+        LOAD CSV FROM '%s' AS row FIELDTERMINATOR ','
+        RETURN row, file() AS r, carrier
+        """.formatted(url))).hasSize(3).allMatch(url::equals);
   }
 
   @Test
   void theReportedRightQueryAnswersNullBecauseAggregationEndsTheRowContext() {
-    // Neo4j answers null here too: its aggregation table builds the output row with QueryState.newRow, which
-    // carries no ResourceLinenumber, and the UNWIND downstream copies that contextless row. Asserted rather
-    // than fixed, so that a later change to the carry-over has to come past this test on purpose.
-    final List<Object> values = rows("RETURN file() AS r, row, carrier",
-        "CALL () { RETURN ['x'] AS carrier } WITH carrier LIMIT 1 ",
-        "WITH {carrier: carrier, row: row} AS row1 WITH collect(row1) AS rows1 UNWIND rows1 AS row1 "
-            + "WITH row1.carrier AS carrier, row1.row AS row ");
-    assertThat(values).hasSize(3).containsOnlyNulls();
+    // The report's second query, quoted as it was filed. Neo4j answers null here too: its aggregation table
+    // builds the output row with QueryState.newRow, which carries no ResourceLinenumber, and the UNWIND
+    // downstream copies that contextless row. Asserted rather than fixed, so that a later change to the
+    // carry-over has to come past this test on purpose.
+    assertThat(query("""
+        CALL () { RETURN ['x'] AS carrier }
+        WITH carrier LIMIT 1
+        LOAD CSV FROM '%s' AS row FIELDTERMINATOR ','
+        WITH {carrier: carrier, row: row} AS row1
+        WITH collect(row1) AS rows1
+        UNWIND rows1 AS row1
+        WITH row1.carrier AS carrier, row1.row AS row
+        RETURN row, file() AS r, carrier
+        """.formatted(url))).hasSize(3).containsOnlyNulls();
   }
 
   @Test
@@ -161,16 +171,13 @@ class CypherLoadCSVRowContextIssue7182Test {
   }
 
   private List<Object> rows(final String tail) {
-    return rows(tail, "", "");
+    return query(load(tail));
   }
 
-  private List<Object> rows(final String tail, final String head) {
-    return rows(tail, head, "");
-  }
-
-  private List<Object> rows(final String tail, final String head, final String middle) {
+  /** Collects the {@code r} column of a whole query, for the two cases quoted from the report verbatim. */
+  private List<Object> query(final String cypher) {
     final List<Object> values = new ArrayList<>();
-    try (final ResultSet resultSet = database.query("opencypher", head + load(middle + tail))) {
+    try (final ResultSet resultSet = database.query("opencypher", cypher)) {
       while (resultSet.hasNext())
         values.add(resultSet.next().getProperty("r"));
     }


### PR DESCRIPTION
Closes #7182

## What the report compared

Two `LOAD CSV` queries returning the same three rows, the second one only rebuilding each row through a map, `collect` and `UNWIND`. `file()` answered with the CSV URL in the first and `NULL` in the second.

## That difference is Neo4j's, and it stays

`file()` and `linenumber()` are functions of the **row**. Neo4j stamps a `ResourceLinenumber` onto each row in `LoadCSVPipe` and reads both functions straight off it (`LineFunction.scala`: `row.getLinenumber match { case Some(ResourceLinenumber(name, _, _)) => ... case _ => NO_VALUE }`). Its aggregation tables - `GroupingAggTable` and `NonGroupingAggTable` alike - build their output row with `QueryState.newRow`, which starts from the query's *initial* row and therefore carries no stamp.

So in Neo4j too, `file()` is `NULL` after `WITH collect(...) AS rows`, and stays `NULL` through the `UNWIND` that expands the list back out, because the row the `UNWIND` copies never had the context to begin with. Preserving it would also have to answer what `linenumber()` means for one row folded out of three, and there is no answer.

The reported pair is therefore **pinned as the correct answer** rather than fixed, and the reasoning is written into `LoadCSVRowContext.carryOver`'s javadoc - where the carry-over lives - so a later change to it has to come past this on purpose.

## What the report did surface

One clause where the context was lost and Neo4j keeps it. A `WITH` carrying an `ORDER BY` defers SKIP/LIMIT and emits a merged scope for the sort to read, which `VariableProjectionStep` then strips back to the projected variables - and the strip took the row context with it:

```cypher
LOAD CSV FROM '...' AS row WITH row ORDER BY row  RETURN file()   -- was NULL
LOAD CSV FROM '...' AS row WITH row               RETURN file()   -- the file
LOAD CSV FROM '...' AS row                        RETURN file() AS f ORDER BY f  -- the file
```

Three spellings of one thing, one of them disagreeing. Neo4j sorts the rows it was handed rather than building new ones, so nothing is lost across its sort. The strip now carries the context the same way `WithStep`'s own projection has since #6402 - it is execution state describing the row, not one of the query's variables - and `RETURN *` still does not see it (#5444).

## Alternative considered and rejected

Making aggregation carry the context forward, which is what the report asks for. Rejected: it diverges from the reference implementation on the exact point the reference implementation is explicit about, and it has no defensible answer for `linenumber()` on a folded row. `file()` and `linenumber()` are deliberately kept as one pair by `LoadCSVRowContext`; splitting them so that one survives a fold and the other does not would be worse than either.

## Verification

- New `CypherLoadCSVRowContextIssue7182Test` (6 tests): the sort forms, the line number following its **own** row across a `DESC` sort (so a stale context variable cannot pass it), `RETURN *` still not exposing the internal bindings, the report's two queries verbatim, and every aggregating clause ending the context alike.
- Full `com.arcadedb.query.opencypher` package: 9371 tests, 0 failures.
- openCypher TCK suite: 3897 tests, 0 failures.

## Files changed

- `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/VariableProjectionStep.java`
- `engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java` (javadoc: the aggregation boundary)
- `engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue7182Test.java` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved `file()` and `linenumber()` values through CSV queries using projections, ordering, limits, skips, and subsequent transformations.
  * Clarified that CSV row context is not retained after aggregation followed by `UNWIND`.
  * Improved consistency when accessing CSV row metadata across common query operations.
* **Tests**
  * Added regression coverage for LOAD CSV row-context behavior, including confirmation that execution context is not exposed by `RETURN *`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->