### PR TITLE
fix(#6989): ship a schema delta in SCHEMA_ENTRY instead of the whole document

### DIFF
--- a/docs/6989-ha-schema-entry-delta.md
+++ b/docs/6989-ha-schema-entry-delta.md
@@ -94,9 +94,24 @@ the "leader falls back to the full document until every peer is upgraded" arm of
 acceptance criteria. The DECODE side is unconditional, so upgrading is a one-way ratchet: every node
 understands deltas before any node is allowed to emit one.
 
+## Deliberate stopping points
+
+- **A changed child is carried whole.** One property added to a type ships that type's entire JSON, not a diff
+  inside it - the "send only the affected subtree" option the issue asks for. One level keeps `compute`/`apply`
+  generic over every section of the schema document, so a section added later needs no change in `SchemaDelta`;
+  the cost is bounded by one type rather than by the schema, and the half-the-document bar refuses a delta that
+  grew past being worth shipping. Recursive diffing is the obvious next step if types ever get large enough.
+- **The three cache fields are written separately, not swapped atomically.** Both writers hold the database's
+  file recording session, which is exclusive per database, so they cannot interleave. Nothing at the call site
+  enforced that, so `rememberReplicatedSchema` now checks it and logs a warning instead of leaving the
+  invariant in prose only. Warn-only: a torn base costs one extra whole-document entry, which is not worth
+  failing replication over.
+
 ## Deferred
 
 - Automatic peer-capability negotiation, which would let the gate default to on.
+- Wiring `getSchemaDeltasShipped()` / `getSchemaDocumentsShipped()` into the Micrometer HA metrics, so the
+  ratio is visible without an API call.
 - The follower still parses and rewrites the whole document (`update()` + `load()` round-trip
   through `schema.json`) - that is the companion "incremental follower apply" issue, and it is why
   `LocalSchema.update()`'s write cannot simply be coalesced: `load()` reads the file back.

--- a/docs/6989-ha-schema-entry-delta.md
+++ b/docs/6989-ha-schema-entry-delta.md
@@ -32,10 +32,14 @@ Delta shape (`SchemaDelta`):
   "rootKeys": [ "<rootKey>", ... ] }              // authoritative root key set
 ```
 
-`keys`/`rootKeys` make `apply` **structure-authoritative**: the merged document has exactly the
-leader's key set regardless of what the receiver started from, so a removal never needs a separate
-drop list and a stale receiver cannot end up with a phantom type. They cost one name per type
-(~1% of a multi-MB schema), which is what keeps the entry proportional to the change in practice.
+`keys`/`rootKeys` make `apply` **structure-authoritative**: for a section the leader added to or removed from,
+the merged document has exactly the leader's key set regardless of what the receiver started from, so a removal
+never needs a separate drop list and a stale receiver cannot come out of that section with a phantom type.
+
+A key set is proportional to its SECTION, not to the change, so one is emitted only for a section whose key set
+actually moved. Emitting them unconditionally (the first draft, caught by the second review) put every type name
+of a 1209-type schema into a delta that only touched a setting or a function, purely because `types` is a map
+present in both documents.
 
 ## When the leader falls back to the whole document
 

--- a/docs/6989-ha-schema-entry-delta.md
+++ b/docs/6989-ha-schema-entry-delta.md
@@ -128,3 +128,32 @@ understands deltas before any node is allowed to emit one.
 - The follower still parses and rewrites the whole document (`update()` + `load()` round-trip
   through `schema.json`) - that is the companion "incremental follower apply" issue, and it is why
   `LocalSchema.update()`'s write cannot simply be coalesced: `load()` reads the file back.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7211
+
+## Review cycles
+
+Four cycles against the `claude` reviewer (plus CodeRabbit on cycle 2). No cycle produced a blocking finding;
+every cycle produced something worth changing.
+
+| # | head | what the review asked for, and what changed |
+|---|---|---|
+| 1 | `cea6edb` | One coverage gap: the term-mismatch arm of `schemaDeltaFor` was reachable only by forcing a re-election. Split the decision into two static side-effect-free predicates (`baseIsUsable`, `deltaIsWorthShipping`) - the `partitionAbandonedFiles` idiom - and pinned every arm. Also spelled out that `lastFullSchemaLength` is a deliberately loose yardstick. |
+| 2 | `2eba89f` | **The one substantive finding.** A key set is proportional to its SECTION, and one was emitted for every root map unconditionally, so a change to `settings` or `functions` still serialized all 1209 type names into `keys.types`. Now emitted only for a section whose key set actually moved, with three tests over schemas large enough for the regression to show. Plus CodeRabbit: the codec test builds its JSON with `JSONObject`. |
+| 3 | `5c1c73e` | Two items asked for a maintainer's sign-off rather than flagging a defect. Both answered in the tree: per-child granularity is the "affected subtree" option the issue proposes (documented as scope, with recursive diffing named as the next step), and the recording-session exclusivity the three non-atomic writes rely on is now CHECKED in `rememberReplicatedSchema` rather than left in prose. |
+| 4 | `b898cc8` | `final` on the two new locals; "structure-authoritative" spelled out as ONE-DIRECTIONAL (drops enforced, gaps not backfilled); the leader-CPU cost stated as a complexity claim and explicitly NOT measured on the 1209-type schema. Also made the IT say what a leftover `target/databasesN` is, instead of failing with a bare "already exists". |
+
+Final head: `af1894d`. Final state: **max-cycles-reached** - the fourth review was non-blocking and everything
+actionable in it was applied, but the loop stops here by its own budget rather than on a clean pass.
+
+## Deferred, for the developer
+
+- **Automatic peer-capability negotiation.** Until it exists, `arcadedb.ha.schemaDelta` must stay off through a
+  rolling upgrade; turning it on early diverges older followers SILENTLY.
+- **Micrometer wiring** for `getSchemaDeltasShipped()` / `getSchemaDocumentsShipped()`. Worth a tracking issue
+  before the setting is turned on anywhere, since the ratio is the only way to see the path is engaged.
+- **A benchmark on the real 1209-type schema** from #6982, to replace the complexity claim about leader CPU
+  with a measured one.
+- **Recursive per-child diffing**, if a schema ever has types large enough for one type's JSON to matter.

--- a/docs/6989-ha-schema-entry-delta.md
+++ b/docs/6989-ha-schema-entry-delta.md
@@ -72,6 +72,19 @@ and there would be nothing to refuse into - a delta entry carries no whole docum
 that safe is `keys`/`rootKeys`: the merged document has the leader's structure whatever the receiver started
 from.
 
+## What "structure-authoritative" does and does not mean
+
+It is one-directional. A child the receiver has and the leader does not is dropped; a child the leader has and
+the receiver is MISSING is not backfilled, because neither `merge` nor `keys` mentions a child that did not
+change. A receiver that fell behind by more than the delta being applied stays behind, and that class of
+divergence is the business of the WAL-version-gap detection and `checkDatabase` - as it was before.
+
+Leader CPU is O(schema) rather than O(change), deliberately: deciding what did NOT change means touching every
+child once. Each comparison is a structural `JSONObject.equals` over an already-parsed tree - no string built,
+nothing allocated per child - against the full render of the whole document it replaces, so it is strictly less
+leader work than before. That is a complexity claim, not a measured one: it has NOT been benchmarked on the
+1209-type schema from #6982, and the savings this exists for are the wire, the Raft log and the follower.
+
 ## Known limitation
 
 A whole-document entry re-imposed the leader's rendering of EVERY type on the follower. A delta only replaces

--- a/docs/6989-ha-schema-entry-delta.md
+++ b/docs/6989-ha-schema-entry-delta.md
@@ -1,0 +1,98 @@
+# 6989 - HA: every SCHEMA_ENTRY ships the full schema JSON instead of a delta
+
+## Problem
+
+Every `SCHEMA_ENTRY` carried a complete serialization of the schema document, no matter how small the
+DDL was. Split out of #6982, where a 1209-type schema took ~3 hours to replicate.
+
+The full document is paid for four times: leader `toJSON().toString()`, the Raft entry itself
+(wire + every node's log segment), the follower's `new JSONObject(json)` parse, and the follower's
+full rewrite of `schema.json`.
+
+## Root cause
+
+`RaftReplicatedDatabase.recordFileChanges` (`:1774`) and the compaction path (`:2612`) both do
+`proxied.getSchema().getEmbedded().toJSON().toString()` unconditionally whenever the schema version
+moved. `SCHEMA_ENTRY` has no other way to express a schema change: the `schemaJson` slot is a whole
+document or nothing.
+
+## Approach
+
+Add an OPTIONAL trailing `SCHEMA_ENTRY` section carrying a **schema delta** instead of the full
+document, using the same unframed self-describing-section mechanism #4382, #5443 and #4416 already
+use (`SCHEMA_ENTRY` is excluded from the #7138 framed-extension mechanism by construction).
+
+Delta shape (`SchemaDelta`):
+
+```
+{ "base": <schemaVersion the delta was computed against>,
+  "put":   { "<rootKey>": <value> },              // changed non-object root values
+  "merge": { "<rootKey>": { "<child>": <val> } }, // upserted children (one type, one trigger, ...)
+  "keys":  { "<rootKey>": [ "<child>", ... ] },   // authoritative child key set
+  "rootKeys": [ "<rootKey>", ... ] }              // authoritative root key set
+```
+
+`keys`/`rootKeys` make `apply` **structure-authoritative**: the merged document has exactly the
+leader's key set regardless of what the receiver started from, so a removal never needs a separate
+drop list and a stale receiver cannot end up with a phantom type. They cost one name per type
+(~1% of a multi-MB schema), which is what keeps the entry proportional to the change in practice.
+
+## When the leader falls back to the whole document
+
+The leader keeps, per replicated database, the document it last SHIPPED plus the **Raft term** it shipped it in,
+and diffs against that. It ships the whole document instead whenever:
+
+- `arcadedb.ha.schemaDelta` is off (the default);
+- nothing has been shipped yet in this database instance's lifetime, so there is no base;
+- the Raft term moved since the cache was filled - another node has been leader in between, so what the
+  followers hold is whatever IT shipped. An unreadable term (a division restarting in place) counts as moved;
+- the delta is not at least half the size of the document, which is the bulk-drop / settings-rewrite case;
+- the change rides the compaction path, whose sealed-payload budget is measured against the serialized schema.
+
+Two defects the integration test caught that no unit test could have:
+
+1. **The HA setting was read off the wrong configuration.** `HA_SCHEMA_DELTA` is `SCOPE.SERVER`, and the
+   per-database `ContextConfiguration` does not carry what a server-scoped setting was set to - so
+   `proxied.getConfiguration()` silently answered "default", the gate was always false, and nothing failed.
+   It is read off `server.getConfiguration()` now, like `HA_QUORUM_TIMEOUT` and
+   `HA_FORWARD_LEADER_WAIT_TIMEOUT_MS` beside it.
+2. **The schema version cannot be the staleness guard**, which is why the guard is the Raft term: `saveConfiguration()` defers
+   while a transaction is active, so the version bump from a DDL run inside `db.transaction(...)` lands AFTER
+   the entry has already shipped. A version-based guard refused every single delta. The version is carried in
+   the payload as a diagnostic only.
+
+On the follower the version is a diagnostic for the mirror-image reason: `load()` re-saves the schema whenever
+it repaired anything, and every save increments `versionSerial`, so a follower legitimately runs one or more
+versions AHEAD of the document the leader shipped. Refusing a delta on a mismatch would refuse the common case,
+and there would be nothing to refuse into - a delta entry carries no whole document to fall back to. What makes
+that safe is `keys`/`rootKeys`: the merged document has the leader's structure whatever the receiver started
+from.
+
+## Known limitation
+
+A whole-document entry re-imposed the leader's rendering of EVERY type on the follower. A delta only replaces
+the children the leader saw change, so content drift in an unchanged child now persists until the next
+whole-document entry (a leader change, a compaction, a restart) instead of being overwritten on the next DDL.
+Structure - which types, triggers, views and functions exist - is still re-imposed on every delta. Genuine
+divergence remains the business of the WAL-version-gap detection and `checkDatabase`.
+
+## Mixed-version safety
+
+An older decoder stops after the sealed-slice section and silently ignores anything after it, so a
+delta entry would look to it like a `SCHEMA_ENTRY` with an EMPTY `schemaJson` - it would apply
+nothing and diverge silently. There is no peer-version negotiation anywhere in `ha-raft` today
+(nothing in the Raft envelope, no peer capability exchange), so the leader cannot detect an older
+follower on its own.
+
+The emission is therefore gated on `arcadedb.ha.schemaDelta` (`GlobalConfiguration.HA_SCHEMA_DELTA`),
+**default `false`**: the leader ships the full document until an operator turns deltas on, which is
+the "leader falls back to the full document until every peer is upgraded" arm of the issue's
+acceptance criteria. The DECODE side is unconditional, so upgrading is a one-way ratchet: every node
+understands deltas before any node is allowed to emit one.
+
+## Deferred
+
+- Automatic peer-capability negotiation, which would let the gate default to on.
+- The follower still parses and rewrites the whole document (`update()` + `load()` round-trip
+  through `schema.json`) - that is the companion "incremental follower apply" issue, and it is why
+  `LocalSchema.update()`'s write cannot simply be coalesced: `load()` reads the file back.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1871,6 +1871,28 @@ public enum GlobalConfiguration {
       Lower it to bound memory exposure on hostile inputs; raise it if a single transaction legitimately exceeds 128MB.""",
       Long.class, 128L * 1024 * 1024),
 
+  HA_SCHEMA_DELTA("arcadedb.ha.schemaDelta", SCOPE.SERVER,
+      """
+      Ship schema changes to the followers as a DELTA against the schema they already hold, instead of a \
+      complete serialization of the schema document on every single DDL (issue #6989). A one-property \
+      CREATE PROPERTY then costs a Raft entry proportional to the change rather than to the whole schema, \
+      which on a large schema is the difference between kilobytes and megabytes per entry - paid four times \
+      over, on the leader's CPU, on the wire, in every node's Raft log, and in the follower's rewrite of \
+      schema.json. The leader falls back to the whole document by itself whenever a delta cannot be trusted: \
+      the first schema entry after it becomes leader, an entry shipped in instalments, a compaction entry, or \
+      a change too large for a delta to be worth it. \
+      \
+      The leader keeps one parsed copy of the schema document per replicated database while this is on, to diff \
+      the next change against; on a multi-MB schema that is tens of MB of heap per database, released as soon as \
+      the setting goes back off. \
+      \
+      OFF BY DEFAULT, and it must stay off during a rolling upgrade. A node running a version that predates \
+      the delta section of SCHEMA_ENTRY cannot see it - it stops decoding after the sections it knows - and \
+      would apply an empty schema change and diverge SILENTLY. Reading a delta needs no configuration, so \
+      upgrade every node first, then turn this on: from that point every peer understands what the leader \
+      emits. Turning it back off is safe at any time.""",
+      Boolean.class, false),
+
   HA_BOOTSTRAP_FROM_LOCAL_DATABASE("arcadedb.ha.bootstrapFromLocalDatabase", SCOPE.SERVER,
       """
       When true (the default) and every peer's Raft log is empty at first cluster formation, peers exchange a \

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2046,11 +2046,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final DatabaseInternal db = (DatabaseInternal) server.getDatabase(decoded.databaseName());
 
     HALog.log(this, HALog.DETAILED,
-        "Applying schema entry to database '%s' (entryIndex=%d): filesToAdd=%d, filesToRemove=%d, hasSchemaJson=%s",
+        "Applying schema entry to database '%s' (entryIndex=%d): filesToAdd=%d, filesToRemove=%d, schemaPayload=%s",
         decoded.databaseName(), entryIndex,
         decoded.filesToAdd() != null ? decoded.filesToAdd().size() : 0,
         decoded.filesToRemove() != null ? decoded.filesToRemove().size() : 0,
-        decoded.schemaJson() != null && !decoded.schemaJson().isEmpty());
+        decoded.schemaDelta() != null ? "delta" :
+            decoded.schemaJson() != null && !decoded.schemaJson().isEmpty() ? "document" : "none");
 
     if (HALog.isEnabled(HALog.DETAILED)) {
       HALog.log(this, HALog.DETAILED, "Received SCHEMA_ENTRY filesToAdd=%s", decoded.filesToAdd());
@@ -2065,7 +2066,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // shard executors with a 30s awaitTermination) on the Raft apply thread, stalling replication.
     // installSealedFileBytes already reopened the sealed store and the clear WAL applies to the live
     // mutable-bucket pages, so neither the schema update nor the reload is needed.
+    // A schema delta (issue #6989) disqualifies an entry from this shortcut for the same reason it disqualifies
+    // it from walOnlyEntry below: the change is carried OUTSIDE schemaJson, so an entry holding one does publish
+    // a schema change and does need the reload. No producer ships both today - the compaction path always
+    // carries the whole document - and this keeps that from becoming a silent skip if one ever does.
     final boolean sealedOnlyEntry = isEmptyMap(decoded.filesToAdd()) && isEmptyMap(decoded.filesToRemove())
+        && decoded.schemaDelta() == null
         && (isNotEmpty(decoded.sealedFileBlobs()) || isNotEmpty(decoded.sealedFileChunks()));
 
     // A non-final chunk of a schema change split across several entries (see
@@ -2089,8 +2095,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // getFileByIdIfExists() - so the reload is pure cost on the single Raft apply thread, where it
     // re-instantiates every TimeSeries engine and closes shard executors with a 30s awaitTermination.
     // Same reasoning as sealedOnlyEntry above.
+    //
+    // A delta entry (issue #6989) carries its schema change OUTSIDE schemaJson, so it must not be mistaken for
+    // one of these: it publishes a schema change and the reload below is exactly what registers it.
     final boolean walOnlyEntry = isEmptyMap(decoded.filesToAdd()) && isEmptyMap(decoded.filesToRemove())
-        && (decoded.schemaJson() == null || decoded.schemaJson().isEmpty())
+        && (decoded.schemaJson() == null || decoded.schemaJson().isEmpty()) && decoded.schemaDelta() == null
         && !isNotEmpty(decoded.sealedFileBlobs()) && !isNotEmpty(decoded.sealedFileChunks())
         && decoded.walEntries() != null && !decoded.walEntries().isEmpty();
 
@@ -2109,7 +2118,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // data-loss window applySealedBlobs closes for a store that fits inline.
       applySealedChunks(db, decoded.sealedFileChunks());
 
-      if (!sealedOnlyEntry && decoded.schemaJson() != null && !decoded.schemaJson().isEmpty())
+      if (decoded.schemaDelta() != null)
+        applySchemaDelta(db, decoded);
+      else if (!sealedOnlyEntry && decoded.schemaJson() != null && !decoded.schemaJson().isEmpty())
         db.getSchema().getEmbedded().update(new JSONObject(decoded.schemaJson()));
 
       // Apply WAL entries BEFORE the schema reload. New files created above are initially empty;
@@ -2164,6 +2175,44 @@ public class ArcadeStateMachine extends BaseStateMachine {
     }
 
     HALog.log(this, HALog.DETAILED, "Applied schema change to database '%s'", decoded.databaseName());
+  }
+
+  /**
+   * Applies a schema change that arrived as a DELTA rather than as a whole document (issue #6989): merges it
+   * into this node's own schema and hands the result to {@code LocalSchema.update()}, which is the same call the
+   * whole-document path makes, so everything downstream of it - the file rewrite, the plan-cache invalidation
+   * and the {@code load()} below - is unchanged.
+   * <p>
+   * <b>{@code baseVersion} is a diagnostic, not a gate.</b> A follower's {@code versionSerial} legitimately runs
+   * AHEAD of the document the leader shipped: the {@code load()} that follows every schema entry re-saves the
+   * schema whenever it repaired anything, and each save increments the counter. Refusing on a mismatch would
+   * therefore refuse the common case - and there is nothing to refuse INTO, because a delta entry carries no
+   * whole document to fall back to.
+   * <p>
+   * What makes that safe is the delta itself rather than the version: it carries the leader's authoritative key
+   * sets, so the merged document has the leader's structure whatever the receiver started from, and only the
+   * content of children the leader considered unchanged is inherited locally. Genuine divergence stays the
+   * business of the WAL-version-gap detection and {@code checkDatabase}, which is where it was before this
+   * entry type existed.
+   */
+  // @VisibleForTesting
+  void applySchemaDelta(final DatabaseInternal db, final RaftLogEntryCodec.DecodedEntry decoded)
+      throws IOException {
+    final SchemaDelta.Payload delta = decoded.schemaDelta();
+    final LocalSchema schema = db.getSchema().getEmbedded();
+
+    HALog.log(this, HALog.DETAILED,
+        "Applying a %d-char schema delta to database '%s' (leader base version %d, local version %d)",
+        delta.deltaJson().length(), db.getName(), delta.baseVersion(), schema.getVersion());
+
+    final JSONObject merged = SchemaDelta.apply(schema.toJSON(), new JSONObject(delta.deltaJson()));
+
+    // The MERGED document is what this entry publishes, so it - not the empty schemaJson slot - is what the
+    // #4083 cross-reference has to look at. Only reached at DETAILED.
+    if (HALog.isEnabled(HALog.DETAILED))
+      logFollowerSchemaPayloadDiagnostics(db.getName(), merged.toString(), decoded.filesToAdd());
+
+    schema.update(merged);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -312,7 +312,14 @@ public final class RaftLogEntryCodec {
        * whose sealed stores fit inline - those arrive as {@code sealedFileBlobs} - and on entries produced by a
        * node that predates this section.
        */
-      List<TsSealedChunk> sealedFileChunks
+      List<TsSealedChunk> sealedFileChunks,
+      /**
+       * The schema change carried as a DELTA rather than as a whole document (issue #6989). Null on every
+       * entry whose {@code schemaJson} is the full document - which is every entry produced by a node that
+       * predates this section, and every entry produced with {@code arcadedb.ha.schemaDelta} off. When it is
+       * set, {@code schemaJson} is empty and the applier merges the delta into its own schema instead.
+       */
+      SchemaDelta.Payload schemaDelta
   ) {
   }
 
@@ -475,6 +482,31 @@ public final class RaftLogEntryCodec {
       final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
       final List<TsSealedBlob> sealedFileBlobs, final boolean moreChunksFollow,
       final List<TsSealedChunk> sealedFileChunks) {
+    return encodeSchemaEntry(databaseName, schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas,
+        sealedFileBlobs, moreChunksFollow, sealedFileChunks, null);
+  }
+
+  /**
+   * @param schemaDelta the schema change expressed as a DELTA against the document the followers already hold
+   *                    (issue #6989), or null to carry the whole document in {@code schemaJson} as before. When
+   *                    it is set, {@code schemaJson} MUST be empty: the two are alternatives, not a belt and
+   *                    braces, and shipping both would defeat the point.
+   *                    <p>
+   *                    Written as the last trailing section, after the sealed slices, with the same presence
+   *                    rule as every section before it. That makes it invisible to a node running an older
+   *                    codec - which stops after the slices - and such a node would therefore see a
+   *                    {@code SCHEMA_ENTRY} with an EMPTY schema JSON and apply NOTHING, diverging silently.
+   *                    <b>That is why emitting a delta is gated on {@code arcadedb.ha.schemaDelta}, which is
+   *                    off by default</b>: the leader keeps shipping whole documents until an operator turns
+   *                    deltas on, which is safe only once every peer understands them. Decoding is
+   *                    unconditional, so the upgrade is a one-way ratchet - every node can read a delta before
+   *                    any node is allowed to write one.
+   */
+  public static ByteString encodeSchemaEntry(final String databaseName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
+      final List<TsSealedBlob> sealedFileBlobs, final boolean moreChunksFollow,
+      final List<TsSealedChunk> sealedFileChunks, final SchemaDelta.Payload schemaDelta) {
     try {
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
       final DataOutputStream dos = new DataOutputStream(baos);
@@ -537,8 +569,13 @@ public final class RaftLogEntryCodec {
 
       // TimeSeries sealed-store SLICE section (issue #4416). Trailing, self-describing, and written only when
       // non-empty, so an entry with nothing to slice is byte-identical to what the previous codec produced.
+      //
+      // A schema delta (issue #6989) forces the count out even when it is zero: the delta section sits AFTER
+      // this one and the reads are positional, so a decoder must be able to consume an explicit "no slices"
+      // before it. Writing a zero here is understood by every decoder that already handles this section - it
+      // is the same value an entry with an empty slice list would carry - so the entry stays readable.
       final int chunkCount = sealedFileChunks != null ? sealedFileChunks.size() : 0;
-      if (chunkCount > 0) {
+      if (chunkCount > 0 || schemaDelta != null) {
         dos.writeInt(chunkCount);
         for (int i = 0; i < chunkCount; i++) {
           final TsSealedChunk chunk = sealedFileChunks.get(i);
@@ -560,6 +597,18 @@ public final class RaftLogEntryCodec {
           dos.writeInt(compressed.length);   // compressed length
           dos.write(compressed);
         }
+      }
+
+      // Schema delta section (issue #6989). Last, so every section that predates it keeps its position, and
+      // compressed like the sections above it: a delta is JSON, which LZ4 shrinks well.
+      if (schemaDelta != null) {
+        final byte[] deltaBytes = schemaDelta.deltaJson().getBytes(StandardCharsets.UTF_8);
+        checkProducedPayloadLength(deltaBytes.length, databaseName, "Schema delta");
+        final byte[] compressedDelta = CompressionFactory.getDefault().compress(deltaBytes);
+        dos.writeLong(schemaDelta.baseVersion());
+        dos.writeInt(deltaBytes.length);        // uncompressed length
+        dos.writeInt(compressedDelta.length);   // compressed length
+        dos.write(compressedDelta);
       }
 
       dos.flush();
@@ -695,7 +744,7 @@ public final class RaftLogEntryCodec {
       final RaftLogEntryType type = RaftLogEntryType.fromId(typeByte);
       if (type == null)
         return new DecodedEntry(null, null, null, null, null, null, null, null, null, null, false, null, -1L,
-            Collections.emptyList(), false, Collections.emptyList());
+            Collections.emptyList(), false, Collections.emptyList(), null);
       final String databaseName = dis.readUTF();
 
       try {
@@ -730,7 +779,7 @@ public final class RaftLogEntryCodec {
       case INSTALL_DATABASE_ENTRY -> decodeInstallDatabaseEntry(dis, databaseName);
       case DROP_DATABASE_ENTRY -> new DecodedEntry(RaftLogEntryType.DROP_DATABASE_ENTRY, databaseName,
           null, null, null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false,
-          Collections.emptyList());
+          Collections.emptyList(), null);
       case SECURITY_USERS_ENTRY -> decodeSecurityUsersEntry(dis);
       case BOOTSTRAP_FINGERPRINT_ENTRY -> decodeBootstrapFingerprintEntry(dis, databaseName);
     };
@@ -795,7 +844,8 @@ public final class RaftLogEntryCodec {
     }
 
     return new DecodedEntry(RaftLogEntryType.TX_ENTRY, databaseName, walData, bucketRecordDelta,
-        null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false, Collections.emptyList());
+        null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false, Collections.emptyList(),
+        null);
   }
 
   private static DecodedEntry decodeSchemaEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -915,9 +965,25 @@ public final class RaftLogEntryCodec {
       }
     }
 
+    // Schema delta section (issue #6989). Same presence rule as every section above: absent on entries
+    // produced by an older codec and on entries that carry the whole document, which decode with a null
+    // delta and keep the pre-#6989 behaviour exactly.
+    SchemaDelta.Payload schemaDelta = null;
+    if (dis.available() > 0) {
+      final long baseVersion = dis.readLong();
+      final int uncompressedLen = dis.readInt();
+      final int compressedLen = dis.readInt();
+      checkByteLength(compressedLen, dis.available(), "SCHEMA_ENTRY schema delta compressed");
+      checkDecompressedLength(uncompressedLen, compressedLen, "SCHEMA_ENTRY schema delta uncompressed");
+      final byte[] compressed = new byte[compressedLen];
+      dis.readFully(compressed);
+      final byte[] raw = CompressionFactory.getDefault().decompress(compressed, uncompressedLen);
+      schemaDelta = new SchemaDelta.Payload(baseVersion, new String(raw, StandardCharsets.UTF_8));
+    }
+
     return new DecodedEntry(RaftLogEntryType.SCHEMA_ENTRY, databaseName, null, null,
         schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, null, false, null, -1L, sealedFileBlobs,
-        moreChunksFollow, sealedFileChunks);
+        moreChunksFollow, sealedFileChunks, schemaDelta);
   }
 
   private static DecodedEntry decodeInstallDatabaseEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -929,7 +995,7 @@ public final class RaftLogEntryCodec {
     }
     return new DecodedEntry(RaftLogEntryType.INSTALL_DATABASE_ENTRY, databaseName,
         null, null, null, null, null, null, null, null, forceSnapshot, null, -1L, Collections.emptyList(), false,
-        Collections.emptyList());
+        Collections.emptyList(), null);
   }
 
   private static DecodedEntry decodeBootstrapFingerprintEntry(final DataInputStream dis, final String databaseName)
@@ -942,7 +1008,7 @@ public final class RaftLogEntryCodec {
     final long lastTxId = dis.readLong();
     return new DecodedEntry(RaftLogEntryType.BOOTSTRAP_FINGERPRINT_ENTRY, databaseName,
         null, null, null, null, null, null, null, null, false, fingerprint, lastTxId, Collections.emptyList(), false,
-        Collections.emptyList());
+        Collections.emptyList(), null);
   }
 
   private static DecodedEntry decodeSecurityUsersEntry(final DataInputStream dis) throws IOException {
@@ -953,7 +1019,7 @@ public final class RaftLogEntryCodec {
     final String usersJson = new String(bytes, StandardCharsets.UTF_8);
     return new DecodedEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, "",
         null, null, null, null, null, null, null, usersJson, false, null, -1L, Collections.emptyList(), false,
-        Collections.emptyList());
+        Collections.emptyList(), null);
   }
 
   private static void writeFileMap(final DataOutputStream dos, final Map<Integer, String> fileMap) throws IOException {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1814,14 +1814,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // Issue #6989: ship what the DDL changed rather than the whole schema document, when the cluster is
       // configured for it and the cached base is still what the followers hold. schemaDeltaFor() returns null
       // whenever either is not true, and then the whole document goes out exactly as before.
-      JSONObject fullSchema = null;
-      SchemaDelta.Payload schemaDelta = null;
-      if (schemaChanged) {
-        fullSchema = proxied.getSchema().getEmbedded().toJSON();
-        schemaDelta = schemaDeltaFor(fullSchema);
-        if (schemaDelta == null)
-          serializedSchema = fullSchema.toString();
-      }
+      final JSONObject fullSchema = schemaChanged ? proxied.getSchema().getEmbedded().toJSON() : null;
+      final SchemaDelta.Payload schemaDelta = fullSchema != null ? schemaDeltaFor(fullSchema) : null;
+      if (fullSchema != null && schemaDelta == null)
+        serializedSchema = fullSchema.toString();
 
       // Collect any WAL entries buffered by commit() calls that occurred inside the callback
       final List<byte[]> walEntries = new ArrayList<>(schemaWalBuffer.get());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -199,6 +199,47 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private final        AtomicLong                                        sealedChunksMaxSequence  = new AtomicLong();
 
   /**
+   * The schema document this node last SHIPPED to the followers, and the length of the last WHOLE document it
+   * shipped (issue #6989). Together they are what lets the next schema change go out as a delta:
+   * {@link SchemaDelta#compute} diffs against the former, and the latter says whether the result is small
+   * enough to be worth shipping instead of the document.
+   * <p>
+   * Written only after {@code replicateSchema} has returned - an entry that never reached the log did not move
+   * the followers - and only from inside a recording session, which is exclusive per database. Volatile for
+   * visibility across the threads that take that session in turn, not for atomicity between the two.
+   * <p>
+   * <b>Staleness is caught by the RAFT TERM the cache was filled in.</b> Only the leader ships schema entries,
+   * and a new leader always runs in a strictly higher term, so within one term this node is the only node that
+   * can have moved the followers - and across a term boundary the cache says nothing about what the other leader
+   * shipped. {@link #schemaDeltaFor} therefore compares the cached term against the current one and falls back
+   * to the whole document when they differ, which covers leadership loss, a re-election, and a step-down that
+   * this node won again.
+   * <p>
+   * The schema VERSION cannot do that job: {@code saveConfiguration()} defers while a transaction is active, so
+   * the version a DDL run inside {@code db.transaction(...)} produces lands AFTER the entry has shipped, and a
+   * version-based guard would refuse every delta. It is carried in the payload for diagnostics only.
+   * <p>
+   * <b>Cost:</b> one parsed schema document retained per replicated database, which for the multi-MB schema this
+   * issue is about is tens of MB of heap. That is why it is held only while {@code arcadedb.ha.schemaDelta} is
+   * on - see {@link #rememberReplicatedSchema} - and why the base is kept parsed rather than as text: a diff
+   * against text would have to re-parse it on every DDL, which is one of the very costs the delta exists to
+   * avoid.
+   */
+  private volatile     JSONObject                                        lastReplicatedSchema     = null;
+  private volatile     long                                              lastReplicatedSchemaTerm = -1L;
+  private volatile     int                                               lastFullSchemaLength     = 0;
+
+  /**
+   * How many schema changes this database has shipped as a DELTA, and how many as a whole document (issue
+   * #6989). Read together they are the operator's answer to "is the delta path actually engaged?", which a
+   * boolean setting alone cannot give: the leader falls back to the document on its own whenever the cached
+   * base is not what the followers hold, so a cluster with {@code arcadedb.ha.schemaDelta} on can still be
+   * shipping documents - and a ratio that never moves is the symptom to chase.
+   */
+  private final        AtomicLong                                        schemaDeltasShipped      = new AtomicLong();
+  private final        AtomicLong                                        schemaDocumentsShipped   = new AtomicLong();
+
+  /**
    * Memoized unreferenced-file count behind the (file modification count, schema version) gate (issue #6168).
    * <p>
    * Lives HERE, on the database instance, rather than in a map on the server: the gauge that reads it is refreshed
@@ -1770,8 +1811,17 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
       reconcileInstalmentFiles(instalmentState.shippedFiles, addFiles, removeFiles);
 
-      if (schemaChanged)
-        serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
+      // Issue #6989: ship what the DDL changed rather than the whole schema document, when the cluster is
+      // configured for it and the cached base is still what the followers hold. schemaDeltaFor() returns null
+      // whenever either is not true, and then the whole document goes out exactly as before.
+      JSONObject fullSchema = null;
+      SchemaDelta.Payload schemaDelta = null;
+      if (schemaChanged) {
+        fullSchema = proxied.getSchema().getEmbedded().toJSON();
+        schemaDelta = schemaDeltaFor(fullSchema);
+        if (schemaDelta == null)
+          serializedSchema = fullSchema.toString();
+      }
 
       // Collect any WAL entries buffered by commit() calls that occurred inside the callback
       final List<byte[]> walEntries = new ArrayList<>(schemaWalBuffer.get());
@@ -1797,7 +1847,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       if (!addFiles.isEmpty() || !removeFiles.isEmpty() || schemaChanged || !walEntries.isEmpty()
           || shippedInstalments > 0) {
         final RaftHAServer raft = requireRaftServer();
-        raft.getTransactionBroker().replicateSchema(getName(), serializedSchema, addFiles, removeFiles, walEntries, bucketDeltas);
+        raft.getTransactionBroker().replicateSchema(getName(), serializedSchema, addFiles, removeFiles, walEntries,
+            bucketDeltas, Collections.emptyList(), Collections.emptyList(), schemaDelta);
         // Set HERE, not after the logging below: the change is published the moment that call returns, and a
         // diagnostic that threw would otherwise send the finally block into retireAbandonedInstalments to report a
         // divergence that does not exist. Harmless for on-disk state - the compensation only ever targets files
@@ -1806,12 +1857,30 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         // Assigned a SECOND time after this block, and neither assignment is redundant: this one covers a throw
         // between here and there, the other covers the path where this block is not entered at all.
         published = true;
-        HALog.log(this, HALog.DETAILED,
-            "Schema changes replicated via Raft: addFiles=%d, removeFiles=%d, schemaChanged=%s, embeddedWalEntries=%d, instalments=%d",
-            addFiles.size(), removeFiles.size(), schemaChanged, walEntries.size(), shippedInstalments);
 
+        // Deliberately BELOW the assignment above, for the reason it documents: this only records what the
+        // followers now hold so the NEXT change can be diffed against it (issue #6989), and it must not be able
+        // to send the finally block hunting a divergence that did not happen. It runs after the entry has gone
+        // out for the converse reason - an entry that threw on its way to the log did not move the followers, so
+        // the base must not advance past it.
+        if (fullSchema != null)
+          rememberReplicatedSchema(fullSchema, schemaDelta == null ? serializedSchema.length() : -1);
+
+        HALog.log(this, HALog.DETAILED,
+            "Schema changes replicated via Raft: addFiles=%d, removeFiles=%d, schemaChanged=%s, schemaPayload=%s, "
+                + "embeddedWalEntries=%d, instalments=%d",
+            addFiles.size(), removeFiles.size(), schemaChanged,
+            schemaDelta != null ?
+                "delta of " + schemaDelta.deltaJson().length() + " chars" :
+                "document of " + serializedSchema.length() + " chars",
+            walEntries.size(), shippedInstalments);
+
+        // The document, not the payload: with a delta the payload is not a schema document at all, and the
+        // #4083 cross-reference below is about the schema being published, not about how it is encoded. Only
+        // reached at DETAILED, so the render this costs is one an operator asked for.
         if (HALog.isEnabled(HALog.DETAILED))
-          logSchemaPayloadDiagnostics("recordFileChanges", serializedSchema, addFiles, removeFiles);
+          logSchemaPayloadDiagnostics("recordFileChanges",
+              fullSchema != null ? fullSchema.toString() : serializedSchema, addFiles, removeFiles);
       }
 
       // The SECOND of the two assignments (see the one inside the block above). This one covers the path where the
@@ -2609,7 +2678,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // here rather than by the splitter after the delivery-only slices are already in the Raft log. The schema
       // JSON is serialized early for the same reason - its encoded size is part of what the sealed payload has
       // to leave room for.
-      final String serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
+      final JSONObject compactionSchema = proxied.getSchema().getEmbedded().toJSON();
+      final String serializedSchema = compactionSchema.toString();
       final long sealedChunkBudget = GlobalConfiguration.replicatedSealedChunkBudget(proxied.getConfiguration());
       final List<SealedSlicePlan> sealedPlans = planSealedShipping(recordedSealed, sealedChunkBudget,
           publishingSealedCapacity(sealedChunkBudget, broker.maxEntrySize(),
@@ -2642,6 +2712,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
       broker.replicateSchema(getName(), serializedSchema, addFiles, removeFiles, walEntries, bucketDeltas,
           sealedBlobs, finalSealedChunks);
+
+      // A compaction entry always carries the whole document - its size is what the sealed payload was budgeted
+      // against, so there is nothing to gain from a delta here - but it still MOVES the followers, so the base a
+      // later delta is diffed against has to advance with it (issue #6989).
+      rememberReplicatedSchema(compactionSchema, serializedSchema.length());
 
       HALog.log(this, HALog.DETAILED,
           "Compaction for database '%s' replicated via Raft: addFiles=%d, removeFiles=%d, walEntries=%d, "
@@ -2768,6 +2843,100 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     }
     throw new TimeoutException("Timeout of " + timeout
         + "ms waiting for the file recording session to replicate a schema change on database '" + getName() + "'");
+  }
+
+  /**
+   * The schema change as a DELTA against what the followers already hold (issue #6989), or null when the whole
+   * document has to go out instead.
+   * <p>
+   * Null is returned - and the whole document shipped - whenever any of these is true:
+   * <ul>
+   *   <li>{@code arcadedb.ha.schemaDelta} is off (the default). A node running a version that predates the
+   *       delta section cannot see it, so emitting one is only safe once every peer understands it; see
+   *       {@link GlobalConfiguration#HA_SCHEMA_DELTA}.</li>
+   *   <li>Nothing has been shipped yet in this instance's lifetime, so there is no base to diff against.</li>
+   *   <li>The Raft term moved since the cache was filled, so another node has been leader in between and what
+   *       the followers hold is whatever IT shipped - see {@link #lastReplicatedSchema}. An unknown term
+   *       ({@code -1}, which is what a division being restarted in place reports) counts as moved.</li>
+   *   <li>The delta is not meaningfully smaller than the document - a bulk drop, a settings change that
+   *       rewrites everything - in which case shipping it would cost the size of the document plus the delta's
+   *       own key sets.</li>
+   * </ul>
+   */
+  private SchemaDelta.Payload schemaDeltaFor(final JSONObject fullSchema) {
+    if (!schemaDeltaEnabled())
+      return null;
+
+    final JSONObject base = lastReplicatedSchema;
+    if (base == null)
+      return null;
+
+    final long term = currentRaftTerm();
+    if (term < 0 || term != lastReplicatedSchemaTerm) {
+      HALog.log(this, HALog.DETAILED,
+          "Shipping the whole schema for database '%s': the cached base was shipped in term %d, this node is in "
+              + "term %d",
+          getName(), lastReplicatedSchemaTerm, term);
+      return null;
+    }
+
+    final String deltaJson = SchemaDelta.compute(base, fullSchema).toString();
+    // Halving is the bar because the entry is not the only cost a delta avoids: the follower still parses and
+    // rewrites whatever arrives, so a "delta" worth most of the document buys nothing and costs the key sets.
+    if (lastFullSchemaLength > 0 && deltaJson.length() * 2L >= lastFullSchemaLength)
+      return null;
+
+    return new SchemaDelta.Payload(base.getLong(SchemaDelta.SCHEMA_VERSION, -1L), deltaJson);
+  }
+
+  /**
+   * Whether this cluster wants schema deltas. Read off the SERVER's configuration, like every other
+   * {@code SCOPE.SERVER} setting this class consults ({@code HA_QUORUM_TIMEOUT},
+   * {@code HA_FORWARD_LEADER_WAIT_TIMEOUT_MS}): the per-database {@code ContextConfiguration} does not carry
+   * what a server-scoped setting was set to, so reading it there silently answers "default" - which for this
+   * setting means the feature never engages at all, and nothing fails.
+   */
+  private boolean schemaDeltaEnabled() {
+    return server != null && server.getConfiguration().getValueAsBoolean(GlobalConfiguration.HA_SCHEMA_DELTA);
+  }
+
+  /** The Raft term this node is in, or {@code -1} when it cannot be read (no server, division restarting). */
+  private long currentRaftTerm() {
+    final RaftHAServer raft = raftHAServer;
+    return raft != null ? raft.getCurrentTerm() : -1L;
+  }
+
+  /**
+   * Records the schema document the followers now hold, so the NEXT change can be diffed against it (issue
+   * #6989). Call only once the entry carrying it has actually been replicated.
+   *
+   * @param fullSchemaLength the length of the whole document when that is what was shipped, or {@code -1} when a
+   *                         delta was shipped and the last known whole-document length therefore still stands as
+   *                         the yardstick {@link #schemaDeltaFor} sizes the next delta against
+   */
+  private void rememberReplicatedSchema(final JSONObject fullSchema, final int fullSchemaLength) {
+    // Only retained when deltas are actually wanted: the document is the size of the schema, and a cluster
+    // running the default configuration would otherwise pay several MB per replicated database for a base
+    // nothing will ever diff against. Turning the setting on at runtime costs one more whole-document entry -
+    // the base is null until then, which is already one of the fallback arms.
+    final boolean wanted = schemaDeltaEnabled();
+    lastReplicatedSchema = wanted ? fullSchema : null;
+    lastReplicatedSchemaTerm = wanted ? currentRaftTerm() : -1L;
+    if (fullSchemaLength >= 0) {
+      lastFullSchemaLength = fullSchemaLength;
+      schemaDocumentsShipped.incrementAndGet();
+    } else
+      schemaDeltasShipped.incrementAndGet();
+  }
+
+  /** Schema changes this database has shipped as a delta since it opened - see {@link #schemaDeltasShipped}. */
+  public long getSchemaDeltasShipped() {
+    return schemaDeltasShipped.get();
+  }
+
+  /** Schema changes this database has shipped as a whole document since it opened. */
+  public long getSchemaDocumentsShipped() {
+    return schemaDocumentsShipped.get();
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2864,29 +2864,63 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * </ul>
    */
   private SchemaDelta.Payload schemaDeltaFor(final JSONObject fullSchema) {
-    if (!schemaDeltaEnabled())
-      return null;
-
     final JSONObject base = lastReplicatedSchema;
-    if (base == null)
-      return null;
-
     final long term = currentRaftTerm();
-    if (term < 0 || term != lastReplicatedSchemaTerm) {
-      HALog.log(this, HALog.DETAILED,
-          "Shipping the whole schema for database '%s': the cached base was shipped in term %d, this node is in "
-              + "term %d",
-          getName(), lastReplicatedSchemaTerm, term);
+
+    if (!baseIsUsable(schemaDeltaEnabled(), base != null, lastReplicatedSchemaTerm, term)) {
+      if (base != null)
+        HALog.log(this, HALog.DETAILED,
+            "Shipping the whole schema for database '%s': the cached base was shipped in term %d, this node is "
+                + "in term %d",
+            getName(), lastReplicatedSchemaTerm, term);
       return null;
     }
 
     final String deltaJson = SchemaDelta.compute(base, fullSchema).toString();
-    // Halving is the bar because the entry is not the only cost a delta avoids: the follower still parses and
-    // rewrites whatever arrives, so a "delta" worth most of the document buys nothing and costs the key sets.
-    if (lastFullSchemaLength > 0 && deltaJson.length() * 2L >= lastFullSchemaLength)
+    if (!deltaIsWorthShipping(deltaJson.length(), lastFullSchemaLength))
       return null;
 
     return new SchemaDelta.Payload(base.getLong(SchemaDelta.SCHEMA_VERSION, -1L), deltaJson);
+  }
+
+  /**
+   * Whether the cached base can be diffed against at all: the setting is on, a base exists, and the Raft term
+   * has not moved since it was cached.
+   * <p>
+   * Static and side-effect-free so the arms can be pinned without a cluster, the way
+   * {@link #partitionAbandonedFiles} is: forcing a re-election in an integration test to reach the term arm is
+   * expensive and flaky, and this is the branch whose failure mode is silent - it does not break replication,
+   * it just quietly stops the feature from ever engaging, which is exactly how the two defects the integration
+   * test caught behaved.
+   *
+   * @param currentTerm the term this node is in, or {@code -1} when it cannot be read (a division restarting in
+   *                    place). Unknown counts as moved: we cannot show the cache is still valid.
+   */
+  // @VisibleForTesting
+  static boolean baseIsUsable(final boolean enabled, final boolean hasBase, final long cachedTerm,
+      final long currentTerm) {
+    return enabled && hasBase && currentTerm >= 0 && currentTerm == cachedTerm;
+  }
+
+  /**
+   * Whether a delta is small enough to be worth shipping in place of the document.
+   * <p>
+   * Halving is the bar because the Raft entry is not the only cost a delta avoids: the follower still parses and
+   * rewrites whatever arrives, so a "delta" worth most of the document buys nothing and costs the authoritative
+   * key sets on top.
+   * <p>
+   * The yardstick is deliberately loose. {@code lastFullSchemaLength} is refreshed only when a WHOLE document
+   * ships, so on a schema that keeps growing through delta-only entries it drifts below the real document size
+   * and the bar tightens. That errs the safe way - the worst case is one extra whole-document entry, which
+   * immediately re-primes the yardstick - and tracking the true size would mean rendering the document on every
+   * DDL, which is the cost this whole path exists to avoid.
+   *
+   * @param lastFullSchemaLength the length of the last whole document shipped, or {@code 0} when none has been
+   *                             (nothing to compare against, so the delta is taken)
+   */
+  // @VisibleForTesting
+  static boolean deltaIsWorthShipping(final int deltaLength, final int lastFullSchemaLength) {
+    return lastFullSchemaLength <= 0 || deltaLength * 2L < lastFullSchemaLength;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2944,11 +2944,26 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * Records the schema document the followers now hold, so the NEXT change can be diffed against it (issue
    * #6989). Call only once the entry carrying it has actually been replicated.
    *
+   * <p>
+   * <b>The three fields are written separately, not swapped atomically</b>, and what makes that safe is that both
+   * callers - {@code recordFileChanges} and {@code runWithCompactionReplication} - hold this database's file
+   * RECORDING SESSION, which is exclusive per database (compaction defers rather than nesting when a session is
+   * already open). That invariant is inherited from a lock taken much earlier in the call chain and nothing at
+   * this call site enforces it, so it is checked here rather than only asserted in prose: whoever changes the
+   * recording-session mechanism gets a log line rather than a silently torn cache. Warn-only deliberately - a
+   * torn base costs one extra whole-document entry, and failing replication over a diagnostic would be a far
+   * worse trade.
+   *
    * @param fullSchemaLength the length of the whole document when that is what was shipped, or {@code -1} when a
    *                         delta was shipped and the last known whole-document length therefore still stands as
    *                         the yardstick {@link #schemaDeltaFor} sizes the next delta against
    */
   private void rememberReplicatedSchema(final JSONObject fullSchema, final int fullSchemaLength) {
+    if (!proxied.getFileManager().isRecordingChangesOnCurrentThread())
+      LogManager.instance().log(this, Level.WARNING,
+          "Schema delta base for database '%s' updated outside a file recording session; the session is what "
+              + "serializes the two writers, so this cache can now be torn (issue #6989)", getName());
+
     // Only retained when deltas are actually wanted: the document is the size of the schema, and a cluster
     // running the default configuration would otherwise pay several MB per replicated database for a base
     // nothing will ever diff against. Turning the setting on at runtime costs one more whole-document entry -

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -127,8 +127,22 @@ public class RaftTransactionBroker {
       final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
       final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs,
       final List<RaftLogEntryCodec.TsSealedChunk> sealedFileChunks) {
+    replicateSchema(dbName, schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, sealedFileBlobs,
+        sealedFileChunks, null);
+  }
+
+  /**
+   * @param schemaDelta the schema change as a delta against the document the followers hold (issue #6989), or
+   *                    null to carry the whole document in {@code schemaJson}. It publishes, exactly like the
+   *                    schema JSON it replaces, so on a split it rides the LAST chunk.
+   */
+  public void replicateSchema(final String dbName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
+      final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs,
+      final List<RaftLogEntryCodec.TsSealedChunk> sealedFileChunks, final SchemaDelta.Payload schemaDelta) {
     final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(dbName, schemaJson,
-        filesToAdd, filesToRemove, walEntries, bucketDeltas, sealedFileBlobs, false, sealedFileChunks);
+        filesToAdd, filesToRemove, walEntries, bucketDeltas, sealedFileBlobs, false, sealedFileChunks, schemaDelta);
 
     final long cap = groupCommitter.maxEntrySize();
     if (entry.size() <= cap) {
@@ -137,7 +151,7 @@ public class RaftTransactionBroker {
     }
 
     for (final ByteString chunk : splitSchemaEntry(dbName, schemaJson, filesToAdd, filesToRemove, walEntries,
-        bucketDeltas, sealedFileBlobs, sealedFileChunks, cap, entry.size(), false))
+        bucketDeltas, sealedFileBlobs, sealedFileChunks, cap, entry.size(), false, schemaDelta))
       groupCommitter.submitAndWait(chunk.toByteArray());
   }
 
@@ -268,6 +282,22 @@ public class RaftTransactionBroker {
       final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs,
       final List<RaftLogEntryCodec.TsSealedChunk> sealedFileChunks, final long cap, final int singleEntrySize,
       final boolean moreAfterLast) {
+    return splitSchemaEntry(dbName, schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas,
+        sealedFileBlobs, sealedFileChunks, cap, singleEntrySize, moreAfterLast, null);
+  }
+
+  /**
+   * @param schemaDelta the delta the change is carried by (issue #6989), or null when the whole document rides
+   *                    {@code schemaJson}. It publishes, so it goes on the LAST chunk and is measured into that
+   *                    chunk's header budget.
+   */
+  // @VisibleForTesting
+  static List<ByteString> splitSchemaEntry(final String dbName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
+      final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs,
+      final List<RaftLogEntryCodec.TsSealedChunk> sealedFileChunks, final long cap, final int singleEntrySize,
+      final boolean moreAfterLast, final SchemaDelta.Payload schemaDelta) {
 
     // Worst-case non-WAL payload: the first entry carries filesToAdd, the last one the schema JSON,
     // filesToRemove, the sealed blobs and the final sealed slices. Measured by encoding both headers with no
@@ -276,7 +306,7 @@ public class RaftTransactionBroker {
         Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList()).size();
     final int lastHeaderSize = RaftLogEntryCodec.encodeSchemaEntry(dbName, schemaJson, Collections.emptyMap(),
         filesToRemove, Collections.emptyList(), Collections.emptyList(), sealedFileBlobs, moreAfterLast,
-        sealedFileChunks).size();
+        sealedFileChunks, schemaDelta).size();
     final long walBudget = cap - Math.max(firstHeaderSize, lastHeaderSize);
 
     if (walEntries == null || walEntries.isEmpty() || walBudget <= 0)
@@ -284,10 +314,12 @@ public class RaftTransactionBroker {
       throw new ReplicatedEntryTooLargeException(String.format(
           """
           Schema change for database '%s' needs a %d bytes Raft entry, above the maximum replicated entry \
-          size of %d bytes, and cannot be split (schema JSON %d bytes, %d file(s) to add, %d file(s) to \
-          remove, %d WAL entry/entries, %d sealed blob(s)). Raise arcadedb.ha.appendBufferSize - and with it \
-          arcadedb.ha.writeBufferSize, which must stay >= appendBufferSize + 8 bytes.""",
+          size of %d bytes, and cannot be split (schema JSON %d bytes, schema delta %d bytes, %d file(s) to \
+          add, %d file(s) to remove, %d WAL entry/entries, %d sealed blob(s)). Raise \
+          arcadedb.ha.appendBufferSize - and with it arcadedb.ha.writeBufferSize, which must stay >= \
+          appendBufferSize + 8 bytes.""",
           dbName, singleEntrySize, cap, schemaJson != null ? schemaJson.length() : 0,
+          schemaDelta != null ? schemaDelta.deltaJson().length() : 0,
           filesToAdd != null ? filesToAdd.size() : 0, filesToRemove != null ? filesToRemove.size() : 0,
           walEntries != null ? walEntries.size() : 0,
           (sealedFileBlobs != null ? sealedFileBlobs.size() : 0)
@@ -339,7 +371,8 @@ public class RaftTransactionBroker {
           walGroups.get(g), deltaGroups.get(g),
           last ? sealedFileBlobs : Collections.emptyList(),
           !last || moreAfterLast,
-          last ? sealedFileChunks : Collections.emptyList());
+          last ? sealedFileChunks : Collections.emptyList(),
+          last ? schemaDelta : null);
 
       if (chunk.size() > cap)
         // A single WAL entry (or the header plus one WAL entry) still does not fit. Fail loudly rather

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SchemaDelta.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SchemaDelta.java
@@ -50,12 +50,17 @@ import java.util.Set;
  * </pre>
  *
  * <h2>Why the key sets are carried rather than a list of removals</h2>
- * {@code keys}/{@code rootKeys} make {@link #apply} <b>structure-authoritative</b>: whatever document it is
- * handed, the result carries exactly the key set the leader had, with the UNCHANGED children taken from the
- * receiver's own copy. A removal therefore needs no separate drop list, and - more importantly - a receiver
- * whose document does not match the leader's base cannot end up with a phantom type that no entry ever
- * removes. The cost is one name per type, roughly 1% of a multi-MB schema, which is what keeps the entry
- * proportional to the change in practice.
+ * {@code keys}/{@code rootKeys} make {@link #apply} <b>structure-authoritative</b>: for a section the leader
+ * added to or removed from, the result carries exactly the key set the leader had, with the UNCHANGED children
+ * taken from the receiver's own copy. A removal therefore needs no separate drop list, and a receiver whose
+ * document does not match the leader's base cannot come out of that section with a phantom type no entry ever
+ * removes.
+ * <p>
+ * A key set is proportional to its SECTION, not to the change, so one is emitted only for a section whose key
+ * set actually moved - a couple of hundred bytes of names on the DDL that added or dropped something, and
+ * nothing at all on a change to another section. Emitting them unconditionally would put every type name of a
+ * 1209-type schema into a delta that only touched a setting, purely because {@code types} is a map present in
+ * both documents.
  * <p>
  * {@code base} is carried for diagnostics only, for exactly that reason: the applier warns on a mismatch
  * rather than refusing, because the delta entry does not carry a full document to fall back to, and a
@@ -126,7 +131,14 @@ public final class SchemaDelta {
 
         if (!childUpserts.isEmpty())
           merge.put(rootKey, childUpserts);
-        keys.put(rootKey, new JSONArray(new ArrayList<>(updatedMap.keySet())));
+
+        // Only when this section's SHAPE moved. A key set is proportional to the section, not to the change, so
+        // emitting it unconditionally would put every one of a 1209-type schema's type names into a delta that
+        // only touched, say, a setting or a function - {@code types} is a map present in both documents, so it
+        // would qualify without having changed at all. When the two key sets match there is nothing for apply()
+        // to drop there, and the children it does not mention are preserved either way.
+        if (baseMap == null || !baseMap.keySet().equals(updatedMap.keySet()))
+          keys.put(rootKey, new JSONArray(new ArrayList<>(updatedMap.keySet())));
 
       } else if (!base.has(rootKey) || !sameValue(baseValue, updatedValue))
         put.put(rootKey, updatedValue);
@@ -205,6 +217,12 @@ public final class SchemaDelta {
    * Structural equality of two values read out of a schema document. {@link JSONObject#equals} compares the
    * underlying tree, so an unchanged type costs no string rendering; everything else in a schema document is
    * a scalar or a small array, for which the rendered form is both cheap and exact.
+   * <p>
+   * Comparing the RENDERED form is what makes a value that JSON round-tripped into a different Java type - an
+   * {@code Integer} on one side and a {@code Long} on the other - compare equal, which {@code equals()} would
+   * not. The converse, two numerically equal values rendered differently ({@code 1} against {@code 1.0}),
+   * compares as changed and ships a redundant upsert; a schema document's root scalars are a long and two
+   * strings, so neither case arises today.
    */
   private static boolean sameValue(final Object left, final Object right) {
     if (left == right)

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SchemaDelta.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SchemaDelta.java
@@ -74,6 +74,20 @@ import java.util.Set;
  * 1209-type schema into a delta that only touched a setting, purely because {@code types} is a map present in
  * both documents.
  * <p>
+ * <b>Structure-authority is ONE-DIRECTIONAL</b>, and reading it as self-healing would be reading too much into
+ * it: a child the receiver has and the leader does not is dropped, but a child the leader has and the receiver
+ * is MISSING is not backfilled - neither {@code merge} nor {@code keys} mentions a child that did not change,
+ * so there is nothing to backfill it from. A receiver that fell behind by more than the delta being applied
+ * stays behind, and that class of divergence is the business of the WAL-version-gap detection and
+ * {@code checkDatabase}, exactly as it was before this entry type existed.
+ * <p>
+ * <b>Leader CPU is O(schema), not O(change)</b>, and deliberately so: deciding what did NOT change means
+ * touching every child once. Each comparison is a structural {@link JSONObject#equals} over an already-parsed
+ * tree - no string is built and nothing is allocated per child - against the full render of the whole document
+ * this replaces, so it is strictly less work than before on the leader as well. It is a complexity claim rather
+ * than a measured one: it has not been benchmarked on the 1209-type schema that motivated #6989, and the
+ * savings this class exists for are the wire, the Raft log, and the follower, not the leader's CPU.
+ * <p>
  * {@code base} is carried for diagnostics only, for exactly that reason: the applier warns on a mismatch
  * rather than refusing, because the delta entry does not carry a full document to fall back to, and a
  * receiver whose {@code schemaVersion} drifted by a purely local {@code saveConfiguration()} is far more

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SchemaDelta.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SchemaDelta.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Difference between two serializations of a database schema, so a {@code SCHEMA_ENTRY} can ship what a DDL
+ * actually changed instead of the whole document (issue #6989).
+ * <p>
+ * {@code CREATE PROPERTY Foo.a STRING} adds a few dozen bytes of logical schema. Before this class every
+ * schema entry carried {@code LocalSchema.toJSON().toString()} in full, which on the schema that motivated
+ * the issue (1209 types, several MB) was serialized on the leader, written into every node's Raft log,
+ * parsed on every follower and rewritten to {@code schema.json} - about 6100 times.
+ *
+ * <h2>Shape</h2>
+ * The schema document is a flat object whose values are either scalars ({@code schemaVersion},
+ * {@code dbmsVersion}, ...) or maps keyed by name ({@code types}, {@code triggers},
+ * {@code materializedViews}, {@code continuousAggregates}, {@code functions}, {@code extensions},
+ * {@code settings}). The delta mirrors that structure and nothing else, so a section added to the schema
+ * document later is diffed by the same generic rules with no change here:
+ *
+ * <pre>
+ * { "base":     &lt;schemaVersion the delta was computed against&gt;,
+ *   "put":      { "&lt;rootKey&gt;": &lt;value&gt; },                 // changed root values that are NOT maps
+ *   "merge":    { "&lt;rootKey&gt;": { "&lt;child&gt;": &lt;value&gt; } },  // added or changed children of a map
+ *   "keys":     { "&lt;rootKey&gt;": [ "&lt;child&gt;", ... ] },      // authoritative child key set of that map
+ *   "rootKeys": [ "&lt;rootKey&gt;", ... ] }                    // authoritative root key set
+ * </pre>
+ *
+ * <h2>Why the key sets are carried rather than a list of removals</h2>
+ * {@code keys}/{@code rootKeys} make {@link #apply} <b>structure-authoritative</b>: whatever document it is
+ * handed, the result carries exactly the key set the leader had, with the UNCHANGED children taken from the
+ * receiver's own copy. A removal therefore needs no separate drop list, and - more importantly - a receiver
+ * whose document does not match the leader's base cannot end up with a phantom type that no entry ever
+ * removes. The cost is one name per type, roughly 1% of a multi-MB schema, which is what keeps the entry
+ * proportional to the change in practice.
+ * <p>
+ * {@code base} is carried for diagnostics only, for exactly that reason: the applier warns on a mismatch
+ * rather than refusing, because the delta entry does not carry a full document to fall back to, and a
+ * receiver whose {@code schemaVersion} drifted by a purely local {@code saveConfiguration()} is far more
+ * likely than genuine divergence - which the existing WAL-version-gap and verify machinery catches anyway.
+ *
+ * @author Arcade Data
+ */
+public final class SchemaDelta {
+
+  /** The {@code schemaVersion} the delta was computed against. Diagnostic - see the class javadoc. */
+  static final String FIELD_BASE      = "base";
+  /** Root values that are not maps and whose value changed, carried verbatim. */
+  static final String FIELD_PUT       = "put";
+  /** Per-map upserts: the children that were added or changed, carried verbatim. */
+  static final String FIELD_MERGE     = "merge";
+  /** Per-map authoritative child key sets. */
+  static final String FIELD_KEYS      = "keys";
+  /** Authoritative root key set. */
+  static final String FIELD_ROOT_KEYS = "rootKeys";
+
+  /** Root field of the schema document holding its monotonic version. */
+  static final String SCHEMA_VERSION  = "schemaVersion";
+
+  /**
+   * One schema delta as it travels inside a {@code SCHEMA_ENTRY}.
+   *
+   * @param baseVersion the {@code schemaVersion} the delta was computed against, {@code -1} when unknown
+   * @param deltaJson   the serialized delta document ({@link #compute})
+   */
+  public record Payload(long baseVersion, String deltaJson) {
+  }
+
+  private SchemaDelta() {
+  }
+
+  /**
+   * Computes the delta that turns {@code base} into {@code updated}.
+   *
+   * @param base    the schema document the receiver is expected to hold
+   * @param updated the schema document to reach
+   *
+   * @return a delta document; never null, and never empty (it always carries {@code base} and
+   *         {@code rootKeys})
+   */
+  public static JSONObject compute(final JSONObject base, final JSONObject updated) {
+    final JSONObject delta = new JSONObject();
+    delta.put(FIELD_BASE, base.getLong(SCHEMA_VERSION, -1L));
+
+    final JSONObject put = new JSONObject();
+    final JSONObject merge = new JSONObject();
+    final JSONObject keys = new JSONObject();
+
+    for (final String rootKey : new ArrayList<>(updated.keySet())) {
+      final Object updatedValue = updated.opt(rootKey);
+      final Object baseValue = base.opt(rootKey);
+
+      if (updatedValue instanceof final JSONObject updatedMap) {
+        // A map section: diff it child by child, and carry its key set so apply() can drop what is gone.
+        final JSONObject baseMap = baseValue instanceof final JSONObject m ? m : null;
+        final JSONObject childUpserts = new JSONObject();
+
+        for (final String childKey : new ArrayList<>(updatedMap.keySet())) {
+          final Object childValue = updatedMap.opt(childKey);
+          if (baseMap == null || !baseMap.has(childKey) || !sameValue(baseMap.opt(childKey), childValue))
+            childUpserts.put(childKey, childValue);
+        }
+
+        if (!childUpserts.isEmpty())
+          merge.put(rootKey, childUpserts);
+        keys.put(rootKey, new JSONArray(new ArrayList<>(updatedMap.keySet())));
+
+      } else if (!base.has(rootKey) || !sameValue(baseValue, updatedValue))
+        put.put(rootKey, updatedValue);
+    }
+
+    if (!put.isEmpty())
+      delta.put(FIELD_PUT, put);
+    if (!merge.isEmpty())
+      delta.put(FIELD_MERGE, merge);
+    if (!keys.isEmpty())
+      delta.put(FIELD_KEYS, keys);
+    delta.put(FIELD_ROOT_KEYS, new JSONArray(new ArrayList<>(updated.keySet())));
+
+    return delta;
+  }
+
+  /**
+   * Applies {@code delta} to {@code current}, returning the resulting schema document. {@code current} is
+   * not modified.
+   * <p>
+   * The result's key set is the one the delta declares, so applying a delta to a document that is not
+   * exactly the base it was computed against still yields the leader's structure; only the content of
+   * children the delta did not mention is inherited from {@code current}.
+   */
+  public static JSONObject apply(final JSONObject current, final JSONObject delta) {
+    final JSONObject result = current.copy();
+
+    final JSONObject put = delta.getJSONObject(FIELD_PUT, null);
+    if (put != null)
+      for (final String rootKey : new ArrayList<>(put.keySet()))
+        result.put(rootKey, put.opt(rootKey));
+
+    final JSONObject merge = delta.getJSONObject(FIELD_MERGE, null);
+    if (merge != null)
+      for (final String rootKey : new ArrayList<>(merge.keySet())) {
+        final JSONObject upserts = merge.getJSONObject(rootKey);
+        final JSONObject target = mapSection(result, rootKey);
+        for (final String childKey : new ArrayList<>(upserts.keySet()))
+          target.put(childKey, upserts.opt(childKey));
+      }
+
+    final JSONObject keys = delta.getJSONObject(FIELD_KEYS, null);
+    if (keys != null)
+      for (final String rootKey : new ArrayList<>(keys.keySet())) {
+        final JSONObject target = mapSection(result, rootKey);
+        final Set<String> allowed = toStringSet(keys.getJSONArray(rootKey));
+        for (final String childKey : new ArrayList<>(target.keySet()))
+          if (!allowed.contains(childKey))
+            target.remove(childKey);
+      }
+
+    final JSONArray rootKeys = delta.getJSONArray(FIELD_ROOT_KEYS, null);
+    if (rootKeys != null) {
+      final Set<String> allowed = toStringSet(rootKeys);
+      for (final String rootKey : new ArrayList<>(result.keySet()))
+        if (!allowed.contains(rootKey))
+          result.remove(rootKey);
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns {@code root}'s map-valued child {@code key}, creating (and installing) an empty one when the
+   * key is absent or holds something that is not a map. Mutations write through to {@code root}.
+   */
+  private static JSONObject mapSection(final JSONObject root, final String key) {
+    if (root.opt(key) instanceof final JSONObject existing)
+      return existing;
+    final JSONObject created = new JSONObject();
+    root.put(key, created);
+    return created;
+  }
+
+  /**
+   * Structural equality of two values read out of a schema document. {@link JSONObject#equals} compares the
+   * underlying tree, so an unchanged type costs no string rendering; everything else in a schema document is
+   * a scalar or a small array, for which the rendered form is both cheap and exact.
+   */
+  private static boolean sameValue(final Object left, final Object right) {
+    if (left == right)
+      return true;
+    if (left == null || right == null)
+      return false;
+    if (left instanceof final JSONObject leftMap)
+      return right instanceof JSONObject && leftMap.equals(right);
+    if (right instanceof JSONObject)
+      return false;
+    return String.valueOf(left).equals(String.valueOf(right));
+  }
+
+  private static Set<String> toStringSet(final JSONArray array) {
+    final Set<String> set = HashSet.newHashSet(array.length());
+    for (int i = 0; i < array.length(); i++)
+      set.add(array.getString(i));
+    return set;
+  }
+
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SchemaDelta.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SchemaDelta.java
@@ -49,6 +49,18 @@ import java.util.Set;
  *   "rootKeys": [ "&lt;rootKey&gt;", ... ] }                    // authoritative root key set
  * </pre>
  *
+ * <h2>Granularity: one whole child, not a nested diff</h2>
+ * A changed child is carried WHOLE - one property added to a type ships that type's entire JSON, not a diff
+ * inside it. That is the "send only the affected subtree" option issue #6989 asks for, and it is a deliberate
+ * stopping point: one level keeps {@link #compute} and {@link #apply} generic over every section of the schema
+ * document, with no per-section knowledge of what a type, a trigger or a function looks like inside, so a
+ * section added to the document later needs no change here.
+ * <p>
+ * The cost is that a type with very many properties still ships all of them when one is added. That is bounded
+ * by ONE type rather than by the schema, and the leader's own half-the-document bar refuses a delta that grew
+ * past being worth shipping. Recursive diffing would shrink that middle ground and is the obvious next step if
+ * a schema ever has types large enough to make it matter.
+ *
  * <h2>Why the key sets are carried rather than a list of removals</h2>
  * {@code keys}/{@code rootKeys} make {@link #apply} <b>structure-authoritative</b>: for a section the leader
  * added to or removed from, the result carries exactly the key set the leader had, with the UNCHANGED children

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaApplyTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaApplyTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6989, follower side: a {@code SCHEMA_ENTRY} carrying a delta must leave the receiver's schema where the
+ * whole document would have left it.
+ * <p>
+ * Driven against REAL {@code LocalSchema} documents rather than hand-built JSON, because that is where the risk
+ * lives: {@link SchemaDelta} diffs the schema document generically, and the shape that has to survive is the one
+ * {@code LocalSchema.toJSON()} actually produces - nested type/property/index maps, a settings section, and root
+ * scalars - not the shape a test author imagines.
+ * <p>
+ * The two databases are built by running the SAME DDL, so their bucket ids and file names line up the way they do
+ * on a leader and a follower that have applied the same entries. Only property-level changes are exercised for
+ * that reason: a change that creates a file needs the {@code createNewFiles} half of {@code applySchemaEntry},
+ * which is not what this test is about.
+ */
+class Issue6989SchemaDeltaApplyTest {
+
+  private static final String DB = "mydb";
+
+  @TempDir
+  private Path serverDir;
+
+  private LocalDatabase leader;
+  private LocalDatabase follower;
+
+  @BeforeEach
+  void setUp() {
+    leader = (LocalDatabase) new DatabaseFactory(serverDir.resolve("db-leader").toString()).create();
+    follower = (LocalDatabase) new DatabaseFactory(serverDir.resolve("db-follower").toString()).create();
+    seed(leader);
+    seed(follower);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (leader != null && leader.isOpen())
+      leader.close();
+    if (follower != null && follower.isOpen())
+      follower.close();
+  }
+
+  private static void seed(final LocalDatabase db) {
+    db.transaction(() -> {
+      final Schema schema = db.getSchema();
+      for (int i = 0; i < 25; i++) {
+        schema.createVertexType("Seed_" + i);
+        schema.getType("Seed_" + i).createProperty("id_" + i, Type.STRING);
+        schema.getType("Seed_" + i).createProperty("name_" + i, Type.STRING);
+      }
+    });
+  }
+
+  @Test
+  void aDeltaLeavesTheFollowerWhereTheWholeDocumentWouldHave() throws Exception {
+    final JSONObject base = leader.getSchema().getEmbedded().toJSON();
+
+    leader.transaction(() -> leader.getSchema().getType("Seed_3").createProperty("added", Type.INTEGER));
+    final JSONObject updated = leader.getSchema().getEmbedded().toJSON();
+
+    final SchemaDelta.Payload payload = new SchemaDelta.Payload(base.getLong("schemaVersion"),
+        SchemaDelta.compute(base, updated).toString());
+
+    assertThat(payload.deltaJson().length())
+        .as("the delta must be a fraction of the document it replaces")
+        .isLessThan(updated.toString().length() / 3);
+
+    applyOnFollower(payload);
+
+    final Schema followerSchema = follower.getSchema();
+    assertThat(followerSchema.getType("Seed_3").existsProperty("added")).isTrue();
+    assertThat(followerSchema.getType("Seed_3").getProperty("added").getType()).isEqualTo(Type.INTEGER);
+    // Nothing else moved: the untouched types are still there, with the properties they had.
+    for (int i = 0; i < 25; i++) {
+      assertThat(followerSchema.existsType("Seed_" + i)).isTrue();
+      assertThat(followerSchema.getType("Seed_" + i).existsProperty("name_" + i)).isTrue();
+      if (i != 3)
+        assertThat(followerSchema.getType("Seed_" + i).existsProperty("added"))
+            .as("type Seed_%d was not part of the change", i).isFalse();
+    }
+    // At least, not exactly: the reload re-saves the schema when it repaired anything, and every save moves
+    // versionSerial on. That drift is why the applier treats the delta's base version as a diagnostic.
+    assertThat(follower.getSchema().getEmbedded().getVersion())
+        .as("the follower took the leader's schema version from the delta")
+        .isGreaterThanOrEqualTo(updated.getLong("schemaVersion"));
+  }
+
+  @Test
+  void aDroppedTypeIsGoneOnTheFollower() throws Exception {
+    final JSONObject base = leader.getSchema().getEmbedded().toJSON();
+
+    leader.transaction(() -> leader.getSchema().dropType("Seed_11"));
+    final JSONObject updated = leader.getSchema().getEmbedded().toJSON();
+
+    applyOnFollower(new SchemaDelta.Payload(base.getLong("schemaVersion"),
+        SchemaDelta.compute(base, updated).toString()));
+
+    assertThat(follower.getSchema().existsType("Seed_11")).isFalse();
+    assertThat(follower.getSchema().existsType("Seed_10")).isTrue();
+    assertThat(follower.getSchema().existsType("Seed_12")).isTrue();
+  }
+
+  /**
+   * Drives the production applier over a real encode/decode round trip, so the test cannot pass on a payload the
+   * wire would not have carried.
+   */
+  private void applyOnFollower(final SchemaDelta.Payload payload) throws Exception {
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false,
+        Collections.emptyList(), payload);
+
+    new ArcadeStateMachine().applySchemaDelta(follower, RaftLogEntryCodec.decode(entry));
+
+    // The reload applySchemaEntry does right after, and what makes the merged document the live schema.
+    final LocalSchema schema = follower.getSchema().getEmbedded();
+    schema.load(ComponentFile.MODE.READ_WRITE, true);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaCodecTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6989: the {@code SCHEMA_ENTRY} wire format carries an OPTIONAL trailing schema-delta section, so a DDL
+ * can ship what it changed instead of the whole schema document.
+ * <p>
+ * These tests pin the section's placement and its presence rule. The rule is the same one #4382, #5443 and
+ * #4416 use - no remaining bytes means the section is absent - which is what keeps an entry produced without a
+ * delta byte-identical to what the previous codec emitted.
+ */
+class Issue6989SchemaDeltaCodecTest {
+
+  private static final String DB = "mydb";
+
+  private static final Map<Integer, String> ADD    = Map.of(7, "Foo_7.bucket");
+  private static final Map<Integer, String> REMOVE = Map.of(3, "Old_3.bucket");
+
+  private static String bigSchema(final int typeCount) {
+    final JSONObject root = new JSONObject();
+    root.put("schemaVersion", 42);
+    final JSONObject types = new JSONObject();
+    for (int i = 0; i < typeCount; i++) {
+      final JSONObject type = new JSONObject();
+      type.put("name", "Type_" + i);
+      type.put("properties", new JSONObject().put("id", new JSONObject().put("type", "STRING")));
+      types.put("Type_" + i, type);
+    }
+    root.put("types", types);
+    return root.toString();
+  }
+
+  @Test
+  void anEntryWithoutADeltaDecodesAsBeforeAndCarriesNoDeltaSection() {
+    final ByteString withDelta = RaftLogEntryCodec.encodeSchemaEntry(DB, "{\"schemaVersion\":1}", ADD, REMOVE);
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(withDelta);
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SCHEMA_ENTRY);
+    assertThat(decoded.schemaDelta()).isNull();
+    assertThat(decoded.schemaJson()).isEqualTo("{\"schemaVersion\":1}");
+    assertThat(decoded.filesToAdd()).isEqualTo(ADD);
+    assertThat(decoded.filesToRemove()).isEqualTo(REMOVE);
+  }
+
+  @Test
+  void aDeltaSurvivesTheRoundTrip() {
+    final String deltaJson = "{\"base\":41,\"put\":{\"schemaVersion\":42},\"rootKeys\":[\"schemaVersion\",\"types\"]}";
+
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", ADD, REMOVE,
+        Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, Collections.emptyList(),
+        new SchemaDelta.Payload(41L, deltaJson));
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
+
+    assertThat(decoded.schemaDelta()).isNotNull();
+    assertThat(decoded.schemaDelta().baseVersion()).isEqualTo(41L);
+    assertThat(decoded.schemaDelta().deltaJson()).isEqualTo(deltaJson);
+    assertThat(decoded.schemaJson()).isEmpty();
+    assertThat(decoded.filesToAdd()).isEqualTo(ADD);
+    assertThat(decoded.filesToRemove()).isEqualTo(REMOVE);
+  }
+
+  @Test
+  void aDeltaRidesAlongsideEveryOtherOptionalSection() {
+    final byte[] wal = "a WAL page".getBytes(StandardCharsets.UTF_8);
+    final byte[] sealed = "a sealed store".getBytes(StandardCharsets.UTF_8);
+    final Map<Integer, Integer> bucketDelta = new HashMap<>();
+    bucketDelta.put(7, 3);
+
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", ADD, REMOVE,
+        List.of(wal), List.of(bucketDelta),
+        List.of(new RaftLogEntryCodec.TsSealedBlob("Metric", 0, "Metric_0.sealed", sealed)),
+        true, Collections.emptyList(), new SchemaDelta.Payload(41L, "{\"base\":41}"));
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
+
+    assertThat(decoded.walEntries()).hasSize(1);
+    assertThat(decoded.walEntries().getFirst()).isEqualTo(wal);
+    assertThat(decoded.bucketDeltas()).containsExactly(bucketDelta);
+    assertThat(decoded.sealedFileBlobs()).hasSize(1);
+    assertThat(decoded.sealedFileBlobs().getFirst().bytes()).isEqualTo(sealed);
+    assertThat(decoded.moreChunksFollow()).isTrue();
+    assertThat(decoded.sealedFileChunks()).isEmpty();
+    assertThat(decoded.schemaDelta().deltaJson()).isEqualTo("{\"base\":41}");
+  }
+
+  @Test
+  void aDeltaRidesAfterSealedSlices() {
+    final byte[] slice = "sliced sealed store".getBytes(StandardCharsets.UTF_8);
+    final RaftLogEntryCodec.TsSealedChunk chunk = new RaftLogEntryCodec.TsSealedChunk("Metric", 0,
+        "Metric_0.sealed", slice.length, 1234L, 0L, slice, true);
+
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false,
+        List.of(chunk), new SchemaDelta.Payload(41L, "{\"base\":41}"));
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
+
+    assertThat(decoded.sealedFileChunks()).hasSize(1);
+    assertThat(decoded.sealedFileChunks().getFirst().bytes()).isEqualTo(slice);
+    assertThat(decoded.schemaDelta().deltaJson()).isEqualTo("{\"base\":41}");
+  }
+
+  @Test
+  void aDeltaEntryIsAFractionOfTheDocumentEntryForTheSameChange() {
+    final String fullSchema = bigSchema(500);
+    final String deltaJson = "{\"base\":41,\"put\":{\"schemaVersion\":42},"
+        + "\"merge\":{\"types\":{\"Type_7\":{\"name\":\"Type_7\",\"properties\":{\"id\":{\"type\":\"STRING\"}}}}}}";
+
+    final int documentEntry = RaftLogEntryCodec.encodeSchemaEntry(DB, fullSchema, ADD, REMOVE).size();
+    final int deltaEntry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", ADD, REMOVE,
+        Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, Collections.emptyList(),
+        new SchemaDelta.Payload(41L, deltaJson)).size();
+
+    assertThat(deltaEntry)
+        .as("a one-type change must not cost an entry sized by the schema (%d bytes) - it costs %d",
+            documentEntry, deltaEntry)
+        .isLessThan(documentEntry / 10);
+  }
+
+  @Test
+  void onASplitTheDeltaRidesTheLastChunkOnly() {
+    // Four WAL entries that cannot share one entry, so the change is split; only the publishing chunk may
+    // carry the delta, exactly like the schema JSON it replaces.
+    final List<byte[]> walEntries = new ArrayList<>();
+    final List<Map<Integer, Integer>> bucketDeltas = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      final byte[] wal = new byte[4096];
+      // Non-repeating content so compression cannot collapse the groups back into one entry.
+      for (int b = 0; b < wal.length; b++)
+        wal[b] = (byte) ((b * 31 + i * 7) & 0xFF);
+      walEntries.add(wal);
+      bucketDeltas.add(Collections.emptyMap());
+    }
+    final SchemaDelta.Payload delta = new SchemaDelta.Payload(41L, "{\"base\":41}");
+
+    final int single = RaftLogEntryCodec.encodeSchemaEntry(DB, "", ADD, REMOVE, walEntries, bucketDeltas,
+        Collections.emptyList(), false, Collections.emptyList(), delta).size();
+
+    final List<ByteString> chunks = RaftTransactionBroker.splitSchemaEntry(DB, "", ADD, REMOVE, walEntries,
+        bucketDeltas, Collections.emptyList(), Collections.emptyList(), single / 2, single, false, delta);
+
+    assertThat(chunks).hasSizeGreaterThan(1);
+    for (int i = 0; i < chunks.size(); i++) {
+      final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(chunks.get(i));
+      if (i < chunks.size() - 1) {
+        assertThat(decoded.schemaDelta()).as("chunk %d only delivers", i).isNull();
+        assertThat(decoded.moreChunksFollow()).isTrue();
+      } else {
+        assertThat(decoded.schemaDelta()).as("the last chunk publishes").isNotNull();
+        assertThat(decoded.schemaDelta().deltaJson()).isEqualTo("{\"base\":41}");
+        assertThat(decoded.moreChunksFollow()).isFalse();
+      }
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaCodecTest.java
@@ -46,7 +46,7 @@ class Issue6989SchemaDeltaCodecTest {
   private static final Map<Integer, String> ADD    = Map.of(7, "Foo_7.bucket");
   private static final Map<Integer, String> REMOVE = Map.of(3, "Old_3.bucket");
 
-  private static String bigSchema(final int typeCount) {
+  private static JSONObject bigSchema(final int typeCount) {
     final JSONObject root = new JSONObject();
     root.put("schemaVersion", 42);
     final JSONObject types = new JSONObject();
@@ -57,24 +57,48 @@ class Issue6989SchemaDeltaCodecTest {
       types.put("Type_" + i, type);
     }
     root.put("types", types);
-    return root.toString();
+    return root;
   }
+
+  /**
+   * A delta the way the leader produces one. Built rather than hand-written so the size comparison below is
+   * anchored to what {@link SchemaDelta} actually emits.
+   */
+  private static String deltaForOneChangedType(final JSONObject schema) {
+    final JSONObject updated = new JSONObject(schema.toString());
+    updated.put("schemaVersion", 43);
+    updated.getJSONObject("types").getJSONObject("Type_7").put("properties",
+        new JSONObject().put("id", new JSONObject().put("type", "STRING"))
+            .put("extra", new JSONObject().put("type", "INTEGER")));
+    return SchemaDelta.compute(schema, updated).toString();
+  }
+
+  /**
+   * The codec treats a delta as an OPAQUE string - it length-prefixes, compresses and hands it back untouched -
+   * so the placement tests carry a marker rather than a realistic document. The round trip asserting the exact
+   * string back out is what pins that opacity; a realistic delta is used where the size is the point.
+   */
+  private static final String DELTA_MARKER = new JSONObject().put(SchemaDelta.FIELD_BASE, 41L).toString();
 
   @Test
   void anEntryWithoutADeltaDecodesAsBeforeAndCarriesNoDeltaSection() {
-    final ByteString withDelta = RaftLogEntryCodec.encodeSchemaEntry(DB, "{\"schemaVersion\":1}", ADD, REMOVE);
-    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(withDelta);
+    final String schemaJson = new JSONObject().put("schemaVersion", 1).toString();
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, schemaJson, ADD, REMOVE);
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
 
     assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SCHEMA_ENTRY);
     assertThat(decoded.schemaDelta()).isNull();
-    assertThat(decoded.schemaJson()).isEqualTo("{\"schemaVersion\":1}");
+    assertThat(decoded.schemaJson()).isEqualTo(schemaJson);
     assertThat(decoded.filesToAdd()).isEqualTo(ADD);
     assertThat(decoded.filesToRemove()).isEqualTo(REMOVE);
   }
 
   @Test
   void aDeltaSurvivesTheRoundTrip() {
-    final String deltaJson = "{\"base\":41,\"put\":{\"schemaVersion\":42},\"rootKeys\":[\"schemaVersion\",\"types\"]}";
+    final JSONObject base = bigSchema(3);
+    final JSONObject updated = new JSONObject(base.toString());
+    updated.put("schemaVersion", 43);
+    final String deltaJson = SchemaDelta.compute(base, updated).toString();
 
     final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", ADD, REMOVE,
         Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, Collections.emptyList(),
@@ -100,7 +124,7 @@ class Issue6989SchemaDeltaCodecTest {
     final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", ADD, REMOVE,
         List.of(wal), List.of(bucketDelta),
         List.of(new RaftLogEntryCodec.TsSealedBlob("Metric", 0, "Metric_0.sealed", sealed)),
-        true, Collections.emptyList(), new SchemaDelta.Payload(41L, "{\"base\":41}"));
+        true, Collections.emptyList(), new SchemaDelta.Payload(41L, DELTA_MARKER));
 
     final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
 
@@ -111,7 +135,7 @@ class Issue6989SchemaDeltaCodecTest {
     assertThat(decoded.sealedFileBlobs().getFirst().bytes()).isEqualTo(sealed);
     assertThat(decoded.moreChunksFollow()).isTrue();
     assertThat(decoded.sealedFileChunks()).isEmpty();
-    assertThat(decoded.schemaDelta().deltaJson()).isEqualTo("{\"base\":41}");
+    assertThat(decoded.schemaDelta().deltaJson()).isEqualTo(DELTA_MARKER);
   }
 
   @Test
@@ -122,22 +146,21 @@ class Issue6989SchemaDeltaCodecTest {
 
     final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false,
-        List.of(chunk), new SchemaDelta.Payload(41L, "{\"base\":41}"));
+        List.of(chunk), new SchemaDelta.Payload(41L, DELTA_MARKER));
 
     final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
 
     assertThat(decoded.sealedFileChunks()).hasSize(1);
     assertThat(decoded.sealedFileChunks().getFirst().bytes()).isEqualTo(slice);
-    assertThat(decoded.schemaDelta().deltaJson()).isEqualTo("{\"base\":41}");
+    assertThat(decoded.schemaDelta().deltaJson()).isEqualTo(DELTA_MARKER);
   }
 
   @Test
   void aDeltaEntryIsAFractionOfTheDocumentEntryForTheSameChange() {
-    final String fullSchema = bigSchema(500);
-    final String deltaJson = "{\"base\":41,\"put\":{\"schemaVersion\":42},"
-        + "\"merge\":{\"types\":{\"Type_7\":{\"name\":\"Type_7\",\"properties\":{\"id\":{\"type\":\"STRING\"}}}}}}";
+    final JSONObject fullSchema = bigSchema(500);
+    final String deltaJson = deltaForOneChangedType(fullSchema);
 
-    final int documentEntry = RaftLogEntryCodec.encodeSchemaEntry(DB, fullSchema, ADD, REMOVE).size();
+    final int documentEntry = RaftLogEntryCodec.encodeSchemaEntry(DB, fullSchema.toString(), ADD, REMOVE).size();
     final int deltaEntry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", ADD, REMOVE,
         Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, Collections.emptyList(),
         new SchemaDelta.Payload(41L, deltaJson)).size();
@@ -162,7 +185,7 @@ class Issue6989SchemaDeltaCodecTest {
       walEntries.add(wal);
       bucketDeltas.add(Collections.emptyMap());
     }
-    final SchemaDelta.Payload delta = new SchemaDelta.Payload(41L, "{\"base\":41}");
+    final SchemaDelta.Payload delta = new SchemaDelta.Payload(41L, DELTA_MARKER);
 
     final int single = RaftLogEntryCodec.encodeSchemaEntry(DB, "", ADD, REMOVE, walEntries, bucketDeltas,
         Collections.emptyList(), false, Collections.emptyList(), delta).size();
@@ -178,7 +201,7 @@ class Issue6989SchemaDeltaCodecTest {
         assertThat(decoded.moreChunksFollow()).isTrue();
       } else {
         assertThat(decoded.schemaDelta()).as("the last chunk publishes").isNotNull();
-        assertThat(decoded.schemaDelta().deltaJson()).isEqualTo("{\"base\":41}");
+        assertThat(decoded.schemaDelta().deltaJson()).isEqualTo(DELTA_MARKER);
         assertThat(decoded.moreChunksFollow()).isFalse();
       }
     }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaFallbackTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaFallbackTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6989: every arm that makes the leader fall back to shipping the WHOLE schema document.
+ * <p>
+ * These are the branches whose failure mode is silent. Neither of the two defects the integration test caught -
+ * the setting read off the per-database configuration instead of the server's, and a staleness guard keyed on
+ * the schema version instead of the Raft term - broke replication or failed a test: they just stopped the delta
+ * path from ever engaging. The term arm in particular is otherwise reachable only by forcing a re-election
+ * mid-test, which is expensive and flaky, so the decision is pinned here instead.
+ */
+class Issue6989SchemaDeltaFallbackTest {
+
+  private static final long TERM = 7L;
+
+  @Test
+  void theSettingBeingOffShipsTheWholeDocument() {
+    assertThat(RaftReplicatedDatabase.baseIsUsable(false, true, TERM, TERM)).isFalse();
+  }
+
+  @Test
+  void noBaseYetShipsTheWholeDocument() {
+    assertThat(RaftReplicatedDatabase.baseIsUsable(true, false, -1L, TERM)).isFalse();
+  }
+
+  @Test
+  void aTermThatMovedShipsTheWholeDocument() {
+    // Another node was leader in between, so what the followers hold is whatever IT shipped.
+    assertThat(RaftReplicatedDatabase.baseIsUsable(true, true, TERM, TERM + 1)).isFalse();
+    // And the same node regaining leadership does not make the cache valid again: a new term is a new term.
+    assertThat(RaftReplicatedDatabase.baseIsUsable(true, true, TERM, TERM + 2)).isFalse();
+  }
+
+  @Test
+  void anUnreadableTermShipsTheWholeDocument() {
+    // A division restarting in place reports -1: unknown cannot show the cache is still valid.
+    assertThat(RaftReplicatedDatabase.baseIsUsable(true, true, TERM, -1L)).isFalse();
+    assertThat(RaftReplicatedDatabase.baseIsUsable(true, true, -1L, -1L))
+        .as("-1 must not match -1 into a usable base")
+        .isFalse();
+  }
+
+  @Test
+  void anUnchangedTermWithTheSettingOnUsesTheBase() {
+    assertThat(RaftReplicatedDatabase.baseIsUsable(true, true, TERM, TERM)).isTrue();
+  }
+
+  @Test
+  void aDeltaWorthMostOfTheDocumentIsNotShipped() {
+    assertThat(RaftReplicatedDatabase.deltaIsWorthShipping(600, 1000)).isFalse();
+    assertThat(RaftReplicatedDatabase.deltaIsWorthShipping(500, 1000))
+        .as("exactly half is not smaller enough to be worth the key sets")
+        .isFalse();
+    assertThat(RaftReplicatedDatabase.deltaIsWorthShipping(499, 1000)).isTrue();
+  }
+
+  @Test
+  void aDeltaIsShippedWhenNoWholeDocumentLengthIsKnownYet() {
+    assertThat(RaftReplicatedDatabase.deltaIsWorthShipping(10_000, 0)).isTrue();
+  }
+
+  @Test
+  void theSizeBarDoesNotOverflow() {
+    // The doubling is done in long arithmetic: an int-sized delta must not wrap into "worth shipping".
+    assertThat(RaftReplicatedDatabase.deltaIsWorthShipping(Integer.MAX_VALUE, 1_000)).isFalse();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaReplicationIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaReplicationIT.java
@@ -67,6 +67,7 @@ class Issue6989SchemaDeltaReplicationIT extends BaseRaftHATest {
     final int replicaIndex = leaderIndex == 0 ? 1 : 0;
 
     final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    requireAPristineDatabase(leaderDb, "DeltaSeed_0");
 
     // A schema worth having a delta for: the point of the fix is the ratio between one type and all of them.
     leaderDb.transaction(() -> {
@@ -120,6 +121,7 @@ class Issue6989SchemaDeltaReplicationIT extends BaseRaftHATest {
     final int leaderIndex = findLeaderIndex();
     final int replicaIndex = leaderIndex == 0 ? 1 : 0;
     final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    requireAPristineDatabase(leaderDb, "Doomed_0");
 
     leaderDb.transaction(() -> {
       final Schema schema = leaderDb.getSchema();
@@ -139,6 +141,21 @@ class Issue6989SchemaDeltaReplicationIT extends BaseRaftHATest {
     assertThat(replicaSchema.existsType("Doomed_7")).as("the dropped type is gone on the replica").isFalse();
     assertThat(replicaSchema.existsType("Doomed_6")).isTrue();
     assertThat(replicaSchema.existsType("Doomed_8")).isTrue();
+  }
+
+  /**
+   * The seed below assumes it is building the schema from nothing, and the whole test rests on that: the delta
+   * counters are read against a base this method primes. {@code BaseGraphServerTest} points the servers at
+   * {@code ./target/databasesN}, which the build's stale-database clean does NOT match (its fileset is
+   * {@code target/databases}, without the index) - so a run killed part-way leaves them behind and the seed
+   * fails with a bare "Cannot create type ... because already exists" that names neither the cause nor the fix.
+   * Say both here instead.
+   */
+  private void requireAPristineDatabase(final Database leaderDb, final String firstSeededType) {
+    assertThat(leaderDb.getSchema().existsType(firstSeededType))
+        .as("this test seeds its own schema and needs a pristine database; remove the leftover "
+            + "ha-raft/target/databases* directories an aborted run left behind")
+        .isFalse();
   }
 
   /** The leader can move between tests, so ask every node rather than guessing which one shipped. */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaReplicationIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaReplicationIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.ToLongFunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6989: with {@code arcadedb.ha.schemaDelta} on, a DDL against a large schema must reach the follower
+ * through a Raft entry proportional to the change rather than to the schema.
+ * <p>
+ * The test builds a schema big enough that the difference matters, then runs a series of single-property DDLs
+ * and checks two things: that the leader actually took the delta path (the whole point - the leader falls back
+ * to the document by itself whenever the cached base is not what the followers hold, so a green functional
+ * assertion alone would pass even if no delta was ever shipped), and that the follower ends up with exactly the
+ * schema the leader has.
+ */
+@Tag("slow")
+class Issue6989SchemaDeltaReplicationIT extends BaseRaftHATest {
+
+  private static final int SEED_TYPES  = 150;
+  private static final int DDL_CHANGES = 12;
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+    config.setValue(GlobalConfiguration.HA_SCHEMA_DELTA, true);
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  @Test
+  void singlePropertyDdlShipsADeltaAndTheFollowerStaysIdentical() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int replicaIndex = leaderIndex == 0 ? 1 : 0;
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+
+    // A schema worth having a delta for: the point of the fix is the ratio between one type and all of them.
+    leaderDb.transaction(() -> {
+      final Schema schema = leaderDb.getSchema();
+      for (int i = 0; i < SEED_TYPES; i++) {
+        final DocumentType type = schema.createVertexType("DeltaSeed_" + i);
+        type.createProperty("id_" + i, Type.STRING);
+        type.createProperty("name_" + i, Type.STRING);
+        type.createProperty("payload_" + i, Type.STRING);
+      }
+    });
+
+    // The seed cannot be a delta - there is no base yet - so it primes the base every later DDL diffs against.
+    assertThat(schemaDocumentsShipped())
+        .as("the seed must have shipped as a whole document, or the shipping path was never reached at all")
+        .isGreaterThan(0);
+
+    final long deltasBefore = schemaDeltasShipped();
+
+    // Each of these is the case from the issue: a few dozen bytes of logical schema.
+    for (int i = 0; i < DDL_CHANGES; i++) {
+      final int typeIndex = i;
+      leaderDb.transaction(() -> leaderDb.getSchema().getType("DeltaSeed_" + typeIndex)
+          .createProperty("added_" + typeIndex, Type.INTEGER));
+    }
+
+    assertThat(schemaDeltasShipped() - deltasBefore)
+        .as("every DDL after the first must have gone out as a delta")
+        .isGreaterThanOrEqualTo(DDL_CHANGES - 1);
+
+    assertClusterConsistency();
+
+    final Schema replicaSchema = getServerDatabase(replicaIndex, getDatabaseName()).getSchema();
+    for (int i = 0; i < SEED_TYPES; i++) {
+      final String typeName = "DeltaSeed_" + i;
+      assertThat(replicaSchema.existsType(typeName)).as("replica has %s", typeName).isTrue();
+      assertThat(replicaSchema.getType(typeName).existsProperty("payload_" + i)).isTrue();
+    }
+    for (int i = 0; i < DDL_CHANGES; i++)
+      assertThat(replicaSchema.getType("DeltaSeed_" + i).existsProperty("added_" + i))
+          .as("the property added by delta %d reached the replica", i)
+          .isTrue();
+
+    assertThat(replicaSchema.getEmbedded().toJSON().getJSONObject("types").keySet())
+        .as("the replica's type set is exactly the leader's")
+        .isEqualTo(leaderDb.getSchema().getEmbedded().toJSON().getJSONObject("types").keySet());
+  }
+
+  @Test
+  void droppingATypeReachesTheReplicaThroughADelta() {
+    final int leaderIndex = findLeaderIndex();
+    final int replicaIndex = leaderIndex == 0 ? 1 : 0;
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+
+    leaderDb.transaction(() -> {
+      final Schema schema = leaderDb.getSchema();
+      for (int i = 0; i < 20; i++)
+        schema.createVertexType("Doomed_" + i).createProperty("id_" + i, Type.STRING);
+    });
+
+    final long deltasBefore = schemaDeltasShipped();
+
+    leaderDb.transaction(() -> leaderDb.getSchema().dropType("Doomed_7"));
+
+    assertThat(schemaDeltasShipped() - deltasBefore).as("the drop went out as a delta").isGreaterThan(0);
+
+    assertClusterConsistency();
+
+    final Schema replicaSchema = getServerDatabase(replicaIndex, getDatabaseName()).getSchema();
+    assertThat(replicaSchema.existsType("Doomed_7")).as("the dropped type is gone on the replica").isFalse();
+    assertThat(replicaSchema.existsType("Doomed_6")).isTrue();
+    assertThat(replicaSchema.existsType("Doomed_8")).isTrue();
+  }
+
+  /** The leader can move between tests, so ask every node rather than guessing which one shipped. */
+  private long schemaDeltasShipped() {
+    return sumOverNodes(RaftReplicatedDatabase::getSchemaDeltasShipped);
+  }
+
+  private long schemaDocumentsShipped() {
+    return sumOverNodes(RaftReplicatedDatabase::getSchemaDocumentsShipped);
+  }
+
+  private long sumOverNodes(final ToLongFunction<RaftReplicatedDatabase> counter) {
+    long total = 0;
+    for (int i = 0; i < getServerCount(); i++) {
+      final DatabaseInternal wrapped =
+          ((DatabaseInternal) getServerDatabase(i, getDatabaseName())).getWrappedDatabaseInstance();
+      if (wrapped instanceof final RaftReplicatedDatabase raft)
+        total += counter.applyAsLong(raft);
+    }
+    return total;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaTest.java
@@ -141,6 +141,63 @@ class Issue6989SchemaDeltaTest {
   }
 
   @Test
+  void aChangeToAnotherSectionCarriesNoTypeNamesAtAll() {
+    // The blind spot the second review found: `types` is a map present in both documents, so an unconditional
+    // key set put all 800 type names into a delta that only touched `settings`.
+    final JSONObject base = schema(41, 800);
+    final JSONObject updated = schema(42, 800);
+    updated.getJSONObject("settings").put("zoneId", "UTC");
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+
+    assertThat(delta.has(SchemaDelta.FIELD_KEYS))
+        .as("no section's key set moved, so no key set is worth carrying")
+        .isFalse();
+    assertThat(delta.toString())
+        .as("a settings change must not name a single type")
+        .doesNotContain("Type_500");
+    assertThat(delta.toString().length())
+        .as("and must not be sized by the schema")
+        .isLessThan(updated.toString().length() / 100);
+
+    assertThat(SchemaDelta.apply(base, delta).toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
+  void aKeySetIsCarriedOnlyForTheSectionWhoseShapeMoved() {
+    final JSONObject base = schema(41, 60);
+    final JSONObject updated = schema(42, 60);
+    updated.getJSONObject("types").put("Brand_New", type("Brand_New", "a"));
+    updated.getJSONObject("triggers").put("onCreate", new JSONObject().put("sql", "SELECT 1"));
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+
+    assertThat(delta.getJSONObject(SchemaDelta.FIELD_KEYS).keySet())
+        .as("only the two sections that gained a child")
+        .containsExactlyInAnyOrder("types", "triggers");
+
+    assertThat(SchemaDelta.apply(base, delta).toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
+  void aChangeConfinedToOneTypeCarriesNoKeySetEither() {
+    final JSONObject base = schema(41, 400);
+    final JSONObject updated = schema(42, 400);
+    updated.getJSONObject("types").put("Type_7", type("Type_7", "id", "name", "payload", "extra"));
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+
+    assertThat(delta.has(SchemaDelta.FIELD_KEYS))
+        .as("no type was added or dropped, so the key set says nothing apply() needs")
+        .isFalse();
+    assertThat(delta.toString().length())
+        .as("which makes the entry proportional to the one type that changed")
+        .isLessThan(updated.toString().length() / 50);
+
+    assertThat(SchemaDelta.apply(base, delta).toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
   void settingsChangeIsCarriedPerKey() {
     final JSONObject base = schema(41, 5);
     final JSONObject updated = schema(42, 5);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6989SchemaDeltaTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6989: a {@code SCHEMA_ENTRY} must be able to carry what a DDL changed rather than the whole schema
+ * document. These tests pin the delta format itself: what {@link SchemaDelta#compute} emits, and that
+ * {@link SchemaDelta#apply} reproduces the leader's document from the receiver's.
+ */
+class Issue6989SchemaDeltaTest {
+
+  /** A schema document shaped like {@code LocalSchema.toJSON()}: scalars, a settings map, and named maps. */
+  private static JSONObject schema(final long version, final int typeCount) {
+    final JSONObject root = new JSONObject();
+    root.put("schemaVersion", version);
+    root.put("dbmsVersion", "26.9.1");
+    root.put("dbmsBuild", "1234");
+
+    final JSONObject settings = new JSONObject();
+    settings.put("zoneId", "Europe/Rome");
+    settings.put("dateFormat", "yyyy-MM-dd");
+    root.put("settings", settings);
+
+    final JSONObject types = new JSONObject();
+    for (int i = 0; i < typeCount; i++)
+      types.put("Type_" + i, type("Type_" + i, "id", "name", "payload"));
+    root.put("types", types);
+
+    root.put("triggers", new JSONObject());
+    root.put("materializedViews", new JSONObject());
+    return root;
+  }
+
+  private static JSONObject type(final String name, final String... propertyNames) {
+    final JSONObject type = new JSONObject();
+    type.put("name", name);
+    type.put("type", "v");
+    final JSONObject properties = new JSONObject();
+    for (final String propertyName : propertyNames) {
+      final JSONObject property = new JSONObject();
+      property.put("type", "STRING");
+      property.put("notNull", false);
+      // Padding so a type is worth several hundred bytes, like a real one.
+      property.put("custom", new JSONObject().put("comment", "property " + propertyName + " of " + name));
+      properties.put(propertyName, property);
+    }
+    type.put("properties", properties);
+    return type;
+  }
+
+  @Test
+  void addingOnePropertyShipsOnlyThatType() {
+    final JSONObject base = schema(41, 200);
+    final JSONObject updated = schema(42, 200);
+    updated.getJSONObject("types").put("Type_7", type("Type_7", "id", "name", "payload", "extra"));
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+
+    assertThat(delta.getLong(SchemaDelta.FIELD_BASE)).isEqualTo(41L);
+    assertThat(delta.getJSONObject(SchemaDelta.FIELD_MERGE).getJSONObject("types").keySet())
+        .as("only the type that changed is carried")
+        .containsExactly("Type_7");
+    assertThat(delta.getJSONObject(SchemaDelta.FIELD_PUT).keySet())
+        .as("only the schema version moved at root level")
+        .containsExactly("schemaVersion");
+
+    assertThat(delta.toString().length())
+        .as("a one-property DDL must not cost a fraction of the schema anywhere near the whole document")
+        .isLessThan(updated.toString().length() / 10);
+
+    assertThat(SchemaDelta.apply(base, delta).toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
+  void addingATypeShipsOnlyThatType() {
+    final JSONObject base = schema(41, 50);
+    final JSONObject updated = schema(42, 50);
+    updated.getJSONObject("types").put("Brand_New", type("Brand_New", "a", "b"));
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+
+    assertThat(delta.getJSONObject(SchemaDelta.FIELD_MERGE).getJSONObject("types").keySet())
+        .containsExactly("Brand_New");
+    assertThat(SchemaDelta.apply(base, delta).toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
+  void droppingATypeIsCarriedByTheAuthoritativeKeySet() {
+    final JSONObject base = schema(41, 30);
+    final JSONObject updated = schema(42, 30);
+    updated.getJSONObject("types").remove("Type_11");
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+
+    assertThat(delta.has(SchemaDelta.FIELD_MERGE))
+        .as("a pure removal upserts nothing")
+        .isFalse();
+    assertThat(delta.getJSONObject(SchemaDelta.FIELD_KEYS).getJSONArray("types").toListOfStrings())
+        .doesNotContain("Type_11")
+        .hasSize(29);
+
+    final JSONObject merged = SchemaDelta.apply(base, delta);
+    assertThat(merged.getJSONObject("types").has("Type_11")).isFalse();
+    assertThat(merged.toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
+  void aRootSectionAddedAndRemovedIsCarried() {
+    final JSONObject base = schema(41, 5);
+    final JSONObject updated = schema(42, 5);
+    updated.remove("materializedViews");
+    updated.put("extensions", new JSONObject().put("ts", new JSONObject().put("enabled", true)));
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+    final JSONObject merged = SchemaDelta.apply(base, delta);
+
+    assertThat(merged.has("materializedViews")).isFalse();
+    assertThat(merged.getJSONObject("extensions").getJSONObject("ts").getBoolean("enabled")).isTrue();
+    assertThat(merged.toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
+  void settingsChangeIsCarriedPerKey() {
+    final JSONObject base = schema(41, 5);
+    final JSONObject updated = schema(42, 5);
+    updated.getJSONObject("settings").put("zoneId", "UTC");
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+
+    assertThat(delta.getJSONObject(SchemaDelta.FIELD_MERGE).getJSONObject("settings").keySet())
+        .containsExactly("zoneId");
+    assertThat(SchemaDelta.apply(base, delta).toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
+  void applyDoesNotMutateTheDocumentItIsGiven() {
+    final JSONObject base = schema(41, 5);
+    final String beforeApply = base.toString();
+    final JSONObject updated = schema(42, 5);
+    updated.getJSONObject("types").put("Type_2", type("Type_2", "id", "extra"));
+
+    SchemaDelta.apply(base, SchemaDelta.compute(base, updated));
+
+    assertThat(base.toString()).isEqualTo(beforeApply);
+  }
+
+  @Test
+  void applyIsStructureAuthoritativeOverAReceiverThatDrifted() {
+    final JSONObject base = schema(41, 10);
+    final JSONObject updated = schema(42, 10);
+    updated.getJSONObject("types").remove("Type_3");
+    updated.getJSONObject("types").put("Type_4", type("Type_4", "id", "renamed"));
+
+    // A receiver carrying a type the leader never had, and missing one it does have.
+    final JSONObject drifted = schema(41, 10);
+    drifted.getJSONObject("types").put("Phantom", type("Phantom", "x"));
+    drifted.getJSONObject("types").remove("Type_8");
+
+    final JSONObject merged = SchemaDelta.apply(drifted, SchemaDelta.compute(base, updated));
+
+    assertThat(merged.getJSONObject("types").keySet())
+        .as("the result carries exactly the leader's key set")
+        .doesNotContain("Phantom", "Type_3")
+        .contains("Type_4");
+    assertThat(merged.getJSONObject("types").getJSONObject("Type_4").toString())
+        .isEqualTo(updated.getJSONObject("types").getJSONObject("Type_4").toString());
+  }
+
+  @Test
+  void anEmptyChangeStillRoundTrips() {
+    final JSONObject base = schema(41, 8);
+    final JSONObject updated = schema(41, 8);
+
+    final JSONObject delta = SchemaDelta.compute(base, updated);
+
+    assertThat(delta.has(SchemaDelta.FIELD_PUT)).isFalse();
+    assertThat(delta.has(SchemaDelta.FIELD_MERGE)).isFalse();
+    assertThat(SchemaDelta.apply(base, delta).toString()).isEqualTo(updated.toString());
+  }
+
+  @Test
+  void theDeltaSurvivesSerializationRoundTrip() {
+    final JSONObject base = schema(41, 40);
+    final JSONObject updated = schema(42, 40);
+    updated.getJSONObject("types").put("Type_9", type("Type_9", "id", "name", "payload", "extra"));
+
+    final String wire = SchemaDelta.compute(base, updated).toString();
+
+    assertThat(SchemaDelta.apply(base, new JSONObject(wire)).toString()).isEqualTo(updated.toString());
+  }
+}


### PR DESCRIPTION
Closes #6989

Every `SCHEMA_ENTRY` carried a complete serialization of the schema document, no matter how small the DDL
was, and that document is paid for four times over: `LocalSchema.toJSON().toString()` on the leader, the Raft
entry itself (wire plus every node's log segment), `new JSONObject(json)` on every follower, and the
follower's full rewrite of `schema.json`. On the schema that motivated the parent report (#6982 - 1209 types,
several MB, ~6100 entries) that is tens of gigabytes serialized, replicated, parsed and rewritten to produce a
schema that is a few MB on disk.

`SCHEMA_ENTRY` now has an optional trailing **schema-delta** section, added through the same unframed
self-describing-section mechanism #4382, #5443 and #4416 use (`SCHEMA_ENTRY` is excluded from #7138's framed
extensions by construction). When the leader ships a delta the `schemaJson` slot is empty and the follower
merges the delta into its own schema instead; everything downstream of `LocalSchema.update()` - the file
rewrite, the plan-cache invalidation, the `load()` - is unchanged.

## The delta

```
{ "base":     <schemaVersion the delta was computed against>,   // diagnostic only, see below
  "put":      { "<rootKey>": <value> },                         // changed root values that are not maps
  "merge":    { "<rootKey>": { "<child>": <value> } },          // added or changed types/triggers/views/...
  "keys":     { "<rootKey>": [ "<child>", ... ] },              // authoritative child key set
  "rootKeys": [ "<rootKey>", ... ] }                            // authoritative root key set
```

The schema document is diffed generically - scalars, and maps keyed by name - so a section added to it later
needs no change in `SchemaDelta`.

`keys`/`rootKeys` make `apply` **structure-authoritative**: for a section the leader added to or removed from,
the result carries exactly the key set the leader had, with unchanged children inherited from the receiver's
own copy. A removal therefore needs no drop list, and a receiver whose document drifted cannot come out of that
section with a phantom type that no entry ever removes.

A key set is proportional to its SECTION, not to the change, so one is emitted only for a section whose key set
actually moved - a couple of hundred bytes of names on the DDL that added or dropped something, and nothing at
all on a change confined to one type or to another section.

## Mixed-version safety: OFF by default

An older decoder stops after the sealed-slice section and silently ignores anything past it, so a delta entry
would look to it like a `SCHEMA_ENTRY` with an EMPTY `schemaJson`: it would apply nothing and diverge in
silence. There is no peer-version negotiation anywhere in `ha-raft` today - nothing in the Raft envelope, no
capability exchange - so the leader cannot detect an older follower on its own.

Emission is therefore gated on **`arcadedb.ha.schemaDelta`, default `false`** - the "leader falls back to the
whole document until every peer is upgraded" arm of the issue's acceptance criteria. Decoding is
unconditional, so the upgrade is a one-way ratchet: every node can read a delta before any node is allowed to
write one. Automatic peer-capability negotiation, which would let the gate default to on, is deliberately left
out of this PR.

## When the leader falls back on its own

The leader caches the document it last SHIPPED plus the **Raft term** it shipped it in, and ships the whole
document instead whenever: the setting is off; nothing has been shipped yet in this database instance's
lifetime; the Raft term moved (another node has been leader in between, so what the followers hold is whatever
IT shipped - an unreadable term counts as moved); the delta is not at least half the size of the document; or
the change rides the compaction path, whose sealed-payload budget is measured against the serialized schema.

**The schema version cannot be that guard**, and this is the one thing worth reading the diff for:
`saveConfiguration()` defers while a transaction is active, so the version bump from a DDL run inside
`db.transaction(...)` lands AFTER the entry has already shipped. A version-based guard refused every single
delta and the feature never engaged - `Issue6989SchemaDeltaReplicationIT` is what caught it. On the follower
the version is a diagnostic for the mirror-image reason: `load()` re-saves the schema whenever it repaired
anything, so a follower legitimately runs AHEAD of the document the leader shipped.

`getSchemaDeltasShipped()` / `getSchemaDocumentsShipped()` expose the ratio, because a boolean setting alone
cannot answer "is the delta path actually engaged?".

## Deliberate stopping points (the two items the third review asked a maintainer to sign off on)

- **A changed child is carried whole.** One property added to a type ships that type's entire JSON rather than
  a diff inside it - which is the "send only the affected subtree" option #6989 proposes, so this is scope, not
  an oversight. One level keeps `compute`/`apply` generic over every section of the schema document, so a
  section added to it later needs no change in `SchemaDelta`. The cost is bounded by ONE type rather than by
  the schema, and the half-the-document bar refuses a delta that grew past being worth shipping. Recursive
  diffing is the obvious next step if types ever get large enough to make the middle ground matter.
- **The three cache fields are written separately, not swapped atomically.** Both writers
  (`recordFileChanges`, `runWithCompactionReplication`) hold this database's file recording session, which is
  exclusive per database - compaction defers rather than nesting when one is open. Nothing at the call site
  enforced that, so `rememberReplicatedSchema` now checks it and warns rather than leaving the invariant in
  prose: whoever changes the recording-session mechanism gets a log line instead of a silently torn cache.
  Warn-only, because a torn base costs one extra whole-document entry and failing replication over a
  diagnostic would be the worse trade.

## Known limitations

- A whole-document entry re-imposed the leader's rendering of EVERY type on the follower. A delta only replaces
  the children the leader saw change, so content drift in an unchanged child now persists until the next
  whole-document entry instead of being overwritten on the next DDL.
- **Structure-authority is one-directional**: a child the receiver has and the leader does not is dropped, but a
  child the leader has and the receiver is MISSING is not backfilled - nothing mentions a child that did not
  change. A receiver that fell behind by more than the delta being applied stays behind. That class of
  divergence remains the business of the WAL-version-gap detection and `checkDatabase`, as it was before.
- **Leader CPU stays O(schema)**, deliberately: deciding what did NOT change means touching every child once.
  Each comparison is a structural `JSONObject.equals` over an already-parsed tree - no string built, nothing
  allocated per child - against the full render of the whole document it replaces, so it is strictly less
  leader work than before. That is a complexity claim, **not a measured one**: it has not been benchmarked on
  the 1209-type schema from #6982, and the savings this PR exists for are the wire, the Raft log and the
  follower.
- `getSchemaDeltasShipped()` / `getSchemaDocumentsShipped()` are not wired into Micrometer yet, so the ratio is
  readable only through the getters or DETAILED HA logging. Worth a follow-up issue before the setting is
  turned on anywhere.

## Test plan

- [ ] `Issue6989SchemaDeltaTest` (12) - the delta format itself: a one-property DDL over a 200-type schema
      produces a delta under a tenth of the document; added/changed/dropped types, a dropped and an added root
      section, per-key settings changes, no-op changes, and a serialization round trip all reproduce the
      leader's document exactly; `apply` does not mutate its input; a receiver that drifted still ends with the
      leader's key set. Three of them pin proportionality specifically: a change to `settings` over an
      800-type schema names no type at all and stays under 1% of the document, a change confined to one type
      over a 400-type schema carries no key set either, and a key set is emitted only for the sections whose
      shape actually moved
- [ ] `Issue6989SchemaDeltaFallbackTest` (8) - every arm that makes the leader ship the whole document:
      setting off, no base, term moved, term unreadable, delta not small enough, no yardstick yet, and no
      overflow in the size doubling
- [ ] `Issue6989SchemaDeltaCodecTest` (6) - the wire section: an entry without a delta decodes exactly as
      before, a delta survives the round trip alongside every other optional section (WAL, bucket deltas,
      sealed blobs, `moreChunksFollow`, sealed slices), a delta entry is under a tenth of the document entry
      for the same change, and on a split only the publishing chunk carries it
- [ ] `Issue6989SchemaDeltaApplyTest` (2) - the follower applier over a real encode/decode round trip against
      real `LocalSchema` documents: a property added on the leader lands on the follower and nothing else
      moves; a dropped type is gone
- [ ] `Issue6989SchemaDeltaReplicationIT` (2, `@Tag("slow")`) - a 2-node cluster with the setting on: 12
      single-property DDLs over a 150-type schema all ship as deltas and the replica's schema is exactly the
      leader's; a type drop reaches the replica through a delta
- [ ] Regression: `RaftLogEntryCodecTest`, `RaftTransactionBrokerTest`, `Issue7138EntryExtensionSectionTest`,
      `Issue4416SlicedSealedApplyTest`, `Issue6933MultiStore*`, `Issue6839TsSealedBlobRecoveryTest`,
      `Issue6136*`, `Issue6143*`, `ArcadeStateMachine*`, `RaftReplicatedDatabase*`, `HAConfigDefaultsTest`,
      `ConfigValidationTest`, `GlobalConfigurationTest`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148Sp4E1ap3wVrB3eUxNYWr
