### PR TITLE
test(#6111): the retry test no longer reads a mark the retry itself resets

### DIFF
--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -472,8 +472,10 @@ class Issue6111StaleSnapshotReadFloorTest {
 
       sm.retryUnfilledSnapshotGap();
 
-      assertThat(readLastRetryMs(sm)).as("a retry was submitted").isNotZero();
-      // The submission runs on the single-threaded lifecycleExecutor; give it a bounded moment.
+      // The submission runs on the single-threaded lifecycleExecutor; give it a bounded moment. The retry mark
+      // is no proof it was submitted: with no databases present the retry completes at once, and
+      // clearStaleSnapshotFloor() resets the mark to 0 on that thread - reading it here races the reset and
+      // failed CI on exactly that (run 34088696222). The resolved floor is the race-free proof of both.
       for (int i = 0; i < 100 && sm.getStaleSnapshotAppliedFloor() >= 0; i++)
         Thread.sleep(20);
       assertThat(sm.getStaleSnapshotAppliedFloor())

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -476,10 +476,12 @@ class Issue6111StaleSnapshotReadFloorTest {
       // is no proof it was submitted: with no databases present the retry completes at once, and
       // clearStaleSnapshotFloor() resets the mark to 0 on that thread - reading it here races the reset and
       // failed CI on exactly that (run 34088696222). The resolved floor is the race-free proof of both.
-      for (int i = 0; i < 100 && sm.getStaleSnapshotAppliedFloor() >= 0; i++)
+      // The bound is a give-up tripwire, not a latency claim: a full-suite run shares this JVM, so it is sized
+      // for a stop-the-world pause rather than for how long the hand-off actually takes.
+      for (int i = 0; i < 500 && sm.getStaleSnapshotAppliedFloor() >= 0; i++)
         Thread.sleep(20);
       assertThat(sm.getStaleSnapshotAppliedFloor())
-          .as("the retry really reached triggerSnapshotDownload(), which resolved the floor")
+          .as("the retry really reached triggerSnapshotDownload(), which resolved the floor, within 10s")
           .isEqualTo(-1L);
     } finally {
       sm.close();


### PR DESCRIPTION
## What does this PR do?

`Issue6111StaleSnapshotReadFloorTest.retryFiresAndResolvesTheFloorWhenNothingIsRunning` asserted `lastStaleSnapshotRetryMs != 0` right after `retryUnfilledSnapshotGap()` returned. The mark is set on the caller's thread, but the retry it submits runs `triggerSnapshotDownload()` on the `lifecycleExecutor` and, with no databases present, finishes at once: `downloadAllDatabasesFrom()` → `resolveStaleSnapshotFloorAfterResync()` → `clearStaleSnapshotFloor()`, which resets the mark to 0. When the executor thread wins that race the assertion reads 0:

```
[a retry was submitted] Expecting actual: 0L not to be equal to: 0L
  at Issue6111StaleSnapshotReadFloorTest.retryFiresAndResolvesTheFloorWhenNothingIsRunning(Issue6111StaleSnapshotReadFloorTest.java:475)
```

That is the only red in the `unit-tests` lane of run [34088696222](https://github.com/ArcadeData/arcadedb/actions/runs/34088696222/job/101638707674) (PR #7217, which touches nothing in `ha-raft`), and the same test was already logged as an unrelated red `main` run in #6415. The test ran in 0.028 s, so the retry had in fact been submitted and had already completed - exactly the case the mark cannot witness.

The state machine is right: the mark is a throttle and is reset on purpose once the gap is closed. The proof the test wants is the resolved floor, which the bounded wait already asserts and which no thread resets back. This drops the racy read and says why in the comment; `readLastRetryMs()` stays in use by the four tests that assert the mark was *not* set, which have no such race.

## Motivation

A test that fails on scheduling alone turns green lanes red on unrelated PRs and pushes to `main`.

## Related issues

Related: #6111 (the test's subject), #6415 (where this failure was first noted as one of the "0L-shaped" flakes), #7217 (the run above).

## Additional Notes

No early return in `retryUnfilledSnapshotGap()` can leave the mark at 0 with the test's mocks (follower, unambiguous leader address, not our own, no download in flight, previous mark 0, `System.currentTimeMillis()` never 0), so the reset on the executor thread is the one mechanism. A throwaway `@RepeatedTest(300)` of the original read did not lose the race on an M-series Mac; the CI runner did.

Disclosure: this change was authored with Claude Code, following the repo's CLAUDE.md guidelines, and human-reviewed before submission.

## Checklist

- [x] I have run the build using `mvn clean package` command (`./mvnw -pl ha-raft -am test -Dtest=Issue6111StaleSnapshotReadFloorTest`: 21/21)
- [x] My unit tests cover both failure and success scenarios (the remaining assertion still fails when no retry is submitted: the floor stays at 100 after the bounded wait)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended the retry-resolution test’s polling window to 10 seconds to accommodate stop-the-world pauses.
  * Updated failure reporting to reflect the expanded timeout and avoid treating the limit as a latency requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->