### PR TITLE
fix(#7183,#7184,#7190): three LSM_VECTOR rebuild and reachability defects

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1221,8 +1221,12 @@ public enum GlobalConfiguration {
       """
       Share of the currently AVAILABLE heap (percentage) that an online vector graph rebuild's estimated peak \
       footprint may occupy before the rebuild is deferred instead of attempted. An online rebuild keeps the old \
-      graph resident so searches keep working, and pays for a full new build's working set on top of it, so it \
-      costs roughly 1.7x what building the same corpus from nothing costs. With no gate at all it simply attempts \
+      graph resident so searches keep working, and pays for a full new build's working set on top of it. What \
+      keeping the old graph resident actually costs is measured rather than assumed, so a graph whose topology lives \
+      on disk - the shape a reopened database serves - is not charged as a second on-heap copy of itself; and the \
+      available heap it is judged against counts the page read cache as reclaimable, because it is: a rebuild that \
+      fits only by giving some of it up evicts those pages first, and they are read back from disk on demand. \
+      With no gate at all it simply attempts \
       the rebuild and dies with an OutOfMemoryError when it does not fit. A deferred cycle is not lost: the next \
       mutation-threshold or inactivity trigger retries it, and pending vectors stay exactly searchable through the \
       in-memory delta buffer meanwhile, so the cost of deferring is a longer delta scan per query rather than \

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1601,6 +1601,13 @@ public class PageManager extends LockContext {
    * them, and concurrent readers are free to cache pages of their own again immediately. Nothing here can promise a
    * caller that the heap it was given up for is still there when it asks - which is why this is used to correct a
    * reading that would otherwise be pessimistic, never to justify an allocation that only fits if it is exact.
+   * <p>
+   * <b>The cache is process-wide, so the eviction is too.</b> {@link #INSTANCE} serves every open database, and the
+   * pages given up here are simply the least recently used ones - which may well belong to a database other than the
+   * caller's. That is how {@code arcadedb.maxPageRAM} already works (one budget, one LRU, every database competing in
+   * it), so this adds no new sharing, but it does mean a large vector-index rebuild on one database can show up as a
+   * cache-miss spike on an unrelated one. Whoever adds the next caller should want that trade for the same reason
+   * this one does: the heap is shared whether or not the eviction policy admits it.
    *
    * @param bytesToFree how much to give up; anything not positive is a no-op
    *

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1572,6 +1572,53 @@ public class PageManager extends LockContext {
       totalReadCacheRAM.addAndGet(-1L * page.getPhysicalSize());
   }
 
+  /**
+   * On-heap bytes currently held by the page READ cache, across every open database.
+   * <p>
+   * Every one of them is evictable: {@link #evictOldestPages} drops the page and the next reader loads it from disk
+   * again. That makes this figure the reclaimable part of what a post-collection heap reading reports as live, which
+   * is what lets a caller about to allocate a lot of heap - the vector index graph rebuild of issue #7184 - tell "the
+   * heap is full" apart from "the heap is full of cached pages".
+   */
+  public long getReadCacheRAM() {
+    return totalReadCacheRAM.get();
+  }
+
+  /**
+   * Gives up at least {@code bytesToFree} bytes of the page read cache, oldest pages first, so a caller that is
+   * about to allocate that much heap for something else actually gets it (issue #7184).
+   * <p>
+   * The counterpart of {@link #getReadCacheRAM()}: a caller that treated the cache as reclaimable when deciding
+   * whether its allocation fits has to <em>reclaim</em> it, or the decision was merely optimistic - the cached pages
+   * are strongly referenced and no collection would have taken them. The pages come back from disk on the next read,
+   * so this costs I/O and nothing else.
+   * <p>
+   * Uses the ordinary eviction path, and therefore the ordinary eviction policy (least recently used, larger pages
+   * first on a tie). Deliberately not clamped to {@code maxRAM}: the point here is to go BELOW the configured cache
+   * size on purpose, temporarily, in exchange for something the caller values more.
+   * <p>
+   * A handover, not a reservation: the bytes are unreferenced when this returns, so the next collection can take
+   * them, and concurrent readers are free to cache pages of their own again immediately. Nothing here can promise a
+   * caller that the heap it was given up for is still there when it asks - which is why this is used to correct a
+   * reading that would otherwise be pessimistic, never to justify an allocation that only fits if it is exact.
+   *
+   * @param bytesToFree how much to give up; anything not positive is a no-op
+   *
+   * @return bytes actually freed, which can be less than asked for when the cache held less than that
+   */
+  public long reclaimReadCacheRAM(final long bytesToFree) {
+    if (bytesToFree <= 0)
+      return 0L;
+
+    final long before = totalReadCacheRAM.get();
+    if (before <= 0)
+      return 0L;
+
+    evictOldestPages(Math.min(bytesToFree, before), before);
+
+    return Math.max(0L, before - totalReadCacheRAM.get());
+  }
+
   public void writePages(final List<MutablePage> updatedPages, final boolean asyncFlush) throws IOException, InterruptedException {
     // Entry point of the asynchronous writers that do NOT go through publishPages (LSM index compaction): they hold
     // no page-manager lock, so the deferred-backlog cap of #4728 (issue #6200) and the flush-queue admission control

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1597,6 +1597,12 @@ public class PageManager extends LockContext {
    * first on a tie). Deliberately not clamped to {@code maxRAM}: the point here is to go BELOW the configured cache
    * size on purpose, temporarily, in exchange for something the caller values more.
    * <p>
+   * <b>Cost.</b> {@link #evictOldestPages} sorts the whole read cache under this class's monitor, so the price is set
+   * by how many pages are cached and NOT by how many bytes are asked for - one sort whether the caller wants 4 MB or
+   * 4 GB. That is the same price the routine {@link #checkForPageDisposal()} pays, minus its 100 ms throttle, so a
+   * caller has to be rare: the vector-index rebuild this was added for happens once per rebuild, holding a JVM-wide
+   * permit. Anything on a per-request path wants a different mechanism, not this one.
+   * <p>
    * A handover, not a reservation: the bytes are unreferenced when this returns, so the next collection can take
    * them, and concurrent readers are free to cache pages of their own again immediately. Nothing here can promise a
    * caller that the heap it was given up for is still there when it asks - which is why this is used to correct a

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1862,11 +1862,25 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
       final int[] unreachableOrdinals = persistedManifest != null ?
           persistedManifest.unreachableOrdinals() : EMPTY_ORDINALS;
+
+      // Nodes the build that produced this graph could not link are physically in it and unreachable to every beam
+      // search, at any efSearch. The session that built it served them from the delta scan; this one has to do the
+      // same or they are simply gone while totalVectors still counts them (issue #7190). Read here, BEFORE the
+      // publish below and unlocked because it is real I/O, so the graph and the entries that complete it become
+      // visible in the same write lock: publishing first and queueing afterwards would leave a window in which a
+      // search sees the graph without them, which is the very thing this fix exists to stop. Same order as the
+      // stale-prefix path, which reads its gap before publishing for the identical reason.
+      final List<DeltaVectorEntry> unreachableEntries = readUnreachableEntries(unreachableOrdinals,
+          rebuiltOrdinalToVectorId, rebuiltOrdinalToVectorId.length, vectorProp);
+
+      final int queuedUnreachable;
       lock.writeLock().lock();
       try {
         this.graphIndex = loadedGraph;
         this.graphUnreachableOrdinals = unreachableOrdinals;
         this.ordinalToVectorId = rebuiltOrdinalToVectorId;
+        // Appended, never counted as mutations and never promoting graphState - see readUnreachableEntries().
+        queuedUnreachable = appendToDeltaBuffer(unreachableEntries);
         if (graphState == GraphState.LOADING)
           this.graphState = GraphState.IMMUTABLE;
         // else: a concurrent put()/putBatch()/remove() already advanced graphState to MUTABLE while
@@ -1878,12 +1892,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
         lock.writeLock().unlock();
       }
 
-      // Nodes the build that produced this graph could not link are physically in it and unreachable to every beam
-      // search, at any efSearch. The session that built it served them from the delta scan; this one has to do the
-      // same or they are simply gone while totalVectors still counts them (issue #7190). Outside the publish lock
-      // because the read is real I/O, and after it rather than before so the graph is searchable at once.
-      requeueUnreachableVectors(unreachableOrdinals, rebuiltOrdinalToVectorId, rebuiltOrdinalToVectorId.length,
-          vectorProp);
+      if (queuedUnreachable > 0)
+        LogManager.instance().log(this, Level.INFO,
+            "Queued %d of the %d vector(s) the persisted graph of index %s leaves unreachable into the delta scan, "
+                + "which is the only way a search can return them (issue #7190)", queuedUnreachable,
+            unreachableOrdinals.length, indexName);
 
       // Build PQ if PRODUCT quantization is enabled but PQ file doesn't exist
       // This handles the case where graph was built before PRODUCT quantization was added
@@ -2153,16 +2166,21 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
-   * Queues the vectors of a loaded graph's unreachable ordinals into the delta buffer, so this session serves them
-   * exactly the way the session that built the graph did (issue #7190).
+   * Reads the vectors of a loaded graph's unreachable ordinals, ready to be queued into the delta buffer so this
+   * session serves them exactly the way the session that built the graph did (issue #7190).
    * <p>
-   * Deliberately touches neither {@code mutationsSinceSerialize} nor {@link #graphState}: those nodes are not
-   * pending work. They are already in the graph on disk, a rebuild does not remove them - a Vamana build orphans a
-   * fresh set - and treating them as mutations would make an index whose last build orphaned one node rebuild
-   * itself on every open, and {@code flush()} rebuild on every close. The identical reasoning, and the identical
-   * pair of consequences, is spelled out where {@code buildGraphFromScratchExclusively} makes the same re-queue at
-   * the end of a build. The cost of leaving the state alone is that these entries are scanned by every query until
-   * some real mutation triggers a rebuild, which is the same cost the building session paid.
+   * Returned rather than appended, and therefore called BEFORE the caller publishes the graph: appending is the only
+   * part that needs {@link #lock}'s write lock, and doing it in the same write lock that publishes the graph is what
+   * keeps a search from ever seeing that graph without the entries which complete it.
+   * <p>
+   * The caller must append these with {@link #appendToDeltaBuffer(List)} and touch neither
+   * {@code mutationsSinceSerialize} nor {@link #graphState} on their account: those nodes are not pending work. They
+   * are already in the graph on disk, a rebuild does not remove them - a Vamana build orphans a fresh set - and
+   * treating them as mutations would make an index whose last build orphaned one node rebuild itself on every open,
+   * and {@code flush()} rebuild on every close. The identical reasoning, and the identical pair of consequences, is
+   * spelled out where {@code buildGraphFromScratchExclusively} makes the same re-queue at the end of a build. The
+   * cost of leaving the state alone is that these entries are scanned by every query until some real mutation
+   * triggers a rebuild, which is the same cost the building session paid.
    * <p>
    * Called while holding {@link #graphBuildLock} (both call sites do) and NOT {@link #lock}'s write lock, which the
    * per-vector read it performs must not run under.
@@ -2171,11 +2189,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @param liveOrdinalToVectorId the live ordinal &rarr; vector id array those ordinals index into
    * @param graphNodes            how many leading entries of that array the graph covers
    * @param vectorProp            the vector property name, for the document-read fallback
+   *
+   * @return the entries to append; empty when there is nothing to re-queue
    */
-  private void requeueUnreachableVectors(final int[] unreachableOrdinals, final int[] liveOrdinalToVectorId,
-      final int graphNodes, final String vectorProp) {
+  private List<DeltaVectorEntry> readUnreachableEntries(final int[] unreachableOrdinals,
+      final int[] liveOrdinalToVectorId, final int graphNodes, final String vectorProp) {
     if (unreachableOrdinals == null || unreachableOrdinals.length == 0)
-      return;
+      return List.of();
 
     final IntHashSet alreadyQueued;
     lock.readLock().lock();
@@ -2187,24 +2207,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
       lock.readLock().unlock();
     }
 
-    final List<DeltaVectorEntry> entries = readDeltaEntriesFor(
+    return readDeltaEntriesFor(
         unreachableVectorIdsOf(unreachableOrdinals, liveOrdinalToVectorId, graphNodes, alreadyQueued), vectorProp);
-    if (entries.isEmpty())
-      return;
-
-    final int queued;
-    lock.writeLock().lock();
-    try {
-      queued = appendToDeltaBuffer(entries);
-    } finally {
-      lock.writeLock().unlock();
-    }
-
-    if (queued > 0)
-      LogManager.instance().log(this, Level.INFO,
-          "Queued %d of %d vector(s) the persisted graph of index %s leaves unreachable into the delta scan, which "
-              + "is the only way a search can return them (issue #7190)", queued, unreachableOrdinals.length,
-          indexName);
   }
 
   /**
@@ -4202,6 +4206,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * true - without saying it is evictable; the gate now asks how much of it must be given up and gives that up
    * before admitting, rather than counting it as free and hoping.
    * <p>
+   * <b>Two indexes do not normally race each other through this gate</b>, which is why the reclaimable figure can be
+   * read as a plain snapshot: {@link #startAsyncGraphRebuild()}'s thread calls this while HOLDING the JVM-wide
+   * {@code REBUILD_SEMAPHORE} permit, so at its default of one permit no other index is inside this method deciding
+   * against the same process-wide page cache. Widen that semaphore and two rebuilds could each be admitted on bytes
+   * only one of them gets - which is what the "did the cache actually give up what it was asked for" check below
+   * exists for, and past that the {@link OutOfMemoryError} handler and the deferral cooldown.
+   * <p>
    * Package-private so tests can drive the decision directly rather than through a background thread.
    *
    * @return true to proceed with the rebuild
@@ -4243,13 +4254,24 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // from disk as they are needed again, which is a cost paid in I/O by whoever touches them - against a rebuild
       // that stops every query paying a linear delta scan.
       final long freed = pageManager.reclaimReadCacheRAM(reclaimNeeded);
+      if (freed >= reclaimNeeded) {
+        LogManager.instance().log(this, Level.INFO,
+            "Freed %d MB of the %d MB page read cache so the graph rebuild of vector index %s (about %d MB for %d "
+                + "nodes) fits the %d MB of available heap that %s allows it. Those pages are read back from disk on "
+                + "demand, and the cache is process-wide, so some of them may belong to another database",
+            freed / (1024 * 1024), reclaimable / (1024 * 1024), indexName, estimate / (1024 * 1024), nodes,
+            availableHeap / (1024 * 1024), GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey());
+        return true;
+      }
+
+      // The cache was smaller by the time it was asked than when it was measured a moment earlier - it shrank on its
+      // own, or something else reclaimed from the same process-wide LRU first. The admission was conditional on
+      // getting those bytes, so not getting them means declining, not proceeding and relying on the
+      // OutOfMemoryError handler this gate exists to keep out of the picture.
       LogManager.instance().log(this, Level.INFO,
-          "Freed %d MB of the %d MB page read cache so the graph rebuild of vector index %s (about %d MB for %d "
-              + "nodes) fits the %d MB of available heap that %s allows it. Those pages are read back from disk on "
-              + "demand, and the cache is process-wide, so some of them may belong to another database",
-          freed / (1024 * 1024), reclaimable / (1024 * 1024), indexName, estimate / (1024 * 1024), nodes,
-          availableHeap / (1024 * 1024), GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey());
-      return true;
+          "The page read cache of index %s gave up %d MB of the %d MB the graph rebuild needed, so the rebuild is "
+              + "deferred rather than attempted on heap it was not actually given",
+          indexName, freed / (1024 * 1024), reclaimNeeded / (1024 * 1024));
     }
 
     metrics.incrementRebuildsDeferredForMemory();

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -37,6 +37,7 @@ import com.arcadedb.engine.ComponentFactory;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PageManager;
 import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.exception.DatabaseIsReadOnlyException;
@@ -70,6 +71,7 @@ import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.NodesIterator;
+import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
@@ -357,6 +359,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   private volatile List<DeltaVectorEntry> deltaVectors = new ArrayList<>();
+
+  /**
+   * Ordinals of the RESIDENT graph that no path from its entry node reaches (issue #5615), or {@code null} when
+   * this session has not established the answer for the graph it is serving - it has neither built one nor loaded
+   * one from disk yet.
+   * <p>
+   * Set by a build (from its own connectivity walk) and by the load path (from the manifest next to the graph it
+   * loaded), so it always describes the graph {@link #graphIndex} currently holds. Two things read it: the manifest
+   * write, so the set survives the process that discovered it (issue #7190), and {@link #getStats()}, so an
+   * operator can see that N vectors are reachable only through the delta scan.
+   */
+  private volatile int[] graphUnreachableOrdinals = null;
 
   /**
    * Exponential moving average of the nodes a graph walk scores per query, from JVector's own
@@ -1527,9 +1541,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @param liveOrdinalToVectorId    every live vector's id, in ordinal order - not only the ones the graph covers
    * @param graphSize                how many of {@code liveOrdinalToVectorId}'s leading entries the graph covers
    * @param vectorProp               the vector property name, for reading the gap vectors back
+   * @param unreachableOrdinals      ordinals of the loaded graph its own build could not link, from the manifest
+   *                                 (issue #7190) - never {@code null}
    */
   private record ReuseCandidate(ImmutableGraphIndex loadedGraph, int[] liveOrdinalToVectorId, int graphSize,
-                                 String vectorProp) {
+                                 String vectorProp, int[] unreachableOrdinals) {
   }
 
   /**
@@ -1831,7 +1847,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // Deliberately not done here: reuseStalePrefixGraph() does real I/O for the gap and must run
           // unlocked (see the field javadoc above). Only the decision - not the read - belongs under this
           // lock, same as every other branch in this method.
-          return new PersistedGraphCheck(false, new ReuseCandidate(loadedGraph, prefix, graphSize, vectorProp));
+          return new PersistedGraphCheck(false,
+              new ReuseCandidate(loadedGraph, prefix, graphSize, vectorProp, persistedManifest.unreachableOrdinals()));
         }
         LogManager.instance().log(this, Level.INFO,
             "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
@@ -1843,9 +1860,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
       // Graph is up to date - publish it under a brief write lock (issue #6713), then finish PQ
       // (if needed) unlocked, mirroring buildGraphFromScratchExclusively's own publish step.
+      final int[] unreachableOrdinals = persistedManifest != null ?
+          persistedManifest.unreachableOrdinals() : EMPTY_ORDINALS;
       lock.writeLock().lock();
       try {
         this.graphIndex = loadedGraph;
+        this.graphUnreachableOrdinals = unreachableOrdinals;
         this.ordinalToVectorId = rebuiltOrdinalToVectorId;
         if (graphState == GraphState.LOADING)
           this.graphState = GraphState.IMMUTABLE;
@@ -1857,6 +1877,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
       } finally {
         lock.writeLock().unlock();
       }
+
+      // Nodes the build that produced this graph could not link are physically in it and unreachable to every beam
+      // search, at any efSearch. The session that built it served them from the delta scan; this one has to do the
+      // same or they are simply gone while totalVectors still counts them (issue #7190). Outside the publish lock
+      // because the read is real I/O, and after it rather than before so the graph is searchable at once.
+      requeueUnreachableVectors(unreachableOrdinals, rebuiltOrdinalToVectorId, rebuiltOrdinalToVectorId.length,
+          vectorProp);
 
       // Build PQ if PRODUCT quantization is enabled but PQ file doesn't exist
       // This handles the case where graph was built before PRODUCT quantization was added
@@ -1921,6 +1948,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final int graphSize = candidate.graphSize();
     final String vectorProp = candidate.vectorProp();
 
+    // Declared out here rather than beside the publish below because the rebuild decision at the tail of this
+    // method - past graphBuildLock - is made on it (issue #7183).
+    int queuedIntoDelta = 0;
+
     graphBuildLock.lock();
     try {
       // Double-check that nobody published a graph while this call waited for graphBuildLock - a concurrent
@@ -1970,51 +2001,36 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final int[] gapOrdinalToVectorId = gapCount == gapCandidates.length ? gapCandidates :
           Arrays.copyOf(gapCandidates, gapCount);
 
-      final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
-          metadata.dimensions, vectorProp,
-          snapshotOf(vectorIndex(), gapOrdinalToVectorId), gapOrdinalToVectorId, this,
-          computeGraphBuildCacheCapacity(gapOrdinalToVectorId.length));
-
       // Collected into a local list first, exactly the way buildGraphFromScratchExclusively collects its own
       // unreachable-node re-queue before its publish step: appended into the shared deltaVectors only once this
       // method holds lock.writeLock() below, never while unlocked.
-      final List<DeltaVectorEntry> gapEntries = new ArrayList<>(gapOrdinalToVectorId.length);
-      for (int ordinal = 0; ordinal < gapOrdinalToVectorId.length; ordinal++) {
-        final int vectorId = gapOrdinalToVectorId[ordinal];
-        final RID rid = vectorIndex().getRid(vectorId);
-        if (rid == null)
-          continue; // gone since the array above was built; the next mutation or rebuild picks it up
-        final VectorFloat<?> vector = vectors.getVector(ordinal);
-        if (vector == null || (vectors instanceof final ArcadePageVectorValues pageValues
-            && pageValues.isDeletedSentinel(vector)))
-          continue;
-        gapEntries.add(new DeltaVectorEntry(vectorId, rid, vector));
-      }
+      final List<DeltaVectorEntry> gapEntries = readDeltaEntriesFor(gapOrdinalToVectorId, vectorProp);
+
+      // The graph being reused is a prefix of the live set, so the nodes ITS build could not link are ordinals
+      // below graphSize and are covered by neither the gap above nor anything in memory (issue #7190). Read them
+      // here, with the gap, so one reopen produces one complete delta buffer.
+      final List<DeltaVectorEntry> unreachableEntries = readDeltaEntriesFor(
+          unreachableVectorIdsOf(candidate.unreachableOrdinals(), rebuiltOrdinalToVectorId, graphSize, alreadyQueued),
+          vectorProp);
 
       // Publish. The graph is not published for the whole unlocked read above - insert() does not wait on it -
       // so a concurrent write could have landed on this index in the meantime and already appended its own
       // entries to deltaVectors and its own count to mutationsSinceSerialize. Appending to the buffer rather
       // than replacing it, and addAndGet() rather than a plain set(), is what keeps those instead of silently
       // dropping them.
-      int queuedIntoDelta = 0;
+      final int queuedUnreachable;
       lock.writeLock().lock();
       try {
         this.graphIndex = loadedGraph;
+        this.graphUnreachableOrdinals = candidate.unreachableOrdinals();
         this.ordinalToVectorId = Arrays.copyOf(rebuiltOrdinalToVectorId, graphSize);
-        // Re-checked here against the buffer as it stands NOW, not only against the pre-read snapshot taken
-        // above: a concurrent put() could have queued one of these ids while the gap was being read unlocked,
-        // and queuing it a second time is the same duplicate the pre-filter exists to avoid (issue #6772).
-        if (!gapEntries.isEmpty()) {
-          final IntHashSet queued = new IntHashSet((deltaVectors.size() + gapEntries.size()) * 4 / 3 + 1);
-          for (final DeltaVectorEntry entry : deltaVectors)
-            queued.add(entry.vectorId);
-          for (final DeltaVectorEntry entry : gapEntries)
-            if (queued.add(entry.vectorId)) {
-              this.deltaVectors.add(entry);
-              queuedIntoDelta++;
-            }
-        }
+        queuedIntoDelta = appendToDeltaBuffer(gapEntries);
+        queuedUnreachable = appendToDeltaBuffer(unreachableEntries);
         this.graphState = GraphState.MUTABLE;
+        // Only the gap counts as pending work. A node the persisted graph leaves unreachable is not a mutation -
+        // it is already in that graph, a rebuild does not remove it, and counting it would let an index whose last
+        // build orphaned a node rebuild itself on every reopen. Same reasoning, and same consequences, as the
+        // re-queue buildGraphFromScratchExclusively does at the end of a build.
         this.mutationsSinceSerialize.addAndGet(queuedIntoDelta);
       } finally {
         lock.writeLock().unlock();
@@ -2023,8 +2039,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
       metrics.incrementStalePrefixGraphReuses();
       LogManager.instance().log(this, Level.INFO,
           "Reusing persisted graph for index %s as a stale prefix: %d of %d live vectors are already in the "
-              + "graph, %d queued into the delta buffer pending an async rebuild (issues #6655, #6772)",
-          indexName, graphSize, rebuiltOrdinalToVectorId.length, queuedIntoDelta);
+              + "graph, %d queued into the delta buffer pending an async rebuild (issues #6655, #6772)%s",
+          indexName, graphSize, rebuiltOrdinalToVectorId.length, queuedIntoDelta,
+          queuedUnreachable > 0 ?
+              ", plus %d its build left unreachable and which the delta scan has to serve (issue #7190)".formatted(
+                  queuedUnreachable) : "");
     } finally {
       // ensureGraphAvailable() handed the latch over rather than clearing it at decision time, so this is where it
       // is released - after the publish above and, crucially, still under graphBuildLock, so the next thread to
@@ -2037,13 +2056,187 @@ public class LSMVectorIndex implements Index, IndexInternal {
     }
 
     // Outside graphBuildLock, the same scope buildGraphFromScratchWithRetry leaves for what runs after it
-    // publishes: only the build/reuse itself needs to be serialized, not its follow-up work. Kicks the same
-    // async rebuild rebuildGraphBeforeSearch() would eventually trigger anyway, so the gap just queued above is
-    // closed promptly instead of waiting on the ordinary mutation threshold, and arms the inactivity timer as a
-    // fallback for when the async attempt is skipped (already in progress, or still cooling down from a prior
-    // OOM deferral - see isCoolingDownFromRebuildDeferral()).
-    startAsyncGraphRebuild();
+    // publishes: only the build/reuse itself needs to be serialized, not its follow-up work.
+    //
+    // The gap queued above is served correctly by the delta scan, so folding it into the graph is a COST decision,
+    // and the mutation threshold is the decision (issue #7183). This used to call startAsyncGraphRebuild()
+    // unconditionally, "so the gap just queued is closed promptly instead of waiting on the ordinary mutation
+    // threshold" - which for a gap of one vector meant rebuilding every node in the graph for that one vector, on
+    // the first search of a session that had done nothing but insert it, with startAsyncGraphRebuild() itself
+    // logging the threshold it was ignoring. A process that opens, searches once and exits then paid a full
+    // rebuild plus the close()-time join on the thread running it, found the same one vector still queued on the
+    // next open (the rebuild was cancelled before it could persist), and did it all again. The inactivity timer had
+    // the same shape and learned the same lesson in #6857; this is that fix on this door. The triggers asked here
+    // are exactly rebuildGraphBeforeSearch()'s large-graph arm: enough mutations have piled up, or the delta scan
+    // those mutations left behind has outgrown the graph walk it supplements (issue #6797). A gap below both stays
+    // in the delta buffer, which is what the buffer is for.
+    //
+    // The inactivity timer is armed either way: as the fallback for when the async attempt above is skipped
+    // (already in progress, or still cooling down from a prior heap deferral - see
+    // isCoolingDownFromRebuildDeferral()), and as the path that eventually folds in a gap too small to trigger
+    // anything here once the index goes quiet.
+    if (queuedIntoDelta > 0
+        && (mutationsSinceSerialize.get() >= getEffectiveMutationsBeforeRebuild() || deltaScanOverBudget()))
+      startAsyncGraphRebuild();
     scheduleInactivityRebuild();
+  }
+
+  /**
+   * Reads the vectors behind {@code vectorIdsAscending} and wraps them as delta-buffer entries, skipping anything
+   * that cannot be read back as a real vector.
+   * <p>
+   * Does real per-vector I/O (a page read, or a document lookup for the non-quantized case) and so must be called
+   * WITHOUT {@link #lock}'s write lock, exactly like the gap read it was extracted from - holding it here would
+   * stall every reader and writer of this index for the duration. The entries are returned rather than appended for
+   * the same reason: the append is the only part that needs the lock, and it is
+   * {@link #appendToDeltaBuffer(List)}'s job.
+   *
+   * @param vectorIdsAscending vector ids to read, ascending - the order {@link #snapshotOf} assumes
+   * @param vectorProp         the vector property name, for the document-read fallback
+   *
+   * @return the readable entries, in the same order; empty when there was nothing to read
+   */
+  private List<DeltaVectorEntry> readDeltaEntriesFor(final int[] vectorIdsAscending, final String vectorProp) {
+    if (vectorIdsAscending == null || vectorIdsAscending.length == 0)
+      return List.of();
+
+    // Sized off the ids actually being read, never off the whole index: snapshotOf() and
+    // computeGraphBuildCacheCapacity() both scale their work with whatever array they are handed (PR #6712 review).
+    final RandomAccessVectorValues vectors = ArcadePageVectorValues.forGraphBuild(getDatabase(),
+        metadata.dimensions, vectorProp,
+        snapshotOf(vectorIndex(), vectorIdsAscending), vectorIdsAscending, this,
+        computeGraphBuildCacheCapacity(vectorIdsAscending.length));
+
+    final List<DeltaVectorEntry> entries = new ArrayList<>(vectorIdsAscending.length);
+    for (int ordinal = 0; ordinal < vectorIdsAscending.length; ordinal++) {
+      final int vectorId = vectorIdsAscending[ordinal];
+      final RID rid = vectorIndex().getRid(vectorId);
+      if (rid == null)
+        continue; // gone since the array above was built; the next mutation or rebuild picks it up
+      // getVector() resolves the location through the snapshot and never returns null: an unreadable ordinal comes
+      // back as the sentinel, which would pair a genuine RID with a meaningless distance in the delta scan.
+      final VectorFloat<?> vector = vectors.getVector(ordinal);
+      if (vector == null || (vectors instanceof final ArcadePageVectorValues pageValues
+          && pageValues.isDeletedSentinel(vector)))
+        continue;
+      entries.add(new DeltaVectorEntry(vectorId, rid, vector));
+    }
+    return entries;
+  }
+
+  /**
+   * Appends the entries the buffer does not already hold. <b>The caller must hold {@link #lock}'s write lock.</b>
+   * <p>
+   * The membership test is made against the buffer as it stands NOW, not only against a snapshot taken before the
+   * unlocked read that produced {@code entries}: a concurrent {@code put()} could have queued one of these ids
+   * meanwhile, and queuing it twice would score the same vector twice in every delta scan (issue #6772).
+   *
+   * @return how many entries were actually added
+   */
+  private int appendToDeltaBuffer(final List<DeltaVectorEntry> entries) {
+    if (entries.isEmpty())
+      return 0;
+
+    // Sized in TABLE SLOTS, not elements: IntHashSet resizes at a 0.75 load factor, so handing it the element
+    // count alone would guarantee one rehash of the whole table on the way in.
+    final IntHashSet queued = new IntHashSet((deltaVectors.size() + entries.size()) * 4 / 3 + 1);
+    for (final DeltaVectorEntry entry : deltaVectors)
+      queued.add(entry.vectorId);
+
+    int added = 0;
+    for (final DeltaVectorEntry entry : entries)
+      if (queued.add(entry.vectorId)) {
+        this.deltaVectors.add(entry);
+        added++;
+      }
+    return added;
+  }
+
+  /**
+   * Queues the vectors of a loaded graph's unreachable ordinals into the delta buffer, so this session serves them
+   * exactly the way the session that built the graph did (issue #7190).
+   * <p>
+   * Deliberately touches neither {@code mutationsSinceSerialize} nor {@link #graphState}: those nodes are not
+   * pending work. They are already in the graph on disk, a rebuild does not remove them - a Vamana build orphans a
+   * fresh set - and treating them as mutations would make an index whose last build orphaned one node rebuild
+   * itself on every open, and {@code flush()} rebuild on every close. The identical reasoning, and the identical
+   * pair of consequences, is spelled out where {@code buildGraphFromScratchExclusively} makes the same re-queue at
+   * the end of a build. The cost of leaving the state alone is that these entries are scanned by every query until
+   * some real mutation triggers a rebuild, which is the same cost the building session paid.
+   * <p>
+   * Called while holding {@link #graphBuildLock} (both call sites do) and NOT {@link #lock}'s write lock, which the
+   * per-vector read it performs must not run under.
+   *
+   * @param unreachableOrdinals   ordinals from the graph's manifest, ascending
+   * @param liveOrdinalToVectorId the live ordinal &rarr; vector id array those ordinals index into
+   * @param graphNodes            how many leading entries of that array the graph covers
+   * @param vectorProp            the vector property name, for the document-read fallback
+   */
+  private void requeueUnreachableVectors(final int[] unreachableOrdinals, final int[] liveOrdinalToVectorId,
+      final int graphNodes, final String vectorProp) {
+    if (unreachableOrdinals == null || unreachableOrdinals.length == 0)
+      return;
+
+    final IntHashSet alreadyQueued;
+    lock.readLock().lock();
+    try {
+      alreadyQueued = new IntHashSet(deltaVectors.size() * 4 / 3 + 1);
+      for (final DeltaVectorEntry entry : deltaVectors)
+        alreadyQueued.add(entry.vectorId);
+    } finally {
+      lock.readLock().unlock();
+    }
+
+    final List<DeltaVectorEntry> entries = readDeltaEntriesFor(
+        unreachableVectorIdsOf(unreachableOrdinals, liveOrdinalToVectorId, graphNodes, alreadyQueued), vectorProp);
+    if (entries.isEmpty())
+      return;
+
+    final int queued;
+    lock.writeLock().lock();
+    try {
+      queued = appendToDeltaBuffer(entries);
+    } finally {
+      lock.writeLock().unlock();
+    }
+
+    if (queued > 0)
+      LogManager.instance().log(this, Level.INFO,
+          "Queued %d of %d vector(s) the persisted graph of index %s leaves unreachable into the delta scan, which "
+              + "is the only way a search can return them (issue #7190)", queued, unreachableOrdinals.length,
+          indexName);
+  }
+
+  /**
+   * Vector ids of the ordinals a persisted graph's own build could not link (issue #7190), ready for
+   * {@link #readDeltaEntriesFor}.
+   * <p>
+   * An ordinal at or past {@code graphNodes} is dropped rather than trusted: the manifest is verified against the
+   * live set before this runs, so it should not happen, but resolving an out-of-range ordinal through the live array
+   * would pair a delta entry with a record the graph never held.
+   *
+   * @param unreachableOrdinals    ordinals recorded in the manifest, ascending
+   * @param liveOrdinalToVectorId  the live ordinal &rarr; vector id array the graph's ordinals index into
+   * @param graphNodes             how many leading entries of that array the graph covers
+   * @param alreadyQueued          vector ids the delta buffer already holds, skipped before any read is paid for
+   *
+   * @return the ids to read, ascending; empty when there is nothing to re-queue
+   */
+  private static int[] unreachableVectorIdsOf(final int[] unreachableOrdinals, final int[] liveOrdinalToVectorId,
+      final int graphNodes, final IntHashSet alreadyQueued) {
+    if (unreachableOrdinals == null || unreachableOrdinals.length == 0)
+      return EMPTY_ORDINALS;
+
+    int count = 0;
+    final int[] candidates = new int[unreachableOrdinals.length];
+    for (final int ordinal : unreachableOrdinals) {
+      if (ordinal < 0 || ordinal >= graphNodes || ordinal >= liveOrdinalToVectorId.length)
+        continue;
+      final int vectorId = liveOrdinalToVectorId[ordinal];
+      if (!alreadyQueued.contains(vectorId))
+        candidates[count++] = vectorId;
+    }
+    return count == candidates.length ? candidates : Arrays.copyOf(candidates, count);
   }
 
   /**
@@ -3069,12 +3262,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
       //  - the decrement just above may take the counter to zero and cancel the inactivity rebuild timer, so an
       //    otherwise idle index has no self-scheduled path out of scanning these entries until the next real
       //    mutation. That is the price of not spinning on rebuilds;
-      //  - deltaVectors is in-memory, so a restart drops the re-queue. The persisted graph still physically holds
-      //    the orphan and reports the same node count as the ordinal map, so the staleness check on load sees an
-      //    up-to-date graph and the vector is unsearchable again until some mutation triggers a rebuild. Closing
-      //    that would mean persisting the orphan set; it is left open because any rebuild re-detects it.
+      //  - deltaVectors is in-memory, so a restart drops the re-queue - and the persisted graph still physically
+      //    holds the orphan and reports the same node count as the ordinal map, so the staleness check on load sees
+      //    an up-to-date graph and nothing rebuilds. Those vectors were then gone from every search at any
+      //    efSearch while totalVectors still counted them, silently (issue #7190). The ordinals are therefore
+      //    recorded in the graph manifest below and re-queued by the load path, which is what makes a reopened
+      //    session serve them exactly the way this one does.
+      final int[] unreachableOrdinals = findUnreachableOrdinals(builtGraph);
       final List<DeltaVectorEntry> unreachableEntries = new ArrayList<>();
-      for (final int ordinal : findUnreachableOrdinals(builtGraph)) {
+      for (final int ordinal : unreachableOrdinals) {
         if (ordinal >= finalActiveVectorIds.length)
           continue;
         final int vectorId = finalActiveVectorIds[ordinal];
@@ -3097,14 +3293,19 @@ public class LSMVectorIndex implements Index, IndexInternal {
       }
       if (!unreachableEntries.isEmpty())
         LogManager.instance().log(this, Level.WARNING,
-            "Graph build left %d of %d vectors unreachable for index %s: serving them from the delta scan. A later "
-                + "rebuild does not repair this - a Vamana build orphans a fresh set - so the count does not "
-                + "converge downwards", unreachableEntries.size(), finalActiveVectorIds.length, indexName);
+            "Graph build left %d of %d vectors unreachable for index %s: serving them from the delta scan, and "
+                + "recording them in the graph manifest so a reopened session serves them the same way (issue "
+                + "#7190). A later rebuild does not repair this - a Vamana build orphans a fresh set - so the count "
+                + "does not converge downwards", unreachableEntries.size(), finalActiveVectorIds.length, indexName);
 
       // Reacquire write lock to update graph state
       lock.writeLock().lock();
       try {
         this.graphIndex = builtGraph;
+        // Published together with the graph they describe, and unconditionally - an empty set is the answer for
+        // almost every build, and leaving a previous build's set in place would make the manifest below vouch for
+        // ordinals this graph does not orphan (issue #7190).
+        this.graphUnreachableOrdinals = unreachableOrdinals;
         // Hand the PREVIOUS generation back now rather than at the next search. borrow() drains the pool when it
         // sees the identity has moved, so this is not a correctness fix - a stale searcher is never handed out -
         // but "the next search" is not a promise on an index that has just rebuilt and gone quiet, which is the
@@ -3466,8 +3667,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (persistedTo == null || graphOrdinalToVectorId == null || graphOrdinalToVectorId.length == 0)
       return;
 
+    // The ordinals the build that produced these pages could not link (issue #7190). Read from the field rather
+    // than passed in because both callers reach here right after a build published it, and only that build knows
+    // the answer: the connectivity walk runs over the graph object, not over anything on disk.
+    final int[] unreachable = graphUnreachableOrdinals;
+
     persistedTo.getManifest().write(graphOrdinalToVectorId.length,
-        LSMVectorIndexGraphManifest.fingerprintOf(graphOrdinalToVectorId, vectorIndex()::getRid));
+        LSMVectorIndexGraphManifest.fingerprintOf(graphOrdinalToVectorId, vectorIndex()::getRid),
+        unreachable != null ? unreachable : EMPTY_ORDINALS);
   }
 
   private long getTxChunkSize() {
@@ -3985,6 +4192,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * {@code COMPACT INDEX} are lifecycle- or operator-driven, have no later trigger to retry them, and in the
    * close case have already released the old graph - declining one of those would turn "slower" into "never".
    * <p>
+   * <b>What issue #7184 changed, on both sides of the comparison.</b> A deferral costs every subsequent query a
+   * linear scan of a delta buffer that keeps growing, and nothing else bounds that scan, so a gate that refuses a
+   * rebuild which would in fact have fitted is not the conservative choice - it is the unbounded one. Two readings
+   * were producing exactly that at 10M vectors in a 24 GB heap, at every attempt. The COST side charged a second
+   * full on-heap graph for the graph kept resident, which a reopened session does not have: it serves an
+   * {@code OnDiskGraphIndex} whose topology lives in pages, so that term is now measured
+   * ({@code ramBytesUsed()}) instead of assumed. The HEAP side counted ArcadeDB's own page read cache as occupied -
+   * true - without saying it is evictable; the gate now asks how much of it must be given up and gives that up
+   * before admitting, rather than counting it as free and hoping.
+   * <p>
    * Package-private so tests can drive the decision directly rather than through a background thread.
    *
    * @return true to proceed with the rebuild
@@ -4002,27 +4219,72 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final long nodes = Math.max(resident.getIdUpperBound(), vectorIndex().getActiveCount());
     final long buildCacheCapacity = computeGraphBuildCacheCapacity((int) Math.min(nodes, Integer.MAX_VALUE / 2));
 
-    final long estimate = VectorHeapBudget.estimateRebuildHeapBytes(nodes, metadata.dimensions, buildCacheCapacity,
-        true);
-    final long budget = VectorHeapBudget.budgetBytes(percent);
-    if (estimate <= budget)
+    // What the graph being kept resident actually costs, asked of the graph rather than assumed (issue #7184). A
+    // reopened session serves an OnDiskGraphIndex, whose topology is in pages: charging it a second full on-heap
+    // graph is how a rebuild the close path would run unconditionally came to be refused at every attempt.
+    final long residentGraphBytes = residentGraphHeapBytes(resident);
+    final long estimate = VectorHeapBudget.estimateOnlineRebuildHeapBytes(nodes, metadata.dimensions,
+        buildCacheCapacity, residentGraphBytes, resident.getIdUpperBound(), resident instanceof OnHeapGraphIndex,
+        metadata.neighborOverflowFactor);
+
+    // The page read cache is heap the last collection counted as live and that the engine can hand back on demand,
+    // so the gate asks how much of it has to go rather than pretending the heap is already free (issue #7184).
+    final PageManager pageManager = getDatabase().getPageManager();
+    final long reclaimable = pageManager != null ? pageManager.getReadCacheRAM() : 0L;
+    final long availableHeap = VectorHeapBudget.availableHeapBytes();
+    final long reclaimNeeded = VectorHeapBudget.reclaimNeededFor(estimate, percent, availableHeap, reclaimable);
+
+    if (reclaimNeeded == 0L)
       return true;
+
+    if (reclaimNeeded > 0L) {
+      // Admitted BECAUSE the cache counts as reclaimable, so reclaim it now, before the build allocates: the pages
+      // are strongly referenced and no collection would have taken them on the build's behalf. They are read back
+      // from disk as they are needed again, which is a cost paid in I/O by whoever touches them - against a rebuild
+      // that stops every query paying a linear delta scan.
+      final long freed = pageManager.reclaimReadCacheRAM(reclaimNeeded);
+      LogManager.instance().log(this, Level.INFO,
+          "Freed %d MB of the %d MB page read cache so the graph rebuild of vector index %s (about %d MB for %d "
+              + "nodes) fits the %d MB of available heap that %s allows it. Those pages are read back from disk on "
+              + "demand",
+          freed / (1024 * 1024), reclaimable / (1024 * 1024), indexName, estimate / (1024 * 1024), nodes,
+          availableHeap / (1024 * 1024), GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey());
+      return true;
+    }
 
     metrics.incrementRebuildsDeferredForMemory();
     // Start the cooldown BEFORE logging, so the timestamp is set no matter what the log call does.
     lastRebuildDeferralMs = System.currentTimeMillis();
     LogManager.instance().log(this, Level.WARNING,
-        "Deferring the graph rebuild of vector index %s: it needs about %d MB (%d nodes, keeping the old graph "
-            + "resident so searches keep working) against %d MB of the %d MB currently available heap that %s "
-            + "allows it. The %d pending vectors stay searchable through the delta scan, and the next mutation or "
-            + "inactivity trigger retries - but until one fits, every query pays that scan. Give the JVM more "
-            + "heap, lower %s, or set %s to 0 to attempt the rebuild regardless",
-        indexName, estimate / (1024 * 1024), nodes, budget / (1024 * 1024),
-        VectorHeapBudget.availableHeapBytes() / (1024 * 1024),
-        GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey(), mutationsSinceSerialize.get(),
+        "Deferring the graph rebuild of vector index %s: it needs about %d MB (%d nodes, plus the %d MB the graph "
+            + "it replaces costs to keep resident so searches keep working) against %d MB of the %d MB currently "
+            + "available heap that %s allows it, and the %d MB of evictable page cache that could be given up does "
+            + "not close the gap. The %d pending vectors stay searchable through the delta scan, and the next "
+            + "mutation or inactivity trigger retries - but until one fits, every query pays that scan. Give the JVM "
+            + "more heap, lower %s, or set %s to 0 to attempt the rebuild regardless",
+        indexName, estimate / (1024 * 1024), nodes, residentGraphBytes / (1024 * 1024),
+        VectorHeapBudget.budgetBytes(percent) / (1024 * 1024), availableHeap / (1024 * 1024),
+        GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey(), reclaimable / (1024 * 1024),
+        mutationsSinceSerialize.get(),
         GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.getKey(),
         GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey());
     return false;
+  }
+
+  /**
+   * What the resident graph costs to keep on the heap, from the graph itself. Every {@code ImmutableGraphIndex} is
+   * {@code Accountable}; a future implementation that refuses the question falls back to the flat per-node estimate
+   * this method exists to replace, so a throwing {@code ramBytesUsed()} costs accuracy rather than a rebuild.
+   */
+  private long residentGraphHeapBytes(final ImmutableGraphIndex resident) {
+    try {
+      return Math.max(0L, resident.ramBytesUsed());
+    } catch (final Exception | LinkageError e) {
+      LogManager.instance().log(this, Level.FINE,
+          "Could not measure the resident graph of index %s (%s): falling back to the per-node estimate", indexName,
+          e.getMessage());
+      return VectorHeapBudget.estimateGraphBytes(resident.getIdUpperBound());
+    }
   }
 
   /**
@@ -7865,6 +8127,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     // Delta vectors cached in RAM for brute-force scan between rebuilds
     stats.put("deltaVectorsCount", (long) deltaVectors.size());
+
+    // Nodes the build that produced the current graph could not link, which no beam search can return at any
+    // efSearch and which the delta scan therefore has to serve (issues #5615, #7190). Answered from the field
+    // while this session has resolved a graph, and from the manifest before it has - the same reason
+    // persistedGraphNodeCount above is read from there: "how many are only reachable by scan" is a question an
+    // operator has to be able to ask on a freshly reopened index too.
+    final int[] unreachableOrdinals = graphUnreachableOrdinals;
+    stats.put("unreachableGraphNodes", unreachableOrdinals != null ?
+        (long) unreachableOrdinals.length :
+        manifestContent != null ? (long) manifestContent.unreachableOrdinals().length : 0L);
 
     // The size-independent bound on that scan and the measured walk cost it is derived from (issue #6797).
     // deltaScanBudget is Long.MAX_VALUE when the policy is off or no search has walked this graph yet, which is

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2539,6 +2539,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
       lock.writeLock().lock();
       try {
         this.graphIndex = null;
+        // Cleared with the graph, for the same reason (issue #7190): the ordinals describe the generation being
+        // released, and a build that then fails would leave getStats() reporting them against no resident graph.
+        // The set on disk is untouched, so a later load reads it back from the manifest.
+        this.graphUnreachableOrdinals = EMPTY_ORDINALS;
         this.searchVectorCache = null;
         releasePooledSearchers();
       } finally {
@@ -2958,6 +2962,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
         try {
           this.ordinalToVectorId = filteredVectorIds;
           this.graphIndex = null;
+          // Cleared with the graph it describes: this build published none, so the previous generation's orphans
+          // describe nothing that is resident any more, and getStats() would otherwise report unreachable nodes for
+          // an index that has no graph at all (issue #7190).
+          this.graphUnreachableOrdinals = EMPTY_ORDINALS;
           // Nulling the field is not enough to free the graph: a pooled searcher holds the graph it was pooled
           // under (issue #6503). Normally borrow() drains the pool when it notices the identity moved, but this
           // path leaves no graph to search, and findNeighborsFromVector() returns on `graphIndex == null` BEFORE

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4246,7 +4246,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       LogManager.instance().log(this, Level.INFO,
           "Freed %d MB of the %d MB page read cache so the graph rebuild of vector index %s (about %d MB for %d "
               + "nodes) fits the %d MB of available heap that %s allows it. Those pages are read back from disk on "
-              + "demand",
+              + "demand, and the cache is process-wide, so some of them may belong to another database",
           freed / (1024 * 1024), reclaimable / (1024 * 1024), indexName, estimate / (1024 * 1024), nodes,
           availableHeap / (1024 * 1024), GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey());
       return true;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -20,6 +20,7 @@ package com.arcadedb.index.vector;
 
 import com.arcadedb.database.RID;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
 import java.io.IOException;
@@ -50,6 +51,7 @@ import java.util.logging.Level;
  * what two different generations both produce; it is the records behind those ids that differ.
  * <p>
  * Like {@link LSMVectorIndexPQFile} this is a plain file rather than a paginated component: it is a few dozen bytes
+ * (plus one number per node the last build left unreachable, normally none - see {@link Content#unreachableOrdinals()})
  * read once per graph load and rewritten once per graph persist, and keeping it out of the page system means it can
  * be removed before the graph pages are touched and written only after they are committed. That order is what makes
  * the check safe under a crash: a persist that fails observably replaces the manifest with one that refuses the
@@ -81,6 +83,9 @@ public class LSMVectorIndexGraphManifest {
    */
   static final int UNUSABLE_VECTOR_COUNT = -1;
 
+  /** Shared by a manifest that records no unreachable ordinal, which is the overwhelmingly common case. */
+  static final int[] NO_UNREACHABLE_ORDINALS = new int[0];
+
   /**
    * What a persisted manifest says about the graph next to it.
    *
@@ -90,12 +95,20 @@ public class LSMVectorIndexGraphManifest {
    * @param closeDeferredRebuild {@code true} when the pages this manifest describes are known stale because the
    *                             most recent {@code close()} chose to defer the rebuild that would otherwise have
    *                             brought them up to date (issue #6657), rather than run it synchronously. Always
-   *                             {@code false} again once a build actually completes - {@link #write(int, long)} and
-   *                             {@link #markUnusable(String)} both clear it - so it answers specifically "did the
+   *                             {@code false} again once a build actually completes - {@link #write(int, long, int[])}
+   *                             and {@link #markUnusable(String)} both clear it - so it answers specifically "did the
    *                             last close skip a rebuild", not the broader "is a rebuild owed" that
    *                             {@code vectorCount}/{@code fingerprint} against the live index already answers.
+   * @param unreachableOrdinals ordinals of the graph next to this manifest that no path from its entry node reaches
+   *                             (issue #5615), ascending, never {@code null}. Those nodes are physically in the graph
+   *                             but no beam search can return them at any {@code efSearch}, so the index serves them
+   *                             from the delta scan instead - and until issue #7190 that re-queue lived only in the
+   *                             heap of the session that built the graph. Recording the set here is what lets a
+   *                             reopened session make the same one, instead of leaving those vectors unreachable by
+   *                             any search while {@code totalVectors} still counts them.
    */
-  public record Content(int formatVersion, int vectorCount, long fingerprint, boolean closeDeferredRebuild) {
+  public record Content(int formatVersion, int vectorCount, long fingerprint, boolean closeDeferredRebuild,
+                        int[] unreachableOrdinals) {
   }
 
   private final Path path;
@@ -182,17 +195,19 @@ public class LSMVectorIndexGraphManifest {
    * @param reason human-readable note stored in the file; nothing reads it back
    */
   public void markUnusable(final String reason) {
-    write(UNUSABLE_VECTOR_COUNT, 0L, reason, false);
+    write(UNUSABLE_VECTOR_COUNT, 0L, reason, false, NO_UNREACHABLE_ORDINALS);
   }
 
   /**
-   * Records the correspondence the just-committed graph was built over. Written through a temporary file so a
-   * crash mid-write cannot leave a truncated manifest that reads as a valid one. Always clears
-   * {@link Content#closeDeferredRebuild()}: a build that reached this call completed, so whatever a previous
-   * {@code close()} deferred has now been paid for.
+   * Records the correspondence the just-committed graph was built over, and which of its ordinals that build left
+   * unreachable (issue #7190). Written through a temporary file so a crash mid-write cannot leave a truncated
+   * manifest that reads as a valid one. Always clears {@link Content#closeDeferredRebuild()}: a build that reached
+   * this call completed, so whatever a previous {@code close()} deferred has now been paid for.
+   *
+   * @param unreachableOrdinals see {@link Content#unreachableOrdinals()}; {@code null} is read as none
    */
-  public void write(final int vectorCount, final long fingerprint) {
-    write(vectorCount, fingerprint, null, false);
+  public void write(final int vectorCount, final long fingerprint, final int[] unreachableOrdinals) {
+    write(vectorCount, fingerprint, null, false, unreachableOrdinals);
   }
 
   /**
@@ -202,8 +217,8 @@ public class LSMVectorIndexGraphManifest {
    * or falls back to {@link #UNUSABLE_VECTOR_COUNT} when nothing has ever been persisted here, so a first-ever
    * build that a large index's close deferred is recorded too.
    * <p>
-   * Cleared automatically the next time {@link #write(int, long)} or {@link #markUnusable(String)} runs, which is
-   * exactly when a rebuild - deferred or not - actually completes.
+   * Cleared automatically the next time {@link #write(int, long, int[])} or {@link #markUnusable(String)} runs,
+   * which is exactly when a rebuild - deferred or not - actually completes.
    * <p>
    * {@code read() == null} is treated as "nothing persisted yet" and takes the {@link #UNUSABLE_VECTOR_COUNT}
    * fallback, which is also what a transient read failure or a format-version mismatch report (both logged as
@@ -222,7 +237,10 @@ public class LSMVectorIndexGraphManifest {
       return;
     final int vectorCount = existing != null ? existing.vectorCount() : UNUSABLE_VECTOR_COUNT;
     final long fingerprint = existing != null ? existing.fingerprint() : 0L;
-    write(vectorCount, fingerprint, null, true);
+    // Carried over with the count and the fingerprint, for the same reason they are: this is a note about pages
+    // that have not changed, so what those pages leave unreachable has not changed either (issue #7190).
+    write(vectorCount, fingerprint, null, true,
+        existing != null ? existing.unreachableOrdinals() : NO_UNREACHABLE_ORDINALS);
   }
 
   /**
@@ -233,7 +251,7 @@ public class LSMVectorIndexGraphManifest {
    * manifest. A unique name costs nothing and removes the assumption.
    */
   private void write(final int vectorCount, final long fingerprint, final String reason,
-      final boolean closeDeferredRebuild) {
+      final boolean closeDeferredRebuild, final int[] unreachableOrdinals) {
     final Path temporary = path.resolveSibling(
         path.getFileName() + "." + Long.toHexString(System.nanoTime()) + ".tmp");
     try {
@@ -254,6 +272,16 @@ public class LSMVectorIndexGraphManifest {
       // As a string: a 64-bit fingerprint is not representable in the double a JSON number decodes to.
       json.put("fingerprint", Long.toString(fingerprint));
       json.put("closeDeferredRebuild", closeDeferredRebuild);
+      // Written only when there is something to say, and as a bare int array rather than as a new formatVersion:
+      // an older build reads the keys it knows and ignores this one, which leaves it exactly at its own
+      // pre-issue-#7190 behaviour instead of forcing every existing index to rebuild on the first open after an
+      // upgrade - which is what bumping FORMAT_VERSION would cost, since read() refuses a version it does not know.
+      if (unreachableOrdinals != null && unreachableOrdinals.length > 0) {
+        final JSONArray ordinals = new JSONArray();
+        for (final int ordinal : unreachableOrdinals)
+          ordinals.put(ordinal);
+        json.put("unreachableOrdinals", ordinals);
+      }
       if (reason != null)
         json.put("reason", reason);
 
@@ -314,11 +342,40 @@ public class LSMVectorIndexGraphManifest {
       }
       return new Content(formatVersion, json.getInt("vectorCount", -1),
           Long.parseLong(json.getString("fingerprint", "0")),
-          json.getBoolean("closeDeferredRebuild", false));
+          json.getBoolean("closeDeferredRebuild", false),
+          unreachableOrdinalsOf(json));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "Could not read the vector graph manifest '%s': %s", path,
           e.getMessage());
       return null;
+    }
+  }
+
+  /**
+   * The {@code unreachableOrdinals} array of a manifest, as primitive ints.
+   * <p>
+   * Absent in every manifest written before issue #7190 and in the overwhelming majority written after it, so the
+   * shared empty array is the answer on the common path. A malformed entry costs the set rather than the whole
+   * manifest: losing it puts the index back at the pre-#7190 behaviour for those nodes, while returning
+   * {@code null} from {@link #read()} would refuse a graph that is otherwise perfectly usable and force a full
+   * rebuild.
+   */
+  private int[] unreachableOrdinalsOf(final JSONObject json) {
+    final JSONArray persisted = json.getJSONArray("unreachableOrdinals", null);
+    if (persisted == null || persisted.length() == 0)
+      return NO_UNREACHABLE_ORDINALS;
+
+    try {
+      final int[] ordinals = new int[persisted.length()];
+      for (int i = 0; i < ordinals.length; i++)
+        ordinals[i] = persisted.getInt(i);
+      return ordinals;
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Vector graph manifest '%s' carries an unreadable unreachableOrdinals entry (%s): ignoring it. Nodes the "
+              + "last build left unreachable will not be served from the delta scan in this session", path,
+          e.getMessage());
+      return NO_UNREACHABLE_ORDINALS;
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorHeapBudget.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorHeapBudget.java
@@ -133,6 +133,49 @@ final class VectorHeapBudget {
   }
 
   /**
+   * How much of the reclaimable page cache has to be given up for an allocation of {@code bytes} to fit inside
+   * {@code percent} of available heap (issue #7184).
+   * <p>
+   * {@link #liveHeapBytes()} counts ArcadeDB's own page read cache as live, because from the JVM's point of view it
+   * is: those pages are strongly referenced and no collection will take them. But they are <em>evictable</em> - the
+   * engine can drop any of them and read the page back from disk - so judging a rebuild against a reading that
+   * treats them as permanently occupied is what refused a rebuild that a 24 GB heap could have run, at every
+   * attempt, leaving the delta scan those pending vectors produce to grow without limit. Issue #7147 applied the
+   * same correction to the build cache's own sizing; this is the admission gate's half of it.
+   * <p>
+   * The answer is not "count the cache as free and hope". A caller told to reclaim N bytes must actually reclaim
+   * them before it allocates, or the reading is simply optimistic in the other direction - which is the failure mode
+   * (an {@link OutOfMemoryError}) issue #6503 built this gate to avoid. Hence the amount, rather than a boolean.
+   *
+   * @param bytes            what the caller wants to allocate
+   * @param percent          share of available heap it may occupy, clamped to {@code [0, 90]} as elsewhere here
+   * @param availableHeap    {@link #availableHeapBytes()}, or a pinned figure in a test
+   * @param reclaimableBytes evictable bytes the {@code availableHeap} reading counts as live - the page read cache
+   *
+   * @return {@code 0} when the allocation already fits and nothing need be given up, a positive number of bytes to
+   * reclaim first, or {@code -1} when it does not fit even with every reclaimable byte handed over
+   */
+  static long reclaimNeededFor(final long bytes, final int percent, final long availableHeap,
+      final long reclaimableBytes) {
+    if (percent <= 0)
+      return 0L; // gate disabled: nothing to decide, and nothing to reclaim on its behalf
+    if (bytes <= 0)
+      return 0L;
+    // Above this the multiplication below would wrap, and a request that large does not fit any heap anyway.
+    if (bytes > Long.MAX_VALUE / 100)
+      return -1L;
+
+    final int p = Math.min(percent, 90);
+    // The available-heap reading that would make budgetBytes(p) cover `bytes`, rounded up so the answer never
+    // lands one byte short of the budget it is derived from.
+    final long neededAvailable = (bytes * 100 + p - 1) / p;
+    final long shortfall = neededAvailable - Math.max(0L, availableHeap);
+    if (shortfall <= 0)
+      return 0L;
+    return shortfall <= Math.max(0L, reclaimableBytes) ? shortfall : -1L;
+  }
+
+  /**
    * The share of {@link #availableHeapBytes()} a caller is allowed to claim.
    *
    * @param percent share to claim, clamped into {@code [0, 90]}: a build is never allowed to plan on the whole
@@ -210,5 +253,64 @@ final class VectorHeapBudget {
     if (oldGraphStaysResident)
       estimate += estimateGraphBytes(nodes);                                // ...on top of the one being replaced
     return estimate;
+  }
+
+  /**
+   * Peak heap an ONLINE rebuild is expected to hold at once: the graph being built, its build cache, and whatever
+   * the graph it is replacing actually costs to keep resident (issue #7184).
+   * <p>
+   * That last term is the correction. {@link #estimateRebuildHeapBytes} charges a second full on-heap graph for it -
+   * {@code nodes x APPROX_GRAPH_BYTES_PER_NODE} again - which is right when the resident graph is the
+   * {@code OnHeapGraphIndex} a build just produced, and badly wrong on the far more common shape: a session that
+   * reopened the database serves an {@code OnDiskGraphIndex}, whose topology lives in pages, and keeping it resident
+   * costs a few caches rather than a gigabyte per million nodes. Charging a phantom second graph there is what made
+   * a 10M-vector index in a 24 GB heap ask for 24 GB and be refused at every attempt, when the rebuild it was
+   * refusing is the same size as the one the close path runs unconditionally. Asking the graph itself
+   * ({@link io.github.jbellis.jvector.util.Accountable#ramBytesUsed()}) replaces the guess with a measurement, and
+   * it is a measurement of exactly the object that will still be there while the new graph is built.
+   * <p>
+   * The graph being BUILT cannot be measured - it does not exist yet - so it is still estimated. When the resident
+   * graph is itself on-heap its measured cost per node is by far the best predictor available for it: same index,
+   * same {@code maxConnections}, same dimensions, measured on this JVM rather than on the 128-dimension index of
+   * issue #6503. Scaled by the neighbour overflow factor, because a build holds up to that many times the final
+   * out-degree per node before {@code cleanup()} trims it. With a disk-backed resident graph there is nothing to
+   * learn from, and the flat constant stands.
+   *
+   * @param nodes                  number of vectors the build will walk
+   * @param dimensions             vector width
+   * @param buildCacheCapacity     vectors the build cache will hold
+   * @param residentGraphBytes     {@code ramBytesUsed()} of the graph being replaced, which stays resident so
+   *                               searches keep working; 0 when there is none
+   * @param residentGraphNodes     how many nodes that measurement covers, 0 when unknown
+   * @param residentGraphOnHeap    whether that graph holds its topology on the heap, which is what makes its
+   *                               per-node cost transferable to the graph about to be built
+   * @param neighborOverflowFactor the index's configured neighbour overflow factor, values below 1 ignored
+   *
+   * @return the estimated peak in bytes
+   */
+  static long estimateOnlineRebuildHeapBytes(final long nodes, final int dimensions, final long buildCacheCapacity,
+      final long residentGraphBytes, final long residentGraphNodes, final boolean residentGraphOnHeap,
+      final float neighborOverflowFactor) {
+    long estimate = nodes > 0 ?
+        nodes * (buildBytesPerNode(residentGraphBytes, residentGraphNodes, residentGraphOnHeap,
+            neighborOverflowFactor) + ORDINAL_MAP_BYTES_PER_NODE) : 0L;
+    estimate += Math.max(0L, buildCacheCapacity) * bytesPerCachedVector(dimensions);
+    estimate += Math.max(0L, residentGraphBytes);
+    return estimate;
+  }
+
+  /**
+   * Bytes per node of the graph a rebuild is about to build: the resident graph's measured cost per node raised by
+   * the neighbour overflow a build holds transiently, or {@link #APPROX_GRAPH_BYTES_PER_NODE} when there is no
+   * on-heap graph to measure. Never below the measurement itself, and never zero.
+   */
+  static long buildBytesPerNode(final long residentGraphBytes, final long residentGraphNodes,
+      final boolean residentGraphOnHeap, final float neighborOverflowFactor) {
+    if (!residentGraphOnHeap || residentGraphBytes <= 0 || residentGraphNodes <= 0)
+      return APPROX_GRAPH_BYTES_PER_NODE;
+
+    final long measured = Math.max(1L, residentGraphBytes / residentGraphNodes);
+    final float overflow = neighborOverflowFactor > 1f ? neighborOverflowFactor : 1f;
+    return Math.max(measured, (long) (measured * overflow));
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6655StaleGraphPrefixReuseTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.vector;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
@@ -154,6 +155,14 @@ class Issue6655StaleGraphPrefixReuseTest {
     try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
       final Database db = factory.open();
       try {
+        // The reuse hands its gap to an async rebuild only when that gap crosses the ordinary rebuild threshold
+        // (issue #7183): rebuilding every node of a graph for a gap below it is exactly what the threshold exists
+        // to refuse, and doing it anyway meant a session that opened, searched once and exited paid a full rebuild
+        // for one vector. GAP_VECTORS is 1% of this fixture, so the ratio-scaled threshold - 20% of the graph, 4,000
+        // here - would not be crossed. Disabling the scaling leaves the absolute floor of 100, which 200 genuinely
+        // exceeds, so the fold-in this test asserts is triggered BY the policy rather than in spite of it.
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
+
         try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
           assertThat(rs.next().<Long>getProperty("cnt"))
               .as("precondition: WAL recovery must have restored every record from the crashed session")

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6657CloseTimeRebuildPendingStatTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.vector;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
@@ -143,6 +144,15 @@ class Issue6657CloseTimeRebuildPendingStatTest {
       try {
         final LSMVectorIndex reopenedIndex = vectorIndex(db);
         assertThat(reopenedIndex).as("reopen must hand back a different Java instance").isNotSameAs(indexAtDeferralTime);
+
+        // This test's gap is ONE vector, and since issue #7183 the search that reuses the persisted graph as a
+        // prefix hands that gap to a rebuild only when it crosses the ordinary rebuild threshold - rebuilding all
+        // 1,006 nodes for one queued vector is precisely what the threshold exists to refuse, and doing it anyway
+        // meant close() then waited on the rebuild it had just started, cancelled it, and the next session found the
+        // same vector queued and repeated the whole thing. So the debt this stat records is paid by the next search
+        // only when a rebuild is actually warranted, which is what a threshold of one mutation says here.
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, 1);
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
 
         assertThat(reopenedIndex.getStats().get("graphState"))
             .as("precondition: LOADING - nothing in this session has searched or written yet")

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6772WriteBeforeSearchPrefixReuseTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.vector;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
@@ -127,6 +128,14 @@ class Issue6772WriteBeforeSearchPrefixReuseTest {
     try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
       final Database db = factory.open();
       try {
+        // The reuse hands its gap to an async rebuild only when that gap crosses the ordinary rebuild threshold
+        // (issue #7183): rebuilding every node of a graph for a gap below it is exactly what the threshold exists
+        // to refuse, and doing it anyway meant a session that opened, searched once and exited paid a full rebuild
+        // for one vector. The gap here is 1% of the fixture, so the ratio-scaled threshold - 20% of the graph, 4,000
+        // here - would not be crossed. Disabling the scaling leaves the absolute floor of 100, which the 201 pending
+        // vectors genuinely exceed, so the fold-in this test asserts is triggered BY the policy, not in spite of it.
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
+
         // count(`@rid`) rather than count(*): the latter answers from the maintained counter, which is written by
         // the very session kill() interrupted, so it can agree with the expected number while the records are
         // absent. This precondition is about what WAL recovery actually restored, so it has to count records.

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7183StalePrefixReuseRebuildThresholdTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7183StalePrefixReuseRebuildThresholdTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -106,14 +107,14 @@ class Issue7183StalePrefixReuseRebuildThresholdTest {
             .as("and must not have completed one either")
             .isZero();
 
-        // The consequence a user sees: close() joins the rebuild thread for up to 5 s. Generous bound, and
-        // deliberately not a latency assertion - the point is "not five seconds", so a stall cannot make it wrong
-        // in the direction that matters.
-        final long startedAt = System.nanoTime();
+        // The consequence a user sees: close() joins the rebuild thread for up to 5 s. A tripwire between a close
+        // that waits on a rebuild and one that has nothing to wait on, not a latency target - so it is measured
+        // with StallAwareStopwatch, which discounts a JVM-wide stop-the-world pause inside the window rather than
+        // letting one turn "did close() join a rebuild thread" into a coin flip on the collector's mood (#6260).
+        final StallAwareStopwatch closing = StallAwareStopwatch.start();
         db.close();
-        assertThat((System.nanoTime() - startedAt) / 1_000_000L)
-            .as("close() must not wait on a rebuild that had no reason to start")
-            .isLessThan(4_000L);
+        closing.assertGaveUpWithin(4_000,
+            "a close() that has no rebuild to wait on from one that joins the rebuild thread for its full 5s");
       } finally {
         if (db.isOpen())
           db.close();

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7183StalePrefixReuseRebuildThresholdTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7183StalePrefixReuseRebuildThresholdTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The first search after a mutation below the rebuild threshold must not start a full async graph rebuild
+ * (issue #7183).
+ * <p>
+ * Scenario, from the report: a persisted graph over N vectors; a session inserts ONE vector and closes without
+ * searching; the next session searches once. {@code ensureGraphAvailable()} correctly reuses the persisted graph as
+ * a stale prefix (issue #6655) and queues that one vector into the delta buffer, and then
+ * {@code reuseStalePrefixGraph()} used to call {@code startAsyncGraphRebuild()} unconditionally - which logged
+ * "accumulated 1 mutations, threshold: 100" and rebuilt every node in the graph anyway. {@code close()} then joined
+ * that thread for up to five seconds, and because the rebuild was cancelled before it could persist, the next
+ * session found the same one vector queued and did it all again. So a process that opens, searches once and exits
+ * paid a full rebuild plus a five-second close, every time, for one mutation. The inactivity timer had the same
+ * shape and learned to respect the threshold in #6857; this pins the search-path door.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("vector")
+class Issue7183StalePrefixReuseRebuildThresholdTest {
+  private static final String   DB_ROOT    = "target/test-databases/Issue7183StalePrefixReuseRebuildThresholdTest";
+  private static final int      DIMENSIONS = 32;
+  private static final int      COUNT      = 1_500;
+  private static final int      THRESHOLD  = 100;
+  private static final Duration REBUILD_SETTLE_TIMEOUT =
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsLong() + 60_000L);
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void firstSearchAfterOneInsertMustNotRebuildTheWholeGraph() {
+    buildAndPersistFixture();
+    insertWithoutSearching(1);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      configure(db);
+      try {
+        search(db);
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("stalePrefixGraphReuses"))
+            .as("precondition: the search reused the persisted graph as a stale prefix")
+            .isEqualTo(1L);
+        assertThat(index.getStats().get("mutationsSinceRebuild"))
+            .as("precondition: exactly one mutation is pending, well under the threshold of " + THRESHOLD)
+            .isEqualTo(1L);
+
+        // The defect. One queued vector is served from the delta scan; nothing about it justifies rebuilding all
+        // COUNT nodes, and the mutation threshold says so.
+        assertThat(index.getStats().get("asyncRebuildInProgress"))
+            .as("one mutation below the threshold must not start an async rebuild on the first search")
+            .isZero();
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("and must not have completed one either")
+            .isZero();
+
+        // The consequence a user sees: close() joins the rebuild thread for up to 5 s. Generous bound, and
+        // deliberately not a latency assertion - the point is "not five seconds", so a stall cannot make it wrong
+        // in the direction that matters.
+        final long startedAt = System.nanoTime();
+        db.close();
+        assertThat((System.nanoTime() - startedAt) / 1_000_000L)
+            .as("close() must not wait on a rebuild that had no reason to start")
+            .isLessThan(4_000L);
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  /**
+   * The vector queued by the reuse stays searchable throughout: the point of the fix is that the delta scan serves
+   * it, not that it is dropped. Without this, "no rebuild" could be passing for the wrong reason.
+   */
+  @Test
+  void theOneQueuedVectorIsStillFoundWithoutARebuild() {
+    buildAndPersistFixture();
+    insertWithoutSearching(1);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      configure(db);
+      try {
+        assertThat(idsNear(db, embedding(COUNT), 5))
+            .as("the vector the write-only session added must come back from the delta scan")
+            .contains(COUNT);
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("...which is where it is: queued, not folded into the graph")
+            .isEqualTo(1L);
+        assertThat(index.getStats().get("graphRebuildCount")).isZero();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  /**
+   * Positive control: with pending mutations AT the threshold the first search is entitled to rebuild, and does.
+   * Without this the assertions above would hold just as well on a build where the async path never ran at all.
+   */
+  @Test
+  void firstSearchAtTheThresholdStillRebuilds() {
+    buildAndPersistFixture();
+    insertWithoutSearching(THRESHOLD);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      configure(db);
+      try {
+        search(db);
+        final LSMVectorIndex index = vectorIndex(db);
+        Awaitility.await("a search with the threshold reached rebuilds the graph")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isPositive());
+        Awaitility.await("the rebuild settles before the close")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  private void buildAndPersistFixture() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      configure(db);
+      try {
+        insert(db, 0, COUNT);
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: the graph must be built and IMMUTABLE before the close that persists it")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  /** A session that writes and leaves: the shape of a batch job, or of a client that inserts and exits. */
+  private void insertWithoutSearching(final int howMany) {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      configure(db);
+      try {
+        insert(db, COUNT, COUNT + howMany);
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  private static void search(final Database db) {
+    assertThat(idsNear(db, halfway(), 5)).as("the search returns neighbours").isNotEmpty();
+  }
+
+  private static java.util.List<Integer> idsNear(final Database db, final float[] query, final int k) {
+    final StringBuilder vector = new StringBuilder();
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector.append(d == 0 ? "" : ", ").append(query[d]);
+
+    final java.util.List<Integer> ids = new java.util.ArrayList<>(k);
+    try (final ResultSet rs = db.query("sql",
+        "SELECT id FROM (SELECT expand(vectorNeighbors('Doc[vector]', [" + vector + "], " + k + ")))")) {
+      while (rs.hasNext())
+        ids.add(rs.next().getProperty("id"));
+    }
+    return ids;
+  }
+
+  private static float[] halfway() {
+    final float[] query = new float[DIMENSIONS];
+    java.util.Arrays.fill(query, 0.5f);
+    return query;
+  }
+
+  private static void configure(final Database db) {
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, THRESHOLD);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
+    // Keep the inactivity timer out of the picture: this test is about the search path.
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 600_000);
+  }
+
+  private static void insert(final Database db, final int fromInclusive, final int toExclusive) {
+    db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"EUCLIDEAN\" }");
+    });
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+      if ((i - fromInclusive) % 500 == 499) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x7150L * 31 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7183StalePrefixReuseRebuildThresholdTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7183StalePrefixReuseRebuildThresholdTest.java
@@ -33,6 +33,9 @@ import org.junit.jupiter.api.TestInfo;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -210,12 +213,12 @@ class Issue7183StalePrefixReuseRebuildThresholdTest {
     assertThat(idsNear(db, halfway(), 5)).as("the search returns neighbours").isNotEmpty();
   }
 
-  private static java.util.List<Integer> idsNear(final Database db, final float[] query, final int k) {
+  private static List<Integer> idsNear(final Database db, final float[] query, final int k) {
     final StringBuilder vector = new StringBuilder();
     for (int d = 0; d < DIMENSIONS; d++)
       vector.append(d == 0 ? "" : ", ").append(query[d]);
 
-    final java.util.List<Integer> ids = new java.util.ArrayList<>(k);
+    final List<Integer> ids = new ArrayList<>(k);
     try (final ResultSet rs = db.query("sql",
         "SELECT id FROM (SELECT expand(vectorNeighbors('Doc[vector]', [" + vector + "], " + k + ")))")) {
       while (rs.hasNext())
@@ -226,7 +229,7 @@ class Issue7183StalePrefixReuseRebuildThresholdTest {
 
   private static float[] halfway() {
     final float[] query = new float[DIMENSIONS];
-    java.util.Arrays.fill(query, 0.5f);
+    Arrays.fill(query, 0.5f);
     return query;
   }
 

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7184RebuildAdmissionHeapReadingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7184RebuildAdmissionHeapReadingTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The two readings the online-rebuild admission gate compares, and the eviction that makes one of them honest
+ * (issue #7184).
+ * <p>
+ * At 10M vectors in a 24 GB heap the gate of issue #6503 refused the rebuild at every single attempt, so the delta
+ * buffer those pending vectors sit in grew without bound and every query paid a linear scan of it - 42 ms at 2.5M
+ * buffered, indistinguishable from the curve with every rebuild trigger disabled. Both sides of its comparison were
+ * wrong in the same direction:
+ * <ul>
+ *   <li>the COST side charged a second full on-heap graph for the graph being kept resident. A session that reopened
+ *   the database serves an {@code OnDiskGraphIndex}, whose topology is in pages - so that term is now measured
+ *   instead of assumed, and a disk-backed graph is charged what it actually retains;</li>
+ *   <li>the HEAP side judged the rebuild against a post-collection live-set reading that counts ArcadeDB's own page
+ *   read cache as occupied. It is occupied, and it is evictable. The gate now asks how much of it has to be given up
+ *   and gives that up before admitting, rather than counting it as free and hoping - which would be the
+ *   {@link OutOfMemoryError} the gate exists to prevent, in the other direction.</li>
+ * </ul>
+ * The arithmetic is pinned here with supplied figures, the way issue #7146's build-cache budget is, because the
+ * shapes that matter (24 GB of heap, 10M nodes) are not shapes a test can allocate.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7184RebuildAdmissionHeapReadingTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue7184RebuildAdmissionHeapReadingTest";
+  private static final long   GB         = 1024L * 1024 * 1024;
+  private static final int    DIMENSIONS = 16;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  // ---------------------------------------------------------------- the heap side
+
+  @Test
+  void anAllocationThatAlreadyFitsAsksForNoEviction() {
+    assertThat(VectorHeapBudget.reclaimNeededFor(GB, 90, 8 * GB, 4 * GB))
+        .as("1 GB inside 90% of 8 GB available: nothing has to be given up")
+        .isZero();
+  }
+
+  @Test
+  void anAllocationShortByLessThanThePageCacheAsksForExactlyTheShortfall() {
+    // 90% of 10 GB is 9 GB, so a 9.9 GB request needs 11 GB of available heap: 1 GB short.
+    final long shortfall = VectorHeapBudget.reclaimNeededFor(9_900L * 1024 * 1024, 90, 10 * GB, 4 * GB);
+
+    assertThat(shortfall).as("the gap must be closed by eviction, not by wishful accounting").isPositive();
+    assertThat(shortfall)
+        .as("and only the gap: evicting the whole cache would cost every other reader for no reason")
+        .isLessThan(2 * GB);
+  }
+
+  @Test
+  void anAllocationTheWholePageCacheCannotCoverIsRefused() {
+    assertThat(VectorHeapBudget.reclaimNeededFor(40 * GB, 90, 10 * GB, 4 * GB))
+        .as("40 GB into a 10 GB reading with 4 GB of evictable pages does not fit, and must be said so")
+        .isEqualTo(-1L);
+  }
+
+  @Test
+  void withNoReclaimablePagesTheAnswerIsTheOldOne() {
+    assertThat(VectorHeapBudget.reclaimNeededFor(20 * GB, 90, 10 * GB, 0L))
+        .as("this is the pre-#7184 behaviour: no page cache to give up, so the rebuild is deferred")
+        .isEqualTo(-1L);
+    assertThat(VectorHeapBudget.reclaimNeededFor(GB, 90, 10 * GB, 0L))
+        .as("...and one that fits is still admitted with nothing evicted")
+        .isZero();
+  }
+
+  @Test
+  void aDisabledGateNeverAsksForEviction() {
+    assertThat(VectorHeapBudget.reclaimNeededFor(400 * GB, 0, GB, GB))
+        .as("percent 0 disables the gate, so it must not evict anything on its way past")
+        .isZero();
+  }
+
+  /** An estimate large enough to overflow the percent arithmetic must read as "does not fit", never as "fits". */
+  @Test
+  void anAbsurdEstimateIsRefusedRatherThanWrappingAround() {
+    assertThat(VectorHeapBudget.reclaimNeededFor(Long.MAX_VALUE / 2, 90, 10 * GB, 4 * GB)).isEqualTo(-1L);
+  }
+
+  // ---------------------------------------------------------------- the cost side
+
+  /**
+   * The shape from the report: 10M nodes, 24 GB heap. The old estimate charged two on-heap graphs and asked for about
+   * 24 GB, which no 24 GB heap can give it. A reopened session's resident graph is disk-backed and retains a few
+   * hundred MB, so the honest figure is one graph plus the build cache.
+   */
+  @Test
+  void aDiskBackedResidentGraphIsNotChargedAsASecondOnHeapGraph() {
+    final long nodes = 10_000_000L;
+    final long buildCache = 2_000_000L;
+    final long residentOnDisk = 200L * 1024 * 1024; // what an OnDiskGraphIndex actually retains
+
+    final long twoGraphs = VectorHeapBudget.estimateRebuildHeapBytes(nodes, 64, buildCache, true);
+    final long measured = VectorHeapBudget.estimateOnlineRebuildHeapBytes(nodes, 64, buildCache, residentOnDisk,
+        nodes, false, 1.2f);
+
+    assertThat(measured)
+        .as("charging a phantom second on-heap graph is what refused a rebuild the close path runs unconditionally")
+        .isLessThan(twoGraphs);
+    assertThat(measured)
+        .as("and the difference must be about one graph's worth")
+        .isLessThan(twoGraphs - VectorHeapBudget.estimateGraphBytes(nodes) + 512L * 1024 * 1024);
+    assertThat(measured)
+        .as("the resident graph is still charged what it does retain")
+        .isGreaterThan(residentOnDisk);
+  }
+
+  @Test
+  void anOnHeapResidentGraphIsChargedWhatItMeasuresAndPredictsTheNextBuildWithIt() {
+    final long nodes = 1_000_000L;
+    final long residentBytes = 400L * nodes; // measured: 400 bytes/node, well under the flat constant
+
+    final long estimate = VectorHeapBudget.estimateOnlineRebuildHeapBytes(nodes, 64, 0L, residentBytes, nodes, true,
+        1.0f);
+
+    assertThat(estimate)
+        .as("a measurement of THIS index beats a constant measured on a 128-dimension index in issue #6503")
+        .isLessThan(VectorHeapBudget.estimateRebuildHeapBytes(nodes, 64, 0L, true));
+    assertThat(estimate).as("and both graphs are still charged")
+        .isGreaterThan(2 * residentBytes - VectorHeapBudget.estimateGraphBytes(1));
+  }
+
+  @Test
+  void theBuildIsChargedTheNeighbourOverflowAGraphHoldsBeforeCleanup() {
+    final long perNodeFlat = VectorHeapBudget.buildBytesPerNode(0L, 0L, true, 1.2f);
+    final long perNodeMeasured = VectorHeapBudget.buildBytesPerNode(1_000L * 1_000L, 1_000L, true, 1.5f);
+
+    assertThat(perNodeFlat)
+        .as("with nothing to measure the flat constant stands, which is the pre-#7184 behaviour")
+        .isEqualTo(VectorHeapBudget.APPROX_GRAPH_BYTES_PER_NODE);
+    assertThat(perNodeMeasured)
+        .as("a build holds up to the overflow factor times the final out-degree per node before cleanup() trims it")
+        .isEqualTo(1_500L);
+    assertThat(VectorHeapBudget.buildBytesPerNode(1_000L * 1_000L, 1_000L, false, 1.5f))
+        .as("a disk-backed graph's per-node cost says nothing about an on-heap build")
+        .isEqualTo(VectorHeapBudget.APPROX_GRAPH_BYTES_PER_NODE);
+    assertThat(VectorHeapBudget.buildBytesPerNode(1_000L * 1_000L, 1_000L, true, 0f))
+        .as("a nonsensical overflow factor must not shrink the estimate below the measurement")
+        .isEqualTo(1_000L);
+  }
+
+  // ---------------------------------------------------------------- the eviction itself
+
+  /**
+   * The gate's promise: what it counted as reclaimable, it reclaims. Cached pages are strongly referenced, so a
+   * collection would never have handed them to the rebuild on its own.
+   */
+  @Test
+  void thePageReadCacheReportsItsSizeAndGivesItUpOnRequest() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        // Read everything back so the pages are in the READ cache rather than only in the write path.
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as total FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("total")).isEqualTo(20_000L);
+        }
+
+        final PageManager pageManager = ((DatabaseInternal) db).getPageManager();
+        final long cached = pageManager.getReadCacheRAM();
+        assertThat(cached).as("precondition: reading 20,000 records has to leave pages in the read cache")
+            .isPositive();
+
+        final long request = cached / 4;
+        final long freed = pageManager.reclaimReadCacheRAM(request);
+
+        assertThat(freed).as("a caller told the cache was reclaimable must actually get the bytes back")
+            .isGreaterThanOrEqualTo(request);
+        assertThat(pageManager.getReadCacheRAM()).as("...and the cache must report the smaller size")
+            .isLessThan(cached);
+
+        // The pages come back from disk: eviction costs I/O, never correctness.
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as total FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("total")).isEqualTo(20_000L);
+        }
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  @Test
+  void reclaimingNothingIsANoOp() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        final PageManager pageManager = ((DatabaseInternal) db).getPageManager();
+        assertThat(pageManager.reclaimReadCacheRAM(0L)).isZero();
+        assertThat(pageManager.reclaimReadCacheRAM(-1L)).isZero();
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static void populate(final Database db) {
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("payload", Type.STRING);
+    });
+
+    final String payload = "x".repeat(512);
+    db.begin();
+    for (int i = 0; i < 20_000; i++) {
+      db.newDocument("Doc").set("id", i).set("payload", payload).save();
+      if (i % 5_000 == 4_999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7190UnreachableVectorsSurviveReopenTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7190UnreachableVectorsSurviveReopenTest.java
@@ -184,6 +184,39 @@ class Issue7190UnreachableVectorsSurviveReopenTest {
   }
 
   /**
+   * The counterpart of persisting the set: it describes one graph generation, so a build that publishes NO graph -
+   * every vector deleted - must leave nothing behind for {@code getStats()} to report against a graph that is not
+   * there.
+   */
+  @Test
+  void aRebuildThatPublishesNoGraphReportsNoUnreachableNodes() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      configure(db);
+      try {
+        insert(db);
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("unreachableGraphNodes"))
+            .as("precondition: this build has to leave nodes unreachable, or there is nothing to clear")
+            .isPositive();
+
+        db.transaction(() -> db.command("sql", "DELETE FROM Doc"));
+        index.buildVectorGraphNow();
+
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("precondition: with every vector gone the build publishes no graph at all")
+            .isZero();
+        assertThat(index.getStats().get("unreachableGraphNodes"))
+            .as("the previous generation's orphans describe a graph that is no longer resident")
+            .isZero();
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
    * @return how many nodes the build left unreachable, asserted to be more than none so nothing above can pass by
    * failing to reproduce the state under test
    */

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7190UnreachableVectorsSurviveReopenTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7190UnreachableVectorsSurviveReopenTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A vector the graph build could not link must still be findable after the database is reopened (issue #7190).
+ * <p>
+ * A Vamana build occasionally leaves a node with a full out-degree and no in-edges (issue #5615): it is physically in
+ * the graph and no beam search can return it at any {@code efSearch}. The session that built the graph re-queues
+ * those vectors into the delta buffer, which is in memory only - so after {@code close()} they used to be gone from
+ * every search while {@code totalVectors} still counted them, with nothing in the log and k results still coming
+ * back, so no caller could tell. The set is now recorded in the graph manifest and re-queued by the load path.
+ * <p>
+ * <b>Why duplicate vectors.</b> The reporter measured one orphan per 50,000 random vectors, which is not something a
+ * test can rely on. Diversity pruning refuses to link a node whose neighbours are all closer to each other than to
+ * it, so drawing every vector from a handful of distinct points orphans nearly the whole graph, every time, at any
+ * {@code maxConnections} - the same state the report describes, deterministically and at a size a test can afford.
+ * The preconditions below assert the orphans were actually produced, so the test cannot pass by not reproducing.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("vector")
+class Issue7190UnreachableVectorsSurviveReopenTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue7190UnreachableVectorsSurviveReopenTest";
+  private static final int    DIMENSIONS = 8;
+  private static final int    COUNT      = 1_000;
+  /** Distinct vector values the corpus is drawn from: what makes the build orphan almost every node. */
+  private static final int    DISTINCT   = 8;
+  /**
+   * Neighbours asked for. Small on purpose: it has to stay under how many nodes the crippled graph can still reach
+   * (about 33 here), because a search the graph leaves short of k falls back to a brute-force scan that reads every
+   * vector and would mask the defect. The reporter's 50,000-vector index had no such fallback for k=10 either.
+   */
+  private static final int    K          = 10;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void vectorsTheBuildLeftUnreachableAreStillFoundAfterAReopen() {
+    final long unreachable = buildAndPersistFixture();
+
+    // Reopen: the graph on disk covers every live vector, so it is published as up to date. The nodes its build
+    // could not link have to be re-queued into the delta scan, or they are unreachable for good.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      configure(db);
+      try {
+        final List<Integer> found = idsNear(db, embedding(0), K);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        // The defect, first and at the level a caller sees it. The query IS the vector of group 0, and 125 records
+        // hold exactly that vector, so every one of the K nearest neighbours must be one of them - at distance 0.
+        // Before this fix the graph walk could reach only a handful of them, the rest of the answer was filled with
+        // records from other groups, and k results still came back, so nothing said anything was wrong.
+        assertThat(found).as("k results must still come back").hasSize(K);
+        assertThat(found).as("and be distinct records").doesNotHaveDuplicates();
+        assertThat(found.stream().filter(id -> id % DISTINCT != 0).toList())
+            .as("every one of the %d nearest neighbours of an exact match must itself be an exact match; the "
+                + "records that are only reachable through the delta scan are exactly what used to be missing "
+                + "after a reopen", K)
+            .isEmpty();
+
+        assertThat(index.getStats().get("unreachableGraphNodes"))
+            .as("the manifest must carry the ordinals the build could not link, so this session knows about them")
+            .isEqualTo(unreachable);
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("...and they must be queued into the delta scan, which is the only way a search can return them")
+            .isEqualTo(unreachable);
+
+        // Re-queueing an orphan is not a mutation: it is already in the persisted graph, and a rebuild does not
+        // remove it. Counting it would rebuild this index on every open and, through flush(), on every close.
+        assertThat(index.getStats().get("mutationsSinceRebuild"))
+            .as("an orphan is not pending work: counting it would make every open trigger a rebuild")
+            .isZero();
+        assertThat(index.getStats().get("graphState"))
+            .as("and must not promote the graph to MUTABLE, which is what makes close() rebuild")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("nothing here justifies a rebuild")
+            .isZero();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // A second reopen must behave identically: the manifest write on close must not have dropped the set.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      configure(db);
+      try {
+        assertThat(idsNear(db, embedding(0), K).stream().filter(id -> id % DISTINCT != 0).toList())
+            .as("the set has to survive every close, not only the one that built the graph")
+            .isEmpty();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  /**
+   * The same guarantee on the other load path: a session that adds vectors after the reopen reuses the persisted
+   * graph as a stale prefix (issue #6655), and the nodes THAT graph leaves unreachable are ordinals inside the
+   * prefix - covered by neither the gap the reuse queues nor anything in memory.
+   */
+  @Test
+  void aStalePrefixReuseAlsoRequeuesWhatItsGraphLeavesUnreachable() {
+    final long unreachable = buildAndPersistFixture();
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      configure(db);
+      try {
+        // One new vector, so the persisted graph is a prefix of the live set rather than up to date.
+        db.transaction(() -> db.newDocument("Doc").set("id", COUNT).set("vector", embedding(COUNT)).save());
+
+        final List<Integer> found = idsNear(db, embedding(0), K);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("stalePrefixGraphReuses"))
+            .as("precondition: the search reused the persisted graph as a stale prefix")
+            .isEqualTo(1L);
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("the prefix's unreachable nodes AND the one-vector gap must both be queued")
+            .isEqualTo(unreachable + 1);
+        assertThat(index.getStats().get("mutationsSinceRebuild"))
+            .as("only the gap counts as a pending mutation - the orphans are already in the graph")
+            .isEqualTo(1L);
+        assertThat(found.stream().filter(id -> id % DISTINCT != 0).toList())
+            .as("and the exact matches only the delta scan can supply must be in the answer")
+            .isEmpty();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  /**
+   * @return how many nodes the build left unreachable, asserted to be more than none so nothing above can pass by
+   * failing to reproduce the state under test
+   */
+  private long buildAndPersistFixture() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      configure(db);
+      try {
+        insert(db);
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+
+        final long unreachable = index.getStats().get("unreachableGraphNodes");
+        assertThat(unreachable)
+            .as("precondition: the build has to leave nodes unreachable, or this test proves nothing. Duplicate "
+                + "vectors make that deterministic - see the class javadoc")
+            .isPositive();
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("precondition: the building session serves them from the delta scan")
+            .isEqualTo(unreachable);
+        assertThat(idsNear(db, embedding(0), K).stream().filter(id -> id % DISTINCT != 0).toList())
+            .as("precondition: with that delta buffer in memory, the building session answers with exact matches")
+            .isEmpty();
+        return unreachable;
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
+  private static List<Integer> idsNear(final Database db, final float[] query, final int k) {
+    final StringBuilder vector = new StringBuilder();
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector.append(d == 0 ? "" : ", ").append(query[d]);
+
+    final List<Integer> ids = new ArrayList<>(k);
+    try (final ResultSet rs = db.query("sql",
+        "SELECT id FROM (SELECT expand(vectorNeighbors('Doc[vector]', [" + vector + "], " + k + ")))")) {
+      while (rs.hasNext())
+        ids.add(rs.next().getProperty("id"));
+    }
+    return ids;
+  }
+
+  private static void configure(final Database db) {
+    // This test is about what the delta buffer holds after a reopen, so nothing must drain it behind the
+    // assertions: no mutation-count trigger, no ratio trigger, no delta-scan budget trigger, no inactivity timer.
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, 1_000_000);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MAX_DELTA_SCAN_RATIO, 0f);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 600_000);
+  }
+
+  private static void insert(final Database db) {
+    db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"EUCLIDEAN\" }");
+    });
+
+    db.begin();
+    for (int i = 0; i < COUNT; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+      if (i % 500 == 499) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  /** Vector of a record: one of {@link #DISTINCT} distinct points, which is what makes the build orphan nodes. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(id % DISTINCT);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifestTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifestTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.index.vector;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -49,7 +50,7 @@ class LSMVectorIndexGraphManifestTest {
     final long fingerprint = LSMVectorIndexGraphManifest.fingerprintOf(new int[] { 0, 1, 2 },
         id -> new RID(3, id * 10L));
 
-    manifest.write(3, fingerprint);
+    manifest.write(3, fingerprint, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
 
     assertThat(manifest.exists()).isTrue();
     final LSMVectorIndexGraphManifest.Content content = manifest.read();
@@ -68,7 +69,7 @@ class LSMVectorIndexGraphManifestTest {
     final LSMVectorIndexGraphManifest manifest = manifest();
     final long awkward = -6_148_914_691_236_517_206L; // 0xAAAA...AAAA
 
-    manifest.write(7, awkward);
+    manifest.write(7, awkward, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
 
     assertThat(manifest.read().fingerprint()).isEqualTo(awkward);
   }
@@ -77,7 +78,7 @@ class LSMVectorIndexGraphManifestTest {
   @Test
   void anUnusableManifestCannotBeMatchedByAnyLiveSet() {
     final LSMVectorIndexGraphManifest manifest = manifest();
-    manifest.write(12, 1234L);
+    manifest.write(12, 1234L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
 
     manifest.markUnusable("simulated persist failure");
 
@@ -90,7 +91,7 @@ class LSMVectorIndexGraphManifestTest {
   @Test
   void aTruncatedOrCorruptedManifestReadsAsAbsent() throws Exception {
     final LSMVectorIndexGraphManifest manifest = manifest();
-    manifest.write(5, 99L);
+    manifest.write(5, 99L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
 
     Files.writeString(manifestPath(), "{\"formatVersion\": 1, \"vectorCou", StandardCharsets.UTF_8);
 
@@ -121,7 +122,7 @@ class LSMVectorIndexGraphManifestTest {
   @Test
   void invalidateRemovesTheManifestSoNothingVouchesForThePages() {
     final LSMVectorIndexGraphManifest manifest = manifest();
-    manifest.write(4, 7L);
+    manifest.write(4, 7L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
 
     manifest.invalidate();
 
@@ -140,7 +141,7 @@ class LSMVectorIndexGraphManifestTest {
     Files.writeString(leftover, "half written", StandardCharsets.UTF_8);
     Files.writeString(unrelated, "the graph itself", StandardCharsets.UTF_8);
 
-    manifest().write(1, 1L);
+    manifest().write(1, 1L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
 
     assertThat(leftover).as("the sweep must remove an abandoned temporary of this manifest").doesNotExist();
     assertThat(unrelated).as("and must match by name, so it cannot reach anything else").exists();
@@ -148,6 +149,98 @@ class LSMVectorIndexGraphManifestTest {
       assertThat(files.map(p -> p.getFileName().toString()).filter(n -> n.endsWith(".tmp")).toList())
           .as("and the write must leave no temporary of its own behind").isEqualTo(List.of());
     }
+  }
+
+  /**
+   * The ordinals a build could not link are part of what the manifest has to say about the pages next to it: the
+   * session that built the graph serves those vectors from the delta scan, and a reopened session can only do the
+   * same if it is told which ones they are (issue #7190).
+   */
+  @Test
+  void unreachableOrdinalsSurviveTheRoundTrip() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+
+    manifest.write(50_000, 42L, new int[] { 7, 39_896, 49_999 });
+
+    assertThat(manifest.read().unreachableOrdinals()).containsExactly(7, 39_896, 49_999);
+  }
+
+  @Test
+  void aManifestWithoutUnreachableOrdinalsReadsAsNoneRatherThanNull() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+
+    manifest.write(10, 5L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
+
+    assertThat(manifest.read().unreachableOrdinals())
+        .as("callers walk this array; an absent entry must read as empty, never as null").isEmpty();
+  }
+
+  /**
+   * The set is a new optional key inside the SAME format version, deliberately: bumping the version would make
+   * every manifest written by an older build read as absent, and every existing index rebuild its graph on the
+   * first open after an upgrade. A manifest from before issue #7190 therefore has to stay perfectly usable.
+   */
+  @Test
+  void aManifestWrittenBeforeThisFieldExistedIsStillUsable() throws Exception {
+    final JSONObject beforeIssue7190 = new JSONObject();
+    beforeIssue7190.put("formatVersion", LSMVectorIndexGraphManifest.FORMAT_VERSION);
+    beforeIssue7190.put("vectorCount", 1_500);
+    beforeIssue7190.put("fingerprint", "-6148914691236517206");
+    beforeIssue7190.put("closeDeferredRebuild", false);
+    Files.writeString(manifestPath(), beforeIssue7190.toString(), StandardCharsets.UTF_8);
+
+    final LSMVectorIndexGraphManifest.Content content = manifest().read();
+    assertThat(content).as("an older manifest must not be refused over a key it could not have written").isNotNull();
+    assertThat(content.vectorCount()).isEqualTo(1_500);
+    assertThat(content.fingerprint()).isEqualTo(-6_148_914_691_236_517_206L);
+    assertThat(content.unreachableOrdinals()).isEmpty();
+  }
+
+  /**
+   * A malformed set costs the set, not the manifest: ignoring it puts the index back at the pre-#7190 behaviour for
+   * those nodes, while refusing the manifest would force a full rebuild of a graph that is otherwise fine.
+   */
+  @Test
+  void anUnreadableUnreachableOrdinalsEntryIsIgnoredRatherThanFailingTheManifest() throws Exception {
+    final JSONObject damaged = new JSONObject();
+    damaged.put("formatVersion", LSMVectorIndexGraphManifest.FORMAT_VERSION);
+    damaged.put("vectorCount", 20);
+    damaged.put("fingerprint", "77");
+    damaged.put("unreachableOrdinals", new JSONArray(new Object[] { "not-a-number" }));
+    Files.writeString(manifestPath(), damaged.toString(), StandardCharsets.UTF_8);
+
+    final LSMVectorIndexGraphManifest.Content content = manifest().read();
+    assertThat(content).isNotNull();
+    assertThat(content.vectorCount()).isEqualTo(20);
+    assertThat(content.unreachableOrdinals()).isEmpty();
+  }
+
+  /**
+   * {@code markCloseDeferred()} is a note about pages that have NOT changed, so what those pages leave unreachable
+   * has not changed either. Losing the set there would make the very next open miss those vectors again.
+   */
+  @Test
+  void markingACloseAsDeferredKeepsTheUnreachableOrdinals() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+    manifest.write(1_000, 11L, new int[] { 3, 4 });
+
+    manifest.markCloseDeferred();
+
+    final LSMVectorIndexGraphManifest.Content content = manifest.read();
+    assertThat(content.closeDeferredRebuild()).isTrue();
+    assertThat(content.vectorCount()).isEqualTo(1_000);
+    assertThat(content.unreachableOrdinals()).containsExactly(3, 4);
+  }
+
+  /** A completed build supersedes whatever the previous one orphaned - a Vamana build orphans a fresh set. */
+  @Test
+  void aLaterWriteReplacesThePreviousUnreachableOrdinals() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+    manifest.write(1_000, 11L, new int[] { 3, 4 });
+
+    manifest.write(1_000, 12L, new int[] { 9 });
+
+    assertThat(manifest.read().unreachableOrdinals()).containsExactly(9);
   }
 
   private LSMVectorIndexGraphManifest manifest() {


### PR DESCRIPTION
Fixes #7183, fixes #7184, fixes #7190.

Three independent LSM_VECTOR defects, all reported off the same benchmark work, all about *when the engine decides to rebuild a graph* and *what a graph leaves unreachable*.

## #7183 - a stale-prefix reuse rebuilt the whole graph for one queued vector

`reuseStalePrefixGraph()` ended with an unconditional `startAsyncGraphRebuild()`, on the argument that the gap it had just queued should be closed "promptly instead of waiting on the ordinary mutation threshold". For a gap of one vector that means rebuilding every node in the graph, on the first search of a session that had done nothing but insert it - with `startAsyncGraphRebuild()` logging the threshold it was ignoring. `close()` then joined that thread for up to 5 s, cancelled it before it could persist, and the next session found the same one vector queued and did it all again.

The tail now asks exactly the two triggers `rebuildGraphBeforeSearch()`'s large-graph arm asks: enough mutations have accumulated, or the delta scan those mutations left behind has outgrown the graph walk it supplements (#6797). This is the fix the inactivity timer received in #6857, applied to the other door. A gap below both triggers stays in the delta buffer, served correctly, which is what the buffer is for - and it is not unbounded, because the #6797 trigger is denominated in exactly the cost that would make it matter.

**On the report's second question** (is the 5 s wait in `close()` the intended contract for a rebuild a read started?): left as it is, deliberately. It is a hang detector, not a routine cost - `releaseBackgroundResources()` shuts the build pool down and interrupts the thread first, and the 5 s bound exists because a rebuild that ignores interruption still holds the JVM-wide `REBUILD_SEMAPHORE` permit and an operator has to be told. With the fix above, a read-only session no longer has a rebuild to wait on in the first place.

## #7190 - a vector the build left unreachable disappeared after a reopen

A Vamana build occasionally leaves a node with a full out-degree and no in-edges (#5615): physically in the graph, returnable by no beam search at any `efSearch`. The building session re-queues those vectors into the delta buffer - which is in memory only. After `close()` they were gone from every search while `totalVectors` still counted them, k results still came back, and nothing warned. The build's own warning said as much ("A later rebuild does not repair this"), and the code comment said the set would have to be persisted to close it.

It is now persisted, in the graph manifest, as an **optional key inside the same `FORMAT_VERSION`** - bumping the version would make every manifest written by an older build read as absent and force every existing index to rebuild its graph on the first open after an upgrade. Both load paths re-queue it: the up-to-date one and the stale-prefix reuse (whose graph's orphans are ordinals *inside* the prefix, covered by neither the gap nor anything in memory).

The re-queue deliberately touches neither `mutationsSinceSerialize` nor `graphState`, for the same reason the build's own re-queue does not: an orphan is not pending work - it is already in the persisted graph and a rebuild does not remove it - and counting it would make the index rebuild on every open and, through `flush()`, on every close.

**Better than the report's alternative** (re-link them at the next rebuild): a rebuild cannot repair the set, it replaces it - a fresh build orphans a fresh set - so per-generation truth recorded next to the generation is the only thing that stays correct. The report's other half is included: `getStats()` gains `unreachableGraphNodes`, so an operator can ask how many vectors only the scan can reach, on a freshly reopened index too.

## #7184 - the rebuild admission gate refused a rebuild that fits, forever

At 10M vectors in a 24 GB heap the #6503 gate deferred at every attempt, so the delta buffer grew without limit and every query paid a linear scan of it: 42 ms at 2.5M buffered, indistinguishable from the curve with every trigger disabled. A gate that refuses a rebuild which would in fact have fitted is not the conservative choice here - it is the unbounded one. Both sides of its comparison were wrong in the same direction:

- **the cost side** charged a second full *on-heap* graph for the graph being kept resident. A session that reopened the database serves an `OnDiskGraphIndex`, whose topology lives in pages and which retains a fraction of that. The term is now **measured** (`ImmutableGraphIndex` is `Accountable`), and when the resident graph *is* on-heap its measured cost per node also replaces the flat 1,100-bytes-per-node constant for the graph about to be built - scaled by the configured neighbour overflow factor, because a build holds up to that many times the final out-degree before `cleanup()` trims it. This is the larger of the two errors, and the one the report did not spot: it is what made a 10M index ask for 24 GB of a 24 GB heap for a rebuild the close path runs unconditionally.
- **the heap side** counted ArcadeDB's own page read cache as occupied - it is - without saying it is evictable, the same correction #7147 applied to the build cache. `VectorHeapBudget.reclaimNeededFor()` now says how much of it has to be given up: nothing, an exact number of bytes, or "not even all of it is enough".

**Better than the report's alternative** (count the page cache as available): counting it free and allocating anyway is the `OutOfMemoryError` this gate exists to prevent, in the other direction - those pages are strongly referenced and no collection would hand them to the build. So the gate *reclaims* what it counted, and only the shortfall, through the new `PageManager.reclaimReadCacheRAM()` (ordinary eviction path, ordinary LRU policy, pages read back from disk on demand). The deferral WARNING now also names the resident graph's measured cost and the evictable page cache that could not close the gap, so the numbers in the log add up.

**Not implemented, with reasons.** A non-resident online rebuild (drop the old graph, serve searches meanwhile) is declined: searches would fall back to a brute-force scan of the whole index for the duration, which is worse than the delta scan it would be avoiding - and with the resident graph now measured, the "two graphs" cost that motivated it largely disappears. A possible follow-up, if a refusal is ever seen again in the field: retry with a smaller build cache instead of deferring, since the cache is the one elastic term in the estimate.

## Tests

- `Issue7183StalePrefixReuseRebuildThresholdTest` - the report's scenario (persisted graph, a session that inserts one vector and leaves, a session that searches once), plus the vector staying findable through the scan, plus a positive control at the threshold. Verified to fail with the old unconditional call.
- `Issue7190UnreachableVectorsSurviveReopenTest` - end to end, on both load paths. Orphans are made **deterministic** by drawing the corpus from 8 distinct points: diversity pruning then orphans ~97% of the graph at any `maxConnections`, so the test does not depend on the 1-in-50,000 the report measured. The discriminating assertion is user-visible - every one of the 10 nearest neighbours of an exact match must itself be an exact match - and without the fix all ten are wrong records. Preconditions assert the orphans were produced, so it cannot pass by not reproducing.
- `Issue7184RebuildAdmissionHeapReadingTest` - the two readings with supplied figures (the way #7146's build-cache budget is pinned, since 24 GB and 10M nodes are not shapes a test can allocate), plus the eviction itself against a real page cache.
- `LSMVectorIndexGraphManifestTest` - the orphan set's round trip, a pre-#7190 manifest staying usable, a malformed entry costing the set rather than the manifest, and `markCloseDeferred()` preserving it.
- `Issue6655StaleGraphPrefixReuseTest`, `Issue6772WriteBeforeSearchPrefixReuseTest`, `Issue6657CloseTimeRebuildPendingStatTest` each pinned the fold-in the reuse used to trigger unconditionally; each now sets a rebuild threshold its own gap genuinely crosses, so what they assert is triggered by the policy rather than in spite of it. (They also got much faster: no more 4-minute rebuild convergence waits.)

Green locally: 2,527 tests across `com.arcadedb.index.**`, `com.arcadedb.engine.**` and the configuration suites, plus the 477-test vector lane.

A behaviour note worth carrying into the docs: `arcadedb.vectorIndex.rebuildMaxHeapPercent` now judges against a reading that treats the page cache as reclaimable and measures what the resident graph costs, so an index that used to log repeated deferrals may now rebuild. Its description in `GlobalConfiguration` is updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vector-index recovery so previously unreachable vectors remain searchable after database restarts and stale-prefix reuse.
  - Improved rebuild scheduling to avoid unnecessary asynchronous rebuilds while still triggering them at configured thresholds.
  - Improved rebuild memory admission by accounting for resident graph size and reclaiming eligible page-cache memory when needed.
  - Corrected unreachable-vector statistics when graph data is released or unavailable.

- **Documentation**
  - Updated vector rebuild memory guidance to reflect measured graph usage and reclaimable page-cache memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->