### PR TITLE
fix(#7172): remote getOrCreate*Type() answers the existing type instead of throwing

### DIFF
--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -281,7 +281,11 @@ public class RemoteSchema implements Schema {
   // The getOrCreate*() methods below do not read the row count of the IF NOT EXISTS command: servers up to 26.9.1
   // answer zero rows when the type already exists, so treating an empty result as a failure threw on the exact case
   // the guard is there for (issue #7172). The schema is the authority: command() throws on a server error, and
-  // getType() throws SchemaException if the type is still missing afterwards.
+  // getType() throws SchemaException if the type is still missing afterwards. The kind is checked here rather than
+  // left to a bare cast, because IF NOT EXISTS is satisfied by a type of ANY kind: asking for a vertex type whose
+  // name is already taken by a document type is a no-op on the server, and the embedded API answers that with
+  // SchemaException("Type 'x' is not a vertex type") (TypeBuilder.checkExistingIsCompatible) rather than with a
+  // ClassCastException from inside the client.
   @Override
   public DocumentType getOrCreateDocumentType(final String typeName) {
     remoteDatabase.command("sql", "create document type `" + typeName + "` if not exists");
@@ -298,27 +302,27 @@ public class RemoteSchema implements Schema {
   public VertexType createVertexType(final String typeName) {
     final ResultSet result = remoteDatabase.command("sql", "create vertex type `" + typeName + "`");
     if (result.hasNext())
-      return (VertexType) reload().getType(typeName);
+      return asKind(reload().getType(typeName), VertexType.class, "vertex");
     throw new SchemaException("Error on creating vertex type '" + typeName + "'");
   }
 
   @Override
   public VertexType getOrCreateVertexType(String typeName, int buckets) {
     remoteDatabase.command("sql", "create vertex type `" + typeName + "` if not exists buckets " + buckets);
-    return (VertexType) reload().getType(typeName);
+    return asKind(reload().getType(typeName), VertexType.class, "vertex");
   }
 
   @Override
   public VertexType getOrCreateVertexType(final String typeName) {
     remoteDatabase.command("sql", "create vertex type `" + typeName + "` if not exists");
-    return (VertexType) reload().getType(typeName);
+    return asKind(reload().getType(typeName), VertexType.class, "vertex");
   }
 
   @Override
   public VertexType createVertexType(String typeName, int buckets) {
     final ResultSet result = remoteDatabase.command("sql", "create vertex type `" + typeName + "` buckets " + buckets);
     if (result.hasNext())
-      return (VertexType) reload().getType(typeName);
+      return asKind(reload().getType(typeName), VertexType.class, "vertex");
     throw new SchemaException("Error on creating vertex type '" + typeName + "'");
   }
 
@@ -326,28 +330,39 @@ public class RemoteSchema implements Schema {
   public EdgeType createEdgeType(final String typeName) {
     final ResultSet result = remoteDatabase.command("sql", "create edge type `" + typeName + "`");
     if (result.hasNext())
-      return (EdgeType) reload().getType(typeName);
+      return asKind(reload().getType(typeName), EdgeType.class, "edge");
     throw new SchemaException("Error on creating edge type '" + typeName + "'");
   }
 
   @Override
   public EdgeType getOrCreateEdgeType(String typeName) {
     remoteDatabase.command("sql", "create edge type `" + typeName + "` if not exists");
-    return (EdgeType) reload().getType(typeName);
+    return asKind(reload().getType(typeName), EdgeType.class, "edge");
   }
 
   @Override
   public EdgeType createEdgeType(String typeName, int buckets) {
     final ResultSet result = remoteDatabase.command("sql", "create edge type `" + typeName + "` buckets " + buckets);
     if (result.hasNext())
-      return (EdgeType) reload().getType(typeName);
+      return asKind(reload().getType(typeName), EdgeType.class, "edge");
     throw new SchemaException("Error on creating edge type '" + typeName + "'");
   }
 
   @Override
   public EdgeType getOrCreateEdgeType(final String typeName, final int buckets) {
     remoteDatabase.command("sql", "create edge type `" + typeName + "` if not exists buckets " + buckets);
-    return (EdgeType) reload().getType(typeName);
+    return asKind(reload().getType(typeName), EdgeType.class, "edge");
+  }
+
+  /**
+   * Answers {@code type} narrowed to {@code expected}, or throws the same {@link SchemaException} the embedded API
+   * throws when a {@code getOrCreate*Type()} call finds the name already taken by a type of another kind.
+   */
+  private static <T extends DocumentType> T asKind(final DocumentType type, final Class<T> expected,
+      final String expectedLabel) {
+    if (!expected.isInstance(type))
+      throw new SchemaException("Type '" + type.getName() + "' is not a " + expectedLabel + " type");
+    return expected.cast(type);
   }
 
   @Override

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -278,21 +278,20 @@ public class RemoteSchema implements Schema {
     throw new SchemaException("Error on creating document type '" + typeName + "'");
   }
 
+  // The getOrCreate*() methods below do not read the row count of the IF NOT EXISTS command: servers up to 26.9.1
+  // answer zero rows when the type already exists, so treating an empty result as a failure threw on the exact case
+  // the guard is there for (issue #7172). The schema is the authority: command() throws on a server error, and
+  // getType() throws SchemaException if the type is still missing afterwards.
   @Override
   public DocumentType getOrCreateDocumentType(final String typeName) {
-    final ResultSet result = remoteDatabase.command("sql", "create document type `" + typeName + "` if not exists");
-    if (result.hasNext())
-      return reload().getType(typeName);
-    throw new SchemaException("Error on creating document type '" + typeName + "'");
+    remoteDatabase.command("sql", "create document type `" + typeName + "` if not exists");
+    return reload().getType(typeName);
   }
 
   @Override
   public DocumentType getOrCreateDocumentType(final String typeName, final int buckets) {
-    final ResultSet result = remoteDatabase.command("sql",
-        "create document type `" + typeName + "` if not exists buckets " + buckets);
-    if (result.hasNext())
-      return reload().getType(typeName);
-    throw new SchemaException("Error on creating document type '" + typeName + "'");
+    remoteDatabase.command("sql", "create document type `" + typeName + "` if not exists buckets " + buckets);
+    return reload().getType(typeName);
   }
 
   @Override
@@ -305,19 +304,14 @@ public class RemoteSchema implements Schema {
 
   @Override
   public VertexType getOrCreateVertexType(String typeName, int buckets) {
-    final ResultSet result = remoteDatabase.command("sql",
-        "create vertex type `" + typeName + "` if not exists buckets " + buckets);
-    if (result.hasNext())
-      return (VertexType) reload().getType(typeName);
-    throw new SchemaException("Error on creating vertex type '" + typeName + "'");
+    remoteDatabase.command("sql", "create vertex type `" + typeName + "` if not exists buckets " + buckets);
+    return (VertexType) reload().getType(typeName);
   }
 
   @Override
   public VertexType getOrCreateVertexType(final String typeName) {
-    final ResultSet result = remoteDatabase.command("sql", "create vertex type `" + typeName + "` if not exists");
-    if (result.hasNext())
-      return (VertexType) reload().getType(typeName);
-    throw new SchemaException("Error on creating vertex type '" + typeName + "'");
+    remoteDatabase.command("sql", "create vertex type `" + typeName + "` if not exists");
+    return (VertexType) reload().getType(typeName);
   }
 
   @Override
@@ -338,10 +332,8 @@ public class RemoteSchema implements Schema {
 
   @Override
   public EdgeType getOrCreateEdgeType(String typeName) {
-    final ResultSet result = remoteDatabase.command("sql", "create edge type `" + typeName + "` if not exists");
-    if (result.hasNext())
-      return (EdgeType) reload().getType(typeName);
-    throw new SchemaException("Error on creating edge type '" + typeName + "'");
+    remoteDatabase.command("sql", "create edge type `" + typeName + "` if not exists");
+    return (EdgeType) reload().getType(typeName);
   }
 
   @Override
@@ -354,10 +346,8 @@ public class RemoteSchema implements Schema {
 
   @Override
   public EdgeType getOrCreateEdgeType(final String typeName, final int buckets) {
-    final ResultSet result = remoteDatabase.command("sql", "create edge type `" + typeName + "` if not exists buckets " + buckets);
-    if (result.hasNext())
-      return (EdgeType) reload().getType(typeName);
-    throw new SchemaException("Error on creating edge type '" + typeName + "'");
+    remoteDatabase.command("sql", "create edge type `" + typeName + "` if not exists buckets " + buckets);
+    return (EdgeType) reload().getType(typeName);
   }
 
   @Override

--- a/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
@@ -610,6 +610,33 @@ class RemoteSchemaTest {
     assertThatThrownBy(() -> schema.getOrCreateVertexType("Person")).isInstanceOf(SchemaException.class);
   }
 
+  @Test
+  void getOrCreateVertexTypeReportsTheKindMismatchInsteadOfCastingBlindly() {
+    // IF NOT EXISTS is satisfied by a type of ANY kind, so the server answers this with a no-op and the client is
+    // left holding a DocumentType. A bare cast would surface that as a ClassCastException from inside the client.
+    final ResultSet noRows = buildSchemaResultSet();
+    final ResultSet schemaRs = buildSchemaResultSet(buildTypeRecord("Person", "document"));
+    when(mockDatabase.command("sql", "create vertex type `Person` if not exists")).thenReturn(noRows);
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(schemaRs);
+
+    assertThatThrownBy(() -> schema.getOrCreateVertexType("Person"))
+        .isInstanceOf(SchemaException.class)
+        .hasMessageContaining("Type 'Person' is not a vertex type");
+  }
+
+  @Test
+  void getOrCreateEdgeTypeReportsTheKindMismatchInsteadOfCastingBlindly() {
+    final ResultSet noRows = buildSchemaResultSet();
+    final ResultSet schemaRs = buildSchemaResultSet(buildTypeRecord("Knows", "vertex"));
+    when(mockDatabase.command("sql", "create edge type `Knows` if not exists")).thenReturn(noRows);
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(schemaRs);
+
+    assertThatThrownBy(() -> schema.getOrCreateEdgeType("Knows"))
+        .isInstanceOf(SchemaException.class)
+        // THE WORDING IS THE EMBEDDED API'S, VERBATIM (TypeBuilder.checkExistingIsCompatible), GRAMMAR AND ALL
+        .hasMessageContaining("Type 'Knows' is not a edge type");
+  }
+
   private static ResultSet buildTypeRecordWithBucket(final String typeName, final String typeCode, final String bucketName) {
     final ResultInternal r = new ResultInternal();
     r.setProperty("name", typeName);

--- a/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
@@ -23,7 +23,9 @@ import com.arcadedb.exception.SchemaException;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -551,6 +553,61 @@ class RemoteSchemaTest {
 
     assertThatThrownBy(() -> schema.getBucketByName("does_not_exist")).isInstanceOf(SchemaException.class);
     verify(mockDatabase, times(2)).command("sql", "select from schema:types");
+  }
+
+  // Issue #7172: servers up to 26.9.1 answer "create ... type X if not exists" with ZERO rows when X already
+  // exists (26.10.1 answers one row with created=false, #7143). getOrCreate*() read the empty answer as a failure
+  // and threw SchemaException on the exact case it exists for. The schema, not the row count, decides.
+
+  @Test
+  void getOrCreateDocumentTypeReturnsExistingTypeWhenServerAnswersNoRows() {
+    final ResultSet noRows = buildSchemaResultSet();
+    final ResultSet schemaRs = buildSchemaResultSet(buildTypeRecord("Doc", "document"));
+    when(mockDatabase.command("sql", "create document type `Doc` if not exists")).thenReturn(noRows);
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(schemaRs);
+
+    final DocumentType type = schema.getOrCreateDocumentType("Doc");
+
+    assertThat(type.getName()).isEqualTo("Doc");
+    verify(mockDatabase).command("sql", "create document type `Doc` if not exists");
+  }
+
+  @Test
+  void getOrCreateVertexTypeReturnsExistingTypeWhenServerAnswersNoRows() {
+    final ResultSet noRows = buildSchemaResultSet();
+    final ResultSet schemaRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    when(mockDatabase.command("sql", "create vertex type `Person` if not exists")).thenReturn(noRows);
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(schemaRs);
+
+    final VertexType type = schema.getOrCreateVertexType("Person");
+
+    assertThat(type.getName()).isEqualTo("Person");
+    verify(mockDatabase).command("sql", "create vertex type `Person` if not exists");
+  }
+
+  @Test
+  void getOrCreateEdgeTypeReturnsExistingTypeWhenServerAnswersNoRows() {
+    final ResultSet noRows = buildSchemaResultSet();
+    final ResultSet schemaRs = buildSchemaResultSet(buildTypeRecord("Knows", "edge"));
+    when(mockDatabase.command("sql", "create edge type `Knows` if not exists")).thenReturn(noRows);
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(schemaRs);
+
+    final EdgeType type = schema.getOrCreateEdgeType("Knows");
+
+    assertThat(type.getName()).isEqualTo("Knows");
+    verify(mockDatabase).command("sql", "create edge type `Knows` if not exists");
+  }
+
+  @Test
+  void getOrCreateVertexTypeStillThrowsWhenTypeIsMissingAfterTheCommand() {
+    final ResultSet noRows = buildSchemaResultSet();
+    // Neither the eager reload nor getType()'s one-shot retry finds it: the command really did not create it.
+    final ResultSet emptySchema = buildSchemaResultSet();
+    final ResultSet emptySchemaRetry = buildSchemaResultSet();
+    when(mockDatabase.command("sql", "create vertex type `Person` if not exists")).thenReturn(noRows);
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(emptySchema, emptySchemaRetry);
+
+    assertThatThrownBy(() -> schema.getOrCreateVertexType("Person")).isInstanceOf(SchemaException.class);
   }
 
   private static ResultSet buildTypeRecordWithBucket(final String typeName, final String typeCode, final String bucketName) {

--- a/server/src/test/java/com/arcadedb/remote/RemoteSchemaIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteSchemaIT.java
@@ -216,6 +216,31 @@ class RemoteSchemaIT extends BaseGraphServerTest {
     });
   }
 
+  /**
+   * Issue #7172: the second getOrCreate*Type() call on a type that already exists threw SchemaException, because the
+   * client read the (then empty) answer of {@code CREATE ... IF NOT EXISTS} as a failure. Every variant must answer
+   * the existing type instead.
+   */
+  @Test
+  void getOrCreateTypesAreIdempotent() throws Exception {
+    testEachServer(serverIndex -> {
+      try (final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
+          BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)) {
+        assertThat(database.getSchema().getOrCreateDocumentType("Doc").getName()).isEqualTo("Doc");
+        assertThat(database.getSchema().getOrCreateDocumentType("Doc").getName()).isEqualTo("Doc");
+        assertThat(database.getSchema().getOrCreateDocumentType("Doc", 2).getName()).isEqualTo("Doc");
+
+        assertThat(database.getSchema().getOrCreateVertexType("Vert").getName()).isEqualTo("Vert");
+        assertThat(database.getSchema().getOrCreateVertexType("Vert").getName()).isEqualTo("Vert");
+        assertThat(database.getSchema().getOrCreateVertexType("Vert", 2).getName()).isEqualTo("Vert");
+
+        assertThat(database.getSchema().getOrCreateEdgeType("Edg").getName()).isEqualTo("Edg");
+        assertThat(database.getSchema().getOrCreateEdgeType("Edg").getName()).isEqualTo("Edg");
+        assertThat(database.getSchema().getOrCreateEdgeType("Edg", 2).getName()).isEqualTo("Edg");
+      }
+    });
+  }
+
   @BeforeEach
   public void beginTest() {
     super.beginTest();


### PR DESCRIPTION
## What does this PR do?

`RemoteSchema.getOrCreate{Document,Vertex,Edge}Type()` took a non-empty answer to `create ... type X if not exists` as the proof that the call succeeded. Servers up to 26.9.1 answer zero rows when `X` already exists, so the helper threw `SchemaException: Error on creating vertex type 'X'` on the exact case `IF NOT EXISTS` is there for. Same code, same failure, in all six `getOrCreate*()` variants.

The six variants now run the command and answer `reload().getType(typeName)`: `command()` throws on a server error, and `getType()` throws `SchemaException` if the type is still missing afterwards. The row count was never the right test; the schema is.

## Motivation

#7162 changed the server to answer one `created=false` row on the retry, which hides this once client and server are both on 26.10.1. The client does not check the server version, though, so a 26.10.1 `arcadedb-network` talking to the current 26.9.1 release still throws, and there was no test on the remote path for calling `getOrCreate*Type()` on a type that exists.

## Related issues

Fixes #7172. Related: #7143 / #7162 (server side of the same row shape).

## Additional Notes

- `RemoteSchemaTest`: the three new `...WhenServerAnswersNoRows` tests fail on `main` with the issue's exact exception and pass with the change; `...StillThrowsWhenTypeIsMissingAfterTheCommand` covers the genuine failure.
- `RemoteSchemaIT.getOrCreateTypesAreIdempotent`: every variant called twice against a real server.
- The plain `create*Type()` methods keep their row-count check: a non-guarded create either answers a row or errors.

Disclosure: this change was authored with Claude Code, following the repo's CLAUDE.md guidelines, and human-reviewed before submission.

## Checklist

- [x] I have run the build using `mvn clean package` command (`mvn -o -pl network test`: `RemoteSchemaTest` 72/72; `mvn -o -pl server -am verify -Dit.test=RemoteSchemaIT`: 7/7)
- [x] My unit tests cover both failure and success scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote schema handling when creating document, vertex, or edge types that already exist.
  - Type creation now succeeds even when the server returns no result rows for an existing type.
  - Requests for genuinely missing types continue to report a schema error.
  - Repeated type-creation calls, including those specifying bucket counts, now consistently resolve the existing type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->