### PR TITLE
fix: preserve edge direction when moving vertices

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -2535,6 +2535,8 @@ public class GraphEngine {
       final RID newIdentity = newVertex.getIdentity();
 
       for (Edge oe : outEdges) {
+        // A SELF-LOOP NAMES THE OLD RID AS ITS DESTINATION TOO: RE-POINT IT AT THE NEW RECORD, WHICH IS THE ONLY
+        // ENDPOINT LEFT. THE MATCHING ENTRY IN inEdges IS SKIPPED BELOW SO THE LOOP IS NOT RECREATED TWICE.
         final RID inV = oe.getIn().equals(oldIdentity) ? newIdentity : oe.getIn();
         if (oe instanceof LightEdge)
           newVertex.newLightEdge(oe.getTypeName(), inV);
@@ -2546,13 +2548,20 @@ public class GraphEngine {
         }
       }
 
+      // AN INCOMING EDGE MUST BE RECREATED FROM ITS ORIGINAL SOURCE VERTEX, NOT FROM newVertex: BUILDING IT FROM
+      // newVertex WOULD SWAP @out AND @in AND SILENTLY REVERSE THE EDGE (ISSUE #7148). THE SOURCE HAS TO BE LOADED
+      // TO REACH ITS OUTGOING EDGE LIST, SO CACHE IT PER RID - A SUPER-NODE CAN HOLD THOUSANDS OF INCOMING EDGES
+      // FROM THE SAME FEW VERTICES, AND ON A UNIQUE LIGHTWEIGHT TYPE EACH newLightEdge() ALSO WALKS THAT LIST.
+      final Map<RID, Vertex> sourceVertices = inEdges.isEmpty() ? Collections.emptyMap() : new HashMap<>();
       for (Edge ie : inEdges) {
         final RID outV = ie.getOut();
         // A self-loop is present in both collections and was already recreated from newVertex above.
         if (outV.equals(oldIdentity))
           continue;
 
-        final Vertex outVertex = outV.asVertex(true);
+        // THIS DEREFERENCES THE SOURCE, SO A DANGLING INCOMING EDGE NOW FAILS THE WHOLE MOVE WITH
+        // RecordNotFoundException INSTEAD OF SILENTLY RECREATING AN EDGE THAT POINTS AT NOTHING.
+        final Vertex outVertex = sourceVertices.computeIfAbsent(outV, rid -> rid.asVertex(true));
         if (ie instanceof LightEdge)
           outVertex.newLightEdge(ie.getTypeName(), newIdentity);
         else {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -2515,6 +2515,7 @@ public class GraphEngine {
         db.begin();
 
       // SAVE OLD VERTEX PROPERTIES AND EDGES
+      final RID oldIdentity = vertex.getIdentity();
       final Map<String, Object> properties = vertex.propertiesAsMap();
       final List<Edge> outEdges = new ArrayList<>();
       for (Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))
@@ -2534,7 +2535,7 @@ public class GraphEngine {
       final RID newIdentity = newVertex.getIdentity();
 
       for (Edge oe : outEdges) {
-        final RID inV = oe.getIn();
+        final RID inV = oe.getIn().equals(oldIdentity) ? newIdentity : oe.getIn();
         if (oe instanceof LightEdge)
           newVertex.newLightEdge(oe.getTypeName(), inV);
         else {
@@ -2547,10 +2548,15 @@ public class GraphEngine {
 
       for (Edge ie : inEdges) {
         final RID outV = ie.getOut();
+        // A self-loop is present in both collections and was already recreated from newVertex above.
+        if (outV.equals(oldIdentity))
+          continue;
+
+        final Vertex outVertex = outV.asVertex(true);
         if (ie instanceof LightEdge)
-          newVertex.newLightEdge(ie.getTypeName(), outV);
+          outVertex.newLightEdge(ie.getTypeName(), newIdentity);
         else {
-          final MutableEdge e = newVertex.newEdge(ie.getTypeName(), outV);
+          final MutableEdge e = outVertex.newEdge(ie.getTypeName(), newIdentity);
           final Map<String, Object> edgeProperties = ie.propertiesAsMap();
           if (!edgeProperties.isEmpty())
             e.set(edgeProperties).save();

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7148MoveVertexEdgeDirectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7148MoveVertexEdgeDirectionTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.LightEdge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for issue #7148: moving a vertex must not reverse incoming edges.
+ */
+class Issue7148MoveVertexEdgeDirectionTest extends TestHelper {
+
+  @Test
+  void movingTheIncomingEndpointPreservesDirectionAndProperties() {
+    final RID[] vertices = new RID[3];
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Issue7148Source");
+      database.getSchema().createVertexType("Issue7148OldTarget");
+      database.getSchema().createVertexType("Issue7148NewTarget");
+      database.getSchema().createEdgeType("Issue7148Regular");
+      database.getSchema().buildEdgeType().withName("Issue7148Light").withLightweight(true).create();
+
+      final MutableVertex regularSource = database.newVertex("Issue7148Source");
+      regularSource.set("uid", "regular-source");
+      regularSource.save();
+      vertices[0] = regularSource.getIdentity();
+
+      final MutableVertex lightSource = database.newVertex("Issue7148Source");
+      lightSource.set("uid", "light-source");
+      lightSource.save();
+      vertices[1] = lightSource.getIdentity();
+
+      final MutableVertex target = database.newVertex("Issue7148OldTarget");
+      target.set("uid", "target");
+      target.save();
+      vertices[2] = target.getIdentity();
+
+      regularSource.newEdge("Issue7148Regular", target, "tag", "preserved").save();
+      lightSource.newEdge("Issue7148Light", target);
+    });
+
+    final RID moved = moveVertex(vertices[2], "Issue7148NewTarget");
+
+    database.transaction(() -> {
+      final Vertex regularSource = vertices[0].asVertex(true);
+      final Edge regular = regularSource.getEdges(Vertex.DIRECTION.OUT, "Issue7148Regular").getFirstOrNull();
+      assertThat(regular).isNotNull();
+      assertThat(regular.getOut()).isEqualTo(vertices[0]);
+      assertThat(regular.getIn()).isEqualTo(moved);
+      assertThat(regular.getString("tag")).isEqualTo("preserved");
+      assertThat(regularSource.getConnectedVertexRIDs(Vertex.DIRECTION.OUT, "Issue7148Regular"))
+          .containsExactly(moved);
+
+      final Vertex lightSource = vertices[1].asVertex(true);
+      final Edge light = lightSource.getEdges(Vertex.DIRECTION.OUT, "Issue7148Light").getFirstOrNull();
+      assertThat(light).isInstanceOf(LightEdge.class);
+      assertThat(light.getOut()).isEqualTo(vertices[1]);
+      assertThat(light.getIn()).isEqualTo(moved);
+      assertThat(lightSource.getConnectedVertexRIDs(Vertex.DIRECTION.OUT, "Issue7148Light"))
+          .containsExactly(moved);
+
+      final Vertex movedVertex = moved.asVertex(true);
+      assertThat(movedVertex.getConnectedVertexRIDs(Vertex.DIRECTION.IN, "Issue7148Regular"))
+          .containsExactly(vertices[0]);
+      assertThat(movedVertex.getConnectedVertexRIDs(Vertex.DIRECTION.IN, "Issue7148Light"))
+          .containsExactly(vertices[1]);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.OUT, "Issue7148Regular", "Issue7148Light")).isZero();
+    });
+  }
+
+  @Test
+  void movingASelfLoopRecreatesEachEdgeOnceAgainstTheNewRid() {
+    final RID[] original = new RID[1];
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Issue7148LoopOld");
+      database.getSchema().createVertexType("Issue7148LoopNew");
+      database.getSchema().createEdgeType("Issue7148RegularLoop");
+      database.getSchema().buildEdgeType().withName("Issue7148LightLoop").withLightweight(true).create();
+
+      final MutableVertex vertex = database.newVertex("Issue7148LoopOld");
+      vertex.save();
+      original[0] = vertex.getIdentity();
+      vertex.newEdge("Issue7148RegularLoop", vertex, "tag", "loop").save();
+      vertex.newEdge("Issue7148LightLoop", vertex);
+    });
+
+    final RID moved = moveVertex(original[0], "Issue7148LoopNew");
+
+    database.transaction(() -> {
+      final Vertex movedVertex = moved.asVertex(true);
+
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.OUT, "Issue7148RegularLoop")).isEqualTo(1);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.IN, "Issue7148RegularLoop")).isEqualTo(1);
+      final Edge regular = movedVertex.getEdges(Vertex.DIRECTION.OUT, "Issue7148RegularLoop").getFirstOrNull();
+      assertThat(regular).isNotNull();
+      assertThat(regular.getOut()).isEqualTo(moved);
+      assertThat(regular.getIn()).isEqualTo(moved);
+      assertThat(regular.getString("tag")).isEqualTo("loop");
+
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.OUT, "Issue7148LightLoop")).isEqualTo(1);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.IN, "Issue7148LightLoop")).isEqualTo(1);
+      final Edge light = movedVertex.getEdges(Vertex.DIRECTION.OUT, "Issue7148LightLoop").getFirstOrNull();
+      assertThat(light).isInstanceOf(LightEdge.class);
+      assertThat(light.getOut()).isEqualTo(moved);
+      assertThat(light.getIn()).isEqualTo(moved);
+    });
+  }
+
+  private RID moveVertex(final RID source, final String targetType) {
+    database.setAutoTransaction(true);
+    try (final ResultSet result = database.command("sql", "MOVE VERTEX " + source + " TO TYPE:" + targetType)) {
+      assertThat(result.hasNext()).isTrue();
+      final RID moved = result.next().getIdentity().orElseThrow();
+      assertThat(result.hasNext()).isFalse();
+      return moved;
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7148MoveVertexEdgeDirectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7148MoveVertexEdgeDirectionTest.java
@@ -26,6 +26,9 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -126,6 +129,153 @@ class Issue7148MoveVertexEdgeDirectionTest extends TestHelper {
       assertThat(light).isInstanceOf(LightEdge.class);
       assertThat(light.getOut()).isEqualTo(moved);
       assertThat(light.getIn()).isEqualTo(moved);
+    });
+  }
+
+  /**
+   * Every incoming edge of a super-node is recreated from the same source vertex, whose outgoing edge list is
+   * rewritten once per edge. Reusing one cached source instance across the whole loop must not lose any of those
+   * appends, and the moved vertex must end up with all of them on its IN side and none on its OUT side.
+   */
+  @Test
+  void manyIncomingEdgesFromASingleSourceAreAllPreserved() {
+    final int edges = 25;
+    final RID[] vertices = new RID[2];
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Issue7148FanSource");
+      database.getSchema().createVertexType("Issue7148FanOld");
+      database.getSchema().createVertexType("Issue7148FanNew");
+      database.getSchema().createEdgeType("Issue7148Fan");
+
+      final MutableVertex source = database.newVertex("Issue7148FanSource");
+      source.save();
+      vertices[0] = source.getIdentity();
+
+      final MutableVertex target = database.newVertex("Issue7148FanOld");
+      target.save();
+      vertices[1] = target.getIdentity();
+
+      for (int i = 0; i < edges; i++)
+        source.newEdge("Issue7148Fan", target, "seq", i).save();
+    });
+
+    final RID moved = moveVertex(vertices[1], "Issue7148FanNew");
+
+    database.transaction(() -> {
+      final Vertex source = vertices[0].asVertex(true);
+      assertThat(source.countEdges(Vertex.DIRECTION.OUT, "Issue7148Fan")).isEqualTo(edges);
+
+      final Vertex movedVertex = moved.asVertex(true);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.IN, "Issue7148Fan")).isEqualTo(edges);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.OUT, "Issue7148Fan")).isZero();
+
+      final Set<Integer> sequences = new HashSet<>();
+      for (final Edge edge : source.getEdges(Vertex.DIRECTION.OUT, "Issue7148Fan")) {
+        assertThat(edge.getOut()).isEqualTo(vertices[0]);
+        assertThat(edge.getIn()).isEqualTo(moved);
+        sequences.add(edge.getInteger("seq"));
+      }
+      assertThat(sequences).hasSize(edges);
+    });
+  }
+
+  /**
+   * The same neighbour on both sides: the moved vertex holds one edge towards it and one edge from it. The
+   * neighbour appears in the outgoing and the incoming collection with a different edge each time, so neither may
+   * be mistaken for a self-loop and skipped.
+   */
+  @Test
+  void anEdgePairWithTheSameNeighbourKeepsBothDirections() {
+    final RID[] vertices = new RID[2];
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Issue7148PairPeer");
+      database.getSchema().createVertexType("Issue7148PairOld");
+      database.getSchema().createVertexType("Issue7148PairNew");
+      database.getSchema().createEdgeType("Issue7148Pair");
+
+      final MutableVertex peer = database.newVertex("Issue7148PairPeer");
+      peer.save();
+      vertices[0] = peer.getIdentity();
+
+      final MutableVertex target = database.newVertex("Issue7148PairOld");
+      target.save();
+      vertices[1] = target.getIdentity();
+
+      peer.newEdge("Issue7148Pair", target, "dir", "incoming").save();
+      target.newEdge("Issue7148Pair", peer, "dir", "outgoing").save();
+    });
+
+    final RID moved = moveVertex(vertices[1], "Issue7148PairNew");
+
+    database.transaction(() -> {
+      final Vertex movedVertex = moved.asVertex(true);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.IN, "Issue7148Pair")).isEqualTo(1);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.OUT, "Issue7148Pair")).isEqualTo(1);
+
+      final Edge incoming = movedVertex.getEdges(Vertex.DIRECTION.IN, "Issue7148Pair").getFirstOrNull();
+      assertThat(incoming).isNotNull();
+      assertThat(incoming.getOut()).isEqualTo(vertices[0]);
+      assertThat(incoming.getIn()).isEqualTo(moved);
+      assertThat(incoming.getString("dir")).isEqualTo("incoming");
+
+      final Edge outgoing = movedVertex.getEdges(Vertex.DIRECTION.OUT, "Issue7148Pair").getFirstOrNull();
+      assertThat(outgoing).isNotNull();
+      assertThat(outgoing.getOut()).isEqualTo(moved);
+      assertThat(outgoing.getIn()).isEqualTo(vertices[0]);
+      assertThat(outgoing.getString("dir")).isEqualTo("outgoing");
+
+      final Vertex peer = vertices[0].asVertex(true);
+      assertThat(peer.countEdges(Vertex.DIRECTION.OUT, "Issue7148Pair")).isEqualTo(1);
+      assertThat(peer.countEdges(Vertex.DIRECTION.IN, "Issue7148Pair")).isEqualTo(1);
+    });
+  }
+
+  /**
+   * {@code MOVE VERTEX ... TO BUCKET:} goes through the very same {@code moveTo()} as the {@code TO TYPE:} form, so
+   * it reversed incoming edges in exactly the same way and needs its own coverage.
+   */
+  @Test
+  void movingToAnotherBucketPreservesIncomingEdgeDirection() {
+    final RID[] vertices = new RID[2];
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Issue7148BucketSource");
+      database.getSchema().createVertexType("Issue7148BucketTarget")
+          .addBucket(database.getSchema().createBucket("Issue7148Bucket_extra"));
+      database.getSchema().createEdgeType("Issue7148BucketEdge");
+
+      final MutableVertex source = database.newVertex("Issue7148BucketSource");
+      source.save();
+      vertices[0] = source.getIdentity();
+
+      final MutableVertex target = database.newVertex("Issue7148BucketTarget");
+      target.save();
+      vertices[1] = target.getIdentity();
+
+      source.newEdge("Issue7148BucketEdge", target, "tag", "preserved").save();
+    });
+
+    database.setAutoTransaction(true);
+    final RID moved;
+    try (final ResultSet result = database.command("sql",
+        "MOVE VERTEX " + vertices[1] + " TO BUCKET:Issue7148Bucket_extra")) {
+      assertThat(result.hasNext()).isTrue();
+      moved = result.next().getIdentity().orElseThrow();
+      assertThat(result.hasNext()).isFalse();
+    }
+    assertThat(moved.getBucketId())
+        .isEqualTo(database.getSchema().getBucketByName("Issue7148Bucket_extra").getFileId());
+
+    database.transaction(() -> {
+      final Vertex source = vertices[0].asVertex(true);
+      final Edge edge = source.getEdges(Vertex.DIRECTION.OUT, "Issue7148BucketEdge").getFirstOrNull();
+      assertThat(edge).isNotNull();
+      assertThat(edge.getOut()).isEqualTo(vertices[0]);
+      assertThat(edge.getIn()).isEqualTo(moved);
+      assertThat(edge.getString("tag")).isEqualTo("preserved");
+
+      final Vertex movedVertex = moved.asVertex(true);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.IN, "Issue7148BucketEdge")).isEqualTo(1);
+      assertThat(movedVertex.countEdges(Vertex.DIRECTION.OUT, "Issue7148BucketEdge")).isZero();
     });
   }
 


### PR DESCRIPTION
## What changed

- recreate incoming edges from their original `@out` vertex to the moved vertex
- remap self-loop endpoints to the moved RID and avoid rebuilding each loop twice
- add regression coverage for regular and lightweight edges, traversal direction, edge properties, and self-loops

## Why

`MOVE VERTEX` previously recreated every incident edge from the moved
vertex. For incoming edges this swapped `@out` and `@in`, silently
reversing graph semantics. Self-loops could also attempt to reconnect
to the deleted source RID.

## Verification

- `mvn -pl engine -Dtest=Issue7148MoveVertexEdgeDirectionTest,MoveVertexStatementExecutionTest,UpdateAutoTransactionIssue7096Test test`
- 27 tests passed

Fixes #7148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed vertex moves so incoming edges retain their correct direction and connections.
  - Preserved self-loop endpoints and prevented duplicate self-loops when moving vertices.
  - Ensured edge properties, adjacency, and counts remain accurate across edge types.
  - Vertex moves now fail when an incoming edge references a missing source vertex.

- **Tests**
  - Added regression coverage for regular and lightweight edges, multiple incoming edges, self-loops, and moving vertices to buckets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->