### PR TITLE
fix(#7119): bucketSelectionStrategy is volatile and bound before it is published

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/ThreadBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/ThreadBucketSelectionStrategy.java
@@ -29,7 +29,13 @@ import java.util.List;
  * @author Luca Garulli
  */
 public class ThreadBucketSelectionStrategy implements BucketSelectionStrategy {
-  protected int total;
+  // VOLATILE FOR THE SAME REASON AS LocalDocumentType.bucketSelectionStrategy (ISSUE #7119). PUBLISHING A NEW STRATEGY
+  // THROUGH THAT VOLATILE FIELD ALREADY CARRIES THIS WRITE, BUT addBucketInternal()/removeBucket() REBIND THE STRATEGY
+  // ALREADY IN PLACE - THEY CALL setType(this) ON THE SAME OBJECT AND MAKE NO VOLATILE WRITE AFTERWARDS - SO WITHOUT
+  // THIS A CONCURRENT INSERT COULD KEEP READING THE BUCKET COUNT FROM BEFORE THE GROW OR SHRINK, AND HAND OUT AN INDEX
+  // ONE PAST THE LAST BUCKET (THE SHAPE OF ISSUE #6380). ONE ACQUIRING LOAD PER RECORD PLACEMENT, AGAINST A LOOKUP AND
+  // AN INSERT.
+  protected volatile int total;
 
   @Override
   public void setType(final LocalDocumentType type) {

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -80,7 +80,10 @@ public class LocalDocumentType implements DocumentType {
   protected volatile List<Bucket>                   cachedPolymorphicBuckets     = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
   protected volatile List<Integer>                  bucketIds                    = new ArrayList<>();
   protected volatile List<Integer>                  cachedPolymorphicBucketIds   = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
-  protected       BucketSelectionStrategy           bucketSelectionStrategy      = new RoundRobinBucketSelectionStrategy();
+  // Fifth member of the same copy-on-write family: reassigned by setBucketSelectionStrategy, read lock-free by
+  // getBucketIdByRecord/getBucketIndexByKeys on the record-write path and by the planner's partition pruning through
+  // getBucketSelectionStrategy(), so it is volatile for the same reason as the four lists above (issue #7119).
+  protected volatile BucketSelectionStrategy        bucketSelectionStrategy      = new RoundRobinBucketSelectionStrategy();
   // Names of the OWN properties that declare a DEFAULT. A cache: the authority is the per-property default value, but
   // record creation would otherwise pay an O(properties) scan to find the (usually empty) subset that has one.
   // Copy-on-write, and read through getPolymorphicPropertiesWithDefaultDefined() by ApplyDefaultsStep (the SQL insert
@@ -883,23 +886,20 @@ public class LocalDocumentType implements DocumentType {
   private DocumentType setBucketSelectionStrategy(final BucketSelectionStrategy selectionStrategy,
       final boolean persistOnItsOwn) {
     checkForSchemaMutation();
+    // Bind and vet the strategy BEFORE publishing it (issue #7119). The field is read lock-free by
+    // getBucketIdByRecord/getBucketIndexByKeys, so assigning first would let a concurrent insert reach a strategy
+    // whose bucket count is still 0 (ThreadBucketSelectionStrategy divides by it) or whose type is still null
+    // (PartitionedBucketSelectionStrategy dereferences it). Binding only reads the bucket lists, never this field,
+    // so nothing here needs the assignment to have happened - and a refusal from the suitability check now leaves
+    // the field untouched instead of needing a rollback. Binding itself no longer validates anything (see
+    // PartitionedBucketSelectionStrategy.setType); every refusal comes out of the suitability check, which is also
+    // what makes the reaction depend on how we got here.
+    selectionStrategy.setType(this);
+    if (selectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
+      reportPartitionSuitability(partitioned,
+          schema.isReadingFromFile() ? PartitionReport.RELOAD : PartitionReport.ASSIGNMENT);
     final BucketSelectionStrategy previous = this.bucketSelectionStrategy;
     this.bucketSelectionStrategy = selectionStrategy;
-    try {
-      // The field is assigned before this so the strategy can read back the type it is being bound to, which means
-      // anything thrown from here would otherwise leave the type carrying a strategy the DDL went on to reject.
-      // Binding no longer validates anything (see PartitionedBucketSelectionStrategy.setType); every refusal comes
-      // out of the suitability check below, which is also what makes the reaction depend on how we got here.
-      this.bucketSelectionStrategy.setType(this);
-      if (selectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
-        reportPartitionSuitability(partitioned,
-            schema.isReadingFromFile() ? PartitionReport.RELOAD : PartitionReport.ASSIGNMENT);
-    } catch (final RuntimeException e) {
-      // Restoring the reference is the whole rollback: previous was bound to this type when it was assigned, and
-      // nothing here unbinds it, so re-invoking previous.setType(this) would be a no-op.
-      this.bucketSelectionStrategy = previous;
-      throw e;
-    }
     // Strategy-change flag flip (issue #4087). Switching the bucket-selection strategy on a
     // populated type can leave existing records in buckets that no longer match the new
     // strategy's hash. Two cases set the flag:

--- a/engine/src/test/java/com/arcadedb/schema/Issue7119BucketSelectionStrategyPublicationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue7119BucketSelectionStrategyPublicationTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.bucketselectionstrategy.BucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
+import com.arcadedb.database.bucketselectionstrategy.ThreadBucketSelectionStrategy;
 import com.arcadedb.exception.SchemaException;
 
 import org.junit.jupiter.api.Test;
@@ -111,6 +112,48 @@ class Issue7119BucketSelectionStrategyPublicationTest extends TestHelper {
         .hasMessageContaining("cannot find a unique automatic index");
 
     assertThat(type.getBucketSelectionStrategy()).isSameAs(previous);
+  }
+
+  @Test
+  void strategyBucketCountMustBeVolatileForTheInPlaceRebind() throws Exception {
+    final Field field = ThreadBucketSelectionStrategy.class.getDeclaredField("total");
+    assertThat(Modifier.isVolatile(field.getModifiers()))
+        .as("addBucketInternal()/removeBucket() rebind the strategy that is ALREADY published, by calling setType() on "
+            + "it and making no volatile write afterwards, so the bucket count it caches must carry its own "
+            + "happens-before edge to the lock-free readers of getBucketIdByRecord() (issue #7119)")
+        .isTrue();
+  }
+
+  @Test
+  void inPlaceRebindTracksABucketCountThatGrows() {
+    database.transaction(() -> database.getSchema().createDocumentType("Product", 2));
+
+    final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType("Product");
+    final ThreadBucketSelectionStrategy strategy = new ThreadBucketSelectionStrategy();
+    database.transaction(() -> type.setBucketSelectionStrategy(strategy));
+    assertThat(readTotal(strategy)).isEqualTo(2);
+
+    database.transaction(
+        () -> type.addBucket(database.getSchema().createBucket("Product_extra")));
+
+    assertThat(readTotal(strategy))
+        .as("the strategy published on the type is rebound in place when the bucket list grows")
+        .isEqualTo(3);
+    // AND THE PLACEMENT IT HANDS OUT IS STILL AN INDEX INTO THE CURRENT LIST
+    assertThat(strategy.getBucketIdByRecord(null, false)).isBetween(0, 2);
+
+    // LEAVE THE TYPE ON A BUILT-IN STRATEGY SO THE PERSISTED SCHEMA DOES NOT NAME A TEST-LOCAL SETUP
+    database.transaction(() -> type.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy()));
+  }
+
+  private static int readTotal(final ThreadBucketSelectionStrategy strategy) {
+    try {
+      final Field total = ThreadBucketSelectionStrategy.class.getDeclaredField("total");
+      total.setAccessible(true);
+      return total.getInt(strategy);
+    } catch (final ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/schema/Issue7119BucketSelectionStrategyPublicationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue7119BucketSelectionStrategyPublicationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.bucketselectionstrategy.BucketSelectionStrategy;
+import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7119: {@code LocalDocumentType.bucketSelectionStrategy} is the fifth copy-on-write member of the class, next
+ * to the four bucket lists issues #6678/#7033 made {@code volatile}. It is reassigned by
+ * {@code setBucketSelectionStrategy} and read lock-free by {@code getBucketIdByRecord}/{@code getBucketIndexByKeys}
+ * on the record-write path and by the planner's partition pruning, so it needs the same happens-before edge. It was
+ * also published before it was bound: the field was assigned first and {@code setType(this)} called afterwards, so a
+ * concurrent insert could reach a strategy whose bucket count was still 0 or whose type was still null.
+ * <p>
+ * The first test pins the modifier, like the sibling {@link Issue6678PolymorphicBucketCacheVisibilityTest} does for
+ * the four lists. The second uses a strategy that records what the type was publishing at the moment it was bound:
+ * with the fix it is still the previous strategy, never the half-bound one. The third checks the rollback contract
+ * the old try/catch provided survives the reordering: a strategy the type refuses is never published.
+ */
+class Issue7119BucketSelectionStrategyPublicationTest extends TestHelper {
+
+  @Test
+  void bucketSelectionStrategyMustBeVolatileForLockFreeReaders() throws Exception {
+    final Field field = LocalDocumentType.class.getDeclaredField("bucketSelectionStrategy");
+    assertThat(Modifier.isVolatile(field.getModifiers()))
+        .as("bucketSelectionStrategy is copy-on-write reassigned by setBucketSelectionStrategy and read lock-free by "
+            + "the record-write path and the planner - it must be volatile like its four sibling bucket lists (issue #7119)")
+        .isTrue();
+  }
+
+  @Test
+  void strategyIsBoundBeforeItIsPublished() {
+    database.transaction(() -> database.getSchema().createDocumentType("Product", 2));
+
+    final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType("Product");
+    final BucketSelectionStrategy previous = type.getBucketSelectionStrategy();
+    final RecordingStrategy recording = new RecordingStrategy();
+
+    database.transaction(() -> type.setBucketSelectionStrategy(recording));
+
+    assertThat(recording.publishedWhenBound)
+        .as("setType(this) must run before the field is assigned, so the type still publishes the previous strategy")
+        .isSameAs(previous);
+    assertThat(recording.bucketsWhenBound).isEqualTo(2);
+    assertThat(type.getBucketSelectionStrategy()).isSameAs(recording);
+
+    // LEAVE THE TYPE ON A BUILT-IN STRATEGY SO THE PERSISTED SCHEMA DOES NOT NAME A TEST CLASS
+    database.transaction(() -> type.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy()));
+  }
+
+  @Test
+  void strategyRefusedWhileBindingIsNeverPublished() {
+    database.transaction(() -> database.getSchema().createDocumentType("Product", 2));
+
+    final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType("Product");
+    final BucketSelectionStrategy previous = type.getBucketSelectionStrategy();
+
+    assertThatThrownBy(() -> database.transaction(() -> type.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy() {
+      @Override
+      public void setType(final LocalDocumentType type) {
+        throw new IllegalStateException("refused");
+      }
+    }))).isInstanceOf(IllegalStateException.class).hasMessage("refused");
+
+    assertThat(type.getBucketSelectionStrategy()).isSameAs(previous);
+  }
+
+  /**
+   * Public with a public no-arg constructor so that, should the schema be reloaded while it is assigned, the strategy
+   * can be re-instantiated by name the way {@code setBucketSelectionStrategy(String, Object...)} does.
+   */
+  public static class RecordingStrategy extends RoundRobinBucketSelectionStrategy {
+    BucketSelectionStrategy publishedWhenBound;
+    int                     bucketsWhenBound;
+
+    @Override
+    public void setType(final LocalDocumentType type) {
+      publishedWhenBound = type.getBucketSelectionStrategy();
+      bucketsWhenBound = type.getBuckets(false).size();
+      super.setType(type);
+    }
+
+    @Override
+    public String getName() {
+      return getClass().getName();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue7119BucketSelectionStrategyPublicationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue7119BucketSelectionStrategyPublicationTest.java
@@ -20,12 +20,15 @@ package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.bucketselectionstrategy.BucketSelectionStrategy;
+import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
+import com.arcadedb.exception.SchemaException;
 
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -40,8 +43,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>
  * The first test pins the modifier, like the sibling {@link Issue6678PolymorphicBucketCacheVisibilityTest} does for
  * the four lists. The second uses a strategy that records what the type was publishing at the moment it was bound:
- * with the fix it is still the previous strategy, never the half-bound one. The third checks the rollback contract
- * the old try/catch provided survives the reordering: a strategy the type refuses is never published.
+ * with the fix it is still the previous strategy, never the half-bound one. The last two check the rollback contract
+ * the old try/catch provided survives the reordering, once per exit of the block it wrapped: a strategy that throws
+ * while binding, and a real {@link PartitionedBucketSelectionStrategy} the suitability check refuses after binding
+ * succeeded, are both never published.
  */
 class Issue7119BucketSelectionStrategyPublicationTest extends TestHelper {
 
@@ -87,6 +92,23 @@ class Issue7119BucketSelectionStrategyPublicationTest extends TestHelper {
         throw new IllegalStateException("refused");
       }
     }))).isInstanceOf(IllegalStateException.class).hasMessage("refused");
+
+    assertThat(type.getBucketSelectionStrategy()).isSameAs(previous);
+  }
+
+  @Test
+  void strategyRefusedBySuitabilityCheckIsNeverPublished() {
+    database.transaction(() -> database.getSchema().createDocumentType("Product", 2));
+
+    final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType("Product");
+    final BucketSelectionStrategy previous = type.getBucketSelectionStrategy();
+
+    // NO UNIQUE AUTOMATIC INDEX ON `id`, SO checkSuitability() REPORTS A BLOCKER AND THE ASSIGNMENT IS REFUSED AFTER
+    // setType(this) HAS ALREADY BOUND THE STRATEGY - THE OTHER EXIT OF THE BLOCK THAT USED TO NEED THE ROLLBACK
+    assertThatThrownBy(() -> database.transaction(
+        () -> type.setBucketSelectionStrategy(new PartitionedBucketSelectionStrategy(List.of("id")))))
+        .isInstanceOf(SchemaException.class)
+        .hasMessageContaining("cannot find a unique automatic index");
 
     assertThat(type.getBucketSelectionStrategy()).isSameAs(previous);
   }


### PR DESCRIPTION
## What does this PR do?

Closes the two halves of #7119 on `LocalDocumentType.bucketSelectionStrategy`, the fifth copy-on-write member of the class that #7033 did not sweep.

- The field is now `volatile`, matching the four bucket lists beside it. It is reassigned by `setBucketSelectionStrategy` and read lock-free by `getBucketIdByRecord`/`getBucketIndexByKeys` on the record-write path (`LocalDatabase.createRecordNoLock`, `DatabaseAsyncExecutorImpl`) and by the planner's partition pruning through `getBucketSelectionStrategy()` (`SelectExecutionPlanner`, `PartitionPruning`), so it needs the same happens-before edge #6678/#7033 gave its siblings.
- `setBucketSelectionStrategy` now binds and vets the strategy before assigning the field. Previously the assignment came first, so a concurrent insert could reach a strategy whose `total` was still 0 (`ThreadBucketSelectionStrategy.getBucketIdByRecord` divides by it) or whose `type` was still null (`PartitionedBucketSelectionStrategy.getBucketIdByRecord` dereferences it). None of the three strategies reads the field back during `setType` (they read `type.getBuckets(false)`), and the two-arg `reportPartitionSuitability` works on its parameter only, so nothing in that block needed the assignment to have happened. With the ordering fixed the try/catch rollback is gone: a refused strategy is simply never published.

## Motivation

Same shape as #6678 and #7033, one field over. The ordering half is the one with a concrete failure mode rather than only a missing barrier, since a half-bound strategy either throws `ArithmeticException` or `NullPointerException` from `getBucketIdByRecord`.

## Related issues

Fixes #7119

## Additional Notes

`Issue7119BucketSelectionStrategyPublicationTest` pins three things: the modifier (as `Issue6678PolymorphicBucketCacheVisibilityTest` does for the four lists), the ordering (a strategy that records what the type publishes at the moment `setType` runs must see the previous strategy, not itself), and the rollback contract the removed try/catch used to provide (a strategy that throws while binding is never published). The first two fail on `main`; the third passes on both and guards the reordering.

Disclosure: this change was authored with Claude Code, following the repo's CLAUDE.md guidelines, and human-reviewed before submission.

## Checklist

- [x] I have run the build using `mvn clean package` command (engine module; the new test plus `Issue6678*`, `Issue6380*`, `PartitioningRepartitionFlagTest`, `PartitionedStrategySuitabilityTest`, `PartitionedStrategyLifecycleTest`, `AlterTypeExecutionTest`, `PartitionPruningPlannerTest`, `RebuildTypeRepartitionTest` and the other bucket-selection suites: 132 tests, 0 failures)
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket selection strategy updates so new strategies are fully validated before becoming active.
  * Prevented unsuccessful strategy changes from replacing the currently active strategy.
  * Improved consistency during concurrent record placement and planning operations.
  * Ensured strategy updates are published atomically, avoiding partially initialized behavior.

* **Tests**
  * Added coverage for strategy visibility, initialization ordering, validation failures, and preservation of the active strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->