### PR TITLE
fix(#7180): answer the regclass cast the Arrow ADBC driver asks for a table's columns with

### DIFF
--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -723,10 +723,70 @@ public class PostgresCatalog {
 
   // ---------------------------------------------------------------- rows
 
-  /** What the emulated catalog is a view of: one database, seen by one authenticated user. */
-  private record Context(Database database, String userName) {
+  /**
+   * What the emulated catalog is a view of: one database, seen by one authenticated user.
+   * <p>
+   * Also where the name/OID lookups a {@code regclass} cast needs are memoised. Both directions are
+   * evaluated once per row - the WHERE clause runs against every row of the family - so a linear scan of
+   * the schema inside them would make a table-schema query quadratic in the number of types. The maps are
+   * built at most once per statement, and only when a query actually casts to an OID-alias type.
+   */
+  private static final class Context {
+    private final Database database;
+    private final String   userName;
+
+    private Map<Integer, String>      namesByOid;
+    private Map<String, DocumentType> typesByFoldedName;
+
+    Context(final Database database, final String userName) {
+      this.database = database;
+      this.userName = userName;
+    }
+
+    Database database() {
+      return database;
+    }
+
+    String userName() {
+      return userName;
+    }
+
     String schema() {
       return database.getName();
+    }
+
+    /** The relation an OID names, for the {@code attrelid::regclass} direction of the cast. */
+    String relationNamed(final int oid) {
+      if (namesByOid == null) {
+        namesByOid = new HashMap<>();
+        for (final DocumentType type : database.getSchema().getTypes())
+          namesByOid.putIfAbsent(oidOf(type.getName()), type.getName());
+      }
+      return namesByOid.get(oid);
+    }
+
+    /**
+     * The type a relation name names. An exact match first, because ArcadeDB type names are case-sensitive
+     * and a quoted name means exactly itself; then a case-insensitive one, because PostgreSQL folds an
+     * unquoted name to lower case and a client that wrote {@code Article} unquoted still means the type
+     * spelled that way. Two types differing only in case leave the folded lookup empty: neither of them is
+     * the one meant, and picking either would be a guess.
+     */
+    DocumentType typeNamed(final String name) {
+      if (name.isEmpty())
+        return null;
+      if (database.getSchema().existsType(name))
+        return database.getSchema().getType(name);
+
+      if (typesByFoldedName == null) {
+        typesByFoldedName = new HashMap<>();
+        // merge() drops the entry when the remapping function answers null, which is what a folded name two
+        // types answer to has to do: neither of them is the one meant.
+        for (final DocumentType type : database.getSchema().getTypes())
+          typesByFoldedName.merge(type.getName().toLowerCase(Locale.ENGLISH), type, (first, second) -> null);
+      }
+
+      return typesByFoldedName.get(name.toLowerCase(Locale.ENGLISH));
     }
   }
 
@@ -982,6 +1042,14 @@ public class PostgresCatalog {
     // an unreadable filter does not get to empty an answer whose every row is one of the user's own types.
     final PostgresCatalogExpression where = statement.where == null ? null :
         PostgresCatalogExpression.parse(statement.where);
+
+    // Unless the rows are pg_type's, where the permissive rule does not hold. A filter that cannot even be
+    // parsed has to be treated exactly like one that parses and then evaluates to UNKNOWN: both mean the
+    // same thing - this catalog does not know which subset was asked for - and only the second was declined,
+    // so a WHERE written with a construct the expression parser does not implement was the way back to
+    // "answer every type".
+    if (where == null && statement.where != null && !toleratesUnreadableFilter)
+      return DECLINED;
 
     final List<Row> surviving = new ArrayList<>(rows.size());
     for (final Row row : rows) {
@@ -1427,6 +1495,11 @@ public class PostgresCatalog {
         case "pg_table_is_visible", "pg_type_is_visible", "pg_function_is_visible" -> Boolean.TRUE;
         case "pg_encoding_to_char" -> "UTF8";
         case "format_type" -> formatType(arguments);
+        // PostgreSQL's OID-alias types, reached either as a cast ('Article'::regclass) or as the function
+        // spelling of the same lookup (to_regclass('Article')). See regClass for which direction each
+        // argument type means.
+        case "regclass", "to_regclass" -> regClass(arguments, context);
+        case "regtype", "to_regtype" -> regType(arguments);
         // Comments, defaults and ACLs have no ArcadeDB equivalent, and NULL is what PostgreSQL answers for an
         // object that has none.
         case "obj_description", "col_description", "shobj_description", "pg_get_expr", "pg_get_indexdef",
@@ -1440,6 +1513,111 @@ public class PostgresCatalog {
         return PostgresCatalogExpression.UNKNOWN;
       final PostgresType type = PostgresType.byCode(oid.intValue());
       return type == null ? null : type.typeName;
+    }
+
+    /**
+     * {@code regclass}: a relation's OID, and a relation's name, depending on which one it was given.
+     * <p>
+     * A real {@code regclass} is one value that holds an OID and prints as the name; there is no such value
+     * here, so the direction the client wrote decides which half it gets - and in both directions it gets
+     * the half it is about to use. A name is what a client casts in order to compare against an OID column
+     * ({@code cls.oid = 'Article'::regclass}, which is how the Apache Arrow ADBC driver asks for a table's
+     * columns, issue #7180), so text answers the OID. An OID is what a client casts in order to print a
+     * relation's name ({@code attrelid::regclass}), so a number answers the name. Digits given as text are
+     * an OID spelled out, which is how PostgreSQL reads them too.
+     * <p>
+     * A name no type carries answers NULL - {@code to_regclass}'s answer, rather than the error the cast
+     * raises in PostgreSQL. That matters for the WHERE clause: NULL makes the equality false and the query
+     * selects nothing, which is the honest answer to "describe the table that is not there", whereas
+     * declining to read the cast would leave the permissive-filter rule describing <b>every</b> table.
+     */
+    private static Object regClass(final List<Object> arguments, final Context context) {
+      if (arguments.size() != 1)
+        return PostgresCatalogExpression.UNKNOWN;
+
+      final Object value = arguments.get(0);
+      if (value == null || value == PostgresCatalogExpression.UNKNOWN)
+        return value;
+
+      if (value instanceof Number oid)
+        return context.relationNamed(oid.intValue());
+
+      final String written = PostgresCatalogExpression.asString(value).trim();
+      if (isDigits(written))
+        try {
+          return Integer.valueOf(written);
+        } catch (final NumberFormatException e) {
+          return null;
+        }
+
+      final DocumentType type = context.typeNamed(unqualify(written));
+      return type == null ? null : oidOf(type.getName());
+    }
+
+    /**
+     * {@code regtype}: the same two directions as {@link #regClass}, over the types this protocol can
+     * produce. {@code atttypid::regtype} is how a client prints a column's type; {@code 'int4'::regtype} is
+     * how it names one to filter by.
+     */
+    private static Object regType(final List<Object> arguments) {
+      if (arguments.size() != 1)
+        return PostgresCatalogExpression.UNKNOWN;
+
+      final Object value = arguments.get(0);
+      if (value == null || value == PostgresCatalogExpression.UNKNOWN)
+        return value;
+
+      if (value instanceof Number)
+        return formatType(arguments);
+
+      final String written = PostgresCatalogExpression.asString(value).trim();
+      if (isDigits(written))
+        try {
+          return formatType(List.of(Integer.valueOf(written)));
+        } catch (final NumberFormatException e) {
+          return null;
+        }
+
+      final PostgresType type = PostgresType.byName(unqualify(written));
+      return type == null ? null : type.code;
+    }
+
+    /**
+     * The relation name out of what a client wrote inside a {@code regclass} literal: the last component of
+     * a qualified name, with the double quotes {@code PQescapeIdentifier} wraps it in taken off. An unquoted
+     * name is left as written rather than folded to lower case, because the fold is undone by
+     * {@link Context#typeNamed} anyway and the verbatim spelling is the one that can match exactly.
+     */
+    private static String unqualify(final String written) {
+      final StringBuilder current = new StringBuilder(written.length());
+      boolean quoted = false;
+
+      for (int i = 0; i < written.length(); i++) {
+        final char c = written.charAt(i);
+        if (c == '"') {
+          // "" inside a quoted identifier is one literal quote.
+          if (quoted && i + 1 < written.length() && written.charAt(i + 1) == '"') {
+            current.append('"');
+            ++i;
+          } else
+            quoted = !quoted;
+        } else if (c == '.' && !quoted)
+          // A new component starts here, so everything read so far was the schema qualification.
+          current.setLength(0);
+        else
+          current.append(c);
+      }
+
+      return current.toString();
+    }
+
+    private static boolean isDigits(final String text) {
+      if (text.isEmpty())
+        return false;
+      for (int i = 0; i < text.length(); i++)
+        if (text.charAt(i) < '0' || text.charAt(i) > '9')
+          return false;
+      return true;
     }
   }
 }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -755,11 +755,17 @@ public class PostgresCatalog {
       return database.getName();
     }
 
-    /** The relation an OID names, for the {@code attrelid::regclass} direction of the cast. */
+    /**
+     * The relation an OID names, for the {@code attrelid::regclass} direction of the cast. Built over the
+     * types in name order rather than in schema iteration order: {@link #oidOf} derives an OID from a hash,
+     * so two names can in principle land on the same one, and this is the first place such a collision
+     * would be externally visible - one type's name printed for another type's row. Which of the two wins
+     * has to at least not depend on the order a hash set happened to iterate in.
+     */
     String relationNamed(final int oid) {
       if (namesByOid == null) {
         namesByOid = new HashMap<>();
-        for (final DocumentType type : database.getSchema().getTypes())
+        for (final DocumentType type : sortedTypes(this))
           namesByOid.putIfAbsent(oidOf(type.getName()), type.getName());
       }
       return namesByOid.get(oid);
@@ -780,12 +786,19 @@ public class PostgresCatalog {
 
       if (typesByFoldedName == null) {
         typesByFoldedName = new HashMap<>();
-        // merge() drops the entry when the remapping function answers null, which is what a folded name two
-        // types answer to has to do: neither of them is the one meant.
-        for (final DocumentType type : database.getSchema().getTypes())
-          typesByFoldedName.merge(type.getName().toLowerCase(Locale.ENGLISH), type, (first, second) -> null);
+        for (final DocumentType type : sortedTypes(this)) {
+          final String folded = type.getName().toLowerCase(Locale.ENGLISH);
+          // A folded name stays in the map once it is struck out, mapped to null. containsKey is what tells
+          // "not seen yet" from "seen and struck out", and removing the entry instead would not: a third
+          // name folding the same way would find the key absent and install itself as the answer.
+          if (typesByFoldedName.containsKey(folded))
+            typesByFoldedName.put(folded, null);
+          else
+            typesByFoldedName.put(folded, type);
+        }
       }
 
+      // Absent and struck out both answer null here, and both mean the same thing: no type this name names.
       return typesByFoldedName.get(name.toLowerCase(Locale.ENGLISH));
     }
   }
@@ -1547,6 +1560,9 @@ public class PostgresCatalog {
         try {
           return Integer.valueOf(written);
         } catch (final NumberFormatException e) {
+          // PostgreSQL's OID space is unsigned 32-bit, and this one is int. A number too big to be an OID
+          // this catalog ever handed out is deliberately read as "no such relation" rather than as an
+          // error: oidOf never produces one, so nothing it could name exists.
           return null;
         }
 

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -772,11 +772,18 @@ public class PostgresCatalog {
     }
 
     /**
-     * The type a relation name names. An exact match first, because ArcadeDB type names are case-sensitive
-     * and a quoted name means exactly itself; then a case-insensitive one, because PostgreSQL folds an
-     * unquoted name to lower case and a client that wrote {@code Article} unquoted still means the type
-     * spelled that way. Two types differing only in case leave the folded lookup empty: neither of them is
-     * the one meant, and picking either would be a guess.
+     * The type a relation name names, given the name with its quoting already taken off by
+     * {@link RowResolver#unqualify} - so whether the client quoted it is not something this method can
+     * still tell, and the order the two lookups run in is what stands in for it.
+     * <p>
+     * The exact match runs first. For a quoted name that is what PostgreSQL means, since a quoted
+     * identifier is itself; for an unquoted one PostgreSQL would have folded it to lower case and found
+     * nothing, and taking the exact match anyway is the deliberate divergence that keeps a case-sensitive
+     * schema addressable - {@code SELECT * FROM Article} has to reach the type spelled that way.
+     * <p>
+     * Then the case-insensitive one, because a client that wrote an unquoted {@code article} still means
+     * the type spelled {@code Article}. Two or more types differing only in case answer nothing: none of
+     * them is the one meant, and picking one would be a guess.
      */
     DocumentType typeNamed(final String name) {
       if (name.isEmpty())

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
@@ -21,6 +21,7 @@ package com.arcadedb.postgres;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -58,6 +59,16 @@ abstract class PostgresCatalogExpression {
 
   /** Distinguishes "this is not one of the scalar functions" from a scalar function that answered UNKNOWN. */
   private static final Object NOT_A_SCALAR_FUNCTION = new Object();
+
+  /**
+   * The cast target types that are a catalog lookup rather than a change of representation. PostgreSQL's
+   * OID-alias types hold an OID and print as the object's name, so a cast to one of them is the only place
+   * in a catalog query where {@code ::} carries meaning this evaluator has to reproduce.
+   */
+  private static final Set<String> LOOKUP_CASTS = Set.of("regclass", "regtype");
+
+  /** Stands for a cast type that is more than a bare name, and so is never one of {@link #LOOKUP_CASTS}. */
+  private static final String COMPOUND_CAST_TYPE = "";
 
   /** Supplies the column values of the row being evaluated, and the session values around it. */
   interface Resolver {
@@ -830,11 +841,18 @@ abstract class PostgresCatalogExpression {
         final PostgresCatalogToken token = peek();
 
         if (token != null && token.isSymbol("::")) {
-          // A cast never changes what a catalog query means here: 'pg_class'::regclass is the name, and
-          // int4/text casts are there for PostgreSQL's type resolution, which this evaluator does not have.
           ++position;
-          if (!skipCastType())
+          final String castType = skipCastType();
+          if (castType == null)
             return null;
+          // Most casts are there for PostgreSQL's own type resolution and do not change what a catalog query
+          // means, so they stay transparent. The OID-alias types are the exception: they are a catalog
+          // lookup written as a cast, and reading them as transparent gives the wrong answer rather than an
+          // unknown one - 'Article'::regclass compared against pg_class.oid would compare a name to a number
+          // and quietly select nothing (issue #7180). Those are handed to the resolver as the function call
+          // they are, which is also how PostgreSQL spells them when written out: to_regclass('Article').
+          if (LOOKUP_CASTS.contains(castType))
+            operand = new FunctionCall(castType, List.of(operand));
         } else if (token != null && token.isSymbol("[")) {
           ++position;
           final PostgresCatalogExpression index = parseExpression();
@@ -846,23 +864,35 @@ abstract class PostgresCatalogExpression {
       }
     }
 
-    /** Consumes a type name after {@code ::}, including {@code varchar(10)} and {@code text[]}. */
-    private boolean skipCastType() {
+    /**
+     * Consumes a type name after {@code ::}, including {@code varchar(10)} and {@code text[]}.
+     *
+     * @return the bare type name in lower case, {@link #COMPOUND_CAST_TYPE} when it carried a length
+     * modifier, an array suffix or more than one word - none of which an OID-alias type ever does - or null
+     * when what follows the {@code ::} is not a type name at all
+     */
+    private String skipCastType() {
       final PostgresCatalogToken token = peek();
       if (token == null || token.type != PostgresCatalogToken.Type.IDENTIFIER)
-        return false;
+        return null;
       ++position;
+
+      String name = token.text.toLowerCase(Locale.ENGLISH);
 
       while (peek() != null && peek().isSymbol(".")) {
         ++position;
         if (peek() == null || peek().type != PostgresCatalogToken.Type.IDENTIFIER)
-          return false;
+          return null;
+        // pg_catalog.regclass is regclass: the schema a type name is qualified by never changes which it is.
+        name = peek().text.toLowerCase(Locale.ENGLISH);
         ++position;
       }
 
       // Some type names are several words: "double precision", "character varying", "timestamp with time zone".
-      while (peek() != null && peek().type == PostgresCatalogToken.Type.IDENTIFIER && isTypeNameWord(peek().text))
+      while (peek() != null && peek().type == PostgresCatalogToken.Type.IDENTIFIER && isTypeNameWord(peek().text)) {
         ++position;
+        name = COMPOUND_CAST_TYPE;
+      }
 
       if (peek() != null && peek().isSymbol("(")) {
         int depth = 0;
@@ -875,15 +905,17 @@ abstract class PostgresCatalogExpression {
           if (depth == 0)
             break;
         }
+        name = COMPOUND_CAST_TYPE;
       }
 
       while (peek() != null && peek().isSymbol("[")) {
         ++position;
         if (!skipSymbol("]"))
-          return false;
+          return null;
+        name = COMPOUND_CAST_TYPE;
       }
 
-      return true;
+      return name;
     }
 
     private static boolean isTypeNameWord(final String text) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -41,8 +41,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -97,6 +99,33 @@ public enum PostgresType {
 
   private static final Map<Integer, PostgresType> CODE_MAP = Arrays.stream(values())
       .collect(Collectors.toMap(type -> type.code, type -> type));
+
+  /**
+   * Every spelling a client may name a type by: its own {@code typname} plus the SQL-standard names
+   * PostgreSQL treats as aliases of it. Built once, because a by-name lookup is a per-query cost.
+   */
+  private static final Map<String, PostgresType> NAME_MAP = buildNameMap();
+
+  private static Map<String, PostgresType> buildNameMap() {
+    final Map<String, PostgresType> names = new HashMap<>();
+    for (final PostgresType type : values())
+      names.put(type.typeName, type);
+
+    names.put("smallint", SMALLINT);
+    names.put("int2", SMALLINT);
+    names.put("integer", INTEGER);
+    names.put("int", INTEGER);
+    names.put("bigint", LONG);
+    names.put("real", REAL);
+    names.put("double precision", DOUBLE);
+    names.put("boolean", BOOLEAN);
+    names.put("character varying", VARCHAR);
+    names.put("character", BPCHAR);
+    names.put("decimal", NUMERIC);
+    names.put("timestamp without time zone", TIMESTAMP);
+
+    return Map.copyOf(names);
+  }
 
   // PostgreSQL-compatible datetime format (ISO 8601 without 'T' separator)
   private static final String            POSTGRES_TIMESTAMP_FORMAT   = "yyyy-MM-dd HH:mm:ss.SSSSSS";
@@ -483,6 +512,18 @@ public enum PostgresType {
    */
   public static PostgresType byCode(final int code) {
     return CODE_MAP.get(code);
+  }
+
+  /**
+   * Returns the type carrying the given {@code typname}, or null when this protocol has no such type.
+   * <p>
+   * PostgreSQL accepts a type under two spellings - its catalog {@code typname} and, for the types the SQL
+   * standard names, that standard name - and a client writing {@code 'integer'::regtype} means the same type
+   * as one writing {@code 'int4'::regtype}. Both are answered here, so a lookup by name does not depend on
+   * which of the two the client happened to write.
+   */
+  public static PostgresType byName(final String name) {
+    return name == null ? null : NAME_MAP.get(name.trim().toLowerCase(Locale.ENGLISH));
   }
 
   /**

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -111,8 +111,9 @@ public enum PostgresType {
     for (final PostgresType type : values())
       names.put(type.typeName, type);
 
+    // Only the spellings the loop above did not already install: every entry here is a SQL-standard name
+    // that is not any type's own typname.
     names.put("smallint", SMALLINT);
-    names.put("int2", SMALLINT);
     names.put("integer", INTEGER);
     names.put("int", INTEGER);
     names.put("bigint", LONG);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -123,6 +123,8 @@ public enum PostgresType {
     names.put("character", BPCHAR);
     names.put("decimal", NUMERIC);
     names.put("timestamp without time zone", TIMESTAMP);
+    // No "timestamp with time zone" on purpose: timestamptz is a different type from timestamp, and this
+    // protocol has none. Mapping it here would answer a client asking for one with the wrong OID.
 
     return Map.copyOf(names);
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7180ArrowAdbcTableSchemaIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7180ArrowAdbcTableSchemaIT.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7180, the follow-up to #7178: with the type-resolver bootstrap answered, the
+ * Apache Arrow native PostgreSQL ADBC driver (1.12.0) connects, but {@code GetTableSchema} comes back with
+ * zero fields for a table that exists.
+ * <p>
+ * {@code PostgresConnection::GetTableSchema} (arrow-adbc {@code c/driver/postgresql/connection.cc}, tag
+ * {@code apache-arrow-adbc-24}) selects a table's columns by casting the table's name to {@code regclass}:
+ *
+ * <pre>
+ * SELECT attname, atttypid
+ * FROM pg_catalog.pg_class AS cls
+ * INNER JOIN pg_catalog.pg_attribute AS attr ON cls.oid = attr.attrelid
+ * INNER JOIN pg_catalog.pg_type AS typ ON attr.atttypid = typ.oid
+ * WHERE attr.attnum &gt;= 0 AND cls.oid = $1::regclass::oid
+ * ORDER BY attr.attnum
+ * </pre>
+ * <p>
+ * The one text parameter is the table name after {@code PQescapeIdentifier}, so the double quotes are part
+ * of the value. Every cast used to be transparent in the catalog's expression evaluator - which is right for
+ * the casts that only steer PostgreSQL's own type resolution, and wrong for the OID-alias types, where the
+ * cast <i>is</i> the lookup. {@code cls.oid = '"adbc_big"'} compared a number against a name, and the
+ * predicate quietly selected nothing, so the driver built a schema with no fields and reported none.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7180ArrowAdbcTableSchemaIT extends PostgresWireProtocolTestBase {
+
+  /** Verbatim from arrow-adbc {@code c/driver/postgresql/connection.cc}, {@code GetTableSchema}. */
+  private static final String ADBC_GET_TABLE_SCHEMA = //
+      "SELECT attname, atttypid FROM pg_catalog.pg_class AS cls "
+          + "INNER JOIN pg_catalog.pg_attribute AS attr ON cls.oid = attr.attrelid "
+          + "INNER JOIN pg_catalog.pg_type AS typ ON attr.atttypid = typ.oid "
+          + "WHERE attr.attnum >= 0 AND cls.oid = $1::regclass::oid "
+          + "ORDER BY attr.attnum";
+
+  @Test
+  void theDriversTableSchemaQueryDescribesTheTableItNames() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createSchema(connection);
+
+      // pgjdbc writes its own placeholder, and the driver's text is written for PQexecParams: the query goes
+      // out with $1 either way, so it is sent as a literal with the escaped identifier already in it, which
+      // is the string PQescapeIdentifier hands the driver.
+      final List<String> columns = tableSchemaOf(connection, "\"adbc_big7180\"");
+
+      assertThat(columns).as("GetTableSchema built a schema with no fields at all")
+          .containsExactly("count", "created", "id", "name", "price");
+    }
+  }
+
+  @Test
+  void theDriversTableSchemaQueryNamesTheColumnTypesTheDriverDecodesWith() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createSchema(connection);
+
+      try (final Statement statement = connection.createStatement();
+          final ResultSet resultSet = statement
+              .executeQuery(ADBC_GET_TABLE_SCHEMA.replace("$1", "'\"adbc_big7180\"'"))) {
+
+        final List<Integer> oids = new ArrayList<>();
+        while (resultSet.next())
+          oids.add(resultSet.getInt("atttypid"));
+
+        // count, created, id, name, price - the properties in the order this catalog reports them.
+        assertThat(oids).containsExactly(PostgresType.LONG.code, PostgresType.DATE.code,
+            PostgresType.INTEGER.code, PostgresType.VARCHAR.code, PostgresType.DOUBLE.code);
+      }
+    }
+  }
+
+  @Test
+  void aTableTheDriverAsksAboutThatDoesNotExistDescribesNoColumnsRatherThanEveryColumn() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createSchema(connection);
+
+      assertThat(tableSchemaOf(connection, "\"no_such_table_7180\""))
+          .as("an unresolvable regclass name must not fall back to describing every column of every table")
+          .isEmpty();
+    }
+  }
+
+  @Test
+  void theSameQuestionThroughTheExtendedProtocolIsAnsweredToo() throws Exception {
+    // PQexecParams is the extended protocol, so the parameter reaches the catalog at Execute time rather
+    // than being inlined. The answer has to be the same one the simple protocol gives.
+    try (final Connection connection = openJdbcConnection()) {
+      createSchema(connection);
+
+      try (final PreparedStatement statement = connection.prepareStatement(ADBC_GET_TABLE_SCHEMA.replace("$1", "?"))) {
+        statement.setString(1, "\"adbc_big7180\"");
+
+        try (final ResultSet resultSet = statement.executeQuery()) {
+          final List<String> columns = new ArrayList<>();
+          while (resultSet.next())
+            columns.add(resultSet.getString("attname"));
+
+          assertThat(columns).containsExactly("count", "created", "id", "name", "price");
+        }
+      }
+    }
+  }
+
+  private List<String> tableSchemaOf(final Connection connection, final String escapedIdentifier) throws Exception {
+    try (final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement
+            .executeQuery(ADBC_GET_TABLE_SCHEMA.replace("$1", "'" + escapedIdentifier + "'"))) {
+
+      final List<String> columns = new ArrayList<>();
+      while (resultSet.next())
+        columns.add(resultSet.getString("attname"));
+      return columns;
+    }
+  }
+
+  private void createSchema(final Connection connection) throws Exception {
+    try (final Statement statement = connection.createStatement()) {
+      statement.execute("CREATE DOCUMENT TYPE adbc_big7180 IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY adbc_big7180.id IF NOT EXISTS INTEGER");
+      statement.execute("CREATE PROPERTY adbc_big7180.name IF NOT EXISTS STRING");
+      statement.execute("CREATE PROPERTY adbc_big7180.price IF NOT EXISTS DOUBLE");
+      statement.execute("CREATE PROPERTY adbc_big7180.created IF NOT EXISTS DATE");
+      statement.execute("CREATE PROPERTY adbc_big7180.count IF NOT EXISTS LONG");
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogExpressionTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogExpressionTest.java
@@ -61,6 +61,10 @@ class PostgresCatalogExpressionTest {
       return switch (name) {
         case "current_schema", "current_database" -> "mydb";
         case "current_schemas" -> List.of("mydb");
+        // Stand-ins for the two OID-alias lookups, so that this test is about the cast reaching the
+        // resolver rather than about what PostgresCatalog then looks the name up in.
+        case "regclass" -> "Article".equals(arguments.get(0)) ? 1042 : null;
+        case "regtype" -> "looked-up-" + arguments.get(0);
         default -> PostgresCatalogExpression.UNKNOWN;
       };
     }
@@ -274,13 +278,30 @@ class PostgresCatalogExpressionTest {
 
   @Test
   void castsAreTransparentAndSubscriptsIndexFromOne() {
-    assertThat(evaluate("'pg_class'::regclass")).isEqualTo("pg_class");
     assertThat(evaluate("attnum::int4")).isEqualTo(3L);
     assertThat(evaluate("relname::character varying(10)")).isEqualTo("Article");
     assertThat(evaluate("relname::text[]")).isEqualTo("Article");
     assertThat(evaluate("(current_schemas(true))[1]")).isEqualTo("mydb");
     assertThat(evaluate("(current_schemas(true))[9]")).isNull();
     assertThat(evaluate("relname[1]")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  @Test
+  void aCastToAnOidAliasTypeIsALookupRatherThanATransparentCast() {
+    // regclass and regtype hold an OID and print as a name, so the cast is the lookup itself (issue #7180).
+    // Reading them as transparent made 'Article'::regclass the string "Article", and a client comparing that
+    // against pg_class.oid - which is how the Arrow ADBC driver asks for a table's columns - silently
+    // matched nothing. They reach the resolver as the function call they are.
+    assertThat(evaluate("'Article'::regclass")).isEqualTo(1042);
+    assertThat(evaluate("'Article'::regclass::oid")).as("::oid over a regclass stays transparent")
+        .isEqualTo(1042);
+    assertThat(evaluate("attnum::regtype")).isEqualTo("looked-up-3");
+    assertThat(evaluate("pg_catalog.regclass('Article')")).as("the schema a cast type is qualified by "
+        + "does not change which type it is").isEqualTo(1042);
+
+    // Anything more than a bare name is never an OID-alias type, so those stay transparent.
+    assertThat(evaluate("relname::regclass[]")).isEqualTo("Article");
+    assertThat(evaluate("relname::regclass(10)")).isEqualTo("Article");
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -720,6 +720,19 @@ class PostgresCatalogTest {
   }
 
   @Test
+  void anOidAliasLookupWrittenWithTheWrongNumberOfArgumentsIsDeclinedRatherThanGuessedAt() {
+    // The cast form can only ever produce one argument, but the function form is what a client writes by
+    // hand, and there it can be given any number. An unreadable projection declines the query whole rather
+    // than answering the rest of the row, which is what every other unknown function here already does.
+    assertThat(resolveRaw("SELECT regclass('Article', 'Author') FROM pg_class")).isSameAs(PostgresCatalog.DECLINED);
+    assertThat(resolveRaw("SELECT to_regtype() FROM pg_class")).isSameAs(PostgresCatalog.DECLINED);
+
+    // The one-argument spelling of the same call is the cast, and still answers.
+    assertThat(resolve("SELECT to_regclass('Article') AS oid FROM pg_class LIMIT 1").rows.get(0).get("oid"))
+        .isEqualTo(resolve("SELECT oid FROM pg_class WHERE relname = 'Article'").rows.get(0).get("oid"));
+  }
+
+  @Test
   void aRegclassCastOfANumericOidStringIsThatOid() {
     // PostgreSQL's regclass input accepts an OID spelled as digits, and the driver's parameter arrives as
     // text either way.

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -700,6 +700,26 @@ class PostgresCatalogTest {
   }
 
   @Test
+  void aThirdTypeFoldingToTheSameNameStaysAmbiguousRatherThanBecomingTheAnswer() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("ARTICLE").createProperty("code", Type.STRING);
+      database.getSchema().createDocumentType("aRticle").createProperty("slug", Type.STRING);
+    });
+
+    // Once a folded name is struck out it has to stay struck out. Removing the entry instead would leave the
+    // key absent, so the third name folding the same way would find nothing there and install itself - and
+    // "article" would resolve to whichever type the schema happened to iterate last.
+    assertThat(resolve(ADBC_GET_TABLE_SCHEMA, "article").rows).isEmpty();
+    assertThat(resolve(ADBC_GET_TABLE_SCHEMA, "artICLE").rows).isEmpty();
+
+    // An unquoted name that IS one of the three verbatim still resolves: the exact match runs first, and it
+    // is the only reading under which a case-sensitive schema stays addressable at all.
+    assertThat(names(resolve(ADBC_GET_TABLE_SCHEMA, "ARTICLE").rows, "attname")).containsExactly("code");
+    assertThat(names(resolve(ADBC_GET_TABLE_SCHEMA, "\"aRticle\"").rows, "attname")).containsExactly("slug");
+    assertThat(names(resolve(ADBC_GET_TABLE_SCHEMA, "\"Article\"").rows, "attname")).containsExactly("id", "title");
+  }
+
+  @Test
   void aRegclassCastOfANumericOidStringIsThatOid() {
     // PostgreSQL's regclass input accepts an OID spelled as digits, and the driver's parameter arrives as
     // text either way.

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -520,25 +520,50 @@ class PostgresCatalogTest {
 
   @Test
   void aPgTypeFilterThisCatalogCannotReadDeclinesRatherThanAnsweringEveryType() {
-    // psycopg looks a type up by name to decide whether the server has it, and casts to ::regtype to do so.
     // The permissive-WHERE rule - an unreadable predicate does not get to remove rows - is right for every
     // other relation here, because their rows are the user's own types and such a predicate can only be
     // excluding rows this catalog never produced. pg_type is a fixed set of built-in types where a filter
     // selects a real subset, so keeping every row answers "all 23 types" to "the one named hstore", and
     // psycopg fails outright with "found 23 different types named hstore" rather than concluding it is
     // absent. An unanswerable filter over pg_type has to decline.
-    assertThat(resolveRaw(PSYCOPG_TYPE_LOOKUP)).isSameAs(PostgresCatalog.DECLINED);
+    assertThat(resolveRaw("SELECT typname, oid FROM pg_type t WHERE t.typname = pg_catalog.quote_ident('hstore')"))
+        .isSameAs(PostgresCatalog.DECLINED);
+  }
+
+  @Test
+  void aPgTypeFilterThatWillNotEvenParseDeclinesToo() {
+    // Parsing and evaluating are two ways to fail to read the same predicate, and only the second used to
+    // decline: a WHERE written with a construct the expression parser does not implement - a scalar
+    // sub-query here - left the parse result null, which the caller read as "no filter" and answered every
+    // type with. The two have to be treated alike (issue #7180).
+    assertThat(resolveRaw("SELECT typname FROM pg_type t WHERE t.oid = (SELECT 1 FROM pg_type LIMIT 1)"))
+        .isSameAs(PostgresCatalog.DECLINED);
+
+    // The same shape over a relation whose rows are the user's own types is still answered permissively.
+    assertThat(names(resolve("SELECT relname FROM pg_class WHERE oid = (SELECT 1 FROM pg_class LIMIT 1)").rows,
+        "relname")).containsExactly("Article", "Author");
   }
 
   /**
    * psycopg's {@code TypeInfo.fetch}, verbatim from {@code psycopg/_typeinfo.py}, with its {@code %(name)s}
-   * parameter bound. {@code to_regtype()} is a function this catalog does not implement, so the whole
-   * predicate evaluates to UNKNOWN - which is exactly the case the permissive-WHERE rule used to wave
-   * through, and pg_type is the one relation where waving it through fabricates an answer.
+   * parameter bound.
    */
   private static final String PSYCOPG_TYPE_LOOKUP =
       "SELECT typname AS name, oid, typarray AS array_oid, oid::regtype::text AS regtype, typdelim AS delimiter "
-          + "FROM pg_type t WHERE t.oid = to_regtype('hstore'::text) ORDER BY t.oid";
+          + "FROM pg_type t WHERE t.oid = to_regtype(%s) ORDER BY t.oid";
+
+  @Test
+  void psycopgsTypeLookupAnswersWhetherThisProtocolHasThatType() {
+    // to_regtype() is the whole predicate of psycopg's lookup, so until it was read the query could only be
+    // declined (issue #7180). Now it is answered the way PostgreSQL answers it: NULL for a type the server
+    // does not have, which makes the equality false and the lookup correctly conclude "absent".
+    assertThat(resolve(PSYCOPG_TYPE_LOOKUP.formatted("'hstore'::text")).rows).isEmpty();
+
+    final PostgresCatalog.Answer present = resolve(PSYCOPG_TYPE_LOOKUP.formatted("'int4'::text"));
+    assertThat(names(present.rows, "name")).containsExactly("int4");
+    assertThat(present.rows.get(0)).containsEntry("regtype", "int4")
+        .containsEntry("array_oid", PostgresType.ARRAY_INT.code);
+  }
 
   @Test
   void wrappingPgTypeInASubSelectDoesNotGetThePermissiveFilterBack() {
@@ -546,7 +571,7 @@ class PostgresCatalogTest {
     // reads the same closed set of types, so a sub-select must not become the way back to "an unreadable
     // predicate keeps every row" - which is the hole that answered psycopg with all 23 types.
     assertThat(resolveRaw("SELECT * FROM (SELECT oid, typname FROM pg_type) t "
-        + "WHERE t.oid = to_regtype('hstore'::text)")).isSameAs(PostgresCatalog.DECLINED);
+        + "WHERE t.typname = pg_catalog.quote_ident('hstore')")).isSameAs(PostgresCatalog.DECLINED);
 
     // A readable outer filter over the same sub-select still answers, so the strictness has not become a
     // blanket refusal of derived tables over pg_type.
@@ -597,6 +622,92 @@ class PostgresCatalogTest {
     final PostgresCatalog.Answer answer = resolve(JDBC_GET_COLUMNS, "Article", "%");
 
     assertThat(names(answer.rows, "attname")).containsExactly("id", "title");
+  }
+
+  // ---------------------------------------------------------------- the ::regclass cast (issue #7180)
+
+  /**
+   * {@code PostgresConnection::GetTableSchema} as the Apache Arrow native ADBC driver writes it
+   * (arrow-adbc {@code c/driver/postgresql/connection.cc}, tag {@code apache-arrow-adbc-24}). It binds one
+   * text parameter: the table name after {@code PQescapeIdentifier}, so the double quotes are part of it.
+   */
+  private static final String ADBC_GET_TABLE_SCHEMA =
+      "SELECT attname, atttypid FROM pg_catalog.pg_class AS cls "
+          + " INNER JOIN pg_catalog.pg_attribute AS attr ON cls.oid = attr.attrelid "
+          + " INNER JOIN pg_catalog.pg_type AS typ ON attr.atttypid = typ.oid "
+          + " WHERE attr.attnum >= 0 AND cls.oid = $1::regclass::oid ORDER BY attr.attnum";
+
+  @Test
+  void theDriversTableSchemaQueryDescribesTheTypeItsRegclassCastNames() {
+    final PostgresCatalog.Answer answer = resolve(ADBC_GET_TABLE_SCHEMA, "\"Article\"");
+
+    assertThat(names(answer.rows, "attname")).containsExactly("id", "title");
+    assertThat(answer.rows.get(0).get("atttypid")).isEqualTo(PostgresType.INTEGER.code);
+    assertThat(answer.rows.get(1).get("atttypid")).isEqualTo(PostgresType.VARCHAR.code);
+  }
+
+  @Test
+  void anUnquotedRegclassNameStillFindsTheTypeThatIsSpelledWithCapitals() {
+    // PostgreSQL folds an unquoted name to lower case; ArcadeDB type names are case-sensitive, so a name
+    // that no type carries verbatim is matched ignoring case rather than answered with nothing.
+    assertThat(names(resolve(ADBC_GET_TABLE_SCHEMA, "article").rows, "attname")).containsExactly("id", "title");
+  }
+
+  @Test
+  void aSchemaQualifiedRegclassNameNamesTheSameType() {
+    assertThat(names(resolve(ADBC_GET_TABLE_SCHEMA, "public.\"Article\"").rows, "attname"))
+        .containsExactly("id", "title");
+  }
+
+  @Test
+  void aRegclassNameNoTypeCarriesSelectsNoRowRatherThanEveryRow() {
+    // The permissive-WHERE rule must not turn "describe the table that does not exist" into "describe every
+    // column of every table": the cast is read, so the equality is false rather than unreadable.
+    assertThat(resolve(ADBC_GET_TABLE_SCHEMA, "\"Missing\"").rows).isEmpty();
+  }
+
+  @Test
+  void regclassOnAnOidRendersTheRelationNameTheWayPostgreSqlPrintsIt() {
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT DISTINCT attrelid::regclass FROM pg_catalog.pg_attribute ORDER BY 1");
+
+    assertThat(answer.columns.keySet()).containsExactly("regclass");
+    assertThat(names(answer.rows, "regclass")).containsExactly("Article", "Author");
+  }
+
+  @Test
+  void regtypeNamesTheTypeOfAColumnAndResolvesATypeNameBackToItsOid() {
+    final PostgresCatalog.Answer named = resolve(
+        "SELECT attname, atttypid::regtype AS t FROM pg_catalog.pg_attribute WHERE attrelid = 'Author'::regclass");
+
+    assertThat(names(named.rows, "t")).containsExactly("varchar");
+
+    final PostgresCatalog.Answer filtered = resolve(
+        "SELECT attname FROM pg_catalog.pg_attribute WHERE atttypid = 'int4'::regtype");
+
+    assertThat(names(filtered.rows, "attname")).containsExactly("id");
+  }
+
+  @Test
+  void aRegclassNameTwoTypesAnswerToOnlyByCaseIsNotGuessedAt() {
+    database.transaction(() -> database.getSchema().createDocumentType("ARTICLE").createProperty("code", Type.STRING));
+
+    // "Article" and "ARTICLE" both fold to "article", and picking either would describe the wrong table. The
+    // exact spelling still resolves, because a quoted identifier means itself.
+    assertThat(resolve(ADBC_GET_TABLE_SCHEMA, "article").rows).isEmpty();
+    assertThat(names(resolve(ADBC_GET_TABLE_SCHEMA, "\"ARTICLE\"").rows, "attname")).containsExactly("code");
+    assertThat(names(resolve(ADBC_GET_TABLE_SCHEMA, "\"Article\"").rows, "attname")).containsExactly("id", "title");
+  }
+
+  @Test
+  void aRegclassCastOfANumericOidStringIsThatOid() {
+    // PostgreSQL's regclass input accepts an OID spelled as digits, and the driver's parameter arrives as
+    // text either way.
+    final PostgresCatalog.Answer byName = resolve(ADBC_GET_TABLE_SCHEMA, "\"Author\"");
+    final Object oid = resolve("SELECT oid FROM pg_catalog.pg_class WHERE relname = 'Author'").rows.get(0).get("oid");
+
+    assertThat(names(resolve(ADBC_GET_TABLE_SCHEMA, String.valueOf(oid)).rows, "attname"))
+        .isEqualTo(names(byName.rows, "attname"));
   }
 
   // ---------------------------------------------------------------- helpers

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -2400,4 +2400,26 @@ class PostgresTypeTest {
 
     assertThat((byte[]) PostgresType.deserialize(PostgresType.BYTEA.code, 0, data)).isEqualTo(payload);
   }
+
+  @Test
+  void byNameAnswersBothSpellingsPostgreSqlAcceptsForAType() {
+    // A client writing 'integer'::regtype means the type one writing 'int4'::regtype means, so both spellings
+    // have to reach the same row (issue #7180).
+    for (final PostgresType type : PostgresType.values())
+      assertThat(PostgresType.byName(type.typeName)).as(type.typeName).isSameAs(type);
+
+    assertThat(PostgresType.byName("integer")).isSameAs(PostgresType.INTEGER);
+    assertThat(PostgresType.byName("INTEGER")).isSameAs(PostgresType.INTEGER);
+    assertThat(PostgresType.byName("bigint")).isSameAs(PostgresType.LONG);
+    assertThat(PostgresType.byName("double precision")).isSameAs(PostgresType.DOUBLE);
+    assertThat(PostgresType.byName("character varying")).isSameAs(PostgresType.VARCHAR);
+    assertThat(PostgresType.byName("decimal")).isSameAs(PostgresType.NUMERIC);
+
+    // "char" and character are different types in PostgreSQL, and the aliases must not merge them.
+    assertThat(PostgresType.byName("char")).isSameAs(PostgresType.CHAR);
+    assertThat(PostgresType.byName("character")).isSameAs(PostgresType.BPCHAR);
+
+    assertThat(PostgresType.byName("hstore")).as("a type this protocol cannot produce").isNull();
+    assertThat(PostgresType.byName(null)).isNull();
+  }
 }


### PR DESCRIPTION
Fixes what remains of #7180, the follow-up to #7178. Reported by @singhpratech, who re-ran the probe against a build of #7179 and then, in the issue's follow-up comment, retracted two of the three items as an artefact of their own test order. So the scope here is exactly what was left:

| item | status |
|---|---|
| 1. `COPY (<query>) TO STDOUT (FORMAT binary)` | **not in this PR** - see below |
| 2. the driver's catalog statements | shrank to one: `GetTableSchema` |
| 3. `SELECT * FROM "adbc_big"` | closed by the reporter - the quoted identifier was never the problem |

## The problem

`PostgresConnection::GetTableSchema` (arrow-adbc `c/driver/postgresql/connection.cc`, tag `apache-arrow-adbc-24`) selects a table's columns by casting the table's name to `regclass`:

```sql
SELECT attname, atttypid
FROM pg_catalog.pg_class AS cls
INNER JOIN pg_catalog.pg_attribute AS attr ON cls.oid = attr.attrelid
INNER JOIN pg_catalog.pg_type AS typ ON attr.atttypid = typ.oid
WHERE attr.attnum >= 0 AND cls.oid = $1::regclass::oid
ORDER BY attr.attnum
```

The one text parameter is the table name after `PQescapeIdentifier`, so the double quotes are part of the value.

Every cast used to be transparent in the catalog's expression evaluator. That is right for the casts that are only there to steer PostgreSQL's own type resolution - `attnum::int4`, `typreceive::TEXT` - and wrong for the OID-alias types, where the cast **is** the lookup. `cls.oid = '"adbc_big"'` compared a number against a name, the predicate was definitely false rather than unreadable, and every row was filtered out: zero rows, no error, and a driver that reports a schema with no fields. The reporter measured the same thing through psqlodbc, which is what identified `::regclass` rather than the join as the missing piece.

## The fix

The narrow repair is to special-case this one query's shape. That fixes one client and leaves `regclass` meaning nothing for the next one.

So `regclass` and `regtype` stop being transparent and reach the resolver as the function call they are - which is also how PostgreSQL spells them when written out, `to_regclass()` and `to_regtype()`, so one implementation answers both forms and the cast is not a second code path. Everything else about a cast is unchanged: a compound cast type (a length modifier, an array suffix, a multi-word name) is never an OID-alias type and stays transparent, and a schema qualification (`pg_catalog.regclass`) does not change which type it names.

**Which half of the value is answered.** A real `regclass` is one value that holds an OID and prints as the relation's name. There is no such value here, so the direction the client wrote decides - and in both directions it gets the half it is about to use:

- **text answers the OID**, because a name is what a client casts in order to compare against an OID column: `cls.oid = 'Article'::regclass` is the ADBC query, and `'int4'::regtype` is how psycopg names a type to filter by;
- **a number answers the name**, because an OID is what a client casts in order to print one: `attrelid::regclass`, `atttypid::regtype`;
- **digits given as text are an OID spelled out**, which is how PostgreSQL's own `regclass` input reads them.

**A name that resolves to nothing answers NULL**, which is `to_regclass()`'s answer rather than the error the cast raises in PostgreSQL. That choice is load-bearing rather than cosmetic: NULL makes the equality false, so "describe the table that is not there" selects nothing. Declining to read the cast instead would hand the row set to the permissive-WHERE rule and describe **every** column of **every** table - a wrong answer where an empty one is correct.

**Case.** PostgreSQL folds an unquoted name to lower case; ArcadeDB type names are case-sensitive. So an exact match is tried first, because a quoted identifier means itself, then a case-insensitive one, because a client that wrote `Article` unquoted still means the type spelled that way. Two types differing only in case resolve to neither: picking one would be a guess.

Both directions are memoised on the per-statement context. The WHERE clause runs against every row of the family, so a linear scan of the schema inside the cast would make a table-schema query quadratic in the number of types; the maps are built at most once per statement, and only when a query actually casts.

## One hole on the other side of the same rule

#7179 established that an unreadable filter over `pg_type` declines rather than answering every type - the fabricated system-catalog row that makes psycopg fail with "found 23 different types named hstore". That rule only covered a predicate that **parsed and then evaluated to UNKNOWN**. A WHERE the expression parser cannot read at all - a scalar sub-query, say - left the parse result null, which the caller reads as "no filter", and every type came back. Parsing and evaluating are two ways to fail to read the same predicate and now decline alike.

The visible consequence of implementing `to_regtype()` is that psycopg's own lookup is no longer declined at all: it is answered the way PostgreSQL answers it, with zero rows and the right column names for a type this protocol does not have, and with the row for one it does.

## Not in this PR: binary COPY

Item 1 of #7180 is `COPY (<query>) TO STDOUT (FORMAT binary)`, which the driver uses for **every** result set. It is a wire-level feature in its own right - `CopyOutResponse`, the `PGCOPY\n\377\r\n\0` framing, per-field binary encoding, the trailer - not a catalog shape, and the issue says it deserves splitting out once scoped. The reporter has confirmed that with this PR's predecessor plus the driver's own `adbc.postgresql.use_copy=false` option, the native driver already connects, lists objects and reads rows correctly; with this PR, `GetTableSchema` joins them. I have opened it as its own issue rather than growing this one.

## Verification

- `Issue7180ArrowAdbcTableSchemaIT` - the driver's `GetTableSchema` text verbatim, over the wire, through both the simple and the extended protocol (the latter is what `PQexecParams` actually uses, so the parameter reaches the catalog at Execute time rather than inlined). Asserts the column names, the `atttypid` the driver picks its decoder by, and that a table that does not exist describes **no** columns rather than every column.
- `PostgresCatalogTest` - the same query at unit level with the escaped identifier, unquoted, schema-qualified and absent; the OID direction of both casts; the two-types-differing-only-in-case decline; psycopg's lookup answered rather than declined; and the new unparseable-filter guard.
- `PostgresCatalogExpressionTest` - the cast reaching the resolver, and the compound cast types that must stay transparent.
- `PostgresTypeTest` - every `typname` round-trips through `byName`, the SQL-standard aliases resolve, and `char` and `character` stay the two different types PostgreSQL has them be.

Full `postgresw` suite green: 453 unit tests, 227 integration tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved PostgreSQL catalog compatibility for `regclass`, `regtype`, `to_regclass`, and `to_regtype` expressions.
  - Added support for numeric, qualified, quoted, and case-insensitive relation and type references.
  - Expanded PostgreSQL type-name recognition, including standard aliases.

- **Bug Fixes**
  - Improved table-schema discovery through PostgreSQL clients using Arrow ADBC.
  - Catalog queries now correctly handle unknown, ambiguous, invalid, unreadable, and unsupported references.
  - Preserved ambiguity across case variants and return `NULL` for unknown or oversized OIDs.
  - Nonexistent tables return no columns instead of misleading schema results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->