### PR TITLE
chore(dependabot): hold every version update for a 3-day cooldown (#7231) [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,32 @@ version: 2
 # is a Security -> Dependabot -> auto-triage rules setting in the GitHub UI and
 # cannot be expressed in this file.
 
+# Cooldown
+# --------
+# Every update block below carries `cooldown: default-days: 3`, so Dependabot
+# will not propose a release until it has been public for three days. The
+# window is the cheapest defence against the npm/PyPI-style supply-chain
+# attacks that publish a malicious version and get it yanked within hours:
+# a compromised release is usually pulled well inside three days, and one
+# that is not has at least been seen by somebody other than us.
+#
+# It costs nothing in security terms: `cooldown` applies to VERSION updates
+# only. Dependabot security updates, the PRs raised from an advisory, ignore
+# it entirely and still open the moment the advisory lands.
+#
+# Three days is the floor GitHub itself defaults to when `cooldown` is
+# present with no `default-days`; it is spelled out here so the intent is
+# visible rather than inherited.
+
 updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 20
     ignore:
       # Groovy's version is dictated by TinkerPop, not by ArcadeDB. It appears
@@ -79,6 +99,9 @@ updates:
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     groups:
       github-actions:
@@ -93,6 +116,9 @@ updates:
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "eclipse-temurin"
@@ -106,6 +132,9 @@ updates:
       day: "sunday"
       time: "09:00"
       timezone: "UTC"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 15
     target-branch: "main"
     commit-message:
@@ -173,6 +202,9 @@ updates:
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     groups:
       pre-commit-hooks:
@@ -194,6 +226,9 @@ updates:
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     groups:
       e2e-js-deps:
@@ -212,6 +247,9 @@ updates:
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     groups:
       e2e-studio-deps:
@@ -227,6 +265,9 @@ updates:
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
 
   # Bindings Python
@@ -235,6 +276,9 @@ updates:
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
 
   # E2E Go Testing Dependencies
@@ -243,6 +287,9 @@ updates:
     schedule:
       interval: weekly
       day: "sunday"
+    # See the shared cooldown note at the head of this file.
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     # Go's transitive tree (testcontainers-go pulls docker/containerd/grpc/otel)
     # is large; group minor/patch bumps into a single PR to keep noise down,


### PR DESCRIPTION
## What

Adds `cooldown: default-days: 3` to every one of the ten update blocks in `.github/dependabot.yml`: maven, github-actions, docker, npm (`/studio`, `/e2e-js`, `/e2e-studio`), pre-commit, uv (`/e2e-python`, `/bindings/python`) and gomod.

Dependabot now waits until a release has been public for three days before proposing it.

## Why

Prompted by [cooldowns.dev](https://cooldowns.dev/). Dependabot's default is to raise a PR the moment a version is published, which is precisely the window an npm/PyPI-style supply-chain compromise lives in: the malicious release is usually yanked within hours, but a bump raised (and, in this repo, potentially auto-merged by `dependabot-auto-merge.yml`) inside that window has already reached the branch. A three-day hold means a compromised release has almost always been pulled before we ever see it, and one that has not has at least been looked at by somebody other than us.

## This does not delay security fixes

`cooldown` applies to **version updates only**. Dependabot *security* updates - the PRs raised from a published advisory - ignore it entirely and still open as soon as the advisory lands. The CVE path is unchanged.

## Notes

- Every ecosystem used here supports `cooldown` with `default-days` ([options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-)).
- Three days is also the value GitHub applies when `cooldown` is present with no `default-days`; it is written out explicitly so the intent is visible rather than inherited.
- A flat `default-days` was chosen over per-semver windows. `semver-major-days` is available if we later want a longer hold on majors, but it is unsupported for github-actions, docker and pre-commit, so it would not apply uniformly.
- The rationale lives in a comment block at the head of the file, next to the existing auto-triage note, with a one-line pointer in each update block.

## Verification

The config parses and all ten blocks carry the setting:

```
$ python3 -c "import yaml;d=yaml.safe_load(open('.github/dependabot.yml'));print(len(d['updates']), set(str(u.get('cooldown')) for u in d['updates']))"
10 {"{'default-days': 3}"}
```

Behaviour is GitHub-side and can only be confirmed by observing that next Sunday's PRs skip releases newer than three days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bxe8KBwi4Ad6YjKoZHGjU8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a three-day cooldown for routine dependency updates across supported package ecosystems.
  * Security updates continue to bypass the cooldown for faster delivery.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->