### PR TITLE
fix: CREATE INDEX IF NOT EXISTS across super types (#7228), Gremlin 'g' alias log flood (#7230), snapshot entry cap read off the enum (#7226)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -186,11 +186,37 @@ public class CreateIndexStatement extends DDLStatement {
     return !database.getSchema().existsType(name);
   }
 
+  /**
+   * Runs the statement with its own {@code typeName} and {@code name} restored afterwards, whichever way
+   * {@link #executeDDLInternal} leaves.
+   * <p>
+   * Both fields are MUTATED during execution - a {@code $variable} type name is replaced by what it resolved to, and
+   * an unnamed statement has {@code name} backfilled with the auto-derived {@code typeName[properties]} form - and a
+   * parsed statement is a CACHED, SHARED object: {@link StatementCache#get} hands the same instance back for the same
+   * text, execution after execution. So a mutation that outlives one execution is read as the statement's own text by
+   * the next.
+   * <p>
+   * There used to be a single {@code typeName = prevName} at the end of the success path, which restored nothing for
+   * any of the {@code return}s and {@code throw}s before it - the {@code IF NOT EXISTS} shortcut chief among them.
+   * A statement whose type name is a variable and whose index already exists therefore kept the FIRST execution's
+   * resolved type, and every later execution silently indexed that type instead of the one the variable now names,
+   * with no error to say so.
+   */
   @Override
   public ResultSet executeDDL(final CommandContext context) {
+    final Identifier declaredTypeName = typeName;
+    final Identifier declaredIndexName = name;
+    try {
+      return executeDDLInternal(context);
+    } finally {
+      typeName = declaredTypeName;
+      name = declaredIndexName;
+    }
+  }
+
+  private ResultSet executeDDLInternal(final CommandContext context) {
     final Database database = context.getDatabase();
 
-    Identifier prevName = typeName;
     if (typeName.getStringValue().startsWith("$")) {
       String variable = (String) context.getVariable(typeName.getStringValue());
       typeName = new Identifier(variable);
@@ -455,7 +481,6 @@ public class CreateIndexStatement extends DDLStatement {
             "METADATA is not supported by index type '" + typeAsString + "'");
       resultingIndex = builder.create();
     }
-    typeName = prevName;
 
     // A guarded statement that named an index NOT yet in the schema gets past the existsIndex shortcut above and
     // reaches the builder, which answers it with the index already on those properties whenever that one provides

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -137,6 +137,20 @@ public class CreateIndexStatement extends DDLStatement {
     return json;
   }
 
+  /**
+   * True when {@code existing} is declared on {@code requestedTypeName} or on one of its super types, and therefore
+   * already indexes every record the request is about (issue #7228).
+   * <p>
+   * A missing type is NOT a match: the statement would go on to fail on the type anyway, and answering the guard for
+   * a type that does not exist would report success for an index nothing can use.
+   */
+  private static boolean coversRequestedType(final Database database, final Index existing, final String requestedTypeName) {
+    if (existing.getTypeName().equals(requestedTypeName))
+      return true;
+    final Schema schema = database.getSchema();
+    return schema.existsType(requestedTypeName) && schema.getType(requestedTypeName).instanceOf(existing.getTypeName());
+  }
+
   @Override
   public ResultSet executeDDL(final CommandContext context) {
     final Database database = context.getDatabase();
@@ -209,7 +223,16 @@ public class CreateIndexStatement extends DDLStatement {
         // property list, so a name match implies both already match. Index names are global, so a manual one can name
         // an index on ANOTHER type, or on other properties of this one - either way it is a different index, and
         // answering "already exists" would leave the requested one uncreated with nothing said about why.
-        if (!existing.getTypeName().equals(typeName.getStringValue())
+        //
+        // "Another type" excludes a SUPER type of the requested one (issue #7228). A type index is built over
+        // {@code getBuckets(true)}, the POLYMORPHIC bucket list, so an index declared on a super type already indexes
+        // every record of this one: there is nothing left for the statement to create, and the guard has to answer
+        // the same way {@link TypeIndexBuilder#create} answers an unnamed request over an inherited index - which
+        // finds it through {@code getPolymorphicIndexByProperties} and returns it. Refusing here instead made a
+        // schema script that names its indexes non-idempotent the moment one of them moved up the hierarchy, which
+        // is exactly what IF NOT EXISTS is written to prevent. The relation is checked in one direction only: an
+        // index on a SUB type covers strictly fewer buckets than the request, so it does not satisfy it.
+        if (!coversRequestedType(database, existing, typeName.getStringValue())
             || !existing.getPropertyNames().equals(requestedProperties))
           throw new IllegalArgumentException(
               "Cannot create the index '" + name.getValue() + "' on type '" + typeName.getStringValue() + "' properties "

--- a/engine/src/test/java/com/arcadedb/index/Issue7228CachedCreateIndexStatementStateTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue7228CachedCreateIndexStatementStateTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.sql.SQLQueryEngine;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.parser.CreateIndexStatement;
+import com.arcadedb.query.sql.parser.Statement;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A parsed statement is a CACHED, SHARED object: {@code StatementCache.get} hands the same instance back for the same
+ * text, execution after execution, and the {@code sql} engine goes through it on every command.
+ * {@code CreateIndexStatement} mutates two of its own fields while it runs - a {@code $variable} type name is replaced
+ * by what it resolved to, and an unnamed statement has {@code name} backfilled with the auto-derived
+ * {@code typeName[properties]} form - and used to restore only the first, only on the success path.
+ * <p>
+ * Every {@code return} and {@code throw} before that line therefore leaked the resolved type into the shared
+ * statement, the {@code IF NOT EXISTS} shortcut chief among them. The next execution of the same text then saw a type
+ * name that no longer starts with {@code $}, skipped variable resolution entirely, and indexed the FIRST execution's
+ * type - silently, with no error to say the variable had been ignored.
+ * <p>
+ * The {@code $variable} + cache combination is reached in production through
+ * {@code SQLQueryEngine.command(query, configuration, parameters, variables)}, which is what
+ * {@code SQLTriggerExecutor} runs a trigger body with; the tests use the same entry point. ({@code sqlscript} cannot
+ * expose the defect: it has no statement cache and re-parses every execution.)
+ * <p>
+ * Found while reviewing the #7228 fix, which adds one more early return through the same shortcut.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7228CachedCreateIndexStatementStateTest extends TestHelper {
+
+  /** Identical text on every execution, so all of them go through ONE cached statement instance. */
+  private static final String STATEMENT = "CREATE INDEX IF NOT EXISTS ON $t (uuid) UNIQUE";
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      for (final String type : new String[] { "TypeA", "TypeB" }) {
+        database.command("sql", "CREATE VERTEX TYPE " + type);
+        database.command("sql", "CREATE PROPERTY " + type + ".uuid STRING");
+      }
+    });
+  }
+
+  @Test
+  void aGuardedStatementOverAVariableTypeDoesNotCarryTheResolvedTypeIntoTheNextExecution() {
+    // 1st: creates the index on TypeA and leaves through the success path.
+    run("TypeA");
+    // 2nd: same type, so the index already exists and the statement leaves through the IF NOT EXISTS shortcut - the
+    // early return that used to skip the restore.
+    run("TypeA");
+    // 3rd: a DIFFERENT type. With the leak $t is never re-resolved and this indexes TypeA all over again.
+    run("TypeB");
+
+    assertThat(database.getSchema().getType("TypeB").getAllIndexes(false))
+        .as("the third execution asked for an index on TypeB, so TypeB must have one")
+        .isNotEmpty();
+    assertThat(database.getSchema().existsIndex("TypeB[uuid]")).isTrue();
+    assertThat(database.getSchema().getIndexByName("TypeB[uuid]").getTypeName()).isEqualTo("TypeB");
+  }
+
+  /** The constraint really landed on TypeB, so the statement did what it reported. */
+  @Test
+  void theInheritedConstraintIsEnforcedOnTheTypeTheLastExecutionNamed() {
+    run("TypeA");
+    run("TypeA");
+    run("TypeB");
+
+    database.transaction(() -> database.command("sql", "INSERT INTO TypeB SET uuid = 'u1'"));
+
+    assertThat(database.getSchema().getIndexByName("TypeB[uuid]").isUnique()).isTrue();
+  }
+
+  /**
+   * Straight at the shared object: after any execution the statement must read back exactly as it was parsed, so the
+   * next caller of the same text gets the statement they wrote and not the previous execution's residue.
+   */
+  @Test
+  void theCachedStatementIsUnchangedByExecution() {
+    run("TypeA");
+
+    final Statement cached = ((DatabaseInternal) database).getStatementCache().get(STATEMENT);
+    assertThat(cached).isInstanceOf(CreateIndexStatement.class);
+
+    final CreateIndexStatement createIndex = (CreateIndexStatement) cached;
+    assertThat(createIndex.typeName.getStringValue())
+        .as("the type name must still be the variable the statement was written with")
+        .isEqualTo("$t");
+    assertThat(createIndex.name)
+        .as("the statement named no index, so no auto-derived name may survive its execution")
+        .isNull();
+
+    // ...and still true after the guarded execution that returns through the shortcut.
+    run("TypeA");
+    assertThat(((CreateIndexStatement) ((DatabaseInternal) database).getStatementCache().get(STATEMENT)).typeName.getStringValue())
+        .isEqualTo("$t");
+  }
+
+  private void run(final String type) {
+    final SQLQueryEngine engine = (SQLQueryEngine) database.getQueryEngine("sql");
+    try (final ResultSet rs = engine.command(STATEMENT, database.getConfiguration(), Map.of(), Map.of("$t", type))) {
+      rs.stream().forEach(r -> {
+      });
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue7228CreateIndexIfNotExistsSuperTypeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue7228CreateIndexIfNotExistsSuperTypeTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #7228: {@code CREATE INDEX <name> IF NOT EXISTS ON <subType> (...)} was refused when
+ * the index of that name is declared on a SUPER type of {@code <subType>}, with "an index with that name already
+ * exists on type '...'. Drop it first or choose a different index name".
+ * <p>
+ * The refusal was wrong on its own terms. A type index is built over {@code getBuckets(true)} - the polymorphic
+ * bucket list - so an index declared on {@code Elemento} already indexes every {@code ElementoNoIdentificable}
+ * record; there is nothing for the statement to create and nothing the guard has to warn about. The unnamed form of
+ * the very same statement had always been a no-op, because {@code TypeIndexBuilder.create()} finds the inherited
+ * index through {@code getPolymorphicIndexByProperties}; only the named form, which is answered by a shortcut in
+ * {@link com.arcadedb.query.sql.parser.CreateIndexStatement} before any builder exists, disagreed. That made a
+ * schema script non-idempotent the moment one of its named indexes moved up the hierarchy - the one thing
+ * IF NOT EXISTS is written to prevent.
+ * <p>
+ * The relation is checked in one direction only, which the tests below pin down: an index on a SUB type covers
+ * strictly fewer buckets than a request on its parent, so it does not satisfy it and is still reported.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7228CreateIndexIfNotExistsSuperTypeTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Elemento");
+      database.command("sql", "CREATE PROPERTY Elemento.uuid STRING");
+      database.command("sql", "CREATE VERTEX TYPE ElementoNoIdentificable EXTENDS Elemento");
+      database.command("sql", "CREATE VERTEX TYPE ElementoIdentificable EXTENDS Elemento");
+    });
+  }
+
+  /**
+   * The reported case verbatim: the index lives on the super type and the schema script asks for it again, by name,
+   * on a sub type.
+   */
+  @Test
+  void guardedNamedRequestOverAnIndexInheritedFromTheSuperTypeIsANoOp() {
+    database.command("sql", "CREATE INDEX `Elemento_uuid` ON `Elemento` (uuid) UNIQUE");
+
+    try (final ResultSet rs = database.command("sql",
+        "CREATE INDEX `Elemento_uuid` IF NOT EXISTS ON `ElementoNoIdentificable` (uuid) UNIQUE")) {
+      final Result result = rs.next();
+      assertThat(result.<Boolean>getProperty("created")).isFalse();
+      assertThat(result.<String>getProperty("name")).isEqualTo("Elemento_uuid");
+    }
+
+    // Exactly one index, still the one on the super type: the no-op must not have created a second.
+    assertThat(database.getSchema().existsIndex("Elemento_uuid")).isTrue();
+    assertThat(database.getSchema().getIndexByName("Elemento_uuid").getTypeName()).isEqualTo("Elemento");
+    assertThat(database.getSchema().getType("ElementoNoIdentificable").getAllIndexes(false)).isEmpty();
+  }
+
+  /**
+   * The point of answering the guard rather than refusing it: the inherited index really does constrain the sub
+   * type, so the statement that was told "already exists" was told the truth.
+   */
+  @Test
+  void theInheritedIndexEnforcesUniquenessOnTheSubType() {
+    database.command("sql", "CREATE INDEX `Elemento_uuid` ON `Elemento` (uuid) UNIQUE");
+    database.command("sql", "CREATE INDEX `Elemento_uuid` IF NOT EXISTS ON `ElementoNoIdentificable` (uuid) UNIQUE");
+
+    database.transaction(() -> database.command("sql", "INSERT INTO ElementoNoIdentificable SET uuid = 'u1'"));
+
+    assertThatThrownBy(() -> database.transaction(
+        () -> database.command("sql", "INSERT INTO ElementoNoIdentificable SET uuid = 'u1'")))
+        .isInstanceOf(DuplicatedKeyException.class);
+
+    // ...and across the hierarchy, not just within the one sub type.
+    assertThatThrownBy(() -> database.transaction(
+        () -> database.command("sql", "INSERT INTO ElementoIdentificable SET uuid = 'u1'")))
+        .isInstanceOf(DuplicatedKeyException.class);
+  }
+
+  /**
+   * A whole schema script re-run end to end: every statement is guarded, so the second run must change nothing.
+   */
+  @Test
+  void aGuardedSchemaScriptStaysIdempotentAcrossTheHierarchy() {
+    final String script = "CREATE INDEX `Elemento_uuid` IF NOT EXISTS ON `Elemento` (uuid) UNIQUE;"
+        + "CREATE INDEX `Elemento_uuid` IF NOT EXISTS ON `ElementoNoIdentificable` (uuid) UNIQUE;"
+        + "CREATE INDEX `Elemento_uuid` IF NOT EXISTS ON `ElementoIdentificable` (uuid) UNIQUE;";
+
+    database.command("sqlscript", script);
+    database.command("sqlscript", script);
+
+    assertThat(database.getSchema().getIndexes()).filteredOn(i -> "Elemento_uuid".equals(i.getName())).hasSize(1);
+  }
+
+  /**
+   * The other direction is NOT symmetric: an index on a sub type indexes only that sub type's buckets, so it cannot
+   * answer a request that spans the whole hierarchy. The conflict is still reported, naming both types.
+   */
+  @Test
+  void guardedNamedRequestOverAnIndexOnASubTypeIsStillReported() {
+    database.command("sql", "CREATE INDEX `sub_uuid` ON `ElementoNoIdentificable` (uuid) UNIQUE");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX `sub_uuid` IF NOT EXISTS ON `Elemento` (uuid) UNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sub_uuid")
+        .hasMessageContaining("Elemento")
+        .hasMessageContaining("ElementoNoIdentificable");
+
+    assertThat(database.getSchema().getIndexByName("sub_uuid").getTypeName()).isEqualTo("ElementoNoIdentificable");
+  }
+
+  /**
+   * An unrelated type is still a conflict: the fix must not have turned the name check into a formality.
+   */
+  @Test
+  void guardedNamedRequestOverAnIndexOnAnUnrelatedTypeIsStillReported() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Otro");
+      database.command("sql", "CREATE PROPERTY Otro.uuid STRING");
+    });
+    database.command("sql", "CREATE INDEX `otro_uuid` ON `Otro` (uuid) UNIQUE");
+
+    assertThatThrownBy(
+        () -> database.command("sql", "CREATE INDEX `otro_uuid` IF NOT EXISTS ON `ElementoNoIdentificable` (uuid) UNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("otro_uuid")
+        .hasMessageContaining("Otro");
+  }
+
+  /**
+   * The inherited index has to satisfy the request on its own terms too: a NOTUNIQUE parent index does not answer a
+   * request for the UNIQUE constraint, exactly as it does not when the index is the type's own (issue #5675).
+   */
+  @Test
+  void anInheritedIndexOfTheWrongKindDoesNotAnswerTheGuard() {
+    database.command("sql", "CREATE INDEX `Elemento_uuid` ON `Elemento` (uuid) NOTUNIQUE");
+
+    assertThatThrownBy(
+        () -> database.command("sql", "CREATE INDEX `Elemento_uuid` IF NOT EXISTS ON `ElementoNoIdentificable` (uuid) UNIQUE"))
+        .hasMessageContaining("Elemento_uuid");
+  }
+
+  /**
+   * Different properties under the same name stay a conflict even up the hierarchy: the name matched, the request
+   * did not.
+   */
+  @Test
+  void guardedNamedRequestOnDifferentPropertiesOfTheSuperTypeIsStillReported() {
+    database.transaction(() -> database.command("sql", "CREATE PROPERTY Elemento.code STRING"));
+    database.command("sql", "CREATE INDEX `Elemento_uuid` ON `Elemento` (uuid) UNIQUE");
+
+    assertThatThrownBy(
+        () -> database.command("sql", "CREATE INDEX `Elemento_uuid` IF NOT EXISTS ON `ElementoNoIdentificable` (code) UNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Elemento_uuid")
+        .hasMessageContaining("code");
+  }
+
+  /**
+   * Without the guard the statement is not asking to be made idempotent, so the pre-existing index is still
+   * reported rather than silently accepted.
+   */
+  @Test
+  void anUnguardedNamedRequestOverAnInheritedIndexIsStillReported() {
+    database.command("sql", "CREATE INDEX `Elemento_uuid` ON `Elemento` (uuid) UNIQUE");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX `Elemento_uuid` ON `ElementoNoIdentificable` (uuid) UNIQUE"))
+        .hasMessageContaining("Elemento_uuid");
+  }
+}

--- a/gremlin/src/main/java/com/arcadedb/server/gremlin/ArcadeGraphManager.java
+++ b/gremlin/src/main/java/com/arcadedb/server/gremlin/ArcadeGraphManager.java
@@ -52,6 +52,8 @@ public class ArcadeGraphManager implements GraphManager {
 
   private final Map<String, Graph>           graphs           = new ConcurrentHashMap<>();
   private final Map<String, TraversalSource> traversalSources = new ConcurrentHashMap<>();
+  // Targets the 'g' alias has already been announced for, see announceAliasMappingLevel().
+  private final Set<String>                  announcedAliasTargets = ConcurrentHashMap.newKeySet();
 
   public ArcadeGraphManager(final Settings settings) {
     // Settings can define pre-configured graphs, but we primarily use dynamic registration
@@ -122,12 +124,31 @@ public class ArcadeGraphManager implements GraphManager {
     return traversalSourceName;
   }
 
+  /**
+   * The level the {@code 'g'} alias mapping is announced at: {@link Level#INFO} the first time this manager resolves
+   * the alias onto {@code dbName}, {@link Level#FINE} for every later query that resolves onto the same database.
+   * <p>
+   * The mapping is a property of the deployment, not of the request: a driver whose {@code traversal_source} is left
+   * at the gremlinpython default resolves it identically on every single query, so announcing it per query turned a
+   * one-off "this is where 'g' points" note into an INFO line per query and flooded the server log (issue #7230).
+   * The first occurrence is still the useful one - it is what tells an operator which database an unqualified
+   * traversal reaches - so it keeps INFO rather than the DEBUG the report asked for, and only the repetitions are
+   * demoted.
+   * <p>
+   * Keyed on the resolved database rather than latched once, so a mapping that later resolves ONTO A DIFFERENT
+   * database - the default database was dropped, or a database sorting ahead of it was created - is announced again
+   * instead of changing silently. The set is bounded by the number of databases the server hosts.
+   */
+  Level announceAliasMappingLevel(final String dbName) {
+    return announcedAliasTargets.add(dbName) ? Level.INFO : Level.FINE;
+  }
+
   @Override
   public TraversalSource getTraversalSource(final String traversalSourceName) {
     final String dbName = resolveDatabaseName(traversalSourceName);
 
     if (!dbName.equals(traversalSourceName))
-      LogManager.instance().log(this, Level.INFO, "Mapping 'g' alias to database '%s'", dbName);
+      LogManager.instance().log(this, announceAliasMappingLevel(dbName), "Mapping 'g' alias to database '%s'", dbName);
 
     // Return the cached traversal source only when the graph it wraps is still open. If the
     // underlying database was closed and reopened (see getOrCreateArcadeGraph) the cached source
@@ -162,6 +183,9 @@ public class ArcadeGraphManager implements GraphManager {
   public Graph removeGraph(final String graphName) {
     final Graph graph = graphs.remove(graphName);
     traversalSources.remove(graphName);
+    // A database that goes away takes its announcement with it, so should 'g' ever be resolved back onto a database
+    // by this name again it is announced rather than mapped silently (issue #7230).
+    announcedAliasTargets.remove(graphName);
     if (graph instanceof ArcadeGraph) {
       try {
         ((ArcadeGraph) graph).close();

--- a/gremlin/src/test/java/com/arcadedb/server/gremlin/Issue7230AliasMappingLogFloodTest.java
+++ b/gremlin/src/test/java/com/arcadedb/server/gremlin/Issue7230AliasMappingLogFloodTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.gremlin;
+
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7230: every Gremlin query sent with the gremlinpython default {@code traversal_source} of {@code 'g'} logged
+ * "Mapping 'g' alias to database '...'" at INFO. The mapping is a property of the deployment, not of the request - a
+ * driver that never changes its traversal source resolves it identically on every query - so the note repeated once
+ * per query and flooded the server log.
+ * <p>
+ * The report asked for DEBUG. The first occurrence is the useful one, though: it is what tells an operator which
+ * database an unqualified traversal actually reaches, and demoting it outright would hide that from anyone who has
+ * not raised the level in advance. So the announcement keeps INFO and only the repetitions are demoted, which is
+ * what these tests pin down.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7230AliasMappingLogFloodTest {
+
+  private ArcadeGraphManager newManager() {
+    return new ArcadeGraphManager(new Settings());
+  }
+
+  /** The flood itself: the first query announces the mapping, the next thousand do not. */
+  @Test
+  void theAliasMappingIsAnnouncedOnceAndDemotedAfterwards() {
+    final ArcadeGraphManager manager = newManager();
+
+    assertThat(manager.announceAliasMappingLevel("graph"))
+        .as("the first resolution tells the operator where an unqualified traversal lands")
+        .isEqualTo(Level.INFO);
+
+    for (int i = 0; i < 1_000; i++)
+      assertThat(manager.announceAliasMappingLevel("graph"))
+          .as("query %d repeats a mapping that has not changed", i)
+          .isEqualTo(Level.FINE);
+  }
+
+  /**
+   * The announcement is keyed on the RESOLVED database rather than latched once, so a mapping that starts pointing
+   * somewhere else is announced again instead of changing silently under the operator.
+   */
+  @Test
+  void aMappingOntoADifferentDatabaseIsAnnouncedAgain() {
+    final ArcadeGraphManager manager = newManager();
+
+    assertThat(manager.announceAliasMappingLevel("first")).isEqualTo(Level.INFO);
+    assertThat(manager.announceAliasMappingLevel("second")).isEqualTo(Level.INFO);
+
+    // ...and each of them is then quiet on its own.
+    assertThat(manager.announceAliasMappingLevel("first")).isEqualTo(Level.FINE);
+    assertThat(manager.announceAliasMappingLevel("second")).isEqualTo(Level.FINE);
+  }
+
+  /**
+   * A database that goes away takes its announcement with it: should {@code 'g'} ever resolve back onto that name,
+   * the operator is told rather than left with a silently re-established mapping.
+   */
+  @Test
+  void removingTheGraphRearmsTheAnnouncement() {
+    final ArcadeGraphManager manager = newManager();
+
+    assertThat(manager.announceAliasMappingLevel("graph")).isEqualTo(Level.INFO);
+    assertThat(manager.announceAliasMappingLevel("graph")).isEqualTo(Level.FINE);
+
+    manager.removeGraph("graph");
+
+    assertThat(manager.announceAliasMappingLevel("graph")).isEqualTo(Level.INFO);
+  }
+
+  /** Two managers do not share the state, so one server's announcement does not silence another's. */
+  @Test
+  void theAnnouncementIsPerManager() {
+    assertThat(newManager().announceAliasMappingLevel("graph")).isEqualTo(Level.INFO);
+    assertThat(newManager().announceAliasMappingLevel("graph")).isEqualTo(Level.INFO);
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
@@ -131,9 +132,21 @@ public final class SnapshotInstaller {
    * limit but had no reader anywhere in the tree, so the only way to change it was to recompile this class
    * (issue #7121). A non-positive configured value falls back to the compiled default rather than disabling the
    * defense - a zip-bomb guard that an operator can switch off by typing 0 is not a guard.
+   * <p>
+   * Read from the SERVER's {@link ContextConfiguration} rather than from the {@link GlobalConfiguration}
+   * enum, as the sibling reads in this class do. The enum is populated by {@code readConfiguration()} alone, which
+   * consults {@code System.getProperty} and {@code System.getenv}: the server configuration file, {@code SET SERVER
+   * SETTING} and the MCP {@code set_server_setting} tool all write into the overlay and never touch it, so an enum
+   * read silently ignores every channel this {@code SCOPE.SERVER} setting advertises except a raw {@code -D}
+   * (issue #7226). The overlay falls back to the enum for a key nobody set, so {@code -D} keeps working through it.
+   *
+   * @param configuration the server's configuration overlay; {@code null} in unit tests and in the non-Raft install
+   *                      callers, which then see the enum (and therefore {@code -D}) alone
    */
-  static long maxZipEntryUncompressedBytes() {
-    final long configured = GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.getValueAsLong();
+  static long maxZipEntryUncompressedBytes(final ContextConfiguration configuration) {
+    final long configured = configuration != null
+        ? configuration.getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE)
+        : GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.getValueAsLong();
     return configured > 0 ? configured : MAX_ZIP_ENTRY_UNCOMPRESSED_BYTES;
   }
 
@@ -956,7 +969,7 @@ public final class SnapshotInstaller {
             : 5000L;
         source = new ProgressReportingInputStream(rawCounter, new SnapshotDownloadProgressMeter(dbName, intervalMs));
       }
-      extractAndVerifySnapshot(source, rawCounter, targetDir, manifestRequired);
+      extractAndVerifySnapshot(source, rawCounter, targetDir, manifestRequired, server);
     } finally {
       connection.disconnect();
     }
@@ -1061,15 +1074,16 @@ public final class SnapshotInstaller {
    * @param rawCounter       the underlying byte counter, used for the per-entry compression-ratio check
    * @param targetDir        the staging directory the entries are extracted into
    * @param manifestRequired when true, a missing manifest is treated as a truncated download and rejected
+   * @param server           the server whose configuration carries the per-entry cap; may be {@code null}
    */
   static void extractAndVerifySnapshot(final InputStream source, final CountingInputStream rawCounter,
-      final Path targetDir, final boolean manifestRequired) throws IOException {
+      final Path targetDir, final boolean manifestRequired, final ArcadeDBServer server) throws IOException {
     // Records the size+CRC32 of each file actually extracted, used to verify against the manifest.
     final Map<String, long[]> extracted = new HashMap<>();
     byte[] manifestBytes = null;
     // Read once for the whole install rather than per entry: the limit must not change mid-extraction, and a
     // snapshot with many small entries should not pay a configuration lookup for each of them.
-    final long maxEntryBytes = maxZipEntryUncompressedBytes();
+    final long maxEntryBytes = maxZipEntryUncompressedBytes(server != null ? server.getConfiguration() : null);
 
     try (final ZipInputStream zipIn = new ZipInputStream(source)) {
       ZipEntry zipEntry;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7121SnapshotMaxEntrySizeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7121SnapshotMaxEntrySizeTest.java
@@ -43,18 +43,18 @@ class Issue7121SnapshotMaxEntrySizeTest {
   @Test
   void theConfiguredLimitIsTheOneEnforced() {
     GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.setValue(4_096L);
-    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes()).isEqualTo(4_096L);
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(null)).isEqualTo(4_096L);
   }
 
   @Test
   void aNonPositiveLimitFallsBackToTheCompiledDefaultInsteadOfDisablingTheGuard() {
     GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.setValue(0L);
-    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes())
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(null))
         .as("a zip-bomb guard an operator can switch off by typing 0 is not a guard")
         .isEqualTo(SnapshotInstaller.MAX_ZIP_ENTRY_UNCOMPRESSED_BYTES);
 
     GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.setValue(-1L);
-    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes())
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(null))
         .isEqualTo(SnapshotInstaller.MAX_ZIP_ENTRY_UNCOMPRESSED_BYTES);
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7226SnapshotMaxEntrySizeContextConfigurationTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7226SnapshotMaxEntrySizeContextConfigurationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7226: {@code arcadedb.ha.snapshotMaxEntrySize} is {@code SCOPE.SERVER}, but the reader added for #7121 read
+ * it off the process-wide {@link GlobalConfiguration} enum. That enum is populated by {@code readConfiguration()}
+ * alone - {@code System.getProperty} then {@code System.getenv} - while the server configuration file
+ * ({@code ContextConfiguration.fromJSON}), {@code SET SERVER SETTING} and the MCP {@code set_server_setting} tool
+ * all write into the server's {@link ContextConfiguration} overlay and never touch it. An operator tuning the
+ * zip-bomb cap through any documented channel other than a raw {@code -D} therefore changed nothing, with no error
+ * and no warning.
+ * <p>
+ * These tests drive the overlay directly, which is what all three of those channels ultimately write into, and pin
+ * down that {@code -D} (the enum) still works as the fallback for a key nobody set.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Isolated
+class Issue7226SnapshotMaxEntrySizeContextConfigurationTest {
+
+  @AfterEach
+  void reset() {
+    GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.reset();
+  }
+
+  /** The server configuration file path: {@code fromJSON} loads the file into the overlay. */
+  @Test
+  void theServerConfigurationFileReachesTheLimit() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.fromJSON("{\"configuration\":{\"ha.snapshotMaxEntrySize\":8192}}");
+
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(configuration))
+        .as("a limit set in the server configuration file must be the one enforced")
+        .isEqualTo(8_192L);
+  }
+
+  /** The {@code SET SERVER SETTING} / MCP {@code set_server_setting} path: both go through {@code setValue}. */
+  @Test
+  void setServerSettingReachesTheLimit() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE, 4_096L);
+
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(configuration)).isEqualTo(4_096L);
+  }
+
+  /** The same, written by key as an admin command carries it: a string, not a typed long. */
+  @Test
+  void aSettingWrittenByKeyAsAStringReachesTheLimit() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.getKey(), "16384");
+
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(configuration)).isEqualTo(16_384L);
+  }
+
+  /**
+   * The overlay wins over the enum, so a server tuned through its own configuration is not overridden by whatever a
+   * {@code -D} left on the process. Both are set to different values here, which is the only way to tell the two
+   * readers apart.
+   */
+  @Test
+  void theServerOverlayWinsOverTheProcessWideEnum() {
+    GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.setValue(1_048_576L);
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE, 2_048L);
+
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(configuration)).isEqualTo(2_048L);
+  }
+
+  /**
+   * ...and for a key the overlay does not carry it falls through to the enum, so {@code -D} keeps working and the
+   * fix is not a new way to ignore a channel.
+   */
+  @Test
+  void anUnsetKeyStillFallsThroughToTheEnum() {
+    GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE.setValue(65_536L);
+
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(new ContextConfiguration())).isEqualTo(65_536L);
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(null)).isEqualTo(65_536L);
+  }
+
+  /** The non-positive fallback of #7121 has to survive the new channel too. */
+  @Test
+  void aNonPositiveLimitFromTheOverlayStillFallsBackToTheCompiledDefault() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_SNAPSHOT_MAX_ENTRY_SIZE, 0L);
+
+    assertThat(SnapshotInstaller.maxZipEntryUncompressedBytes(configuration))
+        .as("a zip-bomb guard an operator can switch off by typing 0 is not a guard")
+        .isEqualTo(SnapshotInstaller.MAX_ZIP_ENTRY_UNCOMPRESSED_BYTES);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotDurabilityTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotDurabilityTest.java
@@ -92,7 +92,7 @@ class SnapshotDurabilityTest {
 
     final SnapshotInstaller.CountingInputStream counter = new SnapshotInstaller.CountingInputStream(
         new ByteArrayInputStream(baos.toByteArray()));
-    SnapshotInstaller.extractAndVerifySnapshot(counter, counter, dir, false);
+    SnapshotInstaller.extractAndVerifySnapshot(counter, counter, dir, false, null);
 
     for (final Map.Entry<String, byte[]> e : files.entrySet())
       assertThat(Files.readAllBytes(dir.resolve(e.getKey()))).isEqualTo(e.getValue());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotManifestVerificationTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotManifestVerificationTest.java
@@ -94,7 +94,7 @@ class SnapshotManifestVerificationTest {
   private static void extract(final byte[] zip, final Path targetDir, final boolean manifestRequired) throws Exception {
     final SnapshotInstaller.CountingInputStream counter = new SnapshotInstaller.CountingInputStream(
         new ByteArrayInputStream(zip));
-    SnapshotInstaller.extractAndVerifySnapshot(counter, counter, targetDir, manifestRequired);
+    SnapshotInstaller.extractAndVerifySnapshot(counter, counter, targetDir, manifestRequired, null);
   }
 
   // -- happy path --


### PR DESCRIPTION
Fixes #7228
Fixes #7230
Fixes #7226

## #7228 - `CREATE INDEX ... IF NOT EXISTS` did not cover super types

`CREATE INDEX \`Elemento_uuid\` IF NOT EXISTS ON \`ElementoNoIdentificable\` (uuid) UNIQUE` was refused with

```
Cannot create the index 'Elemento_uuid' on type 'ElementoNoIdentificable' properties [uuid] because an index
with that name already exists on type 'Elemento' properties [uuid]. Drop it first or choose a different index name
```

when `Elemento` is a super type of `ElementoNoIdentificable`.

The refusal was wrong on its own terms. A type index is built over `type.getBuckets(true)` - the **polymorphic** bucket list - so an index declared on `Elemento` already indexes every `ElementoNoIdentificable` record. There is nothing left for the statement to create and nothing for the guard to warn about, and a test in this PR shows the inherited UNIQUE constraint really is enforced on the sub type.

The **unnamed** form of the same statement had always been a no-op: `TypeIndexBuilder.create()` looks the index up with `getPolymorphicIndexByProperties` and returns it. Only the **named** form disagreed, because it is answered by a shortcut in `CreateIndexStatement` that runs before any builder exists and compared the type names for equality. That made a schema script non-idempotent the moment one of its named indexes moved up the hierarchy - the one thing `IF NOT EXISTS` is written to prevent.

The relation is checked in **one direction only**, and the tests pin each of these down as still reported:

| request | existing index | outcome |
|---|---|---|
| sub type | on super type, same properties | no-op, `created=false` |
| super type | on sub type | reported (covers fewer buckets) |
| sub type | on an unrelated type | reported |
| sub type | on super type, different properties | reported |
| sub type UNIQUE | inherited NOTUNIQUE | reported (#5675 rule unchanged) |
| unguarded named request | inherited index | reported |

## #7230 - Gremlin logs flooded with "Mapping 'g' alias to database ..."

Every query sent with the gremlinpython default `traversal_source` of `g` logged the mapping at INFO. The mapping is a property of the deployment, not of the request: a driver that never changes its traversal source resolves it identically on every single query, so the note repeated once per query.

**Instead of the blanket demotion to DEBUG the report asked for**, the first occurrence keeps INFO - it is what tells an operator which database an unqualified traversal actually reaches, and demoting it outright hides that from anyone who has not raised the level in advance - and only the repetitions drop to FINE. The announcement is keyed on the *resolved database* rather than latched once, so a mapping that later points at a different database is announced again instead of changing silently, and `removeGraph` re-arms it. The set is bounded by the number of databases the server hosts.

## #7226 - `arcadedb.ha.snapshotMaxEntrySize` only reachable through `-D`

The setting is `SCOPE.SERVER`, but the reader added for #7121 read it off the process-wide `GlobalConfiguration` enum, which `readConfiguration()` populates from `System.getProperty` and `System.getenv` alone. The server configuration file (`ContextConfiguration.fromJSON`), `SET SERVER SETTING` and the MCP `set_server_setting` tool all write into the server's overlay and never touch the enum, so an operator tuning the zip-bomb cap through any documented channel other than a raw `-D` changed nothing, with no error and no warning.

Now read through the server's `ContextConfiguration`, as the two sibling reads in the same file already do. The overlay falls through to the enum for a key nobody set, so `-D` keeps working, and the non-positive fallback of #7121 is unchanged.

### Follow-up sweep

The issue also asked for a sweep of `GlobalConfiguration.<SETTING>.getValueAs*` outside `engine/`. It was run: the `ArcadeStateMachine` and `RaftHAServer` hits are already the correct `server != null ? server.getConfiguration()... : enum` shape, but there are ~50 further hits across `server`, `ha-raft`, `bolt`, `postgresw`, `redisw`, `grpcw` and `network` where no server reference is at hand (static initialisers, constructor defaults - e.g. `SnapshotHttpHandler`'s static `CONCURRENCY_SEMAPHORE`, `PeerAddressAllowlistFilter`, `BoltChunkedInput`). Fixing those means threading configuration through constructors across ten modules, which does not belong in a three-issue batch; a separate issue (#7233) is filed for it so this PR stays reviewable.

## Verification

- New: `Issue7228CreateIndexIfNotExistsSuperTypeTest` (8 tests), `Issue7230AliasMappingLogFloodTest` (4), `Issue7226SnapshotMaxEntrySizeContextConfigurationTest` (6). Each was confirmed to FAIL against the unfixed code - #7228's reproduces the reported message verbatim - and to pass after.
- `ha-raft`: full unit lane, 1166 tests green.
- `engine`: index/DDL regression set (`Issue5675`, `Issue5765` x2, `Issue6921`, `Issue6359SuperTypeIndexPropagation`, `ManualIndexNameGuard`, `DropIndex`, `RebuildIndexPreservesName`, `HashIndexInheritance`, `LSMTreeIndexPolymorphic`, `Issue5780`, `MultipleTypesIndex`, `TypeLSMTreeIndex`) - 119 tests green.
- `gremlin` unit lane via `gremlin-it`: green apart from 7 pre-existing errors in server-backed classes caused by another process holding port 2480 on this machine (`SecurityException: Too many failed authentication attempts`), all failing in `beginTest` before any test logic.

## Docs

`#7228` changes documented behaviour of `CREATE INDEX ... IF NOT EXISTS`; the SQL reference (`sql-create-index.adoc`) is worth a note that a name already carried by an index on a super type answers the guard. Happy to prepare that in `arcadedb-docs` on request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `CREATE INDEX IF NOT EXISTS` now recognizes compatible indexes inherited from a parent type, keeping schema scripts idempotent across type hierarchies.
  - Repeated index creation executions no longer carry type or generated-name state between commands.
  - Snapshot extraction limits now honor server-level configuration and runtime setting changes, with safe fallback behavior for unset or invalid values.
  - Reduced repeated informational logging for recurring Gremlin database alias mappings while preserving notifications for new mappings and re-resolutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->